### PR TITLE
ZCS-1248 Sieve attributes should be usable at account level

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -8416,7 +8416,7 @@ public class ZAttrProvisioning {
      * outgoing sieve script defined by admin (not able to edit and view from
      * the end user) applied after the end user filter rule
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public static final String A_zimbraMailAdminOutgoingSieveScriptAfter = "zimbraMailAdminOutgoingSieveScriptAfter";
@@ -8425,7 +8425,7 @@ public class ZAttrProvisioning {
      * outgoing sieve script defined by admin (not able to edit and view from
      * the end user) applied before the end user filter rule
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public static final String A_zimbraMailAdminOutgoingSieveScriptBefore = "zimbraMailAdminOutgoingSieveScriptBefore";
@@ -8434,7 +8434,7 @@ public class ZAttrProvisioning {
      * sieve script defined by admin (not able to edit and view from the end
      * user) applied after the end user filter rule
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public static final String A_zimbraMailAdminSieveScriptAfter = "zimbraMailAdminSieveScriptAfter";
@@ -8443,7 +8443,7 @@ public class ZAttrProvisioning {
      * sieve script defined by admin (not able to edit and view from the end
      * user) applied before the end user filter rule
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public static final String A_zimbraMailAdminSieveScriptBefore = "zimbraMailAdminSieveScriptBefore";
@@ -8920,10 +8920,13 @@ public class ZAttrProvisioning {
     public static final String A_zimbraMailReferMode = "zimbraMailReferMode";
 
     /**
-     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
-     * parses the &#039;notify&#039; action parameters based on the syntax
-     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
-     * &#039;notify&#039; action parameters with Zimbra specific format
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveNotifyActionRFCCompliant, which can be used at account
+     * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
+     * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
+     * based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS
+     * treats the &#039;notify&#039; action parameters with Zimbra specific
+     * format
      *
      * @since ZCS 8.7.8
      */
@@ -15267,13 +15270,35 @@ public class ZAttrProvisioning {
     public static final String A_zimbraShortTermGranteeCacheSize = "zimbraShortTermGranteeCacheSize";
 
     /**
-     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
-     * 5429.
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public static final String A_zimbraSieveNotifyActionRFCCompliant = "zimbraSieveNotifyActionRFCCompliant";
+
+    /**
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
+     * RFC 5429.
      *
      * @since ZCS 8.7.8
      */
     @ZAttr(id=2094)
     public static final String A_zimbraSieveRejectEnabled = "zimbraSieveRejectEnabled";
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public static final String A_zimbraSieveRejectMailEnabled = "zimbraSieveRejectMailEnabled";
 
     /**
      * Unique ID for an signature

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9227,30 +9227,32 @@ TODO: delete them permanently from here
   <desc>Value for postconf postscreen_upstream_proxy_protocol.</desc>
 </attr>
 
-<attr id="2090" name="zimbraMailAdminSieveScriptBefore" type="string" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.8">
+<attr id="2090" name="zimbraMailAdminSieveScriptBefore" type="string" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.9">
 <desc>sieve script defined by admin (not able to edit and view from the end user) applied before the end user filter rule</desc>
 </attr>
 
-<attr id="2091" name="zimbraMailAdminSieveScriptAfter" type="string" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.8">
+<attr id="2091" name="zimbraMailAdminSieveScriptAfter" type="string" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.9">
 <desc>sieve script defined by admin (not able to edit and view from the end user) applied after the end user filter rule</desc>
 </attr>
 
-<attr id="2092" name="zimbraMailAdminOutgoingSieveScriptBefore" type="string" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.8">
+<attr id="2092" name="zimbraMailAdminOutgoingSieveScriptBefore" type="string" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.9">
 <desc>outgoing sieve script defined by admin (not able to edit and view from the end user) applied before the end user filter rule</desc>
 </attr>
 
-<attr id="2093" name="zimbraMailAdminOutgoingSieveScriptAfter" type="string" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.8">
+<attr id="2093" name="zimbraMailAdminOutgoingSieveScriptAfter" type="string" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.9">
 <desc>outgoing sieve script defined by admin (not able to edit and view from the end user) applied after the end user filter rule</desc>
 </attr>
 
-<attr id="2094" name="zimbraSieveRejectEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mailbox" since="8.7.8">
+<attr id="2094" name="zimbraSieveRejectEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mailbox" since="8.7.8" deprecatedSince="8.7.9">
 <globalConfigValue>TRUE</globalConfigValue>
 <desc>Whether to enable the Sieve "reject" action defined in RFC 5429.</desc>
+<deprecateDesc>deprecated in favor of zimbraSieveRejectMailEnabled, which can be used at account level</deprecateDesc>
 </attr>
 
-<attr id="2095" name="zimbraMailSieveNotifyActionRFCCompliant" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mailbox" since="8.7.8">
+<attr id="2095" name="zimbraMailSieveNotifyActionRFCCompliant" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mailbox" since="8.7.8" deprecatedSince="8.7.9">
 <globalConfigValue>FALSE</globalConfigValue>
 <desc>Whether the RFC compliant 'notify' is used. If TRUE, ZCS parses the 'notify' action parameters based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS treats the 'notify' action parameters with Zimbra specific format</desc>
+<deprecateDesc>deprecated in favor of zimbraSieveNotifyActionRFCCompliant, which can be used at account level</deprecateDesc>
 </attr>
 
 <attr id="2097" name="zimbraGalSyncSizeLimit" type="integer" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited" since="8.7.2">
@@ -9446,5 +9448,15 @@ TODO: delete them permanently from here
 
 <attr id="2110" name="zimbraDriveOwnCloudURL" type="string" cardinality="single" optionalIn="domain" since="8.7.6">
   <desc>Drive own or next cloud URL.</desc>
+</attr>
+
+<attr id="2111" name="zimbraSieveRejectMailEnabled" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.9">
+<defaultCOSValue>TRUE</defaultCOSValue>
+<desc>Whether to enable the Sieve "reject" action defined in RFC 5429.</desc>
+</attr>
+
+<attr id="2112" name="zimbraSieveNotifyActionRFCCompliant" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.9">
+<defaultCOSValue>FALSE</defaultCOSValue>
+<desc>Whether the RFC compliant 'notify' is used. If TRUE, ZCS parses the 'notify' action parameters based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS treats the 'notify' action parameters with Zimbra specific format</desc>
 </attr>
 </attrs>

--- a/store/src/java-test/com/zimbra/cs/filter/EscapeSequencesTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/EscapeSequencesTest.java
@@ -63,22 +63,22 @@ public final class EscapeSequencesTest {
 
         Map<String, Object> attrs = Maps.newHashMap();
         attrs = Maps.newHashMap();
-        attrs.put(Provisioning.A_zimbraMailSieveNotifyActionRFCCompliant, "TRUE");
-        prov.getLocalServer().modify(attrs);
 
         prov.createDomain("zimbra.com", attrs);
 
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "TRUE");
         Account account = prov.createAccount("test1@zimbra.com", "secret", attrs);
-        Server server = Provisioning.getInstance().getServer(account);
 
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "TRUE");
         prov.createAccount("test2@zimbra.com", "secret", attrs);
 
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "TRUE");
         prov.createAccount("test3@zimbra.com", "secret", attrs);
 
         // this MailboxManager does everything except actually send mail

--- a/store/src/java-test/com/zimbra/cs/filter/NotifyMailtoTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/NotifyMailtoTest.java
@@ -63,26 +63,27 @@ public class NotifyMailtoTest {
 
         Map<String, Object> attrs = Maps.newHashMap();
         attrs = Maps.newHashMap();
-        attrs.put(Provisioning.A_zimbraMailSieveNotifyActionRFCCompliant, "TRUE");
-        prov.getLocalServer().modify(attrs);
 
         prov.createDomain("zimbra.com", attrs);
 
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "TRUE");
         Account account = prov.createAccount("test1@zimbra.com", "secret", attrs);
-        Server server = Provisioning.getInstance().getServer(account);
 
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "TRUE");
         prov.createAccount("test2@zimbra.com", "secret", attrs);
 
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "TRUE");
         prov.createAccount("\"tes\\\\t2\"@zimbra.com", "secret", attrs);
 
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "TRUE");
         prov.createAccount("test3@zimbra.com", "secret", attrs);
 
         // this MailboxManager does everything except actually send mail

--- a/store/src/java-test/com/zimbra/cs/filter/NotifyTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/NotifyTest.java
@@ -60,10 +60,12 @@ public class NotifyTest {
 
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "FALSE");
         prov.createAccount("test@zimbra.com", "secret", attrs);
 
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "FALSE");
         prov.createAccount("test2@zimbra.com", "secret", attrs);
 
         // this MailboxManager does everything except actually send mail

--- a/store/src/java-test/com/zimbra/cs/service/mail/ModifyFilterRulesTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/mail/ModifyFilterRulesTest.java
@@ -126,7 +126,7 @@ public class ModifyFilterRulesTest {
             fail("This test is expected not to throw exception. ");
         }
 
-        String expectedScript = "require [\"fileinto\", \"reject\", \"tag\", \"flag\"];\n\n";
+        String expectedScript = "require [\"fileinto\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\", \"enotify\"];\n\n";
         expectedScript += "# Test1\n";
         expectedScript += "if anyof (header :contains [\"subject\"] \"important\") {\n";
         expectedScript += "    fileinto \"Junk\";\n";
@@ -186,7 +186,7 @@ public class ModifyFilterRulesTest {
             fail("This test is expected not to throw exception. ");
         }
 
-        String expectedScript = "require [\"fileinto\", \"reject\", \"tag\", \"flag\"];\n\n";
+        String expectedScript = "require [\"fileinto\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\", \"enotify\"];\n\n";
         expectedScript += "# Test1\n";
         expectedScript += "if anyof (header :contains [\"subject\"] \"important\") {\n";
         expectedScript += "    if anyof (header :is [\"subject\"] \"confifential\") {\n";
@@ -272,7 +272,7 @@ public class ModifyFilterRulesTest {
 
         Element nfilteraction2 = nestedRule2.addElement(MailConstants.E_FILTER_ACTIONS);
         Element nactionInto2 = nfilteraction2.addElement(MailConstants.E_ACTION_FILE_INTO);
-        nactionInto2.addAttribute(MailConstants.A_FOLDER_PATH, "Trush");
+        nactionInto2.addAttribute(MailConstants.A_FOLDER_PATH, "Trash");
         nfilteraction2.addElement(MailConstants.E_ACTION_STOP);
 
         try {
@@ -281,7 +281,7 @@ public class ModifyFilterRulesTest {
             fail("This test is expected not to throw exception. ");
         }
 
-        String expectedScript = "require [\"fileinto\", \"reject\", \"tag\", \"flag\"];\n\n";
+        String expectedScript = "require [\"fileinto\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\", \"enotify\"];\n\n";
         expectedScript += "# Test1\n";
         expectedScript += "if anyof (header :contains [\"Subject\"] \"important\") {\n";
         expectedScript += "    if allof (header :is [\"Subject\"] \"confifential\",\n";
@@ -296,7 +296,7 @@ public class ModifyFilterRulesTest {
         expectedScript += "  header :contains [\"from\"] \"solutions\") {\n";
         expectedScript += "    if anyof (header :is [\"subject\"] \"confifential\",\n";
         expectedScript += "      header :contains [\"Cc\"] \"test\") {\n";
-        expectedScript += "        fileinto \"Trush\";\n";
+        expectedScript += "        fileinto \"Trash\";\n";
         expectedScript += "        stop;\n";
         expectedScript += "    }\n";
         expectedScript += "}\n";

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -23328,7 +23328,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @return zimbraMailAdminOutgoingSieveScriptAfter, or null if unset
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public String getMailAdminOutgoingSieveScriptAfter() {
@@ -23342,7 +23342,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param zimbraMailAdminOutgoingSieveScriptAfter new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public void setMailAdminOutgoingSieveScriptAfter(String zimbraMailAdminOutgoingSieveScriptAfter) throws com.zimbra.common.service.ServiceException {
@@ -23359,7 +23359,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public Map<String,Object> setMailAdminOutgoingSieveScriptAfter(String zimbraMailAdminOutgoingSieveScriptAfter, Map<String,Object> attrs) {
@@ -23374,7 +23374,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public void unsetMailAdminOutgoingSieveScriptAfter() throws com.zimbra.common.service.ServiceException {
@@ -23390,7 +23390,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public Map<String,Object> unsetMailAdminOutgoingSieveScriptAfter(Map<String,Object> attrs) {
@@ -23405,7 +23405,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @return zimbraMailAdminOutgoingSieveScriptBefore, or null if unset
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public String getMailAdminOutgoingSieveScriptBefore() {
@@ -23419,7 +23419,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param zimbraMailAdminOutgoingSieveScriptBefore new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public void setMailAdminOutgoingSieveScriptBefore(String zimbraMailAdminOutgoingSieveScriptBefore) throws com.zimbra.common.service.ServiceException {
@@ -23436,7 +23436,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public Map<String,Object> setMailAdminOutgoingSieveScriptBefore(String zimbraMailAdminOutgoingSieveScriptBefore, Map<String,Object> attrs) {
@@ -23451,7 +23451,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public void unsetMailAdminOutgoingSieveScriptBefore() throws com.zimbra.common.service.ServiceException {
@@ -23467,7 +23467,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public Map<String,Object> unsetMailAdminOutgoingSieveScriptBefore(Map<String,Object> attrs) {
@@ -23482,7 +23482,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @return zimbraMailAdminSieveScriptAfter, or null if unset
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public String getMailAdminSieveScriptAfter() {
@@ -23496,7 +23496,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param zimbraMailAdminSieveScriptAfter new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public void setMailAdminSieveScriptAfter(String zimbraMailAdminSieveScriptAfter) throws com.zimbra.common.service.ServiceException {
@@ -23513,7 +23513,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public Map<String,Object> setMailAdminSieveScriptAfter(String zimbraMailAdminSieveScriptAfter, Map<String,Object> attrs) {
@@ -23528,7 +23528,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public void unsetMailAdminSieveScriptAfter() throws com.zimbra.common.service.ServiceException {
@@ -23544,7 +23544,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public Map<String,Object> unsetMailAdminSieveScriptAfter(Map<String,Object> attrs) {
@@ -23559,7 +23559,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @return zimbraMailAdminSieveScriptBefore, or null if unset
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public String getMailAdminSieveScriptBefore() {
@@ -23573,7 +23573,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param zimbraMailAdminSieveScriptBefore new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public void setMailAdminSieveScriptBefore(String zimbraMailAdminSieveScriptBefore) throws com.zimbra.common.service.ServiceException {
@@ -23590,7 +23590,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public Map<String,Object> setMailAdminSieveScriptBefore(String zimbraMailAdminSieveScriptBefore, Map<String,Object> attrs) {
@@ -23605,7 +23605,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public void unsetMailAdminSieveScriptBefore() throws com.zimbra.common.service.ServiceException {
@@ -23621,7 +23621,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public Map<String,Object> unsetMailAdminSieveScriptBefore(Map<String,Object> attrs) {
@@ -55110,6 +55110,170 @@ public abstract class ZAttrAccount  extends MailTarget {
     public Map<String,Object> unsetSharedItem(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSharedItem, "");
+        return attrs;
+    }
+
+    /**
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @return zimbraSieveNotifyActionRFCCompliant, or false if unset
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public boolean isSieveNotifyActionRFCCompliant() {
+        return getBooleanAttr(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, false, true);
+    }
+
+    /**
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @param zimbraSieveNotifyActionRFCCompliant new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public void setSieveNotifyActionRFCCompliant(boolean zimbraSieveNotifyActionRFCCompliant) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, zimbraSieveNotifyActionRFCCompliant ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @param zimbraSieveNotifyActionRFCCompliant new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public Map<String,Object> setSieveNotifyActionRFCCompliant(boolean zimbraSieveNotifyActionRFCCompliant, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, zimbraSieveNotifyActionRFCCompliant ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public void unsetSieveNotifyActionRFCCompliant() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public Map<String,Object> unsetSieveNotifyActionRFCCompliant(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "");
+        return attrs;
+    }
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @return zimbraSieveRejectMailEnabled, or true if unset
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public boolean isSieveRejectMailEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraSieveRejectMailEnabled, true, true);
+    }
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @param zimbraSieveRejectMailEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public void setSieveRejectMailEnabled(boolean zimbraSieveRejectMailEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRejectMailEnabled, zimbraSieveRejectMailEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @param zimbraSieveRejectMailEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public Map<String,Object> setSieveRejectMailEnabled(boolean zimbraSieveRejectMailEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRejectMailEnabled, zimbraSieveRejectMailEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public void unsetSieveRejectMailEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRejectMailEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public Map<String,Object> unsetSieveRejectMailEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRejectMailEnabled, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -28148,10 +28148,13 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
-     * parses the &#039;notify&#039; action parameters based on the syntax
-     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
-     * &#039;notify&#039; action parameters with Zimbra specific format
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveNotifyActionRFCCompliant, which can be used at account
+     * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
+     * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
+     * based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS
+     * treats the &#039;notify&#039; action parameters with Zimbra specific
+     * format
      *
      * @return zimbraMailSieveNotifyActionRFCCompliant, or false if unset
      *
@@ -28163,10 +28166,13 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
-     * parses the &#039;notify&#039; action parameters based on the syntax
-     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
-     * &#039;notify&#039; action parameters with Zimbra specific format
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveNotifyActionRFCCompliant, which can be used at account
+     * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
+     * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
+     * based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS
+     * treats the &#039;notify&#039; action parameters with Zimbra specific
+     * format
      *
      * @param zimbraMailSieveNotifyActionRFCCompliant new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -28181,10 +28187,13 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
-     * parses the &#039;notify&#039; action parameters based on the syntax
-     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
-     * &#039;notify&#039; action parameters with Zimbra specific format
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveNotifyActionRFCCompliant, which can be used at account
+     * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
+     * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
+     * based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS
+     * treats the &#039;notify&#039; action parameters with Zimbra specific
+     * format
      *
      * @param zimbraMailSieveNotifyActionRFCCompliant new value
      * @param attrs existing map to populate, or null to create a new map
@@ -28200,10 +28209,13 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
-     * parses the &#039;notify&#039; action parameters based on the syntax
-     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
-     * &#039;notify&#039; action parameters with Zimbra specific format
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveNotifyActionRFCCompliant, which can be used at account
+     * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
+     * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
+     * based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS
+     * treats the &#039;notify&#039; action parameters with Zimbra specific
+     * format
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -28217,10 +28229,13 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
-     * parses the &#039;notify&#039; action parameters based on the syntax
-     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
-     * &#039;notify&#039; action parameters with Zimbra specific format
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveNotifyActionRFCCompliant, which can be used at account
+     * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
+     * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
+     * based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS
+     * treats the &#039;notify&#039; action parameters with Zimbra specific
+     * format
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
@@ -65286,8 +65301,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
-     * 5429.
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
+     * RFC 5429.
      *
      * @return zimbraSieveRejectEnabled, or true if unset
      *
@@ -65299,8 +65316,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
-     * 5429.
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
+     * RFC 5429.
      *
      * @param zimbraSieveRejectEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -65315,8 +65334,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
-     * 5429.
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
+     * RFC 5429.
      *
      * @param zimbraSieveRejectEnabled new value
      * @param attrs existing map to populate, or null to create a new map
@@ -65332,8 +65353,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
-     * 5429.
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
+     * RFC 5429.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -65347,8 +65370,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
-     * 5429.
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
+     * RFC 5429.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -17279,7 +17279,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @return zimbraMailAdminOutgoingSieveScriptAfter, or null if unset
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public String getMailAdminOutgoingSieveScriptAfter() {
@@ -17293,7 +17293,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param zimbraMailAdminOutgoingSieveScriptAfter new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public void setMailAdminOutgoingSieveScriptAfter(String zimbraMailAdminOutgoingSieveScriptAfter) throws com.zimbra.common.service.ServiceException {
@@ -17310,7 +17310,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public Map<String,Object> setMailAdminOutgoingSieveScriptAfter(String zimbraMailAdminOutgoingSieveScriptAfter, Map<String,Object> attrs) {
@@ -17325,7 +17325,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public void unsetMailAdminOutgoingSieveScriptAfter() throws com.zimbra.common.service.ServiceException {
@@ -17341,7 +17341,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public Map<String,Object> unsetMailAdminOutgoingSieveScriptAfter(Map<String,Object> attrs) {
@@ -17356,7 +17356,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @return zimbraMailAdminOutgoingSieveScriptBefore, or null if unset
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public String getMailAdminOutgoingSieveScriptBefore() {
@@ -17370,7 +17370,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param zimbraMailAdminOutgoingSieveScriptBefore new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public void setMailAdminOutgoingSieveScriptBefore(String zimbraMailAdminOutgoingSieveScriptBefore) throws com.zimbra.common.service.ServiceException {
@@ -17387,7 +17387,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public Map<String,Object> setMailAdminOutgoingSieveScriptBefore(String zimbraMailAdminOutgoingSieveScriptBefore, Map<String,Object> attrs) {
@@ -17402,7 +17402,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public void unsetMailAdminOutgoingSieveScriptBefore() throws com.zimbra.common.service.ServiceException {
@@ -17418,7 +17418,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public Map<String,Object> unsetMailAdminOutgoingSieveScriptBefore(Map<String,Object> attrs) {
@@ -17433,7 +17433,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @return zimbraMailAdminSieveScriptAfter, or null if unset
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public String getMailAdminSieveScriptAfter() {
@@ -17447,7 +17447,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param zimbraMailAdminSieveScriptAfter new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public void setMailAdminSieveScriptAfter(String zimbraMailAdminSieveScriptAfter) throws com.zimbra.common.service.ServiceException {
@@ -17464,7 +17464,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public Map<String,Object> setMailAdminSieveScriptAfter(String zimbraMailAdminSieveScriptAfter, Map<String,Object> attrs) {
@@ -17479,7 +17479,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public void unsetMailAdminSieveScriptAfter() throws com.zimbra.common.service.ServiceException {
@@ -17495,7 +17495,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public Map<String,Object> unsetMailAdminSieveScriptAfter(Map<String,Object> attrs) {
@@ -17510,7 +17510,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @return zimbraMailAdminSieveScriptBefore, or null if unset
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public String getMailAdminSieveScriptBefore() {
@@ -17524,7 +17524,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param zimbraMailAdminSieveScriptBefore new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public void setMailAdminSieveScriptBefore(String zimbraMailAdminSieveScriptBefore) throws com.zimbra.common.service.ServiceException {
@@ -17541,7 +17541,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public Map<String,Object> setMailAdminSieveScriptBefore(String zimbraMailAdminSieveScriptBefore, Map<String,Object> attrs) {
@@ -17556,7 +17556,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public void unsetMailAdminSieveScriptBefore() throws com.zimbra.common.service.ServiceException {
@@ -17572,7 +17572,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public Map<String,Object> unsetMailAdminSieveScriptBefore(Map<String,Object> attrs) {
@@ -42501,6 +42501,170 @@ public abstract class ZAttrCos extends NamedEntry {
     public Map<String,Object> unsetShareLifetime(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraShareLifetime, "");
+        return attrs;
+    }
+
+    /**
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @return zimbraSieveNotifyActionRFCCompliant, or false if unset
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public boolean isSieveNotifyActionRFCCompliant() {
+        return getBooleanAttr(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, false, true);
+    }
+
+    /**
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @param zimbraSieveNotifyActionRFCCompliant new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public void setSieveNotifyActionRFCCompliant(boolean zimbraSieveNotifyActionRFCCompliant) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, zimbraSieveNotifyActionRFCCompliant ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @param zimbraSieveNotifyActionRFCCompliant new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public Map<String,Object> setSieveNotifyActionRFCCompliant(boolean zimbraSieveNotifyActionRFCCompliant, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, zimbraSieveNotifyActionRFCCompliant ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public void unsetSieveNotifyActionRFCCompliant() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public Map<String,Object> unsetSieveNotifyActionRFCCompliant(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "");
+        return attrs;
+    }
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @return zimbraSieveRejectMailEnabled, or true if unset
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public boolean isSieveRejectMailEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraSieveRejectMailEnabled, true, true);
+    }
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @param zimbraSieveRejectMailEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public void setSieveRejectMailEnabled(boolean zimbraSieveRejectMailEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRejectMailEnabled, zimbraSieveRejectMailEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @param zimbraSieveRejectMailEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public Map<String,Object> setSieveRejectMailEnabled(boolean zimbraSieveRejectMailEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRejectMailEnabled, zimbraSieveRejectMailEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public void unsetSieveRejectMailEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRejectMailEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public Map<String,Object> unsetSieveRejectMailEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRejectMailEnabled, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -14658,7 +14658,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @return zimbraMailAdminOutgoingSieveScriptAfter, or null if unset
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public String getMailAdminOutgoingSieveScriptAfter() {
@@ -14672,7 +14672,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param zimbraMailAdminOutgoingSieveScriptAfter new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public void setMailAdminOutgoingSieveScriptAfter(String zimbraMailAdminOutgoingSieveScriptAfter) throws com.zimbra.common.service.ServiceException {
@@ -14689,7 +14689,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public Map<String,Object> setMailAdminOutgoingSieveScriptAfter(String zimbraMailAdminOutgoingSieveScriptAfter, Map<String,Object> attrs) {
@@ -14704,7 +14704,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public void unsetMailAdminOutgoingSieveScriptAfter() throws com.zimbra.common.service.ServiceException {
@@ -14720,7 +14720,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public Map<String,Object> unsetMailAdminOutgoingSieveScriptAfter(Map<String,Object> attrs) {
@@ -14735,7 +14735,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @return zimbraMailAdminOutgoingSieveScriptBefore, or null if unset
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public String getMailAdminOutgoingSieveScriptBefore() {
@@ -14749,7 +14749,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param zimbraMailAdminOutgoingSieveScriptBefore new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public void setMailAdminOutgoingSieveScriptBefore(String zimbraMailAdminOutgoingSieveScriptBefore) throws com.zimbra.common.service.ServiceException {
@@ -14766,7 +14766,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public Map<String,Object> setMailAdminOutgoingSieveScriptBefore(String zimbraMailAdminOutgoingSieveScriptBefore, Map<String,Object> attrs) {
@@ -14781,7 +14781,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public void unsetMailAdminOutgoingSieveScriptBefore() throws com.zimbra.common.service.ServiceException {
@@ -14797,7 +14797,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public Map<String,Object> unsetMailAdminOutgoingSieveScriptBefore(Map<String,Object> attrs) {
@@ -14812,7 +14812,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @return zimbraMailAdminSieveScriptAfter, or null if unset
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public String getMailAdminSieveScriptAfter() {
@@ -14826,7 +14826,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param zimbraMailAdminSieveScriptAfter new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public void setMailAdminSieveScriptAfter(String zimbraMailAdminSieveScriptAfter) throws com.zimbra.common.service.ServiceException {
@@ -14843,7 +14843,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public Map<String,Object> setMailAdminSieveScriptAfter(String zimbraMailAdminSieveScriptAfter, Map<String,Object> attrs) {
@@ -14858,7 +14858,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public void unsetMailAdminSieveScriptAfter() throws com.zimbra.common.service.ServiceException {
@@ -14874,7 +14874,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public Map<String,Object> unsetMailAdminSieveScriptAfter(Map<String,Object> attrs) {
@@ -14889,7 +14889,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @return zimbraMailAdminSieveScriptBefore, or null if unset
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public String getMailAdminSieveScriptBefore() {
@@ -14903,7 +14903,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param zimbraMailAdminSieveScriptBefore new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public void setMailAdminSieveScriptBefore(String zimbraMailAdminSieveScriptBefore) throws com.zimbra.common.service.ServiceException {
@@ -14920,7 +14920,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public Map<String,Object> setMailAdminSieveScriptBefore(String zimbraMailAdminSieveScriptBefore, Map<String,Object> attrs) {
@@ -14935,7 +14935,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public void unsetMailAdminSieveScriptBefore() throws com.zimbra.common.service.ServiceException {
@@ -14951,7 +14951,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public Map<String,Object> unsetMailAdminSieveScriptBefore(Map<String,Object> attrs) {
@@ -20000,6 +20000,170 @@ public abstract class ZAttrDomain extends NamedEntry {
     public Map<String,Object> unsetSSLPrivateKey(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSSLPrivateKey, "");
+        return attrs;
+    }
+
+    /**
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @return zimbraSieveNotifyActionRFCCompliant, or false if unset
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public boolean isSieveNotifyActionRFCCompliant() {
+        return getBooleanAttr(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, false, true);
+    }
+
+    /**
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @param zimbraSieveNotifyActionRFCCompliant new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public void setSieveNotifyActionRFCCompliant(boolean zimbraSieveNotifyActionRFCCompliant) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, zimbraSieveNotifyActionRFCCompliant ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @param zimbraSieveNotifyActionRFCCompliant new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public Map<String,Object> setSieveNotifyActionRFCCompliant(boolean zimbraSieveNotifyActionRFCCompliant, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, zimbraSieveNotifyActionRFCCompliant ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public void unsetSieveNotifyActionRFCCompliant() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public Map<String,Object> unsetSieveNotifyActionRFCCompliant(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "");
+        return attrs;
+    }
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @return zimbraSieveRejectMailEnabled, or false if unset
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public boolean isSieveRejectMailEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraSieveRejectMailEnabled, false, true);
+    }
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @param zimbraSieveRejectMailEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public void setSieveRejectMailEnabled(boolean zimbraSieveRejectMailEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRejectMailEnabled, zimbraSieveRejectMailEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @param zimbraSieveRejectMailEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public Map<String,Object> setSieveRejectMailEnabled(boolean zimbraSieveRejectMailEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRejectMailEnabled, zimbraSieveRejectMailEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public void unsetSieveRejectMailEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRejectMailEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public Map<String,Object> unsetSieveRejectMailEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRejectMailEnabled, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -17704,10 +17704,13 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
-     * parses the &#039;notify&#039; action parameters based on the syntax
-     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
-     * &#039;notify&#039; action parameters with Zimbra specific format
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveNotifyActionRFCCompliant, which can be used at account
+     * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
+     * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
+     * based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS
+     * treats the &#039;notify&#039; action parameters with Zimbra specific
+     * format
      *
      * @return zimbraMailSieveNotifyActionRFCCompliant, or false if unset
      *
@@ -17719,10 +17722,13 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
-     * parses the &#039;notify&#039; action parameters based on the syntax
-     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
-     * &#039;notify&#039; action parameters with Zimbra specific format
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveNotifyActionRFCCompliant, which can be used at account
+     * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
+     * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
+     * based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS
+     * treats the &#039;notify&#039; action parameters with Zimbra specific
+     * format
      *
      * @param zimbraMailSieveNotifyActionRFCCompliant new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -17737,10 +17743,13 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
-     * parses the &#039;notify&#039; action parameters based on the syntax
-     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
-     * &#039;notify&#039; action parameters with Zimbra specific format
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveNotifyActionRFCCompliant, which can be used at account
+     * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
+     * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
+     * based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS
+     * treats the &#039;notify&#039; action parameters with Zimbra specific
+     * format
      *
      * @param zimbraMailSieveNotifyActionRFCCompliant new value
      * @param attrs existing map to populate, or null to create a new map
@@ -17756,10 +17765,13 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
-     * parses the &#039;notify&#039; action parameters based on the syntax
-     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
-     * &#039;notify&#039; action parameters with Zimbra specific format
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveNotifyActionRFCCompliant, which can be used at account
+     * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
+     * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
+     * based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS
+     * treats the &#039;notify&#039; action parameters with Zimbra specific
+     * format
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -17773,10 +17785,13 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
-     * parses the &#039;notify&#039; action parameters based on the syntax
-     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
-     * &#039;notify&#039; action parameters with Zimbra specific format
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveNotifyActionRFCCompliant, which can be used at account
+     * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
+     * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
+     * based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS
+     * treats the &#039;notify&#039; action parameters with Zimbra specific
+     * format
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
@@ -46898,8 +46913,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
-     * 5429.
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
+     * RFC 5429.
      *
      * @return zimbraSieveRejectEnabled, or true if unset
      *
@@ -46911,8 +46928,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
-     * 5429.
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
+     * RFC 5429.
      *
      * @param zimbraSieveRejectEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -46927,8 +46946,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
-     * 5429.
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
+     * RFC 5429.
      *
      * @param zimbraSieveRejectEnabled new value
      * @param attrs existing map to populate, or null to create a new map
@@ -46944,8 +46965,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
-     * 5429.
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
+     * RFC 5429.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -46959,8 +46982,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
-     * 5429.
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
+     * RFC 5429.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/filter/JsieveConfigMapHandler.java
+++ b/store/src/java/com/zimbra/cs/filter/JsieveConfigMapHandler.java
@@ -60,21 +60,8 @@ public class JsieveConfigMapHandler {
         mCommandMap.put("copy", com.zimbra.cs.filter.jsieve.Copy.class.getName());
         mCommandMap.put("log", com.zimbra.cs.filter.jsieve.VariableLog.class.getName());
         mCommandMap.put("deleteheader", com.zimbra.cs.filter.jsieve.DeleteHeader.class.getName());
-
-        if (isNotifyActionRFCCompliantAvailable()) {
-            mCommandMap.put("notify",  com.zimbra.cs.filter.jsieve.NotifyMailto.class.getName());
-            ZimbraLog.filter.info("RFC compliant 'notify' is loaded");
-        } else {
-            mCommandMap.put("notify", com.zimbra.cs.filter.jsieve.Notify.class.getName());
-            ZimbraLog.filter.debug("Zimbra 'notify' is loaded");
-        }
-
-        if (isZimbraSieveRejectEnabled()) {
-            mCommandMap.put("reject", com.zimbra.cs.filter.jsieve.Reject.class.getName());
-        } else {
-            // Disable the 'reject' action defined by the jSieve library
-            mCommandMap.remove("reject");
-        }
+        mCommandMap.put("notify",  com.zimbra.cs.filter.jsieve.NotifyMailto.class.getName());
+        mCommandMap.put("reject", com.zimbra.cs.filter.jsieve.Reject.class.getName());
 
 		mCommandMap.put("variables", com.zimbra.cs.filter.jsieve.Variables.class.getName());
 		ZimbraLog.filter.info("Variables extension is loaded");
@@ -114,14 +101,15 @@ public class JsieveConfigMapHandler {
         mTestMap.put("relational", com.zimbra.cs.filter.jsieve.RelationalTest.class.getName());
         mTestMap.put("string", com.zimbra.cs.filter.jsieve.StringTest.class.getName());
 
-        if (isNotifyActionRFCCompliantAvailable()) {
-            // The capability string associated with the 'notify' action is "enotify"; 
-            // the "enotify" is not accepted as an action name in the sieve filter body, 
-            // such as inside the 'if' body.
-            mTestMap.put("enotify", com.zimbra.cs.filter.jsieve.EnotifyTest.class.getName());
-            mTestMap.put("valid_notify_method", com.zimbra.cs.filter.jsieve.ValidNotifyMethodTest.class.getName());
-            mTestMap.put("notify_method_capability", com.zimbra.cs.filter.jsieve.NotifyMethodCapabilityTest.class.getName());
-        }
+        // The capability string associated with the 'notify' action is
+        // "enotify";
+        // the "enotify" is not accepted as an action name in the sieve filter
+        // body,
+        // such as inside the 'if' body.
+        mTestMap.put("enotify", com.zimbra.cs.filter.jsieve.EnotifyTest.class.getName());
+        mTestMap.put("valid_notify_method", com.zimbra.cs.filter.jsieve.ValidNotifyMethodTest.class.getName());
+        mTestMap.put("notify_method_capability",
+            com.zimbra.cs.filter.jsieve.NotifyMethodCapabilityTest.class.getName());
 
         return mTestMap;
     }
@@ -148,37 +136,5 @@ public class JsieveConfigMapHandler {
 
     public static Map<String, String> getTestMap(){
         return mTestMap;
-    }
-
-    /**
-     * Checks the global config attribute
-     * 'zimbraMailSieveNotifyActionRFCCompliant'.
-     *
-     * @return <tt>true</tt> if the RFC compliant notify action is allowed to
-     *         execute.
-     */
-    public static boolean isNotifyActionRFCCompliantAvailable() {
-        boolean isNotifyActionRFCCompliant = false;
-        try {
-            isNotifyActionRFCCompliant = Provisioning.getInstance().getLocalServer()
-                .isMailSieveNotifyActionRFCCompliant();
-        } catch (ServiceException e) {
-            // the legacy Zimbra specific 'notify' action is used
-        }
-        return isNotifyActionRFCCompliant;
-    }
-
-    /**
-     * Checks the global config attribute 'zimbraSieveRejectEnabled'.
-     *
-     * @return <tt>true</tt> if zimbraSieveRejectEnabled is enabled.
-     */
-    public static boolean isZimbraSieveRejectEnabled() {
-        boolean isZimbraSieveRejectEnabled = true;
-        try {
-            isZimbraSieveRejectEnabled = Provisioning.getInstance().getLocalServer().isSieveRejectEnabled();
-        } catch (ServiceException e) {
-        }
-        return isZimbraSieveRejectEnabled;
     }
 }

--- a/store/src/java/com/zimbra/cs/filter/SoapToSieve.java
+++ b/store/src/java/com/zimbra/cs/filter/SoapToSieve.java
@@ -62,11 +62,7 @@ public final class SoapToSieve {
     public String getSieveScript() throws ServiceException {
         if (buffer == null) {
             buffer = new StringBuilder();
-            buffer.append("require [\"fileinto\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\"");
-            if (JsieveConfigMapHandler.isNotifyActionRFCCompliantAvailable()) {
-                buffer.append(", \"enotify\"");
-            }
-            buffer.append("];\n");
+            buffer.append("require [\"fileinto\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\", \"enotify\"];\n");
             for (FilterRule rule : rules) {
                 buffer.append('\n');
                 handleRule(rule);

--- a/store/src/java/com/zimbra/cs/filter/ZimbraMailAdapter.java
+++ b/store/src/java/com/zimbra/cs/filter/ZimbraMailAdapter.java
@@ -333,16 +333,14 @@ public class ZimbraMailAdapter implements MailAdapter, EnvelopeAccessors {
                     }
                 } else if (action instanceof ActionReject) {
                     ActionReject reject = (ActionReject) action;
-                    if (JsieveConfigMapHandler.isZimbraSieveRejectEnabled()) {
-	                    ZimbraLog.filter.debug("Refusing delivery of a message: %s", reject.getMessage());
-	                    try {
-	                        String msg = FilterUtil.replaceVariables(this, reject.getMessage());
-	                        handler.reject(msg, envelope);
-	                        handler.discard();
-	                    } catch (Exception e) {
-	                        ZimbraLog.filter.info("Unable to reject.", e);
-	                        keep(KeepType.EXPLICIT_KEEP);
-	                    }
+                    ZimbraLog.filter.debug("Refusing delivery of a message: %s", reject.getMessage());
+                    try {
+                        String msg = FilterUtil.replaceVariables(this, reject.getMessage());
+                        handler.reject(msg, envelope);
+                        handler.discard();
+                    } catch (Exception e) {
+                        ZimbraLog.filter.info("Unable to reject.", e);
+                        keep(KeepType.EXPLICIT_KEEP);
                     }
                 } else if (action instanceof ActionEreject) {
                     ActionEreject ereject = (ActionEreject) action;

--- a/store/src/java/com/zimbra/qa/unittest/TestFilter.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestFilter.java
@@ -161,7 +161,7 @@ public final class TestFilter {
         saveOutgoingRules(mMbox, getTestOutgoingRules());
 
         mOriginalSpamApplyUserFilters = account.getAttr(Provisioning.A_zimbraSpamApplyUserFilters);
-        mAvailableRFCCompliantNotify  = Provisioning.getInstance().getConfig().getBooleanAttr(Provisioning.A_zimbraMailSieveNotifyActionRFCCompliant, false);
+        mAvailableRFCCompliantNotify  = account.isSieveNotifyActionRFCCompliant();
     }
 
     /**
@@ -767,11 +767,11 @@ public final class TestFilter {
     /**
      * Tests the Zimbra-specifict 'notify' action format (not RFC compliant format)
      *
-     * Note: please set the global config key 'zimbraMailSieveNotifyActionRFCCompliant' to FALSE.
+     * Note: please set 'zimbraSieveNotifyActionRFCCompliant' to FALSE.
      */    
     public void testNotifyAction() throws Exception {
         if (mAvailableRFCCompliantNotify) {
-            fail("Unable to test because the global config key 'zimbraMailSieveNotifyActionRFCCompliant' is set to TRUE");
+            fail("Unable to test because 'zimbraSieveNotifyActionRFCCompliant' is set to TRUE");
             return;
         }
         List<ZFilterRule> rules = new ArrayList<ZFilterRule>();
@@ -808,7 +808,7 @@ public final class TestFilter {
     @Test
     public void testNotifyActionUseOrigHeaders() throws Exception {
         if (mAvailableRFCCompliantNotify) {
-            fail("Unable to test because the global config key 'zimbraMailSieveNotifyActionRFCCompliant' is set to TRUE");
+            fail("Unable to test because 'zimbraSieveNotifyActionRFCCompliant' is set to TRUE");
             return;
         }
         List<ZFilterRule> rules = new ArrayList<ZFilterRule>();
@@ -866,7 +866,7 @@ public final class TestFilter {
     @Test
     public void testNotifyActionCopyAllOrigHeaders() throws Exception {
         if (mAvailableRFCCompliantNotify) {
-            fail("Unable to test because the global config key 'zimbraMailSieveNotifyActionRFCCompliant' is set to TRUE");
+            fail("Unable to test because 'zimbraSieveNotifyActionRFCCompliant' is set to TRUE");
             return;
         }
         List<ZFilterRule> rules = new ArrayList<ZFilterRule>();
@@ -900,7 +900,7 @@ public final class TestFilter {
     @Test
     public void testNotifyWithDiscard() throws Exception {
         if (mAvailableRFCCompliantNotify) {
-            fail("Unable to test because the global config key 'zimbraMailSieveNotifyActionRFCCompliant' is set to TRUE");
+            fail("Unable to test because 'zimbraSieveNotifyActionRFCCompliant' is set to TRUE");
             return;
         }
         List<ZFilterRule> rules = new ArrayList<ZFilterRule>();
@@ -932,7 +932,7 @@ public final class TestFilter {
     @Test
     public void testMultipleMultilineText() throws Exception {
         if (mAvailableRFCCompliantNotify) {
-            fail("Unable to test because the global config key 'zimbraMailSieveNotifyActionRFCCompliant' is set to TRUE");
+            fail("Unable to test because 'zimbraSieveNotifyActionRFCCompliant' is set to TRUE");
             return;
         }
         List<ZFilterRule> rules;

--- a/store/src/java/com/zimbra/qa/unittest/TestFilterRFCCompliantNotify.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestFilterRFCCompliantNotify.java
@@ -47,7 +47,7 @@ public class TestFilterRFCCompliantNotify extends TestCase {
     public void testNotifyAction()
     throws Exception {
         if (!mAvailableRFCCompliantNotify) {
-            fail("Unable to test because the global config key 'zimbraMailSieveNotifyActionRFCCompliant' is set to FALSE");
+            fail("Unable to test because 'zimbraSieveNotifyActionRFCCompliant' is set to FALSE");
             return;
         }
 
@@ -114,7 +114,7 @@ public class TestFilterRFCCompliantNotify extends TestCase {
         mOriginalIncomingRules = mMbox.getIncomingFilterRules();
         saveIncomingRules(mMbox, getTestIncomingRules());
 
-        mAvailableRFCCompliantNotify  = Provisioning.getInstance().getConfig().getBooleanAttr(Provisioning.A_zimbraMailSieveNotifyActionRFCCompliant, false);
+        mAvailableRFCCompliantNotify  = account.isSieveNotifyActionRFCCompliant();
     }
 
     /**


### PR DESCRIPTION
1. zimbraSieveRejectEnabled and zimbraMailSieveNotifyActionRFCCompliant are now at account level
2. In zimbra-attrs.xml changed since to 8.7.9 [assuming that the next version is 8.7.9]
3. Changed mapping in JSieveConfigMapHandler
4. Modified NotifyMailTo and Reject so that both - RFC complaint version and legacy zimbra version is supported
5. Fixed failing junits
6. I will add the new ldap attributes in develop branch before merging this code

Testing done:
ant test