### PR TITLE
ZMS-603: Modify dynamic ephemeral attributes via Provisioning::modifyAttrs

### DIFF
--- a/store/src/java/com/zimbra/cs/ephemeral/migrate/AttributeMigration.java
+++ b/store/src/java/com/zimbra/cs/ephemeral/migrate/AttributeMigration.java
@@ -124,6 +124,10 @@ public class AttributeMigration {
         converterMap.put(attribute, converter);
     }
 
+    public static AttributeConverter getConverter(String attrName) {
+        return converterMap.get(attrName);
+    }
+
     public void setSource(EntrySource source) {
         this.source = source;
     }

--- a/store/src/java/com/zimbra/cs/ephemeral/migrate/AuthTokenConverter.java
+++ b/store/src/java/com/zimbra/cs/ephemeral/migrate/AuthTokenConverter.java
@@ -9,12 +9,6 @@ import com.zimbra.cs.ephemeral.EphemeralKey;
 /**
  * Converter used to migrate pre-8.8 auth tokens out of LDAP into ephemeral store.
  *
- * The format for the auth tokens was tokenID|expiration|serverVersion.
- * The format for LdapEphemeralStore is serverVersion|tokenID|expiration,
- * so in case we are migrating to LdapEphemeralStore, we need to check that the auth token
- * is not already in the new format. This can be done by checking whether the first component
- * is a Long or not.
- *
  * @author iraykin
  *
  */

--- a/store/src/java/com/zimbra/qa/unittest/TestModifyDynamicEphemeralAttrs.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestModifyDynamicEphemeralAttrs.java
@@ -1,0 +1,62 @@
+package com.zimbra.qa.unittest;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+
+public class TestModifyDynamicEphemeralAttrs {
+
+    private static final String acctName = TestModifyDynamicEphemeralAttrs.class.getSimpleName();
+    private static Account acct;
+    private static Provisioning prov = Provisioning.getInstance();
+
+    @BeforeClass
+    public static void init() throws Exception {
+        if (!TestUtil.accountExists(acctName)) {
+            acct = TestUtil.createAccount(acctName);
+        }
+    }
+
+    @AfterClass
+    public static void shutdown() throws Exception {
+        TestUtil.deleteAccount(acct.getName());
+    }
+
+    @Test
+    public void testModifyDynamicAttrsViaModifyAttrs() throws Exception {
+        Map<String, Object> attrs = new HashMap<String, Object>();
+        // test that if the provided value is invalid, it won't be added
+        attrs.put(Provisioning.A_zimbraAuthTokens, "123|badtoken");
+        prov.modifyAttrs(acct, attrs);
+        assertFalse(acct.hasAuthTokens("123"));
+
+        // test that we can inject an LDAP-formatted auth token value
+        Long millis = System.currentTimeMillis() + 1000 * 60 * 60;
+        attrs.put(Provisioning.A_zimbraAuthTokens, String.format("123|%d|test", millis));
+        prov.modifyAttrs(acct, attrs);
+        assertTrue(acct.hasAuthTokens("123"));
+
+        // test that we can add a second value using the '+' prefix
+        attrs.clear();
+        attrs.put("+" + Provisioning.A_zimbraAuthTokens, String.format("456|%d|test", millis));
+        prov.modifyAttrs(acct, attrs);
+        assertTrue(acct.hasAuthTokens("123"));
+        assertTrue(acct.hasAuthTokens("456"));
+
+        // test that we can delete a single value
+        attrs.clear();
+        attrs.put("-" + Provisioning.A_zimbraAuthTokens, String.format("123|%d|test", millis));
+        prov.modifyAttrs(acct, attrs);
+        assertFalse(acct.hasAuthTokens("123"));
+        assertTrue(acct.hasAuthTokens("456"));
+    }
+}

--- a/store/src/java/com/zimbra/qa/unittest/TestModifyDynamicEphemeralAttrs.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestModifyDynamicEphemeralAttrs.java
@@ -21,9 +21,8 @@ public class TestModifyDynamicEphemeralAttrs {
 
     @BeforeClass
     public static void init() throws Exception {
-        if (!TestUtil.accountExists(acctName)) {
-            acct = TestUtil.createAccount(acctName);
-        }
+        TestUtil.deleteAccount(acctName);
+        acct = TestUtil.createAccount(acctName);
     }
 
     @AfterClass

--- a/store/src/java/com/zimbra/qa/unittest/ZimbraSuite.java
+++ b/store/src/java/com/zimbra/qa/unittest/ZimbraSuite.java
@@ -138,6 +138,7 @@ public class ZimbraSuite  {
         sClasses.add(TestChangeEphemeralStore.class);
         sClasses.add(TestDeployZimlet.class);
         sClasses.add(TestServiceServlet.class);
+        sClasses.add(TestModifyDynamicEphemeralAttrs.class);
     }
 
     /**


### PR DESCRIPTION
Updated _LdapProvisioning::modifyEphemeralAttrs_ to support dynamic ephemeral attributes. This is done by leveraging existing AttributeConverter classes to try to parse the provided as LDAP-formatted strings. If the provided value cannot be parsed with the appropriate AttributeConverter, or if the AttributeConverter does not exist for the ephemeral attribute, then a warning is logged and the  operation is skipped.