### PR TITLE
ZCS-1136:Fixing xml comparisons in GetFilterRulesTest

### DIFF
--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -76,5 +76,6 @@
   <dependency org="zimbra" name="zm-soap" rev="latest.integration" /> 
   <dependency org="zimbra" name="zm-client" rev="latest.integration" /> 
   <dependency org="zimbra" name="zm-native" rev="latest.integration"/>
+  <dependency org="org.xmlunit" name="xmlunit-core" rev="2.3.0"/>
  </dependencies>
 </ivy-module>

--- a/store/src/java-test/com/zimbra/cs/service/mail/GetFilterRulesTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/mail/GetFilterRulesTest.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.cs.service.mail;
 
-import com.zimbra.common.util.ZimbraLog;
 import com.google.common.collect.Maps;
 import com.zimbra.common.account.Key;
 import com.zimbra.common.soap.Element;
@@ -27,6 +26,7 @@ import com.zimbra.cs.filter.RuleManager;
 import com.zimbra.cs.mailbox.*;
 import com.zimbra.cs.service.AuthProvider;
 import com.zimbra.cs.service.MockHttpServletRequest;
+import com.zimbra.cs.util.XMLDiffChecker;
 import com.zimbra.soap.MockSoapEngine;
 import com.zimbra.soap.SoapEngine;
 import com.zimbra.soap.SoapServlet;
@@ -96,9 +96,7 @@ public class GetFilterRulesTest {
         expectedSoap += "</filterRules>";
 
         Element rules = response.getOptionalElement(MailConstants.E_FILTER_RULES);
-        //ZimbraLog.filter.info(rules.prettyPrint());
-        //ZimbraLog.filter.info(expectedSoap);
-        Assert.assertEquals(expectedSoap, rules.prettyPrint());
+        XMLDiffChecker.assertXMLEquals(expectedSoap, rules.prettyPrint());
 
     }
     // allof(with multi conditions) then anyof
@@ -144,9 +142,7 @@ public class GetFilterRulesTest {
         expectedSoap += "</filterRules>";
 
         Element rules = response.getOptionalElement(MailConstants.E_FILTER_RULES);
-        //ZimbraLog.filter.info(rules.prettyPrint());
-        //ZimbraLog.filter.info(expectedSoap);
-        Assert.assertEquals(expectedSoap, rules.prettyPrint());
+        XMLDiffChecker.assertXMLEquals(expectedSoap, rules.prettyPrint());
 
     }
 
@@ -193,9 +189,7 @@ public class GetFilterRulesTest {
         expectedSoap += "</filterRules>";
 
         Element rules = response.getOptionalElement(MailConstants.E_FILTER_RULES);
-        //ZimbraLog.filter.info(rules.prettyPrint());
-        //ZimbraLog.filter.info(expectedSoap);
-        Assert.assertEquals(expectedSoap, rules.prettyPrint());
+        XMLDiffChecker.assertXMLEquals(expectedSoap, rules.prettyPrint());
 
     }
 
@@ -244,9 +238,7 @@ public class GetFilterRulesTest {
         expectedSoap += "</filterRules>";
 
         Element rules = response.getOptionalElement(MailConstants.E_FILTER_RULES);
-        //ZimbraLog.filter.info(rules.prettyPrint());
-        //ZimbraLog.filter.info(expectedSoap);
-        Assert.assertEquals(expectedSoap, rules.prettyPrint());
+        XMLDiffChecker.assertXMLEquals(expectedSoap, rules.prettyPrint());
 
     }
 
@@ -295,9 +287,7 @@ public class GetFilterRulesTest {
         expectedSoap += "</filterRules>";
 
         Element rules = response.getOptionalElement(MailConstants.E_FILTER_RULES);
-        //ZimbraLog.filter.info(rules.prettyPrint());
-        //ZimbraLog.filter.info(expectedSoap);
-        Assert.assertEquals(expectedSoap, rules.prettyPrint());
+        XMLDiffChecker.assertXMLEquals(expectedSoap, rules.prettyPrint());
 
     }
 
@@ -419,9 +409,7 @@ public class GetFilterRulesTest {
         expectedSoap += "</filterRules>";
 
         Element rules = response.getOptionalElement(MailConstants.E_FILTER_RULES);
-        //ZimbraLog.filter.info(rules.prettyPrint());
-        //ZimbraLog.filter.info(expectedSoap);
-        Assert.assertEquals(expectedSoap, rules.prettyPrint());
+        XMLDiffChecker.assertXMLEquals(expectedSoap, rules.prettyPrint());
 
     }
 
@@ -477,9 +465,7 @@ public class GetFilterRulesTest {
 
 
         Element rules = response.getOptionalElement(MailConstants.E_FILTER_RULES);
-        //ZimbraLog.filter.info(rules.prettyPrint());
-        //ZimbraLog.filter.info(expectedSoap);
-        Assert.assertEquals(expectedSoap, rules.prettyPrint());
+        XMLDiffChecker.assertXMLEquals(expectedSoap, rules.prettyPrint());
 
     }
 

--- a/store/src/java-test/com/zimbra/cs/util/XMLDiffChecker.java
+++ b/store/src/java-test/com/zimbra/cs/util/XMLDiffChecker.java
@@ -1,0 +1,15 @@
+package com.zimbra.cs.util;
+
+import org.junit.Assert;
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.builder.Input;
+import org.xmlunit.diff.Diff;
+
+public class XMLDiffChecker {
+
+    public static void assertXMLEquals(String expected, String actual) {
+        Diff myDiff = DiffBuilder.compare(Input.fromString(expected))
+            .withTest(Input.fromString(actual)).ignoreWhitespace().build();
+        Assert.assertFalse(myDiff.toString(), myDiff.hasDifferences());
+    }
+}


### PR DESCRIPTION
Fixed following unit tests failures:
ZCS-1135,ZCS-1136,ZCS-1137,ZCS-1138,ZCS-1139,ZCS-1140,ZCS-1141

XML comparison was failing due to change in attribute order
