### PR TITLE
ZCS-1006:SIEVE:"i;ascii-numeric" doesn't handle negative number

### DIFF
--- a/store/src/java-test/com/zimbra/cs/filter/AddressTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/AddressTest.java
@@ -352,4 +352,28 @@ public class AddressTest {
             fail("No exception should be thrown");
         }
     }
+
+    @Test
+    public void testNumericNegativeValueIs() {
+        try {
+            Account acct = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+            RuleManager.clearCachedRules(acct);
+            Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+
+            String filterScript = "require \"tag\";\n"
+                    + "if address :count \"lt\" :comparator \"i;ascii-numeric\" \"To\" \"-1\" {"
+                    + "  tag \"compareAsciiNumericNegativeValue\";"
+                    + "}";
+
+            acct.setMailSieveScript(filterScript);
+            List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(
+                    new OperationContext(mbox), mbox, new ParsedMessage("To: test1@zimbra.com".getBytes(), false), 0,
+                    acct.getName(), new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
+            Assert.assertEquals(1, ids.size());
+            Message msg = mbox.getMessageById(null, ids.get(0).getId());
+            Assert.assertEquals(null, ArrayUtil.getFirstElement(msg.getTags()));
+        } catch (Exception e) {
+            fail("No exception should be thrown");
+        }
+    }
 }

--- a/store/src/java-test/com/zimbra/cs/filter/DeleteHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/DeleteHeaderTest.java
@@ -975,4 +975,42 @@ public class DeleteHeaderTest {
             fail("No exception should be thrown: " + e.getMessage());
         }
     }
