### PR TITLE
Bugfix/zms 594 test folder acl cache

### DIFF
--- a/store/src/java/com/zimbra/qa/unittest/TestFolderACLCache.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestFolderACLCache.java
@@ -16,18 +16,18 @@
  */
 package com.zimbra.qa.unittest;
 
-import com.zimbra.common.util.CliUtil;
-import com.zimbra.common.service.ServiceException;
-import com.zimbra.cs.account.Account;
-import com.zimbra.cs.account.GuestAccount;
-import com.zimbra.cs.account.Provisioning;
-import com.zimbra.common.account.Key.AccountBy;
-import com.zimbra.cs.mailbox.ACL;
-import com.zimbra.cs.mailbox.OperationContext;
-import com.zimbra.cs.mailbox.acl.FolderACL;
 import com.zimbra.client.ZFolder;
 import com.zimbra.client.ZGrant;
 import com.zimbra.client.ZMailbox;
+import com.zimbra.common.account.Key.AccountBy;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.CliUtil;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.GuestAccount;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.ACL;
+import com.zimbra.cs.mailbox.OperationContext;
+import com.zimbra.cs.mailbox.acl.FolderACL;
 
 import junit.framework.TestCase;
 
@@ -35,131 +35,132 @@ public class TestFolderACLCache extends TestCase {
 
     /*
      * setup owner(user1) folders and grants with zmmailbox or webclient:
-     * 
+     *
      * /inbox/sub1       share with user2 with w right
      *                   share with user3 with rw rights
-     *                   
+     *
      * /inbox/sub1/sub2  should inherit grants from sub1
-     * 
+     *
      * /inbox/sub1/sub3  share with public with r right
-     * 
+     *
      *                inbox
      *                /   \
      *             sub1   sub3
      *              |
-     *             sub2     
-     * 
+     *             sub2
+     *
      * zmmailbox -z -m user1 cf /inbox/sub1
      * zmmailbox -z -m user1 cf /inbox/sub1/sub2
      * zmmailbox -z -m user1 cf /inbox/sub3
      * zmmailbox -z -m user1 mfg /inbox/sub1 account user2 w
      * zmmailbox -z -m user1 mfg /inbox/sub1 account user3 rw
      * zmmailbox -z -m user1 mfg /inbox/sub3 public r
-     * 
+     *
      * To setup memcached:
      * zmprov mcf zimbraMemcachedClientServerList 'localhost:11211'
-     * /opt/zimbra/memcached/bin/memcached -vv       
-     * 
+     * /opt/zimbra/memcached/bin/memcached -vv
+     *
      * To test all scenarios, after reset-the-world:
-     * 
+     *
      * 1. Test the case when memcached is not configured/running.
      *    (A) just run the test
      *            This tests the case when the effective permissions
      *            are computed locally.
-     *                
-     *    (B) modify FolderACL.ShareTarget.onLocalServer() to 
+     *
+     *    (B) modify FolderACL.ShareTarget.onLocalServer() to
      *     boolean onLocalServer() throws ServiceException {
      *       // return Provisioning.onLocalServer(mOwnerAcct);
      *       return false;
-     *     } 
+     *     }
      *     ==> run the test
      *     This tests the GetEffectiveFolderPerms soap.
-     * 
-     * 2. Test the case when memcached is configured/running. 
+     *
+     * 2. Test the case when memcached is configured/running.
      *    zmprov mcf zimbraMemcachedClientServerList 'localhost:11211'
      *    (restart server)
      *    /opt/zimbra/memcached/bin/memcached -vv
      *    ==> run the test
      */
-    
+
     String OWNER_ACCT_ID;
     Account USER1;
     Account USER2;
     Account USER3;
-    
+
     int INBOX_FID;
     int SUB1_FID;
     int SUB2_FID;
     int SUB3_FID;
-    
+
+    @Override
     public void setUp() throws Exception {
-        
+
         Provisioning prov = Provisioning.getInstance();
-        
+
         Account ownerAcct = prov.get(AccountBy.name, "user1");
         ZMailbox ownerMbx = TestUtil.getZMailbox(ownerAcct.getName());
-        
+
         ZFolder inbox = ownerMbx.getFolderByPath("inbox");
-        
+
         String sub1Path = "/inbox/sub1";
         ZFolder sub1 = ownerMbx.getFolderByPath(sub1Path);
         if (sub1 == null) {
             sub1 = TestUtil.createFolder(ownerMbx, sub1Path);
             ownerMbx.modifyFolderGrant(sub1.getId(), ZGrant.GranteeType.usr, "user2", "w", null);
             ownerMbx.modifyFolderGrant(sub1.getId(), ZGrant.GranteeType.usr, "user3", "rw", null);
-        } 
-        
+        }
+
         String sub2Path = "/inbox/sub1/sub2";
         ZFolder sub2 = ownerMbx.getFolderByPath(sub2Path);
         if (sub2 == null)
             sub2 = TestUtil.createFolder(ownerMbx, sub2Path);
-        
+
         String sub3Path = "/inbox/sub3";
         ZFolder sub3 = ownerMbx.getFolderByPath(sub3Path);
         if (sub3 == null) {
             sub3 = TestUtil.createFolder(ownerMbx, sub3Path);
             ownerMbx.modifyFolderGrant(sub3.getId(), ZGrant.GranteeType.pub, null, "r", null);
         }
-        
+
         OWNER_ACCT_ID = ownerAcct.getId();
         USER1 = prov.get(AccountBy.name, "user1");
         USER2 = prov.get(AccountBy.name, "user2");
         USER3 = prov.get(AccountBy.name, "user3");
-        
+
         INBOX_FID = Integer.valueOf(inbox.getId());
         SUB1_FID = Integer.valueOf(sub1.getId());
         SUB2_FID = Integer.valueOf(sub2.getId());
         SUB3_FID = Integer.valueOf(sub3.getId());
     }
