### PR TITLE
ZCS-1088 : SIEVE: Any space(s) in header name should error out during validation

### DIFF
--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -76,7 +76,5 @@
   <dependency org="zimbra" name="zm-soap" rev="latest.integration" /> 
   <dependency org="zimbra" name="zm-client" rev="latest.integration" /> 
   <dependency org="zimbra" name="zm-native" rev="latest.integration"/>
-  <!-- need to run unit tests from eclipse -->
-  <dependency org="commons-logging" name="commons-logging" rev="1.2"/>
  </dependencies>
 </ivy-module>

--- a/store/src/java-test/com/zimbra/cs/filter/AddHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/AddHeaderTest.java
@@ -34,6 +34,7 @@ import com.google.common.collect.Maps;
 import com.zimbra.common.account.Key;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.Server;
 import com.zimbra.cs.mailbox.DeliveryContext;
 import com.zimbra.cs.mailbox.MailItem;
 import com.zimbra.cs.mailbox.Mailbox;
@@ -231,7 +232,7 @@ public class AddHeaderTest {
     @Test
     public void testAddHeaderWithVariables() {
         try {
-            String filterScript = "require [\"editheader\"];\n"
+            String filterScript = "require [\"editheader\", \"variables\"];\n"
                     + " set \"nm\" \"X-New-Header\"; \r\n"
                     + " set \"vl\" \"test\"; \r\n"
                     + " addheader :last \"${nm}\" \"${vl}\" \r\n"
@@ -515,6 +516,38 @@ public class AddHeaderTest {
             for (Enumeration<Header> e = mdnMsg.getMimeMessage().getAllHeaders(); e.hasMoreElements();) {
                 Header temp = e.nextElement();
                 Assert.assertFalse(temp.getName().equals("X-My-Test"));
+                Assert.assertFalse(temp.getValue().equals("my-new-header-value"));
+            }
+        } catch (Exception e) {
+            fail("No exception should be thrown: " + e.getMessage());
+        }
+    }
+
+    /*
+     * Try adding new header with header name starting with space, which should fail
+     */
+    @Test
+    public void testAddHeaderNameWithSpaceFromVariable() {
+        try {
+           String filterScript = "require [\"editheader\",\"variables\"];\n"
+                    + "set \"var1\" \" X-My-Test \";\n"
+                    + "addheader \"${var1}\" \"my-new-header-value\" \r\n"
+                    + "  ;\n";
+            Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+            Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
+            RuleManager.clearCachedRules(acct1);
+            acct1.setMailSieveScript(filterScript);
+            RuleManager.applyRulesToIncomingMessage(
+                    new OperationContext(mbox1), mbox1, new ParsedMessage(
+                            sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
+                            null, new DeliveryContext(),
+                            Mailbox.ID_FOLDER_INBOX, true);
+            Integer itemId = mbox1.getItemIds(null, Mailbox.ID_FOLDER_INBOX).getIds(MailItem.Type.MESSAGE).get(0);
+            Message mdnMsg = mbox1.getMessageById(null, itemId);
+            for (Enumeration<Header> e = mdnMsg.getMimeMessage().getAllHeaders(); e.hasMoreElements();) {
+                Header temp = e.nextElement();
+                Assert.assertFalse(temp.getName().equals("X-My-Test"));
+                Assert.assertFalse(temp.getName().equals(" X-My-Test"));
                 Assert.assertFalse(temp.getValue().equals("my-new-header-value"));
             }
         } catch (Exception e) {

--- a/store/src/java-test/com/zimbra/cs/filter/AddHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/AddHeaderTest.java
@@ -524,7 +524,7 @@ public class AddHeaderTest {
     }
 
     /*
-     * Try adding new header with header name starting with space, which should fail
+     * Try adding new header with header name with space, which should not be added in mime.
      */
     @Test
     public void testAddHeaderNameWithSpaceFromVariable() {
@@ -547,7 +547,7 @@ public class AddHeaderTest {
             for (Enumeration<Header> e = mdnMsg.getMimeMessage().getAllHeaders(); e.hasMoreElements();) {
                 Header temp = e.nextElement();
                 Assert.assertFalse(temp.getName().equals("X-My-Test"));
-                Assert.assertFalse(temp.getName().equals(" X-My-Test"));
+                Assert.assertFalse(temp.getName().equals(" X-My-Test "));
                 Assert.assertFalse(temp.getValue().equals("my-new-header-value"));
             }
         } catch (Exception e) {

--- a/store/src/java-test/com/zimbra/cs/filter/ReplaceHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/ReplaceHeaderTest.java
@@ -34,7 +34,6 @@ import com.google.common.collect.Maps;
 import com.zimbra.common.account.Key;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.Provisioning;
-import com.zimbra.cs.account.Server;
 import com.zimbra.cs.mailbox.DeliveryContext;
 import com.zimbra.cs.mailbox.MailItem;
 import com.zimbra.cs.mailbox.Mailbox;
@@ -187,7 +186,6 @@ public class ReplaceHeaderTest {
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
         Account acct = prov.createAccount("test@zimbra.com", "secret", attrs);
-        Server server = Provisioning.getInstance().getServer(acct);
 
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());

--- a/store/src/java/com/zimbra/cs/filter/FilterUtil.java
+++ b/store/src/java/com/zimbra/cs/filter/FilterUtil.java
@@ -1039,6 +1039,9 @@ public final class FilterUtil {
     }
 
     public static void headerNameHasSpace(String headerName) throws SyntaxException {
+        if (headerName == null) {
+            return;
+        }
         if (headerName.contains(" ")) {
             throw new SyntaxException("ZimbraComparatorUtils : Header name must not have space(s) : \"" + headerName + "\"");
         }

--- a/store/src/java/com/zimbra/cs/filter/FilterUtil.java
+++ b/store/src/java/com/zimbra/cs/filter/FilterUtil.java
@@ -1039,8 +1039,8 @@ public final class FilterUtil {
     }
 
     public static void headerNameHasSpace(String headerName) throws SyntaxException {
-        if (headerName == null) {
-            return;
+        if (StringUtil.isNullOrEmpty(headerName)) {
+            throw new SyntaxException("ZimbraComparatorUtils : Header name must not be null or empty");
         }
         if (headerName.contains(" ")) {
             throw new SyntaxException("ZimbraComparatorUtils : Header name must not have space(s) : \"" + headerName + "\"");

--- a/store/src/java/com/zimbra/cs/filter/ZimbraComparatorUtils.java
+++ b/store/src/java/com/zimbra/cs/filter/ZimbraComparatorUtils.java
@@ -159,11 +159,6 @@ public class ZimbraComparatorUtils {
             throw context.getCoordinate().syntaxException(
                     "Expecting a StringList of header names");
         }
-        for (String headerName : headerNames) {
-            if (headerName != null) {
-                FilterUtil.headerNameHasSpace(headerName);
-            }
-        }
 
         // The next argument MUST be a string-list of keys
         if (argumentsIter.hasNext()) {

--- a/store/src/java/com/zimbra/cs/filter/jsieve/AddHeader.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/AddHeader.java
@@ -61,6 +61,7 @@ public class AddHeader extends AbstractCommand {
 
         ZimbraMailAdapter mailAdapter = (ZimbraMailAdapter) mail;
         headerName = FilterUtil.replaceVariables(mailAdapter, headerName);
+        FilterUtil.headerNameHasSpace(headerName);
         headerValue = FilterUtil.replaceVariables(mailAdapter, headerValue);
         try {
             headerValue = MimeUtility.fold(headerName.length() + 2, MimeUtility.encodeText(headerValue));
@@ -153,7 +154,6 @@ public class AddHeader extends AbstractCommand {
         }
 
         if (!StringUtil.isNullOrEmpty(headerName)) {
-            FilterUtil.headerNameHasSpace(headerName);
             if (!CharsetUtil.US_ASCII.equals(CharsetUtil.checkCharset(headerName, CharsetUtil.US_ASCII))) {
                 throw new SyntaxException("AddHeader:Header name must be printable ASCII only.");
             }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/AddressTest.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/AddressTest.java
@@ -38,6 +38,7 @@ import org.apache.jsieve.mail.MailAdapter;
 import org.apache.jsieve.tests.Address;
 
 import com.zimbra.cs.filter.DummyMailAdapter;
+import com.zimbra.cs.filter.FilterUtil;
 import com.zimbra.cs.filter.ZimbraComparatorUtils;
 import com.zimbra.cs.filter.ZimbraMailAdapter;
 
@@ -68,6 +69,9 @@ public class AddressTest extends Address {
         ZimbraComparatorUtils.TestParameters params = ZimbraComparatorUtils.parseTestArguments(mail, arguments, context);
         params.setKeys(HeaderTest.replaceVariables(params.getKeys(), mail));
         params.setHeaderNames(HeaderTest.replaceVariables(params.getHeaderNames(), mail));
+        for (String headerName : params.getHeaderNames()) {
+            FilterUtil.headerNameHasSpace(headerName);
+        }
 
         if (MatchTypeTags.MATCHES_TAG.equals(params.getMatchType())) {
             ZimbraMailAdapter zma  = (ZimbraMailAdapter) mail;

--- a/store/src/java/com/zimbra/cs/filter/jsieve/DeleteHeader.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/DeleteHeader.java
@@ -35,6 +35,7 @@ import org.apache.jsieve.exception.SyntaxException;
 import org.apache.jsieve.mail.MailAdapter;
 
 import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.filter.FilterUtil;
 import com.zimbra.cs.filter.ZimbraMailAdapter;
 
 public class DeleteHeader extends AbstractCommand {
@@ -63,6 +64,7 @@ public class DeleteHeader extends AbstractCommand {
         // replace sieve variables
         ehe.replaceVariablesInValueList(mailAdapter);
         ehe.replaceVariablesInKey(mailAdapter);
+        FilterUtil.headerNameHasSpace(ehe.getKey());
         MimeMessage mm = mailAdapter.getMimeMessage();
         Enumeration<Header> headers;
         try {

--- a/store/src/java/com/zimbra/cs/filter/jsieve/EditHeaderExtension.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/EditHeaderExtension.java
@@ -303,7 +303,6 @@ public class EditHeaderExtension {
                             if (StringUtil.isNullOrEmpty(origNewName)) {
                                 throw new SyntaxException("New name must be present with :newname in replaceheader : " + arg);
                             }
-                            FilterUtil.headerNameHasSpace(origNewName);
                             this.newName = origNewName;
                         } else {
                             throw new SyntaxException("New name not provided with :newname in replaceheader : " + arg);
@@ -487,7 +486,6 @@ public class EditHeaderExtension {
      */
     public void commonValidation() throws SyntaxException {
         if (!StringUtil.isNullOrEmpty(this.key)) {
-            FilterUtil.headerNameHasSpace(this.key);
             if (!CharsetUtil.US_ASCII.equals(CharsetUtil.checkCharset(this.key, CharsetUtil.US_ASCII))) {
                 throw new SyntaxException("key must be printable ASCII only.");
             }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/EnvelopeTest.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/EnvelopeTest.java
@@ -41,6 +41,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.filter.DummyMailAdapter;
+import com.zimbra.cs.filter.FilterUtil;
 import com.zimbra.cs.filter.ZimbraComparatorUtils;
 import com.zimbra.cs.filter.ZimbraMailAdapter;
 
@@ -67,6 +68,9 @@ public class EnvelopeTest extends Envelope {
         ZimbraComparatorUtils.TestParameters params = ZimbraComparatorUtils.parseTestArguments(mail, arguments, context);
         params.setKeys(HeaderTest.replaceVariables(params.getKeys(), mail));
         params.setHeaderNames(HeaderTest.replaceVariables(params.getHeaderNames(), mail));
+        for (String headerName : params.getHeaderNames()) {
+            FilterUtil.headerNameHasSpace(headerName);
+        }
 
         if (MatchTypeTags.MATCHES_TAG.equals(params.getMatchType())) {
             ZimbraMailAdapter zma  = (ZimbraMailAdapter) mail;

--- a/store/src/java/com/zimbra/cs/filter/jsieve/ReplaceHeader.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/ReplaceHeader.java
@@ -68,6 +68,9 @@ public class ReplaceHeader extends AbstractCommand {
         if(ehe.getValueList() == null || ehe.getValueList().isEmpty()) {
             ehe.setValueList(Arrays.asList("*"));
         }
+        FilterUtil.headerNameHasSpace(ehe.getNewName());
+        FilterUtil.headerNameHasSpace(ehe.getKey());
+
         MimeMessage mm = mailAdapter.getMimeMessage();
         Enumeration<Header> headers;
         try {


### PR DESCRIPTION
Problem:
Header name should be checked for space after replacing variables.

Fix:
Updated AddHeader, ReplaceHeader, DeleteHeader, EnvolopTest and AddressTest classes for the same. HeaderTest and NotifyMailto classes has already expected implementation.
