### PR TITLE
ZCS-1006:rework(3):"i;ascii-numeric" doesn't handle negative number

### DIFF
--- a/store/src/java/com/zimbra/cs/filter/ZimbraMailAdapter.java
+++ b/store/src/java/com/zimbra/cs/filter/ZimbraMailAdapter.java
@@ -697,10 +697,6 @@ public class ZimbraMailAdapter implements MailAdapter, EnvelopeAccessors {
             return FilterAddress.EMPTY_ADDRESS_ARRAY;
         }
 
-        return stringAddress2MailAdapterAddress(hdrValues);
-    }
-
-    public static MailAdapter.Address[] stringAddress2MailAdapterAddress(String[] hdrValues) {
         List<Address> retVal = new LinkedList<Address>();
         for (String hdrValue : hdrValues) {
             for (InternetAddress addr : InternetAddress.parseHeader(hdrValue)) {

--- a/store/src/java/com/zimbra/cs/filter/jsieve/AddressTest.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/AddressTest.java
@@ -158,7 +158,7 @@ public class AddressTest extends Address {
         return isMatched;
     }
 
-    public static String getMatchAddress(String addressPart, String localPart, String domain) {
+    private String getMatchAddress(String addressPart, String localPart, String domain) {
         // Extract the part of the address we are matching on
         final String matchAddress;
         if (ALL_TAG.equals(addressPart))


### PR DESCRIPTION
[bug]
If the :localpart or :domain is specified in the envelope test with
:is match type, and if the given envelope address contains some
special characters, such as double-quotation, backslash, or comma,
the envelope test failes.

[fix]
* Backout the previous changes (79fd899e421e2acafb89f45c4849d92b9ee35fd5)
* Copy the logic for extracting the :localpart and :domain part from
  org.apache.jsieve.tests.optional.Envelope.match().

[Unit test]
EnvelopTest, AddressTest, HeaderTest, AddHeaderTest, DeleteHeaderTest,
ReplaceHeaderTest: PASS

[Automation script]
Run ZCS-559_EscapeSeq.xml, zcs-1006_AsciiNumericNegativNumber.xml on
my sandbox: PASS