### PR TITLE
implement getLastChangeId

### DIFF
--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -527,6 +527,7 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
     private boolean mNoTagCache;
     private ZContactByPhoneCache mContactByPhoneCache;
     private final ZMailboxLock lock;
+    private int lastChangeId = 0;
 
     private final List<ZEventHandler> mHandlers = new ArrayList<ZEventHandler>();
 
@@ -856,6 +857,12 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
         Element refresh = context.getOptionalElement(ZimbraNamespace.E_REFRESH);
         if (refresh != null) {
             handleRefresh(refresh);
+        }
+
+        // handle refresh blocks
+        Element change = context.getOptionalElement(HeaderConstants.E_CHANGE);
+        if (change != null) {
+            lastChangeId = change.getAttributeInt(HeaderConstants.A_CHANGE_ID);
         }
 
         for (Element notify : context.listElements(ZimbraNamespace.E_NOTIFY)) {
@@ -6153,8 +6160,7 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
      */
     @Override
     public int getLastChangeID() {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("ZMailbox method not supported yet");
+        return lastChangeId;
     }
 
     @VisibleForTesting

--- a/store/src/java/com/zimbra/qa/unittest/TestZClient.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestZClient.java
@@ -598,6 +598,20 @@ public class TestZClient extends TestCase {
         assertTrue(msg.isTagged("testSetTags tag3"));
     }
 
+    @Test
+    public void testLastChangeId() throws Exception {
+        ZMailbox zmbox = TestUtil.getZMailbox(USER_NAME);
+        Mailbox mbox = TestUtil.getMailbox(USER_NAME);
+        int firstChangeId = zmbox.getLastChangeID();
+        assertEquals("wrong change ID before adding message", mbox.getLastChangeID(), firstChangeId);
+        String msgId = TestUtil.addMessage(zmbox, "testLastChangeId message");
+        ZMessage msg = zmbox.getMessageById(msgId);
+        assertNotNull("msg should not be NULL", msg);
+        int secondChangeId = zmbox.getLastChangeID();
+        assertTrue("lastChangeId should have increased", firstChangeId < secondChangeId);
+        assertEquals("wrong change ID after adding message", mbox.getLastChangeID(), secondChangeId);
+    }
+
     private void compareMsgAndZMsg(String testname, Message msg, ZMessage zmsg) throws IOException, ServiceException {
         assertNotNull("Message is null", msg);
         assertNotNull("ZMessage is null", zmsg);


### PR DESCRIPTION
ZMailbox will always have the value of lastChangeId that reflects lastChangeId of Mailbox object at the time of last SOAP request sent by ZMailbox to mailstore. IMAP uses last change ID to create an ID string for a serialized session cache. 