### PR TITLE
Feature/deploy all

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -575,4 +575,13 @@
       <ant dir="${client.dir}" target="deploy" inheritAll="false"/>
       <ant dir="${server.dir}" target="deploy" inheritAll="false"/>
     </target>
+
+    <target name="stop-webserver">
+      <ant dir="${server.dir}" target="stop-webserver" inheritAll="false"/>
+    </target>
+
+    <target name="start-webserver">
+      <ant  dir="${server.dir}" target="start-webserver" inheritAll="false"/>
+    </target>
+
 </project>

--- a/build.xml
+++ b/build.xml
@@ -18,4 +18,21 @@
       <ant dir="./client" target="clean" inheritAll="false"/>
       <ant dir="./store"  target="clean" inheritAll="false"/>
    </target>
+
+   <target name="undeploy-all">
+      <ant dir="./native" target="undeploy" inheritAll="false"/>
+      <ant dir="./common" target="undeploy-no-stop" inheritAll="false"/>
+      <ant dir="./soap" target="undeploy-no-stop" inheritAll="false"/>
+      <ant dir="./client" target="undeploy-no-stop" inheritAll="false"/>
+      <ant dir="./store" target="undeploy-no-stop" inheritAll="false"/>
+   </target>
+
+   <target name="deploy-all">
+      <ant dir="./native" target="deploy-no-start" inheritAll="false"/>
+      <ant dir="./common" target="deploy-no-start" inheritAll="false"/>
+      <ant dir="./soap"   target="deploy-no-start" inheritAll="false"/>
+      <ant dir="./client" target="deploy-no-start" inheritAll="false"/>
+      <ant dir="./store"  target="deploy" inheritAll="false"/>
+   </target>
+
 </project>

--- a/client/build.xml
+++ b/client/build.xml
@@ -1,6 +1,6 @@
 <project xmlns:ivy="antlib:org.apache.ivy.ant" name="zm-client" default="jar">
   <import file="../build-common.xml"/>
-  <target name="deploy" depends="jar,set-dev-version,undeploy">
+  <target name="deploy-no-start" depends="jar,set-dev-version,undeploy">
     <ant dir="${server.dir}" target="stop-webserver" inheritAll="false"/>
     <!-- untill zm* scripts are fixed to use versioned zm* jars, we have to deploy this with jar with a fixed name -->
     <copy file="${build.dir}/${jar.file}" tofile="${common.jars.dir}/zimbraclient.jar"/>
@@ -22,11 +22,12 @@
         <copy file="${build.dir}/${jar.file}" tofile="${jetty.webapps.dir}/service/WEB-INF/lib/${jar.file}"/>
       </then>
     </if>
-    <ant dir="${server.dir}" target="start-webserver" inheritAll="false"/>
+  </target>
+  <target name="deploy" depends="deploy-no-start">
+    <antcall target="start-webserver"/>
   </target>
   <!-- mailboxd will not start without zm-client library, so this target does not attempt to start it -->
-  <target name="undeploy">
-    <ant dir="${server.dir}" target="stop-webserver" inheritAll="false"/>
+  <target name="undeploy-no-stop">
     <delete>
       <fileset dir="${common.jars.dir}" includes="zm-client*.jar,zimbraclient*.jar"/>
       <fileset dir="${jetty.endorsed.jars.dir}" includes="zm-client*.jar,zimbraclient*.jar"/>
@@ -55,6 +56,9 @@
         </delete>
       </then>
     </if>
+  </target>
+  <target name="undeploy" depends="stop-webserver">
+    <antcall target="undeploy-no-stop"/>
   </target>
   <target name="jar" depends="compile" description="Creates the jar file">
     <antcall target="zimbra-jar">

--- a/common/build.xml
+++ b/common/build.xml
@@ -10,19 +10,26 @@
   </target>
 
   <!-- mailboxd will not start without zm-common library, so this target does not attempt to start it -->
-  <target name="undeploy">
-    <ant dir="${server.dir}" target="stop-webserver" inheritAll="false"/>
+  <target name="undeploy-no-stop">
     <delete quiet="true" verbose="true">
       <fileset dir="${common.jars.dir}" includes="zm-common*.jar,zimbracommon*.jar"/>
       <fileset dir="${jetty.common.jars.dir}" includes="zm-common*.jar,zimbracommon*.jar"/>
     </delete>
   </target>
 
+  <target name="undeploy" depends="stop-webserver">
+    <antcall target="undeploy-no-stop"/>
+  </target>
+
   <!-- relies on undeploy to stop the webserver -->
-  <target name="deploy" depends="jar,set-dev-version,undeploy">
+  <target name="deploy-no-start" depends="jar,set-dev-version,undeploy">
     <!-- until zm* scripts are fixed to use versioned zm* jars, we have to deploy this jar with a fixed name -->
     <copy file="${build.dir}/${jar.file}" tofile="${common.jars.dir}/zimbracommon.jar"/>
     <copy file="${build.dir}/${jar.file}" tofile="${jetty.common.jars.dir}/${jar.file}"/>
