### PR TITLE
ZCS-1001 CalDav shared calendar fix

### DIFF
--- a/store/src/java/com/zimbra/cs/dav/service/DavServlet.java
+++ b/store/src/java/com/zimbra/cs/dav/service/DavServlet.java
@@ -20,6 +20,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URLDecoder;
 import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -814,6 +815,8 @@ public class DavServlet extends ZimbraServlet {
                         }
                         Element href = ((Element)responseObj).element(DavElements.E_HREF);
                         String v = href.getText();
+                        v = URLDecoder.decode(v);
+                        // Bug:106438, because v contains URL encoded value(%40) for '@' the comparison fails
                         if (v.startsWith(newPrefix)) {
                             href.setText(prefix + v.substring(newPrefix.length()+1));
                         }


### PR DESCRIPTION
Added code to URLDecode calendar path string before comparison. This was a regression. 
The regression caused value: /dav/test1@domain.com/Calendar to be compared to  value: /dav/test1%40domain.com/Calendar/39e4bcf0-c3e7-4603-b202-8b521ca29c64.ics. This resulted in long URL being returned in calendar-query

Checked by installing zm-store jar with the fix on 8.7.5 installation. Configured an account with shared calendar in iCal on Mac and verified that appts  in shared and own calendar are shown and do not disappear. Verified with both recurring and non recurring appts.
