### PR TITLE
ZMS-361 ensure messages have a delivered date

### DIFF
--- a/store/src/java/com/zimbra/qa/unittest/TestUtil.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestUtil.java
@@ -387,7 +387,8 @@ public class TestUtil extends Assert {
     public static String addMessage(ZMailbox mbox, String subject, String folderId, String flags)
             throws ServiceException, IOException, MessagingException {
         String message = getTestMessage(subject);
-        return mbox.addMessage(folderId, flags, null, 0, message, true);
+        long millis = System.currentTimeMillis() % 1000;
+        return mbox.addMessage(folderId, flags, null, millis, message, true);
     }
 
     public static String addRawMessage(ZMailbox mbox, String rawMessage) throws ServiceException {


### PR DESCRIPTION
The error this was attempting to address no longer occurs for me with or without this patch but adding an explicit date to the messages delivered using the TestUtil was Ilya's suggestion.  

`<RunUnitTestsResponse numFailed="1" numSkipped="0" numExecuted="1" xmlns="urn:zimbraAdmin">
  <results>
    <failure name="testListFolderContents" class="com.zimbra.qa.unittest.TestRemoteImapShared" execSeconds="0.66">Internal date</failure>
  </results>
</RunUnitTestsResponse>`

The error looks like this. 
