### PR TITLE
ZMS-194: RemoteImapMailboxStore::addressMatchesAccountOrSendAs

### DIFF
--- a/store/src/java/com/zimbra/cs/imap/RemoteImapMailboxStore.java
+++ b/store/src/java/com/zimbra/cs/imap/RemoteImapMailboxStore.java
@@ -50,6 +50,7 @@ import com.zimbra.cs.mailbox.OperationContext;
 import com.zimbra.cs.service.UserServlet;
 import com.zimbra.cs.service.util.ItemId;
 import com.zimbra.cs.store.Blob;
+import com.zimbra.cs.util.AccountUtil;
 import com.zimbra.soap.account.message.ImapMessageInfo;
 
 public class RemoteImapMailboxStore extends ImapMailboxStore {
@@ -187,7 +188,7 @@ public class RemoteImapMailboxStore extends ImapMailboxStore {
 
     @Override
     public boolean addressMatchesAccountOrSendAs(String givenAddress) throws ServiceException {
-        throw new UnsupportedOperationException("RemoteImapMailboxStore method not supported yet");
+        return (AccountUtil.addressMatchesAccountOrSendAs(getAccount(), givenAddress));
     }
 
     @Override

--- a/store/src/java/com/zimbra/qa/unittest/TestRemoteImapMailboxStore.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestRemoteImapMailboxStore.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import com.zimbra.client.ZMailbox;
 import com.zimbra.common.mailbox.ItemIdentifier;
 import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.Account;
 import com.zimbra.cs.imap.ImapMessage;
 import com.zimbra.cs.imap.RemoteImapMailboxStore;
 import com.zimbra.cs.mailbox.DeliveryOptions;
@@ -153,5 +154,13 @@ public class TestRemoteImapMailboxStore extends TestCase {
             fail("beginTrackingImap should succeed");
         }
         assertTrue(mbox.isTrackingImap());
+    }
+
+    @Test
+    public void testAddressMatchesAccountOrSendAs() throws Exception {
+        ZMailbox zmbox = TestUtil.getZMailbox(USER_NAME);
+        Account acct = TestUtil.getAccount(USER_NAME);
+        RemoteImapMailboxStore remoteStore = new RemoteImapMailboxStore(zmbox, acct.getId());
+        assertTrue(remoteStore.addressMatchesAccountOrSendAs(acct.getMail()));
     }
 }


### PR DESCRIPTION
Implemented _RemoteImapMailboxStore::addressMatchesAccountOrSendAs_, as well as a corresponding unit test. The method uses the same underlying call as _LocalImapMailboxStore_, except it gets the account instance using the _RemoteImapMailboxStore.getAccount()_ method.