### PR TITLE
Feature/zms 323

### DIFF
--- a/soap/src/java/com/zimbra/soap/admin/message/AdminCreateWaitSetRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/AdminCreateWaitSetRequest.java
@@ -68,7 +68,7 @@ public class AdminCreateWaitSetRequest implements CreateWaitSetReq {
     private final String defaultInterests;
 
     /**
-     * @zm-api-field-tag all-accounts
+     * @zm-api-field-tag deprecated-all-accounts
      * @zm-api-field-description If <b>{all-accounts}</b> is set, then all mailboxes on the system will be listened
      * to, including any mailboxes which are created on the system while the WaitSet is in existence.
      * Additionally:
@@ -81,6 +81,7 @@ public class AdminCreateWaitSetRequest implements CreateWaitSetReq {
      * &lt;WaitSetRequest> passing in your previous sequence number.  The server will attempt to resynchronize the
      * waitset using the sequence number you provide (the server's ability to do this is limited by the RedoLogs that
      * are available)
+     * Note: AllAccounts WaitSets are deprecated
      */
     @XmlAttribute(name=MailConstants.A_ALL_ACCOUNTS /* allAccounts */, required=false)
     private final ZmBoolean allAccounts;

--- a/store/src/java/com/zimbra/cs/session/AllAccountsRedoCommitCallback.java
+++ b/store/src/java/com/zimbra/cs/session/AllAccountsRedoCommitCallback.java
@@ -22,6 +22,11 @@ import com.zimbra.cs.mailbox.MailItem;
 import com.zimbra.cs.redolog.CommitId;
 import com.zimbra.cs.redolog.RedoCommitCallback;
 
+/**
+ * 
+ * @deprecated AllAccountsWaitSet is being deprecated
+ *
+ */
 public class AllAccountsRedoCommitCallback implements RedoCommitCallback {
     private final String accountId;
     private final Set<MailItem.Type> changeTypes;

--- a/store/src/java/com/zimbra/cs/session/AllAccountsWaitSet.java
+++ b/store/src/java/com/zimbra/cs/session/AllAccountsWaitSet.java
@@ -40,6 +40,7 @@ import com.zimbra.soap.admin.type.WaitSetInfo;
 
 /**
  * An implementation of IWaitSet that listens across all accounts on the server
+ * @deprecated this API is not being used by any known clients
  */
 public final class AllAccountsWaitSet extends WaitSetBase {
 

--- a/store/src/java/com/zimbra/qa/unittest/TestImapServerListener.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestImapServerListener.java
@@ -107,10 +107,10 @@ public class TestImapServerListener {
             Provisioning.getInstance().setPassword(remoteAccount, PASS);
             imapServersForRemoteHost = remoteServer.getReverseProxyUpstreamImapServers();
             remoteServer.setReverseProxyUpstreamImapServers(new String[]{localServer.getServiceHostname()});
+            mboxStore = TestUtil.getZMailbox(REMOTE_USER_NAME);
+            remoteListener = ImapServerListenerPool.getInstance().get(mboxStore);
         }
         sp.flushCache("all", null, true);
-        mboxStore = TestUtil.getZMailbox(REMOTE_USER_NAME);
-        remoteListener = ImapServerListenerPool.getInstance().get(mboxStore);
     }
 
     @After

--- a/store/src/java/com/zimbra/qa/unittest/TestRemoteImapNotifications.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestRemoteImapNotifications.java
@@ -75,8 +75,8 @@ public class TestRemoteImapNotifications {
 
     @AfterClass
     public static void afterClass() throws Exception {
-        imapServer.setReverseProxyUpstreamImapServers(saved_imap_servers);
         if (imapServer != null) {
+            imapServer.setReverseProxyUpstreamImapServers(saved_imap_servers);
             imapServer.setImapDisplayMailFoldersOnly(mIMAPDisplayMailFoldersOnly);
         }
         TestUtil.setLCValue(LC.imap_always_use_remote_store, String.valueOf(saved_imap_always_use_remote_store));

--- a/store/src/java/com/zimbra/qa/unittest/TestRemoteImapNotifications.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestRemoteImapNotifications.java
@@ -27,6 +27,7 @@ import com.zimbra.common.localconfig.ConfigException;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.Log;
+import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.Server;
@@ -73,10 +74,13 @@ public class TestRemoteImapNotifications {
     }
 
     @AfterClass
-    public static void afterClass() throws ServiceException {
+    public static void afterClass() throws Exception {
         imapServer.setReverseProxyUpstreamImapServers(saved_imap_servers);
+        if (imapServer != null) {
+            imapServer.setImapDisplayMailFoldersOnly(mIMAPDisplayMailFoldersOnly);
+        }
+        TestUtil.setLCValue(LC.imap_always_use_remote_store, String.valueOf(saved_imap_always_use_remote_store));
     }
-
 
     @Before
     public void setUp() throws ServiceException, IOException, DocumentException, ConfigException  {
@@ -94,10 +98,6 @@ public class TestRemoteImapNotifications {
     @After
     public void tearDown() throws ServiceException, DocumentException, ConfigException, IOException  {
         sharedCleanup();
-        if (imapServer != null) {
-            imapServer.setImapDisplayMailFoldersOnly(mIMAPDisplayMailFoldersOnly);
-        }
-        TestUtil.setLCValue(LC.imap_always_use_remote_store, String.valueOf(saved_imap_always_use_remote_store));
     }
 
     private ImapConnection connect(Server server) throws IOException {


### PR DESCRIPTION
- added a test for AllAccountsWaitSet
- fixed intermittent failures of other SOAP tests for WaitSets
- marked AllAccountsWaitSet as deprecated. It was created for BES, which was is no longer supported.