-    
+
     private String formatRights(short rights) {
         return ACL.rightsToString(rights) + "(" + rights + ")";
     }
-    
+
     /*
      * To test remote: hardcode FolderACL.ShareTarget.onLocalServer() to return false.
      *                 make sure you change it back after testing
      */
     private void doTest(
             Account authedAcct, String ownerAcctId, int targetFolderId,
-            short expectedEffectivePermissions, 
+            short expectedEffectivePermissions,
             short needRightsForCanAccessTest, boolean expectedCanAccess) throws ServiceException {
-        
+
         OperationContext octxt;
         if (authedAcct == null)
             octxt = null;
         else
             octxt = new OperationContext(authedAcct);
-        
+
         FolderACL folderAcl = new FolderACL(octxt, ownerAcctId, targetFolderId);
-        
+
         short effectivePermissions = folderAcl.getEffectivePermissions();
         boolean canAccess = folderAcl.canAccess(needRightsForCanAccessTest);
-        
+
         boolean good = false;
-        
-        // mask out the create folder right, it is an internal right, which is returned 
-        // by getEffectivePermissions if owner is on local server but not returned if 
+
+        // mask out the create folder right, it is an internal right, which is returned
+        // by getEffectivePermissions if owner is on local server but not returned if
         // the owner is remote.
         //
         // The diff is not a real bug and can be ignored
@@ -169,10 +170,10 @@ public class TestFolderACLCache extends TestCase {
             actual = ACL.stringToRights(ACL.rightsToString(actual));
         if (expected == -1)
             expected = ACL.stringToRights(ACL.rightsToString(expected));
-        
+
         assertEquals(expected, actual);
         assertEquals(expectedCanAccess, canAccess);
-        
+
         good = true;
         /*
         System.out.println();
@@ -181,16 +182,16 @@ public class TestFolderACLCache extends TestCase {
         System.out.println("    canAccess:            " + canAccess                          + " (expected: " + expectedCanAccess + ")");
         */
     }
-    
+
     public void testPublicUser() throws Exception {
         doTest(GuestAccount.ANONYMOUS_ACCT,    OWNER_ACCT_ID, INBOX_FID, (short)0,       ACL.RIGHT_READ, false);
         doTest(GuestAccount.ANONYMOUS_ACCT,    OWNER_ACCT_ID, SUB1_FID,  (short)0,       ACL.RIGHT_READ, false);
         doTest(GuestAccount.ANONYMOUS_ACCT,    OWNER_ACCT_ID, SUB2_FID,  (short)0,       ACL.RIGHT_READ, false);
-        
+
         doTest(GuestAccount.ANONYMOUS_ACCT,    OWNER_ACCT_ID, SUB3_FID,  ACL.RIGHT_READ, ACL.RIGHT_READ,  true);
         doTest(GuestAccount.ANONYMOUS_ACCT,    OWNER_ACCT_ID, SUB3_FID,  ACL.RIGHT_READ, ACL.RIGHT_WRITE, false);
     }
-    
+
     public void testOwner() throws Exception {
         // pass a null authed account
         // the owner itself accessing, should have all rights
@@ -199,7 +200,7 @@ public class TestFolderACLCache extends TestCase {
         doTest(null, OWNER_ACCT_ID, SUB2_FID,  (short)~0, (short)~0, true);
         doTest(null, OWNER_ACCT_ID, SUB3_FID,  (short)~0, (short)~0, true);
     }
-    
+
     public void testUser1() throws Exception {
         // the owner itself accessing, should have all rights
         doTest(USER1, OWNER_ACCT_ID, INBOX_FID, (short)~0, (short)~0, true);
@@ -207,30 +208,30 @@ public class TestFolderACLCache extends TestCase {
         doTest(USER1, OWNER_ACCT_ID, SUB2_FID,  (short)~0, (short)~0, true);
         doTest(USER1, OWNER_ACCT_ID, SUB3_FID,  (short)~0, (short)~0, true);
     }
-    
+
     public void testUser2() throws Exception {
         doTest(USER2, OWNER_ACCT_ID, INBOX_FID, (short)0,         ACL.RIGHT_WRITE, false);
         doTest(USER2, OWNER_ACCT_ID, SUB1_FID,  ACL.RIGHT_WRITE,  ACL.RIGHT_WRITE, true);
         doTest(USER2, OWNER_ACCT_ID, SUB2_FID,  ACL.RIGHT_WRITE,  ACL.RIGHT_WRITE, true);
-        
+
         doTest(USER2, OWNER_ACCT_ID, SUB3_FID,  ACL.RIGHT_READ, ACL.RIGHT_READ,  true);
         doTest(USER2, OWNER_ACCT_ID, SUB3_FID,  ACL.RIGHT_READ, ACL.RIGHT_WRITE, false);
    }
-    
+
     public void testUser3() throws Exception {
         doTest(USER3, OWNER_ACCT_ID, INBOX_FID, (short)0,                                ACL.RIGHT_WRITE, false);
         doTest(USER3, OWNER_ACCT_ID, SUB1_FID,  (short)(ACL.RIGHT_READ|ACL.RIGHT_WRITE), ACL.RIGHT_WRITE, true);
         doTest(USER3, OWNER_ACCT_ID, SUB2_FID,  (short)(ACL.RIGHT_READ|ACL.RIGHT_WRITE), ACL.RIGHT_WRITE, true);
-        
+
         doTest(USER3, OWNER_ACCT_ID, SUB3_FID,  ACL.RIGHT_READ, ACL.RIGHT_READ,  true);
         doTest(USER3, OWNER_ACCT_ID, SUB3_FID,  ACL.RIGHT_READ, ACL.RIGHT_WRITE, false);
     }
-    
+
     public static void main(String[] args) throws ServiceException {
-        
+
         com.zimbra.cs.db.DbPool.startup();
         com.zimbra.cs.memcached.MemcachedConnector.startup();
-        
+
         CliUtil.toolSetup();
         TestUtil.runTest(TestFolderACLCache.class);
     }

--- a/store/src/java/com/zimbra/qa/unittest/TestFolderACLCache.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestFolderACLCache.java
@@ -16,8 +16,6 @@
  */
 package com.zimbra.qa.unittest;
 
-import java.util.List;
-
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -25,7 +23,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 
-import com.google.common.collect.Lists;
 import com.zimbra.client.ZFolder;
 import com.zimbra.client.ZGrant;
 import com.zimbra.client.ZMailbox;
@@ -95,11 +92,13 @@ public class TestFolderACLCache {
      *    ==> run the test
      */
 
+    String ownerName = null;
+    String user2Name = null;
+    String user3Name = null;
     Account ownerAcct = null;
     Account USER2 = null;
     Account USER3 = null;
     String OWNER_ACCT_ID = null;
-    static List<Account> accts = Lists.newArrayList();
     Provisioning prov = Provisioning.getInstance();
 
     int INBOX_FID;
@@ -111,10 +110,14 @@ public class TestFolderACLCache {
     public void setUp() throws Exception {
         testName = testInfo.getMethodName();
         userNamePrefix = "testfolderaclcache-" + testName + "-user-";
+        ownerName = userNamePrefix + "owner";
+        user2Name = userNamePrefix + "haswriteaccess";
+        user3Name = userNamePrefix + "hasreadwriteaccess";
+        cleanUp();
 
-        ownerAcct = createAcct(userNamePrefix + "1");
-        USER2 = createAcct(userNamePrefix + "haswriteaccess");
-        USER3 = createAcct(userNamePrefix + "hasreadwriteaccess");
+        ownerAcct = createAcct(ownerName);
+        USER2 = createAcct(user2Name);
+        USER3 = createAcct(user3Name);
         ZMailbox ownerMbx = TestUtil.getZMailbox(ownerAcct.getName());
 
         ZFolder inbox = ownerMbx.getFolderByPath("inbox");
@@ -149,18 +152,14 @@ public class TestFolderACLCache {
 
     @After
     public void cleanUp() throws Exception {
-        for (Account acct : accts) {
-            if (acct != null) {
-                prov.deleteAccount(acct.getId());
-            }
-        }
-        accts.clear();
+        TestUtil.deleteAccountIfExists(ownerName);
+        TestUtil.deleteAccountIfExists(user2Name);
+        TestUtil.deleteAccountIfExists(user3Name);
     }
 
     private Account createAcct(String name) throws ServiceException {
         Account acct = TestUtil.createAccount(name);
         Assert.assertNotNull(String.format("Unable to create account for %s", name), acct);
-        accts.add(acct);
         return acct;
     }
 

--- a/store/src/java/com/zimbra/qa/unittest/TestUtil.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestUtil.java
@@ -765,8 +765,9 @@ public class TestUtil extends Assert {
         }
     }
 
-    /*
-     * Deletes the account for the given username.
+    /**
+     * Deletes the account for the given username. Consider using {@link deleteAccountIfExists} as alternative
+     * to reduce logging where the account may not exist.
      */
     public static void deleteAccount(String username) throws ServiceException {
         Provisioning prov = Provisioning.getInstance();
@@ -798,6 +799,17 @@ public class TestUtil extends Assert {
             if (!sfe.getMessage().contains("no such account")) {
                 ZimbraLog.test.error("GetAccountResponse for '%s' hit unexpected problem", username, sfe);
             }
+        }
+    }
+
+    /**
+     * Less chatty than deleteAccount if the account doesn't already exist.  Useful for cleanUp()
+     * methods which are called before running a test to delete any accounts left over from previous
+     * failed runs without spouting lots of logging to mailbox.log
+     */
+    public static void deleteAccountIfExists(String username) throws ServiceException {
+        if (TestUtil.accountExists(username)) {
+            deleteAccount(username);
         }
     }
 


### PR DESCRIPTION
Results:

    zmsoap -z RunUnitTestsRequest/test=com.zimbra.qa.unittest.TestFolderACLCache
    <RunUnitTestsResponse numFailed="0" numSkipped="0" numExecuted="5" xmlns="urn:zimbraAdmin">
      <results>
        <completed name="publicUser" class="com.zimbra.qa.unittest.TestFolderACLCache" execSeconds="4.83"/>
        <completed name="nullAuthedAcct" class="com.zimbra.qa.unittest.TestFolderACLCache" execSeconds="0.37"/>
        <completed name="authedAcctIsOwner" class="com.zimbra.qa.unittest.TestFolderACLCache" execSeconds="0.37"/>
        <completed name="authedAcctHasWriteAccess" class="com.zimbra.qa.unittest.TestFolderACLCache" execSeconds="0.39"/>
        <completed name="authedAcctHasReadWriteAccess" class="com.zimbra.qa.unittest.TestFolderACLCache" execSeconds="0.19"/>
      </results>
    </RunUnitTestsResponse>
