### PR TITLE
ZCS-876: fix match logic for out of range index with leading zeroes

### DIFF
--- a/store/src/java-test/com/zimbra/cs/filter/SetVariableTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/SetVariableTest.java
@@ -2291,4 +2291,62 @@ public class SetVariableTest {
             fail("No exception should be thrown");
         }
     }
+
+    @Test
+    public void testNonExistingVarIndexWithLeadingZeroes() {
+        try {
+            Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+            RuleManager.clearCachedRules(account);
+            Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
+
+            filterScript = "if header :matches :comparator \"i;ascii-casemap\" \"Subject\" \"t*t*\" { "
+                       + "addheader :last \"X-New-Header\" \"${009}\";}";
+
+            account.setMailSieveScript(filterScript);
+            String raw = "From: sender@zimbra.com\n"
+                       + "To: test1@zimbra.com\n"
+                       + "Subject: test 123";
+
+            List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox), mbox,
+                    new ParsedMessage(raw.getBytes(), false), 0, account.getName(), new DeliveryContext(),
+                    Mailbox.ID_FOLDER_INBOX, true);
+            Assert.assertEquals(1, ids.size());
+            Message msg = mbox.getMessageById(null, ids.get(0).getId());
+            String[] value = msg.getMimeMessage().getHeader("X-New-Header");
+            Assert.assertEquals("", value[0]);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("No exception should be thrown");
+        }
+    }
+
+    @Test
+    public void testNonExistingVarIndexWithLeadingZeroesForQuestionMark() {
+        try {
+            Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+            RuleManager.clearCachedRules(account);
+            Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
+
+            filterScript = "if header :matches :comparator \"i;ascii-casemap\" \"Subject\" \"t??t\" { "
+                       + "addheader :last \"X-New-Header\" \"${005}\";}";
+
+            account.setMailSieveScript(filterScript);
+            String raw = "From: sender@zimbra.com\n"
+                       + "To: test1@zimbra.com\n"
+                       + "Subject: test";
+
+            List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox), mbox,
+                    new ParsedMessage(raw.getBytes(), false), 0, account.getName(), new DeliveryContext(),
+                    Mailbox.ID_FOLDER_INBOX, true);
+            Assert.assertEquals(1, ids.size());
+            Message msg = mbox.getMessageById(null, ids.get(0).getId());
+            String[] value = msg.getMimeMessage().getHeader("X-New-Header");
+            Assert.assertEquals("", value[0]);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("No exception should be thrown");
+        }
+    }
 }

--- a/store/src/java/com/zimbra/cs/filter/FilterUtil.java
+++ b/store/src/java/com/zimbra/cs/filter/FilterUtil.java
@@ -873,7 +873,7 @@ public final class FilterUtil {
         }
         // (2) Replace the empty string to Matched Variables whose index is out of range
         for (; i < 10; i++) {
-            String keyName = "(?i)" + "\\$\\{" + String.valueOf(i) + "\\}";
+            String keyName = "(?i)" + "\\$\\{0*" + String.valueOf(i) + "\\}";
             resultStr = resultStr.replaceAll(keyName, Matcher.quoteReplacement(""));
         }
 


### PR DESCRIPTION
modified the match pattern to ignore leading zeroes while handling out of range indexes.

Testing done: added unit tests for relevant scenarios.