### PR TITLE
ZMS-607: Deleting ephemeral data on account deletion

### DIFF
--- a/store/src/java-test/com/zimbra/cs/ephemeral/EphemeralStoreTest.java
+++ b/store/src/java-test/com/zimbra/cs/ephemeral/EphemeralStoreTest.java
@@ -133,6 +133,21 @@ public class EphemeralStoreTest {
     }
 
     @Test
+    public void testDeleteData() throws Exception {
+        EphemeralLocation location1 = new TestLocation("location1");
+        EphemeralLocation location2 = new TestLocation("location2");
+        EphemeralKey key1 = new EphemeralKey("attr1");
+        EphemeralInput input1 = new EphemeralInput(key1, "value1");
+        EphemeralKey key2 = new EphemeralKey("attr2");
+        EphemeralInput input2 = new EphemeralInput(key2, "value2");
+        store.set(input1, location1);
+        store.set(input2, location2);
+        store.deleteData(location1);
+        assertTrue(store.get(key1, location1).isEmpty());
+        assertEquals(store.get(key2, location2).getValue(), "value2");
+    }
+
+    @Test
     public void testHas() throws Exception {
         EphemeralLocation target = new TestLocation();
 
@@ -281,9 +296,19 @@ public class EphemeralStoreTest {
 
     static class TestLocation extends EphemeralLocation {
 
+        private String locationName;
+
+        public TestLocation(String locationName) {
+            this.locationName = locationName;
+        }
+
+        public TestLocation() {
+            this("test");
+        }
+
         @Override
         public String[] getLocation() {
-            return new String[] { "test" };
+            return new String[] { locationName };
         }
     }
 }

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -3277,6 +3277,11 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
             // eat the exception and continue
             ZimbraLog.account.warn("cannot revoke grants", e);
         }
+        // if ephemeral backend is not LDAP, need to explicitly delete ephemeral data
+        EphemeralStore.Factory factory = EphemeralStore.getFactory();
+        if (!(factory instanceof LdapEphemeralStore.Factory)) {
+            factory.getStore().deleteData(new LdapEntryLocation(acc));
+        }
         final Map<String, Object> attrs = new HashMap<String, Object>(acc.getAttrs());
         ZLdapContext zlc = null;
         try {

--- a/store/src/java/com/zimbra/cs/ephemeral/EphemeralStore.java
+++ b/store/src/java/com/zimbra/cs/ephemeral/EphemeralStore.java
@@ -114,6 +114,15 @@ public abstract class EphemeralStore {
     public abstract void purgeExpired(EphemeralKey key, EphemeralLocation location)
             throws ServiceException;
 
+    /**
+     * Delete all ephemeral data for the specified EphemeralLocation
+     *
+     * @param location
+     * @throws ServiceException
+     */
+    public abstract void deleteData(EphemeralLocation location)
+            throws ServiceException;
+
     public static void registerFactory(String prefix, String klass) {
         if (factories.containsKey(prefix)) {
             ZimbraLog.ephemeral.warn("Replacing ephemeral factory class '%s' registered for '%s' with '%s'",

--- a/store/src/java/com/zimbra/cs/ephemeral/FallbackEphemeralStore.java
+++ b/store/src/java/com/zimbra/cs/ephemeral/FallbackEphemeralStore.java
@@ -56,6 +56,12 @@ public class FallbackEphemeralStore extends EphemeralStore {
         secondary.purgeExpired(key, location);
     }
 
+    @Override
+    public void deleteData(EphemeralLocation location) throws ServiceException {
+        primary.deleteData(location);
+        secondary.deleteData(location);
+    }
+
     @VisibleForTesting
     public EphemeralStore getPrimaryStore() {
         return primary;

--- a/store/src/java/com/zimbra/cs/ephemeral/InMemoryEphemeralStore.java
+++ b/store/src/java/com/zimbra/cs/ephemeral/InMemoryEphemeralStore.java
@@ -75,6 +75,14 @@ public class InMemoryEphemeralStore extends EphemeralStore {
     }
 
     @Override
+    public void deleteData(EphemeralLocation location) throws ServiceException {
+        String[] locationHierarchy = location.getLocation();
+        String storeKey = Joiner.on("|").join(locationHierarchy);;
+        storeMap.remove(storeKey);
+    }
+
+
+    @Override
     public boolean has(EphemeralKey key, EphemeralLocation target)
             throws ServiceException {
         Multimap<String, String> map = getSpecifiedMap(target);

--- a/store/src/java/com/zimbra/cs/ephemeral/LdapEphemeralStore.java
+++ b/store/src/java/com/zimbra/cs/ephemeral/LdapEphemeralStore.java
@@ -96,6 +96,12 @@ public class LdapEphemeralStore extends EphemeralStore {
         helper.executeChange();
     }
 
+    @Override
+    public void deleteData(EphemeralLocation location) throws ServiceException {
+        // LDAP backend does not need to support deleting ephemeral data; deletion
+        // is handled by LdapProvisioning
+    }
+
     public static class Factory implements EphemeralStore.Factory {
 
         @Override


### PR DESCRIPTION
Added a new _deleteData_ method to the EphemeralStore interface that is meant to delete all ephemeral data for a given EphemeralLocation instance. This is called from LdapProvisioning::deleteAccount. If the ephemeral backend is LDAP, this step is skipped, since the data will be deleted anyways.