### PR TITLE
Zms 576

### DIFF
--- a/store/src/java/com/zimbra/qa/unittest/TestBlobDeduper.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestBlobDeduper.java
@@ -18,21 +18,16 @@ package com.zimbra.qa.unittest;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
+
+import junit.framework.Assert;
 
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
-import junit.framework.Assert;
-
-import com.google.common.collect.Maps;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
-import com.zimbra.cs.account.Provisioning;
-import com.zimbra.cs.account.Server;
 import com.zimbra.cs.mailbox.DeliveryOptions;
 import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.MailboxManager;

--- a/store/src/java/com/zimbra/qa/unittest/TestBlobDeduper.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestBlobDeduper.java
@@ -18,12 +18,21 @@ package com.zimbra.qa.unittest;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 import junit.framework.Assert;
-import junit.framework.TestCase;
 
+import com.google.common.collect.Maps;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.Server;
 import com.zimbra.cs.mailbox.DeliveryOptions;
 import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.MailboxManager;
@@ -37,32 +46,60 @@ import com.zimbra.cs.volume.Volume;
 import com.zimbra.cs.volume.VolumeManager;
 import com.zimbra.znative.IO;
 
-public final class TestBlobDeduper extends TestCase {
+public final class TestBlobDeduper {
 
-    private static String USER_NAME = "user1";
+    private static final Provisioning prov = Provisioning.getInstance();
     private static String TEST_NAME = "TestBlobDeduper";
+    private static String USER_NAME = TEST_NAME + "-user1";
     private Mailbox mbox;
     private Account account;
+    private static Server localServer = null;
 
-    public TestBlobDeduper(String testName) {
-        super(testName);
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        localServer = prov.getLocalServer();
     }
 
-    @Override
+    @Before
     public void setUp() throws Exception {
-        super.setUp();
-        account = TestUtil.getAccount(USER_NAME);
-        mbox = MailboxManager.getInstance().getMailboxByAccount(account);
-        // Clean up data, in case a previous test didn't exit cleanly
-        cleanUp();
-    }
-
-
-    public void testBlobDeduper() throws Exception {
-        if (!(StoreManager.getInstance() instanceof FileBlobStore)) {
+        if(!(StoreManager.getInstance() instanceof FileBlobStore)) {
             ZimbraLog.test.info("Skipping deduper test for non-FileBlobStore");
             return;
         }
+        cleanUp();
+        Map<String, Object> attrs = Maps.newHashMap();
+        attrs.put(Provisioning.A_zimbraMailHost, localServer.getServiceHostname());
+        account = TestUtil.createAccount(USER_NAME, attrs);
+        mbox = MailboxManager.getInstance().getMailboxByAccount(account);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        try {
+            cleanUp();
+        } catch (Throwable t) {
+            // Catch exceptions during cleanup, so that the original test error
+            // isn't lost
+            if (t instanceof OutOfMemoryError) {
+                Zimbra.halt("TestBlobDeduper ran out of memory", t);
+            }
+            ZimbraLog.test.error("", t);
+        }
+    }
+
+    /**
+     * Moves all items back to the primary volume and deletes the temporary
+     * volume created for the test.
+     */
+    private void cleanUp() throws Exception {
+        if(TestUtil.accountExists(USER_NAME)) {
+            TestUtil.deleteAccount(USER_NAME);
+        }
+    }
+
+    @Test
+    public void testBlobDeduper() throws Exception {
+        Assume.assumeTrue(StoreManager.getInstance() instanceof FileBlobStore); 
         DeliveryOptions opt = new DeliveryOptions();
         opt.setFolderId(Mailbox.ID_FOLDER_INBOX);
         String[] paths = new String[5];
@@ -89,27 +126,4 @@ public final class TestBlobDeduper extends TestCase {
             Assert.assertTrue(IO.fileInfo(paths[i]).getInodeNum() == IO.fileInfo(paths[i+1]).getInodeNum());
         }
     }
-
-    @Override public void tearDown()
-    throws Exception {
-        try {
-            cleanUp();
-        } catch (Throwable t) {
-            // Catch exceptions during cleanup, so that the original test error
-            // isn't lost
-            if (t instanceof OutOfMemoryError) {
-                Zimbra.halt("TestBlobDeduper ran out of memory", t);
-            }
-            ZimbraLog.test.error("", t);
-        }
-    }
-
-    /**
-     * Moves all items back to the primary volume and deletes the temporary
-     * volume created for the test.
-     */
-    private void cleanUp() throws Exception {
-        TestUtil.deleteTestData(USER_NAME, TEST_NAME);
-    }
 }
-

--- a/store/src/java/com/zimbra/qa/unittest/TestBlobDeduper.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestBlobDeduper.java
@@ -48,17 +48,10 @@ import com.zimbra.znative.IO;
 
 public final class TestBlobDeduper {
 
-    private static final Provisioning prov = Provisioning.getInstance();
     private static String TEST_NAME = "TestBlobDeduper";
     private static String USER_NAME = TEST_NAME + "-user1";
     private Mailbox mbox;
     private Account account;
-    private static Server localServer = null;
-
-    @BeforeClass
-    public static void beforeClass() throws Exception {
-        localServer = prov.getLocalServer();
-    }
 
     @Before
     public void setUp() throws Exception {
@@ -67,9 +60,7 @@ public final class TestBlobDeduper {
             return;
         }
         cleanUp();
-        Map<String, Object> attrs = Maps.newHashMap();
-        attrs.put(Provisioning.A_zimbraMailHost, localServer.getServiceHostname());
-        account = TestUtil.createAccount(USER_NAME, attrs);
+        account = TestUtil.createAccount(USER_NAME);
         mbox = MailboxManager.getInstance().getMailboxByAccount(account);
     }
 

--- a/store/src/java/com/zimbra/qa/unittest/TestCalDav.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestCalDav.java
@@ -122,21 +122,17 @@ import static org.junit.Assert.fail;
 public class TestCalDav {
 
     static final TimeZoneRegistry tzRegistry = TimeZoneRegistryFactory.getInstance().createRegistry();
-    private static String TEST_NAME = "TestCalDav";
-    private static String USER_NAME = TEST_NAME + "-user1";
-    private static String DAV1 = TEST_NAME + "dav1";
-    private static String DAV2 = TEST_NAME + "dav2";
-    private static String DAV3 = TEST_NAME + "dav3";
-    private static String DAV4 = TEST_NAME + "dav4";
+    private static String NAME_PREFIX = "TestCalDav";
+    private static TestUtil.UserInfo[] users = {
+        new TestUtil.UserInfo("dav0user"),
+        new TestUtil.UserInfo("dav1user"),
+        new TestUtil.UserInfo("dav2user"),
+        new TestUtil.UserInfo("dav3user"),
+        new TestUtil.UserInfo("dav4user")
+    };
     private static String DL1 = "davdistlist1";
     private static Server localServer = null;
     private static final Provisioning prov = Provisioning.getInstance();
-
-    private Account dav1;
-    private Account dav2;
-    private Account dav3;
-    private Account dav4;
-    private Account user1;
 
     public static class MkColMethod extends EntityEnclosingMethod {
         @Override
@@ -342,6 +338,7 @@ public class TestCalDav {
 
     @Test
     public void testBadBasicAuth() throws Exception {
+        Account dav1 = users[1].create();
         String calFolderUrl = getFolderUrl(dav1, "Calendar").replaceAll("@", "%40");
         HttpClient client = new HttpClient();
         GetMethod method = new GetMethod(calFolderUrl);
@@ -351,6 +348,9 @@ public class TestCalDav {
 
     @Test
     public void testPostToSchedulingOutbox() throws Exception {
+        Account dav1 = users[1].create();
+        Account dav2 = users[2].create();
+        Account dav3 = users[3].create();
         String url = getSchedulingOutboxUrl(dav1, dav1);
         HttpClient client = new HttpClient();
         PostMethod method = new PostMethod(url);
@@ -368,6 +368,9 @@ public class TestCalDav {
 
     @Test
     public void testBadPostToSchedulingOutbox() throws Exception {
+        Account dav1 = users[1].create();
+        Account dav2 = users[2].create();
+        Account dav3 = users[3].create();
         String url = getSchedulingOutboxUrl(dav2, dav2);
         HttpClient client = new HttpClient();
         PostMethod method = new PostMethod(url);
@@ -538,14 +541,15 @@ public class TestCalDav {
 
     @Test
     public void testCalendarQueryOnInbox() throws Exception {
+        Account dav1 = users[1].create();
         String url = getSchedulingInboxUrl(dav1, dav1);
         Document doc = calendarQuery(url, dav1);
         org.w3c.dom.Element rootElem = doc.getDocumentElement();
         assertFalse("response when there are no items should have no child elements", rootElem.hasChildNodes());
 
         // Send an invite from user1 and check tags.
-        ZMailbox organizer = TestUtil.getZMailbox(USER_NAME);
-        String subject = TEST_NAME + " testInvite request 1";
+        ZMailbox organizer = users[0].getZMailbox();
+        String subject = NAME_PREFIX + " testInvite request 1";
         Date startDate = new Date(System.currentTimeMillis() + Constants.MILLIS_PER_DAY);
         Date endDate = new Date(startDate.getTime() + Constants.MILLIS_PER_HOUR);
         TestUtil.createAppointment(organizer, subject, dav1.getName(), startDate, endDate);
@@ -558,15 +562,16 @@ public class TestCalDav {
 
     @Test
     public void testCalendarQueryOnOutbox() throws Exception {
-        ZMailbox dav1mbox = TestUtil.getZMailbox(USER_NAME);
+        Account dav1 = users[1].create();
+        ZMailbox dav1mbox = users[0].getZMailbox();
         String url = getSchedulingOutboxUrl(dav1, dav1);
         Document doc = calendarQuery(url, dav1);
         org.w3c.dom.Element rootElem = doc.getDocumentElement();
         assertFalse("response when there are no items should have no child elements", rootElem.hasChildNodes());
 
         // Send an invite to user2 and check tags.
-        ZMailbox recipient = TestUtil.getZMailbox(USER_NAME);
-        String subject = TEST_NAME + " testInvite request 1";
+        ZMailbox recipient = users[0].getZMailbox();
+        String subject = NAME_PREFIX + " testInvite request 1";
         Date startDate = new Date(System.currentTimeMillis() + Constants.MILLIS_PER_DAY);
         Date endDate = new Date(startDate.getTime() + Constants.MILLIS_PER_HOUR);
         TestUtil.createAppointment(dav1mbox, subject, recipient.getName(), startDate, endDate);
@@ -581,12 +586,14 @@ public class TestCalDav {
 
     @Test
     public void testPropFindSupportedReportSetOnInbox() throws Exception {
+        Account user1 = users[0].create();
         checkPropFindSupportedReportSet(user1, getSchedulingInboxUrl(user1, user1),
                 UrlNamespace.getSchedulingInboxUrl(user1.getName(), user1.getName()));
     }
 
     @Test
     public void testPropFindSupportedReportSetOnOutbox() throws Exception {
+        Account user1 = users[0].create();
         checkPropFindSupportedReportSet(user1, getSchedulingOutboxUrl(user1, user1),
                 UrlNamespace.getSchedulingOutboxUrl(user1.getName(), user1.getName()));
     }
@@ -711,24 +718,28 @@ public class TestCalDav {
 
     @Test
     public void testPropFindSupportedCalendarComponentSetOnInbox() throws Exception {
+        Account user1 = users[0].create();
         checkPropFindSupportedCalendarComponentSet(user1, getSchedulingInboxUrl(user1, user1),
                 UrlNamespace.getSchedulingInboxUrl(user1.getName(), user1.getName()), componentsForBothTasksAndEvents);
     }
 
     @Test
     public void testPropFindSupportedCalendarComponentSetOnOutbox() throws Exception {
+        Account user1 = users[0].create();
         checkPropFindSupportedCalendarComponentSet(user1, getSchedulingOutboxUrl(user1, user1),
                 UrlNamespace.getSchedulingOutboxUrl(user1.getName(), user1.getName()), componentsForBothTasksAndEvents);
     }
 
     @Test
     public void testPropFindSupportedCalendarComponentSetOnCalendar() throws Exception {
+        Account user1 = users[0].create();
         checkPropFindSupportedCalendarComponentSet(user1, getFolderUrl(user1, "Calendar"),
                 UrlNamespace.getFolderUrl(user1.getName(), "Calendar"), eventComponents);
     }
 
     @Test
     public void testPropFindSupportedCalendarComponentSetOnTasks() throws Exception {
+        Account user1 = users[0].create();
         checkPropFindSupportedCalendarComponentSet(user1, getFolderUrl(user1, "Tasks"),
                 UrlNamespace.getFolderUrl(user1.getName(), "Tasks"), todoComponents);
     }
@@ -744,6 +755,7 @@ public class TestCalDav {
      */
     @Test
     public void testCreateUsingClientChosenName() throws ServiceException, IOException {
+        Account dav1 = users[1].create();
         String davBaseName = "clientInvented.now";
         String calFolderUrl = getFolderUrl(dav1, "Calendar");
         String url = String.format("%s%s", calFolderUrl, davBaseName);
@@ -827,6 +839,10 @@ public class TestCalDav {
      */
     @Test
     public void testCreateModifyDeleteAttendeeModifyAndCancel() throws ServiceException, IOException {
+        Account dav1 = users[1].create();
+        Account dav2 = users[2].create();
+        Account dav3 = users[3].create();
+        Account dav4 = users[4].create();
         DistributionList dl = TestUtil.createDistributionList(DL1);
         String[] members = { dav4.getName() };
         prov.addMembers(dl, members);
@@ -862,8 +878,8 @@ public class TestCalDav {
         doDeleteMethod(getLocalServerRoot().append(inboxhref).toString(), dav4, HttpStatus.SC_NO_CONTENT);
 
         // Test that iTip handling still happens when some of the attendees no longer exist.
-        TestUtil.deleteAccount(DAV3);
-        TestUtil.deleteAccount(DAV4); // attendee via DL
+        users[3].cleanup();
+        users[4].cleanup(); // attendee via DL
         vCal = simpleMeeting(dav1, attendees, uid, "3", 10);
         doIcalPut(url, dav1, zvcalendarToBytes(vCal), HttpStatus.SC_CREATED);
         inboxhref = TestCalDav.waitForNewSchedulingRequestByUID(dav2, uid);
@@ -932,7 +948,9 @@ public class TestCalDav {
 
     @Test
     public void testAndroidMeetingSeries() throws Exception {
-        ZMailbox dav2MB = TestUtil.getZMailbox(DAV2); // Force creation of mailbox - shouldn't be needed
+        Account dav1 = users[1].create();
+        Account dav2 = users[2].create();
+        users[2].getZMailbox();  // Force creation of mailbox - shouldn't be needed
         String calFolderUrl = getFolderUrl(dav1, "Calendar").replaceAll("@", "%40");
         String url = String.format("%s%s.ics", calFolderUrl, androidSeriesMeetingUid);
         HttpClient client = new HttpClient();
@@ -1082,6 +1100,7 @@ public class TestCalDav {
 
     @Test
     public void testSimpleMkcol() throws Exception {
+        Account dav1 = users[1].create();
         StringBuilder url = getLocalServerRoot();
         url.append(DavServlet.DAV_PATH).append("/").append(dav1.getName()).append("/simpleMkcol/");
         MkColMethod method = new MkColMethod(url.toString());
@@ -1104,6 +1123,7 @@ public class TestCalDav {
                 "       </D:prop>" +
                 "     </D:set>" +
                 "</D:mkcol>";
+        Account dav1 = users[1].create();
         StringBuilder url = getLocalServerRoot();
         url.append(DavServlet.DAV_PATH).append("/").append(dav1.getName()).append("/OtherContacts/");
         MkColMethod method = new MkColMethod(url.toString());
@@ -1213,9 +1233,11 @@ public class TestCalDav {
                 "</A:propertyupdate>";
 
 
+        Account dav1 = users[1].create();
+
         // Create an event in Dav1's calendar
-        ZMailbox organizer = TestUtil.getZMailbox(DAV1);
-        String subject = TEST_NAME + " testInvite request 1";
+        ZMailbox organizer = users[1].getZMailbox();
+        String subject = NAME_PREFIX + " testInvite request 1";
         Date startDate = new Date(System.currentTimeMillis() + Constants.MILLIS_PER_DAY);
         Date endDate = new Date(startDate.getTime() + Constants.MILLIS_PER_HOUR);
         Date fbStartDate = new Date(startDate.getTime() - (Constants.MILLIS_PER_DAY * 2));
@@ -1404,13 +1426,15 @@ public class TestCalDav {
     }
 
     private void attendeeDeleteFromCalendar(boolean suppressReply) throws Exception {
+        Account dav1 = users[1].create();
+        users[2].create();
         String url = getSchedulingInboxUrl(dav1, dav1);
         ReportMethod method = new ReportMethod(url);
         addBasicAuthHeaderForUser(method, dav1);
 
-        ZMailbox organizer = TestUtil.getZMailbox(DAV2);
-        ZMailbox dav1MB = TestUtil.getZMailbox(DAV1); // Force creation of mailbox - shouldn't be needed
-        String subject = String.format("%s %s", TEST_NAME,
+        ZMailbox organizer = users[2].getZMailbox();
+        users[1].getZMailbox(); // Force creation of mailbox - shouldn't be needed
+        String subject = String.format("%s %s", NAME_PREFIX,
                 suppressReply ? "testInvite which shouldNOT be replied to" : "testInvite to be auto-declined");
         Date startDate = new Date(System.currentTimeMillis() + Constants.MILLIS_PER_DAY);
         Date endDate = new Date(startDate.getTime() + Constants.MILLIS_PER_HOUR);
@@ -1467,6 +1491,7 @@ public class TestCalDav {
 
     @Test
     public void testCreateContactWithIfNoneMatchTesting() throws ServiceException, IOException {
+        Account dav1 = users[1].create();
         String davBaseName = "SCRUFF1.vcf";  // Based on UID
         String contactsFolderUrl = getFolderUrl(dav1, "Contacts");
         String url = String.format("%s%s", contactsFolderUrl, davBaseName);
@@ -1541,6 +1566,7 @@ public class TestCalDav {
 
     @Test
     public void testAppleStyleGroup() throws ServiceException, IOException {
+        Account dav1 = users[1].create();
         String contactsFolderUrl = getFolderUrl(dav1, "Contacts");
         HttpClient client = new HttpClient();
 
@@ -1598,7 +1624,7 @@ public class TestCalDav {
         searchRequest.setLimit(8);
         searchRequest.setSearchTypes("contact");
         searchRequest.setQuery("in:Contacts");
-        ZMailbox mbox = TestUtil.getZMailbox(DAV1);
+        ZMailbox mbox = users[1].getZMailbox();
         SearchResponse searchResp = mbox.invokeJaxb(searchRequest);
         assertNotNull("JAXB SearchResponse object", searchResp);
         List<SearchHit> hits = searchResp.getSearchHits();
@@ -1657,6 +1683,7 @@ public class TestCalDav {
 
     @Test
     public void testXBusyMacAttach() throws ServiceException, IOException {
+        Account dav1 = users[1].create();
         String contactsFolderUrl = getFolderUrl(dav1, "Contacts");
         HttpClient client = new HttpClient();
 
@@ -1699,7 +1726,7 @@ public class TestCalDav {
         searchRequest.setLimit(8);
         searchRequest.setSearchTypes("contact");
         searchRequest.setQuery("in:Contacts");
-        ZMailbox mbox = TestUtil.getZMailbox(DAV1);
+        ZMailbox mbox = users[1].getZMailbox();
         SearchResponse searchResp = mbox.invokeJaxb(searchRequest);
         assertNotNull("JAXB SearchResponse object", searchResp);
         List<SearchHit> hits = searchResp.getSearchHits();
@@ -1762,9 +1789,9 @@ public class TestCalDav {
      */
     @Test
     public void testAppleCaldavProxyFunctions() throws ServiceException, IOException {
-        Account sharer = dav3;
-        Account sharee1 = dav1;
-        Account sharee2 = dav2;
+        Account sharer = users[3].create();
+        Account sharee1 = users[1].create();
+        Account sharee2 = users[2].create();
         ZMailbox mboxSharer = TestUtil.getZMailbox(sharer.getName());
         ZMailbox mboxSharee1 = TestUtil.getZMailbox(sharee1.getName());
         ZMailbox mboxSharee2 = TestUtil.getZMailbox(sharee2.getName());
@@ -1937,11 +1964,6 @@ public class TestCalDav {
             File tzFile = new File(tzFilePath);
             WellKnownTimeZones.loadFromFile(tzFile);
         }
-        user1 = TestUtil.createAccount(USER_NAME);
-        dav1 = TestUtil.createAccount(DAV1);
-        dav2 = TestUtil.createAccount(DAV2);
-        dav3 = TestUtil.createAccount(DAV3);
-        dav4 = TestUtil.createAccount(DAV4);
     }
 
     @After
@@ -1950,21 +1972,7 @@ public class TestCalDav {
     }
 
     private void cleanUp() throws Exception {
-        if(TestUtil.accountExists(DAV1)) {
-            TestUtil.deleteAccount(DAV1);
-        }
-        if(TestUtil.accountExists(DAV2)) {
-            TestUtil.deleteAccount(DAV2);
-        }
-        if(TestUtil.accountExists(DAV3)) {
-            TestUtil.deleteAccount(DAV3);
-        }
-        if(TestUtil.accountExists(DAV4)) {
-            TestUtil.deleteAccount(DAV4);
-        }
-        if(TestUtil.accountExists(USER_NAME)) {
-            TestUtil.deleteAccount(USER_NAME);
-        }
+        TestUtil.UserInfo.cleanup(users);
         try {
             TestUtil.deleteDistributionList(DL1);
         } catch (Exception e) {

--- a/store/src/java/com/zimbra/qa/unittest/TestCalDav.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestCalDav.java
@@ -38,6 +38,9 @@ import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
+import net.fortuna.ical4j.model.TimeZoneRegistry;
+import net.fortuna.ical4j.model.TimeZoneRegistryFactory;
+
 import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpMethod;
@@ -105,22 +108,35 @@ import com.zimbra.soap.mail.type.ContactInfo;
 import com.zimbra.soap.mail.type.NewMountpointSpec;
 import com.zimbra.soap.type.SearchHit;
 
-import junit.framework.TestCase;
-import net.fortuna.ical4j.model.TimeZoneRegistry;
-import net.fortuna.ical4j.model.TimeZoneRegistryFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
-public class TestCalDav extends TestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+public class TestCalDav {
 
     static final TimeZoneRegistry tzRegistry = TimeZoneRegistryFactory.getInstance().createRegistry();
-    private static String NAME_PREFIX = "TestCalDav";
+    private static String TEST_NAME = "TestCalDav";
+    private static String USER_NAME = TEST_NAME + "-user1";
+    private static String DAV1 = TEST_NAME + "dav1";
+    private static String DAV2 = TEST_NAME + "dav2";
+    private static String DAV3 = TEST_NAME + "dav3";
+    private static String DAV4 = TEST_NAME + "dav4";
     private static String DL1 = "davdistlist1";
-    private static TestUtil.UserInfo[] users = {
-            new TestUtil.UserInfo("dav0user"),
-            new TestUtil.UserInfo("dav1user"),
-            new TestUtil.UserInfo("dav2user"),
-            new TestUtil.UserInfo("dav3user"),
-            new TestUtil.UserInfo("dav4user")
-    };
+    private static Server localServer = null;
+    private static final Provisioning prov = Provisioning.getInstance();
+
+    private Account dav1;
+    private Account dav2;
+    private Account dav3;
+    private Account dav4;
+    private Account user1;
 
     public static class MkColMethod extends EntityEnclosingMethod {
         @Override
@@ -324,8 +340,8 @@ public class TestCalDav extends TestCase {
         }
     }
 
+    @Test
     public void testBadBasicAuth() throws Exception {
-        Account dav1 = users[1].create();
         String calFolderUrl = getFolderUrl(dav1, "Calendar").replaceAll("@", "%40");
         HttpClient client = new HttpClient();
         GetMethod method = new GetMethod(calFolderUrl);
@@ -333,10 +349,8 @@ public class TestCalDav extends TestCase {
         HttpMethodExecutor.execute(client, method, HttpStatus.SC_UNAUTHORIZED);
     }
 
+    @Test
     public void testPostToSchedulingOutbox() throws Exception {
-        Account dav1 = users[1].create();
-        Account dav2 = users[2].create();
-        Account dav3 = users[3].create();
         String url = getSchedulingOutboxUrl(dav1, dav1);
         HttpClient client = new HttpClient();
         PostMethod method = new PostMethod(url);
@@ -352,10 +366,8 @@ public class TestCalDav extends TestCase {
         HttpMethodExecutor.execute(client, method, HttpStatus.SC_OK);
     }
 
+    @Test
     public void testBadPostToSchedulingOutbox() throws Exception {
-        Account dav1 = users[1].create();
-        Account dav2 = users[2].create();
-        Account dav3 = users[3].create();
         String url = getSchedulingOutboxUrl(dav2, dav2);
         HttpClient client = new HttpClient();
         PostMethod method = new PostMethod(url);
@@ -382,9 +394,8 @@ public class TestCalDav extends TestCase {
     }
 
     public static StringBuilder getLocalServerRoot() throws ServiceException {
-        Server localServer = Provisioning.getInstance().getLocalServer();
         StringBuilder sb = new StringBuilder();
-        sb.append("https://").append(localServer.getAttr(Provisioning.A_zimbraServiceHostname, "localhost"));
+        sb.append(TestUtil.getBaseUrl(localServer));
         return sb;
     }
 
@@ -525,16 +536,16 @@ public class TestCalDav extends TestCase {
         return waitForItemInCalendarCollectionByUID(url, acct, UID, true, 10000);
     }
 
+    @Test
     public void testCalendarQueryOnInbox() throws Exception {
-        Account dav1 = users[1].create();
         String url = getSchedulingInboxUrl(dav1, dav1);
         Document doc = calendarQuery(url, dav1);
         org.w3c.dom.Element rootElem = doc.getDocumentElement();
         assertFalse("response when there are no items should have no child elements", rootElem.hasChildNodes());
 
         // Send an invite from user1 and check tags.
-        ZMailbox organizer = users[0].getZMailbox();
-        String subject = NAME_PREFIX + " testInvite request 1";
+        ZMailbox organizer = TestUtil.getZMailbox(USER_NAME);
+        String subject = TEST_NAME + " testInvite request 1";
         Date startDate = new Date(System.currentTimeMillis() + Constants.MILLIS_PER_DAY);
         Date endDate = new Date(startDate.getTime() + Constants.MILLIS_PER_HOUR);
         TestUtil.createAppointment(organizer, subject, dav1.getName(), startDate, endDate);
@@ -545,17 +556,17 @@ public class TestCalDav extends TestCase {
         assertTrue("response should have child elements", rootElem.hasChildNodes());
     }
 
+    @Test
     public void testCalendarQueryOnOutbox() throws Exception {
-        Account dav1 = users[1].create();
-        ZMailbox dav1mbox = users[0].getZMailbox();
+        ZMailbox dav1mbox = TestUtil.getZMailbox(USER_NAME);
         String url = getSchedulingOutboxUrl(dav1, dav1);
         Document doc = calendarQuery(url, dav1);
         org.w3c.dom.Element rootElem = doc.getDocumentElement();
         assertFalse("response when there are no items should have no child elements", rootElem.hasChildNodes());
 
         // Send an invite to user2 and check tags.
-        ZMailbox recipient = users[0].getZMailbox();
-        String subject = NAME_PREFIX + " testInvite request 1";
+        ZMailbox recipient = TestUtil.getZMailbox(USER_NAME);
+        String subject = TEST_NAME + " testInvite request 1";
         Date startDate = new Date(System.currentTimeMillis() + Constants.MILLIS_PER_DAY);
         Date endDate = new Date(startDate.getTime() + Constants.MILLIS_PER_HOUR);
         TestUtil.createAppointment(dav1mbox, subject, recipient.getName(), startDate, endDate);
@@ -568,14 +579,14 @@ public class TestCalDav extends TestCase {
         rootElem.hasChildNodes());
     }
 
+    @Test
     public void testPropFindSupportedReportSetOnInbox() throws Exception {
-        Account user1 = users[0].create();
         checkPropFindSupportedReportSet(user1, getSchedulingInboxUrl(user1, user1),
                 UrlNamespace.getSchedulingInboxUrl(user1.getName(), user1.getName()));
     }
 
+    @Test
     public void testPropFindSupportedReportSetOnOutbox() throws Exception {
-        Account user1 = users[0].create();
         checkPropFindSupportedReportSet(user1, getSchedulingOutboxUrl(user1, user1),
                 UrlNamespace.getSchedulingOutboxUrl(user1.getName(), user1.getName()));
     }
@@ -697,26 +708,27 @@ public class TestCalDav extends TestCase {
     private final String[] componentsForBothTasksAndEvents = {"VEVENT", "VTODO", "VFREEBUSY"};
     private final String[] eventComponents = {"VEVENT", "VFREEBUSY"};
     private final String[] todoComponents = {"VTODO", "VFREEBUSY"};
+
+    @Test
     public void testPropFindSupportedCalendarComponentSetOnInbox() throws Exception {
-        Account user1 = users[0].create();
         checkPropFindSupportedCalendarComponentSet(user1, getSchedulingInboxUrl(user1, user1),
                 UrlNamespace.getSchedulingInboxUrl(user1.getName(), user1.getName()), componentsForBothTasksAndEvents);
     }
 
+    @Test
     public void testPropFindSupportedCalendarComponentSetOnOutbox() throws Exception {
-        Account user1 = users[0].create();
         checkPropFindSupportedCalendarComponentSet(user1, getSchedulingOutboxUrl(user1, user1),
                 UrlNamespace.getSchedulingOutboxUrl(user1.getName(), user1.getName()), componentsForBothTasksAndEvents);
     }
 
+    @Test
     public void testPropFindSupportedCalendarComponentSetOnCalendar() throws Exception {
-        Account user1 = users[0].create();
         checkPropFindSupportedCalendarComponentSet(user1, getFolderUrl(user1, "Calendar"),
                 UrlNamespace.getFolderUrl(user1.getName(), "Calendar"), eventComponents);
     }
 
+    @Test
     public void testPropFindSupportedCalendarComponentSetOnTasks() throws Exception {
-        Account user1 = users[0].create();
         checkPropFindSupportedCalendarComponentSet(user1, getFolderUrl(user1, "Tasks"),
                 UrlNamespace.getFolderUrl(user1.getName(), "Tasks"), todoComponents);
     }
@@ -730,8 +742,8 @@ public class TestCalDav extends TestCase {
      *      at com.zimbra.cs.dav.service.method.Put.handle(Put.java:49)
      *      at com.zimbra.cs.dav.service.DavServlet.service(DavServlet.java:322)
      */
+    @Test
     public void testCreateUsingClientChosenName() throws ServiceException, IOException {
-        Account dav1 = users[1].create();
         String davBaseName = "clientInvented.now";
         String calFolderUrl = getFolderUrl(dav1, "Calendar");
         String url = String.format("%s%s", calFolderUrl, davBaseName);
@@ -813,13 +825,9 @@ public class TestCalDav extends TestCase {
     /** Mostly checking that if attendees cease to exist (even via DLs) then modification and cancel iTip
      * messages still work to the remaining attendees.
      */
+    @Test
     public void testCreateModifyDeleteAttendeeModifyAndCancel() throws ServiceException, IOException {
-        Account dav1 = users[1].create();
-        Account dav2 = users[2].create();
-        Account dav3 = users[3].create();
-        Account dav4 = users[4].create();
         DistributionList dl = TestUtil.createDistributionList(DL1);
-        Provisioning prov = Provisioning.getInstance();
         String[] members = { dav4.getName() };
         prov.addMembers(dl, members);
         List<MailTarget> attendees = Lists.newArrayList();
@@ -854,8 +862,8 @@ public class TestCalDav extends TestCase {
         doDeleteMethod(getLocalServerRoot().append(inboxhref).toString(), dav4, HttpStatus.SC_NO_CONTENT);
 
         // Test that iTip handling still happens when some of the attendees no longer exist.
-        users[3].cleanup();
-        users[4].cleanup(); // attendee via DL
+        TestUtil.deleteAccount(DAV3);
+        TestUtil.deleteAccount(DAV4); // attendee via DL
         vCal = simpleMeeting(dav1, attendees, uid, "3", 10);
         doIcalPut(url, dav1, zvcalendarToBytes(vCal), HttpStatus.SC_CREATED);
         inboxhref = TestCalDav.waitForNewSchedulingRequestByUID(dav2, uid);
@@ -921,10 +929,10 @@ public class TestCalDav extends TestCase {
             "END:VEVENT\n" +
             "END:VCALENDAR\n";
             public String androidSeriesMeetingUid = "6db50587-d283-49a1-9cf4-63aa27406829";
+
+    @Test
     public void testAndroidMeetingSeries() throws Exception {
-        Account dav1 = users[1].create();
-        Account dav2 = users[2].create();
-        users[2].getZMailbox(); // Force creation of mailbox - shouldn't be needed
+        ZMailbox dav2MB = TestUtil.getZMailbox(DAV2); // Force creation of mailbox - shouldn't be needed
         String calFolderUrl = getFolderUrl(dav1, "Calendar").replaceAll("@", "%40");
         String url = String.format("%s%s.ics", calFolderUrl, androidSeriesMeetingUid);
         HttpClient client = new HttpClient();
@@ -1072,8 +1080,8 @@ public class TestCalDav extends TestCase {
         return vcal;
     }
 
+    @Test
     public void testSimpleMkcol() throws Exception {
-        Account dav1 = users[1].create();
         StringBuilder url = getLocalServerRoot();
         url.append(DavServlet.DAV_PATH).append("/").append(dav1.getName()).append("/simpleMkcol/");
         MkColMethod method = new MkColMethod(url.toString());
@@ -1082,6 +1090,7 @@ public class TestCalDav extends TestCase {
         HttpMethodExecutor.execute(client, method, HttpStatus.SC_CREATED);
     }
 
+    @Test
     public void testMkcol4addressBook() throws Exception {
         String xml = "<D:mkcol xmlns:D=\"DAV:\" xmlns:C=\"urn:ietf:params:xml:ns:carddav\">" +
                 "     <D:set>" +
@@ -1095,7 +1104,6 @@ public class TestCalDav extends TestCase {
                 "       </D:prop>" +
                 "     </D:set>" +
                 "</D:mkcol>";
-        Account dav1 = users[1].create();
         StringBuilder url = getLocalServerRoot();
         url.append(DavServlet.DAV_PATH).append("/").append(dav1.getName()).append("/OtherContacts/");
         MkColMethod method = new MkColMethod(url.toString());
@@ -1182,6 +1190,7 @@ public class TestCalDav extends TestCase {
      * If the list is not empty, each listed calendar affects freebusy.
      * Bug 85275 - Apple Calendar specifies URLs with "@" encoded as %40 - causing us to drop all calendar from FB set
      */
+    @Test
     public void testPropPatchCalendarFreeBusySetSettingUsingEscapedUrls() throws Exception {
         String disableFreeBusyXml =
                 "<A:propertyupdate xmlns:A=\"DAV:\">" +
@@ -1203,11 +1212,10 @@ public class TestCalDav extends TestCase {
                 "  </A:set>" +
                 "</A:propertyupdate>";
 
-        Account dav1 = users[1].create();
 
         // Create an event in Dav1's calendar
-        ZMailbox organizer = users[1].getZMailbox();
-        String subject = NAME_PREFIX + " testInvite request 1";
+        ZMailbox organizer = TestUtil.getZMailbox(DAV1);
+        String subject = TEST_NAME + " testInvite request 1";
         Date startDate = new Date(System.currentTimeMillis() + Constants.MILLIS_PER_DAY);
         Date endDate = new Date(startDate.getTime() + Constants.MILLIS_PER_HOUR);
         Date fbStartDate = new Date(startDate.getTime() - (Constants.MILLIS_PER_DAY * 2));
@@ -1270,6 +1278,8 @@ public class TestCalDav extends TestCase {
             "END:DAYLIGHT\n" +
             "END:VTIMEZONE\n" +
             "END:VCALENDAR\n";
+
+    @Test
     public void testFuzzyTimeZoneMatchGMT_06() throws Exception {
         try (ByteArrayInputStream bais = new ByteArrayInputStream(VtimeZoneGMT_0600_0500.getBytes())) {
             ZVCalendar tzcal = ZCalendar.ZCalendarBuilder.build(bais, MimeConstants.P_CHARSET_UTF8);
@@ -1301,6 +1311,8 @@ public class TestCalDav extends TestCase {
             "END:DAYLIGHT\n" +
             "END:VTIMEZONE\n" +
             "END:VCALENDAR\n";
+
+    @Test
     public void testFuzzyTimeZoneMatchGMT_08() throws Exception {
         try (ByteArrayInputStream bais = new ByteArrayInputStream(VtimeZoneGMT_0800_0700.getBytes())) {
             ZVCalendar tzcal = ZCalendar.ZCalendarBuilder.build(bais, MimeConstants.P_CHARSET_UTF8);
@@ -1359,6 +1371,7 @@ public class TestCalDav extends TestCase {
             "END:VEVENT\r\n" +
             "END:VCALENDAR\r\n";
 
+    @Test
     public void testLondonTimeZoneCalledGMTkeepSameName() throws Exception {
         try (ByteArrayInputStream bais = new ByteArrayInputStream(LOTUS_NOTES_WITH_BAD_GMT_TZID.getBytes())) {
             ZVCalendar tzcal = ZCalendar.ZCalendarBuilder.build(bais, MimeConstants.P_CHARSET_UTF8);
@@ -1374,6 +1387,7 @@ public class TestCalDav extends TestCase {
         }
     }
 
+    @Test
     public void testLondonTimeZoneCalledGMT() throws Exception {
         try (ByteArrayInputStream bais = new ByteArrayInputStream(LOTUS_NOTES_WITH_BAD_GMT_TZID.getBytes())) {
             ZVCalendar tzcal = ZCalendar.ZCalendarBuilder.build(bais, MimeConstants.P_CHARSET_UTF8);
@@ -1390,15 +1404,13 @@ public class TestCalDav extends TestCase {
     }
 
     private void attendeeDeleteFromCalendar(boolean suppressReply) throws Exception {
-        Account dav1 = users[1].create();
-        users[2].create();
         String url = getSchedulingInboxUrl(dav1, dav1);
         ReportMethod method = new ReportMethod(url);
         addBasicAuthHeaderForUser(method, dav1);
 
-        ZMailbox organizer = users[2].getZMailbox();
-        users[1].getZMailbox(); // Force creation of mailbox - shouldn't be needed
-        String subject = String.format("%s %s", NAME_PREFIX,
+        ZMailbox organizer = TestUtil.getZMailbox(DAV2);
+        ZMailbox dav1MB = TestUtil.getZMailbox(DAV1); // Force creation of mailbox - shouldn't be needed
+        String subject = String.format("%s %s", TEST_NAME,
                 suppressReply ? "testInvite which shouldNOT be replied to" : "testInvite to be auto-declined");
         Date startDate = new Date(System.currentTimeMillis() + Constants.MILLIS_PER_DAY);
         Date endDate = new Date(startDate.getTime() + Constants.MILLIS_PER_HOUR);
@@ -1435,10 +1447,12 @@ public class TestCalDav extends TestCase {
         }
     }
 
+    @Test
     public void testAttendeeAutoDecline() throws Exception {
         attendeeDeleteFromCalendar(false /* suppressReply */);
     }
 
+    @Test
     public void testAttendeeSuppressedAutoDecline() throws Exception {
         attendeeDeleteFromCalendar(true /* suppressReply */);
     }
@@ -1451,8 +1465,8 @@ public class TestCalDav extends TestCase {
                                         "UID:SCRUFF1\r\n" +
                                         "END:VCARD\r\n";
 
+    @Test
     public void testCreateContactWithIfNoneMatchTesting() throws ServiceException, IOException {
-        Account dav1 = users[1].create();
         String davBaseName = "SCRUFF1.vcf";  // Based on UID
         String contactsFolderUrl = getFolderUrl(dav1, "Contacts");
         String url = String.format("%s%s", contactsFolderUrl, davBaseName);
@@ -1525,8 +1539,8 @@ public class TestCalDav extends TestCase {
             "X-ADDRESSBOOKSERVER-MEMBER:urn:uuid:07139DE2-EA7B-46CB-A970-C4DF7F72D9AE\n" +
             "END:VCARD\n";
 
+    @Test
     public void testAppleStyleGroup() throws ServiceException, IOException {
-        Account dav1 = users[1].create();
         String contactsFolderUrl = getFolderUrl(dav1, "Contacts");
         HttpClient client = new HttpClient();
 
@@ -1584,7 +1598,7 @@ public class TestCalDav extends TestCase {
         searchRequest.setLimit(8);
         searchRequest.setSearchTypes("contact");
         searchRequest.setQuery("in:Contacts");
-        ZMailbox mbox = users[1].getZMailbox();
+        ZMailbox mbox = TestUtil.getZMailbox(DAV1);
         SearchResponse searchResp = mbox.invokeJaxb(searchRequest);
         assertNotNull("JAXB SearchResponse object", searchResp);
         List<SearchHit> hits = searchResp.getSearchHits();
@@ -1641,9 +1655,8 @@ public class TestCalDav extends TestCase {
             "X-CREATED:2015-04-05T09:50:44Z\r\n" +
             "END:VCARD\r\n";
 
-
+    @Test
     public void testXBusyMacAttach() throws ServiceException, IOException {
-        Account dav1 = users[1].create();
         String contactsFolderUrl = getFolderUrl(dav1, "Contacts");
         HttpClient client = new HttpClient();
 
@@ -1686,13 +1699,12 @@ public class TestCalDav extends TestCase {
         searchRequest.setLimit(8);
         searchRequest.setSearchTypes("contact");
         searchRequest.setQuery("in:Contacts");
-        ZMailbox mbox = users[1].getZMailbox();
+        ZMailbox mbox = TestUtil.getZMailbox(DAV1);
         SearchResponse searchResp = mbox.invokeJaxb(searchRequest);
         assertNotNull("JAXB SearchResponse object", searchResp);
         List<SearchHit> hits = searchResp.getSearchHits();
         assertNotNull("JAXB SearchResponse hits", hits);
         assertEquals("JAXB SearchResponse hits", 1, hits.size());
-        ContactInfo contactInfo = (ContactInfo) hits.get(0);
     }
 
     public static final String expandPropertyGroupMemberSet =
@@ -1748,10 +1760,11 @@ public class TestCalDav extends TestCase {
      * sharing model for calendars.  The model is simpler than Zimbra's native model and there are mismatches,
      * for instance Zimbra requires the proposed delegate to accept shares.
      */
+    @Test
     public void testAppleCaldavProxyFunctions() throws ServiceException, IOException {
-        Account sharer = users[3].create();
-        Account sharee1 = users[1].create();
-        Account sharee2 = users[2].create();
+        Account sharer = dav3;
+        Account sharee1 = dav1;
+        Account sharee2 = dav2;
         ZMailbox mboxSharer = TestUtil.getZMailbox(sharer.getName());
         ZMailbox mboxSharee1 = TestUtil.getZMailbox(sharee1.getName());
         ZMailbox mboxSharee2 = TestUtil.getZMailbox(sharee2.getName());
@@ -1910,22 +1923,53 @@ public class TestCalDav extends TestCase {
         return doc;
     }
 
-    @Override
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        localServer = prov.getLocalServer();
+    }
+
+    @Before
     public void setUp() throws Exception {
+        cleanUp();
         if (!TestUtil.fromRunUnitTests) {
             TestUtil.cliSetup();
             String tzFilePath = LC.timezone_file.value();
             File tzFile = new File(tzFilePath);
             WellKnownTimeZones.loadFromFile(tzFile);
         }
-        tearDown();
+        user1 = TestUtil.createAccount(USER_NAME);
+        dav1 = TestUtil.createAccount(DAV1);
+        dav2 = TestUtil.createAccount(DAV2);
+        dav3 = TestUtil.createAccount(DAV3);
+        dav4 = TestUtil.createAccount(DAV4);
     }
 
-    @Override
-    public void tearDown()
-    throws Exception {
-        TestUtil.UserInfo.cleanup(users);
-        TestUtil.deleteDistributionList(DL1);
+    @After
+    public void tearDown() throws Exception {
+        cleanUp();
+    }
+
+    private void cleanUp() throws Exception {
+        if(TestUtil.accountExists(DAV1)) {
+            TestUtil.deleteAccount(DAV1);
+        }
+        if(TestUtil.accountExists(DAV2)) {
+            TestUtil.deleteAccount(DAV2);
+        }
+        if(TestUtil.accountExists(DAV3)) {
+            TestUtil.deleteAccount(DAV3);
+        }
+        if(TestUtil.accountExists(DAV4)) {
+            TestUtil.deleteAccount(DAV4);
+        }
+        if(TestUtil.accountExists(USER_NAME)) {
+            TestUtil.deleteAccount(USER_NAME);
+        }
+        try {
+            TestUtil.deleteDistributionList(DL1);
+        } catch (Exception e) {
+            //ignore
+        }
     }
 
     /**

--- a/store/src/java/com/zimbra/qa/unittest/TestCalDav.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestCalDav.java
@@ -505,9 +505,9 @@ public class TestCalDav {
                 ZimbraLog.test.debug("xpath problem", e1);
             }
             try {
-                if (timeout_millis > 100) {
-                    Thread.sleep(100);
-                    timeout_millis = timeout_millis - 100;
+                if (timeout_millis > TestUtil.DEFAULT_WAIT) {
+                    Thread.sleep(TestUtil.DEFAULT_WAIT);
+                    timeout_millis = timeout_millis - TestUtil.DEFAULT_WAIT;
                 } else {
                     Thread.sleep(timeout_millis);
                     timeout_millis = 0;

--- a/store/src/java/com/zimbra/qa/unittest/TestDbUtil.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestDbUtil.java
@@ -54,9 +54,7 @@ public class TestDbUtil {
 
     @Before
     public void setUp() throws Exception {
-        Map<String, Object> attrs = Maps.newHashMap();
-        attrs.put(Provisioning.A_zimbraMailHost, localServer.getServiceHostname());
-        TestUtil.createAccount(USER_NAME, attrs);
+        TestUtil.createAccount(USER_NAME);
         mbox = TestUtil.getMailbox(USER_NAME);
     }
 

--- a/store/src/java/com/zimbra/qa/unittest/TestDbUtil.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestDbUtil.java
@@ -21,14 +21,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Map;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.google.common.collect.Maps;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.Server;
 import com.zimbra.cs.db.Db;

--- a/store/src/java/com/zimbra/qa/unittest/TestDbUtil.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestDbUtil.java
@@ -17,31 +17,59 @@
 
 package com.zimbra.qa.unittest;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.common.collect.Maps;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.Server;
 import com.zimbra.cs.db.Db;
 import com.zimbra.cs.db.DbMailbox;
 import com.zimbra.cs.db.DbPool;
-import com.zimbra.cs.db.DbUtil;
 import com.zimbra.cs.db.DbPool.DbConnection;
+import com.zimbra.cs.db.DbUtil;
 import com.zimbra.cs.mailbox.Mailbox;
 
 /**
  * @author bburtin
  */
-public class TestDbUtil extends TestCase
-{
-    public void testNormalizeSql()
-    throws Exception {
+public class TestDbUtil {
+    private static final String USER_NAME = "TestDbUtil-user1";
+    private static final Provisioning prov = Provisioning.getInstance();
+    private static Server localServer = null;
+    private Mailbox mbox = null;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        localServer = prov.getLocalServer();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        Map<String, Object> attrs = Maps.newHashMap();
+        attrs.put(Provisioning.A_zimbraMailHost, localServer.getServiceHostname());
+        TestUtil.createAccount(USER_NAME, attrs);
+        mbox = TestUtil.getMailbox(USER_NAME);
+    }
+
+    @Test
+    public void testNormalizeSql() throws Exception {
         String sql = " \t SELECT a, 'b', 1, '', ',', NULL, '\\'' FROM table1\n\nWHERE c IN (1, 2, 3) ";
         String normalized = DbUtil.normalizeSql(sql);
         String expected = "SELECT a, XXX, XXX, XXX, XXX, XXX, XXX FROM tableXXX WHERE c IN (...)";
         assertEquals(expected, normalized);
     }
 
-    public void testDatabaseExists()
-    throws Exception {
-        Mailbox mbox = TestUtil.getMailbox("user1");
+    @Test
+    public void testDatabaseExists() throws Exception {
         Db db = Db.getInstance();
         String dbName = DbMailbox.getDatabaseName(mbox);
         DbConnection conn = DbPool.getConnection();
@@ -50,5 +78,12 @@ public class TestDbUtil extends TestCase
         assertFalse("False positive", db.databaseExists(conn, "foobar"));
 
         DbPool.quietClose(conn);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if(TestUtil.accountExists(USER_NAME)) {
+            TestUtil.deleteAccount(USER_NAME);
+        }
     }
 }

--- a/store/src/java/com/zimbra/qa/unittest/TestDeployZimlet.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestDeployZimlet.java
@@ -48,7 +48,7 @@ import com.zimbra.soap.admin.message.UndeployZimletResponse;
 import com.zimbra.soap.admin.type.AttachmentIdAttrib;
 
 /**
- * copy test data from data/unittest to /opt/zimbra/data/unittest before running this test 
+ * copy test data from data/unittest to /opt/zimbra/unittest before running this test 
  * 
  */
 public class TestDeployZimlet {
@@ -245,7 +245,7 @@ public class TestDeployZimlet {
         Element response = transport.invoke(JaxbUtil.jaxbToElement(authReq, SoapProtocol.SoapJS.getFactory()));
         com.zimbra.soap.admin.message.AuthResponse authResp = JaxbUtil.elementToJaxb(response);
         String authToken = authResp.getAuthToken();
-        String aid = adminUpload(authToken, "attack.zip", "/opt/zimbra/data/unittest/zimlets/attack.zip");
+        String aid = adminUpload(authToken, "attack.zip", "/opt/zimbra/unittest/zimlets/attack.zip");
         assertNotNull("Attachment ID should not be null", aid);
 
         AttachmentIdAttrib att = new AttachmentIdAttrib(aid);
@@ -271,7 +271,7 @@ public class TestDeployZimlet {
         Element response = transport.invoke(JaxbUtil.jaxbToElement(authReq, SoapProtocol.SoapJS.getFactory()));
         com.zimbra.soap.admin.message.AuthResponse authResp = JaxbUtil.elementToJaxb(response);
         String authToken = authResp.getAuthToken();
-        String aid = adminUpload(authToken, "adminextension.zip", "/opt/zimbra/data/unittest/zimlets/adminextension.zip");
+        String aid = adminUpload(authToken, "adminextension.zip", "/opt/zimbra/unittest/zimlets/adminextension.zip");
         assertNotNull("Attachment ID should not be null", aid);
 
         AttachmentIdAttrib att = new AttachmentIdAttrib(aid);
@@ -301,7 +301,7 @@ public class TestDeployZimlet {
         Element response = transport.invoke(JaxbUtil.jaxbToElement(authReq, SoapProtocol.SoapJS.getFactory()));
         com.zimbra.soap.admin.message.AuthResponse authResp = JaxbUtil.elementToJaxb(response);
         String authToken = authResp.getAuthToken();
-        String aid = adminUpload(authToken, "adminextension.zip", "/opt/zimbra/data/unittest/zimlets/adminextension.zip");
+        String aid = adminUpload(authToken, "adminextension.zip", "/opt/zimbra/unittest/zimlets/adminextension.zip");
         assertNotNull("Attachment ID should not be null", aid);
 
         AttachmentIdAttrib att = new AttachmentIdAttrib(aid);
@@ -373,7 +373,7 @@ public class TestDeployZimlet {
         Element response = transport.invoke(JaxbUtil.jaxbToElement(authReq, SoapProtocol.SoapJS.getFactory()));
         com.zimbra.soap.admin.message.AuthResponse authResp = JaxbUtil.elementToJaxb(response);
         String authToken = authResp.getAuthToken();
-        String aid = adminUpload(authToken, "attack.zip", "/opt/zimbra/data/unittest/zimlets/com_zimbra_url.zip");
+        String aid = adminUpload(authToken, "attack.zip", "/opt/zimbra/unittest/zimlets/com_zimbra_url.zip");
         assertNotNull("Attachment ID should not be null", aid);
 
         AttachmentIdAttrib att = new AttachmentIdAttrib(aid);
@@ -399,7 +399,7 @@ public class TestDeployZimlet {
         Element response = transport.invoke(JaxbUtil.jaxbToElement(authReq, SoapProtocol.SoapJS.getFactory()));
         com.zimbra.soap.admin.message.AuthResponse authResp = JaxbUtil.elementToJaxb(response);
         String authToken = authResp.getAuthToken();
-        String aid = adminUpload(authToken, "jelmer.zip", "/opt/zimbra/data/unittest/zimlets/jelmer.zip");
+        String aid = adminUpload(authToken, "jelmer.zip", "/opt/zimbra/unittest/zimlets/jelmer.zip");
         assertNotNull("Attachment ID should not be null", aid);
 
         AttachmentIdAttrib att = new AttachmentIdAttrib(aid);
@@ -425,7 +425,7 @@ public class TestDeployZimlet {
         Element response = transport.invoke(JaxbUtil.jaxbToElement(authReq, SoapProtocol.SoapJS.getFactory()));
         com.zimbra.soap.admin.message.AuthResponse authResp = JaxbUtil.elementToJaxb(response);
         String authToken = authResp.getAuthToken();
-        String aid = adminUpload(authToken, "absolute.zip", "/opt/zimbra/data/unittest/zimlets/absolute.zip");
+        String aid = adminUpload(authToken, "absolute.zip", "/opt/zimbra/unittest/zimlets/absolute.zip");
         assertNotNull("Attachment ID should not be null", aid);
 
         AttachmentIdAttrib att = new AttachmentIdAttrib(aid);
@@ -455,7 +455,7 @@ public class TestDeployZimlet {
         Element response = transport.invoke(JaxbUtil.jaxbToElement(authReq, SoapProtocol.SoapJS.getFactory()));
         com.zimbra.soap.admin.message.AuthResponse authResp = JaxbUtil.elementToJaxb(response);
         String authToken = authResp.getAuthToken();
-        String aid = adminUpload(authToken, "phil.zip", "/opt/zimbra/data/unittest/zimlets/phil.zip");
+        String aid = adminUpload(authToken, "phil.zip", "/opt/zimbra/unittest/zimlets/phil.zip");
         assertNotNull("Attachment ID should not be null", aid);
 
         AttachmentIdAttrib att = new AttachmentIdAttrib(aid);

--- a/store/src/java/com/zimbra/qa/unittest/TestFilter.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestFilter.java
@@ -16,28 +16,40 @@
  */
 package com.zimbra.qa.unittest;
 
-import com.google.common.base.Strings;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-import com.zimbra.common.filter.Sieve;
-import com.zimbra.common.mime.MimeConstants;
-import com.zimbra.common.mime.MimeMessage;
-import com.zimbra.common.service.ServiceException;
-import com.zimbra.common.soap.SoapFaultException;
-import com.zimbra.common.util.ByteUtil;
-import com.zimbra.common.util.Constants;
-import com.zimbra.common.util.StringUtil;
-import com.zimbra.cs.account.Account;
-import com.zimbra.cs.account.Config;
-import com.zimbra.cs.account.Provisioning;
-import com.zimbra.cs.account.Server;
-import com.zimbra.cs.filter.FilterUtil;
-import com.zimbra.cs.filter.RuleManager;
-import com.zimbra.cs.filter.RuleRewriter;
-import com.zimbra.cs.filter.SieveToSoap;
-import com.zimbra.cs.filter.SoapToSieve;
-import com.zimbra.cs.ldap.LdapConstants;
-import com.zimbra.cs.mailbox.Mailbox;
-import com.zimbra.cs.mailbox.calendar.Util;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TimeZone;
+
+import org.apache.jsieve.parser.generated.Node;
+import org.apache.jsieve.parser.generated.ParseException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
 import com.zimbra.client.ZEmailAddress;
 import com.zimbra.client.ZFilterAction;
 import com.zimbra.client.ZFilterAction.MarkOp;
@@ -61,58 +73,68 @@ import com.zimbra.client.ZFilterCondition.ZMimeHeaderCondition;
 import com.zimbra.client.ZFilterRule;
 import com.zimbra.client.ZFilterRules;
 import com.zimbra.client.ZFolder;
+import com.zimbra.client.ZItem.Flag;
 import com.zimbra.client.ZMailbox;
 import com.zimbra.client.ZMessage;
-import com.zimbra.client.ZItem.Flag;
 import com.zimbra.client.ZTag;
-import junit.framework.TestCase;
-import org.apache.jsieve.parser.generated.Node;
-import org.apache.jsieve.parser.generated.ParseException;
+import com.zimbra.common.filter.Sieve;
+import com.zimbra.common.mime.MimeConstants;
+import com.zimbra.common.mime.MimeMessage;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.SoapFaultException;
+import com.zimbra.common.util.ByteUtil;
+import com.zimbra.common.util.Constants;
+import com.zimbra.common.util.StringUtil;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Config;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.Server;
+import com.zimbra.cs.filter.FilterUtil;
+import com.zimbra.cs.filter.RuleManager;
+import com.zimbra.cs.filter.RuleRewriter;
+import com.zimbra.cs.filter.SieveToSoap;
+import com.zimbra.cs.filter.SoapToSieve;
+import com.zimbra.cs.ldap.LdapConstants;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.calendar.Util;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.StringReader;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
-import java.util.TimeZone;
+public final class TestFilter {
 
-public final class TestFilter extends TestCase {
-
-    private static String USER_NAME = "user1";
-    private static String REMOTE_USER_NAME = "user2";
     private static String NAME_PREFIX = "TestFilter";
-    private static String FOLDER1_NAME = NAME_PREFIX + "-folder1";
-    private static String FOLDER2_NAME = NAME_PREFIX + "-folder2";
+    private static String USER_NAME = NAME_PREFIX + "-user1";
+    private static String REMOTE_USER_NAME = NAME_PREFIX + "-user2";
+    private static String FOLDER1_NAME = "folder1";
+    private static String FOLDER2_NAME = "folder2";
     private static String FOLDER1_PATH = "/" + FOLDER1_NAME;
     private static String FOLDER2_PATH = "/" + FOLDER2_NAME;
-    private static String TAG1_NAME = NAME_PREFIX + "-tag1";
-    private static String TAG2_NAME = NAME_PREFIX + "-tag2";
+    private static String TAG1_NAME = "tag1";
+    private static String TAG2_NAME = "tag2";
     private static String MOUNTPOINT_FOLDER_NAME = NAME_PREFIX + " mountpoint";
     private static String MOUNTPOINT_SUBFOLDER_NAME = NAME_PREFIX + " mountpoint subfolder";
     private static String MOUNTPOINT_SUBFOLDER_PATH = "/" + MOUNTPOINT_FOLDER_NAME + "/" + MOUNTPOINT_SUBFOLDER_NAME;
 
+    private Account user1;
     private ZMailbox mMbox;
-    private ZFilterRules mOriginalIncomingRules;
-    private ZFilterRules mOriginalOutgoingRules;
-    private String mOriginalSpamApplyUserFilters;
-    private String mOriginalSmtpPort = null;
-    private String mOriginalSetEnvelopeSender = null;
+    private static Integer mOriginalSmtpPort = null;
+    private static Boolean mOriginalSetEnvelopeSender = null;
     private ZTag mTag1;
     private ZTag mTag2;
+    private static Server localServer = null;
+    private static final Provisioning prov = Provisioning.getInstance();
 
-    @Override
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        localServer = prov.getLocalServer();
+        mOriginalSmtpPort = localServer.getSmtpPort();
+        mOriginalSetEnvelopeSender = localServer.isMailRedirectSetEnvelopeSender();
+    }
+
+    @Before
     public void setUp() throws Exception {
         cleanUp();
 
+        user1 = TestUtil.createAccount(USER_NAME);
+        TestUtil.createAccount(REMOTE_USER_NAME);
         mMbox = TestUtil.getZMailbox(USER_NAME);
         mTag1 = mMbox.createTag(TAG1_NAME, null);
         mTag2 = mMbox.createTag(TAG2_NAME, null);
@@ -122,22 +144,15 @@ public final class TestFilter extends TestCase {
         TestUtil.createMountpoint(remoteMbox, "/" + MOUNTPOINT_FOLDER_NAME, mMbox, MOUNTPOINT_FOLDER_NAME);
         TestUtil.createFolder(remoteMbox, MOUNTPOINT_SUBFOLDER_PATH);
 
-        mOriginalIncomingRules = mMbox.getIncomingFilterRules();
         saveIncomingRules(mMbox, getTestIncomingRules());
-        mOriginalOutgoingRules = mMbox.getOutgoingFilterRules();
         saveOutgoingRules(mMbox, getTestOutgoingRules());
-
-        Account account = TestUtil.getAccount(USER_NAME);
-        mOriginalSpamApplyUserFilters = account.getAttr(Provisioning.A_zimbraSpamApplyUserFilters);
-        mOriginalSmtpPort = Provisioning.getInstance().getLocalServer().getSmtpPortAsString();
-        mOriginalSetEnvelopeSender = TestUtil.getServerAttr(Provisioning.A_zimbraMailRedirectSetEnvelopeSender);
     }
 
     /**
      * Confirms that outgoing filters are applied as expected when a message is sent via SendMsgRequest.
      */
-    public void testOutgoingFiltersWithSendMsg()
-    throws Exception {
+    @Test
+    public void testOutgoingFiltersWithSendMsg() throws Exception {
         String sender = TestUtil.getAddress(USER_NAME);
         String recipient = TestUtil.getAddress(REMOTE_USER_NAME);
         String subject = NAME_PREFIX + " outgoing";
@@ -557,9 +572,9 @@ public final class TestFilter extends TestCase {
         assertTrue("message should have been tagged with tag1", tagIds.contains(mTag1.getId()));
     }
 
-    public void testCurrentTimeTest()
-    throws Exception {
-        TimeZone userTz = Util.getAccountTimeZone(TestUtil.getAccount(USER_NAME));
+    @Test
+    public void testCurrentTimeTest() throws Exception {
+        TimeZone userTz = Util.getAccountTimeZone(user1);
         Calendar calendar = Calendar.getInstance(userTz);
         // Add 5 mins to current time
         calendar.add(Calendar.MINUTE, 5);
@@ -598,9 +613,9 @@ public final class TestFilter extends TestCase {
         assertTrue("message should have been tagged with tag1", tagIds.contains(mTag1.getId()));
     }
 
-    public void testCurrentDayOfWeekTest()
-    throws Exception {
-        TimeZone userTz = Util.getAccountTimeZone(TestUtil.getAccount(USER_NAME));
+    @Test
+    public void testCurrentDayOfWeekTest() throws Exception {
+        TimeZone userTz = Util.getAccountTimeZone(user1);
         Calendar calendar = Calendar.getInstance(userTz);
         int dayToday = calendar.get(Calendar.DAY_OF_WEEK) - 1;
         int dayYesterday = dayToday == 0 ? 6 : dayToday - 1;
@@ -636,8 +651,8 @@ public final class TestFilter extends TestCase {
         assertTrue("message should have been tagged with tag1", tagIds.contains(mTag1.getId()));
     }
 
-    public void testAddressTest()
-    throws Exception {
+    @Test
+    public void testAddressTest() throws Exception {
         List<ZFilterRule> rules = new ArrayList<ZFilterRule>();
         List<ZFilterCondition> conditions = new ArrayList<ZFilterCondition>();
         List<ZFilterAction> actions = new ArrayList<ZFilterAction>();
@@ -668,8 +683,8 @@ public final class TestFilter extends TestCase {
         assertTrue("Unexpected message flag state", msg.isFlagged());
     }
 
-    public void testAddressTestPart()
-    throws Exception {
+    @Test
+    public void testAddressTestPart() throws Exception {
         List<ZFilterRule> rules = new ArrayList<ZFilterRule>();
         List<ZFilterCondition> conditions = new ArrayList<ZFilterCondition>();
         List<ZFilterAction> actions = new ArrayList<ZFilterAction>();
@@ -701,8 +716,8 @@ public final class TestFilter extends TestCase {
         assertTrue("Unexpected message flag state", msg.isFlagged());
     }
 
-    public void testReplyAction()
-    throws Exception {
+    @Test
+    public void testReplyAction() throws Exception {
         List<ZFilterRule> rules = new ArrayList<ZFilterRule>();
         List<ZFilterCondition> conditions = new ArrayList<ZFilterCondition>();
         List<ZFilterAction> actions = new ArrayList<ZFilterAction>();
@@ -732,8 +747,8 @@ public final class TestFilter extends TestCase {
                 mimeStructure.getContentType().contains(MimeConstants.P_CHARSET_ASCII));
     }
 
-    public void testNotifyAction()
-    throws Exception {
+    @Test
+    public void testNotifyAction() throws Exception {
         List<ZFilterRule> rules = new ArrayList<ZFilterRule>();
         List<ZFilterCondition> conditions = new ArrayList<ZFilterCondition>();
         List<ZFilterAction> actions = new ArrayList<ZFilterAction>();
@@ -765,8 +780,8 @@ public final class TestFilter extends TestCase {
                 mimeStructure.getContentType().contains(MimeConstants.P_CHARSET_ASCII));
     }
 
-    public void testNotifyActionUseOrigHeaders()
-    throws Exception {
+    @Test
+    public void testNotifyActionUseOrigHeaders() throws Exception {
         List<ZFilterRule> rules = new ArrayList<ZFilterRule>();
         List<ZFilterCondition> conditions = new ArrayList<ZFilterCondition>();
         List<ZFilterAction> actions = new ArrayList<ZFilterAction>();
@@ -819,8 +834,8 @@ public final class TestFilter extends TestCase {
         assertEquals(subject, zMessage.getSubject());
     }
 
-    public void testNotifyActionCopyAllOrigHeaders()
-    throws Exception {
+    @Test
+    public void testNotifyActionCopyAllOrigHeaders() throws Exception {
         List<ZFilterRule> rules = new ArrayList<ZFilterRule>();
         List<ZFilterCondition> conditions = new ArrayList<ZFilterCondition>();
         List<ZFilterAction> actions = new ArrayList<ZFilterAction>();
@@ -849,8 +864,8 @@ public final class TestFilter extends TestCase {
         assertTrue(content.contains("Subject: " + subject));
     }
 
-    public void testNotifyWithDiscard()
-    throws Exception {
+    @Test
+    public void testNotifyWithDiscard() throws Exception {
         List<ZFilterRule> rules = new ArrayList<ZFilterRule>();
         List<ZFilterCondition> conditions = new ArrayList<ZFilterCondition>();
         List<ZFilterAction> actions = new ArrayList<ZFilterAction>();
@@ -877,8 +892,8 @@ public final class TestFilter extends TestCase {
     /**
      * Tests fix for bug 57890 (https://issues.apache.org/jira/browse/JSIEVE-75).
      */
-    public void testMultipleMultilineText()
-    throws Exception {
+    @Test
+    public void testMultipleMultilineText() throws Exception {
         List<ZFilterRule> rules;
         List<ZFilterCondition> conditions;
         List<ZFilterAction> actions;
@@ -912,8 +927,8 @@ public final class TestFilter extends TestCase {
         assertEquals(((ZFilterAction.ZReplyAction) rules.get(1).getActions().get(0)).getBodyTemplate(), replyMsg);
     }
 
-    public void testMarkRead()
-    throws Exception {
+    @Test
+    public void testMarkRead() throws Exception {
         String folderName = NAME_PREFIX + " testMarkRead";
 
         // if the subject contains "testMarkRead", file into a folder and mark read
@@ -942,8 +957,8 @@ public final class TestFilter extends TestCase {
      * Confirms that the header test works with headers that are folded.
      * See section 2.2.3 of RFC 2822 and bug 14942.
      */
-    public void testHeaderFolding()
-    throws Exception {
+    @Test
+    public void testHeaderFolding() throws Exception {
         List<ZFilterCondition> conditions = new ArrayList<ZFilterCondition>();
         List<ZFilterAction> actions = new ArrayList<ZFilterAction>();
         List<ZFilterRule> rules = new ArrayList<ZFilterRule>();
@@ -964,8 +979,8 @@ public final class TestFilter extends TestCase {
         assertTrue("Message was not flagged", msg.isFlagged());
     }
 
-    public void testInvite()
-    throws Exception {
+    @Test
+    public void testInvite() throws Exception {
         ZMailbox mbox = TestUtil.getZMailbox(USER_NAME);
 
         // Create tags.
@@ -1049,8 +1064,8 @@ public final class TestFilter extends TestCase {
     /**
      * Make sure we disallow more than four asterisks in a :matches condition (bug 35983).
      */
-    public void testManyAsterisks()
-    throws Exception {
+    @Test
+    public void testManyAsterisks() throws Exception {
         List<ZFilterCondition> conditions = new ArrayList<ZFilterCondition>();
         List<ZFilterAction> actions = new ArrayList<ZFilterAction>();
         List<ZFilterRule> rules = new ArrayList<ZFilterRule>();
@@ -1071,8 +1086,8 @@ public final class TestFilter extends TestCase {
         }
     }
 
-    public void testDateFiltering()
-    throws Exception {
+    @Test
+    public void testDateFiltering() throws Exception {
         // Before tomorrow.
         ZTag tagBeforeTomorrow = mMbox.createTag(NAME_PREFIX + " before tomorrow", null);
         List<ZFilterCondition> conditions = new ArrayList<ZFilterCondition>();
@@ -1163,8 +1178,8 @@ public final class TestFilter extends TestCase {
     /**
      * Tests matching a header against a wildcard expression.  See bug 21701.
      */
-    public void testHeaderMatches()
-    throws Exception {
+    @Test
+    public void testHeaderMatches() throws Exception {
         List<ZFilterCondition> conditions = new ArrayList<ZFilterCondition>();
         List<ZFilterAction> actions = new ArrayList<ZFilterAction>();
         List<ZFilterRule> rules = new ArrayList<ZFilterRule>();
@@ -1190,8 +1205,9 @@ public final class TestFilter extends TestCase {
      * Confirms that the body test looks for text in the main message
      * body and attached message bodies, but not in attachments.
      */
-    public void testBodyContains()
-    throws Exception {
+    @Test
+    public void testBodyContains() throws Exception {
+        assertTrue("To run this test copy data/unittest/TestFilter-testBodyContains.msg to /opt/zimbra/unittest", Files.exists(Paths.get("/opt/zimbra/unittest/TestFilter-testBodyContains.msg")));
         doBodyContainsTest("text version of the main body", true);
         doBodyContainsTest("HTML version of the main body", true);
         doBodyContainsTest("text attachment", false);
@@ -1238,8 +1254,8 @@ public final class TestFilter extends TestCase {
     /**
      * Tests fix for bug 55927.
      */
-    public void testFullMatchAfterPartialMatch()
-    throws Exception {
+    @Test
+    public void testFullMatchAfterPartialMatch() throws Exception {
         List<ZFilterCondition> conditions = new ArrayList<ZFilterCondition>();
         List<ZFilterAction> actions = new ArrayList<ZFilterAction>();
         List<ZFilterRule> rules = new ArrayList<ZFilterRule>();
@@ -1262,8 +1278,9 @@ public final class TestFilter extends TestCase {
     /**
      * Tests fix for bug 56019.
      */
-    public void testSpecialCharInBody()
-    throws Exception {
+    @Test
+    public void testSpecialCharInBody() throws Exception {
+        assertTrue("To run this test copy data/unittest/TestFilter-testSpecialCharInBody.msg to /opt/zimbra/unittest", Files.exists(Paths.get("/opt/zimbra/unittest/TestFilter-testSpecialCharInBody.msg")));
         List<ZFilterCondition> conditions = new ArrayList<ZFilterCondition>();
         List<ZFilterAction> actions = new ArrayList<ZFilterAction>();
         List<ZFilterRule> rules = new ArrayList<ZFilterRule>();
@@ -1289,8 +1306,8 @@ public final class TestFilter extends TestCase {
      * Tests the redirect filter action and confirms that the X-ZimbraForwarded
      * header is set on the redirected message.
      */
-    public void testRedirect()
-    throws Exception {
+    @Test
+    public void testRedirect() throws Exception {
         List<ZFilterCondition> conditions = new ArrayList<ZFilterCondition>();
         List<ZFilterAction> actions = new ArrayList<ZFilterAction>();
         List<ZFilterRule> rules = new ArrayList<ZFilterRule>();
@@ -1318,23 +1335,21 @@ public final class TestFilter extends TestCase {
         ZMessage msg = TestUtil.waitForMessage(remoteMbox, "in:inbox subject:\"" + subject + "\"");
         byte[] content = TestUtil.getContent(remoteMbox, msg.getId()).getBytes();
         MimeMessage mimeMsg = new MimeMessage(new ByteArrayInputStream(content));
-        Account user1 = TestUtil.getAccount(USER_NAME);
         assertEquals(user1.getName(), mimeMsg.getHeader(FilterUtil.HEADER_FORWARDED));
         assertEquals(from, mimeMsg.getHeader("From"));
 
         // Check zimbraMailRedirectSetEnvelopeSender=FALSE.
         int port = 6025;
         DummySmtpServer smtp = startSmtpServer(port);
-        Server server = Provisioning.getInstance().getLocalServer();
-        server.setSmtpPort(port);
-        server.setMailRedirectSetEnvelopeSender(false);
+        localServer.setSmtpPort(port);
+        localServer.setMailRedirectSetEnvelopeSender(false);
 
         TestUtil.addMessageLmtp(subject, USER_NAME, from);
         assertEquals(from, smtp.getMailFrom());
 
         // Check zimbraMailRedirectSetEnvelopeSender=TRUE.
         smtp = startSmtpServer(port);
-        server.setMailRedirectSetEnvelopeSender(true);
+        localServer.setMailRedirectSetEnvelopeSender(true);
         subject = NAME_PREFIX + " testRedirect 2";
         TestUtil.addMessageLmtp(subject, USER_NAME, from);
         String userAddress = Strings.nullToEmpty(
@@ -1382,8 +1397,8 @@ public final class TestFilter extends TestCase {
     /**
      * Confirms that the message gets delivered even when a mail loop occurs.
      */
-    public void testRedirectMailLoop()
-    throws Exception {
+    @Test
+    public void testRedirectMailLoop() throws Exception {
         List<ZFilterCondition> conditions = new ArrayList<ZFilterCondition>();
         List<ZFilterAction> actions = new ArrayList<ZFilterAction>();
         List<ZFilterRule> rules = new ArrayList<ZFilterRule>();
@@ -1404,12 +1419,11 @@ public final class TestFilter extends TestCase {
         ZMessage msg = TestUtil.waitForMessage(mMbox, "subject:\"" + subject + "\"");
         byte[] content = TestUtil.getContent(mMbox, msg.getId()).getBytes();
         MimeMessage mimeMsg = new MimeMessage(new ByteArrayInputStream(content));
-        Account user1 = TestUtil.getAccount(USER_NAME);
         assertEquals(user1.getName(), mimeMsg.getHeader(FilterUtil.HEADER_FORWARDED));
     }
 
-    public void testAttachment()
-    throws Exception {
+    @Test
+    public void testAttachment() throws Exception {
         List<ZFilterCondition> conditions = new ArrayList<ZFilterCondition>();
         List<ZFilterAction> actions = new ArrayList<ZFilterAction>();
         List<ZFilterRule> rules = new ArrayList<ZFilterRule>();
@@ -1458,8 +1472,8 @@ public final class TestFilter extends TestCase {
     /**
      * Tests {@link FilterUtil#parseSize}.
      */
-    public void testParseSize()
-    throws Exception {
+    @Test
+    public void testParseSize() throws Exception {
         assertEquals(10, FilterUtil.parseSize("10"));
         assertEquals(10 * 1024, FilterUtil.parseSize("10k"));
         assertEquals(10 * 1024, FilterUtil.parseSize("10K"));
@@ -1487,8 +1501,8 @@ public final class TestFilter extends TestCase {
         return soapToSieve.getSieveScript();
     }
 
-    public void testStripBracketsAndQuotes()
-    throws Exception {
+    @Test
+    public void testStripBracketsAndQuotes() throws Exception {
         assertEquals(null, RuleRewriter.stripBracketsAndQuotes(null));
         assertEquals("", RuleRewriter.stripBracketsAndQuotes(""));
         assertEquals("x", RuleRewriter.stripBracketsAndQuotes("x"));
@@ -1502,8 +1516,9 @@ public final class TestFilter extends TestCase {
      * Confirms that we handle the negative test flag properly with multiple
      * tests (bug 46007).
      */
-    public void testPositiveAndNegative()
-    throws Exception {
+    @Test
+    public void testPositiveAndNegative() throws Exception {
+        assertTrue("To run this test copy data/unittest/bug46007.sieve to /opt/zimbra/unittest", Files.exists(Paths.get("/opt/zimbra/unittest/bug46007.sieve")));
         String script = new String(ByteUtil.getContent(new File("/opt/zimbra/unittest/bug46007.sieve")));
         String normalized = normalize(script); // Convert to XML and back again.
         assertEquals(normalizeWhiteSpace(script), normalizeWhiteSpace(normalized));
@@ -1527,26 +1542,19 @@ public final class TestFilter extends TestCase {
         return buf.toString();
     }
 
-    @Override
-    protected void tearDown() throws Exception {
-        mMbox.saveIncomingFilterRules(mOriginalIncomingRules);
-        mMbox.saveOutgoingFilterRules(mOriginalOutgoingRules);
-        TestUtil.setAccountAttr(USER_NAME, Provisioning.A_zimbraSpamApplyUserFilters, mOriginalSpamApplyUserFilters);
-        TestUtil.setServerAttr(Provisioning.A_zimbraSmtpPort, mOriginalSmtpPort);
-        TestUtil.setServerAttr(Provisioning.A_zimbraMailRedirectSetEnvelopeSender, mOriginalSetEnvelopeSender);
+    @After
+    public void tearDown() throws Exception {
+        localServer.setSmtpPort(mOriginalSmtpPort);
+        localServer.setMailRedirectSetEnvelopeSender(mOriginalSetEnvelopeSender);
         cleanUp();
     }
 
-    private void cleanUp()
-    throws Exception {
-        TestUtil.deleteTestData(USER_NAME, NAME_PREFIX);
-        TestUtil.deleteTestData(REMOTE_USER_NAME, NAME_PREFIX);
-
-        // Clean up messages created by testBase64Subject()
-        // bug 36705 for (ZMessage msg : TestUtil.search(mMbox, "villanueva")) {
-        ZMailbox mbox = TestUtil.getZMailbox(USER_NAME);
-        for (ZMessage msg : TestUtil.search(mbox, "cortes de luz")) {
-            mbox.deleteMessage(msg.getId());
+    private void cleanUp() throws Exception {
+        if(TestUtil.accountExists(USER_NAME)) {
+            TestUtil.deleteAccount(USER_NAME);
+        }
+        if(TestUtil.accountExists(REMOTE_USER_NAME)) {
+            TestUtil.deleteAccount(REMOTE_USER_NAME);
         }
     }
 

--- a/store/src/java/com/zimbra/qa/unittest/TestSpellCheck.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestSpellCheck.java
@@ -77,8 +77,7 @@ public class TestSpellCheck {
     @Before
     public void setUp() throws Exception {
         Map<String, Object> attrs = Maps.newHashMap();
-        attrs.put(Provisioning.A_zimbraMailHost, localServer.getServiceHostname());
-        account = TestUtil.createAccount(USER_NAME, attrs);
+        account = TestUtil.createAccount(USER_NAME);
         originalDomainIgnoreWords = prov.getDomain(account).getPrefSpellIgnoreWord();
         originalCosIgnoreWords = prov.getCOS(account).getPrefSpellIgnoreWord();
 

--- a/store/src/java/com/zimbra/qa/unittest/TestSpellCheck.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestSpellCheck.java
@@ -78,7 +78,7 @@ public class TestSpellCheck {
     public void setUp() throws Exception {
         Map<String, Object> attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraMailHost, localServer.getServiceHostname());
-        account = TestUtil.createAccount(USER_NAME);
+        account = TestUtil.createAccount(USER_NAME, attrs);
         originalDomainIgnoreWords = prov.getDomain(account).getPrefSpellIgnoreWord();
         originalCosIgnoreWords = prov.getCOS(account).getPrefSpellIgnoreWord();
 

--- a/store/src/java/com/zimbra/qa/unittest/TestSpellCheck.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestSpellCheck.java
@@ -49,7 +49,7 @@ import com.zimbra.soap.mail.type.Misspelling;
  */
 public class TestSpellCheck {
     private static final String USER_NAME = "TestSpellCheck-user1";
-    
+
     private static final String TEXT =
         "On a cycle the fram is gone. You're completly in cotnact with it all.\n" +
         "You're in the scene, not just watching it anmore, and the sense of presence\n" +
@@ -58,7 +58,7 @@ public class TestSpellCheck {
         "focus on it, yet you can put your foot down and touch it anytime, and the\n" +
         "whole thing, the whole experience, is nevr removed from immediate\n" +
         "consciousness.";
-        
+
     private static String[] originalDictionaries;
     private boolean available = false;
     private String[] originalDomainIgnoreWords;
@@ -114,7 +114,7 @@ public class TestSpellCheck {
         assertTrue("nevr", hasSuggestion(result, "nevr", "never"));
         ZimbraLog.test.debug("Successfully tested spell checking");
     }
-    
+
     /**
      * Tests the <tt>ignore</tt> attribute for <tt>CheckSpellingRequest</tt>.
      */
@@ -126,11 +126,11 @@ public class TestSpellCheck {
         assertEquals("Number of misspelled words", 1, getNumMisspellings(result));
         assertTrue(hasSuggestion(result, "forr", "four"));
     }
-    
+
     private int getNumMisspellings(CheckSpellingResponse result) {
         return result.getMisspelledWords().size();
     }
-    
+
     private boolean hasSuggestion(CheckSpellingResponse result, String misspelled, String expectedSuggestion) {
         for (Misspelling mis : result.getMisspelledWords()) {
             if (mis.getWord().equals(misspelled)) {
@@ -143,7 +143,7 @@ public class TestSpellCheck {
         }
         return false;
     }
-    
+
     /**
      * Confirms that <tt>GetSpellDictionaries</tt> returns the current list of
      * dictionaries from <tt>zimbraSpellAvailableDictionary</tt>.
@@ -169,7 +169,7 @@ public class TestSpellCheck {
         actual.removeAll(expected);
         assertEquals(0, actual.size());
     }
-    
+
     /**
      * Confirms that spell checking doesn't bomb on unexpected characters.
      */
@@ -181,7 +181,7 @@ public class TestSpellCheck {
         CheckSpellingResponse result = mbox.checkSpelling("one \u00a0tuo two");
         assertEquals(1, result.getMisspelledWords().size());
     }
-    
+
     /**
      * Confirms that accented characters are returned correctly (bug 41394).
      */
@@ -195,7 +195,7 @@ public class TestSpellCheck {
         assertEquals("reunion", misspelling.getWord());
         assertTrue(misspelling.getSuggestionsList().contains("reuni\u00f3n"));
     }
-    
+
     /**
      * Confirms that accented characters are sent correctly (bug 43626).
      */
@@ -209,7 +209,7 @@ public class TestSpellCheck {
         assertEquals("esst\u00e1", misspelling.getWord());
         assertTrue(misspelling.getSuggestionsList().contains("est\u00e1"));
     }
-    
+
     @Test
     public void testRussian() throws Exception {
         Assume.assumeTrue(available);
@@ -224,7 +224,7 @@ public class TestSpellCheck {
         assertEquals(krokodilMisspelled, misspelling.getWord());
         assertTrue(misspelling.getSuggestionsList().contains(krokodil));
     }
-    
+
     @Test
     public void testAllCaps() throws Exception {
         Assume.assumeTrue(available);

--- a/store/src/java/com/zimbra/qa/unittest/TestSpellCheck.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestSpellCheck.java
@@ -17,6 +17,9 @@
 
 package com.zimbra.qa.unittest;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -24,23 +27,28 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
+import com.google.common.collect.Maps;
+import com.zimbra.client.ZMailbox;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.MailConstants;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.Server;
-import com.zimbra.client.ZMailbox;
 import com.zimbra.soap.mail.message.CheckSpellingResponse;
 import com.zimbra.soap.mail.type.Misspelling;
 
 /**
  * @author bburtin
  */
-public class TestSpellCheck extends TestCase {
-    private static final String USER_NAME = "user1";
+public class TestSpellCheck {
+    private static final String USER_NAME = "TestSpellCheck-user1";
     
     private static final String TEXT =
         "On a cycle the fram is gone. You're completly in cotnact with it all.\n" +
@@ -51,55 +59,55 @@ public class TestSpellCheck extends TestCase {
         "whole thing, the whole experience, is nevr removed from immediate\n" +
         "consciousness.";
         
-    private String[] originalDictionaries;
+    private static String[] originalDictionaries;
     private boolean available = false;
-    private String[] originalAccountIgnoreWords;
     private String[] originalDomainIgnoreWords;
     private String[] originalCosIgnoreWords;
-    private String originalIgnoreAllCaps;
-    
-    public void setUp()
-    throws Exception {
-        Provisioning prov = Provisioning.getInstance();
-        originalDictionaries = prov.getLocalServer().getSpellAvailableDictionary();
-        
-        Account account = TestUtil.getAccount(USER_NAME);
-        originalAccountIgnoreWords = account.getPrefSpellIgnoreWord();
+    private static final Provisioning prov = Provisioning.getInstance();
+    private static Server localServer = null;
+    private Account account = null;
+    private ZMailbox mbox = null;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        localServer = prov.getLocalServer();
+        originalDictionaries = localServer.getSpellAvailableDictionary();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        Map<String, Object> attrs = Maps.newHashMap();
+        attrs.put(Provisioning.A_zimbraMailHost, localServer.getServiceHostname());
+        account = TestUtil.createAccount(USER_NAME);
         originalDomainIgnoreWords = prov.getDomain(account).getPrefSpellIgnoreWord();
         originalCosIgnoreWords = prov.getCOS(account).getPrefSpellIgnoreWord();
-        originalIgnoreAllCaps = account.getAttr(Provisioning.A_zimbraPrefSpellIgnoreAllCaps);
-        
-        ZMailbox mbox = TestUtil.getZMailbox(USER_NAME);
+
+        mbox = TestUtil.getZMailbox(USER_NAME);
         CheckSpellingResponse result = mbox.checkSpelling("test");
         available = result.isAvailable();
         if (!available) {
             ZimbraLog.test.info("Spell checking service is not available.  Skipping tests.");
         }
     }
-    
 
+    @Test
     public void testCheckSpelling() throws Exception {
-        if (!available) {
-            return;
-        }
-        
+        Assume.assumeTrue(available);
+
         // Add ignored words to pref on account, cos, and domain.
-        Account account = TestUtil.getAccount(USER_NAME);
         account.setPrefSpellIgnoreWord(new String[] { "completly" });
-        Provisioning prov = Provisioning.getInstance();
         prov.getDomain(account).setPrefSpellIgnoreWord(new String[] { "anmore" });
         prov.getCOS(account).setPrefSpellIgnoreWord(new String[] { "concret" });
-        
-        ZMailbox mbox = TestUtil.getZMailbox(USER_NAME);
+
         CheckSpellingResponse result = mbox.checkSpelling(TEXT);
         assertTrue(result.isAvailable());
-        
+
         // Verify the response
         Map<String, List<String>> map = new HashMap<String, List<String>>();
         for (Misspelling mis : result.getMisspelledWords()) {
             map.put(mis.getWord(), mis.getSuggestionsList());
         }
-        
+
         assertEquals("Number of misspelled words", 4, getNumMisspellings(result));
         assertTrue("fram", hasSuggestion(result, "fram", "from"));
         assertTrue("cotnact", hasSuggestion(result, "cotnact", "contact"));
@@ -111,13 +119,10 @@ public class TestSpellCheck extends TestCase {
     /**
      * Tests the <tt>ignore</tt> attribute for <tt>CheckSpellingRequest</tt>.
      */
-    public void testIgnore()
-    throws Exception {
-        if (!available) {
-            return;
-        }
-        
-        ZMailbox mbox = TestUtil.getZMailbox(USER_NAME);
+    @Test
+    public void testIgnore() throws Exception {
+        Assume.assumeTrue(available);
+
         CheckSpellingResponse result = mbox.checkSpelling("one twi thre forr", null, Arrays.asList("twi", "thre"));
         assertEquals("Number of misspelled words", 1, getNumMisspellings(result));
         assertTrue(hasSuggestion(result, "forr", "four"));
@@ -144,24 +149,23 @@ public class TestSpellCheck extends TestCase {
      * Confirms that <tt>GetSpellDictionaries</tt> returns the current list of
      * dictionaries from <tt>zimbraSpellAvailableDictionary</tt>.
      */
-    public void testGetDictionaries()
-    throws Exception {
-        Server server = Provisioning.getInstance().getLocalServer();
-        server.setSpellAvailableDictionary(new String[] { "dict1", "dict2" });
-        ZMailbox mbox = TestUtil.getZMailbox(USER_NAME);
+    @Test
+    public void testGetDictionaries() throws Exception {
+        Assume.assumeTrue(available);
+        localServer.setSpellAvailableDictionary(new String[] { "dict1", "dict2" });
         Element request = new Element.XMLElement(MailConstants.GET_SPELL_DICTIONARIES_REQUEST);
         Element response = mbox.invoke(request);
-        
+
         // Compare results.
         Set<String> expected = new HashSet<String>();
         expected.add("dict1");
         expected.add("dict2");
-        
+
         Set<String> actual = new HashSet<String>();
         for (Element eDict : response.listElements(MailConstants.E_DICTIONARY)) {
             actual.add(eDict.getText());
         }
-        
+
         assertEquals(2, actual.size());
         actual.removeAll(expected);
         assertEquals(0, actual.size());
@@ -170,14 +174,11 @@ public class TestSpellCheck extends TestCase {
     /**
      * Confirms that spell checking doesn't bomb on unexpected characters.
      */
-    public void testUnexpectedCharacters()
-    throws Exception {
-        if (!available) {
-            return;
-        }
-        
+    @Test
+    public void testUnexpectedCharacters() throws Exception {
+        Assume.assumeTrue(available);
+
         // bug 41760 - non-breaking space
-        ZMailbox mbox = TestUtil.getZMailbox(USER_NAME);
         CheckSpellingResponse result = mbox.checkSpelling("one \u00a0tuo two");
         assertEquals(1, result.getMisspelledWords().size());
     }
@@ -185,13 +186,10 @@ public class TestSpellCheck extends TestCase {
     /**
      * Confirms that accented characters are returned correctly (bug 41394).
      */
-    public void testReceiveSpanish()
-    throws Exception {
-        if (!available) {
-            return;
-        }
-        
-        ZMailbox mbox = TestUtil.getZMailbox(USER_NAME);
+    @Test
+    public void testReceiveSpanish() throws Exception {
+        Assume.assumeTrue(available);
+
         CheckSpellingResponse result = mbox.checkSpelling("reunion", "es");
         assertEquals(1, result.getMisspelledWords().size());
         Misspelling misspelling = result.getMisspelledWords().get(0);
@@ -202,13 +200,10 @@ public class TestSpellCheck extends TestCase {
     /**
      * Confirms that accented characters are sent correctly (bug 43626).
      */
-    public void testSendSpanish()
-    throws Exception {
-        if (!available) {
-            return;
-        }
-        
-        ZMailbox mbox = TestUtil.getZMailbox(USER_NAME);
+    @Test
+    public void testSendSpanish() throws Exception {
+        Assume.assumeTrue(available);
+
         CheckSpellingResponse result = mbox.checkSpelling("\u00faltimos esst\u00e1", "es");
         assertEquals(1, result.getMisspelledWords().size());
         Misspelling misspelling = result.getMisspelledWords().get(0);
@@ -216,17 +211,14 @@ public class TestSpellCheck extends TestCase {
         assertTrue(misspelling.getSuggestionsList().contains("est\u00e1"));
     }
     
-    public void testRussian()
-    throws Exception {
-        if (!available) {
-            return;
-        }
-        
+    @Test
+    public void testRussian() throws Exception {
+        Assume.assumeTrue(available);
+
         String krokodil = "\u041a\u0440\u043e\u043a\u043e\u0434\u0438\u043b";
         String krokodilMisspelled = "\u041a\u0440\u043e\u043a\u043e\u0434\u0438\u043b\u043b";
         String cherepaha = "\u0427\u0435\u0440\u0435\u043f\u0430\u0445\u0430";
-        
-        ZMailbox mbox = TestUtil.getZMailbox(USER_NAME);
+
         CheckSpellingResponse result = mbox.checkSpelling(krokodilMisspelled + " " + cherepaha, "ru");
         assertEquals(1, result.getMisspelledWords().size());
         Misspelling misspelling = result.getMisspelledWords().get(0);
@@ -234,38 +226,33 @@ public class TestSpellCheck extends TestCase {
         assertTrue(misspelling.getSuggestionsList().contains(krokodil));
     }
     
-    public void testAllCaps()
-    throws Exception {
-        if (!available) {
-            return;
-        }
-        
-        Account account = TestUtil.getAccount(USER_NAME);
-        ZMailbox mbox = TestUtil.getZMailbox(USER_NAME);
-        
+    @Test
+    public void testAllCaps() throws Exception {
+        Assume.assumeTrue(available);
+
         account.setPrefSpellIgnoreAllCaps(false);
         CheckSpellingResponse result = mbox.checkSpelling("XYZ");
         assertEquals(1, result.getMisspelledWords().size());
-        
+
         account.setPrefSpellIgnoreAllCaps(true);
         result = mbox.checkSpelling("XYZ");
         assertEquals(0, result.getMisspelledWords().size());
     }
-    
-    public void tearDown()
-    throws Exception {
-        Provisioning prov = Provisioning.getInstance();
-        prov.getLocalServer().setSpellAvailableDictionary(originalDictionaries);
-        
-        Account account = TestUtil.getAccount(USER_NAME);
-        account.setPrefSpellIgnoreWord(originalAccountIgnoreWords);
-        prov.getDomain(account).setPrefSpellIgnoreWord(originalDomainIgnoreWords);
-        prov.getCOS(account).setPrefSpellIgnoreWord(originalCosIgnoreWords);
-        TestUtil.setAccountAttr(USER_NAME, Provisioning.A_zimbraPrefSpellIgnoreAllCaps, originalIgnoreAllCaps);
+
+    @After
+    public void tearDown() throws Exception {
+        localServer.setSpellAvailableDictionary(originalDictionaries);
+        if(account != null) {
+            prov.getDomain(account).setPrefSpellIgnoreWord(originalDomainIgnoreWords);
+            prov.getCOS(account).setPrefSpellIgnoreWord(originalCosIgnoreWords);
+        }
+        if(TestUtil.accountExists(USER_NAME)) {
+            TestUtil.deleteAccount(USER_NAME);
+            account = null;
+        }
     }
 
-    public static void main(String[] args)
-    throws Exception {
+    public static void main(String[] args) throws Exception {
         TestUtil.cliSetup();
         TestUtil.runTest(TestSpellCheck.class);
     }

--- a/store/src/java/com/zimbra/qa/unittest/TestUnread.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestUnread.java
@@ -16,7 +16,6 @@
  */
 
 package com.zimbra.qa.unittest;
-
 import java.util.EnumSet;
 
 import org.junit.After;
@@ -42,7 +41,6 @@ import com.zimbra.cs.mailbox.MailboxManager;
 import com.zimbra.cs.mailbox.Message;
 import com.zimbra.cs.mailbox.OperationContext;
 import com.zimbra.cs.mailbox.Tag;
-
 /**
  * @author bburtin
  */
@@ -56,11 +54,11 @@ public class TestUnread {
     private static String TEST_NAME = "TestUnread";
     private static String USER_NAME = TEST_NAME.toLowerCase() + "user1";
 
-    private static String FOLDER1_NAME = TEST_NAME + " Folder 1";
-    private static String FOLDER2_NAME = TEST_NAME + " Folder 2";
-    private static String TAG1_NAME = TEST_NAME + " Tag 1";
-    private static String TAG2_NAME = TEST_NAME + " Tag 2";
-    private static String TAG3_NAME = TEST_NAME + " Tag 3";
+    private static String FOLDER1_NAME =  "Folder 1";
+    private static String FOLDER2_NAME = "Folder 2";
+    private static String TAG1_NAME = "Tag 1";
+    private static String TAG2_NAME = "Tag 2";
+    private static String TAG3_NAME = "Tag 3";
 
     private int mMessage1Id;
     private int mMessage2Id;
@@ -352,6 +350,7 @@ public class TestUnread {
     public void testMoveToTrash()
     throws Exception {
         ZimbraLog.test.debug("Starting Test %s", name.getMethodName());
+
         verifySetUp();
 
         Folder inbox = mMbox.getFolderById(null, Mailbox.ID_FOLDER_INBOX);
@@ -392,6 +391,7 @@ public class TestUnread {
     public void testDeleteConversation()
     throws Exception {
         ZimbraLog.test.debug("Starting Test %s", name.getMethodName());
+
         verifySetUp();
 
         mMbox.delete(null, getConv().getId(), getConv().getType());
@@ -407,6 +407,7 @@ public class TestUnread {
     public void testDeleteFolder2()
     throws Exception {
         ZimbraLog.test.debug("Starting Test %s", name.getMethodName());
+
         verifySetUp();
 
         mMbox.delete(null, mFolder2Id, getFolder2().getType());
@@ -423,6 +424,7 @@ public class TestUnread {
     public void testDeleteFolder1()
     throws Exception {
         ZimbraLog.test.debug("Starting Test %s", name.getMethodName());
+
         verifySetUp();
 
         mMbox.delete(null, mFolder1Id, getFolder1().getType());
@@ -447,8 +449,7 @@ public class TestUnread {
         verifyAllUnreadFlags();
     }
 
-    private void verifyAllUnreadFlags()
-    throws Exception {
+    private void verifyAllUnreadFlags() throws Exception {
         verifyUnreadFlag(getMessage1());
         verifyUnreadFlag(getMessage2());
         verifyUnreadFlag(getMessage3());
@@ -531,3 +532,4 @@ public class TestUnread {
         Assert.assertTrue("getMessage2().isTagged(getTag2())", getMessage2().isTagged(getTag2()));
     }
 }
+

--- a/store/src/java/com/zimbra/qa/unittest/TestUtil.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestUtil.java
@@ -165,7 +165,7 @@ import junit.framework.Assert;
  * @author bburtin
  */
 public class TestUtil extends Assert {
-
+    public static int DEFAULT_WAIT = 200;
     public static final String DEFAULT_PASSWORD = "test123";
     public static boolean fromRunUnitTests = false; /* set if run from within RunUnitTestsRequest */
 
@@ -537,9 +537,9 @@ public class TestUtil extends Assert {
                 Assert.fail("Unexpected number of messages (" + msgs.size() + ") returned by query '" + query + "'");
             }
             try {
-                if (timeout_millis > 100) {
-                    Thread.sleep(100);
-                    timeout_millis = timeout_millis - 100;
+                if (timeout_millis > DEFAULT_WAIT) {
+                    Thread.sleep(DEFAULT_WAIT);
+                    timeout_millis = timeout_millis - DEFAULT_WAIT;
                 } else {
                     Thread.sleep(timeout_millis);
                     timeout_millis = 0;

--- a/store/src/java/com/zimbra/qa/unittest/TestUtil.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestUtil.java
@@ -198,8 +198,12 @@ public class TestUtil extends Assert {
     }
 
     public static String getSoapUrl() {
+        return getSoapUrl(null);
+    }
+
+    public static String getSoapUrl(Server server) {
         try {
-            return getBaseUrl() + AccountConstants.USER_SERVICE_URI;
+            return getBaseUrl(server) + AccountConstants.USER_SERVICE_URI;
         } catch (ServiceException e) {
             ZimbraLog.test.error("Unable to determine SOAP URL", e);
         }
@@ -207,27 +211,38 @@ public class TestUtil extends Assert {
     }
 
     public static String getBaseUrl() throws ServiceException {
+        return getBaseUrl(null);
+    }
+
+    public static String getBaseUrl(Server server) throws ServiceException {
         String scheme;
-        int port;
-        port = Provisioning.getInstance().getLocalServer().getIntAttr(Provisioning.A_zimbraMailPort, 0);
-        if (port > 0) {
-            scheme = "http";
-        } else {
-            port = Provisioning.getInstance().getLocalServer().getIntAttr(Provisioning.A_zimbraMailSSLPort, 0);
-            scheme = "https";
+        Provisioning prov = Provisioning.getInstance();
+        if(server == null) {
+            server = prov.getLocalServer();
         }
-        return scheme + "://localhost:" + port;
+        String hostname = server.getServiceHostname();
+        int port;
+        port = server.getIntAttr(Provisioning.A_zimbraMailSSLPort, 0);
+        if (port > 0) {
+            scheme = "https";
+        } else {
+            port = server.getIntAttr(Provisioning.A_zimbraMailPort, 0);
+            scheme = "http";
+        }
+        return scheme + "://" + hostname + ":" + port;
     }
 
     public static String getAdminSoapUrl() {
         int port;
+        String hostname = "localhost";
         try {
             port = Provisioning.getInstance().getLocalServer().getIntAttr(Provisioning.A_zimbraAdminPort, 0);
+            hostname = Provisioning.getInstance().getLocalServer().getServiceHostname();
         } catch (ServiceException e) {
             ZimbraLog.test.error("Unable to get admin SOAP port", e);
             port = LC.zimbra_admin_service_port.intValue();
         }
-        return "https://localhost:" + port + AdminConstants.ADMIN_SERVICE_URI;
+        return "https://" + hostname + ":" + port + AdminConstants.ADMIN_SERVICE_URI;
     }
 
     public static LmcSession getSoapSession(String userName) throws ServiceException, LmcSoapClientException,


### PR DESCRIPTION
Testing:
`zimbra@zimbra-dev:/Users/gsolovyev/ubuntuhome/git/zm-mailbox$ zmsoap -z RunUnitTestsRequest test=TestUnread ../test=TestFilter ../test=TestBlobDeduper ../test=TestCalDav ../test=TestDbUtil ../test=TestDeployZimlet ../test=TestSpellCheck ../test=TestUnread`

&lt;RunUnitTestsResponse numFailed="0" numSkipped="0" numExecuted="114" xmlns="urn:zimbraAdmin"&gt;
  &lt;results&gt;
    &lt;completed name="testReadMessage1" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.17"/&gt;
    &lt;completed name="testReadMessage2" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.10"/&gt;
    &lt;completed name="testReadAllMessages" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.13"/&gt;
    &lt;completed name="testReadConversation" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.10"/&gt;
    &lt;completed name="testReadFolder1" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.11"/&gt;
    &lt;completed name="testReadFolder2" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.11"/&gt;
    &lt;completed name="testReadAllFolders" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.12"/&gt;
    &lt;completed name="testReadTag1" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.12"/&gt;
    &lt;completed name="testReadTag2" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.11"/&gt;
    &lt;completed name="testMoveMessage" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.12"/&gt;
    &lt;completed name="testMoveConversation" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.10"/&gt;
    &lt;completed name="testTagMessage" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.12"/&gt;
    &lt;completed name="testTagConversation" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.10"/&gt;
    &lt;completed name="testMoveToTrash" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.11"/&gt;
    &lt;completed name="testSearch" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.10"/&gt;
    &lt;completed name="testDeleteConversation" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.11"/&gt;
    &lt;completed name="testDeleteFolder2" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.11"/&gt;
    &lt;completed name="testDeleteFolder1" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.11"/&gt;
    &lt;completed name="testOutgoingFiltersWithSendMsg" class="com.zimbra.qa.unittest.TestFilter" execSeconds="0.42"/&gt;
    &lt;completed name="testCurrentTimeTest" class="com.zimbra.qa.unittest.TestFilter" execSeconds="0.53"/&gt;
    &lt;completed name="testCurrentDayOfWeekTest" class="com.zimbra.qa.unittest.TestFilter" execSeconds="0.53"/&gt;
    &lt;completed name="testAddressTest" class="com.zimbra.qa.unittest.TestFilter" execSeconds="0.57"/&gt;
    &lt;completed name="testAddressTestPart" class="com.zimbra.qa.unittest.TestFilter" execSeconds="0.58"/&gt;
    &lt;completed name="testReplyAction" class="com.zimbra.qa.unittest.TestFilter" execSeconds="0.91"/&gt;
    &lt;completed name="testNotifyAction" class="com.zimbra.qa.unittest.TestFilter" execSeconds="0.88"/&gt;
    &lt;completed name="testNotifyActionUseOrigHeaders" class="com.zimbra.qa.unittest.TestFilter" execSeconds="0.94"/&gt;
    &lt;completed name="testNotifyActionCopyAllOrigHeaders" class="com.zimbra.qa.unittest.TestFilter" execSeconds="1.00"/&gt;
    &lt;completed name="testNotifyWithDiscard" class="com.zimbra.qa.unittest.TestFilter" execSeconds="0.52"/&gt;
    &lt;completed name="testMultipleMultilineText" class="com.zimbra.qa.unittest.TestFilter" execSeconds="0.33"/&gt;
    &lt;completed name="testMarkRead" class="com.zimbra.qa.unittest.TestFilter" execSeconds="0.52"/&gt;
    &lt;completed name="testHeaderFolding" class="com.zimbra.qa.unittest.TestFilter" execSeconds="0.46"/&gt;
    &lt;completed name="testInvite" class="com.zimbra.qa.unittest.TestFilter" execSeconds="2.64"/&gt;
    &lt;completed name="testManyAsterisks" class="com.zimbra.qa.unittest.TestFilter" execSeconds="0.32"/&gt;
    &lt;completed name="testDateFiltering" class="com.zimbra.qa.unittest.TestFilter" execSeconds="0.84"/&gt;
    &lt;completed name="testHeaderMatches" class="com.zimbra.qa.unittest.TestFilter" execSeconds="0.42"/&gt;
    &lt;completed name="testBodyContains" class="com.zimbra.qa.unittest.TestFilter" execSeconds="1.98"/&gt;
    &lt;completed name="testFullMatchAfterPartialMatch" class="com.zimbra.qa.unittest.TestFilter" execSeconds="0.42"/&gt;
    &lt;completed name="testSpecialCharInBody" class="com.zimbra.qa.unittest.TestFilter" execSeconds="0.40"/&gt;
    &lt;completed name="testRedirect" class="com.zimbra.qa.unittest.TestFilter" execSeconds="1.50"/&gt;
    &lt;completed name="testRedirectMailLoop" class="com.zimbra.qa.unittest.TestFilter" execSeconds="0.87"/&gt;
    &lt;completed name="testAttachment" class="com.zimbra.qa.unittest.TestFilter" execSeconds="0.59"/&gt;
    &lt;completed name="testParseSize" class="com.zimbra.qa.unittest.TestFilter" execSeconds="0.27"/&gt;
    &lt;completed name="testStripBracketsAndQuotes" class="com.zimbra.qa.unittest.TestFilter" execSeconds="0.28"/&gt;
    &lt;completed name="testPositiveAndNegative" class="com.zimbra.qa.unittest.TestFilter" execSeconds="0.30"/&gt;
    &lt;completed name="testBlobDeduper" class="com.zimbra.qa.unittest.TestBlobDeduper" execSeconds="2.13"/&gt;
    &lt;completed name="testBadBasicAuth" class="com.zimbra.qa.unittest.TestCalDav" execSeconds="0.09"/&gt;
    &lt;completed name="testPostToSchedulingOutbox" class="com.zimbra.qa.unittest.TestCalDav" execSeconds="0.46"/&gt;
    &lt;completed name="testBadPostToSchedulingOutbox" class="com.zimbra.qa.unittest.TestCalDav" execSeconds="0.24"/&gt;
    &lt;completed name="testCalendarQueryOnInbox" class="com.zimbra.qa.unittest.TestCalDav" execSeconds="0.83"/&gt;
    &lt;completed name="testCalendarQueryOnOutbox" class="com.zimbra.qa.unittest.TestCalDav" execSeconds="0.22"/&gt;
    &lt;completed name="testPropFindSupportedReportSetOnInbox" class="com.zimbra.qa.unittest.TestCalDav" execSeconds="0.10"/&gt;
    &lt;completed name="testPropFindSupportedReportSetOnOutbox" class="com.zimbra.qa.unittest.TestCalDav" execSeconds="0.10"/&gt;
    &lt;completed name="testPropFindSupportedCalendarComponentSetOnInbox" class="com.zimbra.qa.unittest.TestCalDav" execSeconds="0.10"/&gt;
    &lt;completed name="testPropFindSupportedCalendarComponentSetOnOutbox" class="com.zimbra.qa.unittest.TestCalDav" execSeconds="0.12"/&gt;
    &lt;completed name="testPropFindSupportedCalendarComponentSetOnCalendar" class="com.zimbra.qa.unittest.TestCalDav" execSeconds="0.10"/&gt;
    &lt;completed name="testPropFindSupportedCalendarComponentSetOnTasks" class="com.zimbra.qa.unittest.TestCalDav" execSeconds="0.10"/&gt;
    &lt;completed name="testCreateUsingClientChosenName" class="com.zimbra.qa.unittest.TestCalDav" execSeconds="0.09"/&gt;
    &lt;completed name="testCreateModifyDeleteAttendeeModifyAndCancel" class="com.zimbra.qa.unittest.TestCalDav" execSeconds="2.51"/&gt;
    &lt;completed name="testAndroidMeetingSeries" class="com.zimbra.qa.unittest.TestCalDav" execSeconds="0.73"/&gt;
    &lt;completed name="testSimpleMkcol" class="com.zimbra.qa.unittest.TestCalDav" execSeconds="0.12"/&gt;
    &lt;completed name="testMkcol4addressBook" class="com.zimbra.qa.unittest.TestCalDav" execSeconds="0.10"/&gt;
    &lt;completed name="testPropPatchCalendarFreeBusySetSettingUsingEscapedUrls" class="com.zimbra.qa.unittest.TestCalDav" execSeconds="0.21"/&gt;
    &lt;completed name="testFuzzyTimeZoneMatchGMT_06" class="com.zimbra.qa.unittest.TestCalDav" execSeconds="0.02"/&gt;
    &lt;completed name="testFuzzyTimeZoneMatchGMT_08" class="com.zimbra.qa.unittest.TestCalDav" execSeconds="0.02"/&gt;
    &lt;completed name="testLondonTimeZoneCalledGMTkeepSameName" class="com.zimbra.qa.unittest.TestCalDav" execSeconds="0.02"/&gt;
    &lt;completed name="testLondonTimeZoneCalledGMT" class="com.zimbra.qa.unittest.TestCalDav" execSeconds="0.02"/&gt;
    &lt;completed name="testAttendeeAutoDecline" class="com.zimbra.qa.unittest.TestCalDav" execSeconds="1.20"/&gt;
    &lt;completed name="testAttendeeSuppressedAutoDecline" class="com.zimbra.qa.unittest.TestCalDav" execSeconds="2.75"/&gt;
    &lt;completed name="testCreateContactWithIfNoneMatchTesting" class="com.zimbra.qa.unittest.TestCalDav" execSeconds="0.12"/&gt;
    &lt;completed name="testAppleStyleGroup" class="com.zimbra.qa.unittest.TestCalDav" execSeconds="0.27"/&gt;
    &lt;completed name="testXBusyMacAttach" class="com.zimbra.qa.unittest.TestCalDav" execSeconds="0.12"/&gt;
    &lt;completed name="testAppleCaldavProxyFunctions" class="com.zimbra.qa.unittest.TestCalDav" execSeconds="0.98"/&gt;
    &lt;completed name="testNormalizeSql" class="com.zimbra.qa.unittest.TestDbUtil" execSeconds="0.11"/&gt;
    &lt;completed name="testDatabaseExists" class="com.zimbra.qa.unittest.TestDbUtil" execSeconds="0.04"/&gt;
    &lt;completed name="testValidZimlet" class="com.zimbra.qa.unittest.TestDeployZimlet" execSeconds="0.69"/&gt;
    &lt;completed name="testEmptyAid" class="com.zimbra.qa.unittest.TestDeployZimlet" execSeconds="0.03"/&gt;
    &lt;completed name="testNoAid" class="com.zimbra.qa.unittest.TestDeployZimlet" execSeconds="0.02"/&gt;
    &lt;completed name="testBadAid" class="com.zimbra.qa.unittest.TestDeployZimlet" execSeconds="0.01"/&gt;
    &lt;completed name="testInvalidAction" class="com.zimbra.qa.unittest.TestDeployZimlet" execSeconds="0.06"/&gt;
    &lt;completed name="testBadZimletName" class="com.zimbra.qa.unittest.TestDeployZimlet" execSeconds="0.08"/&gt;
    &lt;completed name="testValidAdminExtension" class="com.zimbra.qa.unittest.TestDeployZimlet" execSeconds="0.07"/&gt;
    &lt;completed name="testAdminExtensionDelegatedAdmin" class="com.zimbra.qa.unittest.TestDeployZimlet" execSeconds="0.06"/&gt;
    &lt;completed name="testUndeployBadName" class="com.zimbra.qa.unittest.TestDeployZimlet" execSeconds="0.02"/&gt;
    &lt;completed name="testZimletDelegatedAdmin" class="com.zimbra.qa.unittest.TestDeployZimlet" execSeconds="0.06"/&gt;
    &lt;completed name="testZipWithTraversal" class="com.zimbra.qa.unittest.TestDeployZimlet" execSeconds="0.02"/&gt;
    &lt;completed name="testZipWithInvalidCharacter" class="com.zimbra.qa.unittest.TestDeployZimlet" execSeconds="0.02"/&gt;
    &lt;completed name="testZipWithAbsolutePath" class="com.zimbra.qa.unittest.TestDeployZimlet" execSeconds="0.06"/&gt;
    &lt;completed name="testPhilsZip" class="com.zimbra.qa.unittest.TestDeployZimlet" execSeconds="0.06"/&gt;
    &lt;completed name="testCheckSpelling" class="com.zimbra.qa.unittest.TestSpellCheck" execSeconds="0.18"/&gt;
    &lt;completed name="testIgnore" class="com.zimbra.qa.unittest.TestSpellCheck" execSeconds="0.12"/&gt;
    &lt;completed name="testGetDictionaries" class="com.zimbra.qa.unittest.TestSpellCheck" execSeconds="0.11"/&gt;
    &lt;completed name="testUnexpectedCharacters" class="com.zimbra.qa.unittest.TestSpellCheck" execSeconds="0.10"/&gt;
    &lt;completed name="testReceiveSpanish" class="com.zimbra.qa.unittest.TestSpellCheck" execSeconds="0.13"/&gt;
    &lt;completed name="testSendSpanish" class="com.zimbra.qa.unittest.TestSpellCheck" execSeconds="0.12"/&gt;
    &lt;completed name="testRussian" class="com.zimbra.qa.unittest.TestSpellCheck" execSeconds="0.13"/&gt;
    &lt;completed name="testAllCaps" class="com.zimbra.qa.unittest.TestSpellCheck" execSeconds="0.11"/&gt;
    &lt;completed name="testReadMessage1" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.11"/&gt;
    &lt;completed name="testReadMessage2" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.10"/&gt;
    &lt;completed name="testReadAllMessages" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.13"/&gt;
    &lt;completed name="testReadConversation" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.09"/&gt;
    &lt;completed name="testReadFolder1" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.09"/&gt;
    &lt;completed name="testReadFolder2" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.09"/&gt;
    &lt;completed name="testReadAllFolders" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.12"/&gt;
    &lt;completed name="testReadTag1" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.11"/&gt;
    &lt;completed name="testReadTag2" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.11"/&gt;
    &lt;completed name="testMoveMessage" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.11"/&gt;
    &lt;completed name="testMoveConversation" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.12"/&gt;
    &lt;completed name="testTagMessage" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.11"/&gt;
    &lt;completed name="testTagConversation" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.10"/&gt;
    &lt;completed name="testMoveToTrash" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.11"/&gt;
    &lt;completed name="testSearch" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.10"/&gt;
    &lt;completed name="testDeleteConversation" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.09"/&gt;
    &lt;completed name="testDeleteFolder2" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.11"/&gt;
    &lt;completed name="testDeleteFolder1" class="com.zimbra.qa.unittest.TestUnread" execSeconds="0.16"/&gt;
  &lt;/results&gt;
&lt;/RunUnitTestsResponse&gt;