### PR TITLE
ZCS-860 : Sieve: addheader/replaceheader must not add a header withou…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,9 @@
 .classpath
 .project
-<<<<<<< HEAD
-<<<<<<< HEAD
 .settings/
 .idea/
 build/
 bin/
 .DS_Store
-=======
-bin/
->>>>>>> 930a35fff43bfe1ed04198837bf3c4d71e9eaa92
-=======
-bin/
-build/
-outgoing
->>>>>>> 84aa293433812373a85c2c8664e8f62c5a7360d2
+.metadata/
+.recommenders/

--- a/store/src/java-test/com/zimbra/cs/filter/AddHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/AddHeaderTest.java
@@ -434,4 +434,92 @@ public class AddHeaderTest {
             fail("No exception should be thrown: " + e.getMessage());
         }
     }
+
+    /*
+     * Try adding new header with space as header name, which should fail
+     */
+    @Test
+    public void testAddHeaderNameAsSingleSpace() {
+        try {
+           String filterScript = "require [\"editheader\"];\n"
+                    + " addheader \" \" \"my-new-header-value\" \r\n"
+                    + "  ;\n";
+            Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+            Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
+            RuleManager.clearCachedRules(acct1);
+            acct1.setMailSieveScript(filterScript);
+            RuleManager.applyRulesToIncomingMessage(
+                    new OperationContext(mbox1), mbox1, new ParsedMessage(
+                            sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
+                            null, new DeliveryContext(),
+                            Mailbox.ID_FOLDER_INBOX, true);
+            Integer itemId = mbox1.getItemIds(null, Mailbox.ID_FOLDER_INBOX).getIds(MailItem.Type.MESSAGE).get(0);
+            Message mdnMsg = mbox1.getMessageById(null, itemId);
+            for (Enumeration<Header> e = mdnMsg.getMimeMessage().getAllHeaders(); e.hasMoreElements();) {
+                Header temp = e.nextElement();
+                Assert.assertFalse(temp.getValue().equals("my-new-header-value"));
+            }
+        } catch (Exception e) {
+            fail("No exception should be thrown: " + e.getMessage());
+        }
+    }
+
+    /*
+     * Try adding new header with multiple spaces as header name, which should fail
+     */
+    @Test
+    public void testAddHeaderNameAsMultipleSpace() {
+        try {
+           String filterScript = "require [\"editheader\"];\n"
+                    + " addheader \"    \" \"my-new-header-value\" \r\n"
+                    + "  ;\n";
+            Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+            Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
+            RuleManager.clearCachedRules(acct1);
+            acct1.setMailSieveScript(filterScript);
+            RuleManager.applyRulesToIncomingMessage(
+                    new OperationContext(mbox1), mbox1, new ParsedMessage(
+                            sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
+                            null, new DeliveryContext(),
+                            Mailbox.ID_FOLDER_INBOX, true);
+            Integer itemId = mbox1.getItemIds(null, Mailbox.ID_FOLDER_INBOX).getIds(MailItem.Type.MESSAGE).get(0);
+            Message mdnMsg = mbox1.getMessageById(null, itemId);
+            for (Enumeration<Header> e = mdnMsg.getMimeMessage().getAllHeaders(); e.hasMoreElements();) {
+                Header temp = e.nextElement();
+                Assert.assertFalse(temp.getValue().equals("my-new-header-value"));
+            }
+        } catch (Exception e) {
+            fail("No exception should be thrown: " + e.getMessage());
+        }
+    }
+
+    /*
+     * Try adding new header with header name starting with space, which should fail
+     */
+    @Test
+    public void testAddHeaderNameStartingWithSpace() {
+        try {
+           String filterScript = "require [\"editheader\"];\n"
+                    + " addheader \" X-My-Test\" \"my-new-header-value\" \r\n"
+                    + "  ;\n";
+            Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+            Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
+            RuleManager.clearCachedRules(acct1);
+            acct1.setMailSieveScript(filterScript);
+            RuleManager.applyRulesToIncomingMessage(
+                    new OperationContext(mbox1), mbox1, new ParsedMessage(
+                            sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
+                            null, new DeliveryContext(),
+                            Mailbox.ID_FOLDER_INBOX, true);
+            Integer itemId = mbox1.getItemIds(null, Mailbox.ID_FOLDER_INBOX).getIds(MailItem.Type.MESSAGE).get(0);
+            Message mdnMsg = mbox1.getMessageById(null, itemId);
+            for (Enumeration<Header> e = mdnMsg.getMimeMessage().getAllHeaders(); e.hasMoreElements();) {
+                Header temp = e.nextElement();
+                Assert.assertFalse(temp.getName().equals("X-My-Test"));
+                Assert.assertFalse(temp.getValue().equals("my-new-header-value"));
+            }
+        } catch (Exception e) {
+            fail("No exception should be thrown: " + e.getMessage());
+        }
+    }
 }

--- a/store/src/java-test/com/zimbra/cs/filter/ReplaceHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/ReplaceHeaderTest.java
@@ -1116,4 +1116,144 @@ public class ReplaceHeaderTest {
             fail("No exception should be thrown: " + e.getMessage());
         }
     }
+
+    /*
+     * Replace header with single space as new name, should not replace the original header
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testReplaceHeaderWithSinlgeSpaceAsHeaderNewName() {
+        try {
+            String filterScript = "require [\"editheader\"];\n"
+                    + " replaceheader :newname \" \" :newvalue \"0\" :value \"lt\" :comparator \"i;ascii-casemap\" \"X-Test-Header\" \"test2\" \r\n"
+                    + "  ;\n";
+            Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+            Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
+            RuleManager.clearCachedRules(acct1);
+            acct1.setMailSieveScript(filterScript);
+            RuleManager.applyRulesToIncomingMessage(
+                    new OperationContext(mbox1), mbox1, new ParsedMessage(
+                            sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
+                            null, new DeliveryContext(),
+                            Mailbox.ID_FOLDER_INBOX, true);
+            Integer itemId = mbox1.getItemIds(null, Mailbox.ID_FOLDER_INBOX).getIds(MailItem.Type.MESSAGE).get(0);
+            Message message = mbox1.getMessageById(null, itemId);
+            boolean found = false;
+            for (Enumeration<Header> enumeration = message.getMimeMessage().getAllHeaders(); enumeration.hasMoreElements();) {
+                Header header = enumeration.nextElement();
+                Assert.assertFalse(header.getName().equals(""));
+                if (header.getName().equals("X-Test-Header") && header.getValue().equals("test2")) {
+                    found = true;
+                }
+            }
+            Assert.assertTrue(found);
+        } catch (Exception e) {
+            fail("No exception should be thrown: " + e.getMessage());
+        }
+    }
+
+    /*
+     * Replace header with multiple spaces as new name, should not replace the original header
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testReplaceHeaderWithMultipleSpacesAsHeaderNewName() {
+        try {
+            String filterScript = "require [\"editheader\"];\n"
+                    + " replaceheader :newname \"    \" :newvalue \"0\" :value \"lt\" :comparator \"i;ascii-casemap\" \"X-Test-Header\" \"test2\" \r\n"
+                    + "  ;\n";
+            Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+            Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
+            RuleManager.clearCachedRules(acct1);
+            acct1.setMailSieveScript(filterScript);
+            RuleManager.applyRulesToIncomingMessage(
+                    new OperationContext(mbox1), mbox1, new ParsedMessage(
+                            sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
+                            null, new DeliveryContext(),
+                            Mailbox.ID_FOLDER_INBOX, true);
+            Integer itemId = mbox1.getItemIds(null, Mailbox.ID_FOLDER_INBOX).getIds(MailItem.Type.MESSAGE).get(0);
+            Message message = mbox1.getMessageById(null, itemId);
+            boolean found = false;
+            for (Enumeration<Header> enumeration = message.getMimeMessage().getAllHeaders(); enumeration.hasMoreElements();) {
+                Header header = enumeration.nextElement();
+                Assert.assertFalse(header.getName().equals(""));
+                if (header.getName().equals("X-Test-Header") && header.getValue().equals("test2")) {
+                    found = true;
+                }
+            }
+            Assert.assertTrue(found);
+        } catch (Exception e) {
+            fail("No exception should be thrown: " + e.getMessage());
+        }
+    }
+
+    /*
+     * Replace header with name starting with spaces as new name, should not replace the original header
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testReplaceHeaderStartingWithSpacesAsHeaderNewName() {
+        try {
+            String filterScript = "require [\"editheader\"];\n"
+                    + " replaceheader :newname \" asdf\" :newvalue \"0\" :value \"lt\" :comparator \"i;ascii-casemap\" \"X-Test-Header\" \"test2\" \r\n"
+                    + "  ;\n";
+            Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+            Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
+            RuleManager.clearCachedRules(acct1);
+            acct1.setMailSieveScript(filterScript);
+            RuleManager.applyRulesToIncomingMessage(
+                    new OperationContext(mbox1), mbox1, new ParsedMessage(
+                            sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
+                            null, new DeliveryContext(),
+                            Mailbox.ID_FOLDER_INBOX, true);
+            Integer itemId = mbox1.getItemIds(null, Mailbox.ID_FOLDER_INBOX).getIds(MailItem.Type.MESSAGE).get(0);
+            Message message = mbox1.getMessageById(null, itemId);
+            boolean found = false;
+            for (Enumeration<Header> enumeration = message.getMimeMessage().getAllHeaders(); enumeration.hasMoreElements();) {
+                Header header = enumeration.nextElement();
+                Assert.assertFalse(header.getName().equals(""));
+                if (header.getName().equals("X-Test-Header") && header.getValue().equals("test2")) {
+                    found = true;
+                }
+            }
+            Assert.assertTrue(found);
+        } catch (Exception e) {
+            fail("No exception should be thrown: " + e.getMessage());
+        }
+    }
+
+    /*
+     * Replace header with name starting with spaces as name, should not replace the original header
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testReplaceHeaderStartingWithSpacesAsHeaderName() {
+        try {
+            String filterScript = "require [\"editheader\"];\n"
+                    + " replaceheader :newname \"X-Test-New-Name\" :newvalue \"0\" :value \"lt\" :comparator \"i;ascii-casemap\" \" X-Test-Header\" \"test2\" \r\n"
+                    + "  ;\n";
+            Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+            Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
+            RuleManager.clearCachedRules(acct1);
+            acct1.setMailSieveScript(filterScript);
+            RuleManager.applyRulesToIncomingMessage(
+                    new OperationContext(mbox1), mbox1, new ParsedMessage(
+                            sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
+                            null, new DeliveryContext(),
+                            Mailbox.ID_FOLDER_INBOX, true);
+            Integer itemId = mbox1.getItemIds(null, Mailbox.ID_FOLDER_INBOX).getIds(MailItem.Type.MESSAGE).get(0);
+            Message message = mbox1.getMessageById(null, itemId);
+            boolean found = false;
+            for (Enumeration<Header> enumeration = message.getMimeMessage().getAllHeaders(); enumeration.hasMoreElements();) {
+                Header header = enumeration.nextElement();
+                Assert.assertFalse(header.getName().equals(""));
+                if (header.getName().equals("X-Test-Header") && header.getValue().equals("test2")) {
+                    found = true;
+                }
+            }
+            Assert.assertTrue(found);
+        } catch (Exception e) {
+            fail("No exception should be thrown: " + e.getMessage());
+        }
+    }
 }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/AddHeader.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/AddHeader.java
@@ -17,7 +17,6 @@
 package com.zimbra.cs.filter.jsieve;
 
 import java.io.UnsupportedEncodingException;
-
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Iterator;
@@ -28,6 +27,7 @@ import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeUtility;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.jsieve.Argument;
 import org.apache.jsieve.Arguments;
 import org.apache.jsieve.Block;
@@ -154,6 +154,10 @@ public class AddHeader extends AbstractCommand {
         }
 
         if (!StringUtil.isNullOrEmpty(headerName)) {
+            String tempHeaderName = StringUtils.stripStart(headerName, null);
+            if (!tempHeaderName.equals(headerName)) {
+                throw new SyntaxException("Header name must not start with spaces : \"" + headerName + "\"");
+            }
             if (!CharsetUtil.US_ASCII.equals(CharsetUtil.checkCharset(headerName, CharsetUtil.US_ASCII))) {
                 throw new SyntaxException("AddHeader:Header name must be printable ASCII only.");
             }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/EditHeaderExtension.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/EditHeaderExtension.java
@@ -29,6 +29,7 @@ import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeUtility;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.jsieve.Argument;
 import org.apache.jsieve.Arguments;
 import org.apache.jsieve.NumberArgument;
@@ -299,11 +300,15 @@ public class EditHeaderExtension {
                         arg = itr.next();
                         if (arg instanceof StringListArgument) {
                             StringListArgument sla = (StringListArgument) arg;
-                            String newName = sla.getList().get(0);
-                            if (StringUtil.isNullOrEmpty(newName)) {
+                            String origNewName = sla.getList().get(0);
+                            if (StringUtil.isNullOrEmpty(origNewName)) {
                                 throw new SyntaxException("New name must be present with :newname in replaceheader : " + arg);
                             }
-                            this.newName = newName;
+                            String newName2 = StringUtils.stripStart(origNewName, null);
+                            if (!newName2.equals(origNewName)) {
+                                throw new SyntaxException("New name must not start with spaces in :newname in replaceheader : " + arg);
+                            }
+                            this.newName = origNewName;
                         } else {
                             throw new SyntaxException("New name not provided with :newname in replaceheader : " + arg);
                         }
@@ -485,10 +490,16 @@ public class EditHeaderExtension {
      * @throws SyntaxException
      */
     public void commonValidation() throws SyntaxException {
-        if (this.key != null) {
+        if (!StringUtil.isNullOrEmpty(this.key)) {
+            String tempKey = StringUtils.stripStart(this.key, null);
+            if (!tempKey.equals(this.key)) {
+                throw new SyntaxException("Header name must not start with spaces : \"" + this.key + "\"");
+            }
             if (!CharsetUtil.US_ASCII.equals(CharsetUtil.checkCharset(this.key, CharsetUtil.US_ASCII))) {
                 throw new SyntaxException("key must be printable ASCII only.");
             }
+        } else {
+            throw new SyntaxException("EditHeaderExtension:Header name must be present.");
         }
         // relation comparator must be valid
         if (this.relationalComparator != null) {


### PR DESCRIPTION
Problem : header name used as space or starting with space should not be allowed.

Fix : left trimmed header name before validation.

Testing done : added unit tests for
1) addheader
    a) header name as single space should fail
    b) header name as multiple spaces should fail
    c) header name starting with space(s) should fail
2) replaceheader
    a) new header name as single space should fail
    b) new header name as multiple spaces should fail
    c) new header name starting with space(s) should fail
    d) header name mentioned as key should fail if same as a, b and c
3) deleteheader
    a) header name as single space should fail
    b) header name as multiple spaces should fail
    c) header name starting with space(s) should fail

Testing to be done by QA : verify all mentioned scenarios and do sanity around the same.