+
+    /*
+     * Parameter of the Negative number causes an exception and filter execution
+     * will be failed --> message is delivered to the Inbox without deleting the
+     * header "X-Numeric-Header"
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testDeleteHeaderCountNegative() {
+        try {
+            String filterScript = "require [\"editheader\"];\n"
+                    + "deleteheader :count \"le\" :comparator \"i;ascii-numeric\" \"X-Numeric-Header\" \"-1\";\n";
+            Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+            Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
+
+            RuleManager.clearCachedRules(acct1);
+
+            acct1.setMailSieveScript(filterScript);
+            RuleManager.applyRulesToIncomingMessage(
+                    new OperationContext(mbox1), mbox1, new ParsedMessage(
+                            sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
+                    null, new DeliveryContext(),
+                    Mailbox.ID_FOLDER_INBOX, true);
+            Integer itemId = mbox1.getItemIds(null, Mailbox.ID_FOLDER_INBOX).getIds(MailItem.Type.MESSAGE).get(0);
+            Message message = mbox1.getMessageById(null, itemId);
+            boolean matchFound = false;
+            for (Enumeration<Header> enumeration = message.getMimeMessage()
+                    .getAllHeaders(); enumeration.hasMoreElements();) {
+                Header header = enumeration.nextElement();
+                if ("X-Numeric-Header".equals(header.getName())) {
+                    matchFound = true;
+                }
+            }
+            Assert.assertTrue(matchFound);
+        } catch (Exception e) {
+            fail("No exception should be thrown: " + e.getMessage());
+        }
+    }
 }

--- a/store/src/java-test/com/zimbra/cs/filter/ReplaceHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/ReplaceHeaderTest.java
@@ -1256,4 +1256,50 @@ public class ReplaceHeaderTest {
             fail("No exception should be thrown: " + e.getMessage());
         }
     }
+
+    /*
+     * Replace header with numeric comparator :value
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testReplaceHeaderValueNegative() {
+        try {
+            String filterScript = "require [\"editheader\"];\n"
+                    + "replaceheader :newname \"X-Numeric2-Header\" :newvalue \"0\" :value \"lt\" :comparator \"i;ascii-numeric\" \"X-Numeric-Header\" \"-3\";\n";
+            Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+            Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
+
+            RuleManager.clearCachedRules(acct1);
+
+            acct1.setMailSieveScript(filterScript);
+            RuleManager.applyRulesToIncomingMessage(
+                    new OperationContext(mbox1), mbox1, new ParsedMessage(
+                            sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
+                            null, new DeliveryContext(),
+                            Mailbox.ID_FOLDER_INBOX, true);
+            Integer itemId = mbox1.getItemIds(null, Mailbox.ID_FOLDER_INBOX).getIds(MailItem.Type.MESSAGE).get(0);
+            Message message = mbox1.getMessageById(null, itemId);
+            boolean matchFound = false;
+            for (Enumeration<Header> enumeration = message.getMimeMessage().getAllHeaders(); enumeration.hasMoreElements();) {
+                Header header = enumeration.nextElement();
+                if ("X-Numeric2-Header".equals(header.getName())) {
+                    matchFound = true;
+                }
+            }
+            Assert.assertFalse(matchFound);
+
+            matchFound = false;
+            for (Enumeration<Header> enumeration = message.getMimeMessage()
+                    .getAllHeaders(); enumeration.hasMoreElements();) {
+                Header header = enumeration.nextElement();
+                if ("X-Numeric-Header".equals(header.getName())) {
+                    matchFound = true;
+                }
+            }
+            Assert.assertTrue(matchFound);
+        } catch (Exception e) {
+            fail("No exception should be thrown: " + e.getMessage());
+        }
+    }
+
 }

--- a/store/src/java-test/com/zimbra/cs/filter/SetVariableTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/SetVariableTest.java
@@ -2295,4 +2295,37 @@ public class SetVariableTest {
             fail("No exception should be thrown");
         }
     }
+
+    @Test
+    public void testStringNumericNegativeTest() {
+        try {
+            Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+            RuleManager.clearCachedRules(account);
+            Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
+
+            
+            filterScript = "require [\"variables\", \"tag\"];\n"
+                    + "set \"negative\" \"-123\";\n"
+                    + "if string :is :comparator \"i;ascii-numeric\" \"${negative}\" \"-123\" {\n"
+                    + "  tag \"negative\";\n"
+                    + "}"
+                    + "tag \"123\";";
+
+            account.setMailSieveScript(filterScript);
+            String raw = "From: sender@in.telligent.com\n" 
+                       + "To: coyote@ACME.Example.COM\n"
+                       + "Subject: hello version 1.0 is out\n"
+                       + "\n"
+                       + "Hello World.";
+            List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox), mbox,
+                new ParsedMessage(raw.getBytes(), false), 0, account.getName(), new DeliveryContext(),
+                Mailbox.ID_FOLDER_INBOX, true);
+            Assert.assertEquals(1, ids.size());
+            Message msg = mbox.getMessageById(null, ids.get(0).getId());
+            Assert.assertEquals(null, ArrayUtil.getFirstElement(msg.getTags()));
+
+        } catch (Exception e) {
+            fail("No exception should be thrown");
+        }
+    }
 }

--- a/store/src/java/com/zimbra/cs/filter/ZimbraAsciiCasemap.java
+++ b/store/src/java/com/zimbra/cs/filter/ZimbraAsciiCasemap.java
@@ -72,4 +72,12 @@ public class ZimbraAsciiCasemap extends AsciiCasemap implements ZimbraComparator
         return ZimbraComparatorUtils
                 .matches(string.toUpperCase(), glob.toUpperCase());
     }
+
+    /**
+     * @see org.apache.jsieve.comparators.AsciiCasemap#equals(String, String)
+     */
+    @Override
+    public boolean equals2(String string1, String string2) throws FeatureException {
+        return equals(string1, string2);
+    }
 }

--- a/store/src/java/com/zimbra/cs/filter/ZimbraComparatorUtils.java
+++ b/store/src/java/com/zimbra/cs/filter/ZimbraComparatorUtils.java
@@ -16,6 +16,7 @@
  */
 package com.zimbra.cs.filter;
 
+import static org.apache.jsieve.comparators.ComparatorNames.ASCII_CASEMAP_COMPARATOR;
 import static org.apache.jsieve.comparators.MatchTypeTags.CONTAINS_TAG;
 import static org.apache.jsieve.comparators.MatchTypeTags.IS_TAG;
 import static org.apache.jsieve.comparators.MatchTypeTags.MATCHES_TAG;
@@ -23,6 +24,7 @@ import static org.apache.jsieve.tests.AddressPartTags.ALL_TAG;
 import static org.apache.jsieve.tests.AddressPartTags.DOMAIN_TAG;
 import static org.apache.jsieve.tests.AddressPartTags.LOCALPART_TAG;
 import static org.apache.jsieve.tests.ComparatorTags.COMPARATOR_TAG;
