### PR TITLE
Implement ZMailbox.delete - ZMS-624 & ZMS-198

### DIFF
--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -189,6 +189,7 @@ import com.zimbra.soap.mail.message.RecordIMAPSessionResponse;
 import com.zimbra.soap.mail.type.ActionSelector;
 import com.zimbra.soap.mail.type.Content;
 import com.zimbra.soap.mail.type.Folder;
+import com.zimbra.soap.mail.type.IdAndOperation;
 import com.zimbra.soap.mail.type.ImportContact;
 import com.zimbra.soap.type.AccountSelector;
 import com.zimbra.soap.type.CalDataSource;
@@ -6025,7 +6026,11 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
          ActionSelector action = ActionSelector.createForIdsAndOperation(ids, MailConstants.OP_HARD_DELETE);
          ItemActionRequest req = new ItemActionRequest(action);
          ItemActionResponse resp = invokeJaxb(req);
-         // TODO: Parse response and update nonExistingItems
+         IdAndOperation idOperation = resp.getAction();
+         for (String id: idOperation.getNonExistentIds().split(","))
+         {
+             nonExistingItems.add(Integer.parseInt(id));
+         }
     }
 
     /** Resets the mailbox's "recent message count" to 0.  A message is considered "recent" if:

--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -6024,6 +6024,7 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
     public void delete(OpContext octxt, List<Integer> itemIds, List<Integer> nonExistingItems) throws ServiceException {
          String ids = Joiner.on(",").join(itemIds);
          ActionSelector action = ActionSelector.createForIdsAndOperation(ids, MailConstants.OP_HARD_DELETE);
+         action.setNonExistentIds(true);
          ItemActionRequest req = new ItemActionRequest(action);
          ItemActionResponse resp = invokeJaxb(req);
          ActionResult ar = resp.getAction();

--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -186,10 +186,10 @@ import com.zimbra.soap.mail.message.ModifyFilterRulesRequest;
 import com.zimbra.soap.mail.message.ModifyOutgoingFilterRulesRequest;
 import com.zimbra.soap.mail.message.RecordIMAPSessionRequest;
 import com.zimbra.soap.mail.message.RecordIMAPSessionResponse;
+import com.zimbra.soap.mail.type.ActionResult;
 import com.zimbra.soap.mail.type.ActionSelector;
 import com.zimbra.soap.mail.type.Content;
 import com.zimbra.soap.mail.type.Folder;
-import com.zimbra.soap.mail.type.IdAndOperation;
 import com.zimbra.soap.mail.type.ImportContact;
 import com.zimbra.soap.type.AccountSelector;
 import com.zimbra.soap.type.CalDataSource;
@@ -6026,8 +6026,8 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
          ActionSelector action = ActionSelector.createForIdsAndOperation(ids, MailConstants.OP_HARD_DELETE);
          ItemActionRequest req = new ItemActionRequest(action);
          ItemActionResponse resp = invokeJaxb(req);
-         IdAndOperation idOperation = resp.getAction();
-         for (String id: idOperation.getNonExistentIds().split(","))
+         ActionResult ar = resp.getAction();
+         for (String id: ar.getNonExistentIds().split(","))
          {
              nonExistingItems.add(Integer.parseInt(id));
          }

--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -6021,7 +6021,11 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
      */
     @Override
     public void delete(OpContext octxt, List<Integer> itemIds, List<Integer> nonExistingItems) throws ServiceException {
-        throw new UnsupportedOperationException("ZMailbox does not support method yet");
+         String ids = Joiner.on(",").join(itemIds);
+         ActionSelector action = ActionSelector.createForIdsAndOperation(ids, MailConstants.OP_HARD_DELETE);
+         ItemActionRequest req = new ItemActionRequest(action);
+         ItemActionResponse resp = invokeJaxb(req);
+         // TODO: Parse response and update nonExistingItems
     }
 
     /** Resets the mailbox's "recent message count" to 0.  A message is considered "recent" if:

--- a/common/src/java/com/zimbra/common/soap/MailConstants.java
+++ b/common/src/java/com/zimbra/common/soap/MailConstants.java
@@ -761,6 +761,7 @@ public final class MailConstants {
     public static final String A_ACTIVESYNC_DISABLED = "activesyncdisabled";
     public static final String A_WEB_OFFLINE_SYNC_DAYS = "webOfflineSyncDays";
     public static final String A_NUM_DAYS = "numDays";
+    public static final String A_NON_EXISTENT_IDS = "nei";
 
     // contact group
     public static final String E_CONTACT_GROUP_MEMBER = "m";

--- a/soap/src/java/com/zimbra/soap/mail/message/ConvActionResponse.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/ConvActionResponse.java
@@ -24,7 +24,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import com.zimbra.common.soap.MailConstants;
-import com.zimbra.soap.mail.type.IdAndOperation;
+import com.zimbra.soap.mail.type.ActionResult;
 import com.zimbra.soap.json.jackson.annotate.ZimbraUniqueElement;
 
 @XmlAccessorType(XmlAccessType.NONE)
@@ -36,21 +36,21 @@ public class ConvActionResponse {
      */
     @ZimbraUniqueElement
     @XmlElement(name=MailConstants.E_ACTION /* action */, required=true)
-    private final IdAndOperation action;
+    private final ActionResult action;
 
     /**
      * no-argument constructor wanted by JAXB
      */
     @SuppressWarnings("unused")
     private ConvActionResponse() {
-        this((IdAndOperation) null);
+        this((ActionResult) null);
     }
 
