### PR TITLE
ZCS-1135:Fixing GetFilterRulesTest::testBug71036_SingleRuleSimpleNest…

### DIFF
--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -77,5 +77,6 @@
   <dependency org="zimbra" name="zm-client" rev="latest.integration" /> 
   <dependency org="zimbra" name="zm-native" rev="latest.integration"/>
   <dependency org="org.xmlunit" name="xmlunit-core" rev="2.3.0"/>
+  <dependency org="org.xmlunit" name="xmlunit-legacy" rev="2.3.0"/>
  </dependencies>
 </ivy-module>

--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -76,5 +76,6 @@
   <dependency org="zimbra" name="zm-soap" rev="latest.integration" /> 
   <dependency org="zimbra" name="zm-client" rev="latest.integration" /> 
   <dependency org="zimbra" name="zm-native" rev="latest.integration"/>
+  <dependency org="org.xmlunit" name="xmlunit-core" rev="2.3.0"/>
  </dependencies>
 </ivy-module>

--- a/store/src/java-test/com/zimbra/cs/service/mail/GetFilterRulesTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/mail/GetFilterRulesTest.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.cs.service.mail;
 
-import com.zimbra.common.util.ZimbraLog;
 import com.google.common.collect.Maps;
 import com.zimbra.common.account.Key;
 import com.zimbra.common.soap.Element;
@@ -36,6 +35,9 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.builder.Input;
+import org.xmlunit.diff.Diff;
 
 import java.net.URL;
 import java.util.HashMap;
@@ -193,10 +195,11 @@ public class GetFilterRulesTest {
         expectedSoap += "</filterRules>";
 
         Element rules = response.getOptionalElement(MailConstants.E_FILTER_RULES);
-        //ZimbraLog.filter.info(rules.prettyPrint());
-        //ZimbraLog.filter.info(expectedSoap);
-        Assert.assertEquals(expectedSoap, rules.prettyPrint());
 
+        Diff myDiff = DiffBuilder.compare(Input.fromString(rules.prettyPrint()))
+            .withTest(Input.fromString(expectedSoap))
+            .build();
+        Assert.assertFalse(myDiff.toString(), myDiff.hasDifferences());
     }
 
     // allof(with multi conditions) then allof(with multi conditions)

--- a/store/src/java-test/com/zimbra/cs/service/mail/GetFilterRulesTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/mail/GetFilterRulesTest.java
@@ -31,16 +31,22 @@ import com.zimbra.soap.SoapEngine;
 import com.zimbra.soap.SoapServlet;
 import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.common.soap.SoapProtocol;
+
+import org.custommonkey.xmlunit.DetailedDiff;
+import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.xml.sax.SAXException;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.builder.Input;
 import org.xmlunit.diff.Diff;
 
+import java.io.IOException;
 import java.net.URL;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class GetFilterRulesTest {
@@ -196,10 +202,7 @@ public class GetFilterRulesTest {
 
         Element rules = response.getOptionalElement(MailConstants.E_FILTER_RULES);
 
-        Diff myDiff = DiffBuilder.compare(Input.fromString(rules.prettyPrint()))
-            .withTest(Input.fromString(expectedSoap))
-            .build();
-        Assert.assertFalse(myDiff.toString(), myDiff.hasDifferences());
+        assertXMLEquals(rules.prettyPrint(), expectedSoap);
     }
 
     // allof(with multi conditions) then allof(with multi conditions)
@@ -486,4 +489,18 @@ public class GetFilterRulesTest {
 
     }
 
+    public static void assertXMLEquals(String expected, String actual) {
+        XMLUnit.setIgnoreWhitespace(true);
+        XMLUnit.setIgnoreAttributeOrder(true);
+        DetailedDiff diff;
+        try {
+            diff = new DetailedDiff(XMLUnit.compareXML(expected, actual));
+            List<?> allDifferences = diff.getAllDifferences();
+            Assert.assertEquals("Differences found: " + diff.toString(), 0, allDifferences.size());
+        } catch (SAXException e) {
+            Assert.fail("SAXException in comparing xml");
+        } catch (IOException e) {
+            Assert.fail("IOException in comparing xml");
+        }
+    }
 }

--- a/store/src/java-test/com/zimbra/cs/service/mail/GetFilterRulesTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/mail/GetFilterRulesTest.java
@@ -202,7 +202,7 @@ public class GetFilterRulesTest {
 
         Element rules = response.getOptionalElement(MailConstants.E_FILTER_RULES);
 
-        assertXMLEquals(rules.prettyPrint(), expectedSoap);
+        assertXMLEquals(expectedSoap, rules.prettyPrint());
     }
 
     // allof(with multi conditions) then allof(with multi conditions)


### PR DESCRIPTION
Fixing GetFilterRulesTest::testBug71036_SingleRuleSimpleNestedIfwithMultiConditions02
The response was being compared with static String. The order of the attributes was changed which was causing the unit test failure.
