### PR TITLE
ZCS-1006:SIEVE:rework:"i;ascii-numeric" doesn't handle negative number

### DIFF
--- a/store/src/java/com/zimbra/cs/filter/ZimbraMailAdapter.java
+++ b/store/src/java/com/zimbra/cs/filter/ZimbraMailAdapter.java
@@ -697,6 +697,10 @@ public class ZimbraMailAdapter implements MailAdapter, EnvelopeAccessors {
             return FilterAddress.EMPTY_ADDRESS_ARRAY;
         }
 
+        return stringAddress2MailAdapterAddress(hdrValues);
+    }
+
+    public static MailAdapter.Address[] stringAddress2MailAdapterAddress(String[] hdrValues) {
         List<Address> retVal = new LinkedList<Address>();
         for (String hdrValue : hdrValues) {
             for (InternetAddress addr : InternetAddress.parseHeader(hdrValue)) {

--- a/store/src/java/com/zimbra/cs/filter/jsieve/AddressTest.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/AddressTest.java
@@ -158,7 +158,7 @@ public class AddressTest extends Address {
         return isMatched;
     }
 
-    private String getMatchAddress(String addressPart, String localPart, String domain) {
+    public static String getMatchAddress(String addressPart, String localPart, String domain) {
         // Extract the part of the address we are matching on
         final String matchAddress;
         if (ALL_TAG.equals(addressPart))


### PR DESCRIPTION
[Problem]
ADDRESS-PART of the envelope test was ignored, and always :all was set.

[Fix]
Before calling the EnvelopeTest.match(String, ...) method, the target
address is parsed and the specified part (domain part, local part, or
entire part) is extracted to set to the headerValues List.  Then this
list will be used as a target address to be compared with the key string.

[Unit test]
EnvelopeTest, AddressTest PASS