### PR TITLE
ZCS-1207 Envelope test executes the action even if condition is not true

### DIFF
--- a/store/src/java-test/com/zimbra/cs/filter/EnvelopeTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/EnvelopeTest.java
@@ -887,4 +887,76 @@ public class EnvelopeTest {
             fail("No exception should be thrown");
         }
     }
+
+    @Test
+    public void testInvalidHeaderName() {
+        String filterScript = "require  \"envelope\";\n"
+                + "if anyof envelope :matches \"to123\" \"t1@zimbra.com\" {\n"
+                + "    fileinto \"Junk\";\n"
+                + "}\n"
+                ;
+        LmtpEnvelope env = new LmtpEnvelope();
+        LmtpAddress sender = new LmtpAddress("<t1@zimbra.com>", new String[] { "BODY", "SIZE" }, null);
+        LmtpAddress recipient = new LmtpAddress("<xyz@zimbra.com>", null, null);
+        env.setSender(sender);
+        env.addLocalRecipient(recipient);
+
+        try {
+            Provisioning prov = Provisioning.getInstance();
+            Account account = prov.createAccount("xyz@zimbra.com", "secret", new HashMap<String, Object>());
+            account.setMail("xyz@zimbra.com");
+            RuleManager.clearCachedRules(account);
+            Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(
+                    account);
+
+            account.setMailSieveScript(filterScript);
+            List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(
+                    new OperationContext(mbox), mbox,
+                    new ParsedMessage(sampleMsg.getBytes(), false), 0,
+                    account.getName(), env,
+                    new DeliveryContext(),
+                    Mailbox.ID_FOLDER_INBOX, true);
+            Assert.assertEquals(1, ids.size());
+            Message msg = mbox.getMessageById(null, ids.get(0).getId());
+            Assert.assertEquals(Mailbox.ID_FOLDER_INBOX, msg.getFolderId());
+        } catch (Exception e) {
+            fail("No exception should be thrown");
+        }
+    }
+
+    @Test
+    public void testInvalidHeaderName2() {
+        String filterScript = "require  \"envelope\";\n"
+                + "if anyof envelope :matches \"from123\" \"t1@zimbra.com\" {\n"
+                + "    fileinto \"Junk\";\n"
+                + "}\n"
+                ;
+        LmtpEnvelope env = new LmtpEnvelope();
+        LmtpAddress sender = new LmtpAddress("<t1@zimbra.com>", new String[] { "BODY", "SIZE" }, null);
+        LmtpAddress recipient = new LmtpAddress("<xyz@zimbra.com>", null, null);
+        env.setSender(sender);
+        env.addLocalRecipient(recipient);
+
+        try {
+            Provisioning prov = Provisioning.getInstance();
+            Account account = prov.createAccount("xyz@zimbra.com", "secret", new HashMap<String, Object>());
+            account.setMail("xyz@zimbra.com");
+            RuleManager.clearCachedRules(account);
+            Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(
+                    account);
+
+            account.setMailSieveScript(filterScript);
+            List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(
+                    new OperationContext(mbox), mbox,
+                    new ParsedMessage(sampleMsg.getBytes(), false), 0,
+                    account.getName(), env,
+                    new DeliveryContext(),
+                    Mailbox.ID_FOLDER_INBOX, true);
+            Assert.assertEquals(1, ids.size());
+            Message msg = mbox.getMessageById(null, ids.get(0).getId());
+            Assert.assertEquals(Mailbox.ID_FOLDER_INBOX, msg.getFolderId());
+        } catch (Exception e) {
+            fail("No exception should be thrown");
+        }
+    }
 }

--- a/store/src/java/com/zimbra/cs/filter/ZimbraMailAdapter.java
+++ b/store/src/java/com/zimbra/cs/filter/ZimbraMailAdapter.java
@@ -752,7 +752,8 @@ public class ZimbraMailAdapter implements MailAdapter, EnvelopeAccessors {
             return result;
         }
 
-        if (name.compareToIgnoreCase("to") == 0) {
+        switch (name.toLowerCase()) {
+        case "to":
             /* RFC 5228 5.4. Test envelope
              * ---
              * If the SMTP transaction involved several RCPT commands, only the data
@@ -784,13 +785,18 @@ public class ZimbraMailAdapter implements MailAdapter, EnvelopeAccessors {
             } catch (ServiceException e) {
                 // nothing to do with this exception. Just return an empty list
             }
-        } else {
+            break;
+
+        case "from":
             LmtpAddress sender = envelope.getSender();
             result.add(sender.getEmailAddress());
+            break;
+
         }
+
         return result;
     }
-    
+
     public String getVariable(String key) {
         return variables.get(key);
     }


### PR DESCRIPTION
This issue occurs for any invalid header name with value=<Sender's email address>

To fix this issue,
In ZimbraMailAdapter.getMatchingEnvelope(String name) we are now checking for exact match for "to" and "from" header names

Testing done:
- Added junit for the failing scenarios
- Manual testing

ToDo: Will send a separate pull request for automation