### PR TITLE
ZCS-1238 : SIEVE: Match variable not getting replaced within header name of replaceheader

### DIFF
--- a/store/src/java/com/zimbra/cs/filter/jsieve/ReplaceHeader.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/ReplaceHeader.java
@@ -68,7 +68,6 @@ public class ReplaceHeader extends AbstractCommand {
         if(ehe.getValueList() == null || ehe.getValueList().isEmpty()) {
             ehe.setValueList(Arrays.asList("*"));
         }
-        FilterUtil.headerNameHasSpace(ehe.getNewName());
         FilterUtil.headerNameHasSpace(ehe.getKey());
 
         MimeMessage mm = mailAdapter.getMimeMessage();
@@ -107,7 +106,8 @@ public class ReplaceHeader extends AbstractCommand {
                             replace = ehe.matchCondition(mailAdapter, header, matchingeHeaderList, value, sieveContext);
                             if (replace) {
                                 if (ehe.getNewName() != null) {
-                                    newHeaderName = ehe.getNewName();
+                                    newHeaderName = FilterUtil.replaceVariables(mailAdapter, ehe.getNewName());
+                                    FilterUtil.headerNameHasSpace(newHeaderName);
                                 } else {
                                     newHeaderName = header.getName();
                                 }


### PR DESCRIPTION
Problem: newName in replaceheader command, is not replaced from the match condition.

Fix: added code to replace newName.

Testing done: added unit test for the scenario

Testing to be done by QA: verify mentioned scenario.