### PR TITLE
Feature/zms 568installer ephem url

### DIFF
--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProv.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProv.java
@@ -27,37 +27,36 @@ import com.zimbra.cs.account.Domain;
 import com.zimbra.cs.account.Entry;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.auth.AuthMechanism.AuthMech;
-import com.zimbra.cs.account.ldap.LdapHelper;
 import com.zimbra.cs.ldap.LdapClient;
+import com.zimbra.cs.ldap.LdapTODO.TODO;
 import com.zimbra.cs.ldap.SearchLdapOptions;
 import com.zimbra.cs.ldap.ZLdapFilter;
-import com.zimbra.cs.ldap.LdapTODO.*;
 import com.zimbra.cs.mime.MimeTypeInfo;
 
 /**
- * 
+ *
  * @author pshao
  *
  */
 public abstract class LdapProv extends Provisioning {
-    
+
     protected LdapDIT mDIT;
     protected LdapHelper helper;
-       
+
     protected LdapProv() {
         LdapClient.initialize();
     }
-    
+
     public static LdapProv getInst() throws ServiceException {
         Provisioning prov = Provisioning.getInstance();
-        
+
         if (prov instanceof LdapProv) {
             return (LdapProv) prov;
         } else {
             throw ServiceException.FAILURE("not an instance of LdapProv", null);
         }
     }
-    
+
     protected void setDIT() {
         mDIT = new LdapDIT(this);
     }
@@ -65,15 +64,15 @@ public abstract class LdapProv extends Provisioning {
     public LdapDIT getDIT() {
         return mDIT;
     }
-    
+
     protected void setHelper(LdapHelper helper) {
         this.helper = helper;
     }
-    
+
     public LdapHelper getHelper() {
         return helper;
     }
-    
+
     public abstract int getAccountCacheSize();
     public abstract double getAccountCacheHitRate();
     public abstract int getCosCacheSize();
@@ -90,60 +89,60 @@ public abstract class LdapProv extends Provisioning {
     public abstract double getGroupCacheHitRate();
     public abstract int getXMPPCacheSize();
     public abstract double getXMPPCacheHitRate();
-    
-    
+
+
     public abstract void waitForLdapServer();
     public abstract void alwaysUseMaster();
-    
+
     public abstract void dumpLdapSchema(PrintWriter pw) throws ServiceException;
-    
+
     public abstract void renameDomain(String domainId, String newDomainName)
     throws ServiceException;
-    
+
     public abstract void searchOCsForSuperClasses(Map<String, Set<String>> ocs);
-    public abstract void getAttrsInOCs(String[] ocs, Set<String> attrsInOCs) 
+    public abstract void getAttrsInOCs(String[] ocs, Set<String> attrsInOCs)
     throws ServiceException;
-    
-    public abstract List<MimeTypeInfo> getAllMimeTypesByQuery() 
+
+    public abstract List<MimeTypeInfo> getAllMimeTypesByQuery()
     throws ServiceException;
-    public abstract List<MimeTypeInfo> getMimeTypesByQuery(String mimeType) 
+    public abstract List<MimeTypeInfo> getMimeTypesByQuery(String mimeType)
     throws ServiceException;
-    
-    public abstract void externalLdapAuth(Domain domain, AuthMech authMech, Account acct, 
-            String password, Map<String, Object> authCtxt) 
+
+    public abstract void externalLdapAuth(Domain domain, AuthMech authMech, Account acct,
+            String password, Map<String, Object> authCtxt)
     throws ServiceException;
-    
-    
-    public abstract void externalLdapAuth(Domain domain, AuthMech authMech, String principal, 
-            String password, Map<String, Object> authCtxt) 
+
+
+    public abstract void externalLdapAuth(Domain domain, AuthMech authMech, String principal,
+            String password, Map<String, Object> authCtxt)
     throws ServiceException;
-    
+
     /**
      * Authenticate to Zimbra LDAP server with bind DN and password.
      * Used when stored password is not SSHA.
      */
-    public abstract void zimbraLdapAuthenticate(Account acct, String password, 
+    public abstract void zimbraLdapAuthenticate(Account acct, String password,
             Map<String, Object> authCtxt)
     throws ServiceException;
-    
+
     public abstract void removeFromCache(Entry entry);
-    
+
     @TODO  // deprecate
-    public abstract void searchLdapOnMaster(String base, String filter, 
-            String[] returnAttrs, SearchLdapOptions.SearchLdapVisitor visitor) 
+    public abstract void searchLdapOnMaster(String base, String filter,
+            String[] returnAttrs, SearchLdapOptions.SearchLdapVisitor visitor)
     throws ServiceException;
-    
-    public abstract void searchLdapOnMaster(String base, ZLdapFilter filter, 
-            String[] returnAttrs, SearchLdapOptions.SearchLdapVisitor visitor) 
+
+    public abstract void searchLdapOnMaster(String base, ZLdapFilter filter,
+            String[] returnAttrs, SearchLdapOptions.SearchLdapVisitor visitor)
     throws ServiceException;
 
     @TODO  // deprecate
-    public abstract void searchLdapOnReplica(String base, String filter, 
-            String[] returnAttrs, SearchLdapOptions.SearchLdapVisitor visitor) 
+    public abstract void searchLdapOnReplica(String base, String filter,
+            String[] returnAttrs, SearchLdapOptions.SearchLdapVisitor visitor)
     throws ServiceException;
-    
-    public abstract void searchLdapOnReplica(String base, ZLdapFilter filter, 
-            String[] returnAttrs, SearchLdapOptions.SearchLdapVisitor visitor) 
+
+    public abstract void searchLdapOnReplica(String base, ZLdapFilter filter,
+            String[] returnAttrs, SearchLdapOptions.SearchLdapVisitor visitor)
     throws ServiceException;
 
 }

--- a/store/src/java/com/zimbra/cs/ephemeral/EphemeralStore.java
+++ b/store/src/java/com/zimbra/cs/ephemeral/EphemeralStore.java
@@ -312,7 +312,8 @@ public abstract class EphemeralStore {
         try {
             theFactory.test(url);
         } catch (ServiceException e) {
-            ZimbraLog.ephemeral.error("cannot set '%s' to '%s'", Provisioning.A_zimbraEphemeralBackendURL, url);
+            ZimbraLog.ephemeral.error("cannot set '%s' to '%s' (%s)", Provisioning.A_zimbraEphemeralBackendURL,
+                    url, e.getMessage());
             return false;
         }
         ZimbraLog.ephemeral.debug("Successfully connected to URL '%s'.  Valid value for '%s'",

--- a/store/src/java/com/zimbra/cs/ldap/LdapClient.java
+++ b/store/src/java/com/zimbra/cs/ldap/LdapClient.java
@@ -31,36 +31,36 @@ import com.zimbra.cs.util.Zimbra;
  * @author pshao
  */
 public abstract class LdapClient {
-    
+
     private static LdapClient ldapClient;
     private static boolean ALWAYS_USE_MASTER = false;
-    
+
      static synchronized LdapClient getInstance() {
         if (ldapClient == null) {
-            
+
             if (InMemoryLdapServer.isOn()) {
                 try {
-                    InMemoryLdapServer.start(InMemoryLdapServer.ZIMBRA_LDAP_SERVER, 
+                    InMemoryLdapServer.start(InMemoryLdapServer.ZIMBRA_LDAP_SERVER,
                             new InMemoryLdapServer.ServerConfig(
                             Lists.newArrayList(LdapConstants.ATTR_dc + "=" + InMemoryLdapServer.UNITTEST_BASE_DOMAIN_SEGMENT)));
                 } catch (Exception e) {
                     ZimbraLog.system.error("could not start InMemoryLdapServer", e);
                 }
             }
-            
+
             String className = LC.zimbra_class_ldap_client.value();
             if (className != null && !className.equals("")) {
                 try {
                     ldapClient = (LdapClient) Class.forName(className).newInstance();
                 } catch (Exception e) {
-                    ZimbraLog.system.error("could not instantiate LDAP client '" + className + 
+                    ZimbraLog.system.error("could not instantiate LDAP client '" + className +
                             "'; defaulting to JNDI LDAP SDK", e);
                 }
             }
             if (ldapClient == null) {
                 ldapClient = new UBIDLdapClient();
             }
-            
+
             try {
                 ldapClient.init(ALWAYS_USE_MASTER);
             } catch (LdapException e) {
@@ -69,49 +69,47 @@ public abstract class LdapClient {
         }
         return ldapClient;
     }
-     
+
     private static synchronized void unsetInstance() {
         ldapClient = null;
     }
-    
-    
+
     public static synchronized void masterOnly() {
         ALWAYS_USE_MASTER = true;
-        
+
         if (ldapClient != null) {
             // already initialized
             ldapClient.alwaysUseMaster();
         }
     }
-    
+
     public static void initialize() {
         LdapClient.getInstance();
     }
-    
+
     // called from unittest only
     public static void shutdown() {
         LdapClient.getInstance().terminate();
         unsetInstance();
     }
-    
+
     public static ZLdapContext toZLdapContext(
             com.zimbra.cs.account.Provisioning prov, ILdapContext ldapContext) {
-        
+
         if (!(getInstance() instanceof UBIDLdapClient)) {
-            Zimbra.halt("LdapClient instance is not UBIDLdapClient", 
+            Zimbra.halt("LdapClient instance is not UBIDLdapClient",
                     ServiceException.FAILURE("internal error, wrong ldap context instance", null));
         }
-        
+
         // just a safety check, this should really not happen at this point
         if (ldapContext != null && !(ldapContext instanceof ZLdapContext)) {
-            Zimbra.halt("ILdapContext instance is not ZLdapContext", 
+            Zimbra.halt("ILdapContext instance is not ZLdapContext",
                     ServiceException.FAILURE("internal error, wrong ldap context instance", null));
         }
-        
+
         return (ZLdapContext)ldapContext;
     }
-    
-    
+
     /*
      * ========================================================
      * static methods just to short-hand the getInstance() call
@@ -120,86 +118,86 @@ public abstract class LdapClient {
     public static void waitForLdapServer() {
         getInstance().waitForLdapServerImpl();
     }
-    
+
     public static ZLdapContext getContext(LdapUsage usage) throws ServiceException {
         return getContext(LdapServerType.REPLICA, usage);
     }
-    
-    public static ZLdapContext getContext(LdapServerType serverType, LdapUsage usage) 
+
+    public static ZLdapContext getContext(LdapServerType serverType, LdapUsage usage)
     throws ServiceException {
         return getInstance().getContextImpl(serverType, usage);
     }
-    
+
     public static ZLdapContext getContext(LdapServerType serverType, boolean useConnPool,
-            LdapUsage usage) 
+            LdapUsage usage)
     throws ServiceException {
         return getInstance().getContextImpl(serverType, useConnPool, usage);
     }
-    
+
     /**
-     * For zmconfigd only.  
-     * 
-     * zmconfigd uses ldapi connection with root LDAP bind DN/password to bind to 
-     * Zimbra OpenLdap, whereas LdapClient.getContext() methods use LC keys for 
+     * For zmconfigd only.
+     *
+     * zmconfigd uses ldapi connection with root LDAP bind DN/password to bind to
+     * Zimbra OpenLdap, whereas LdapClient.getContext() methods use LC keys for
      * the URL/bind DN/password.
-     * 
-     * Changing LC keys in  zmconfigd is not an option, because it also uses 
+     *
+     * Changing LC keys in  zmconfigd is not an option, because it also uses
      * LdapProvisioing, which uses the LC settings.
-     * 
-     * We could have zmconfigd call getExternalContext with a ExternalLdapConfig, which 
+     *
+     * We could have zmconfigd call getExternalContext with a ExternalLdapConfig, which
      * takes URL/bind DN/password from parameters.  But the name "external" is misleading.
-     * 
-     * This method id just a wrapper around LdapClient.getExternalContext, the sole 
+     *
+     * This method id just a wrapper around LdapClient.getExternalContext, the sole
      * purpose is masking out the "external" in method/parameter names.
-     * 
+     *
      * @param ldapConfig
      * @param usage
      * @return
      * @throws ServiceException
      */
     public static ZLdapContext getContext(GenericLdapConfig ldapConfig,
-            LdapUsage usage) 
+            LdapUsage usage)
     throws ServiceException {
         return getInstance().getExternalContextImpl(ldapConfig, usage);
     }
-    
+
     public static ZLdapContext getExternalContext(ExternalLdapConfig ldapConfig,
-            LdapUsage usage) 
+            LdapUsage usage)
     throws ServiceException {
         return getInstance().getExternalContextImpl(ldapConfig, usage);
     }
-    
+
     public static void closeContext(ZLdapContext lctxt) {
         if (lctxt != null) {
             lctxt.closeContext(false);
         }
     }
-    
+
     public static ZMutableEntry createMutableEntry() {
         return getInstance().createMutableEntryImpl();
     }
-    
-    public static void externalLdapAuthenticate(String urls[], boolean wantStartTLS, 
-            String bindDN, String password, String note) 
+
+    public static void externalLdapAuthenticate(String urls[], boolean wantStartTLS,
+            String bindDN, String password, String note)
     throws ServiceException {
-        getInstance().externalLdapAuthenticateImpl(urls, wantStartTLS, 
+        getInstance().externalLdapAuthenticateImpl(urls, wantStartTLS,
                 bindDN, password, note);
     }
-    
+
     /**
      * LDAP authenticate to the Zimbra LDAP server.
      * Used when stored password is not SSHA.
-     * 
+     *
      * @param principal
      * @param password
      * @param note
      * @throws ServiceException
      */
-    public static void zimbraLdapAuthenticate(String bindDN, String password) 
+    public static void zimbraLdapAuthenticate(String bindDN, String password)
     throws ServiceException {
         getInstance().zimbraLdapAuthenticateImpl(bindDN, password);
     }
-    
+
     /*
      * ========================================================
      * abstract methods
@@ -209,38 +207,38 @@ public abstract class LdapClient {
         ZSearchScope.init(getSearchScopeFactoryInstance());
         ZLdapFilterFactory.setInstance(getLdapFilterFactoryInstance());
     }
-    
+
     protected abstract void terminate();
-    
+
     protected abstract void alwaysUseMaster();
-    
-    protected abstract ZSearchScopeFactory getSearchScopeFactoryInstance(); 
-    
-    protected abstract ZLdapFilterFactory getLdapFilterFactoryInstance() 
+
+    protected abstract ZSearchScopeFactory getSearchScopeFactoryInstance();
+
+    protected abstract ZLdapFilterFactory getLdapFilterFactoryInstance()
     throws LdapException;
-    
+
     protected abstract void waitForLdapServerImpl();
-    
-    protected abstract ZLdapContext getContextImpl(LdapServerType serverType, LdapUsage usage) 
+
+    protected abstract ZLdapContext getContextImpl(LdapServerType serverType, LdapUsage usage)
     throws ServiceException;
-    
-    protected abstract ZLdapContext getContextImpl(LdapServerType serverType, 
-            boolean useConnPool, LdapUsage usage) 
+
+    protected abstract ZLdapContext getContextImpl(LdapServerType serverType,
+            boolean useConnPool, LdapUsage usage)
     throws ServiceException;
-    
+
     protected abstract ZLdapContext getExternalContextImpl(ExternalLdapConfig ldapConfig,
-            LdapUsage usage) 
+            LdapUsage usage)
     throws ServiceException;
-    
+
     protected abstract ZMutableEntry createMutableEntryImpl();
-    
+
     protected abstract ZSearchControls createSearchControlsImpl(
             ZSearchScope searchScope, int sizeLimit, String[] returnAttrs);
-    
-    protected abstract void externalLdapAuthenticateImpl(String urls[], 
-            boolean wantStartTLS, String bindDN, String password, String note) 
+
+    protected abstract void externalLdapAuthenticateImpl(String urls[],
+            boolean wantStartTLS, String bindDN, String password, String note)
     throws ServiceException;
-    
-    protected abstract void zimbraLdapAuthenticateImpl(String bindDN, String password) 
+
+    protected abstract void zimbraLdapAuthenticateImpl(String bindDN, String password)
     throws ServiceException;
 }


### PR DESCRIPTION
Testing screenshot showing able to change URL.  Needs zm-ssdb-ephemeral-store changes too.

    Value for zimbraEphemeralBackendURL: ssdb:yak.fatkudu.co.uk:8888

    Common configuration

   1) Hostname:                                trusty.fatkudu.co.uk
   2) Ldap master host:                        yak.fatkudu.co.uk
   3) Ldap port:                               389
   4) Ldap Admin password:                     set
   5) LDAP Base DN:                            cn=zimbra
   6) Store ephemeral attributes outside Ldap: yes
   7) Value for zimbraEphemeralBackendURL:     ssdb:yak.fatkudu.co.uk:8888
   8) Secure interprocess communications:      yes
   9) TimeZone:                                Pacific/Bougainville
  10) IP Mode:                                 ipv4
  11) Default SSL digest:                      sha256