-    public ConvActionResponse(IdAndOperation action) {
+    public ConvActionResponse(ActionResult action) {
         this.action = action;
     }
 
-    public IdAndOperation getAction() { return action; }
+    public ActionResult getAction() { return action; }
 
     @Override
     public String toString() {

--- a/soap/src/java/com/zimbra/soap/mail/message/DocumentActionResponse.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/DocumentActionResponse.java
@@ -25,7 +25,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 import com.zimbra.common.soap.MailConstants;
 import com.zimbra.common.soap.OctopusXmlConstants;
-import com.zimbra.soap.mail.type.IdAndOperation;
+import com.zimbra.soap.mail.type.ActionResult;
 import com.zimbra.soap.json.jackson.annotate.ZimbraUniqueElement;
 
 @XmlAccessorType(XmlAccessType.NONE)
@@ -37,22 +37,22 @@ public class DocumentActionResponse {
      */
     @ZimbraUniqueElement
     @XmlElement(name=MailConstants.E_ACTION /* action */, required=true)
-    private IdAndOperation action;
+    private ActionResult action;
 
     @SuppressWarnings("unused")
     private DocumentActionResponse() {
     }
 
-    public DocumentActionResponse(IdAndOperation action) {
+    public DocumentActionResponse(ActionResult action) {
         setAction(action);
     }
 
-    public static DocumentActionResponse create (IdAndOperation action) {
+    public static DocumentActionResponse create (ActionResult action) {
         return new DocumentActionResponse(action);
     }
 
-    public void setAction(IdAndOperation action) { this.action = action; }
-    public IdAndOperation getAction() { return action; }
+    public void setAction(ActionResult action) { this.action = action; }
+    public ActionResult getAction() { return action; }
 
     public Objects.ToStringHelper addToStringInfo(Objects.ToStringHelper helper) {
         return helper

--- a/soap/src/java/com/zimbra/soap/mail/message/ItemActionResponse.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/ItemActionResponse.java
@@ -24,7 +24,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import com.zimbra.common.soap.MailConstants;
-import com.zimbra.soap.mail.type.IdAndOperation;
+import com.zimbra.soap.mail.type.ActionResult;
 import com.zimbra.soap.json.jackson.annotate.ZimbraUniqueElement;
 
 @XmlAccessorType(XmlAccessType.NONE)
@@ -38,21 +38,21 @@ public class ItemActionResponse {
      */
     @ZimbraUniqueElement
     @XmlElement(name=MailConstants.E_ACTION /* action */, required=true)
-    private final IdAndOperation action;
+    private final ActionResult action;
 
     /**
      * no-argument constructor wanted by JAXB
      */
     @SuppressWarnings("unused")
     private ItemActionResponse() {
-        this((IdAndOperation) null);
+        this((ActionResult) null);
     }
 
-    public ItemActionResponse(IdAndOperation action) {
+    public ItemActionResponse(ActionResult action) {
         this.action = action;
     }
 
-    public IdAndOperation getAction() { return action; }
+    public ActionResult getAction() { return action; }
 
     public Objects.ToStringHelper addToStringInfo(Objects.ToStringHelper helper) {
         return helper

--- a/soap/src/java/com/zimbra/soap/mail/message/MsgActionResponse.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/MsgActionResponse.java
@@ -24,7 +24,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import com.zimbra.common.soap.MailConstants;
-import com.zimbra.soap.mail.type.IdAndOperation;
+import com.zimbra.soap.mail.type.ActionResult;
 import com.zimbra.soap.json.jackson.annotate.ZimbraUniqueElement;
 
 @XmlAccessorType(XmlAccessType.NONE)
@@ -38,21 +38,21 @@ public class MsgActionResponse {
      */
     @ZimbraUniqueElement
     @XmlElement(name=MailConstants.E_ACTION /* action */, required=true)
-    private final IdAndOperation action;
+    private final ActionResult action;
 
     /**
      * no-argument constructor wanted by JAXB
      */
     @SuppressWarnings("unused")
     private MsgActionResponse() {
-        this((IdAndOperation) null);
+        this((ActionResult) null);
     }
 
-    public MsgActionResponse(IdAndOperation action) {
+    public MsgActionResponse(ActionResult action) {
         this.action = action;
     }
 
-    public IdAndOperation getAction() { return action; }
+    public ActionResult getAction() { return action; }
 
     @Override
     public String toString() {

--- a/soap/src/java/com/zimbra/soap/mail/message/NoteActionResponse.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/NoteActionResponse.java
@@ -24,7 +24,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import com.zimbra.common.soap.MailConstants;
-import com.zimbra.soap.mail.type.IdAndOperation;
+import com.zimbra.soap.mail.type.ActionResult;
 import com.zimbra.soap.json.jackson.annotate.ZimbraUniqueElement;
 
 @XmlAccessorType(XmlAccessType.NONE)
@@ -38,21 +38,21 @@ public class NoteActionResponse {
      */
     @ZimbraUniqueElement
     @XmlElement(name=MailConstants.E_ACTION /* action */, required=true)
-    private final IdAndOperation action;
+    private final ActionResult action;
 
     /**
      * no-argument constructor wanted by JAXB
      */
     @SuppressWarnings("unused")
     private NoteActionResponse() {
-        this((IdAndOperation) null);
+        this((ActionResult) null);
     }
 
-    public NoteActionResponse(IdAndOperation action) {
+    public NoteActionResponse(ActionResult action) {
         this.action = action;
     }
 
-    public IdAndOperation getAction() { return action; }
+    public ActionResult getAction() { return action; }
 
     @Override
     public String toString() {

--- a/soap/src/java/com/zimbra/soap/mail/type/ActionResult.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ActionResult.java
@@ -25,7 +25,7 @@ import javax.xml.bind.annotation.XmlAttribute;
 import com.zimbra.common.soap.MailConstants;
 
 @XmlAccessorType(XmlAccessType.NONE)
-public class IdAndOperation {
+public class ActionResult {
 
     /**
      * @zm-api-field-tag id
@@ -52,11 +52,11 @@ public class IdAndOperation {
      * no-argument constructor wanted by JAXB
      */
     @SuppressWarnings("unused")
-    protected IdAndOperation() {
+    protected ActionResult() {
         this((String) null, (String) null);
     }
 
-    public IdAndOperation(String id, String operation) {
+    public ActionResult(String id, String operation) {
         this.id = id;
         this.operation = operation;
     }

--- a/soap/src/java/com/zimbra/soap/mail/type/ActionSelector.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ActionSelector.java
@@ -24,6 +24,7 @@ import javax.xml.bind.annotation.XmlSeeAlso;
 
 import com.google.common.base.Objects;
 import com.zimbra.common.soap.MailConstants;
+import com.zimbra.soap.type.ZmBoolean;
 
 @XmlAccessorType(XmlAccessType.NONE)
 @XmlSeeAlso({
@@ -154,10 +155,10 @@ public class ActionSelector {
 
     /**
      * @zm-api-field-tag non-existent-ids
-     * @zm-api-field-description Comma-separated list of non-existent ids
+     * @zm-api-field-description Flag to signify any non-existent ids should be returned
      */
     @XmlAttribute(name=MailConstants.A_NON_EXISTENT_IDS /* nei */, required=false)
-    protected String nonExistentIds;
+    protected ZmBoolean nonExistentIds;
 
     /**
      * no-argument constructor wanted by JAXB
@@ -187,7 +188,7 @@ public class ActionSelector {
     public void setColor(Byte color) { this.color = color; }
     public void setName(String name) { this.name = name; }
     public void setFlags(String flags) { this.flags = flags; }
-    public void setNonExistentIds(String ids) { this.nonExistentIds = ids; };
+    public void setNonExistentIds(boolean r) { this.nonExistentIds = ZmBoolean.fromBool(r); };
     /**
      * Use {@link ActionSelector#setTagNames(String)} instead.
      */
@@ -198,7 +199,7 @@ public class ActionSelector {
     public String getIds() { return ids; }
     public String getOperation() { return operation; }
     public String getConstraint() { return constraint; }
-    public String getNonExistentIds() { return nonExistentIds; };
+    public boolean getNonExistentIds() { return ZmBoolean.toBool(nonExistentIds); };
 
     /**
      * Use {@link ActionSelector#getTagNames()} instead.

--- a/soap/src/java/com/zimbra/soap/mail/type/ActionSelector.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ActionSelector.java
@@ -153,6 +153,13 @@ public class ActionSelector {
     protected String tagNames;
 
     /**
+     * @zm-api-field-tag non-existent-ids
+     * @zm-api-field-description Comma-separated list of non-existent ids
+     */
+    @XmlAttribute(name=MailConstants.A_NON_EXISTENT_IDS /* nei */, required=false)
+    protected String nonExistentIds;
+
+    /**
      * no-argument constructor wanted by JAXB
      */
     protected ActionSelector() {

--- a/soap/src/java/com/zimbra/soap/mail/type/ActionSelector.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ActionSelector.java
@@ -187,6 +187,7 @@ public class ActionSelector {
     public void setColor(Byte color) { this.color = color; }
     public void setName(String name) { this.name = name; }
     public void setFlags(String flags) { this.flags = flags; }
+    public void setNonExistentIds(String ids) { this.nonExistentIds = ids; };
     /**
      * Use {@link ActionSelector#setTagNames(String)} instead.
      */
@@ -197,6 +198,7 @@ public class ActionSelector {
     public String getIds() { return ids; }
     public String getOperation() { return operation; }
     public String getConstraint() { return constraint; }
+    public String getNonExistentIds() { return nonExistentIds; };
 
     /**
      * Use {@link ActionSelector#getTagNames()} instead.
@@ -227,7 +229,8 @@ public class ActionSelector {
             .add("name", name)
             .add("flags", flags)
             .add("tags", tags)
-            .add("tagNames", tagNames);
+            .add("tagNames", tagNames)
+            .add("nonExistentIds", nonExistentIds);
     }
 
     @Override

--- a/soap/src/java/com/zimbra/soap/mail/type/FolderActionResult.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/FolderActionResult.java
@@ -25,7 +25,7 @@ import javax.xml.bind.annotation.XmlAttribute;
 import com.zimbra.common.soap.MailConstants;
 
 @XmlAccessorType(XmlAccessType.NONE)
-public class FolderActionResult extends IdAndOperation {
+public class FolderActionResult extends ActionResult {
 
     /**
      * @zm-api-field-tag grantee-zimbra-id

--- a/soap/src/java/com/zimbra/soap/mail/type/IdAndOperation.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/IdAndOperation.java
@@ -42,6 +42,13 @@ public class IdAndOperation {
     private final String operation;
 
     /**
+     * @zm-api-field-tag non-existent-ids
+     * @zm-api-field-description Comma-separated list of non-existent ids
+     */
+    @XmlAttribute(name=MailConstants.A_NON_EXISTENT_IDS /* nei */, required=false)
+    protected String nonExistentIds;
+
+    /**
      * no-argument constructor wanted by JAXB
      */
     @SuppressWarnings("unused")
@@ -57,10 +64,15 @@ public class IdAndOperation {
     public String getId() { return id; }
     public String getOperation() { return operation; }
 
+    public void setNonExistentIds(String ids) { this.nonExistentIds = ids; };
+    public String getNonExistentIds() { return nonExistentIds; };
+
+
     public Objects.ToStringHelper addToStringInfo(Objects.ToStringHelper helper) {
         return helper
             .add("id", id)
-            .add("operation", operation);
+            .add("operation", operation)
+            .add("nei", nonExistentIds);
     }
 
     @Override

--- a/store/src/java-test/com/zimbra/cs/service/mail/ItemActionTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/mail/ItemActionTest.java
@@ -115,9 +115,9 @@ public class ItemActionTest {
         ItemId iidTarget = new ItemId(mbox, Mailbox.ID_FOLDER_SENT);
         ItemActionHelper op = ItemActionHelper.COPY(null, mbox, SoapProtocol.Soap12, Arrays.asList(msgId), MailItem.Type.MESSAGE, null, iidTarget);
         Assert.assertNotNull(op);
-        Assert.assertNotNull(op.getCreatedIds());
-        Assert.assertEquals(1, op.getCreatedIds().size());
-        ItemId iid = new ItemId(op.getCreatedIds().get(0), acct.getId());
+        Assert.assertNotNull(op.getResult().getSuccessIds());
+        Assert.assertEquals(1, op.getResult().getSuccessIds().size());
+        ItemId iid = new ItemId(op.getResult().getSuccessIds().get(0), acct.getId());
         Assert.assertNotNull(iid);
         Message copiedMessage = mbox.getMessageById(null, iid.getId());
         Assert.assertNotNull(copiedMessage);

--- a/store/src/java/com/zimbra/cs/service/mail/ContactAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ContactAction.java
@@ -65,7 +65,7 @@ public class ContactAction extends ItemAction {
         if (CONTACT_OPS.contains(operation)) {
             successes = handleContact(context, request, operation);
         } else {
-            successes = handleCommon(context, request, operation, MailItem.Type.CONTACT);
+            successes = handleCommon(context, request, MailItem.Type.CONTACT);
         }
         Element response = zsc.createElement(MailConstants.CONTACT_ACTION_RESPONSE);
         Element actionOut = response.addUniqueElement(MailConstants.E_ACTION);

--- a/store/src/java/com/zimbra/cs/service/mail/ContactActionHelper.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ContactActionHelper.java
@@ -16,6 +16,7 @@
  */
 package com.zimbra.cs.service.mail;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import com.zimbra.common.mailbox.Color;
@@ -86,11 +87,12 @@ public class ContactActionHelper extends ItemActionHelper {
             throw ServiceException.INVALID_REQUEST("unknown operation: " + mOperation, null);
         }
 
-        StringBuilder successes = new StringBuilder();
+        List<String> successes = new ArrayList<String>();
         for (int id : itemIds) {
-            successes.append(successes.length() > 0 ? "," : "").append(mIdFormatter.formatItemId(id));
+            successes.add(mIdFormatter.formatItemId(id));
         }
-        mResult = successes.toString();
+        mResult = new ItemActionResult();
+        mResult.appendSuccessIds(successes);
     }
 
     @Override

--- a/store/src/java/com/zimbra/cs/service/mail/ConvAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ConvAction.java
@@ -40,7 +40,7 @@ public class ConvAction extends ItemAction {
         Element action = request.getElement(MailConstants.E_ACTION);
         String operation = action.getAttribute(MailConstants.A_OPERATION).toLowerCase();
 
-        String successes = Joiner.on(",").join(handleCommon(context, request, operation, MailItem.Type.CONVERSATION).getSuccessIds());
+        String successes = Joiner.on(",").join(handleCommon(context, request, MailItem.Type.CONVERSATION).getSuccessIds());
 
         Element response = lc.createElement(MailConstants.CONV_ACTION_RESPONSE);
         Element act = response.addUniqueElement(MailConstants.E_ACTION);

--- a/store/src/java/com/zimbra/cs/service/mail/ConvAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ConvAction.java
@@ -18,6 +18,8 @@ package com.zimbra.cs.service.mail;
 
 import java.util.Map;
 
+import com.google.common.base.Joiner;
+
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.MailConstants;
 import com.zimbra.common.soap.Element;
@@ -38,7 +40,7 @@ public class ConvAction extends ItemAction {
         Element action = request.getElement(MailConstants.E_ACTION);
         String operation = action.getAttribute(MailConstants.A_OPERATION).toLowerCase();
 
-        String successes = handleCommon(context, request, operation, MailItem.Type.CONVERSATION);
+        String successes = Joiner.on(",").join(handleCommon(context, request, operation, MailItem.Type.CONVERSATION).getSuccessIds());
 
         Element response = lc.createElement(MailConstants.CONV_ACTION_RESPONSE);
         Element act = response.addUniqueElement(MailConstants.E_ACTION);

--- a/store/src/java/com/zimbra/cs/service/mail/CopyActionResult.java
+++ b/store/src/java/com/zimbra/cs/service/mail/CopyActionResult.java
@@ -1,0 +1,49 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2017 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.service.mail;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CopyActionResult extends ItemActionResult {
+
+    protected List<String> mCreatedIds;
+
+    public CopyActionResult() {
+        super();
+        mCreatedIds = new ArrayList<String>();
+    }
+
+    public CopyActionResult(List<String> ids, List<String> createdIds) {
+        super();
+        mCreatedIds = createdIds;
+        setSuccessIds(ids);
+    }
+
+    public List<String> getCreatedIds() {
+        return mCreatedIds;
+    }
+
+    public void setCreatedIds(List<String> mCreatedIds) {
+        this.mCreatedIds = mCreatedIds;
+    }
+
+    public void appendCreatedIds(List<String> createdIds) {
+        this.mCreatedIds.addAll(createdIds);
+    }
+
+}

--- a/store/src/java/com/zimbra/cs/service/mail/DeleteActionResult.java
+++ b/store/src/java/com/zimbra/cs/service/mail/DeleteActionResult.java
@@ -1,0 +1,52 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2017 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.service.mail;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DeleteActionResult extends ItemActionResult {
+
+    protected List<String> mNonExistentIds;
+
+    public DeleteActionResult() {
+        mNonExistentIds = new ArrayList<String>();
+    }
+
+    public DeleteActionResult(List<String> ids, List<String> nonExistentIds) {
+        super();
+        mNonExistentIds = nonExistentIds;
+        setSuccessIds(ids);
+    }
+
+    public List<String> getNonExistentIds() {
+        return mNonExistentIds;
+    }
+
+    public void setNonExistentIds(List<String> mNonExistentIds) {
+        this.mNonExistentIds = mNonExistentIds;
+    }
+
+    public void appendNonExistentIds(List<String> nonExistentIds) {
+        this.mNonExistentIds.addAll(nonExistentIds);
+    }
+
+    public void appendNonExistentId(String nonExistentId) {
+        this.mNonExistentIds.add(nonExistentId);
+    }
+
+}

--- a/store/src/java/com/zimbra/cs/service/mail/FolderAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/FolderAction.java
@@ -119,7 +119,7 @@ public class FolderAction extends ItemAction {
         if (FOLDER_OPS.contains(operation)) {
             successes = handleFolder(context, request, operation, result);
         } else {
-            successes = Joiner.on(",").join(handleCommon(context, request, operation, MailItem.Type.FOLDER).getSuccessIds());
+            successes = Joiner.on(",").join(handleCommon(context, request, MailItem.Type.FOLDER).getSuccessIds());
         }
         result.addAttribute(MailConstants.A_ID, successes);
         result.addAttribute(MailConstants.A_OPERATION, operation);
@@ -192,7 +192,7 @@ public class FolderAction extends ItemAction {
                         Domain domain = Provisioning.getInstance().getDomain(mbox.getAccount());
                         String granteeDomainName = ((MailTarget) nentry).getDomainName();
                         if (domain.isInternalSharingCrossDomainEnabled() ||
-                                domain.getName().equals(granteeDomainName) || 
+                                domain.getName().equals(granteeDomainName) ||
                                 Sets.newHashSet(domain.getInternalSharingDomain()).contains(granteeDomainName)) {
                             guestGrantee = false;
                             zid = nentry.getId();
@@ -420,7 +420,7 @@ public class FolderAction extends ItemAction {
         } else {
             throw ServiceException.INVALID_REQUEST("invalid grantee type for revokeOrphanGrants", null);
         }
-        
+
         String query = "(" + Provisioning.A_zimbraId + "=" + granteeId + ")";
         opts.setFilterString(FilterId.SEARCH_GRANTEE, query);
         opts.setOnMaster(true);  // search the grantee on LDAP master
@@ -429,7 +429,7 @@ public class FolderAction extends ItemAction {
         if (entries.size() != 0) {
             throw ServiceException.INVALID_REQUEST("grantee " + granteeId + " exists", null);
         }
-        
+
         // the grantee indeed does not exist, revoke all grants granted to the grantee
         // in this folder and all subfolders
         FolderNode rootNode = mbox.getFolderTree(octxt, iid, true);
@@ -469,5 +469,5 @@ public class FolderAction extends ItemAction {
         for (FolderNode subNode : node.mSubfolders)
             revokeOrphanGrants(octxt, mbox, subNode, granteeId, gtype);
     }
-    
+
 }

--- a/store/src/java/com/zimbra/cs/service/mail/FolderAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/FolderAction.java
@@ -20,6 +20,7 @@
  */
 package com.zimbra.cs.service.mail;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.zimbra.common.account.Key;
@@ -118,7 +119,7 @@ public class FolderAction extends ItemAction {
         if (FOLDER_OPS.contains(operation)) {
             successes = handleFolder(context, request, operation, result);
         } else {
-            successes = handleCommon(context, request, operation, MailItem.Type.FOLDER);
+            successes = Joiner.on(",").join(handleCommon(context, request, operation, MailItem.Type.FOLDER).getSuccessIds());
         }
         result.addAttribute(MailConstants.A_ID, successes);
         result.addAttribute(MailConstants.A_OPERATION, operation);

--- a/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
@@ -542,7 +542,7 @@ public class ItemAction extends MailDocumentHandler {
             action.addAttribute(MailConstants.A_FOLDER, iidFolder.toString());
         }
 
-        ItemActionResult successes = new ItemActionResult();
+        ItemActionResult result = new ItemActionResult();
         for (Map.Entry<String, StringBuilder> entry : remote.entrySet()) {
             // update the <action> element to reference the subset of target items belonging to this user...
             String itemIds = entry.getValue().toString();
@@ -565,7 +565,7 @@ public class ItemAction extends MailDocumentHandler {
             }
         }
 
-        return successes;
+        return result;
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
@@ -144,7 +144,7 @@ public class ItemAction extends MailDocumentHandler {
         Account remoteNotify = forceRemoteSession(zsc, context, octxt, opStr, action);
 
         // handle referenced items living on other servers
-        ItemActionResult remoteResults = proxyRemoteItems(action, remote, request, context);
+        ItemActionResult result = proxyRemoteItems(action, remote, request, context);
 
         // handle referenced items living on this server
         if (!local.isEmpty()) {
@@ -231,7 +231,12 @@ public class ItemAction extends MailDocumentHandler {
             } else {
                 throw ServiceException.INVALID_REQUEST("unknown operation: " + opStr, null);
             }
-            successes.appendSuccessIds(localResults.getSuccessIds());
+
+            result.appendSuccessIds(localResults.getSuccessIds());
+            if (opStr.equals(MailConstants.OP_HARD_DELETE))
+            {
+                ((DeleteActionResult)result).appendNonExistentIds(((DeleteActionResult)localResults).getNonExistentIds());
+            }
         }
 
         // for moves/copies, make sure that we received notifications from the target folder
@@ -239,7 +244,7 @@ public class ItemAction extends MailDocumentHandler {
             proxyRequest(zsc.createElement(MailConstants.NO_OP_REQUEST), context, remoteNotify.getId());
         }
 
-        return successes;
+        return result;
     }
 
     protected ItemActionResult handleTrashOperation(OperationContext octxt, Element request, Mailbox mbox,

--- a/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
@@ -518,7 +518,7 @@ public class ItemAction extends MailDocumentHandler {
         }
     }
 
-    protected StringBuilder proxyRemoteItems(Element action, Map<String, StringBuilder> remote, Element request, Map<String, Object> context)
+    protected ItemActionResult proxyRemoteItems(Element action, Map<String, StringBuilder> remote, Element request, Map<String, Object> context)
     throws ServiceException {
         String folderStr = action.getAttribute(MailConstants.A_FOLDER, null);
         if (folderStr != null) {
@@ -527,7 +527,7 @@ public class ItemAction extends MailDocumentHandler {
             action.addAttribute(MailConstants.A_FOLDER, iidFolder.toString());
         }
 
-        StringBuilder successes = new StringBuilder();
+        ItemActionResult successes = new ItemActionResult();
         for (Map.Entry<String, StringBuilder> entry : remote.entrySet()) {
             // update the <action> element to reference the subset of target items belonging to this user...
             String itemIds = entry.getValue().toString();
@@ -538,7 +538,7 @@ public class ItemAction extends MailDocumentHandler {
             // ... and try to extract the list of items affected by the operation
             try {
                 String completed = response.getElement(MailConstants.E_ACTION).getAttribute(MailConstants.A_ID);
-                successes.append(completed.length() > 0 && successes.length() > 0 ? "," : "").append(completed);
+                successes.appendSuccessIds(completed.split(","));
             } catch (ServiceException e) {
                 ZimbraLog.misc.warn("could not extract ItemAction successes from proxied response", e);
             }

--- a/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
@@ -107,6 +107,11 @@ public class ItemAction extends MailDocumentHandler {
         Element act = response.addUniqueElement(MailConstants.E_ACTION);
         act.addAttribute(MailConstants.A_ID, Joiner.on(",").join(result.getSuccessIds()));
         act.addAttribute(MailConstants.A_OPERATION, operation);
+        String opStr = getOperation(operation);
+        if (opStr.equals(MailConstants.OP_HARD_DELETE))
+        {
+            act.addAttribute(MailConstants.A_NON_EXISTENT_IDS, Joiner.on(",").join(((DeleteActionResult)result).getNonExistentIds()));
+        }
         return response;
     }
 

--- a/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
@@ -553,6 +553,9 @@ public class ItemAction extends MailDocumentHandler {
             ItemId iidFolder = new ItemId(folderStr, getZimbraSoapContext(context));
             action.addAttribute(MailConstants.A_FOLDER, iidFolder.toString());
         }
+
+        String opStr = getOperation(request);
+
         ItemActionResult result = null;
         if (opStr.equals(MailConstants.OP_HARD_DELETE))
         {

--- a/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
@@ -100,11 +100,11 @@ public class ItemAction extends MailDocumentHandler {
         Element action = request.getElement(MailConstants.E_ACTION);
         String operation = action.getAttribute(MailConstants.A_OPERATION).toLowerCase();
 
-        String successes = handleCommon(context, request, operation, MailItem.Type.UNKNOWN);
+        ItemActionResult result = handleCommon(context, request, operation, MailItem.Type.UNKNOWN);
 
         Element response = zsc.createElement(MailConstants.ITEM_ACTION_RESPONSE);
         Element act = response.addUniqueElement(MailConstants.E_ACTION);
-        act.addAttribute(MailConstants.A_ID, successes);
+        act.addAttribute(MailConstants.A_ID, Joiner.on(",").join(result.getSuccessIds()));
         act.addAttribute(MailConstants.A_OPERATION, operation);
         return response;
     }

--- a/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
@@ -210,7 +210,7 @@ public class ItemAction extends MailDocumentHandler {
                 localResults = ItemActionHelper.UNLOCK(octxt, mbox, responseProto, local, type, tcon).getResult();
             } else if (opStr.equals(MailConstants.OP_INHERIT)) {
                 mbox.alterTag(octxt, ArrayUtil.toIntArray(local), type, Flag.FlagInfo.NO_INHERIT, false, tcon);
-                localResults = Joiner.on(",").join(local);
+                localResults = new ItemActionResult(local);
             } else if (opStr.equals(MailConstants.OP_MUTE) && type == MailItem.Type.CONVERSATION) {
                 // note that "mute" ignores the tcon value
                 localResults = ItemActionHelper.TAG(octxt, mbox, responseProto, local, type, Flag.FlagInfo.MUTED.toString(), flagValue, null).getResult();

--- a/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
@@ -108,8 +108,7 @@ public class ItemAction extends MailDocumentHandler {
         act.addAttribute(MailConstants.A_ID, Joiner.on(",").join(result.getSuccessIds()));
         act.addAttribute(MailConstants.A_OPERATION, operation);
         String opStr = getOperation(operation);
-        if (opStr.equals(MailConstants.OP_HARD_DELETE) && nonExistentIdsRequested)
-        {
+        if (opStr.equals(MailConstants.OP_HARD_DELETE) && nonExistentIdsRequested) {
             act.addAttribute(MailConstants.A_NON_EXISTENT_IDS, Joiner.on(",").join(((DeleteActionResult)result).getNonExistentIds()));
         }
         return response;
@@ -245,8 +244,7 @@ public class ItemAction extends MailDocumentHandler {
             }
 
             result.appendSuccessIds(localResults.getSuccessIds());
-            if (opStr.equals(MailConstants.OP_HARD_DELETE))
-            {
+            if (opStr.equals(MailConstants.OP_HARD_DELETE)) {
                 ((DeleteActionResult)result).appendNonExistentIds(((DeleteActionResult)localResults).getNonExistentIds());
             }
         }
@@ -559,12 +557,10 @@ public class ItemAction extends MailDocumentHandler {
         String opStr = getOperation(request);
 
         ItemActionResult result = null;
-        if (opStr.equals(MailConstants.OP_HARD_DELETE))
-        {
+        if (opStr.equals(MailConstants.OP_HARD_DELETE)) {
             result = new DeleteActionResult();
         }
-        else
-        {
+        else {
             result = new ItemActionResult();
         }
         for (Map.Entry<String, StringBuilder> entry : remote.entrySet()) {
@@ -577,12 +573,10 @@ public class ItemAction extends MailDocumentHandler {
             // ... and try to extract the list of items affected by the operation
             try {
                 String completed = response.getElement(MailConstants.E_ACTION).getAttribute(MailConstants.A_ID);
-                for (String id: completed.split(","))
-                {
+                for (String id: completed.split(",")) {
                     result.appendSuccessId(id);
                 }
-                if (opStr.equals(MailConstants.OP_HARD_DELETE) && nonExistentIdsRequested)
-                {
+                if (opStr.equals(MailConstants.OP_HARD_DELETE) && nonExistentIdsRequested) {
                     for (String nonExistentId: response.getElement(MailConstants.E_ACTION).getAttribute(MailConstants.A_NON_EXISTENT_IDS).split(",")) {
                         ((DeleteActionResult)result).appendNonExistentId(nonExistentId);
                     }

--- a/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
@@ -365,7 +365,6 @@ public class ItemAction extends MailDocumentHandler {
         return localResults;
     }
 
-
     private String getDataSourceOfItem(OperationContext octxt, Mailbox mbox, MailItem item) throws ServiceException {
         Folder folder = mbox.getFolderById(octxt, item.getFolderId());
         Map<Integer, String> dataSources = new HashMap<Integer, String>();

--- a/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
@@ -17,6 +17,7 @@
 package com.zimbra.cs.service.mail;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -322,9 +323,8 @@ public class ItemAction extends MailDocumentHandler {
             trashResults.appendSuccessIds(imapTrashResults.getSuccessIds());
         }
         if (!msgToConvId.isEmpty()) {
-            String[] ids = localResults.split(",");
             Set<String> reconstructedConvIds = new HashSet<String>();
-            for (String id: ids) {
+            for (String id: localResults.getSuccessIds()) {
                 String convId = msgToConvId.get(id);
                 if (convId != null) {
                     reconstructedConvIds.add(convId);
@@ -332,7 +332,11 @@ public class ItemAction extends MailDocumentHandler {
                     reconstructedConvIds.add(id);
                 }
             }
-            localResults.appendSuccessIds(reconstructedConvIds.toArray());
+            List<String> reconstructedIds = new ArrayList<String>();
+            for (String id: reconstructedConvIds) {
+                reconstructedConvIds.add(id);
+            }
+            localResults.setSuccessIds(reconstructedIds);
         }
 
         return localResults;
@@ -537,12 +541,14 @@ public class ItemAction extends MailDocumentHandler {
             String accountId = entry.getKey();
             // TODO: Add 'advanced' option to trigger Create / Delete additional information response
 
-            request.setAttribute("", "");
             Element response = proxyRequest(request, context, accountId);
             // ... and try to extract the list of items affected by the operation
             try {
                 String completed = response.getElement(MailConstants.E_ACTION).getAttribute(MailConstants.A_ID);
-                successes.appendSuccessIds(completed.split(","));
+                for (String id: completed.split(","))
+                {
+                    result.appendSuccessId(id);
+                }
                 // TODO: Handle Copy createdIds and Delete: non-existent IDs
             } catch (ServiceException e) {
                 ZimbraLog.misc.warn("could not extract ItemAction successes from proxied response", e);

--- a/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
@@ -340,11 +340,11 @@ public class ItemAction extends MailDocumentHandler {
         return localResults;
     }
 
-    protected String handleMoveOperation(ZimbraSoapContext zsc, OperationContext octxt,
+    protected ItemActionResult handleMoveOperation(ZimbraSoapContext zsc, OperationContext octxt,
             Element request, Element action, Mailbox mbox,
             SoapProtocol responseProto, List<Integer> local, MailItem.Type type, TargetConstraint tcon)
                     throws ServiceException {
-        String localResults;
+        ItemActionResult localResults = new ItemActionResult();
         String acctRelativePath = action.getAttribute(MailConstants.A_ACCT_RELATIVE_PATH, null);
         if (acctRelativePath == null) {
             ItemId iidFolder = new ItemId(action.getAttribute(MailConstants.A_FOLDER), zsc);
@@ -355,17 +355,8 @@ public class ItemAction extends MailDocumentHandler {
             }
             List<ItemActionHelper> actionHelpers =
                     ItemActionHelper.MOVE(octxt, mbox, responseProto, local, tcon, acctRelativePath);
-            if (actionHelpers.isEmpty()) {
-                localResults = "";
-            } else {
-                StringBuilder resultsBuilder = new StringBuilder(actionHelpers.get(0).getResult());
-                for (int i = 1; i < actionHelpers.size(); i++) {
-                    String result = actionHelpers.get(i).getResult();
-                    if (!result.isEmpty()) {
-                        resultsBuilder.append(',').append(result);
-                    }
-                }
-                localResults = resultsBuilder.toString();
+            for (ItemActionHelper helper: actionHelpers) {
+                localResults.appendSuccessIds(helper.getResult().getSuccessIds());
             }
         } else {
             throw ServiceException.INVALID_REQUEST(MailConstants.A_ACCT_RELATIVE_PATH +

--- a/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
@@ -541,8 +541,15 @@ public class ItemAction extends MailDocumentHandler {
             ItemId iidFolder = new ItemId(folderStr, getZimbraSoapContext(context));
             action.addAttribute(MailConstants.A_FOLDER, iidFolder.toString());
         }
-
-        ItemActionResult result = new ItemActionResult();
+        ItemActionResult result = null;
+        if (opStr.equals(MailConstants.OP_HARD_DELETE))
+        {
+            result = new DeleteActionResult();
+        }
+        else
+        {
+            result = new ItemActionResult();
+        }
         for (Map.Entry<String, StringBuilder> entry : remote.entrySet()) {
             // update the <action> element to reference the subset of target items belonging to this user...
             String itemIds = entry.getValue().toString();

--- a/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
@@ -144,7 +144,7 @@ public class ItemAction extends MailDocumentHandler {
         Account remoteNotify = forceRemoteSession(zsc, context, octxt, opStr, action);
 
         // handle referenced items living on other servers
-        ItemActionResult successes = proxyRemoteItems(action, remote, request, context);
+        ItemActionResult remoteResults = proxyRemoteItems(action, remote, request, context);
 
         // handle referenced items living on this server
         if (!local.isEmpty()) {

--- a/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
@@ -101,7 +101,7 @@ public class ItemAction extends MailDocumentHandler {
         Element action = request.getElement(MailConstants.E_ACTION);
         String operation = action.getAttribute(MailConstants.A_OPERATION).toLowerCase();
 
-        ItemActionResult result = handleCommon(context, request, operation, MailItem.Type.UNKNOWN);
+        ItemActionResult result = handleCommon(context, request, MailItem.Type.UNKNOWN);
 
         Element response = zsc.createElement(MailConstants.ITEM_ACTION_RESPONSE);
         Element act = response.addUniqueElement(MailConstants.E_ACTION);
@@ -132,7 +132,7 @@ public class ItemAction extends MailDocumentHandler {
         return operation.startsWith("!");
     }
 
-    protected ItemActionResult handleCommon(Map<String, Object> context, Element request, String opAttr, MailItem.Type type)
+    protected ItemActionResult handleCommon(Map<String, Object> context, Element request, MailItem.Type type)
     throws ServiceException {
         Element action = request.getElement(MailConstants.E_ACTION);
         ZimbraSoapContext zsc = getZimbraSoapContext(context);

--- a/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
@@ -120,6 +120,18 @@ public class ItemAction extends MailDocumentHandler {
         return (opAttr.startsWith("!") ? opAttr.substring(1) : opAttr).toLowerCase();
     }
 
+    protected String getOperation(Element request) throws ServiceException {
+        Element action = request.getElement(MailConstants.E_ACTION);
+        String operation = action.getAttribute(MailConstants.A_OPERATION).toLowerCase();
+        return getOperation(operation);
+    }
+
+    protected boolean isOperationFlagged(Element request) throws ServiceException {
+        Element action = request.getElement(MailConstants.E_ACTION);
+        String operation = action.getAttribute(MailConstants.A_OPERATION).toLowerCase();
+        return operation.startsWith("!");
+    }
+
     protected ItemActionResult handleCommon(Map<String, Object> context, Element request, String opAttr, MailItem.Type type)
     throws ServiceException {
         Element action = request.getElement(MailConstants.E_ACTION);
@@ -129,8 +141,8 @@ public class ItemAction extends MailDocumentHandler {
         SoapProtocol responseProto = zsc.getResponseProtocol();
 
         // determine the requested operation
-        boolean flagValue = !opAttr.startsWith("!");
-        String opStr = getOperation(opAttr);
+        boolean flagValue = !isOperationFlagged(request);
+        String opStr = getOperation(request);
 
         // figure out which items are local and which ones are remote, and proxy accordingly
         List<Integer> local = new ArrayList<Integer>();

--- a/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
@@ -455,8 +455,9 @@ public class ItemActionHelper {
         // iterate over the local items and perform the requested operation
 
         List<String> originalIds = new ArrayList<String>(ids.length);
-        for (int id : ids)
+        for (int id : ids) {
             originalIds.add(mIdFormatter.formatItemId(id));
+        }
         ItemActionResult result = new ItemActionResult();
         result.setSuccessIds(originalIds);
 
@@ -846,12 +847,12 @@ public class ItemActionHelper {
                     if (msgs == null) {
                         mMailbox.delete(mOpCtxt, new int[] { item.getId() }, item.getType(), null, nonExistentItems);
                     } else {
-                        for (Message msg : msgs)
+                        for (Message msg : msgs) {
                             mMailbox.delete(mOpCtxt, new int[] { msg.getId() }, msg.getType(), null, nonExistentItems);
+                        }
                     }
 
-                    for (Integer id: nonExistentItems)
-                    {
+                    for (Integer id: nonExistentItems) {
                         nonExistentIds.add(id.toString());
                     }
                 }

--- a/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
@@ -297,7 +297,6 @@ public class ItemActionHelper {
     }
 
     protected ItemActionResult mResult;
-    protected List<String> mCreatedIds;
 
     protected SoapProtocol mResponseProtocol;
     protected Op mOperation;
@@ -451,10 +450,6 @@ public class ItemActionHelper {
         return mResult;
     }
 
-    public List<String> getCreatedIds() {
-        return mCreatedIds;
-    }
-
     private ItemActionResult executeLocalBatch(int[] ids) throws ServiceException {
         // iterate over the local items and perform the requested operation
 
@@ -503,7 +498,7 @@ public class ItemActionHelper {
                 List<MailItem> copies = getMailbox().copy(getOpCtxt(), ids, type, mIidFolder.getId());
                 List<String> createdIds = new ArrayList<String>(ids.length);
                 for (MailItem item : copies) {
-                    mCreatedIds.add(mIdFormatter.formatItemId(item));
+                     createdIds.add(mIdFormatter.formatItemId(item));
                 }
                 result = new CopyActionResult(originalIds, createdIds);
                 break;
@@ -644,7 +639,7 @@ public class ItemActionHelper {
 
         boolean deleteOriginal = mOperation != Op.COPY;
         String folderStr = mIidFolder.toString();
-        mCreatedIds = new ArrayList<String>(itemIds.length);
+        List<String> createdIds = new ArrayList<String>(itemIds.length);
 
         boolean toSpam = mIidFolder.getId() == Mailbox.ID_FOLDER_SPAM;
         boolean toMailbox = !toSpam && mIidFolder.getId() != Mailbox.ID_FOLDER_TRASH;
@@ -732,7 +727,7 @@ public class ItemActionHelper {
                 fields.remove(ContactConstants.A_groupMember);
                 ZContact contact = zmbx.createContact(folderStr, null, fields, attachments, members);
                 createdId = contact.getId();
-                mCreatedIds.add(createdId);
+                createdIds.add(createdId);
                 break;
             case MESSAGE:
                 try {
@@ -741,7 +736,7 @@ public class ItemActionHelper {
                 } finally {
                     ByteUtil.closeStream(in);
                 }
-                mCreatedIds.add(createdId);
+                createdIds.add(createdId);
                 break;
             case VIRTUAL_CONVERSATION:
             case CONVERSATION:
@@ -753,7 +748,7 @@ public class ItemActionHelper {
                     } finally {
                         ByteUtil.closeStream(in);
                     }
-                    mCreatedIds.add(createdId);
+                    createdIds.add(createdId);
                 }
                 break;
             case DOCUMENT:
@@ -781,7 +776,7 @@ public class ItemActionHelper {
                     ByteUtil.closeStream(in);
                     transport.shutdown();
                 }
-                mCreatedIds.add(createdId);
+                createdIds.add(createdId);
                 break;
             case APPOINTMENT:
             case TASK:
@@ -836,7 +831,7 @@ public class ItemActionHelper {
                 ToXML.encodeCalendarReplies(request, cal);
 
                 createdId = zmbx.invoke(request).getAttribute(MailConstants.A_CAL_ID);
-                mCreatedIds.add(createdId);
+                createdIds.add(createdId);
                 break;
             default:
                 throw MailServiceException.CANNOT_COPY(item.getId());

--- a/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
@@ -439,17 +439,12 @@ public class ItemActionHelper {
 
         try {
             if (!targeted || mIidFolder.belongsTo(mMailbox))
-                executeLocal();
+                mResult = executeLocal();
             else
-                executeRemote();
+                mResult = executeRemote();
         } catch (IOException ioe) {
             throw ServiceException.FAILURE("exception reading item blob", ioe);
         }
-
-        List<String> successes = new ArrayList<String>(itemIds.length);
-        for (int id : itemIds)
-            successes.add(mIdFormatter.formatItemId(id));
-        mResult = new ItemActionResult(successes);
     }
 
     public ItemActionResult getResult() {

--- a/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
@@ -565,6 +565,15 @@ public class ItemActionHelper {
         }
         int offset = 0;
         ItemActionResult localResult = new ItemActionResult();
+        switch (mOperation)
+        {
+        case COPY:
+            localResult = new CopyActionResult();
+        case HARD_DELETE:
+            localResult = new DeleteActionResult();
+            break;
+        }
+
         while (offset < itemIds.length) {
             ItemActionResult batchResult = null;
             int[] batchOfIds = Arrays.copyOfRange(itemIds, offset,

--- a/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
@@ -863,7 +863,19 @@ public class ItemActionHelper {
             }
         }
 
-        ItemActionResult result = new ItemActionResult();
+        ItemActionResult result = null;
+
+        if (Op.HARD_DELETE.equals(mOperation)) {
+            result = new DeleteActionResult();
+            result.setNonExistentIds(nonExistentIds);
+        }
+        else if (Op.COPY.equals(mOperation)) {
+            result = new CopyActionResult();
+            result.setCreatedIds(createdIds);
+        }
+        else
+            result = new ItemActionResult();
+
         result.setSuccessIds(createdIds);
         return result;
     }

--- a/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
@@ -557,18 +557,19 @@ public class ItemActionHelper {
      return result;
     }
 
-    private void executeLocal() throws ServiceException {
+    private ItemActionResult executeLocal() throws ServiceException {
         int batchSize = Provisioning.getInstance().getLocalServer().getItemActionBatchSize();
         ZimbraLog.mailbox.debug("ItemAction batchSize=%d", batchSize);
         if (itemIds.length <= batchSize) {
-            executeLocalBatch(itemIds);
-            return;
+            return executeLocalBatch(itemIds);
         }
         int offset = 0;
+        ItemActionResult localResult = new ItemActionResult();
         while (offset < itemIds.length) {
             ItemActionResult batchResult = null;
             int[] batchOfIds = Arrays.copyOfRange(itemIds, offset,
                     (offset + batchSize < itemIds.length) ? offset + batchSize : itemIds.length);
+
             switch (mOperation)
             {
             case COPY:
@@ -584,11 +585,13 @@ public class ItemActionHelper {
             default:
                 localResult.appendSuccessIds(executeLocalBatch(batchOfIds).getSuccessIds());
             }
+
             offset += batchSize;
             if (offset < itemIds.length) {
                 Thread.yield();
             }
         }
+        return localResult;
     }
 
     private AuthToken getAuthToken() throws ServiceException {

--- a/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
@@ -867,11 +867,11 @@ public class ItemActionHelper {
 
         if (Op.HARD_DELETE.equals(mOperation)) {
             result = new DeleteActionResult();
-            result.setNonExistentIds(nonExistentIds);
+            ((DeleteActionResult)result).setNonExistentIds(nonExistentIds);
         }
         else if (Op.COPY.equals(mOperation)) {
             result = new CopyActionResult();
-            result.setCreatedIds(createdIds);
+            ((CopyActionResult)result).setCreatedIds(createdIds);
         }
         else
             result = new ItemActionResult();

--- a/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
@@ -296,7 +296,7 @@ public class ItemActionHelper {
         }
     }
 
-    protected String mResult;
+    protected ItemActionResult mResult;
     protected List<String> mCreatedIds;
 
     protected SoapProtocol mResponseProtocol;
@@ -446,13 +446,13 @@ public class ItemActionHelper {
             throw ServiceException.FAILURE("exception reading item blob", ioe);
         }
 
-        StringBuilder successes = new StringBuilder();
+        List<String> successes = new ArrayList<String>(itemIds.length);
         for (int id : itemIds)
-            successes.append(successes.length() > 0 ? "," : "").append(mIdFormatter.formatItemId(id));
-        mResult = successes.toString();
+            successes.add(mIdFormatter.formatItemId(id));
+        mResult = new ItemActionResult(successes);
     }
 
-    public String getResult() {
+    public ItemActionResult getResult() {
         return mResult;
     }
 

--- a/store/src/java/com/zimbra/cs/service/mail/ItemActionResult.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemActionResult.java
@@ -1,0 +1,62 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2017 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.service.mail;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ItemActionResult {
+
+    protected List<String> mSuccessIds;
+
+    public ItemActionResult() {
+        mSuccessIds = new ArrayList<String>();
+    }
+
+    public ItemActionResult(int[] ids) {
+        mSuccessIds = new ArrayList<String>(ids.length);
+        for (int id : ids) {
+            mSuccessIds.add(Integer.toString(id));
+        }
+    }
+
+    public ItemActionResult(List<Integer> ids) {
+        mSuccessIds = new ArrayList<String>(ids.size());
+        for (Integer id : ids) {
+            mSuccessIds.add(id.toString());
+        }
+    }
+
+    public List<String> getSuccessIds() {
+        return mSuccessIds;
+    }
+
+    public void setSuccessIds(List<String> ids) {
+        mSuccessIds = ids;
+    }
+
+    public void appendSuccessIds(List<String> ids) {
+        for (String id : ids) {
+            appendSuccessId(id);
+        }
+    }
+
+    public void appendSuccessId(String id) {
+        mSuccessIds.add(id);
+    }
+
+}

--- a/store/src/java/com/zimbra/cs/service/mail/MsgAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/MsgAction.java
@@ -40,7 +40,7 @@ public class MsgAction extends ItemAction {
         Element action = request.getElement(MailConstants.E_ACTION);
         String operation = action.getAttribute(MailConstants.A_OPERATION).toLowerCase();
 
-        String successes = Joiner.on(",").join(handleCommon(context, request, operation, MailItem.Type.MESSAGE).getSuccessIds());
+        String successes = Joiner.on(",").join(handleCommon(context, request, MailItem.Type.MESSAGE).getSuccessIds());
 
         Element response = lc.createElement(MailConstants.MSG_ACTION_RESPONSE);
         Element act = response.addUniqueElement(MailConstants.E_ACTION);

--- a/store/src/java/com/zimbra/cs/service/mail/MsgAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/MsgAction.java
@@ -18,6 +18,8 @@ package com.zimbra.cs.service.mail;
 
 import java.util.Map;
 
+import com.google.common.base.Joiner;
+
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.MailConstants;
 import com.zimbra.common.soap.Element;
@@ -38,7 +40,7 @@ public class MsgAction extends ItemAction {
         Element action = request.getElement(MailConstants.E_ACTION);
         String operation = action.getAttribute(MailConstants.A_OPERATION).toLowerCase();
 
-        String successes = handleCommon(context, request, operation, MailItem.Type.MESSAGE);
+        String successes = Joiner.on(",").join(handleCommon(context, request, operation, MailItem.Type.MESSAGE).getSuccessIds());
 
         Element response = lc.createElement(MailConstants.MSG_ACTION_RESPONSE);
         Element act = response.addUniqueElement(MailConstants.E_ACTION);

--- a/store/src/java/com/zimbra/cs/service/mail/NoteAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/NoteAction.java
@@ -68,7 +68,7 @@ public class NoteAction extends ItemAction {
         if (NOTE_OPS.contains(operation)) {
             successes = handleNote(context, request, operation);
         } else {
-            successes = Joiner.on(",").join(handleCommon(context, request, operation, MailItem.Type.NOTE).getSuccessIds());
+            successes = Joiner.on(",").join(handleCommon(context, request, MailItem.Type.NOTE).getSuccessIds());
         }
         Element response = lc.createElement(MailConstants.NOTE_ACTION_RESPONSE);
         Element act = response.addUniqueElement(MailConstants.E_ACTION);

--- a/store/src/java/com/zimbra/cs/service/mail/NoteAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/NoteAction.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import com.google.common.base.Joiner;
 
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.MailConstants;
@@ -67,7 +68,7 @@ public class NoteAction extends ItemAction {
         if (NOTE_OPS.contains(operation)) {
             successes = handleNote(context, request, operation);
         } else {
-            successes = handleCommon(context, request, operation, MailItem.Type.NOTE);
+            successes = Joiner.on(",").join(handleCommon(context, request, operation, MailItem.Type.NOTE).getSuccessIds());
         }
         Element response = lc.createElement(MailConstants.NOTE_ACTION_RESPONSE);
         Element act = response.addUniqueElement(MailConstants.E_ACTION);

--- a/store/src/java/com/zimbra/cs/service/mail/TagAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/TagAction.java
@@ -18,6 +18,7 @@ package com.zimbra.cs.service.mail;
 
 import java.util.Map;
 import java.util.Set;
+import com.google.common.base.Joiner;
 
 import com.google.common.collect.ImmutableSet;
 import com.zimbra.common.service.ServiceException;
@@ -76,7 +77,7 @@ public class TagAction extends ItemAction  {
             mbox.setRetentionPolicy(octxt, iid.getId(), MailItem.Type.TAG, rp);
             successes = new ItemIdFormatter(zsc).formatItemId(iid);
         } else {
-            successes = handleCommon(context, request, opAttr, MailItem.Type.TAG);
+            successes = Joiner.on(",").join(handleCommon(context, request, opAttr, MailItem.Type.TAG).getSuccessIds());
         }
 
         Element response = zsc.createElement(MailConstants.TAG_ACTION_RESPONSE);

--- a/store/src/java/com/zimbra/cs/service/mail/TagAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/TagAction.java
@@ -77,7 +77,7 @@ public class TagAction extends ItemAction  {
             mbox.setRetentionPolicy(octxt, iid.getId(), MailItem.Type.TAG, rp);
             successes = new ItemIdFormatter(zsc).formatItemId(iid);
         } else {
-            successes = Joiner.on(",").join(handleCommon(context, request, opAttr, MailItem.Type.TAG).getSuccessIds());
+            successes = Joiner.on(",").join(handleCommon(context, request, MailItem.Type.TAG).getSuccessIds());
         }
 
         Element response = zsc.createElement(MailConstants.TAG_ACTION_RESPONSE);

--- a/store/src/java/com/zimbra/qa/unittest/TestZClient.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestZClient.java
@@ -635,6 +635,23 @@ public class TestZClient extends TestCase {
         assertEquals("Comparing getContentStream() on msg and zmsg", msgContent, zmsgContent);
     }
 
+    @Test
+    public void testDelete() throws Exception {
+        ZMailbox zmbox = TestUtil.getZMailbox(USER_NAME);
+        Mailbox mbox = TestUtil.getMailbox(USER_NAME);
+        Message msg = TestUtil.addMessage(mbox, Mailbox.ID_FOLDER_INBOX, "testDelete message", System.currentTimeMillis());
+
+        List<Integer> ids = new ArrayList<Integer>(2);
+        ids.add(msg.getId());
+        ids.add(300);
+
+        List<Integer> nonExistentIds = new ArrayList<Integer>(1);
+        zmbox.delete(null, ids, nonExistentIds);
+        List<Integer> expectedNonExistentIds = new ArrayList<Integer>(1);
+        expectedNonExistentIds.add(300);
+        assertEquals("Non-Existent IDs should be: ", expectedNonExistentIds, nonExistentIds);
+    }
+
     @Override
     public void tearDown()
     throws Exception {


### PR DESCRIPTION
Note: This contains a lot of commits.

The original return type was a comma-separated string of integers.
This needed to be expanded to include the ability to return more than one set of data depending on the operation.
Currently only the 'delete' operation was expanded in order to return the non-existent ids which were attempted to be deleted but not present.

Optimizations are still needed but this is a first pass at getting this working.