### PR TITLE
Bugfix/zcs 1195

### DIFF
--- a/store/build.xml
+++ b/store/build.xml
@@ -80,7 +80,7 @@
       <param name="base.dir" value="${dist.dir}"/>
     </antcall>
   </target>
-  <target name="generate-buildinfo" depends="build-init">
+  <target name="generate-buildinfo" depends="build-init,setversion">
     <mkdir dir="${build.dir}/buildinfo/com/zimbra/cs/util"/>
     <echo file="${build.dir}/buildinfo/com/zimbra/cs/util/BuildInfoGenerated.java">
             package com.zimbra.cs.util;


### PR DESCRIPTION
ZCS-1195: Fix dependency to generate proper BuildInfoGenerated.java