+import static com.zimbra.cs.filter.jsieve.ComparatorName.ASCII_NUMERIC_COMPARATOR;
 import static com.zimbra.cs.filter.jsieve.MatchRelationalOperators.EQ_OP;
 import static com.zimbra.cs.filter.jsieve.MatchRelationalOperators.GE_OP;
 import static com.zimbra.cs.filter.jsieve.MatchRelationalOperators.GT_OP;
@@ -54,6 +56,7 @@ import org.apache.jsieve.mail.MailAdapter;
 
 import com.zimbra.cs.filter.jsieve.Counts;
 import com.zimbra.cs.filter.jsieve.Values;
+import com.zimbra.cs.filter.jsieve.Equals2;
 
 public class ZimbraComparatorUtils {
 
@@ -197,7 +200,7 @@ public class ZimbraComparatorUtils {
             throws SieveException {
         boolean isMatched = false;
         if (IS_TAG.equals(matchType)) {
-            isMatched = ComparatorUtils.is(comparatorName, matchTarget, matchArgument, context);
+            isMatched = is(comparatorName, matchTarget, matchArgument, context);
         } else if (CONTAINS_TAG.equals(matchType)) {
             isMatched = ComparatorUtils.contains(comparatorName, matchTarget, matchArgument,
                     context);
@@ -316,5 +319,39 @@ public class ZimbraComparatorUtils {
         } catch (PatternSyntaxException e) {
             throw new SievePatternException(e.getMessage());
         }
+    }
+
+    /**
+     * Method <code>is<code> answers a boolean indicating if the parameter
+     * <code>container</code> is equal to the parameter <code>contents</code> using
+     * an instance of <code>comparatorName</code>.
+     * @param comparatorName
+     * @param string1 not null
+     * @param string2 not null
+     * @param context not null
+     * @return boolean
+     * @throws FeatureException the number is negative value
+     */
+    public static boolean is(String comparatorName, String string1,
+            String string2, SieveContext context) throws LookupException, FeatureException {
+        Equals2 comparatorObj = (Equals2) context.getComparatorManager().getComparator(comparatorName);
+        return comparatorObj.equals2(string1, string2);
+    }
+
+    /**
+     * Get default comparator corresponding to the match type
+     * @param comparator comparator label or null
+     * @param matchType :is :contains :matches :count :value
+     * @return default comparator
+     */
+    public static String getComparator(String comparator, String matchType) {
+        if (null == comparator) {
+            if (COUNT_TAG.equalsIgnoreCase(matchType) || VALUE_TAG.equalsIgnoreCase(matchType)) {
+                return ASCII_NUMERIC_COMPARATOR;
+            } else {
+                return ASCII_CASEMAP_COMPARATOR;
+            }
+        }
+        return comparator;
     }
 }

--- a/store/src/java/com/zimbra/cs/filter/ZimbraOctet.java
+++ b/store/src/java/com/zimbra/cs/filter/ZimbraOctet.java
@@ -70,4 +70,12 @@ public class ZimbraOctet extends Octet implements ZimbraComparator {
             throws SievePatternException {
         return ZimbraComparatorUtils.matches(string, glob);
     }
+
+    /**
+     * @see org.apache.jsieve.comparators.Octet#equals(String, String)
+     */
+    @Override
+    public boolean equals2(String string1, String string2) throws FeatureException {
+        return equals(string1, string2);
+    }
 }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/AddressTest.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/AddressTest.java
@@ -77,10 +77,10 @@ public class AddressTest extends Address {
                 throw new SieveException("Exception occured while evaluating variable expression.", e);
             }
         }
-        if (COUNT_TAG.equals(params.getMatchType()) || VALUE_TAG.equals(params.getMatchType())) {
+        if (COUNT_TAG.equals(params.getMatchType()) || VALUE_TAG.equals(params.getMatchType()) || IS_TAG.equalsIgnoreCase(params.getMatchType())) {
             return match(mail,
                          (params.getAddressPart() == null ? ALL_TAG : params.getAddressPart()),
-                         (params.getComparator() == null ? ASCII_NUMERIC_COMPARATOR : params.getComparator()),
+                         ZimbraComparatorUtils.getComparator(params.getComparator(), params.getMatchType()),
                          params.getMatchType(),
                          params.getOperator(),
                          params.getHeaderNames(),
@@ -88,7 +88,7 @@ public class AddressTest extends Address {
         } else {
             return match(mail,
                          (params.getAddressPart() == null ? ALL_TAG : params.getAddressPart()),
-                         (params.getComparator() == null ? ASCII_CASEMAP_COMPARATOR : params.getComparator()),
+                         ZimbraComparatorUtils.getComparator(params.getComparator(), params.getMatchType()),
                          (params.getMatchType() == null ? IS_TAG : params.getMatchType()),
                          params.getHeaderNames(),
                          params.getKeys(), context);

--- a/store/src/java/com/zimbra/cs/filter/jsieve/Equals2.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/Equals2.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2016 Synacor, Inc.
+ * Copyright (C) 2017 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -14,18 +14,15 @@
  * If not, see <https://www.gnu.org/licenses/>.
  * ***** END LICENSE BLOCK *****
  */
-package com.zimbra.cs.filter;
 
-import org.apache.jsieve.comparators.Comparator;
+package com.zimbra.cs.filter.jsieve;
 
-import com.zimbra.cs.filter.jsieve.Counts;
-import com.zimbra.cs.filter.jsieve.Values;
-import com.zimbra.cs.filter.jsieve.Equals2;
+import org.apache.jsieve.exception.FeatureException;
 
 /**
- * Class ZimbraComparator enhances the jsieve's Comparator to support
- * the RFC 5231: Relational Extension
+ * Interface of the match type :is for the comparator i;ascii-numeric.
+ * For other comparator's :is, see {@link org.apache.jsieve.comparators.Equals#equals(String, String)}
  */
-public interface ZimbraComparator extends Comparator, Values, Counts, Equals2 {
-
+public interface Equals2 {
+    public boolean equals2(String string1, String string2) throws FeatureException;
 }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/HeaderTest.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/HeaderTest.java
@@ -182,13 +182,13 @@ public class HeaderTest extends Header {
         }
 
         if (matchType != null
-           && (COUNT_TAG.equalsIgnoreCase(matchType) || VALUE_TAG.equalsIgnoreCase(matchType))) {
+           && (COUNT_TAG.equalsIgnoreCase(matchType) || VALUE_TAG.equalsIgnoreCase(matchType) || IS_TAG.equalsIgnoreCase(matchType))) {
             return match(mail,
-                         (comparator == null ? ASCII_NUMERIC_COMPARATOR : comparator),
+                    ZimbraComparatorUtils.getComparator(comparator, matchType),
                          matchType, operator, headerNames, keys, context);
         } else {
             return match(mail,
-                         (comparator == null ? ASCII_CASEMAP_COMPARATOR : comparator),
+                    ZimbraComparatorUtils.getComparator(comparator, matchType),
                          (matchType == null ? IS_TAG : matchType),
                          headerNames, keys, context);
         }


### PR DESCRIPTION
[Problem]
The negative number was treated as positive infinity. The "i;ascii-numeric" comparator does not support negative numbers. In case of negative numbers, exception should be thrown, and the entire filter execution should be canceled.

[Fix]
* When evaluating the test, such as "string", "header", "envelope", "address", "deleteheader", and "replaceheader", under the ascii-numeric comparator, the sieve processor find the negative value as a parameter, it throws the FeatureException. The negative number is defined as a string which starts with '-' (0x2d) followed by a digit. If the given string is empty or started with non-digit character or started with '-' but not followed by a digit, such string is continuously treated as positive infinity.  When the given string is started with a digit, it is continuously treated as digit.

* The signature of the Equals interface is defined inside the jsieve library, and the Equals.equals() method does not throw the exception. To make it throw an exception, a new interface Equals2 is introduced, and the equals2() method throws the FeatureException exception.

[Testing done]
* Unit test for verifying that the filter execution is canceled when the negative number is found during the :is, :count and :value match pattern under the i;ascii-numeric for the tests listed above.

* Ran all the unit tests com.zimbra.cs.filter.* and all PASS.

* Ran automation scripts which test the "i;ascii-numeric"; zm-qa/data/soapvalidator/MailClient/Filters/Sieve/ZCS-865.xml, ZCS-863.xml, ZCS-373.xml and all PASS.

[Testing to be done by QA]
* Once the negative number is found, the filter execution should be canceled and the message will be delivered to the Inbox.  Additionally let's execute the cases for the ZCS-863 to cover the normal case for the :is, :count, and :value match type under the "i;ascii-numeric".