### PR TITLE
ZCS-1088 : SIEVE: Any space(s) in header name should error out during…

### DIFF
--- a/store/src/java-test/com/zimbra/cs/filter/AddHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/AddHeaderTest.java
@@ -499,9 +499,16 @@ public class AddHeaderTest {
     @Test
     public void testAddHeaderNameStartingWithSpace() {
         try {
-           String filterScript = "require [\"editheader\"];\n"
-                    + " addheader \" X-My-Test\" \"my-new-header-value\" \r\n"
-                    + "  ;\n";
+//           String filterScript = "require [\"editheader\"];\n"
+//                    + " addheader \" X-My-Test\" \"my-new-header-value\" \r\n"
+//                    + "  ;\n";
+            String filterScript =
+                    "require [\"log\",\"fileinto\",\"tag\"];"
+                    + "addheader \"X-ZCS860-Header8\" \"  Val13\";"
+                    + "if header :comparator \"i;ascii-casemap\" :contains \"Subject\" \"sub12\" {"
+                    + "      deleteheader :comparator \"i;ascii-casemap\" :matches \"X-ZCS860-Header8\" \"  Val13\";"
+                    + "      tag \"tag12\";"
+                    + "}";
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
             RuleManager.clearCachedRules(acct1);

--- a/store/src/java-test/com/zimbra/cs/filter/AddHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/AddHeaderTest.java
@@ -499,16 +499,9 @@ public class AddHeaderTest {
     @Test
     public void testAddHeaderNameStartingWithSpace() {
         try {
-//           String filterScript = "require [\"editheader\"];\n"
-//                    + " addheader \" X-My-Test\" \"my-new-header-value\" \r\n"
-//                    + "  ;\n";
-            String filterScript =
-                    "require [\"log\",\"fileinto\",\"tag\"];"
-                    + "addheader \"X-ZCS860-Header8\" \"  Val13\";"
-                    + "if header :comparator \"i;ascii-casemap\" :contains \"Subject\" \"sub12\" {"
-                    + "      deleteheader :comparator \"i;ascii-casemap\" :matches \"X-ZCS860-Header8\" \"  Val13\";"
-                    + "      tag \"tag12\";"
-                    + "}";
+           String filterScript = "require [\"editheader\"];\n"
+                    + " addheader \" X-My-Test\" \"my-new-header-value\" \r\n"
+                    + "  ;\n";
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
             RuleManager.clearCachedRules(acct1);

--- a/store/src/java-test/com/zimbra/cs/filter/AddressTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/AddressTest.java
@@ -352,4 +352,79 @@ public class AddressTest {
             fail("No exception should be thrown");
         }
     }
+
+    @Test
+    public void compareHeaderNameWithLeadingSpaces() {
+        try {
+            Account acct = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+            RuleManager.clearCachedRules(acct);
+            Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+
+            String filterScript =
+                    "if address :is :comparator \"i;ascii-numeric\" \" To\" \"test1@zimbra.com\" {"
+                    + "  tag \"t1\";"
+                    + "}"
+                    ;
+
+            acct.setMailSieveScript(filterScript);
+            List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(
+                    new OperationContext(mbox), mbox, new ParsedMessage("To: test1@zimbra.com".getBytes(), false), 0,
+                    acct.getName(), new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
+            Assert.assertEquals(1, ids.size());
+            Message msg = mbox.getMessageById(null, ids.get(0).getId());
+            Assert.assertEquals(0, msg.getTags().length);
+        } catch (Exception e) {
+            fail("No exception should be thrown");
+        }
+    }
+
+    @Test
+    public void compareHeaderNameWithTrailingSpaces() {
+        try {
+            Account acct = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+            RuleManager.clearCachedRules(acct);
+            Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+
+            String filterScript =
+                    "if address :is :comparator \"i;ascii-numeric\" \"To \" \"test1@zimbra.com\" {"
+                    + "  tag \"t2\";"
+                    + "}"
+                    ;
+
+            acct.setMailSieveScript(filterScript);
+            List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(
+                    new OperationContext(mbox), mbox, new ParsedMessage("To: test1@zimbra.com".getBytes(), false), 0,
+                    acct.getName(), new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
+            Assert.assertEquals(1, ids.size());
+            Message msg = mbox.getMessageById(null, ids.get(0).getId());
+            Assert.assertEquals(0, msg.getTags().length);
+        } catch (Exception e) {
+            fail("No exception should be thrown");
+        }
+    }
+
+    @Test
+    public void compareHeaderNameWithLeadingAndTrailingSpaces() {
+        try {
+            Account acct = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+            RuleManager.clearCachedRules(acct);
+            Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+
+            String filterScript =
+                    "if address :is :comparator \"i;ascii-numeric\" \" To \" \"test1@zimbra.com\" {"
+                    + "  tag \"t3\";"
+                    + "}"
+                    ;
+
+            acct.setMailSieveScript(filterScript);
+            List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(
+                    new OperationContext(mbox), mbox, new ParsedMessage("To: test1@zimbra.com".getBytes(), false), 0,
+                    acct.getName(), new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
+            Assert.assertEquals(1, ids.size());
+            Message msg = mbox.getMessageById(null, ids.get(0).getId());
+            Assert.assertEquals(0, msg.getTags().length);
+        } catch (Exception e) {
+            fail("No exception should be thrown");
+        }
+    }
 }

--- a/store/src/java-test/com/zimbra/cs/filter/AddressTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/AddressTest.java
@@ -360,8 +360,8 @@ public class AddressTest {
             RuleManager.clearCachedRules(acct);
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
 
-            String filterScript =
-                    "if address :is :comparator \"i;ascii-numeric\" \" To\" \"test1@zimbra.com\" {"
+            String filterScript = "require [\"tag\"];\n"
+                    + "if address :is :comparator \"i;ascii-numeric\" \" To\" \"test1@zimbra.com\" {"
                     + "  tag \"t1\";"
                     + "}"
                     ;
@@ -385,8 +385,8 @@ public class AddressTest {
             RuleManager.clearCachedRules(acct);
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
 
-            String filterScript =
-                    "if address :is :comparator \"i;ascii-numeric\" \"To \" \"test1@zimbra.com\" {"
+            String filterScript = "require [\"tag\"];\n"
+                    + "if address :is :comparator \"i;ascii-numeric\" \"To \" \"test1@zimbra.com\" {"
                     + "  tag \"t2\";"
                     + "}"
                     ;
@@ -410,8 +410,8 @@ public class AddressTest {
             RuleManager.clearCachedRules(acct);
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
 
-            String filterScript =
-                    "if address :is :comparator \"i;ascii-numeric\" \" To \" \"test1@zimbra.com\" {"
+            String filterScript = "require [\"tag\"];\n"
+                    + "if address :is :comparator \"i;ascii-numeric\" \" To \" \"test1@zimbra.com\" {"
                     + "  tag \"t3\";"
                     + "}"
                     ;

--- a/store/src/java-test/com/zimbra/cs/filter/EnvelopeTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/EnvelopeTest.java
@@ -747,4 +747,109 @@ public class EnvelopeTest {
             fail("No exception should be thrown");
         }
     }
+
+    @Test
+    public void testHeaderNameWithLeadingSpace() {
+        String filterScript = "require \"envelope\";\n"
+                + "if envelope :matches \" TO\" \"*@zimbra.com\" {\n"
+                + "    tag \"t1\";\n"
+                + "}\n"
+                ;
+        LmtpEnvelope env = new LmtpEnvelope();
+        LmtpAddress sender = new LmtpAddress("<>", new String[] { "BODY", "SIZE" }, null);
+        LmtpAddress recipient = new LmtpAddress("<xyz@zimbra.com>", null, null);
+        env.setSender(sender);
+        env.addLocalRecipient(recipient);
+
+        try {
+            Provisioning prov = Provisioning.getInstance();
+            Account account = prov.createAccount("xyz@zimbra.com", "secret", new HashMap<String, Object>());
+            RuleManager.clearCachedRules(account);
+            Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(
+                    account);
+
+            account.setMailSieveScript(filterScript);
+            List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(
+                    new OperationContext(mbox), mbox,
+                    new ParsedMessage(sampleMsg.getBytes(), false), 0,
+                    account.getName(), env,
+                    new DeliveryContext(),
+                    Mailbox.ID_FOLDER_INBOX, true);
+            Assert.assertEquals(1, ids.size());
+            Message msg = mbox.getMessageById(null, ids.get(0).getId());
+            Assert.assertEquals(0, msg.getTags().length);
+        } catch (Exception e) {
+            fail("No exception should be thrown");
+        }
+    }
+
+    @Test
+    public void testHeaderNameWithTrailingSpace() {
+        String filterScript = "require \"envelope\";\n"
+                + "if envelope :matches \"TO \" \"*@zimbra.com\" {\n"
+                + "    tag \"t1\";\n"
+                + "}\n"
+                ;
+        LmtpEnvelope env = new LmtpEnvelope();
+        LmtpAddress sender = new LmtpAddress("<>", new String[] { "BODY", "SIZE" }, null);
+        LmtpAddress recipient = new LmtpAddress("<xyz@zimbra.com>", null, null);
+        env.setSender(sender);
+        env.addLocalRecipient(recipient);
+
+        try {
+            Provisioning prov = Provisioning.getInstance();
+            Account account = prov.createAccount("xyz@zimbra.com", "secret", new HashMap<String, Object>());
+            RuleManager.clearCachedRules(account);
+            Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(
+                    account);
+
+            account.setMailSieveScript(filterScript);
+            List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(
+                    new OperationContext(mbox), mbox,
+                    new ParsedMessage(sampleMsg.getBytes(), false), 0,
+                    account.getName(), env,
+                    new DeliveryContext(),
+                    Mailbox.ID_FOLDER_INBOX, true);
+            Assert.assertEquals(1, ids.size());
+            Message msg = mbox.getMessageById(null, ids.get(0).getId());
+            Assert.assertEquals(0, msg.getTags().length);
+        } catch (Exception e) {
+            fail("No exception should be thrown");
+        }
+    }
+
+    @Test
+    public void testHeaderNameWithLeadingAndTrailingSpace() {
+        String filterScript = "require \"envelope\";\n"
+                + "if envelope :matches \" TO \" \"*@zimbra.com\" {\n"
+                + "    tag \"t1\";\n"
+                + "}\n"
+                ;
+        LmtpEnvelope env = new LmtpEnvelope();
+        LmtpAddress sender = new LmtpAddress("<>", new String[] { "BODY", "SIZE" }, null);
+        LmtpAddress recipient = new LmtpAddress("<xyz@zimbra.com>", null, null);
+        env.setSender(sender);
+        env.addLocalRecipient(recipient);
+
+        try {
+            Provisioning prov = Provisioning.getInstance();
+            Account account = prov.createAccount("xyz@zimbra.com", "secret", new HashMap<String, Object>());
+            RuleManager.clearCachedRules(account);
+            Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(
+                    account);
+
+            account.setMailSieveScript(filterScript);
+            List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(
+                    new OperationContext(mbox), mbox,
+                    new ParsedMessage(sampleMsg.getBytes(), false), 0,
+                    account.getName(), env,
+                    new DeliveryContext(),
+                    Mailbox.ID_FOLDER_INBOX, true);
+            Assert.assertEquals(1, ids.size());
+            Message msg = mbox.getMessageById(null, ids.get(0).getId());
+            Assert.assertEquals(0, msg.getTags().length);
+        } catch (Exception e) {
+            fail("No exception should be thrown");
+        }
+    }
 }

--- a/store/src/java-test/com/zimbra/cs/filter/HeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/HeaderTest.java
@@ -323,4 +323,70 @@ public class HeaderTest {
             fail("No exception should be thrown");
         }
     }
+
+    @Test
+    public void testHeaderNamesWithSpaces() throws Exception {
+        String script =
+                "if header :matches \" X-Header1\" \"*\" {"
+                + "    tag \"01\";"
+                + "}"
+                + "if header :matches \"X-Header1 \" \"*\" {"
+                + "    tag \"02\";"
+                + "}"
+                + "if header :matches \" X-Header1 \" \"*\" {"
+                + "    tag \"03\";"
+                + "}"
+                + "if header :matches \"X-He ader1\" \"*\" {"
+                + "    tag \"04\";"
+                + "}"
+                ;
+        String sourceMsg =
+            "X-Header1: sample\\\\pattern\n";
+            try {
+            Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+            RuleManager.clearCachedRules(account);
+            account.setMailAdminSieveScriptBefore(script);
+            Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
+
+            List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox), mbox,
+                    new ParsedMessage(sourceMsg.getBytes(), false),
+                    0, account.getName(), new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
+            Assert.assertEquals(1, ids.size());
+
+            Message msg = mbox.getMessageById(null, ids.get(0).getId());
+            Assert.assertEquals(0, msg.getTags().length);
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("No exception should be thrown");
+        }
+    }
+
+    @Test
+    public void ttt() throws Exception {
+        String script =
+                "if anyof (header :contains [\"X_Header\"] \"123\") { "
+                + "    tag \"321321\";"
+                + "    stop;"
+                + "}"
+                ;
+        String sourceMsg =
+            "X_Header: sample\\\\pattern\n";
+            try {
+            Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+            RuleManager.clearCachedRules(account);
+            account.setMailAdminSieveScriptBefore(script);
+            Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
+
+            List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox), mbox,
+                    new ParsedMessage(sourceMsg.getBytes(), false),
+                    0, account.getName(), new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
+            Assert.assertEquals(1, ids.size());
+
+            Message msg = mbox.getMessageById(null, ids.get(0).getId());
+            Assert.assertEquals(0, msg.getTags().length);
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("No exception should be thrown");
+        }
+    }
 }

--- a/store/src/java-test/com/zimbra/cs/filter/HeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/HeaderTest.java
@@ -326,8 +326,8 @@ public class HeaderTest {
 
     @Test
     public void testHeaderNamesWithSpaces() throws Exception {
-        String script =
-                "if header :matches \" X-Header1\" \"*\" {"
+        String script = "require [\"tag\"];\n"
+                + "if header :matches \" X-Header1\" \"*\" {"
                 + "    tag \"01\";"
                 + "}"
                 + "if header :matches \"X-Header1 \" \"*\" {"
@@ -363,8 +363,8 @@ public class HeaderTest {
 
     @Test
     public void ttt() throws Exception {
-        String script =
-                "if anyof (header :contains [\"X_Header\"] \"123\") { "
+        String script = "require [\"tag\"];\n"
+                + "if anyof (header :contains [\"X_Header\"] \"123\") { "
                 + "    tag \"321321\";"
                 + "    stop;"
                 + "}"

--- a/store/src/java-test/com/zimbra/cs/filter/NotifyMailtoTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/NotifyMailtoTest.java
@@ -213,6 +213,23 @@ public class NotifyMailtoTest {
           + "  :from \"test1@zimbra.com\" "
           + "  \"mailto:test2@zimbra.com?body=notifybody&message-id=dummymessageid&date=dummydate\";\n";
 
+    String filterScriptWithSpaceInHeaderName =
+            "require [\"enotify\", \"variables\"];\n"
+          + "set \"subject\" \"おしらせ\";\n"
+          + "set \"contents\" text:\r\n"
+          + "新しいメールが届きました。\n"
+          + "You've got a mail.\n"
+          + "Chao!\r\n"
+          + ".\r\n"
+          + ";\n"
+          + "if anyof (true) { \n"
+          + "  notify :message \"${subject}\"\n"
+          + "    :from \"test1@zimbra.com\"\n"
+          + "    :importance \"3\"\n"
+          + "    \"mailto:test2@zimbra.com?to=test3@zimbra.com&Importance=High&X-Priority =1&From=notifyfrom@example.com&body=${contents}\";"
+          + "  keep;\n"
+          + "}\n";
+
     /**
      * Tests 'notify' filter rule:
      *  - Set :message (Subject field), :from (From field) and mechanism (mailto:...)
@@ -603,7 +620,7 @@ public class NotifyMailtoTest {
         }
     }
 
-	@Test
+    @Test
     public void testNoMessageBody() {
         String sampleMsg = "Auto-Submitted: \"no\"\n"
                 + "from: xyz@example.com\n"
@@ -660,7 +677,7 @@ public class NotifyMailtoTest {
         }
     }
 
-	@Test
+    @Test
     public void testFromTag_noFromTag() {
         fromTag(filterScript_NoFrom);
     }
@@ -1138,4 +1155,43 @@ public class NotifyMailtoTest {
         }
     }
 
+    @Test
+    public void testNotifyMailtoWithSpaceInHeaderName() {
+        String sampleMsg = "Auto-Submitted: \"no\"\n"
+                + "from: xyz@example.com\n"
+                + "Subject: [acme-users] [fwd] version 1.0 is out\n"
+                + "to: foo@example.com, baz@example.com\n"
+                + "cc: qux@example.com\n";
+        try {
+            Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test1@zimbra.com");
+            Account acct2 = Provisioning.getInstance().get(Key.AccountBy.name, "test2@zimbra.com");
+            Account acct3 = Provisioning.getInstance().get(Key.AccountBy.name, "test3@zimbra.com");
+
+            Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
+            Mailbox mbox2 = MailboxManager.getInstance().getMailboxByAccount(acct2);
+            Mailbox mbox3 = MailboxManager.getInstance().getMailboxByAccount(acct3);
+            RuleManager.clearCachedRules(acct1);
+
+            LmtpEnvelope env = new LmtpEnvelope();
+            LmtpAddress sender = new LmtpAddress("<>", new String[] { "BODY", "SIZE" }, null);
+            LmtpAddress recipient = new LmtpAddress("<xyz@zimbra.com>", null, null);
+            env.setSender(sender);
+            env.addLocalRecipient(recipient);
+
+            acct1.setMailSieveScript(filterScriptWithSpaceInHeaderName);
+            List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(
+                    new OperationContext(mbox1), mbox1,
+                    new ParsedMessage(sampleMsg.getBytes(), false), 0,
+                    acct1.getName(), env, new DeliveryContext(),
+                    Mailbox.ID_FOLDER_INBOX, true);
+
+            // The triggered message should be delivered to the target mailbox
+            Assert.assertEquals(1, ids.size());
+
+            // Notification message should be delivered to mailto and to= addresses
+            Assert.assertTrue(mbox2.getItemIds(null, Mailbox.ID_FOLDER_INBOX).isEmpty());
+        } catch (Exception e) {
+            fail("No exception should be thrown");
+        }
+    }
 }

--- a/store/src/java/com/zimbra/cs/filter/FilterUtil.java
+++ b/store/src/java/com/zimbra/cs/filter/FilterUtil.java
@@ -1036,5 +1036,11 @@ public final class FilterUtil {
            throw new SyntaxException("Invalid variable index " + srcStr);
        }
     }
+
+    public static void headerNameHasSpace(String headerName) throws SyntaxException {
+        if (headerName.contains(" ")) {
+            throw new SyntaxException("ZimbraComparatorUtils : Header name must not have space(s) : \"" + headerName + "\"");
+        }
+    }
 }
 

--- a/store/src/java/com/zimbra/cs/filter/ZimbraComparatorUtils.java
+++ b/store/src/java/com/zimbra/cs/filter/ZimbraComparatorUtils.java
@@ -156,6 +156,11 @@ public class ZimbraComparatorUtils {
             throw context.getCoordinate().syntaxException(
                     "Expecting a StringList of header names");
         }
+        for (String headerName : headerNames) {
+            if (headerName != null && headerName.contains(" ")) {
+                throw new SyntaxException("ZimbraComparatorUtils : Header name must not have space(s) : \"" + headerName + "\"");
+            }
+        }
 
         // The next argument MUST be a string-list of keys
         if (argumentsIter.hasNext()) {

--- a/store/src/java/com/zimbra/cs/filter/ZimbraComparatorUtils.java
+++ b/store/src/java/com/zimbra/cs/filter/ZimbraComparatorUtils.java
@@ -157,8 +157,8 @@ public class ZimbraComparatorUtils {
                     "Expecting a StringList of header names");
         }
         for (String headerName : headerNames) {
-            if (headerName != null && headerName.contains(" ")) {
-                throw new SyntaxException("ZimbraComparatorUtils : Header name must not have space(s) : \"" + headerName + "\"");
+            if (headerName != null) {
+                FilterUtil.headerNameHasSpace(headerName);
             }
         }
 

--- a/store/src/java/com/zimbra/cs/filter/jsieve/AddHeader.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/AddHeader.java
@@ -154,9 +154,8 @@ public class AddHeader extends AbstractCommand {
         }
 
         if (!StringUtil.isNullOrEmpty(headerName)) {
-            String tempHeaderName = StringUtils.stripStart(headerName, null);
-            if (!tempHeaderName.equals(headerName)) {
-                throw new SyntaxException("Header name must not start with spaces : \"" + headerName + "\"");
+            if (headerName.contains(" ")) {
+                throw new SyntaxException("Header name must not have space(s) : \"" + headerName + "\"");
             }
             if (!CharsetUtil.US_ASCII.equals(CharsetUtil.checkCharset(headerName, CharsetUtil.US_ASCII))) {
                 throw new SyntaxException("AddHeader:Header name must be printable ASCII only.");

--- a/store/src/java/com/zimbra/cs/filter/jsieve/AddHeader.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/AddHeader.java
@@ -27,7 +27,6 @@ import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeUtility;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.jsieve.Argument;
 import org.apache.jsieve.Arguments;
 import org.apache.jsieve.Block;
@@ -154,9 +153,7 @@ public class AddHeader extends AbstractCommand {
         }
 
         if (!StringUtil.isNullOrEmpty(headerName)) {
-            if (headerName.contains(" ")) {
-                throw new SyntaxException("Header name must not have space(s) : \"" + headerName + "\"");
-            }
+            FilterUtil.headerNameHasSpace(headerName);
             if (!CharsetUtil.US_ASCII.equals(CharsetUtil.checkCharset(headerName, CharsetUtil.US_ASCII))) {
                 throw new SyntaxException("AddHeader:Header name must be printable ASCII only.");
             }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/EditHeaderExtension.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/EditHeaderExtension.java
@@ -304,9 +304,8 @@ public class EditHeaderExtension {
                             if (StringUtil.isNullOrEmpty(origNewName)) {
                                 throw new SyntaxException("New name must be present with :newname in replaceheader : " + arg);
                             }
-                            String newName2 = StringUtils.stripStart(origNewName, null);
-                            if (!newName2.equals(origNewName)) {
-                                throw new SyntaxException("New name must not start with spaces in :newname in replaceheader : " + arg);
+                            if (origNewName.contains(" ")) {
+                                throw new SyntaxException("New name must not have space(s) in :newname in replaceheader : " + arg);
                             }
                             this.newName = origNewName;
                         } else {
@@ -491,9 +490,8 @@ public class EditHeaderExtension {
      */
     public void commonValidation() throws SyntaxException {
         if (!StringUtil.isNullOrEmpty(this.key)) {
-            String tempKey = StringUtils.stripStart(this.key, null);
-            if (!tempKey.equals(this.key)) {
-                throw new SyntaxException("Header name must not start with spaces : \"" + this.key + "\"");
+            if (this.key.contains(" ")) {
+                throw new SyntaxException("Header name must not have space(s) : \"" + this.key + "\"");
             }
             if (!CharsetUtil.US_ASCII.equals(CharsetUtil.checkCharset(this.key, CharsetUtil.US_ASCII))) {
                 throw new SyntaxException("key must be printable ASCII only.");

--- a/store/src/java/com/zimbra/cs/filter/jsieve/EditHeaderExtension.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/EditHeaderExtension.java
@@ -29,7 +29,6 @@ import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeUtility;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.jsieve.Argument;
 import org.apache.jsieve.Arguments;
 import org.apache.jsieve.NumberArgument;
@@ -304,9 +303,7 @@ public class EditHeaderExtension {
                             if (StringUtil.isNullOrEmpty(origNewName)) {
                                 throw new SyntaxException("New name must be present with :newname in replaceheader : " + arg);
                             }
-                            if (origNewName.contains(" ")) {
-                                throw new SyntaxException("New name must not have space(s) in :newname in replaceheader : " + arg);
-                            }
+                            FilterUtil.headerNameHasSpace(origNewName);
                             this.newName = origNewName;
                         } else {
                             throw new SyntaxException("New name not provided with :newname in replaceheader : " + arg);
@@ -426,9 +423,9 @@ public class EditHeaderExtension {
         }
 
         if (this.valueTag) {
-        	matchFound = ZimbraComparatorUtils.values(comparator, relationalComparator, unfoldedAndDecodedHeaderValue, value, context);
+            matchFound = ZimbraComparatorUtils.values(comparator, relationalComparator, unfoldedAndDecodedHeaderValue, value, context);
         } else if (this.countTag) {
-        	matchFound = ZimbraComparatorUtils.counts(comparator, relationalComparator, headerList, value, context);
+            matchFound = ZimbraComparatorUtils.counts(comparator, relationalComparator, headerList, value, context);
         } else if (this.is && ComparatorUtils.is(this.comparator, unfoldedAndDecodedHeaderValue, value, context)) {
             matchFound = true;
         } else if (this.contains && ComparatorUtils.contains(this.comparator, unfoldedAndDecodedHeaderValue, value, context)) {
@@ -490,9 +487,7 @@ public class EditHeaderExtension {
      */
     public void commonValidation() throws SyntaxException {
         if (!StringUtil.isNullOrEmpty(this.key)) {
-            if (this.key.contains(" ")) {
-                throw new SyntaxException("Header name must not have space(s) : \"" + this.key + "\"");
-            }
+            FilterUtil.headerNameHasSpace(this.key);
             if (!CharsetUtil.US_ASCII.equals(CharsetUtil.checkCharset(this.key, CharsetUtil.US_ASCII))) {
                 throw new SyntaxException("key must be printable ASCII only.");
             }
@@ -538,11 +533,11 @@ public class EditHeaderExtension {
      * @throws OperationException 
      */
     public List<String> getMatchingHeaders(MimeMessage mm) throws OperationException {
-    	List<String> headerList = new ArrayList<String>();
+        List<String> headerList = new ArrayList<String>();
         try {
             String[] headerValues = mm.getHeader(this.key);
             if (headerValues != null) {
-            	headerList = Arrays.asList(headerValues);
+                headerList = Arrays.asList(headerValues);
             }
         } catch (MessagingException e) {
             throw new OperationException("Error occured while fetching " + this.key + " headers from mime.", e);

--- a/store/src/java/com/zimbra/cs/filter/jsieve/EnotifyTest.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/EnotifyTest.java
@@ -18,7 +18,6 @@ package com.zimbra.cs.filter.jsieve;
 
 import org.apache.jsieve.Arguments;
 import org.apache.jsieve.SieveContext;
-import org.apache.jsieve.exception.LookupException;
 import org.apache.jsieve.exception.SieveException;
 import org.apache.jsieve.exception.SyntaxException;
 import org.apache.jsieve.mail.MailAdapter;

--- a/store/src/java/com/zimbra/cs/filter/jsieve/HeaderTest.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/HeaderTest.java
@@ -162,8 +162,8 @@ public class HeaderTest extends Header {
         }
         headerNames = replaceVariables(headerNames, mail);
         for (String headerName : headerNames) {
-            if (headerName != null && headerName.contains(" ")) {
-                throw new SyntaxException("HeaderTest : Header name must not have space(s) : \"" + headerName + "\"");
+            if (headerName != null) {
+                FilterUtil.headerNameHasSpace(headerName);
             }
         }
 

--- a/store/src/java/com/zimbra/cs/filter/jsieve/HeaderTest.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/HeaderTest.java
@@ -37,7 +37,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
-import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -157,10 +156,15 @@ public class HeaderTest extends Header {
                 headerNames = ((StringListArgument) argument).getList();
             }
         }
-        headerNames = replaceVariables(headerNames, mail);
         if (null == headerNames) {
             throw context.getCoordinate().syntaxException(
                     "Expecting a StringListof header names");
+        }
+        headerNames = replaceVariables(headerNames, mail);
+        for (String headerName : headerNames) {
+            if (headerName != null && headerName.contains(" ")) {
+                throw new SyntaxException("HeaderTest : Header name must not have space(s) : \"" + headerName + "\"");
+            }
         }
 
         // The next argument MUST be a string-list of keys

--- a/store/src/java/com/zimbra/cs/filter/jsieve/NotifyMailto.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/NotifyMailto.java
@@ -74,8 +74,6 @@ public class NotifyMailto extends AbstractActionCommand {
             return null;
         }
         ZimbraMailAdapter mailAdapter = (ZimbraMailAdapter) mail;
-        Map<String, String> variables = mailAdapter.getVariables();
-        List<String> matchedVariables = mailAdapter.getMatchedValues();
 
         /*
          * RFC 5435 3.1. Notify Action
@@ -243,9 +241,7 @@ public class NotifyMailto extends AbstractActionCommand {
                         if (StringUtils.isEmpty(token[0])) {
                             throw new SyntaxException("'mailto' method syntax error: empty parameter name");
                         }
-                        if (token[0].contains(" ")) {
-                            throw new SyntaxException("mailto : Header name must not have space(s) : \"" + token[0] + "\"");
-                        }
+                        FilterUtil.headerNameHasSpace(token[0]);
                     }
                     // If the value or parameter name is URL encoded, it should be
                     // decoded.  If it is not even URL encoded, more or less decoding

--- a/store/src/java/com/zimbra/cs/filter/jsieve/NotifyMailto.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/NotifyMailto.java
@@ -243,6 +243,9 @@ public class NotifyMailto extends AbstractActionCommand {
                         if (StringUtils.isEmpty(token[0])) {
                             throw new SyntaxException("'mailto' method syntax error: empty parameter name");
                         }
+                        if (token[0].contains(" ")) {
+                            throw new SyntaxException("mailto : Header name must not have space(s) : \"" + token[0] + "\"");
+                        }
                     }
                     // If the value or parameter name is URL encoded, it should be
                     // decoded.  If it is not even URL encoded, more or less decoding


### PR DESCRIPTION
Problem : space in header name should not be allowed

Fix : added validation for header name in addheader, replaceheader, deleteheader, headerTest, addressTest, envelopTest, notifyMailto, enotify

Testing done: unit tests added for all above mentioned extensions

Testing to be done by QA: All above mentioned extensions should be tested by adding space in header name, which should fail.