### PR TITLE
ZMS-573: TestFolder unit test fix

### DIFF
--- a/store/src/java/com/zimbra/qa/unittest/TestFolders.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestFolders.java
@@ -25,6 +25,7 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.google.common.base.Strings;
@@ -92,14 +93,10 @@ public class TestFolders {
         assertNull(mbox.getFolderByPath(childPath));
     }
 
+    @Ignore
     @Test
     public void testCreateManyFolders() throws Exception {
         //normally skip this test since it takes a long time to complete. just keep it around for quick perf checks
-        boolean skip = true;
-        if (skip) {
-            return;
-        }
-
         ZMailbox mbox = TestUtil.getZMailbox(USER_NAME);
         String parentPath = "/parent";
 

--- a/store/src/java/com/zimbra/qa/unittest/TestFolders.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestFolders.java
@@ -35,21 +35,19 @@ import com.zimbra.cs.account.Provisioning;
 
 public class TestFolders {
     private static String USER_NAME = TestFolders.class.getSimpleName();
-    private static String NAME_PREFIX = "TestFolders";
 
-    private String mOriginalEmptyFolderBatchSize;
+    private static String mOriginalEmptyFolderBatchSize;
 
 
     @BeforeClass
     public static void init() throws Exception {
-        TestUtil.deleteAccount(USER_NAME);
-        TestUtil.createAccount(USER_NAME);
+        mOriginalEmptyFolderBatchSize = TestUtil.getServerAttr(Provisioning.A_zimbraMailEmptyFolderBatchSize);
     }
 
     @Before
     public void setUp() throws Exception {
-        cleanUp();
-        mOriginalEmptyFolderBatchSize = TestUtil.getServerAttr(Provisioning.A_zimbraMailEmptyFolderBatchSize);
+        TestUtil.deleteAccountIfExists(USER_NAME);
+        TestUtil.createAccount(USER_NAME);
     }
 
     @Test
@@ -57,15 +55,15 @@ public class TestFolders {
         TestUtil.setServerAttr(Provisioning.A_zimbraMailEmptyFolderBatchSize, Integer.toString(3));
 
         // Create folders.
-        String parentPath = "/" + NAME_PREFIX + "-parent";
+        String parentPath = "/parent";
         ZMailbox mbox = TestUtil.getZMailbox(USER_NAME);
         ZFolder parent = TestUtil.createFolder(mbox, parentPath);
         ZFolder child = TestUtil.createFolder(mbox, parent.getId(), "child");
 
         // Add messages.
         for (int i = 1; i <= 5; i++) {
-            TestUtil.addMessage(mbox, NAME_PREFIX + " parent " + i, parent.getId());
-            TestUtil.addMessage(mbox, NAME_PREFIX + " child " + i, child.getId());
+            TestUtil.addMessage(mbox, "parent " + i, parent.getId());
+            TestUtil.addMessage(mbox, "child " + i, child.getId());
         }
         mbox.noOp();
         assertEquals(5, parent.getMessageCount());
@@ -79,7 +77,7 @@ public class TestFolders {
 
         // Add more messages to the parent folder.
         for (int i = 6; i <= 10; i++) {
-            TestUtil.addMessage(mbox, NAME_PREFIX + " parent " + i, parent.getId());
+            TestUtil.addMessage(mbox, "parent " + i, parent.getId());
         }
         mbox.noOp();
         assertEquals(5, parent.getMessageCount());
@@ -103,7 +101,7 @@ public class TestFolders {
         }
 
         ZMailbox mbox = TestUtil.getZMailbox(USER_NAME);
-        String parentPath = "/" + NAME_PREFIX + "-parent";
+        String parentPath = "/parent";
 
         ZFolder parent = TestUtil.createFolder(mbox, parentPath);
         int max = 10000;
@@ -128,25 +126,14 @@ public class TestFolders {
         }
     }
 
-    private void cleanUp()
-    throws Exception {
-        TestUtil.deleteTestData(USER_NAME, NAME_PREFIX);
-        ZMailbox mbox = TestUtil.getZMailbox(USER_NAME);
-        ZFolder f = mbox.getFolderByPath("/f1");
-        if (f != null) {
-            mbox.deleteFolder(f.getId());
-        }
-    }
-
     @After
     public void tearDown() throws Exception {
-        cleanUp();
-        TestUtil.setServerAttr(Provisioning.A_zimbraMailEmptyFolderBatchSize, mOriginalEmptyFolderBatchSize);
+        TestUtil.deleteAccountIfExists(USER_NAME);
     }
 
     @AfterClass
     public static void shutdown() throws Exception {
-        TestUtil.deleteAccount(USER_NAME);
+        TestUtil.setServerAttr(Provisioning.A_zimbraMailEmptyFolderBatchSize, mOriginalEmptyFolderBatchSize);
     }
 
     public static void main(String[] args)

--- a/store/src/java/com/zimbra/qa/unittest/TestFolders.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestFolders.java
@@ -17,31 +17,43 @@
 
 package com.zimbra.qa.unittest;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 import com.google.common.base.Strings;
-import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.client.ZFolder;
 import com.zimbra.client.ZMailbox;
+import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Provisioning;
 
-public class TestFolders extends TestCase
-{
-    private static String USER_NAME = "user1";
+public class TestFolders {
+    private static String USER_NAME = TestFolders.class.getSimpleName();
     private static String NAME_PREFIX = "TestFolders";
 
     private String mOriginalEmptyFolderBatchSize;
 
-    @Override
-    protected void setUp()
-    throws Exception {
+
+    @BeforeClass
+    public static void init() throws Exception {
+        TestUtil.deleteAccount(USER_NAME);
+        TestUtil.createAccount(USER_NAME);
+    }
+
+    @Before
+    public void setUp() throws Exception {
         cleanUp();
         mOriginalEmptyFolderBatchSize = TestUtil.getServerAttr(Provisioning.A_zimbraMailEmptyFolderBatchSize);
     }
 
-
-    public void testEmptyLargeFolder()
-    throws Exception {
+    @Test
+    public void testEmptyLargeFolder() throws Exception {
         TestUtil.setServerAttr(Provisioning.A_zimbraMailEmptyFolderBatchSize, Integer.toString(3));
 
         // Create folders.
@@ -81,7 +93,8 @@ public class TestFolders extends TestCase
         assertEquals(0, parent.getMessageCount());
         assertNull(mbox.getFolderByPath(childPath));
     }
-    
+
+    @Test
     public void testCreateManyFolders() throws Exception {
         //normally skip this test since it takes a long time to complete. just keep it around for quick perf checks
         boolean skip = true;
@@ -125,10 +138,15 @@ public class TestFolders extends TestCase
         }
     }
 
-    @Override
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() throws Exception {
         cleanUp();
         TestUtil.setServerAttr(Provisioning.A_zimbraMailEmptyFolderBatchSize, mOriginalEmptyFolderBatchSize);
+    }
+
+    @AfterClass
+    public static void shutdown() throws Exception {
+        TestUtil.deleteAccount(USER_NAME);
     }
 
     public static void main(String[] args)


### PR DESCRIPTION
Removed TestCase subclass from TestFolder; added @BeforeClass/@AfterClass-annotated methods to create/destroy a test account.