### PR TITLE
ZCS-1108 TestSearchConv

### DIFF
--- a/store/src/java/com/zimbra/qa/unittest/TestSearchConv.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestSearchConv.java
@@ -47,247 +47,249 @@ import com.zimbra.common.util.ZimbraLog;
 
 @RunWith(Parameterized.class)
 public class TestSearchConv {
-	private static final String USER_NAME = "user1";
-	private static final String REMOTE_USER_NAME = "user2";
-	private static String subject = "TestSearchConv";
-	private static ZMailbox mbox;
-	private static ZMailbox remote_mbox;
-	private static String convId;
-	private static ArrayList<String> msgIds = new ArrayList<String>();
-	private static ZConversation conv;
 
-	private final String query;
-	private final Fetch fetch;
-	private final int[] expected;
-	private final int[] unread;
+    private static final String USER_NAME = "user1";
+    private static final String REMOTE_USER_NAME = "user2";
+    private static String subject = "TestSearchConv";
+    private static ZMailbox mbox;
+    private static ZMailbox remote_mbox;
+    private static String convId;
+    private static ArrayList<String> msgIds = new ArrayList<String>();
+    private static ZConversation conv;
 
-	public TestSearchConv(String query, Fetch fetch, int[] unread, int[] expected) {
-		this.query = query;
-		this.fetch = fetch;
-		this.expected = expected;
-		this.unread   = unread;
-	}
+    private final String query;
+    private final Fetch fetch;
+    private final int[] expected;
+    private final int[] unread;
 
-	@Parameterized.Parameters()
-	public static Collection<Object[]> testInputs() throws Exception {
-		//calling setUp here instead of using @BeforeClass annotation
-		//because the annotation actually causes it to run AFTER the @Parameters method,
-		//and we need results from setUp to properly configure all the tests
-		setUp();
-		ArrayList<Object[]> testCases = new ArrayList<Object[]>();
-		String q;     //the query
-		int[] unread; //indexes of messages that are unread in the conversation
-		Fetch fetchLastMsg          = new Fetch(msgIds.get(3));
-		Fetch fetchFirstAndThirdMsg = new Fetch(msgIds.get(0)+","+msgIds.get(2));
+    public TestSearchConv(String query, Fetch fetch, int[] unread, int[] expected) {
+        this.query = query;
+        this.fetch = fetch;
+        this.expected = expected;
+        this.unread   = unread;
+    }
 
-		//check a query that matches messages 2 and 3 (0-indexed)
-		q = "dungeons or mountains";
-		//first, set all messages to unread
-		unread = new int[]{0,1,2,3};
-		addTestCase(testCases, q, Fetch.none,              unread, new int[]{});
-		addTestCase(testCases, q, Fetch.all,               unread, new int[]{0,1,2,3});
-		addTestCase(testCases, q, Fetch.hits,              unread, new int[]{2,3});
-		addTestCase(testCases, q, Fetch.first,             unread, new int[]{2});
-		addTestCase(testCases, q, Fetch.unread,            unread, new int[]{2,3});
-		addTestCase(testCases, q, Fetch.u1,                unread, new int[]{2,3});
-		addTestCase(testCases, q, Fetch.first_msg,         unread, new int[]{0});
-		addTestCase(testCases, q, Fetch.hits_or_first_msg, unread, new int[]{2,3});
-		addTestCase(testCases, q, Fetch.u_or_first_msg,    unread, new int[]{2,3});
-		addTestCase(testCases, q, Fetch.u1_or_first_msg,   unread, new int[]{2,3});
-		addTestCase(testCases, q, fetchLastMsg,            unread, new int[]{3});
-		addTestCase(testCases, q, fetchFirstAndThirdMsg,   unread, new int[]{0,2});
+    /** Note not using @Before annotation - see testInputs() for why */
+    public static void setUp() throws Exception {
+        mbox = TestUtil.getZMailbox(USER_NAME);
+        remote_mbox = TestUtil.getZMailbox(REMOTE_USER_NAME);
+        setupConversation();
+        conv = mbox.getConversation(convId, Fetch.all);
+        List<ZMessageSummary> msgs = conv.getMessageSummaries();
+        for (ZMessageSummary msg: msgs) {
+            msgIds.add(msg.getId());
+        }
+        //getMessageSummaries are in chronological order; hits are returned latest-first, so should reverse
+        Collections.reverse(msgIds);
+    }
 
-		//now test when only one of the matching hits is unread
-		unread = new int[]{3};
-		addTestCase(testCases, q, Fetch.none,              unread, new int[]{});
-		addTestCase(testCases, q, Fetch.all,               unread, new int[]{0,1,2,3});
-		addTestCase(testCases, q, Fetch.hits,              unread, new int[]{2,3});
-		addTestCase(testCases, q, Fetch.first,             unread, new int[]{2});
-		addTestCase(testCases, q, Fetch.unread,            unread, new int[]{3});
-		addTestCase(testCases, q, Fetch.u1,                unread, new int[]{3});
-		addTestCase(testCases, q, Fetch.first_msg,         unread, new int[]{0});
-		addTestCase(testCases, q, Fetch.hits_or_first_msg, unread, new int[]{2,3});
-		addTestCase(testCases, q, Fetch.u_or_first_msg,    unread, new int[]{3});
-		addTestCase(testCases, q, Fetch.u1_or_first_msg,   unread, new int[]{3});
-		addTestCase(testCases, q, fetchLastMsg,            unread, new int[]{3});
-		addTestCase(testCases, q, fetchFirstAndThirdMsg,   unread, new int[]{0,2});
+    @Parameterized.Parameters()
+    public static Collection<Object[]> testInputs() throws Exception {
+        //calling setUp here instead of using @BeforeClass annotation
+        //because the annotation actually causes it to run AFTER the @Parameters method,
+        //and we need results from setUp to properly configure all the tests
+        setUp();
+        ArrayList<Object[]> testCases = new ArrayList<Object[]>();
+        String q;     //the query
+        int[] unread; //indexes of messages that are unread in the conversation
+        Fetch fetchLastMsg          = new Fetch(msgIds.get(3));
+        Fetch fetchFirstAndThirdMsg = new Fetch(msgIds.get(0)+","+msgIds.get(2));
 
-		//now test when all messages are read
-		unread = new int[]{};
-		addTestCase(testCases, q, Fetch.none,              unread, new int[]{});
-		addTestCase(testCases, q, Fetch.all,               unread, new int[]{0,1,2,3});
-		addTestCase(testCases, q, Fetch.hits,              unread, new int[]{2,3});
-		addTestCase(testCases, q, Fetch.first,             unread, new int[]{2});
-		addTestCase(testCases, q, Fetch.unread,            unread, new int[]{});
-		addTestCase(testCases, q, Fetch.u1,                unread, new int[]{2});
-		addTestCase(testCases, q, Fetch.first_msg,         unread, new int[]{0});
-		addTestCase(testCases, q, Fetch.hits_or_first_msg, unread, new int[]{2,3});
-		addTestCase(testCases, q, Fetch.u_or_first_msg,    unread, new int[]{0});
-		addTestCase(testCases, q, Fetch.u1_or_first_msg,   unread, new int[]{0,2});
-		addTestCase(testCases, q, fetchLastMsg,            unread, new int[]{3});
-		addTestCase(testCases, q, fetchFirstAndThirdMsg,   unread, new int[]{0,2});
+        //check a query that matches messages 2 and 3 (0-indexed)
+        q = "dungeons or mountains";
+        //first, set all messages to unread
+        unread = new int[]{0,1,2,3};
+        addTestCase(testCases, q, Fetch.none,              unread, new int[]{});
+        addTestCase(testCases, q, Fetch.all,               unread, new int[]{0,1,2,3});
+        addTestCase(testCases, q, Fetch.hits,              unread, new int[]{2,3});
+        addTestCase(testCases, q, Fetch.first,             unread, new int[]{2});
+        addTestCase(testCases, q, Fetch.unread,            unread, new int[]{2,3});
+        addTestCase(testCases, q, Fetch.u1,                unread, new int[]{2,3});
+        addTestCase(testCases, q, Fetch.first_msg,         unread, new int[]{0});
+        addTestCase(testCases, q, Fetch.hits_or_first_msg, unread, new int[]{2,3});
+        addTestCase(testCases, q, Fetch.u_or_first_msg,    unread, new int[]{2,3});
+        addTestCase(testCases, q, Fetch.u1_or_first_msg,   unread, new int[]{2,3});
+        addTestCase(testCases, q, fetchLastMsg,            unread, new int[]{3});
+        addTestCase(testCases, q, fetchFirstAndThirdMsg,   unread, new int[]{0,2});
 
-		//now check a query that doesn't match any messages in the conversation
-		q = "thiswontmatch";
-		unread = new int[]{};
-		addTestCase(testCases, q, Fetch.none,              unread, new int[]{});
-		addTestCase(testCases, q, Fetch.all,               unread, new int[]{0,1,2,3});
-		addTestCase(testCases, q, Fetch.hits,              unread, new int[]{});
-		addTestCase(testCases, q, Fetch.first,             unread, new int[]{});
-		addTestCase(testCases, q, Fetch.unread,            unread, new int[]{});
-		addTestCase(testCases, q, Fetch.u1,                unread, new int[]{});
-		addTestCase(testCases, q, Fetch.first_msg,         unread, new int[]{0});
-		addTestCase(testCases, q, Fetch.hits_or_first_msg, unread, new int[]{0});
-		addTestCase(testCases, q, Fetch.u_or_first_msg,    unread, new int[]{0});
-		addTestCase(testCases, q, Fetch.u1_or_first_msg,   unread, new int[]{0});
-		addTestCase(testCases, q, fetchLastMsg,            unread, new int[]{3});
-		addTestCase(testCases, q, fetchFirstAndThirdMsg,   unread, new int[]{0,2});
+        //now test when only one of the matching hits is unread
+        unread = new int[]{3};
+        addTestCase(testCases, q, Fetch.none,              unread, new int[]{});
+        addTestCase(testCases, q, Fetch.all,               unread, new int[]{0,1,2,3});
+        addTestCase(testCases, q, Fetch.hits,              unread, new int[]{2,3});
+        addTestCase(testCases, q, Fetch.first,             unread, new int[]{2});
+        addTestCase(testCases, q, Fetch.unread,            unread, new int[]{3});
+        addTestCase(testCases, q, Fetch.u1,                unread, new int[]{3});
+        addTestCase(testCases, q, Fetch.first_msg,         unread, new int[]{0});
+        addTestCase(testCases, q, Fetch.hits_or_first_msg, unread, new int[]{2,3});
+        addTestCase(testCases, q, Fetch.u_or_first_msg,    unread, new int[]{3});
+        addTestCase(testCases, q, Fetch.u1_or_first_msg,   unread, new int[]{3});
+        addTestCase(testCases, q, fetchLastMsg,            unread, new int[]{3});
+        addTestCase(testCases, q, fetchFirstAndThirdMsg,   unread, new int[]{0,2});
 
-		//test when there are no matches, but some of the messages are unread.
-		//this should be the same as when there are no unread messages
-		unread = new int[]{2,3};
-		addTestCase(testCases, q, Fetch.none,              unread, new int[]{});
-		addTestCase(testCases, q, Fetch.all,               unread, new int[]{0,1,2,3});
-		addTestCase(testCases, q, Fetch.hits,              unread, new int[]{});
-		addTestCase(testCases, q, Fetch.first,             unread, new int[]{});
-		addTestCase(testCases, q, Fetch.unread,            unread, new int[]{});
-		addTestCase(testCases, q, Fetch.u1,                unread, new int[]{});
-		addTestCase(testCases, q, Fetch.first_msg,         unread, new int[]{0});
-		addTestCase(testCases, q, Fetch.hits_or_first_msg, unread, new int[]{0});
-		addTestCase(testCases, q, Fetch.u_or_first_msg,    unread, new int[]{0});
-		addTestCase(testCases, q, Fetch.u1_or_first_msg,   unread, new int[]{0});
-		addTestCase(testCases, q, fetchLastMsg,            unread, new int[]{3});
-		addTestCase(testCases, q, fetchFirstAndThirdMsg,   unread, new int[]{0,2});
+        //now test when all messages are read
+        unread = new int[]{};
+        addTestCase(testCases, q, Fetch.none,              unread, new int[]{});
+        addTestCase(testCases, q, Fetch.all,               unread, new int[]{0,1,2,3});
+        addTestCase(testCases, q, Fetch.hits,              unread, new int[]{2,3});
+        addTestCase(testCases, q, Fetch.first,             unread, new int[]{2});
+        addTestCase(testCases, q, Fetch.unread,            unread, new int[]{});
+        addTestCase(testCases, q, Fetch.u1,                unread, new int[]{2});
+        addTestCase(testCases, q, Fetch.first_msg,         unread, new int[]{0});
+        addTestCase(testCases, q, Fetch.hits_or_first_msg, unread, new int[]{2,3});
+        addTestCase(testCases, q, Fetch.u_or_first_msg,    unread, new int[]{0});
+        addTestCase(testCases, q, Fetch.u1_or_first_msg,   unread, new int[]{0,2});
+        addTestCase(testCases, q, fetchLastMsg,            unread, new int[]{3});
+        addTestCase(testCases, q, fetchFirstAndThirdMsg,   unread, new int[]{0,2});
 
-		//test values with "!" when the first message is also a hit
-		q = "enchanted or mountains"; //matches messages 0 and 3
-		//all messages read
-		unread = new int[]{};
-		addTestCase(testCases, q, Fetch.first_msg,         unread, new int[]{0});
-		addTestCase(testCases, q, Fetch.hits_or_first_msg, unread, new int[]{0,3});
-		addTestCase(testCases, q, Fetch.u_or_first_msg,    unread, new int[]{0});
-		addTestCase(testCases, q, Fetch.u1_or_first_msg,   unread, new int[]{0});
+        //now check a query that doesn't match any messages in the conversation
+        q = "thiswontmatch";
+        unread = new int[]{};
+        addTestCase(testCases, q, Fetch.none,              unread, new int[]{});
+        addTestCase(testCases, q, Fetch.all,               unread, new int[]{0,1,2,3});
+        addTestCase(testCases, q, Fetch.hits,              unread, new int[]{});
+        addTestCase(testCases, q, Fetch.first,             unread, new int[]{});
+        addTestCase(testCases, q, Fetch.unread,            unread, new int[]{});
+        addTestCase(testCases, q, Fetch.u1,                unread, new int[]{});
+        addTestCase(testCases, q, Fetch.first_msg,         unread, new int[]{0});
+        addTestCase(testCases, q, Fetch.hits_or_first_msg, unread, new int[]{0});
+        addTestCase(testCases, q, Fetch.u_or_first_msg,    unread, new int[]{0});
+        addTestCase(testCases, q, Fetch.u1_or_first_msg,   unread, new int[]{0});
+        addTestCase(testCases, q, fetchLastMsg,            unread, new int[]{3});
+        addTestCase(testCases, q, fetchFirstAndThirdMsg,   unread, new int[]{0,2});
 
-		//all messages unread
-		unread = new int[]{0,1,2,3};
-		addTestCase(testCases, q, Fetch.first_msg,         unread, new int[]{0});
-		addTestCase(testCases, q, Fetch.hits_or_first_msg, unread, new int[]{0,3});
-		addTestCase(testCases, q, Fetch.u_or_first_msg,    unread, new int[]{0,3});
-		addTestCase(testCases, q, Fetch.u1_or_first_msg,   unread, new int[]{0,3});
+        //test when there are no matches, but some of the messages are unread.
+        //this should be the same as when there are no unread messages
+        unread = new int[]{2,3};
+        addTestCase(testCases, q, Fetch.none,              unread, new int[]{});
+        addTestCase(testCases, q, Fetch.all,               unread, new int[]{0,1,2,3});
+        addTestCase(testCases, q, Fetch.hits,              unread, new int[]{});
+        addTestCase(testCases, q, Fetch.first,             unread, new int[]{});
+        addTestCase(testCases, q, Fetch.unread,            unread, new int[]{});
+        addTestCase(testCases, q, Fetch.u1,                unread, new int[]{});
+        addTestCase(testCases, q, Fetch.first_msg,         unread, new int[]{0});
+        addTestCase(testCases, q, Fetch.hits_or_first_msg, unread, new int[]{0});
+        addTestCase(testCases, q, Fetch.u_or_first_msg,    unread, new int[]{0});
+        addTestCase(testCases, q, Fetch.u1_or_first_msg,   unread, new int[]{0});
+        addTestCase(testCases, q, fetchLastMsg,            unread, new int[]{3});
+        addTestCase(testCases, q, fetchFirstAndThirdMsg,   unread, new int[]{0,2});
 
-		//one of the hits is unread
-		unread = new int[]{2,3};
-		addTestCase(testCases, q, Fetch.first_msg,         unread, new int[]{0});
-		addTestCase(testCases, q, Fetch.hits_or_first_msg, unread, new int[]{0,3});
-		addTestCase(testCases, q, Fetch.u_or_first_msg,    unread, new int[]{3});
-		addTestCase(testCases, q, Fetch.u1_or_first_msg,   unread, new int[]{3});
+        //test values with "!" when the first message is also a hit
+        q = "enchanted or mountains"; //matches messages 0 and 3
+        //all messages read
+        unread = new int[]{};
+        addTestCase(testCases, q, Fetch.first_msg,         unread, new int[]{0});
+        addTestCase(testCases, q, Fetch.hits_or_first_msg, unread, new int[]{0,3});
+        addTestCase(testCases, q, Fetch.u_or_first_msg,    unread, new int[]{0});
+        addTestCase(testCases, q, Fetch.u1_or_first_msg,   unread, new int[]{0});
 
-		return testCases;
-	}
+        //all messages unread
+        unread = new int[]{0,1,2,3};
+        addTestCase(testCases, q, Fetch.first_msg,         unread, new int[]{0});
+        addTestCase(testCases, q, Fetch.hits_or_first_msg, unread, new int[]{0,3});
+        addTestCase(testCases, q, Fetch.u_or_first_msg,    unread, new int[]{0,3});
+        addTestCase(testCases, q, Fetch.u1_or_first_msg,   unread, new int[]{0,3});
 
-	private static void addTestCase(ArrayList<Object[]> testCases, String query, Fetch fetch, int[] unread, int[] expected){
-		Object[] args = new Object[]{query,fetch,unread,expected};
-		testCases.add(args);
-	}
+        //one of the hits is unread
+        unread = new int[]{2,3};
+        addTestCase(testCases, q, Fetch.first_msg,         unread, new int[]{0});
+        addTestCase(testCases, q, Fetch.hits_or_first_msg, unread, new int[]{0,3});
+        addTestCase(testCases, q, Fetch.u_or_first_msg,    unread, new int[]{3});
+        addTestCase(testCases, q, Fetch.u1_or_first_msg,   unread, new int[]{3});
 
-	private static void setupConversation() throws Exception{
-		ZOutgoingMessage msg;
-		ZOutgoingMessage reply;
-		msg = TestUtil.getOutgoingMessage(REMOTE_USER_NAME, subject, "far over the misty mountains cold",null);
-		ZSendMessageResponse resp = mbox.sendMessage(msg,null,false);
-		Thread.sleep(1000);
-		String remoteMsgId = TestUtil.getMessage(remote_mbox, subject).getId();
-		reply = TestUtil.getOutgoingMessage(USER_NAME, subject , "to dungeons deep and caverns old", null);
-		reply.setOriginalMessageId(remoteMsgId);
-		reply.setReplyType("r");
-		remote_mbox.sendMessage(reply, null,false);
-		Thread.sleep(1000);
-		reply = TestUtil.getOutgoingMessage(USER_NAME, subject , "we must away ere break of day", null);
-		reply.setOriginalMessageId(remoteMsgId);
-		reply.setReplyType("r");
-		remote_mbox.sendMessage(reply, null, false);
-		Thread.sleep(1000);
-		reply = TestUtil.getOutgoingMessage(USER_NAME, subject , "to seek the pale enchanted gold", null);
-		reply.setOriginalMessageId(remoteMsgId);
-		reply.setReplyType("r");
-		remote_mbox.sendMessage(reply, null, false);
-		Thread.sleep(1000);
-		convId = mbox.getMessageById(resp.getId()).getConversationId();
-	}
+        return testCases;
+    }
 
-	public static void setUp() throws Exception {
-		mbox = TestUtil.getZMailbox(USER_NAME);
-		remote_mbox = TestUtil.getZMailbox(REMOTE_USER_NAME);
-		setupConversation();
-		conv = mbox.getConversation(convId, Fetch.all);
-		List<ZMessageSummary> msgs = conv.getMessageSummaries();
-		for (ZMessageSummary msg: msgs) {
-			msgIds.add(msg.getId());
-		}
-		//getMessageSummaries are in chronological order; hits are returned latest-first, so should reverse
-		Collections.reverse(msgIds);
-	}
+    private static void addTestCase(ArrayList<Object[]> testCases, String query, Fetch fetch, int[] unread, int[] expected){
+        Object[] args = new Object[]{query,fetch,unread,expected};
+        testCases.add(args);
+    }
 
-	@Test
-	public void searchConversation()
-	throws Exception {
-		ZimbraLog.search.debug("testing query '%s' with fetch='%s', unread=%s (expecting '%s')",query,fetch,Arrays.toString(unread),Arrays.toString(expected));
-		markMessagesUnreadByIndex(unread);
-		ZSearchParams params = new ZSearchParams(query);
-		params.setFetch(fetch);
-		ZSearchResult result = mbox.searchConversation(convId,params);
-		List<ZSearchHit> hits = result.getHits();
-		List<String> expandedList = new ArrayList<String>();
-		for (Integer idx: expected){
-			expandedList.add(msgIds.get(idx));
-		}
-		for (ZSearchHit hit: hits){
-			boolean expanded = isExpanded(hit);
-			if(expandedList.contains(hit.getId())){
-				assertTrue(expanded);
-				expandedList.remove(hit.getId());
-			}
-			else{
-				assertFalse(expanded);
-			}
-		}
-		assertEquals(0,expandedList.size());
-	}
+    private static void setupConversation() throws Exception{
+        ZOutgoingMessage msg;
+        ZOutgoingMessage reply;
+        msg = TestUtil.getOutgoingMessage(REMOTE_USER_NAME, subject, "far over the misty mountains cold",null);
+        ZSendMessageResponse resp = mbox.sendMessage(msg,null,false);
+        Thread.sleep(1000);
+        String remoteMsgId = TestUtil.getMessage(remote_mbox, subject).getId();
+        reply = TestUtil.getOutgoingMessage(USER_NAME, subject , "to dungeons deep and caverns old", null);
+        reply.setOriginalMessageId(remoteMsgId);
+        reply.setReplyType("r");
+        remote_mbox.sendMessage(reply, null,false);
+        Thread.sleep(1000);
+        reply = TestUtil.getOutgoingMessage(USER_NAME, subject , "we must away ere break of day", null);
+        reply.setOriginalMessageId(remoteMsgId);
+        reply.setReplyType("r");
+        remote_mbox.sendMessage(reply, null, false);
+        Thread.sleep(1000);
+        reply = TestUtil.getOutgoingMessage(USER_NAME, subject , "to seek the pale enchanted gold", null);
+        reply.setOriginalMessageId(remoteMsgId);
+        reply.setReplyType("r");
+        remote_mbox.sendMessage(reply, null, false);
+        Thread.sleep(1000);
+        convId = mbox.getMessageById(resp.getId()).getConversationId();
+    }
 
-	private void markAllMessagesRead() throws Exception {
-		mbox.markMessageRead(Joiner.on(",").join(msgIds),true);
-	}
+    @Test
+    public void searchConversation()
+    throws Exception {
+        ZimbraLog.search.debug("testing query '%s' with fetch='%s', unread=%s (expecting '%s')",query,fetch,Arrays.toString(unread),Arrays.toString(expected));
+        markMessagesUnreadByIndex(unread);
+        ZSearchParams params = new ZSearchParams(query);
+        params.setFetch(fetch);
+        ZSearchResult result = mbox.searchConversation(convId,params);
+        List<ZSearchHit> hits = result.getHits();
+        List<String> expandedList = new ArrayList<String>();
+        for (Integer idx: expected){
+            expandedList.add(msgIds.get(idx));
+        }
+        for (ZSearchHit hit: hits){
+            boolean expanded = isExpanded(hit);
+            if(expandedList.contains(hit.getId())){
+                assertTrue(expanded);
+                expandedList.remove(hit.getId());
+            }
+            else{
+                assertFalse(expanded);
+            }
+        }
+        assertEquals(0,expandedList.size());
+    }
 
-	private void markMessagesUnreadByIndex(int[] indexes) throws Exception{
-		ArrayList<String> ids = new ArrayList<String>();
-		for (int i: indexes){
-			ids.add(msgIds.get(i));
-		}
-		String commaSeparatedIds = Joiner.on(",").join(ids);
-		markAllMessagesRead();
-		if (commaSeparatedIds.length() > 0) {
-		mbox.markMessageRead(commaSeparatedIds, false);
-		}
-		//make sure the messages are marked read/unread correctly
-		for (String id: msgIds) {
-			ZMessage message = mbox.getMessageById(id);
-			boolean unread = message.isUnread();
-			if (ids.contains(id)) {assertTrue(unread);}
-			else {assertFalse(unread);}
-		}
-	}
+    private void markAllMessagesRead() throws Exception {
+        mbox.markMessageRead(Joiner.on(",").join(msgIds),true);
+    }
 
-	private boolean isExpanded(ZSearchHit hit){
-		//expanded hits include the message object, non-expanded don't
-		ZMessage msg = ((ZMessageHit) hit).getMessage();
-		boolean expanded = msg != null;
-		return expanded;
-	}
+    private void markMessagesUnreadByIndex(int[] indexes) throws Exception{
+        ArrayList<String> ids = new ArrayList<String>();
+        for (int i: indexes){
+            ids.add(msgIds.get(i));
+        }
+        String commaSeparatedIds = Joiner.on(",").join(ids);
+        markAllMessagesRead();
+        if (commaSeparatedIds.length() > 0) {
+        mbox.markMessageRead(commaSeparatedIds, false);
+        }
+        //make sure the messages are marked read/unread correctly
+        for (String id: msgIds) {
+            ZMessage message = mbox.getMessageById(id);
+            boolean unread = message.isUnread();
+            if (ids.contains(id)) {assertTrue(unread);}
+            else {assertFalse(unread);}
+        }
+    }
 
-	@AfterClass
-	public static void cleanUp() throws Exception{
-		TestUtil.deleteTestData(USER_NAME, subject);
-		TestUtil.deleteTestData(REMOTE_USER_NAME,subject);
-	}
+    private boolean isExpanded(ZSearchHit hit){
+        //expanded hits include the message object, non-expanded don't
+        ZMessage msg = ((ZMessageHit) hit).getMessage();
+        boolean expanded = msg != null;
+        return expanded;
+    }
+
+    @AfterClass
+    public static void cleanUp() throws Exception{
+        TestUtil.deleteTestData(USER_NAME, subject);
+        TestUtil.deleteTestData(REMOTE_USER_NAME,subject);
+    }
 
 }

