### PR TITLE
ZCS-1076 Filter in user preferences is not deactivated

### DIFF
--- a/store/src/java/com/zimbra/cs/filter/FolderDeleted.java
+++ b/store/src/java/com/zimbra/cs/filter/FolderDeleted.java
@@ -52,7 +52,7 @@ extends SieveVisitor {
 
     @Override
     protected void visitFileIntoAction(Node node, VisitPhase phase, RuleProperties props,
-                                       String folderPath) {
+                                       String folderPath, boolean copy) {
         if (phase != VisitPhase.begin) {
             return;
         }

--- a/store/src/java/com/zimbra/cs/filter/FolderRenamer.java
+++ b/store/src/java/com/zimbra/cs/filter/FolderRenamer.java
@@ -38,7 +38,7 @@ class FolderRenamer extends SieveVisitor {
     }
     
     @Override
-    protected void visitFileIntoAction(Node node, VisitPhase phase, RuleProperties props, String folderPath)
+    protected void visitFileIntoAction(Node node, VisitPhase phase, RuleProperties props, String folderPath, boolean copy)
     throws ServiceException {
         if (phase != SieveVisitor.VisitPhase.begin || folderPath == null) {
             return;


### PR DESCRIPTION
This is a regression from ZCS-422:Support for copy extension in FileInto/Redirect FilterActions

The visitFileIntoAction method in SieveVisitor has been overloaded with a additional boolean parameter required for supporting copy extension. The sub classes FolderDeleted and FolderRenamer classes were still overriding the old method. Hence, the method from these sub classes are not getting called if a folder is deleted or renamed.
Adding the boolean parameter to visitFileIntoAction in FolderDeleted and FolderRenamer will fixes the issue.

Manual testing done.
 - Create a filter from ZWC->Preferences->Filters
 - Deleting the folder should deactivate the filter
 - Renaming the folder should update the the sieve script with the new folder name

Automation is to be done