### PR TITLE
ZCS-1099:correct the comparator validation for count match type

### DIFF
--- a/store/src/java/com/zimbra/cs/filter/SoapToSieve.java
+++ b/store/src/java/com/zimbra/cs/filter/SoapToSieve.java
@@ -401,17 +401,13 @@ public final class SoapToSieve {
         try {
             Integer.parseInt(value);
         } catch (NumberFormatException e) {
-            if (isCount) {
-                throw ServiceException.INVALID_REQUEST("Invalid Value: " + value, e);
-            } else {
-                numeric = false;
-            }
+            numeric = false;
         }
         //for :count, iasciinumeric comparator will be used always.
         //for :value, iasciinumeric comparator will be used if value is numeric else
-        //iasciicasemap will be used.
+        //iasciicasemap will be used until comparator value can be set from soap api.
         Sieve.Comparator comparator= Sieve.Comparator.iasciinumeric;
-        if (!numeric) {
+        if (!numeric && !isCount) {
             comparator= Sieve.Comparator.iasciicasemap;
         }
         if (part == null) {


### PR DESCRIPTION
1. removed numeric value check for count as non-numeric value is allowed and should be considered as positive infinity for i;ascii-numeric comparator.
2. modified comparator check to just validate that for count match type, only i;ascii-numeric comparator value is valid.

Testing Done: 
1. tested the scenario mentioned in bug, no null pointer exception thrown.
2. tested non-numeric value is getting set from soap api for count.
3. tested error is thrown if comparator other than i;ascii-numeric is used with count.