### PR TITLE
ZCS-842:fix sieveToJava regex as per RFC 5229

### DIFF
--- a/store/src/java-test/com/zimbra/cs/filter/FilterUtilTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/FilterUtilTest.java
@@ -233,8 +233,7 @@ public class FilterUtilTest {
 
     @Test
     public void testToJavaRegex() {
-    	String regex = FilterUtil.sieveToJavaRegex("coyote@**.com");
-    	Assert.assertEquals("coyote@(.*)?(.*)?\\.com", regex);
-    	
+        String regex = FilterUtil.sieveToJavaRegex("coyote@**.com");
+        Assert.assertEquals("coyote@(.*?)(.*)\\.com", regex);
     }
 }

--- a/store/src/java/com/zimbra/cs/filter/FilterUtil.java
+++ b/store/src/java/com/zimbra/cs/filter/FilterUtil.java
@@ -38,6 +38,7 @@ import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.jsieve.exception.SyntaxException;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -964,15 +965,27 @@ public final class FilterUtil {
      */
     public static String sieveToJavaRegex(String pattern) {
         int ch;
+        boolean singleOccurrence = false;
+        int starWildCardCount = StringUtils.countMatches(pattern, "*");
+        if (starWildCardCount == 1) {
+            singleOccurrence = true;
+        }
+
         StringBuffer buffer = new StringBuffer(2 * pattern.length());
         for (ch = 0; ch < pattern.length(); ch++) {
             final char nextChar = pattern.charAt(ch);
             switch (nextChar) {
             case '*':
-                //
-                // Java Matcher has issues with repeated stars
-                //
-                buffer.append("(.*)?");
+                //If there are two or more wildcards,all wildcards should be non-greedy except the last wildcard.
+                //If there is only one wildcard in the sieve pattern, it is set as a greedy wildcard.
+                if (singleOccurrence) {
+                    buffer.append("(.*)");
+                } else if (starWildCardCount > 1) {
+                    buffer.append("(.*?)");
+                } else {
+                    buffer.append("(.*)");
+                }
+                starWildCardCount--;
                 break;
             case '?':
                 buffer.append("(.)");

--- a/store/src/java/com/zimbra/cs/filter/FilterUtil.java
+++ b/store/src/java/com/zimbra/cs/filter/FilterUtil.java
@@ -965,11 +965,7 @@ public final class FilterUtil {
      */
     public static String sieveToJavaRegex(String pattern) {
         int ch;
-        boolean singleOccurrence = false;
         int starWildCardCount = StringUtils.countMatches(pattern, "*");
-        if (starWildCardCount == 1) {
-            singleOccurrence = true;
-        }
 
         StringBuffer buffer = new StringBuffer(2 * pattern.length());
         for (ch = 0; ch < pattern.length(); ch++) {
@@ -978,9 +974,7 @@ public final class FilterUtil {
             case '*':
                 //If there are two or more wildcards,all wildcards should be non-greedy except the last wildcard.
                 //If there is only one wildcard in the sieve pattern, it is set as a greedy wildcard.
-                if (singleOccurrence) {
-                    buffer.append("(.*)");
-                } else if (starWildCardCount > 1) {
+                if (starWildCardCount > 1) {
                     buffer.append("(.*?)");
                 } else {
                     buffer.append("(.*)");


### PR DESCRIPTION
If there are two or more "*" wildcards in the sieve matching pattern, all wildcards should match non-greedy except the last wildcard. If there is only one wildcard in the sieve pattern, it should be greedy match.

Testing Done: Added JUnit tests for various scenarios tested.