-    <ant dir="${server.dir}" target="start-webserver" inheritAll="false"/>
   </target>
+
+  <target name="deploy" depends="deploy-no-start">
+    <antcall target="start-webserver"/>
+  </target>
+
 </project>

--- a/native/build.xml
+++ b/native/build.xml
@@ -11,20 +11,26 @@
     </target>
 
   <!-- mailboxd will not start without zm-native library, so this target does not attempt to start it -->
-  <target name="undeploy">
-    <ant dir="${server.dir}" target="stop-webserver" inheritAll="false"/>
+  <target name="undeploy-no-stop">
     <delete verbose="true">
       <fileset dir="${common.jars.dir}" includes="zm-native*.jar,zimbra-native*.jar"/>
       <fileset dir="${jetty.common.jars.dir}" includes="zm-native*.jar,zimbra-native*.jar"/>
     </delete>
   </target>
 
+  <target name="undeploy" depends="stop-webserver">
+    <antcall target="undeploy-no-stop"/>
+  </target>
+
   <!-- relies on undeploy to stop the webserver -->
-  <target name="deploy" depends="jar,set-dev-version,undeploy">
+  <target name="deploy-no-start" depends="jar,set-dev-version,undeploy">
     <!-- until /opt/zimbra/bin/zm* scripts are fixed to use versioned zm-* jars, we have to deploy this jar with a fixed name -->
     <copy file="${build.dir}/${jar.file}" tofile="${common.jars.dir}/zimbra-native.jar"/>
     <copy file="${build.dir}/${jar.file}" tofile="${jetty.common.jars.dir}/${jar.file}"/>
-    <ant dir="${server.dir}" target="start-webserver" inheritAll="false"/>
+  </target>
+
+  <target name="deploy" depends="deploy-no-start">
+    <antcall target="start-webserver"/>
   </target>
 
   <path id="build.class.path">

--- a/soap/build.xml
+++ b/soap/build.xml
@@ -199,8 +199,8 @@
   </target>
 
   <!-- mailboxd will not start without zm-soap library, so this target does not attempt to start it -->
-  <target name="undeploy">
-    <ant dir="${server.dir}" target="stop-webserver" inheritAll="false"/>
+  <target name="undeploy-no-stop">
+
     <delete verbose="true">
       <fileset dir="${common.jars.dir}" includes="zm-soap*.jar,zimbrasoap*.jar"/>
       <fileset dir="${jetty.endorsed.jars.dir}" includes="zm-soap*.jar,zimbrasoap*.jar"/>
@@ -231,8 +231,12 @@
     </if>
   </target>
 
+  <target name="undeploy" depends="stop-webserver">
+    <antcall target="undeploy-no-stop"/>
+  </target>
+
   <!-- relies on undeploy to stop the webserver -->
-  <target name="deploy" depends="jar,set-dev-version,undeploy" description="Deploy">
+  <target name="deploy-no-start" depends="jar,set-dev-version,undeploy" description="Deploy">
     <!-- until zm* scripts are fixed to use versioned zm* jars, we have to deploy this jar with a fixed name -->
     <copy file="${build.dir}/${jar.file}" tofile="${common.jars.dir}/zimbrasoap.jar"/>
     <if>
@@ -253,6 +257,10 @@
         <copy file="${build.dir}/${jar.file}" tofile="${jetty.webapps.dir}/service/WEB-INF/lib/${jar.file}"/>
       </then>
     </if>
-    <ant dir="${server.dir}" target="start-webserver" inheritAll="false"/>
   </target>
+
+  <target name="deploy" depends="deploy-no-start">
+    <antcall target="start-webserver"/>
+  </target>
+
 </project>

--- a/store/build.xml
+++ b/store/build.xml
@@ -170,8 +170,7 @@
   <target name="clean" description="Deletes classes from build directories">
     <delete dir="${build.dir}"/>
   </target>
-  <target name="undeploy">
-    <antcall target="stop-webserver"/>
+  <target name="undeploy-no-stop">
     <delete>
       <fileset dir="${common.jars.dir}" includes="zm-store*.jar,zimbrastore*.jar"/>
     </delete>
@@ -199,6 +198,9 @@
         </delete>
       </then>
     </if>
+  </target>
+  <target name="undeploy" depends="stop-webserver">
+    <antcall target="undeploy-no-stop"/>
   </target>
   <target name="deploy" depends="jar,set-dev-version,undeploy">
     <copy file="${build.dir}/${jar.file}" tofile="${common.jars.dir}/zimbrastore.jar"/>


### PR DESCRIPTION
I got tired of having to wait for the webserver to stop and start again as it deployed each of the 5 pieces of the zm-mailbox project.

This update adds two new ant targets to the zm-mailbox / build.xml:
 - `deploy-all`
     * stops the webserver
     * deploys all 5 internal jar files
     * starts the webserver
- `undeploy-all`
     * stops the webserver
     * undeploys all 5 internal jar files


Note:  This is opened against `feature/imap` since that is where I was working at the time.  I felt it would help further development of the imap feature instead of being a 'feature' all on it's own.