--- a/store/src/java/com/zimbra/qa/unittest/TestSearchConv.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestSearchConv.java
@@ -48,9 +48,10 @@ import com.zimbra.common.util.ZimbraLog;
 @RunWith(Parameterized.class)
 public class TestSearchConv {
 
-    private static final String USER_NAME = "user1";
-    private static final String REMOTE_USER_NAME = "user2";
-    private static String subject = "TestSearchConv";
+    private static final String TEST_CLASS_NAME = TestSearchConv.class.getSimpleName();
+    private static String USER_NAME = "user1";
+    private static String REMOTE_USER_NAME = "user2";
+    private static String subject = TEST_CLASS_NAME;
     private static ZMailbox mbox;
     private static ZMailbox remote_mbox;
     private static String convId;
@@ -71,6 +72,11 @@ public class TestSearchConv {
 
     /** Note not using @Before annotation - see testInputs() for why */
     public static void setUp() throws Exception {
+        USER_NAME = String.format("%s-user1", TEST_CLASS_NAME).toLowerCase();
+        REMOTE_USER_NAME = String.format("%s-remote-user", TEST_CLASS_NAME).toLowerCase();
+        cleanUp();
+        TestUtil.createAccount(USER_NAME);
+        TestUtil.createAccount(REMOTE_USER_NAME);
         mbox = TestUtil.getZMailbox(USER_NAME);
         remote_mbox = TestUtil.getZMailbox(REMOTE_USER_NAME);
         setupConversation();
@@ -233,7 +239,8 @@ public class TestSearchConv {
     @Test
     public void searchConversation()
     throws Exception {
-        ZimbraLog.search.debug("testing query '%s' with fetch='%s', unread=%s (expecting '%s')",query,fetch,Arrays.toString(unread),Arrays.toString(expected));
+        ZimbraLog.search.debug("testing query '%s' with fetch='%s', unread=%s (expecting '%s')",
+                query, fetch, Arrays.toString(unread), Arrays.toString(expected));
         markMessagesUnreadByIndex(unread);
         ZSearchParams params = new ZSearchParams(query);
         params.setFetch(fetch);
@@ -288,8 +295,7 @@ public class TestSearchConv {
 
     @AfterClass
     public static void cleanUp() throws Exception{
-        TestUtil.deleteTestData(USER_NAME, subject);
-        TestUtil.deleteTestData(REMOTE_USER_NAME,subject);
+        TestUtil.deleteAccountIfExists(USER_NAME);
+        TestUtil.deleteAccountIfExists(REMOTE_USER_NAME);
     }
-
 }


### PR DESCRIPTION
This still intermittently fails.  I think there may be a genuine bug underlying this
where **SearchConvResponse** contains the messages out of order.  Comments suggest they should be in reverse age, which would imply the message IDs should be descending but when I see
failures, I see the messages ordered e.g.:

        <m rev="7" s="2280" d="1492727425000" id="261" l="2" cid="260">
        <m rev="8" s="2282" d="1492727425000" id="262" l="2" cid="260">
        <m rev="6" s="2283" d="1492727424000" f="u" id="259" l="2" cid="260">
        <m rev="2" s="539" d="1492727415000" f="su" id="257" l="5" cid="260">

Suggest we stick with this for now and if it continues to fail intermittently, either investigate more or lob a bug in and remove this test from the set that gets run.
