### PR TITLE
ZMS-226: ZMailbox::setTags implementation

### DIFF
--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -6103,8 +6103,8 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
     @Override
     public void alterTag(OpContext octxt, Collection<ItemIdentifier> ids, String tagName, boolean addTag)
             throws ServiceException {
-        // Probably need to get the items and then do a tag operation on them
-        throw new UnsupportedOperationException("ZMailbox does not support method yet");
+        String idStr = itemIdsToString(ids);
+        doAction(itemAction(addTag ? "tag" : "!tag", idStr, null).addAttribute(MailConstants.A_TAG_NAMES, tagName));
     }
 
     @Override
@@ -6112,6 +6112,14 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
             throws ServiceException {
         // Probably need to get the items and then do a tag operation on them
         throw new UnsupportedOperationException("ZMailbox does not support method yet");
+    }
+
+    private static String itemIdsToString(Collection<ItemIdentifier> ids) {
+        List<String> itemIds = new ArrayList<String>();
+        for (ItemIdentifier itemIdentifer: ids) {
+            itemIds.add(itemIdentifer.toString());
+        }
+        return Joiner.on(",").join(itemIds);
     }
 
     @Override

--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -6110,8 +6110,12 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
     @Override
     public void setTags(OpContext octxt, Collection<ItemIdentifier> itemIds, int flags, Collection<String> tags)
             throws ServiceException {
-        // Probably need to get the items and then do a tag operation on them
-        throw new UnsupportedOperationException("ZMailbox does not support method yet");
+        String idStr = itemIdsToString(itemIds);
+        Element actionEl = itemAction("update", idStr, null);
+        String tagList = Joiner.on(",").join(tags);
+        actionEl.addAttribute(MailConstants.A_TAG_NAMES, tagList);
+        actionEl.addAttribute(MailConstants.A_FLAGS, String.valueOf(flags));
+        doAction(actionEl);
     }
 
     private static String itemIdsToString(Collection<ItemIdentifier> ids) {

--- a/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
@@ -190,11 +190,14 @@ public class ItemAction extends MailDocumentHandler {
                 localResults = ItemActionHelper.RENAME(octxt, mbox, responseProto, local, type, tcon, name, iidFolder).getResult();
             } else if (opStr.equals(MailConstants.OP_UPDATE)) {
                 String folderId = action.getAttribute(MailConstants.A_FOLDER, null);
-                ItemId iidFolder = new ItemId(folderId == null ? "-1" : folderId, zsc);
-                if (!iidFolder.belongsTo(mbox)) {
-                    throw ServiceException.INVALID_REQUEST("cannot move item between mailboxes", null);
-                } else if (folderId != null && iidFolder.getId() <= 0) {
-                    throw MailServiceException.NO_SUCH_FOLDER(iidFolder.getId());
+                ItemId iidFolder = null;
+                if (folderId != null) {
+                    iidFolder = new ItemId(folderId, zsc);
+                    if (!iidFolder.belongsTo(mbox)) {
+                        throw ServiceException.INVALID_REQUEST("cannot move item between mailboxes", null);
+                    } else if (iidFolder.getId() <= 0) {
+                        throw MailServiceException.NO_SUCH_FOLDER(iidFolder.getId());
+                    }
                 }
                 String name = action.getAttribute(MailConstants.A_NAME, null);
                 String flags = action.getAttribute(MailConstants.A_FLAGS, null);

--- a/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
@@ -422,7 +422,7 @@ public class ItemActionHelper {
     protected OperationContext getOpCtxt() { return mOpCtxt; }
 
     protected void schedule() throws ServiceException {
-        boolean targeted = mOperation == Op.MOVE || mOperation == Op.SPAM || mOperation == Op.COPY || mOperation == Op.RENAME || mOperation == Op.UPDATE;
+        boolean targeted = mOperation == Op.MOVE || mOperation == Op.SPAM || mOperation == Op.COPY || mOperation == Op.RENAME || (mOperation == Op.UPDATE && mIidFolder != null);
 
         // deal with local mountpoints pointing at local folders here
         if (targeted && mIidFolder.belongsTo(mMailbox) && mIidFolder.getId() > 0 && mIidFolder.getId() != Mailbox.ID_FOLDER_TRASH && mIidFolder.getId() != Mailbox.ID_FOLDER_SPAM) {
@@ -508,7 +508,7 @@ public class ItemActionHelper {
                     for (int id : ids) {
                         getMailbox().rename(getOpCtxt(), id, type, mName, mIidFolder.getId());
                     }
-                } else if (mIidFolder.getId() > 0) {
+                } else if (mIidFolder != null && mIidFolder.getId() > 0) {
                     getMailbox().move(getOpCtxt(), ids, type, mIidFolder.getId(), mTargetConstraint);
                 }
                 if (mTags != null || mFlags != null) {

--- a/store/src/java/com/zimbra/qa/unittest/TestZClient.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestZClient.java
@@ -575,6 +575,29 @@ public class TestZClient extends TestCase {
         assertFalse(msg.isUnread());
     }
 
+    @Test
+    public void testSetTags() throws Exception {
+        ZMailbox zmbox = TestUtil.getZMailbox(USER_NAME);
+        Mailbox mbox = TestUtil.getMailbox(USER_NAME);
+        Message msg = TestUtil.addMessage(mbox, Mailbox.ID_FOLDER_INBOX, "testAlterTag message", System.currentTimeMillis());
+        ZTag tag1 = zmbox.createTag("testSetTags tag1", ZTag.Color.blue);
+        Collection<ItemIdentifier> ids = new ArrayList<ItemIdentifier>(1);
+        ids.add(new ItemIdentifier(mbox.getAccountId(), msg.getId()));
+
+        //add tag via zmailbox
+        zmbox.alterTag(null, ids, tag1.getName(), true);
+        assertTrue(msg.isTagged(tag1.getName()));
+
+        //override via setTags
+        Collection<String> newTags = new ArrayList<String>();
+        newTags.add("testSetTags tag2");
+        newTags.add("testSetTags tag3");
+        zmbox.setTags(null, ids, 0, newTags);
+        assertFalse(msg.isTagged("testSetTags tag1"));
+        assertTrue(msg.isTagged("testSetTags tag2"));
+        assertTrue(msg.isTagged("testSetTags tag3"));
+    }
+
     private void compareMsgAndZMsg(String testname, Message msg, ZMessage zmsg) throws IOException, ServiceException {
         assertNotNull("Message is null", msg);
         assertNotNull("ZMessage is null", zmsg);

--- a/store/src/java/com/zimbra/qa/unittest/TestZClient.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestZClient.java
@@ -21,12 +21,16 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+
+import junit.framework.Assert;
+import junit.framework.TestCase;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
@@ -41,6 +45,7 @@ import com.zimbra.client.ZMailbox.Options;
 import com.zimbra.client.ZMessage;
 import com.zimbra.client.ZPrefs;
 import com.zimbra.client.ZSignature;
+import com.zimbra.client.ZTag;
 import com.zimbra.common.account.Key.AccountBy;
 import com.zimbra.common.mailbox.ItemIdentifier;
 import com.zimbra.common.mailbox.MailItemType;
@@ -68,9 +73,6 @@ import com.zimbra.cs.mime.ParsedMessage;
 import com.zimbra.soap.account.message.ImapMessageInfo;
 import com.zimbra.soap.account.message.OpenIMAPFolderResponse;
 import com.zimbra.soap.mail.message.ItemActionResponse;
-
-import junit.framework.Assert;
-import junit.framework.TestCase;
 
 public class TestZClient extends TestCase {
     private static String NAME_PREFIX = "TestZClient";
@@ -547,6 +549,30 @@ public class TestZClient extends TestCase {
         ZMessage zmsg = zmbox.getMessageById(
                 ItemIdentifier.fromAccountIdAndItemId(mbox.getAccountId(), msg.getId()), true, 0);
         compareMsgAndZMsg(testNam, msg, zmsg);
+    }
+
+    @Test
+    public void testAlterTag() throws Exception {
+        ZMailbox zmbox = TestUtil.getZMailbox(USER_NAME);
+        Mailbox mbox = TestUtil.getMailbox(USER_NAME);
+        Message msg = TestUtil.addMessage(mbox, Mailbox.ID_FOLDER_INBOX, "testAlterTag message", System.currentTimeMillis());
+        ZTag tag = zmbox.createTag("testAlterTag tag", ZTag.Color.blue);
+        Collection<ItemIdentifier> ids = new ArrayList<ItemIdentifier>(1);
+        ids.add(new ItemIdentifier(mbox.getAccountId(), msg.getId()));
+
+        //add tag via zmailbox
+        zmbox.alterTag(null, ids, tag.getName(), true);
+        assertTrue(msg.isTagged(tag.getName()));
+
+        //remove tag via zmailbox
+        zmbox.alterTag(null, ids, tag.getName(), false);
+        assertFalse(msg.isTagged(tag.getName()));
+
+        //test setting/unsetting unread flag
+        zmbox.alterTag(null, ids, "\\Unread", true);
+        assertTrue(msg.isUnread());
+        zmbox.alterTag(null, ids, "\\Unread", false);
+        assertFalse(msg.isUnread());
     }
 
     private void compareMsgAndZMsg(String testname, Message msg, ZMessage zmsg) throws IOException, ServiceException {


### PR DESCRIPTION
Implemented _ZMailbox::setTags_ method, with corresponding unit test. This was a little more tricky than alterTag, since the ItemAction SOAP handler used to require the folderId to be included in the request in order to perform a tag update operation, while _MailboxStore.setTags_ does not include it. I updated the server code as follows:
1. ItemAction::handleCommon allows for iidFolder to remain null.
2. ItemActionHelper::schedule does not set targeted=true if the operation is UPDATE but the folder id is null.

The SOAP docs do not state that the folder ID is required for the "update tags" operation, so this change actually makes the ItemActionRequest API consistent with the documentation:

> For op="update", caller can specify any or all of: l="{folder}", name="{name}", color="{color}",
> tn="{tag-names}", f="{flags}".  When modifying tags or flags, all specified tags and flags are set, and all others are unset.