### PR TITLE
ZCS-1291 Deprecate old sieve ldap attributes and add new

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -8416,7 +8416,7 @@ public class ZAttrProvisioning {
      * outgoing sieve script defined by admin (not able to edit and view from
      * the end user) applied after the end user filter rule
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public static final String A_zimbraMailAdminOutgoingSieveScriptAfter = "zimbraMailAdminOutgoingSieveScriptAfter";
@@ -8425,7 +8425,7 @@ public class ZAttrProvisioning {
      * outgoing sieve script defined by admin (not able to edit and view from
      * the end user) applied before the end user filter rule
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public static final String A_zimbraMailAdminOutgoingSieveScriptBefore = "zimbraMailAdminOutgoingSieveScriptBefore";
@@ -8434,7 +8434,7 @@ public class ZAttrProvisioning {
      * sieve script defined by admin (not able to edit and view from the end
      * user) applied after the end user filter rule
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public static final String A_zimbraMailAdminSieveScriptAfter = "zimbraMailAdminSieveScriptAfter";
@@ -8443,7 +8443,7 @@ public class ZAttrProvisioning {
      * sieve script defined by admin (not able to edit and view from the end
      * user) applied before the end user filter rule
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public static final String A_zimbraMailAdminSieveScriptBefore = "zimbraMailAdminSieveScriptBefore";
@@ -8920,10 +8920,13 @@ public class ZAttrProvisioning {
     public static final String A_zimbraMailReferMode = "zimbraMailReferMode";
 
     /**
-     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
-     * parses the &#039;notify&#039; action parameters based on the syntax
-     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
-     * &#039;notify&#039; action parameters with Zimbra specific format
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveNotifyActionRFCCompliant, which can be used at account
+     * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
+     * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
+     * based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS
+     * treats the &#039;notify&#039; action parameters with Zimbra specific
+     * format
      *
      * @since ZCS 8.7.8
      */
@@ -15267,13 +15270,35 @@ public class ZAttrProvisioning {
     public static final String A_zimbraShortTermGranteeCacheSize = "zimbraShortTermGranteeCacheSize";
 
     /**
-     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
-     * 5429.
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public static final String A_zimbraSieveNotifyActionRFCCompliant = "zimbraSieveNotifyActionRFCCompliant";
+
+    /**
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
+     * RFC 5429.
      *
      * @since ZCS 8.7.8
      */
     @ZAttr(id=2094)
     public static final String A_zimbraSieveRejectEnabled = "zimbraSieveRejectEnabled";
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public static final String A_zimbraSieveRejectMailEnabled = "zimbraSieveRejectMailEnabled";
 
     /**
      * Unique ID for an signature

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -3015,6 +3015,24 @@ public class ZAttrProvisioning {
     public static final String A_zimbraAdminLocalBind = "zimbraAdminLocalBind";
 
     /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied after the end user filter rule
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2116)
+    public static final String A_zimbraAdminOutgoingSieveScriptAfter = "zimbraAdminOutgoingSieveScriptAfter";
+
+    /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied before the end user filter rule
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2115)
+    public static final String A_zimbraAdminOutgoingSieveScriptBefore = "zimbraAdminOutgoingSieveScriptBefore";
+
+    /**
      * SSL port for admin UI
      */
     @ZAttr(id=155)
@@ -3033,6 +3051,24 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=446)
     public static final String A_zimbraAdminSavedSearches = "zimbraAdminSavedSearches";
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied after the end user filter rule
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2114)
+    public static final String A_zimbraAdminSieveScriptAfter = "zimbraAdminSieveScriptAfter";
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied before the end user filter rule
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2113)
+    public static final String A_zimbraAdminSieveScriptBefore = "zimbraAdminSieveScriptBefore";
 
     /**
      * URL prefix for where the zimbraAdmin app resides on this server
@@ -8413,37 +8449,45 @@ public class ZAttrProvisioning {
     public static final String A_zimbraMailAddressValidationRegex = "zimbraMailAddressValidationRegex";
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptAfter. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * after the end user filter rule
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2093)
     public static final String A_zimbraMailAdminOutgoingSieveScriptAfter = "zimbraMailAdminOutgoingSieveScriptAfter";
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptBefore. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * before the end user filter rule
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2092)
     public static final String A_zimbraMailAdminOutgoingSieveScriptBefore = "zimbraMailAdminOutgoingSieveScriptBefore";
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptAfter. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied after the end
+     * user filter rule
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2091)
     public static final String A_zimbraMailAdminSieveScriptAfter = "zimbraMailAdminSieveScriptAfter";
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptBefore. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied before the end
+     * user filter rule
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2090)
     public static final String A_zimbraMailAdminSieveScriptBefore = "zimbraMailAdminSieveScriptBefore";
@@ -8920,7 +8964,7 @@ public class ZAttrProvisioning {
     public static final String A_zimbraMailReferMode = "zimbraMailReferMode";
 
     /**
-     * Deprecated since: 8.7.9. deprecated in favor of
+     * Deprecated since: 8.7.8. deprecated in favor of
      * zimbraSieveNotifyActionRFCCompliant, which can be used at account
      * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
      * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
@@ -8928,7 +8972,7 @@ public class ZAttrProvisioning {
      * treats the &#039;notify&#039; action parameters with Zimbra specific
      * format
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2095)
     public static final String A_zimbraMailSieveNotifyActionRFCCompliant = "zimbraMailSieveNotifyActionRFCCompliant";
@@ -15275,18 +15319,18 @@ public class ZAttrProvisioning {
      * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
      * &#039;notify&#039; action parameters with Zimbra specific format
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2112)
     public static final String A_zimbraSieveNotifyActionRFCCompliant = "zimbraSieveNotifyActionRFCCompliant";
 
     /**
-     * Deprecated since: 8.7.9. deprecated in favor of
+     * Deprecated since: 8.7.8. deprecated in favor of
      * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
      * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
      * RFC 5429.
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2094)
     public static final String A_zimbraSieveRejectEnabled = "zimbraSieveRejectEnabled";
@@ -15295,7 +15339,7 @@ public class ZAttrProvisioning {
      * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
      * 5429.
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2111)
     public static final String A_zimbraSieveRejectMailEnabled = "zimbraSieveRejectMailEnabled";

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -15314,6 +15314,17 @@ public class ZAttrProvisioning {
     public static final String A_zimbraShortTermGranteeCacheSize = "zimbraShortTermGranteeCacheSize";
 
     /**
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;Variables&quot; extension
+     * defined in RFC 5229 in the user-defined sieve rule.
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2096)
+    public static final String A_zimbraSieveFeatureVariablesEnabled = "zimbraSieveFeatureVariablesEnabled";
+
+    /**
      * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
      * parses the &#039;notify&#039; action parameters based on the syntax
      * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9227,29 +9227,33 @@ TODO: delete them permanently from here
   <desc>Value for postconf postscreen_upstream_proxy_protocol.</desc>
 </attr>
 
-<attr id="2090" name="zimbraMailAdminSieveScriptBefore" type="string" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.9">
+<attr id="2090" name="zimbraMailAdminSieveScriptBefore" type="string" cardinality="single" optionalIn="account,cos,domain,server" since="8.7.6" deprecatedSince="8.7.8">
 <desc>sieve script defined by admin (not able to edit and view from the end user) applied before the end user filter rule</desc>
+<deprecateDesc>deprecated in favor of zimbraAdminSieveScriptBefore</deprecateDesc>
 </attr>
 
-<attr id="2091" name="zimbraMailAdminSieveScriptAfter" type="string" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.9">
+<attr id="2091" name="zimbraMailAdminSieveScriptAfter" type="string" cardinality="single" optionalIn="account,cos,domain,server" since="8.7.6" deprecatedSince="8.7.8">
 <desc>sieve script defined by admin (not able to edit and view from the end user) applied after the end user filter rule</desc>
+<deprecateDesc>deprecated in favor of zimbraAdminSieveScriptAfter</deprecateDesc>
 </attr>
 
-<attr id="2092" name="zimbraMailAdminOutgoingSieveScriptBefore" type="string" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.9">
+<attr id="2092" name="zimbraMailAdminOutgoingSieveScriptBefore" type="string" cardinality="single" optionalIn="account,cos,domain,server" since="8.7.6" deprecatedSince="8.7.8">
 <desc>outgoing sieve script defined by admin (not able to edit and view from the end user) applied before the end user filter rule</desc>
+<deprecateDesc>deprecated in favor of zimbraAdminOutgoingSieveScriptBefore</deprecateDesc>
 </attr>
 
-<attr id="2093" name="zimbraMailAdminOutgoingSieveScriptAfter" type="string" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.9">
+<attr id="2093" name="zimbraMailAdminOutgoingSieveScriptAfter" type="string" cardinality="single" optionalIn="account,cos,domain,server" since="8.7.6" deprecatedSince="8.7.8">
 <desc>outgoing sieve script defined by admin (not able to edit and view from the end user) applied after the end user filter rule</desc>
+<deprecateDesc>deprecated in favor of zimbraAdminOutgoingSieveScriptAfter</deprecateDesc>
 </attr>
 
-<attr id="2094" name="zimbraSieveRejectEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mailbox" since="8.7.8" deprecatedSince="8.7.9">
+<attr id="2094" name="zimbraSieveRejectEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mailbox" since="8.7.6" deprecatedSince="8.7.8">
 <globalConfigValue>TRUE</globalConfigValue>
 <desc>Whether to enable the Sieve "reject" action defined in RFC 5429.</desc>
 <deprecateDesc>deprecated in favor of zimbraSieveRejectMailEnabled, which can be used at account level</deprecateDesc>
 </attr>
 
-<attr id="2095" name="zimbraMailSieveNotifyActionRFCCompliant" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mailbox" since="8.7.8" deprecatedSince="8.7.9">
+<attr id="2095" name="zimbraMailSieveNotifyActionRFCCompliant" type="boolean" cardinality="single" optionalIn="globalConfig" requiresRestart="mailbox" since="8.7.6" deprecatedSince="8.7.8">
 <globalConfigValue>FALSE</globalConfigValue>
 <desc>Whether the RFC compliant 'notify' is used. If TRUE, ZCS parses the 'notify' action parameters based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS treats the 'notify' action parameters with Zimbra specific format</desc>
 <deprecateDesc>deprecated in favor of zimbraSieveNotifyActionRFCCompliant, which can be used at account level</deprecateDesc>
@@ -9450,13 +9454,29 @@ TODO: delete them permanently from here
   <desc>Drive own or next cloud URL.</desc>
 </attr>
 
-<attr id="2111" name="zimbraSieveRejectMailEnabled" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.9">
+<attr id="2111" name="zimbraSieveRejectMailEnabled" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.8">
 <defaultCOSValue>TRUE</defaultCOSValue>
 <desc>Whether to enable the Sieve "reject" action defined in RFC 5429.</desc>
 </attr>
 
-<attr id="2112" name="zimbraSieveNotifyActionRFCCompliant" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.9">
+<attr id="2112" name="zimbraSieveNotifyActionRFCCompliant" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.8">
 <defaultCOSValue>FALSE</defaultCOSValue>
 <desc>Whether the RFC compliant 'notify' is used. If TRUE, ZCS parses the 'notify' action parameters based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS treats the 'notify' action parameters with Zimbra specific format</desc>
+</attr>
+
+<attr id="2113" name="zimbraAdminSieveScriptBefore" type="string" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.8">
+<desc>sieve script defined by admin (not able to edit and view from the end user) applied before the end user filter rule</desc>
+</attr>
+
+<attr id="2114" name="zimbraAdminSieveScriptAfter" type="string" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.8">
+<desc>sieve script defined by admin (not able to edit and view from the end user) applied after the end user filter rule</desc>
+</attr>
+
+<attr id="2115" name="zimbraAdminOutgoingSieveScriptBefore" type="string" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.8">
+<desc>outgoing sieve script defined by admin (not able to edit and view from the end user) applied before the end user filter rule</desc>
+</attr>
+
+<attr id="2116" name="zimbraAdminOutgoingSieveScriptAfter" type="string" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.8">
+<desc>outgoing sieve script defined by admin (not able to edit and view from the end user) applied after the end user filter rule</desc>
 </attr>
 </attrs>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9227,30 +9227,32 @@ TODO: delete them permanently from here
   <desc>Value for postconf postscreen_upstream_proxy_protocol.</desc>
 </attr>
 
-<attr id="2090" name="zimbraMailAdminSieveScriptBefore" type="string" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.8">
+<attr id="2090" name="zimbraMailAdminSieveScriptBefore" type="string" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.9">
 <desc>sieve script defined by admin (not able to edit and view from the end user) applied before the end user filter rule</desc>
 </attr>
 
-<attr id="2091" name="zimbraMailAdminSieveScriptAfter" type="string" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.8">
+<attr id="2091" name="zimbraMailAdminSieveScriptAfter" type="string" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.9">
 <desc>sieve script defined by admin (not able to edit and view from the end user) applied after the end user filter rule</desc>
 </attr>
 
-<attr id="2092" name="zimbraMailAdminOutgoingSieveScriptBefore" type="string" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.8">
+<attr id="2092" name="zimbraMailAdminOutgoingSieveScriptBefore" type="string" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.9">
 <desc>outgoing sieve script defined by admin (not able to edit and view from the end user) applied before the end user filter rule</desc>
 </attr>
 
-<attr id="2093" name="zimbraMailAdminOutgoingSieveScriptAfter" type="string" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.8">
+<attr id="2093" name="zimbraMailAdminOutgoingSieveScriptAfter" type="string" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.9">
 <desc>outgoing sieve script defined by admin (not able to edit and view from the end user) applied after the end user filter rule</desc>
 </attr>
 
-<attr id="2094" name="zimbraSieveRejectEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mailbox" since="8.7.8">
+<attr id="2094" name="zimbraSieveRejectEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mailbox" since="8.7.8" deprecatedSince="8.7.9">
 <globalConfigValue>TRUE</globalConfigValue>
 <desc>Whether to enable the Sieve "reject" action defined in RFC 5429.</desc>
+<deprecateDesc>deprecated in favor of zimbraSieveRejectMailEnabled, which can be used at account level</deprecateDesc>
 </attr>
 
-<attr id="2095" name="zimbraMailSieveNotifyActionRFCCompliant" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mailbox" since="8.7.8">
+<attr id="2095" name="zimbraMailSieveNotifyActionRFCCompliant" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mailbox" since="8.7.8" deprecatedSince="8.7.9">
 <globalConfigValue>FALSE</globalConfigValue>
 <desc>Whether the RFC compliant 'notify' is used. If TRUE, ZCS parses the 'notify' action parameters based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS treats the 'notify' action parameters with Zimbra specific format</desc>
+<deprecateDesc>deprecated in favor of zimbraSieveNotifyActionRFCCompliant, which can be used at account level</deprecateDesc>
 </attr>
 
 <attr id="2097" name="zimbraGalSyncSizeLimit" type="integer" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited" since="8.7.2">
@@ -9446,5 +9448,15 @@ TODO: delete them permanently from here
 
 <attr id="2110" name="zimbraDriveOwnCloudURL" type="string" cardinality="single" optionalIn="domain" since="8.7.6">
   <desc>Drive own or next cloud URL.</desc>
+</attr>
+
+<attr id="2111" name="zimbraSieveRejectMailEnabled" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.9">
+<defaultCOSValue>TRUE</defaultCOSValue>
+<desc>Whether to enable the Sieve "reject" action defined in RFC 5429.</desc>
+</attr>
+
+<attr id="2112" name="zimbraSieveNotifyActionRFCCompliant" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.9">
+<defaultCOSValue>FALSE</defaultCOSValue>
+<desc>Whether the RFC compliant 'notify' is used. If TRUE, ZCS parses the 'notify' action parameters based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS treats the 'notify' action parameters with Zimbra specific format</desc>
 </attr>
 </attrs>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9228,35 +9228,41 @@ TODO: delete them permanently from here
 </attr>
 
 <attr id="2090" name="zimbraMailAdminSieveScriptBefore" type="string" cardinality="single" optionalIn="account,cos,domain,server" since="8.7.6" deprecatedSince="8.7.8">
-<desc>sieve script defined by admin (not able to edit and view from the end user) applied before the end user filter rule</desc>
-<deprecateDesc>deprecated in favor of zimbraAdminSieveScriptBefore</deprecateDesc>
+  <desc>sieve script defined by admin (not able to edit and view from the end user) applied before the end user filter rule</desc>
+  <deprecateDesc>deprecated in favor of zimbraAdminSieveScriptBefore</deprecateDesc>
 </attr>
 
 <attr id="2091" name="zimbraMailAdminSieveScriptAfter" type="string" cardinality="single" optionalIn="account,cos,domain,server" since="8.7.6" deprecatedSince="8.7.8">
-<desc>sieve script defined by admin (not able to edit and view from the end user) applied after the end user filter rule</desc>
-<deprecateDesc>deprecated in favor of zimbraAdminSieveScriptAfter</deprecateDesc>
+  <desc>sieve script defined by admin (not able to edit and view from the end user) applied after the end user filter rule</desc>
+  <deprecateDesc>deprecated in favor of zimbraAdminSieveScriptAfter</deprecateDesc>
 </attr>
 
 <attr id="2092" name="zimbraMailAdminOutgoingSieveScriptBefore" type="string" cardinality="single" optionalIn="account,cos,domain,server" since="8.7.6" deprecatedSince="8.7.8">
-<desc>outgoing sieve script defined by admin (not able to edit and view from the end user) applied before the end user filter rule</desc>
-<deprecateDesc>deprecated in favor of zimbraAdminOutgoingSieveScriptBefore</deprecateDesc>
+  <desc>outgoing sieve script defined by admin (not able to edit and view from the end user) applied before the end user filter rule</desc>
+  <deprecateDesc>deprecated in favor of zimbraAdminOutgoingSieveScriptBefore</deprecateDesc>
 </attr>
 
 <attr id="2093" name="zimbraMailAdminOutgoingSieveScriptAfter" type="string" cardinality="single" optionalIn="account,cos,domain,server" since="8.7.6" deprecatedSince="8.7.8">
-<desc>outgoing sieve script defined by admin (not able to edit and view from the end user) applied after the end user filter rule</desc>
-<deprecateDesc>deprecated in favor of zimbraAdminOutgoingSieveScriptAfter</deprecateDesc>
+  <desc>outgoing sieve script defined by admin (not able to edit and view from the end user) applied after the end user filter rule</desc>
+  <deprecateDesc>deprecated in favor of zimbraAdminOutgoingSieveScriptAfter</deprecateDesc>
 </attr>
 
 <attr id="2094" name="zimbraSieveRejectEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mailbox" since="8.7.6" deprecatedSince="8.7.8">
-<globalConfigValue>TRUE</globalConfigValue>
-<desc>Whether to enable the Sieve "reject" action defined in RFC 5429.</desc>
-<deprecateDesc>deprecated in favor of zimbraSieveRejectMailEnabled, which can be used at account level</deprecateDesc>
+  <globalConfigValue>TRUE</globalConfigValue>
+  <desc>Whether to enable the Sieve "reject" action defined in RFC 5429.</desc>
+  <deprecateDesc>deprecated in favor of zimbraSieveRejectMailEnabled, which can be used at account level</deprecateDesc>
 </attr>
 
 <attr id="2095" name="zimbraMailSieveNotifyActionRFCCompliant" type="boolean" cardinality="single" optionalIn="globalConfig" requiresRestart="mailbox" since="8.7.6" deprecatedSince="8.7.8">
-<globalConfigValue>FALSE</globalConfigValue>
-<desc>Whether the RFC compliant 'notify' is used. If TRUE, ZCS parses the 'notify' action parameters based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS treats the 'notify' action parameters with Zimbra specific format</desc>
-<deprecateDesc>deprecated in favor of zimbraSieveNotifyActionRFCCompliant, which can be used at account level</deprecateDesc>
+  <globalConfigValue>FALSE</globalConfigValue>
+  <desc>Whether the RFC compliant 'notify' is used.  If TRUE, ZCS parses the 'notify' action parameters based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS treats the 'notify' action parameters with Zimbra specific format</desc>
+  <deprecateDesc>deprecated in favor of zimbraSieveNotifyActionRFCCompliant, which can be used at account level</deprecateDesc>
+</attr>
+
+<attr id="2096" name="zimbraSieveFeatureVariablesEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mailbox" since="8.7.6" deprecatedSince="8.7.8">
+  <globalConfigValue>FALSE</globalConfigValue>
+  <desc>Whether to enable the Sieve "Variables" extension defined in RFC 5229 in the user-defined sieve rule.</desc>
+  <deprecateDesc>deprecated in favor of zimbraSieveRejectMailEnabled, which can be used at account level</deprecateDesc>
 </attr>
 
 <attr id="2097" name="zimbraGalSyncSizeLimit" type="integer" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited" since="8.7.2">

--- a/store/src/java-test/com/zimbra/cs/filter/EnvelopeTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/EnvelopeTest.java
@@ -680,7 +680,7 @@ public class EnvelopeTest {
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(
                     account);
 
-            account.setMailAdminSieveScriptBefore(filterScript);
+            account.setAdminSieveScriptBefore(filterScript);
             account.setMail("original1@zimbra.com");
             String[] alias = {"alias1@zimbra.com", "alias2@zimbra.com"};
             account.setMailAlias(alias);

--- a/store/src/java-test/com/zimbra/cs/filter/EscapeSequencesTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/EscapeSequencesTest.java
@@ -63,22 +63,22 @@ public final class EscapeSequencesTest {
 
         Map<String, Object> attrs = Maps.newHashMap();
         attrs = Maps.newHashMap();
-        attrs.put(Provisioning.A_zimbraMailSieveNotifyActionRFCCompliant, "TRUE");
-        prov.getLocalServer().modify(attrs);
 
         prov.createDomain("zimbra.com", attrs);
 
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "TRUE");
         Account account = prov.createAccount("test1@zimbra.com", "secret", attrs);
-        Server server = Provisioning.getInstance().getServer(account);
 
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "TRUE");
         prov.createAccount("test2@zimbra.com", "secret", attrs);
 
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "TRUE");
         prov.createAccount("test3@zimbra.com", "secret", attrs);
 
         // this MailboxManager does everything except actually send mail

--- a/store/src/java-test/com/zimbra/cs/filter/HeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/HeaderTest.java
@@ -292,7 +292,7 @@ public class HeaderTest {
         try {
             Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
             RuleManager.clearCachedRules(account);
-            account.setMailAdminSieveScriptBefore(script);
+            account.setAdminSieveScriptBefore(script);
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
             List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox), mbox,
@@ -359,7 +359,7 @@ public class HeaderTest {
             try {
             Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
             RuleManager.clearCachedRules(account);
-            account.setMailAdminSieveScriptBefore(script);
+            account.setAdminSieveScriptBefore(script);
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
             List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox), mbox,
@@ -400,7 +400,7 @@ public class HeaderTest {
             try {
             Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
             RuleManager.clearCachedRules(account);
-            account.setMailAdminSieveScriptBefore(script);
+            account.setAdminSieveScriptBefore(script);
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
             List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox), mbox,
@@ -429,7 +429,7 @@ public class HeaderTest {
             try {
             Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
             RuleManager.clearCachedRules(account);
-            account.setMailAdminSieveScriptBefore(script);
+            account.setAdminSieveScriptBefore(script);
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
             List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox), mbox,

--- a/store/src/java-test/com/zimbra/cs/filter/NotifyMailtoTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/NotifyMailtoTest.java
@@ -63,26 +63,27 @@ public class NotifyMailtoTest {
 
         Map<String, Object> attrs = Maps.newHashMap();
         attrs = Maps.newHashMap();
-        attrs.put(Provisioning.A_zimbraMailSieveNotifyActionRFCCompliant, "TRUE");
-        prov.getLocalServer().modify(attrs);
 
         prov.createDomain("zimbra.com", attrs);
 
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "TRUE");
         Account account = prov.createAccount("test1@zimbra.com", "secret", attrs);
-        Server server = Provisioning.getInstance().getServer(account);
 
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "TRUE");
         prov.createAccount("test2@zimbra.com", "secret", attrs);
 
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "TRUE");
         prov.createAccount("\"tes\\\\t2\"@zimbra.com", "secret", attrs);
 
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "TRUE");
         prov.createAccount("test3@zimbra.com", "secret", attrs);
 
         // this MailboxManager does everything except actually send mail

--- a/store/src/java-test/com/zimbra/cs/filter/NotifyTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/NotifyTest.java
@@ -60,10 +60,12 @@ public class NotifyTest {
 
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "FALSE");
         prov.createAccount("test@zimbra.com", "secret", attrs);
 
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "FALSE");
         prov.createAccount("test2@zimbra.com", "secret", attrs);
 
         // this MailboxManager does everything except actually send mail

--- a/store/src/java-test/com/zimbra/cs/filter/RuleManagerAdminFilterTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/RuleManagerAdminFilterTest.java
@@ -97,13 +97,13 @@ public final class RuleManagerAdminFilterTest {
         Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
         RuleManager.clearCachedRules(account);
-        account.unsetMailAdminSieveScriptBefore();
+        account.unsetAdminSieveScriptBefore();
         account.unsetMailSieveScript();
-        account.unsetMailAdminSieveScriptAfter();
+        account.unsetAdminSieveScriptAfter();
 
-        account.setMailAdminSieveScriptBefore(scriptAdminBefore);
+        account.setAdminSieveScriptBefore(scriptAdminBefore);
         account.setMailSieveScript(scriptUser);
-        account.setMailAdminSieveScriptAfter(scriptAdminAfter);
+        account.setAdminSieveScriptAfter(scriptAdminAfter);
 
         List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox),
             mbox, new ParsedMessage(message.getBytes(), false),
@@ -125,9 +125,9 @@ public final class RuleManagerAdminFilterTest {
         Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
         RuleManager.clearCachedRules(account);
-        account.unsetMailAdminSieveScriptBefore();
+        account.unsetAdminSieveScriptBefore();
         account.unsetMailSieveScript();
-        account.unsetMailAdminSieveScriptAfter();
+        account.unsetAdminSieveScriptAfter();
 
         account.setMailSieveScript(scriptUser);
 
@@ -145,13 +145,13 @@ public final class RuleManagerAdminFilterTest {
         Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
         RuleManager.clearCachedRules(account);
-        account.unsetMailAdminSieveScriptBefore();
+        account.unsetAdminSieveScriptBefore();
         account.unsetMailSieveScript();
-        account.unsetMailAdminSieveScriptAfter();
+        account.unsetAdminSieveScriptAfter();
 
-        account.setMailAdminSieveScriptBefore(scriptAdminBeforeStop);
+        account.setAdminSieveScriptBefore(scriptAdminBeforeStop);
         account.setMailSieveScript(scriptUser);
-        account.setMailAdminSieveScriptAfter(scriptAdminAfter);
+        account.setAdminSieveScriptAfter(scriptAdminAfter);
 
         List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox),
             mbox, new ParsedMessage(message.getBytes(), false),
@@ -167,13 +167,13 @@ public final class RuleManagerAdminFilterTest {
         Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
         RuleManager.clearCachedRules(account);
-        account.unsetMailAdminSieveScriptBefore();
+        account.unsetAdminSieveScriptBefore();
         account.unsetMailSieveScript();
-        account.unsetMailAdminSieveScriptAfter();
+        account.unsetAdminSieveScriptAfter();
 
-        account.setMailAdminSieveScriptBefore(scriptAdminBeforeStop);
+        account.setAdminSieveScriptBefore(scriptAdminBeforeStop);
         account.setMailSieveScript(scriptUser);
-        account.setMailAdminSieveScriptAfter(scriptUserBadRequireName);
+        account.setAdminSieveScriptAfter(scriptUserBadRequireName);
 
         List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox),
             mbox, new ParsedMessage(message.getBytes(), false),
@@ -302,13 +302,13 @@ public final class RuleManagerAdminFilterTest {
         Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
         RuleManager.clearCachedRules(account);
 
-        account.unsetMailAdminSieveScriptBefore();
+        account.unsetAdminSieveScriptBefore();
         account.unsetMailSieveScript();
-        account.unsetMailAdminSieveScriptAfter();
+        account.unsetAdminSieveScriptAfter();
 
-        account.setMailAdminSieveScriptBefore(adminBefore);
+        account.setAdminSieveScriptBefore(adminBefore);
         account.setMailSieveScript(enduser);
-        account.setMailAdminSieveScriptAfter(adminAfter);
+        account.setAdminSieveScriptAfter(adminAfter);
 
         List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox),
                 mbox, new ParsedMessage(message.getBytes(), false),
@@ -330,13 +330,13 @@ public final class RuleManagerAdminFilterTest {
         Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
         RuleManager.clearCachedRules(account);
 
-        account.unsetMailAdminSieveScriptBefore();
+        account.unsetAdminSieveScriptBefore();
         account.unsetMailSieveScript();
-        account.unsetMailAdminSieveScriptAfter();
+        account.unsetAdminSieveScriptAfter();
 
-        account.setMailAdminSieveScriptBefore(adminBefore);
+        account.setAdminSieveScriptBefore(adminBefore);
         account.setMailSieveScript(enduser);
-        account.setMailAdminSieveScriptAfter(adminAfter);
+        account.setAdminSieveScriptAfter(adminAfter);
 
         List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox),
                 mbox, new ParsedMessage(message.getBytes(), false),
@@ -354,13 +354,13 @@ public final class RuleManagerAdminFilterTest {
         Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
         RuleManager.clearCachedRules(account);
 
-        account.unsetMailAdminSieveScriptBefore();
+        account.unsetAdminSieveScriptBefore();
         account.unsetMailSieveScript();
-        account.unsetMailAdminSieveScriptAfter();
+        account.unsetAdminSieveScriptAfter();
 
-        account.setMailAdminSieveScriptBefore(adminBefore);
+        account.setAdminSieveScriptBefore(adminBefore);
         account.setMailSieveScript(enduser);
-        account.setMailAdminSieveScriptAfter(adminAfter);
+        account.setAdminSieveScriptAfter(adminAfter);
 
         String rawTest = "From: sender@zimbra.com\n"
                        + "To: test1@zimbra.com\n"
@@ -395,11 +395,11 @@ public final class RuleManagerAdminFilterTest {
         Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
         RuleManager.clearCachedRules(account);
 
-        account.unsetMailAdminSieveScriptBefore();
+        account.unsetAdminSieveScriptBefore();
         account.unsetMailSieveScript();
-        account.unsetMailAdminSieveScriptAfter();
+        account.unsetAdminSieveScriptAfter();
 
-        account.setMailAdminSieveScriptBefore(adminBefore);
+        account.setAdminSieveScriptBefore(adminBefore);
 
         String rawTest = "From: sender@zimbra.com\n"
                        + "To: test1@zimbra.com\n"
@@ -434,9 +434,9 @@ public final class RuleManagerAdminFilterTest {
         Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
         RuleManager.clearCachedRules(account);
 
-        account.unsetMailAdminSieveScriptBefore();
+        account.unsetAdminSieveScriptBefore();
         account.unsetMailSieveScript();
-        account.unsetMailAdminSieveScriptAfter();
+        account.unsetAdminSieveScriptAfter();
 
         account.setMailSieveScript(endUser);
 
@@ -473,11 +473,11 @@ public final class RuleManagerAdminFilterTest {
         Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
         RuleManager.clearCachedRules(account);
 
-        account.unsetMailAdminSieveScriptBefore();
+        account.unsetAdminSieveScriptBefore();
         account.unsetMailSieveScript();
-        account.unsetMailAdminSieveScriptAfter();
+        account.unsetAdminSieveScriptAfter();
 
-        account.setMailAdminSieveScriptAfter(adminAfter);
+        account.setAdminSieveScriptAfter(adminAfter);
 
         String rawTest = "From: sender@zimbra.com\n"
                        + "To: test1@zimbra.com\n"
@@ -517,11 +517,11 @@ public final class RuleManagerAdminFilterTest {
         Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
         RuleManager.clearCachedRules(account);
 
-        account.unsetMailAdminSieveScriptBefore();
+        account.unsetAdminSieveScriptBefore();
         account.unsetMailSieveScript();
-        account.unsetMailAdminSieveScriptAfter();
+        account.unsetAdminSieveScriptAfter();
 
-        account.setMailAdminSieveScriptAfter(adminAfter);
+        account.setAdminSieveScriptAfter(adminAfter);
 
         RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox),
                 mbox, new ParsedMessage("Subject: require abc def\n".getBytes(), false), 0, account.getName(),

--- a/store/src/java-test/com/zimbra/cs/service/mail/ModifyFilterRulesTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/mail/ModifyFilterRulesTest.java
@@ -126,7 +126,7 @@ public class ModifyFilterRulesTest {
             fail("This test is expected not to throw exception. ");
         }
 
-        String expectedScript = "require [\"fileinto\", \"reject\", \"tag\", \"flag\"];\n\n";
+        String expectedScript = "require [\"fileinto\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\", \"enotify\"];\n\n";
         expectedScript += "# Test1\n";
         expectedScript += "if anyof (header :contains [\"subject\"] \"important\") {\n";
         expectedScript += "    fileinto \"Junk\";\n";
@@ -186,7 +186,7 @@ public class ModifyFilterRulesTest {
             fail("This test is expected not to throw exception. ");
         }
 
-        String expectedScript = "require [\"fileinto\", \"reject\", \"tag\", \"flag\"];\n\n";
+        String expectedScript = "require [\"fileinto\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\", \"enotify\"];\n\n";
         expectedScript += "# Test1\n";
         expectedScript += "if anyof (header :contains [\"subject\"] \"important\") {\n";
         expectedScript += "    if anyof (header :is [\"subject\"] \"confifential\") {\n";
@@ -272,7 +272,7 @@ public class ModifyFilterRulesTest {
 
         Element nfilteraction2 = nestedRule2.addElement(MailConstants.E_FILTER_ACTIONS);
         Element nactionInto2 = nfilteraction2.addElement(MailConstants.E_ACTION_FILE_INTO);
-        nactionInto2.addAttribute(MailConstants.A_FOLDER_PATH, "Trush");
+        nactionInto2.addAttribute(MailConstants.A_FOLDER_PATH, "Trash");
         nfilteraction2.addElement(MailConstants.E_ACTION_STOP);
 
         try {
@@ -281,7 +281,7 @@ public class ModifyFilterRulesTest {
             fail("This test is expected not to throw exception. ");
         }
 
-        String expectedScript = "require [\"fileinto\", \"reject\", \"tag\", \"flag\"];\n\n";
+        String expectedScript = "require [\"fileinto\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\", \"enotify\"];\n\n";
         expectedScript += "# Test1\n";
         expectedScript += "if anyof (header :contains [\"Subject\"] \"important\") {\n";
         expectedScript += "    if allof (header :is [\"Subject\"] \"confifential\",\n";
@@ -296,7 +296,7 @@ public class ModifyFilterRulesTest {
         expectedScript += "  header :contains [\"from\"] \"solutions\") {\n";
         expectedScript += "    if anyof (header :is [\"subject\"] \"confifential\",\n";
         expectedScript += "      header :contains [\"Cc\"] \"test\") {\n";
-        expectedScript += "        fileinto \"Trush\";\n";
+        expectedScript += "        fileinto \"Trash\";\n";
         expectedScript += "        stop;\n";
         expectedScript += "    }\n";
         expectedScript += "}\n";

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -3130,6 +3130,160 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied after the end user filter rule
+     *
+     * @return zimbraAdminOutgoingSieveScriptAfter, or null if unset
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2116)
+    public String getAdminOutgoingSieveScriptAfter() {
+        return getAttr(Provisioning.A_zimbraAdminOutgoingSieveScriptAfter, null, true);
+    }
+
+    /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied after the end user filter rule
+     *
+     * @param zimbraAdminOutgoingSieveScriptAfter new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2116)
+    public void setAdminOutgoingSieveScriptAfter(String zimbraAdminOutgoingSieveScriptAfter) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminOutgoingSieveScriptAfter, zimbraAdminOutgoingSieveScriptAfter);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied after the end user filter rule
+     *
+     * @param zimbraAdminOutgoingSieveScriptAfter new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2116)
+    public Map<String,Object> setAdminOutgoingSieveScriptAfter(String zimbraAdminOutgoingSieveScriptAfter, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminOutgoingSieveScriptAfter, zimbraAdminOutgoingSieveScriptAfter);
+        return attrs;
+    }
+
+    /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied after the end user filter rule
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2116)
+    public void unsetAdminOutgoingSieveScriptAfter() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminOutgoingSieveScriptAfter, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied after the end user filter rule
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2116)
+    public Map<String,Object> unsetAdminOutgoingSieveScriptAfter(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminOutgoingSieveScriptAfter, "");
+        return attrs;
+    }
+
+    /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied before the end user filter rule
+     *
+     * @return zimbraAdminOutgoingSieveScriptBefore, or null if unset
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2115)
+    public String getAdminOutgoingSieveScriptBefore() {
+        return getAttr(Provisioning.A_zimbraAdminOutgoingSieveScriptBefore, null, true);
+    }
+
+    /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied before the end user filter rule
+     *
+     * @param zimbraAdminOutgoingSieveScriptBefore new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2115)
+    public void setAdminOutgoingSieveScriptBefore(String zimbraAdminOutgoingSieveScriptBefore) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminOutgoingSieveScriptBefore, zimbraAdminOutgoingSieveScriptBefore);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied before the end user filter rule
+     *
+     * @param zimbraAdminOutgoingSieveScriptBefore new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2115)
+    public Map<String,Object> setAdminOutgoingSieveScriptBefore(String zimbraAdminOutgoingSieveScriptBefore, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminOutgoingSieveScriptBefore, zimbraAdminOutgoingSieveScriptBefore);
+        return attrs;
+    }
+
+    /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied before the end user filter rule
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2115)
+    public void unsetAdminOutgoingSieveScriptBefore() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminOutgoingSieveScriptBefore, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied before the end user filter rule
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2115)
+    public Map<String,Object> unsetAdminOutgoingSieveScriptBefore(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminOutgoingSieveScriptBefore, "");
+        return attrs;
+    }
+
+    /**
      * admin saved searches
      *
      * @return zimbraAdminSavedSearches, or empty array if unset
@@ -3242,6 +3396,160 @@ public abstract class ZAttrAccount  extends MailTarget {
     public Map<String,Object> unsetAdminSavedSearches(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraAdminSavedSearches, "");
+        return attrs;
+    }
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied after the end user filter rule
+     *
+     * @return zimbraAdminSieveScriptAfter, or null if unset
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2114)
+    public String getAdminSieveScriptAfter() {
+        return getAttr(Provisioning.A_zimbraAdminSieveScriptAfter, null, true);
+    }
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied after the end user filter rule
+     *
+     * @param zimbraAdminSieveScriptAfter new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2114)
+    public void setAdminSieveScriptAfter(String zimbraAdminSieveScriptAfter) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveScriptAfter, zimbraAdminSieveScriptAfter);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied after the end user filter rule
+     *
+     * @param zimbraAdminSieveScriptAfter new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2114)
+    public Map<String,Object> setAdminSieveScriptAfter(String zimbraAdminSieveScriptAfter, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveScriptAfter, zimbraAdminSieveScriptAfter);
+        return attrs;
+    }
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied after the end user filter rule
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2114)
+    public void unsetAdminSieveScriptAfter() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveScriptAfter, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied after the end user filter rule
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2114)
+    public Map<String,Object> unsetAdminSieveScriptAfter(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveScriptAfter, "");
+        return attrs;
+    }
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied before the end user filter rule
+     *
+     * @return zimbraAdminSieveScriptBefore, or null if unset
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2113)
+    public String getAdminSieveScriptBefore() {
+        return getAttr(Provisioning.A_zimbraAdminSieveScriptBefore, null, true);
+    }
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied before the end user filter rule
+     *
+     * @param zimbraAdminSieveScriptBefore new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2113)
+    public void setAdminSieveScriptBefore(String zimbraAdminSieveScriptBefore) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveScriptBefore, zimbraAdminSieveScriptBefore);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied before the end user filter rule
+     *
+     * @param zimbraAdminSieveScriptBefore new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2113)
+    public Map<String,Object> setAdminSieveScriptBefore(String zimbraAdminSieveScriptBefore, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveScriptBefore, zimbraAdminSieveScriptBefore);
+        return attrs;
+    }
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied before the end user filter rule
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2113)
+    public void unsetAdminSieveScriptBefore() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveScriptBefore, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied before the end user filter rule
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2113)
+    public Map<String,Object> unsetAdminSieveScriptBefore(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveScriptBefore, "");
         return attrs;
     }
 
@@ -23323,12 +23631,14 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptAfter. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * after the end user filter rule
      *
      * @return zimbraMailAdminOutgoingSieveScriptAfter, or null if unset
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2093)
     public String getMailAdminOutgoingSieveScriptAfter() {
@@ -23336,13 +23646,15 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptAfter. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * after the end user filter rule
      *
      * @param zimbraMailAdminOutgoingSieveScriptAfter new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2093)
     public void setMailAdminOutgoingSieveScriptAfter(String zimbraMailAdminOutgoingSieveScriptAfter) throws com.zimbra.common.service.ServiceException {
@@ -23352,14 +23664,16 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptAfter. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * after the end user filter rule
      *
      * @param zimbraMailAdminOutgoingSieveScriptAfter new value
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2093)
     public Map<String,Object> setMailAdminOutgoingSieveScriptAfter(String zimbraMailAdminOutgoingSieveScriptAfter, Map<String,Object> attrs) {
@@ -23369,12 +23683,14 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptAfter. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * after the end user filter rule
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2093)
     public void unsetMailAdminOutgoingSieveScriptAfter() throws com.zimbra.common.service.ServiceException {
@@ -23384,13 +23700,15 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptAfter. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * after the end user filter rule
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2093)
     public Map<String,Object> unsetMailAdminOutgoingSieveScriptAfter(Map<String,Object> attrs) {
@@ -23400,12 +23718,14 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptBefore. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * before the end user filter rule
      *
      * @return zimbraMailAdminOutgoingSieveScriptBefore, or null if unset
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2092)
     public String getMailAdminOutgoingSieveScriptBefore() {
@@ -23413,13 +23733,15 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptBefore. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * before the end user filter rule
      *
      * @param zimbraMailAdminOutgoingSieveScriptBefore new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2092)
     public void setMailAdminOutgoingSieveScriptBefore(String zimbraMailAdminOutgoingSieveScriptBefore) throws com.zimbra.common.service.ServiceException {
@@ -23429,14 +23751,16 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptBefore. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * before the end user filter rule
      *
      * @param zimbraMailAdminOutgoingSieveScriptBefore new value
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2092)
     public Map<String,Object> setMailAdminOutgoingSieveScriptBefore(String zimbraMailAdminOutgoingSieveScriptBefore, Map<String,Object> attrs) {
@@ -23446,12 +23770,14 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptBefore. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * before the end user filter rule
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2092)
     public void unsetMailAdminOutgoingSieveScriptBefore() throws com.zimbra.common.service.ServiceException {
@@ -23461,13 +23787,15 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptBefore. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * before the end user filter rule
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2092)
     public Map<String,Object> unsetMailAdminOutgoingSieveScriptBefore(Map<String,Object> attrs) {
@@ -23477,12 +23805,14 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptAfter. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied after the end
+     * user filter rule
      *
      * @return zimbraMailAdminSieveScriptAfter, or null if unset
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2091)
     public String getMailAdminSieveScriptAfter() {
@@ -23490,13 +23820,15 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptAfter. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied after the end
+     * user filter rule
      *
      * @param zimbraMailAdminSieveScriptAfter new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2091)
     public void setMailAdminSieveScriptAfter(String zimbraMailAdminSieveScriptAfter) throws com.zimbra.common.service.ServiceException {
@@ -23506,14 +23838,16 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptAfter. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied after the end
+     * user filter rule
      *
      * @param zimbraMailAdminSieveScriptAfter new value
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2091)
     public Map<String,Object> setMailAdminSieveScriptAfter(String zimbraMailAdminSieveScriptAfter, Map<String,Object> attrs) {
@@ -23523,12 +23857,14 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptAfter. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied after the end
+     * user filter rule
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2091)
     public void unsetMailAdminSieveScriptAfter() throws com.zimbra.common.service.ServiceException {
@@ -23538,13 +23874,15 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptAfter. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied after the end
+     * user filter rule
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2091)
     public Map<String,Object> unsetMailAdminSieveScriptAfter(Map<String,Object> attrs) {
@@ -23554,12 +23892,14 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptBefore. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied before the end
+     * user filter rule
      *
      * @return zimbraMailAdminSieveScriptBefore, or null if unset
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2090)
     public String getMailAdminSieveScriptBefore() {
@@ -23567,13 +23907,15 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptBefore. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied before the end
+     * user filter rule
      *
      * @param zimbraMailAdminSieveScriptBefore new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2090)
     public void setMailAdminSieveScriptBefore(String zimbraMailAdminSieveScriptBefore) throws com.zimbra.common.service.ServiceException {
@@ -23583,14 +23925,16 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptBefore. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied before the end
+     * user filter rule
      *
      * @param zimbraMailAdminSieveScriptBefore new value
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2090)
     public Map<String,Object> setMailAdminSieveScriptBefore(String zimbraMailAdminSieveScriptBefore, Map<String,Object> attrs) {
@@ -23600,12 +23944,14 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptBefore. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied before the end
+     * user filter rule
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2090)
     public void unsetMailAdminSieveScriptBefore() throws com.zimbra.common.service.ServiceException {
@@ -23615,13 +23961,15 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptBefore. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied before the end
+     * user filter rule
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2090)
     public Map<String,Object> unsetMailAdminSieveScriptBefore(Map<String,Object> attrs) {
@@ -55121,7 +55469,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @return zimbraSieveNotifyActionRFCCompliant, or false if unset
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2112)
     public boolean isSieveNotifyActionRFCCompliant() {
@@ -55137,7 +55485,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param zimbraSieveNotifyActionRFCCompliant new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2112)
     public void setSieveNotifyActionRFCCompliant(boolean zimbraSieveNotifyActionRFCCompliant) throws com.zimbra.common.service.ServiceException {
@@ -55156,7 +55504,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2112)
     public Map<String,Object> setSieveNotifyActionRFCCompliant(boolean zimbraSieveNotifyActionRFCCompliant, Map<String,Object> attrs) {
@@ -55173,7 +55521,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2112)
     public void unsetSieveNotifyActionRFCCompliant() throws com.zimbra.common.service.ServiceException {
@@ -55191,7 +55539,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2112)
     public Map<String,Object> unsetSieveNotifyActionRFCCompliant(Map<String,Object> attrs) {
@@ -55206,7 +55554,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @return zimbraSieveRejectMailEnabled, or true if unset
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2111)
     public boolean isSieveRejectMailEnabled() {
@@ -55220,7 +55568,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param zimbraSieveRejectMailEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2111)
     public void setSieveRejectMailEnabled(boolean zimbraSieveRejectMailEnabled) throws com.zimbra.common.service.ServiceException {
@@ -55237,7 +55585,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2111)
     public Map<String,Object> setSieveRejectMailEnabled(boolean zimbraSieveRejectMailEnabled, Map<String,Object> attrs) {
@@ -55252,7 +55600,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2111)
     public void unsetSieveRejectMailEnabled() throws com.zimbra.common.service.ServiceException {
@@ -55268,7 +55616,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2111)
     public Map<String,Object> unsetSieveRejectMailEnabled(Map<String,Object> attrs) {

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -23328,7 +23328,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @return zimbraMailAdminOutgoingSieveScriptAfter, or null if unset
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public String getMailAdminOutgoingSieveScriptAfter() {
@@ -23342,7 +23342,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param zimbraMailAdminOutgoingSieveScriptAfter new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public void setMailAdminOutgoingSieveScriptAfter(String zimbraMailAdminOutgoingSieveScriptAfter) throws com.zimbra.common.service.ServiceException {
@@ -23359,7 +23359,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public Map<String,Object> setMailAdminOutgoingSieveScriptAfter(String zimbraMailAdminOutgoingSieveScriptAfter, Map<String,Object> attrs) {
@@ -23374,7 +23374,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public void unsetMailAdminOutgoingSieveScriptAfter() throws com.zimbra.common.service.ServiceException {
@@ -23390,7 +23390,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public Map<String,Object> unsetMailAdminOutgoingSieveScriptAfter(Map<String,Object> attrs) {
@@ -23405,7 +23405,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @return zimbraMailAdminOutgoingSieveScriptBefore, or null if unset
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public String getMailAdminOutgoingSieveScriptBefore() {
@@ -23419,7 +23419,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param zimbraMailAdminOutgoingSieveScriptBefore new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public void setMailAdminOutgoingSieveScriptBefore(String zimbraMailAdminOutgoingSieveScriptBefore) throws com.zimbra.common.service.ServiceException {
@@ -23436,7 +23436,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public Map<String,Object> setMailAdminOutgoingSieveScriptBefore(String zimbraMailAdminOutgoingSieveScriptBefore, Map<String,Object> attrs) {
@@ -23451,7 +23451,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public void unsetMailAdminOutgoingSieveScriptBefore() throws com.zimbra.common.service.ServiceException {
@@ -23467,7 +23467,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public Map<String,Object> unsetMailAdminOutgoingSieveScriptBefore(Map<String,Object> attrs) {
@@ -23482,7 +23482,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @return zimbraMailAdminSieveScriptAfter, or null if unset
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public String getMailAdminSieveScriptAfter() {
@@ -23496,7 +23496,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param zimbraMailAdminSieveScriptAfter new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public void setMailAdminSieveScriptAfter(String zimbraMailAdminSieveScriptAfter) throws com.zimbra.common.service.ServiceException {
@@ -23513,7 +23513,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public Map<String,Object> setMailAdminSieveScriptAfter(String zimbraMailAdminSieveScriptAfter, Map<String,Object> attrs) {
@@ -23528,7 +23528,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public void unsetMailAdminSieveScriptAfter() throws com.zimbra.common.service.ServiceException {
@@ -23544,7 +23544,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public Map<String,Object> unsetMailAdminSieveScriptAfter(Map<String,Object> attrs) {
@@ -23559,7 +23559,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @return zimbraMailAdminSieveScriptBefore, or null if unset
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public String getMailAdminSieveScriptBefore() {
@@ -23573,7 +23573,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param zimbraMailAdminSieveScriptBefore new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public void setMailAdminSieveScriptBefore(String zimbraMailAdminSieveScriptBefore) throws com.zimbra.common.service.ServiceException {
@@ -23590,7 +23590,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public Map<String,Object> setMailAdminSieveScriptBefore(String zimbraMailAdminSieveScriptBefore, Map<String,Object> attrs) {
@@ -23605,7 +23605,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public void unsetMailAdminSieveScriptBefore() throws com.zimbra.common.service.ServiceException {
@@ -23621,7 +23621,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public Map<String,Object> unsetMailAdminSieveScriptBefore(Map<String,Object> attrs) {
@@ -55110,6 +55110,170 @@ public abstract class ZAttrAccount  extends MailTarget {
     public Map<String,Object> unsetSharedItem(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSharedItem, "");
+        return attrs;
+    }
+
+    /**
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @return zimbraSieveNotifyActionRFCCompliant, or false if unset
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public boolean isSieveNotifyActionRFCCompliant() {
+        return getBooleanAttr(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, false, true);
+    }
+
+    /**
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @param zimbraSieveNotifyActionRFCCompliant new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public void setSieveNotifyActionRFCCompliant(boolean zimbraSieveNotifyActionRFCCompliant) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, zimbraSieveNotifyActionRFCCompliant ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @param zimbraSieveNotifyActionRFCCompliant new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public Map<String,Object> setSieveNotifyActionRFCCompliant(boolean zimbraSieveNotifyActionRFCCompliant, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, zimbraSieveNotifyActionRFCCompliant ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public void unsetSieveNotifyActionRFCCompliant() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public Map<String,Object> unsetSieveNotifyActionRFCCompliant(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "");
+        return attrs;
+    }
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @return zimbraSieveRejectMailEnabled, or true if unset
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public boolean isSieveRejectMailEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraSieveRejectMailEnabled, true, true);
+    }
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @param zimbraSieveRejectMailEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public void setSieveRejectMailEnabled(boolean zimbraSieveRejectMailEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRejectMailEnabled, zimbraSieveRejectMailEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @param zimbraSieveRejectMailEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public Map<String,Object> setSieveRejectMailEnabled(boolean zimbraSieveRejectMailEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRejectMailEnabled, zimbraSieveRejectMailEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public void unsetSieveRejectMailEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRejectMailEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public Map<String,Object> unsetSieveRejectMailEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRejectMailEnabled, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -28148,7 +28148,7 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Deprecated since: 8.7.9. deprecated in favor of
+     * Deprecated since: 8.7.8. deprecated in favor of
      * zimbraSieveNotifyActionRFCCompliant, which can be used at account
      * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
      * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
@@ -28158,7 +28158,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @return zimbraMailSieveNotifyActionRFCCompliant, or false if unset
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2095)
     public boolean isMailSieveNotifyActionRFCCompliant() {
@@ -28166,7 +28166,7 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Deprecated since: 8.7.9. deprecated in favor of
+     * Deprecated since: 8.7.8. deprecated in favor of
      * zimbraSieveNotifyActionRFCCompliant, which can be used at account
      * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
      * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
@@ -28177,7 +28177,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param zimbraMailSieveNotifyActionRFCCompliant new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2095)
     public void setMailSieveNotifyActionRFCCompliant(boolean zimbraMailSieveNotifyActionRFCCompliant) throws com.zimbra.common.service.ServiceException {
@@ -28187,7 +28187,7 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Deprecated since: 8.7.9. deprecated in favor of
+     * Deprecated since: 8.7.8. deprecated in favor of
      * zimbraSieveNotifyActionRFCCompliant, which can be used at account
      * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
      * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
@@ -28199,7 +28199,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2095)
     public Map<String,Object> setMailSieveNotifyActionRFCCompliant(boolean zimbraMailSieveNotifyActionRFCCompliant, Map<String,Object> attrs) {
@@ -28209,7 +28209,7 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Deprecated since: 8.7.9. deprecated in favor of
+     * Deprecated since: 8.7.8. deprecated in favor of
      * zimbraSieveNotifyActionRFCCompliant, which can be used at account
      * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
      * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
@@ -28219,7 +28219,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2095)
     public void unsetMailSieveNotifyActionRFCCompliant() throws com.zimbra.common.service.ServiceException {
@@ -28229,7 +28229,7 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Deprecated since: 8.7.9. deprecated in favor of
+     * Deprecated since: 8.7.8. deprecated in favor of
      * zimbraSieveNotifyActionRFCCompliant, which can be used at account
      * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
      * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
@@ -28240,7 +28240,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2095)
     public Map<String,Object> unsetMailSieveNotifyActionRFCCompliant(Map<String,Object> attrs) {
@@ -65301,14 +65301,14 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Deprecated since: 8.7.9. deprecated in favor of
+     * Deprecated since: 8.7.8. deprecated in favor of
      * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
      * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
      * RFC 5429.
      *
      * @return zimbraSieveRejectEnabled, or true if unset
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2094)
     public boolean isSieveRejectEnabled() {
@@ -65316,7 +65316,7 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Deprecated since: 8.7.9. deprecated in favor of
+     * Deprecated since: 8.7.8. deprecated in favor of
      * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
      * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
      * RFC 5429.
@@ -65324,7 +65324,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param zimbraSieveRejectEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2094)
     public void setSieveRejectEnabled(boolean zimbraSieveRejectEnabled) throws com.zimbra.common.service.ServiceException {
@@ -65334,7 +65334,7 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Deprecated since: 8.7.9. deprecated in favor of
+     * Deprecated since: 8.7.8. deprecated in favor of
      * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
      * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
      * RFC 5429.
@@ -65343,7 +65343,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2094)
     public Map<String,Object> setSieveRejectEnabled(boolean zimbraSieveRejectEnabled, Map<String,Object> attrs) {
@@ -65353,14 +65353,14 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Deprecated since: 8.7.9. deprecated in favor of
+     * Deprecated since: 8.7.8. deprecated in favor of
      * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
      * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
      * RFC 5429.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2094)
     public void unsetSieveRejectEnabled() throws com.zimbra.common.service.ServiceException {
@@ -65370,7 +65370,7 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Deprecated since: 8.7.9. deprecated in favor of
+     * Deprecated since: 8.7.8. deprecated in favor of
      * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
      * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
      * RFC 5429.
@@ -65378,7 +65378,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2094)
     public Map<String,Object> unsetSieveRejectEnabled(Map<String,Object> attrs) {

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -65303,6 +65303,93 @@ public abstract class ZAttrConfig extends Entry {
     /**
      * Deprecated since: 8.7.8. deprecated in favor of
      * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;Variables&quot; extension
+     * defined in RFC 5229 in the user-defined sieve rule.
+     *
+     * @return zimbraSieveFeatureVariablesEnabled, or false if unset
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2096)
+    public boolean isSieveFeatureVariablesEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraSieveFeatureVariablesEnabled, false, true);
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;Variables&quot; extension
+     * defined in RFC 5229 in the user-defined sieve rule.
+     *
+     * @param zimbraSieveFeatureVariablesEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2096)
+    public void setSieveFeatureVariablesEnabled(boolean zimbraSieveFeatureVariablesEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveFeatureVariablesEnabled, zimbraSieveFeatureVariablesEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;Variables&quot; extension
+     * defined in RFC 5229 in the user-defined sieve rule.
+     *
+     * @param zimbraSieveFeatureVariablesEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2096)
+    public Map<String,Object> setSieveFeatureVariablesEnabled(boolean zimbraSieveFeatureVariablesEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveFeatureVariablesEnabled, zimbraSieveFeatureVariablesEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;Variables&quot; extension
+     * defined in RFC 5229 in the user-defined sieve rule.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2096)
+    public void unsetSieveFeatureVariablesEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveFeatureVariablesEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;Variables&quot; extension
+     * defined in RFC 5229 in the user-defined sieve rule.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2096)
+    public Map<String,Object> unsetSieveFeatureVariablesEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveFeatureVariablesEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
      * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
      * RFC 5429.
      *

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -28148,10 +28148,13 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
-     * parses the &#039;notify&#039; action parameters based on the syntax
-     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
-     * &#039;notify&#039; action parameters with Zimbra specific format
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveNotifyActionRFCCompliant, which can be used at account
+     * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
+     * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
+     * based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS
+     * treats the &#039;notify&#039; action parameters with Zimbra specific
+     * format
      *
      * @return zimbraMailSieveNotifyActionRFCCompliant, or false if unset
      *
@@ -28163,10 +28166,13 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
-     * parses the &#039;notify&#039; action parameters based on the syntax
-     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
-     * &#039;notify&#039; action parameters with Zimbra specific format
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveNotifyActionRFCCompliant, which can be used at account
+     * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
+     * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
+     * based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS
+     * treats the &#039;notify&#039; action parameters with Zimbra specific
+     * format
      *
      * @param zimbraMailSieveNotifyActionRFCCompliant new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -28181,10 +28187,13 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
-     * parses the &#039;notify&#039; action parameters based on the syntax
-     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
-     * &#039;notify&#039; action parameters with Zimbra specific format
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveNotifyActionRFCCompliant, which can be used at account
+     * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
+     * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
+     * based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS
+     * treats the &#039;notify&#039; action parameters with Zimbra specific
+     * format
      *
      * @param zimbraMailSieveNotifyActionRFCCompliant new value
      * @param attrs existing map to populate, or null to create a new map
@@ -28200,10 +28209,13 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
-     * parses the &#039;notify&#039; action parameters based on the syntax
-     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
-     * &#039;notify&#039; action parameters with Zimbra specific format
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveNotifyActionRFCCompliant, which can be used at account
+     * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
+     * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
+     * based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS
+     * treats the &#039;notify&#039; action parameters with Zimbra specific
+     * format
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -28217,10 +28229,13 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
-     * parses the &#039;notify&#039; action parameters based on the syntax
-     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
-     * &#039;notify&#039; action parameters with Zimbra specific format
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveNotifyActionRFCCompliant, which can be used at account
+     * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
+     * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
+     * based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS
+     * treats the &#039;notify&#039; action parameters with Zimbra specific
+     * format
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
@@ -65286,8 +65301,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
-     * 5429.
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
+     * RFC 5429.
      *
      * @return zimbraSieveRejectEnabled, or true if unset
      *
@@ -65299,8 +65316,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
-     * 5429.
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
+     * RFC 5429.
      *
      * @param zimbraSieveRejectEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -65315,8 +65334,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
-     * 5429.
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
+     * RFC 5429.
      *
      * @param zimbraSieveRejectEnabled new value
      * @param attrs existing map to populate, or null to create a new map
@@ -65332,8 +65353,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
-     * 5429.
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
+     * RFC 5429.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -65347,8 +65370,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
-     * 5429.
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
+     * RFC 5429.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -17279,7 +17279,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @return zimbraMailAdminOutgoingSieveScriptAfter, or null if unset
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public String getMailAdminOutgoingSieveScriptAfter() {
@@ -17293,7 +17293,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param zimbraMailAdminOutgoingSieveScriptAfter new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public void setMailAdminOutgoingSieveScriptAfter(String zimbraMailAdminOutgoingSieveScriptAfter) throws com.zimbra.common.service.ServiceException {
@@ -17310,7 +17310,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public Map<String,Object> setMailAdminOutgoingSieveScriptAfter(String zimbraMailAdminOutgoingSieveScriptAfter, Map<String,Object> attrs) {
@@ -17325,7 +17325,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public void unsetMailAdminOutgoingSieveScriptAfter() throws com.zimbra.common.service.ServiceException {
@@ -17341,7 +17341,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public Map<String,Object> unsetMailAdminOutgoingSieveScriptAfter(Map<String,Object> attrs) {
@@ -17356,7 +17356,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @return zimbraMailAdminOutgoingSieveScriptBefore, or null if unset
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public String getMailAdminOutgoingSieveScriptBefore() {
@@ -17370,7 +17370,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param zimbraMailAdminOutgoingSieveScriptBefore new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public void setMailAdminOutgoingSieveScriptBefore(String zimbraMailAdminOutgoingSieveScriptBefore) throws com.zimbra.common.service.ServiceException {
@@ -17387,7 +17387,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public Map<String,Object> setMailAdminOutgoingSieveScriptBefore(String zimbraMailAdminOutgoingSieveScriptBefore, Map<String,Object> attrs) {
@@ -17402,7 +17402,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public void unsetMailAdminOutgoingSieveScriptBefore() throws com.zimbra.common.service.ServiceException {
@@ -17418,7 +17418,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public Map<String,Object> unsetMailAdminOutgoingSieveScriptBefore(Map<String,Object> attrs) {
@@ -17433,7 +17433,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @return zimbraMailAdminSieveScriptAfter, or null if unset
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public String getMailAdminSieveScriptAfter() {
@@ -17447,7 +17447,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param zimbraMailAdminSieveScriptAfter new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public void setMailAdminSieveScriptAfter(String zimbraMailAdminSieveScriptAfter) throws com.zimbra.common.service.ServiceException {
@@ -17464,7 +17464,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public Map<String,Object> setMailAdminSieveScriptAfter(String zimbraMailAdminSieveScriptAfter, Map<String,Object> attrs) {
@@ -17479,7 +17479,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public void unsetMailAdminSieveScriptAfter() throws com.zimbra.common.service.ServiceException {
@@ -17495,7 +17495,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public Map<String,Object> unsetMailAdminSieveScriptAfter(Map<String,Object> attrs) {
@@ -17510,7 +17510,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @return zimbraMailAdminSieveScriptBefore, or null if unset
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public String getMailAdminSieveScriptBefore() {
@@ -17524,7 +17524,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param zimbraMailAdminSieveScriptBefore new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public void setMailAdminSieveScriptBefore(String zimbraMailAdminSieveScriptBefore) throws com.zimbra.common.service.ServiceException {
@@ -17541,7 +17541,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public Map<String,Object> setMailAdminSieveScriptBefore(String zimbraMailAdminSieveScriptBefore, Map<String,Object> attrs) {
@@ -17556,7 +17556,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public void unsetMailAdminSieveScriptBefore() throws com.zimbra.common.service.ServiceException {
@@ -17572,7 +17572,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public Map<String,Object> unsetMailAdminSieveScriptBefore(Map<String,Object> attrs) {
@@ -42501,6 +42501,170 @@ public abstract class ZAttrCos extends NamedEntry {
     public Map<String,Object> unsetShareLifetime(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraShareLifetime, "");
+        return attrs;
+    }
+
+    /**
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @return zimbraSieveNotifyActionRFCCompliant, or false if unset
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public boolean isSieveNotifyActionRFCCompliant() {
+        return getBooleanAttr(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, false, true);
+    }
+
+    /**
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @param zimbraSieveNotifyActionRFCCompliant new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public void setSieveNotifyActionRFCCompliant(boolean zimbraSieveNotifyActionRFCCompliant) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, zimbraSieveNotifyActionRFCCompliant ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @param zimbraSieveNotifyActionRFCCompliant new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public Map<String,Object> setSieveNotifyActionRFCCompliant(boolean zimbraSieveNotifyActionRFCCompliant, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, zimbraSieveNotifyActionRFCCompliant ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public void unsetSieveNotifyActionRFCCompliant() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public Map<String,Object> unsetSieveNotifyActionRFCCompliant(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "");
+        return attrs;
+    }
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @return zimbraSieveRejectMailEnabled, or true if unset
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public boolean isSieveRejectMailEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraSieveRejectMailEnabled, true, true);
+    }
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @param zimbraSieveRejectMailEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public void setSieveRejectMailEnabled(boolean zimbraSieveRejectMailEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRejectMailEnabled, zimbraSieveRejectMailEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @param zimbraSieveRejectMailEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public Map<String,Object> setSieveRejectMailEnabled(boolean zimbraSieveRejectMailEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRejectMailEnabled, zimbraSieveRejectMailEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public void unsetSieveRejectMailEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRejectMailEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public Map<String,Object> unsetSieveRejectMailEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRejectMailEnabled, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -450,6 +450,160 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied after the end user filter rule
+     *
+     * @return zimbraAdminOutgoingSieveScriptAfter, or null if unset
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2116)
+    public String getAdminOutgoingSieveScriptAfter() {
+        return getAttr(Provisioning.A_zimbraAdminOutgoingSieveScriptAfter, null, true);
+    }
+
+    /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied after the end user filter rule
+     *
+     * @param zimbraAdminOutgoingSieveScriptAfter new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2116)
+    public void setAdminOutgoingSieveScriptAfter(String zimbraAdminOutgoingSieveScriptAfter) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminOutgoingSieveScriptAfter, zimbraAdminOutgoingSieveScriptAfter);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied after the end user filter rule
+     *
+     * @param zimbraAdminOutgoingSieveScriptAfter new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2116)
+    public Map<String,Object> setAdminOutgoingSieveScriptAfter(String zimbraAdminOutgoingSieveScriptAfter, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminOutgoingSieveScriptAfter, zimbraAdminOutgoingSieveScriptAfter);
+        return attrs;
+    }
+
+    /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied after the end user filter rule
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2116)
+    public void unsetAdminOutgoingSieveScriptAfter() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminOutgoingSieveScriptAfter, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied after the end user filter rule
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2116)
+    public Map<String,Object> unsetAdminOutgoingSieveScriptAfter(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminOutgoingSieveScriptAfter, "");
+        return attrs;
+    }
+
+    /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied before the end user filter rule
+     *
+     * @return zimbraAdminOutgoingSieveScriptBefore, or null if unset
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2115)
+    public String getAdminOutgoingSieveScriptBefore() {
+        return getAttr(Provisioning.A_zimbraAdminOutgoingSieveScriptBefore, null, true);
+    }
+
+    /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied before the end user filter rule
+     *
+     * @param zimbraAdminOutgoingSieveScriptBefore new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2115)
+    public void setAdminOutgoingSieveScriptBefore(String zimbraAdminOutgoingSieveScriptBefore) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminOutgoingSieveScriptBefore, zimbraAdminOutgoingSieveScriptBefore);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied before the end user filter rule
+     *
+     * @param zimbraAdminOutgoingSieveScriptBefore new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2115)
+    public Map<String,Object> setAdminOutgoingSieveScriptBefore(String zimbraAdminOutgoingSieveScriptBefore, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminOutgoingSieveScriptBefore, zimbraAdminOutgoingSieveScriptBefore);
+        return attrs;
+    }
+
+    /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied before the end user filter rule
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2115)
+    public void unsetAdminOutgoingSieveScriptBefore() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminOutgoingSieveScriptBefore, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied before the end user filter rule
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2115)
+    public Map<String,Object> unsetAdminOutgoingSieveScriptBefore(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminOutgoingSieveScriptBefore, "");
+        return attrs;
+    }
+
+    /**
      * admin saved searches
      *
      * @return zimbraAdminSavedSearches, or empty array if unset
@@ -562,6 +716,160 @@ public abstract class ZAttrCos extends NamedEntry {
     public Map<String,Object> unsetAdminSavedSearches(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraAdminSavedSearches, "");
+        return attrs;
+    }
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied after the end user filter rule
+     *
+     * @return zimbraAdminSieveScriptAfter, or null if unset
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2114)
+    public String getAdminSieveScriptAfter() {
+        return getAttr(Provisioning.A_zimbraAdminSieveScriptAfter, null, true);
+    }
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied after the end user filter rule
+     *
+     * @param zimbraAdminSieveScriptAfter new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2114)
+    public void setAdminSieveScriptAfter(String zimbraAdminSieveScriptAfter) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveScriptAfter, zimbraAdminSieveScriptAfter);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied after the end user filter rule
+     *
+     * @param zimbraAdminSieveScriptAfter new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2114)
+    public Map<String,Object> setAdminSieveScriptAfter(String zimbraAdminSieveScriptAfter, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveScriptAfter, zimbraAdminSieveScriptAfter);
+        return attrs;
+    }
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied after the end user filter rule
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2114)
+    public void unsetAdminSieveScriptAfter() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveScriptAfter, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied after the end user filter rule
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2114)
+    public Map<String,Object> unsetAdminSieveScriptAfter(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveScriptAfter, "");
+        return attrs;
+    }
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied before the end user filter rule
+     *
+     * @return zimbraAdminSieveScriptBefore, or null if unset
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2113)
+    public String getAdminSieveScriptBefore() {
+        return getAttr(Provisioning.A_zimbraAdminSieveScriptBefore, null, true);
+    }
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied before the end user filter rule
+     *
+     * @param zimbraAdminSieveScriptBefore new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2113)
+    public void setAdminSieveScriptBefore(String zimbraAdminSieveScriptBefore) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveScriptBefore, zimbraAdminSieveScriptBefore);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied before the end user filter rule
+     *
+     * @param zimbraAdminSieveScriptBefore new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2113)
+    public Map<String,Object> setAdminSieveScriptBefore(String zimbraAdminSieveScriptBefore, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveScriptBefore, zimbraAdminSieveScriptBefore);
+        return attrs;
+    }
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied before the end user filter rule
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2113)
+    public void unsetAdminSieveScriptBefore() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveScriptBefore, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied before the end user filter rule
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2113)
+    public Map<String,Object> unsetAdminSieveScriptBefore(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveScriptBefore, "");
         return attrs;
     }
 
@@ -17274,12 +17582,14 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptAfter. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * after the end user filter rule
      *
      * @return zimbraMailAdminOutgoingSieveScriptAfter, or null if unset
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2093)
     public String getMailAdminOutgoingSieveScriptAfter() {
@@ -17287,13 +17597,15 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptAfter. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * after the end user filter rule
      *
      * @param zimbraMailAdminOutgoingSieveScriptAfter new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2093)
     public void setMailAdminOutgoingSieveScriptAfter(String zimbraMailAdminOutgoingSieveScriptAfter) throws com.zimbra.common.service.ServiceException {
@@ -17303,14 +17615,16 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptAfter. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * after the end user filter rule
      *
      * @param zimbraMailAdminOutgoingSieveScriptAfter new value
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2093)
     public Map<String,Object> setMailAdminOutgoingSieveScriptAfter(String zimbraMailAdminOutgoingSieveScriptAfter, Map<String,Object> attrs) {
@@ -17320,12 +17634,14 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptAfter. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * after the end user filter rule
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2093)
     public void unsetMailAdminOutgoingSieveScriptAfter() throws com.zimbra.common.service.ServiceException {
@@ -17335,13 +17651,15 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptAfter. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * after the end user filter rule
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2093)
     public Map<String,Object> unsetMailAdminOutgoingSieveScriptAfter(Map<String,Object> attrs) {
@@ -17351,12 +17669,14 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptBefore. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * before the end user filter rule
      *
      * @return zimbraMailAdminOutgoingSieveScriptBefore, or null if unset
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2092)
     public String getMailAdminOutgoingSieveScriptBefore() {
@@ -17364,13 +17684,15 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptBefore. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * before the end user filter rule
      *
      * @param zimbraMailAdminOutgoingSieveScriptBefore new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2092)
     public void setMailAdminOutgoingSieveScriptBefore(String zimbraMailAdminOutgoingSieveScriptBefore) throws com.zimbra.common.service.ServiceException {
@@ -17380,14 +17702,16 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptBefore. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * before the end user filter rule
      *
      * @param zimbraMailAdminOutgoingSieveScriptBefore new value
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2092)
     public Map<String,Object> setMailAdminOutgoingSieveScriptBefore(String zimbraMailAdminOutgoingSieveScriptBefore, Map<String,Object> attrs) {
@@ -17397,12 +17721,14 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptBefore. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * before the end user filter rule
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2092)
     public void unsetMailAdminOutgoingSieveScriptBefore() throws com.zimbra.common.service.ServiceException {
@@ -17412,13 +17738,15 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptBefore. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * before the end user filter rule
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2092)
     public Map<String,Object> unsetMailAdminOutgoingSieveScriptBefore(Map<String,Object> attrs) {
@@ -17428,12 +17756,14 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptAfter. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied after the end
+     * user filter rule
      *
      * @return zimbraMailAdminSieveScriptAfter, or null if unset
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2091)
     public String getMailAdminSieveScriptAfter() {
@@ -17441,13 +17771,15 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptAfter. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied after the end
+     * user filter rule
      *
      * @param zimbraMailAdminSieveScriptAfter new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2091)
     public void setMailAdminSieveScriptAfter(String zimbraMailAdminSieveScriptAfter) throws com.zimbra.common.service.ServiceException {
@@ -17457,14 +17789,16 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptAfter. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied after the end
+     * user filter rule
      *
      * @param zimbraMailAdminSieveScriptAfter new value
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2091)
     public Map<String,Object> setMailAdminSieveScriptAfter(String zimbraMailAdminSieveScriptAfter, Map<String,Object> attrs) {
@@ -17474,12 +17808,14 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptAfter. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied after the end
+     * user filter rule
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2091)
     public void unsetMailAdminSieveScriptAfter() throws com.zimbra.common.service.ServiceException {
@@ -17489,13 +17825,15 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptAfter. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied after the end
+     * user filter rule
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2091)
     public Map<String,Object> unsetMailAdminSieveScriptAfter(Map<String,Object> attrs) {
@@ -17505,12 +17843,14 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptBefore. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied before the end
+     * user filter rule
      *
      * @return zimbraMailAdminSieveScriptBefore, or null if unset
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2090)
     public String getMailAdminSieveScriptBefore() {
@@ -17518,13 +17858,15 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptBefore. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied before the end
+     * user filter rule
      *
      * @param zimbraMailAdminSieveScriptBefore new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2090)
     public void setMailAdminSieveScriptBefore(String zimbraMailAdminSieveScriptBefore) throws com.zimbra.common.service.ServiceException {
@@ -17534,14 +17876,16 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptBefore. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied before the end
+     * user filter rule
      *
      * @param zimbraMailAdminSieveScriptBefore new value
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2090)
     public Map<String,Object> setMailAdminSieveScriptBefore(String zimbraMailAdminSieveScriptBefore, Map<String,Object> attrs) {
@@ -17551,12 +17895,14 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptBefore. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied before the end
+     * user filter rule
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2090)
     public void unsetMailAdminSieveScriptBefore() throws com.zimbra.common.service.ServiceException {
@@ -17566,13 +17912,15 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptBefore. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied before the end
+     * user filter rule
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2090)
     public Map<String,Object> unsetMailAdminSieveScriptBefore(Map<String,Object> attrs) {
@@ -42512,7 +42860,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @return zimbraSieveNotifyActionRFCCompliant, or false if unset
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2112)
     public boolean isSieveNotifyActionRFCCompliant() {
@@ -42528,7 +42876,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param zimbraSieveNotifyActionRFCCompliant new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2112)
     public void setSieveNotifyActionRFCCompliant(boolean zimbraSieveNotifyActionRFCCompliant) throws com.zimbra.common.service.ServiceException {
@@ -42547,7 +42895,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2112)
     public Map<String,Object> setSieveNotifyActionRFCCompliant(boolean zimbraSieveNotifyActionRFCCompliant, Map<String,Object> attrs) {
@@ -42564,7 +42912,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2112)
     public void unsetSieveNotifyActionRFCCompliant() throws com.zimbra.common.service.ServiceException {
@@ -42582,7 +42930,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2112)
     public Map<String,Object> unsetSieveNotifyActionRFCCompliant(Map<String,Object> attrs) {
@@ -42597,7 +42945,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @return zimbraSieveRejectMailEnabled, or true if unset
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2111)
     public boolean isSieveRejectMailEnabled() {
@@ -42611,7 +42959,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param zimbraSieveRejectMailEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2111)
     public void setSieveRejectMailEnabled(boolean zimbraSieveRejectMailEnabled) throws com.zimbra.common.service.ServiceException {
@@ -42628,7 +42976,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2111)
     public Map<String,Object> setSieveRejectMailEnabled(boolean zimbraSieveRejectMailEnabled, Map<String,Object> attrs) {
@@ -42643,7 +42991,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2111)
     public void unsetSieveRejectMailEnabled() throws com.zimbra.common.service.ServiceException {
@@ -42659,7 +43007,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2111)
     public Map<String,Object> unsetSieveRejectMailEnabled(Map<String,Object> attrs) {

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -871,6 +871,314 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied after the end user filter rule
+     *
+     * @return zimbraAdminOutgoingSieveScriptAfter, or null if unset
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2116)
+    public String getAdminOutgoingSieveScriptAfter() {
+        return getAttr(Provisioning.A_zimbraAdminOutgoingSieveScriptAfter, null, true);
+    }
+
+    /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied after the end user filter rule
+     *
+     * @param zimbraAdminOutgoingSieveScriptAfter new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2116)
+    public void setAdminOutgoingSieveScriptAfter(String zimbraAdminOutgoingSieveScriptAfter) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminOutgoingSieveScriptAfter, zimbraAdminOutgoingSieveScriptAfter);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied after the end user filter rule
+     *
+     * @param zimbraAdminOutgoingSieveScriptAfter new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2116)
+    public Map<String,Object> setAdminOutgoingSieveScriptAfter(String zimbraAdminOutgoingSieveScriptAfter, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminOutgoingSieveScriptAfter, zimbraAdminOutgoingSieveScriptAfter);
+        return attrs;
+    }
+
+    /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied after the end user filter rule
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2116)
+    public void unsetAdminOutgoingSieveScriptAfter() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminOutgoingSieveScriptAfter, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied after the end user filter rule
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2116)
+    public Map<String,Object> unsetAdminOutgoingSieveScriptAfter(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminOutgoingSieveScriptAfter, "");
+        return attrs;
+    }
+
+    /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied before the end user filter rule
+     *
+     * @return zimbraAdminOutgoingSieveScriptBefore, or null if unset
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2115)
+    public String getAdminOutgoingSieveScriptBefore() {
+        return getAttr(Provisioning.A_zimbraAdminOutgoingSieveScriptBefore, null, true);
+    }
+
+    /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied before the end user filter rule
+     *
+     * @param zimbraAdminOutgoingSieveScriptBefore new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2115)
+    public void setAdminOutgoingSieveScriptBefore(String zimbraAdminOutgoingSieveScriptBefore) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminOutgoingSieveScriptBefore, zimbraAdminOutgoingSieveScriptBefore);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied before the end user filter rule
+     *
+     * @param zimbraAdminOutgoingSieveScriptBefore new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2115)
+    public Map<String,Object> setAdminOutgoingSieveScriptBefore(String zimbraAdminOutgoingSieveScriptBefore, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminOutgoingSieveScriptBefore, zimbraAdminOutgoingSieveScriptBefore);
+        return attrs;
+    }
+
+    /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied before the end user filter rule
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2115)
+    public void unsetAdminOutgoingSieveScriptBefore() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminOutgoingSieveScriptBefore, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * outgoing sieve script defined by admin (not able to edit and view from
+     * the end user) applied before the end user filter rule
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2115)
+    public Map<String,Object> unsetAdminOutgoingSieveScriptBefore(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminOutgoingSieveScriptBefore, "");
+        return attrs;
+    }
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied after the end user filter rule
+     *
+     * @return zimbraAdminSieveScriptAfter, or null if unset
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2114)
+    public String getAdminSieveScriptAfter() {
+        return getAttr(Provisioning.A_zimbraAdminSieveScriptAfter, null, true);
+    }
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied after the end user filter rule
+     *
+     * @param zimbraAdminSieveScriptAfter new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2114)
+    public void setAdminSieveScriptAfter(String zimbraAdminSieveScriptAfter) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveScriptAfter, zimbraAdminSieveScriptAfter);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied after the end user filter rule
+     *
+     * @param zimbraAdminSieveScriptAfter new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2114)
+    public Map<String,Object> setAdminSieveScriptAfter(String zimbraAdminSieveScriptAfter, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveScriptAfter, zimbraAdminSieveScriptAfter);
+        return attrs;
+    }
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied after the end user filter rule
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2114)
+    public void unsetAdminSieveScriptAfter() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveScriptAfter, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied after the end user filter rule
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2114)
+    public Map<String,Object> unsetAdminSieveScriptAfter(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveScriptAfter, "");
+        return attrs;
+    }
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied before the end user filter rule
+     *
+     * @return zimbraAdminSieveScriptBefore, or null if unset
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2113)
+    public String getAdminSieveScriptBefore() {
+        return getAttr(Provisioning.A_zimbraAdminSieveScriptBefore, null, true);
+    }
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied before the end user filter rule
+     *
+     * @param zimbraAdminSieveScriptBefore new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2113)
+    public void setAdminSieveScriptBefore(String zimbraAdminSieveScriptBefore) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveScriptBefore, zimbraAdminSieveScriptBefore);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied before the end user filter rule
+     *
+     * @param zimbraAdminSieveScriptBefore new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2113)
+    public Map<String,Object> setAdminSieveScriptBefore(String zimbraAdminSieveScriptBefore, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveScriptBefore, zimbraAdminSieveScriptBefore);
+        return attrs;
+    }
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied before the end user filter rule
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2113)
+    public void unsetAdminSieveScriptBefore() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveScriptBefore, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * sieve script defined by admin (not able to edit and view from the end
+     * user) applied before the end user filter rule
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2113)
+    public Map<String,Object> unsetAdminSieveScriptBefore(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveScriptBefore, "");
+        return attrs;
+    }
+
+    /**
      * last calculated aggregate quota usage for the domain in bytes
      *
      * @return zimbraAggregateQuotaLastUsage, or -1 if unset
@@ -14653,12 +14961,14 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptAfter. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * after the end user filter rule
      *
      * @return zimbraMailAdminOutgoingSieveScriptAfter, or null if unset
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2093)
     public String getMailAdminOutgoingSieveScriptAfter() {
@@ -14666,13 +14976,15 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptAfter. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * after the end user filter rule
      *
      * @param zimbraMailAdminOutgoingSieveScriptAfter new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2093)
     public void setMailAdminOutgoingSieveScriptAfter(String zimbraMailAdminOutgoingSieveScriptAfter) throws com.zimbra.common.service.ServiceException {
@@ -14682,14 +14994,16 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptAfter. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * after the end user filter rule
      *
      * @param zimbraMailAdminOutgoingSieveScriptAfter new value
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2093)
     public Map<String,Object> setMailAdminOutgoingSieveScriptAfter(String zimbraMailAdminOutgoingSieveScriptAfter, Map<String,Object> attrs) {
@@ -14699,12 +15013,14 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptAfter. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * after the end user filter rule
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2093)
     public void unsetMailAdminOutgoingSieveScriptAfter() throws com.zimbra.common.service.ServiceException {
@@ -14714,13 +15030,15 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptAfter. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * after the end user filter rule
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2093)
     public Map<String,Object> unsetMailAdminOutgoingSieveScriptAfter(Map<String,Object> attrs) {
@@ -14730,12 +15048,14 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptBefore. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * before the end user filter rule
      *
      * @return zimbraMailAdminOutgoingSieveScriptBefore, or null if unset
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2092)
     public String getMailAdminOutgoingSieveScriptBefore() {
@@ -14743,13 +15063,15 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptBefore. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * before the end user filter rule
      *
      * @param zimbraMailAdminOutgoingSieveScriptBefore new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2092)
     public void setMailAdminOutgoingSieveScriptBefore(String zimbraMailAdminOutgoingSieveScriptBefore) throws com.zimbra.common.service.ServiceException {
@@ -14759,14 +15081,16 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptBefore. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * before the end user filter rule
      *
      * @param zimbraMailAdminOutgoingSieveScriptBefore new value
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2092)
     public Map<String,Object> setMailAdminOutgoingSieveScriptBefore(String zimbraMailAdminOutgoingSieveScriptBefore, Map<String,Object> attrs) {
@@ -14776,12 +15100,14 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptBefore. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * before the end user filter rule
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2092)
     public void unsetMailAdminOutgoingSieveScriptBefore() throws com.zimbra.common.service.ServiceException {
@@ -14791,13 +15117,15 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * outgoing sieve script defined by admin (not able to edit and view from
-     * the end user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptBefore. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * before the end user filter rule
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2092)
     public Map<String,Object> unsetMailAdminOutgoingSieveScriptBefore(Map<String,Object> attrs) {
@@ -14807,12 +15135,14 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptAfter. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied after the end
+     * user filter rule
      *
      * @return zimbraMailAdminSieveScriptAfter, or null if unset
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2091)
     public String getMailAdminSieveScriptAfter() {
@@ -14820,13 +15150,15 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptAfter. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied after the end
+     * user filter rule
      *
      * @param zimbraMailAdminSieveScriptAfter new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2091)
     public void setMailAdminSieveScriptAfter(String zimbraMailAdminSieveScriptAfter) throws com.zimbra.common.service.ServiceException {
@@ -14836,14 +15168,16 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptAfter. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied after the end
+     * user filter rule
      *
      * @param zimbraMailAdminSieveScriptAfter new value
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2091)
     public Map<String,Object> setMailAdminSieveScriptAfter(String zimbraMailAdminSieveScriptAfter, Map<String,Object> attrs) {
@@ -14853,12 +15187,14 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptAfter. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied after the end
+     * user filter rule
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2091)
     public void unsetMailAdminSieveScriptAfter() throws com.zimbra.common.service.ServiceException {
@@ -14868,13 +15204,15 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied after the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptAfter. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied after the end
+     * user filter rule
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2091)
     public Map<String,Object> unsetMailAdminSieveScriptAfter(Map<String,Object> attrs) {
@@ -14884,12 +15222,14 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptBefore. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied before the end
+     * user filter rule
      *
      * @return zimbraMailAdminSieveScriptBefore, or null if unset
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2090)
     public String getMailAdminSieveScriptBefore() {
@@ -14897,13 +15237,15 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptBefore. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied before the end
+     * user filter rule
      *
      * @param zimbraMailAdminSieveScriptBefore new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2090)
     public void setMailAdminSieveScriptBefore(String zimbraMailAdminSieveScriptBefore) throws com.zimbra.common.service.ServiceException {
@@ -14913,14 +15255,16 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptBefore. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied before the end
+     * user filter rule
      *
      * @param zimbraMailAdminSieveScriptBefore new value
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2090)
     public Map<String,Object> setMailAdminSieveScriptBefore(String zimbraMailAdminSieveScriptBefore, Map<String,Object> attrs) {
@@ -14930,12 +15274,14 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptBefore. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied before the end
+     * user filter rule
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2090)
     public void unsetMailAdminSieveScriptBefore() throws com.zimbra.common.service.ServiceException {
@@ -14945,13 +15291,15 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * sieve script defined by admin (not able to edit and view from the end
-     * user) applied before the end user filter rule
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptBefore. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied before the end
+     * user filter rule
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2090)
     public Map<String,Object> unsetMailAdminSieveScriptBefore(Map<String,Object> attrs) {
@@ -20011,7 +20359,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @return zimbraSieveNotifyActionRFCCompliant, or false if unset
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2112)
     public boolean isSieveNotifyActionRFCCompliant() {
@@ -20027,7 +20375,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param zimbraSieveNotifyActionRFCCompliant new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2112)
     public void setSieveNotifyActionRFCCompliant(boolean zimbraSieveNotifyActionRFCCompliant) throws com.zimbra.common.service.ServiceException {
@@ -20046,7 +20394,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2112)
     public Map<String,Object> setSieveNotifyActionRFCCompliant(boolean zimbraSieveNotifyActionRFCCompliant, Map<String,Object> attrs) {
@@ -20063,7 +20411,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2112)
     public void unsetSieveNotifyActionRFCCompliant() throws com.zimbra.common.service.ServiceException {
@@ -20081,7 +20429,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2112)
     public Map<String,Object> unsetSieveNotifyActionRFCCompliant(Map<String,Object> attrs) {
@@ -20096,7 +20444,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @return zimbraSieveRejectMailEnabled, or false if unset
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2111)
     public boolean isSieveRejectMailEnabled() {
@@ -20110,7 +20458,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param zimbraSieveRejectMailEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2111)
     public void setSieveRejectMailEnabled(boolean zimbraSieveRejectMailEnabled) throws com.zimbra.common.service.ServiceException {
@@ -20127,7 +20475,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2111)
     public Map<String,Object> setSieveRejectMailEnabled(boolean zimbraSieveRejectMailEnabled, Map<String,Object> attrs) {
@@ -20142,7 +20490,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2111)
     public void unsetSieveRejectMailEnabled() throws com.zimbra.common.service.ServiceException {
@@ -20158,7 +20506,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.9
+     * @since ZCS 8.7.8
      */
     @ZAttr(id=2111)
     public Map<String,Object> unsetSieveRejectMailEnabled(Map<String,Object> attrs) {

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -14658,7 +14658,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @return zimbraMailAdminOutgoingSieveScriptAfter, or null if unset
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public String getMailAdminOutgoingSieveScriptAfter() {
@@ -14672,7 +14672,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param zimbraMailAdminOutgoingSieveScriptAfter new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public void setMailAdminOutgoingSieveScriptAfter(String zimbraMailAdminOutgoingSieveScriptAfter) throws com.zimbra.common.service.ServiceException {
@@ -14689,7 +14689,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public Map<String,Object> setMailAdminOutgoingSieveScriptAfter(String zimbraMailAdminOutgoingSieveScriptAfter, Map<String,Object> attrs) {
@@ -14704,7 +14704,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public void unsetMailAdminOutgoingSieveScriptAfter() throws com.zimbra.common.service.ServiceException {
@@ -14720,7 +14720,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2093)
     public Map<String,Object> unsetMailAdminOutgoingSieveScriptAfter(Map<String,Object> attrs) {
@@ -14735,7 +14735,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @return zimbraMailAdminOutgoingSieveScriptBefore, or null if unset
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public String getMailAdminOutgoingSieveScriptBefore() {
@@ -14749,7 +14749,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param zimbraMailAdminOutgoingSieveScriptBefore new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public void setMailAdminOutgoingSieveScriptBefore(String zimbraMailAdminOutgoingSieveScriptBefore) throws com.zimbra.common.service.ServiceException {
@@ -14766,7 +14766,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public Map<String,Object> setMailAdminOutgoingSieveScriptBefore(String zimbraMailAdminOutgoingSieveScriptBefore, Map<String,Object> attrs) {
@@ -14781,7 +14781,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public void unsetMailAdminOutgoingSieveScriptBefore() throws com.zimbra.common.service.ServiceException {
@@ -14797,7 +14797,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2092)
     public Map<String,Object> unsetMailAdminOutgoingSieveScriptBefore(Map<String,Object> attrs) {
@@ -14812,7 +14812,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @return zimbraMailAdminSieveScriptAfter, or null if unset
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public String getMailAdminSieveScriptAfter() {
@@ -14826,7 +14826,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param zimbraMailAdminSieveScriptAfter new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public void setMailAdminSieveScriptAfter(String zimbraMailAdminSieveScriptAfter) throws com.zimbra.common.service.ServiceException {
@@ -14843,7 +14843,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public Map<String,Object> setMailAdminSieveScriptAfter(String zimbraMailAdminSieveScriptAfter, Map<String,Object> attrs) {
@@ -14858,7 +14858,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public void unsetMailAdminSieveScriptAfter() throws com.zimbra.common.service.ServiceException {
@@ -14874,7 +14874,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2091)
     public Map<String,Object> unsetMailAdminSieveScriptAfter(Map<String,Object> attrs) {
@@ -14889,7 +14889,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @return zimbraMailAdminSieveScriptBefore, or null if unset
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public String getMailAdminSieveScriptBefore() {
@@ -14903,7 +14903,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param zimbraMailAdminSieveScriptBefore new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public void setMailAdminSieveScriptBefore(String zimbraMailAdminSieveScriptBefore) throws com.zimbra.common.service.ServiceException {
@@ -14920,7 +14920,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public Map<String,Object> setMailAdminSieveScriptBefore(String zimbraMailAdminSieveScriptBefore, Map<String,Object> attrs) {
@@ -14935,7 +14935,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public void unsetMailAdminSieveScriptBefore() throws com.zimbra.common.service.ServiceException {
@@ -14951,7 +14951,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.9
      */
     @ZAttr(id=2090)
     public Map<String,Object> unsetMailAdminSieveScriptBefore(Map<String,Object> attrs) {
@@ -20000,6 +20000,170 @@ public abstract class ZAttrDomain extends NamedEntry {
     public Map<String,Object> unsetSSLPrivateKey(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSSLPrivateKey, "");
+        return attrs;
+    }
+
+    /**
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @return zimbraSieveNotifyActionRFCCompliant, or false if unset
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public boolean isSieveNotifyActionRFCCompliant() {
+        return getBooleanAttr(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, false, true);
+    }
+
+    /**
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @param zimbraSieveNotifyActionRFCCompliant new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public void setSieveNotifyActionRFCCompliant(boolean zimbraSieveNotifyActionRFCCompliant) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, zimbraSieveNotifyActionRFCCompliant ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @param zimbraSieveNotifyActionRFCCompliant new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public Map<String,Object> setSieveNotifyActionRFCCompliant(boolean zimbraSieveNotifyActionRFCCompliant, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, zimbraSieveNotifyActionRFCCompliant ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public void unsetSieveNotifyActionRFCCompliant() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
+     * parses the &#039;notify&#039; action parameters based on the syntax
+     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
+     * &#039;notify&#039; action parameters with Zimbra specific format
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2112)
+    public Map<String,Object> unsetSieveNotifyActionRFCCompliant(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "");
+        return attrs;
+    }
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @return zimbraSieveRejectMailEnabled, or false if unset
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public boolean isSieveRejectMailEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraSieveRejectMailEnabled, false, true);
+    }
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @param zimbraSieveRejectMailEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public void setSieveRejectMailEnabled(boolean zimbraSieveRejectMailEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRejectMailEnabled, zimbraSieveRejectMailEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @param zimbraSieveRejectMailEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public Map<String,Object> setSieveRejectMailEnabled(boolean zimbraSieveRejectMailEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRejectMailEnabled, zimbraSieveRejectMailEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public void unsetSieveRejectMailEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRejectMailEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
+     * 5429.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.9
+     */
+    @ZAttr(id=2111)
+    public Map<String,Object> unsetSieveRejectMailEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRejectMailEnabled, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -17704,10 +17704,13 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
-     * parses the &#039;notify&#039; action parameters based on the syntax
-     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
-     * &#039;notify&#039; action parameters with Zimbra specific format
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveNotifyActionRFCCompliant, which can be used at account
+     * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
+     * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
+     * based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS
+     * treats the &#039;notify&#039; action parameters with Zimbra specific
+     * format
      *
      * @return zimbraMailSieveNotifyActionRFCCompliant, or false if unset
      *
@@ -17719,10 +17722,13 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
-     * parses the &#039;notify&#039; action parameters based on the syntax
-     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
-     * &#039;notify&#039; action parameters with Zimbra specific format
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveNotifyActionRFCCompliant, which can be used at account
+     * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
+     * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
+     * based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS
+     * treats the &#039;notify&#039; action parameters with Zimbra specific
+     * format
      *
      * @param zimbraMailSieveNotifyActionRFCCompliant new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -17737,10 +17743,13 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
-     * parses the &#039;notify&#039; action parameters based on the syntax
-     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
-     * &#039;notify&#039; action parameters with Zimbra specific format
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveNotifyActionRFCCompliant, which can be used at account
+     * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
+     * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
+     * based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS
+     * treats the &#039;notify&#039; action parameters with Zimbra specific
+     * format
      *
      * @param zimbraMailSieveNotifyActionRFCCompliant new value
      * @param attrs existing map to populate, or null to create a new map
@@ -17756,10 +17765,13 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
-     * parses the &#039;notify&#039; action parameters based on the syntax
-     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
-     * &#039;notify&#039; action parameters with Zimbra specific format
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveNotifyActionRFCCompliant, which can be used at account
+     * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
+     * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
+     * based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS
+     * treats the &#039;notify&#039; action parameters with Zimbra specific
+     * format
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -17773,10 +17785,13 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
-     * parses the &#039;notify&#039; action parameters based on the syntax
-     * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
-     * &#039;notify&#039; action parameters with Zimbra specific format
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveNotifyActionRFCCompliant, which can be used at account
+     * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
+     * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
+     * based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS
+     * treats the &#039;notify&#039; action parameters with Zimbra specific
+     * format
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
@@ -46898,8 +46913,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
-     * 5429.
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
+     * RFC 5429.
      *
      * @return zimbraSieveRejectEnabled, or true if unset
      *
@@ -46911,8 +46928,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
-     * 5429.
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
+     * RFC 5429.
      *
      * @param zimbraSieveRejectEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -46927,8 +46946,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
-     * 5429.
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
+     * RFC 5429.
      *
      * @param zimbraSieveRejectEnabled new value
      * @param attrs existing map to populate, or null to create a new map
@@ -46944,8 +46965,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
-     * 5429.
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
+     * RFC 5429.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -46959,8 +46982,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Whether to enable the Sieve &quot;reject&quot; action defined in RFC
-     * 5429.
+     * Deprecated since: 8.7.9. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
+     * RFC 5429.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -14954,6 +14954,354 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptAfter. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * after the end user filter rule
+     *
+     * @return zimbraMailAdminOutgoingSieveScriptAfter, or null if unset
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2093)
+    public String getMailAdminOutgoingSieveScriptAfter() {
+        return getAttr(Provisioning.A_zimbraMailAdminOutgoingSieveScriptAfter, null, true);
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptAfter. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * after the end user filter rule
+     *
+     * @param zimbraMailAdminOutgoingSieveScriptAfter new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2093)
+    public void setMailAdminOutgoingSieveScriptAfter(String zimbraMailAdminOutgoingSieveScriptAfter) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailAdminOutgoingSieveScriptAfter, zimbraMailAdminOutgoingSieveScriptAfter);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptAfter. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * after the end user filter rule
+     *
+     * @param zimbraMailAdminOutgoingSieveScriptAfter new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2093)
+    public Map<String,Object> setMailAdminOutgoingSieveScriptAfter(String zimbraMailAdminOutgoingSieveScriptAfter, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailAdminOutgoingSieveScriptAfter, zimbraMailAdminOutgoingSieveScriptAfter);
+        return attrs;
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptAfter. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * after the end user filter rule
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2093)
+    public void unsetMailAdminOutgoingSieveScriptAfter() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailAdminOutgoingSieveScriptAfter, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptAfter. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * after the end user filter rule
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2093)
+    public Map<String,Object> unsetMailAdminOutgoingSieveScriptAfter(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailAdminOutgoingSieveScriptAfter, "");
+        return attrs;
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptBefore. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * before the end user filter rule
+     *
+     * @return zimbraMailAdminOutgoingSieveScriptBefore, or null if unset
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2092)
+    public String getMailAdminOutgoingSieveScriptBefore() {
+        return getAttr(Provisioning.A_zimbraMailAdminOutgoingSieveScriptBefore, null, true);
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptBefore. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * before the end user filter rule
+     *
+     * @param zimbraMailAdminOutgoingSieveScriptBefore new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2092)
+    public void setMailAdminOutgoingSieveScriptBefore(String zimbraMailAdminOutgoingSieveScriptBefore) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailAdminOutgoingSieveScriptBefore, zimbraMailAdminOutgoingSieveScriptBefore);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptBefore. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * before the end user filter rule
+     *
+     * @param zimbraMailAdminOutgoingSieveScriptBefore new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2092)
+    public Map<String,Object> setMailAdminOutgoingSieveScriptBefore(String zimbraMailAdminOutgoingSieveScriptBefore, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailAdminOutgoingSieveScriptBefore, zimbraMailAdminOutgoingSieveScriptBefore);
+        return attrs;
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptBefore. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * before the end user filter rule
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2092)
+    public void unsetMailAdminOutgoingSieveScriptBefore() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailAdminOutgoingSieveScriptBefore, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminOutgoingSieveScriptBefore. Orig desc: outgoing sieve script
+     * defined by admin (not able to edit and view from the end user) applied
+     * before the end user filter rule
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2092)
+    public Map<String,Object> unsetMailAdminOutgoingSieveScriptBefore(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailAdminOutgoingSieveScriptBefore, "");
+        return attrs;
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptAfter. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied after the end
+     * user filter rule
+     *
+     * @return zimbraMailAdminSieveScriptAfter, or null if unset
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2091)
+    public String getMailAdminSieveScriptAfter() {
+        return getAttr(Provisioning.A_zimbraMailAdminSieveScriptAfter, null, true);
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptAfter. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied after the end
+     * user filter rule
+     *
+     * @param zimbraMailAdminSieveScriptAfter new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2091)
+    public void setMailAdminSieveScriptAfter(String zimbraMailAdminSieveScriptAfter) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailAdminSieveScriptAfter, zimbraMailAdminSieveScriptAfter);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptAfter. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied after the end
+     * user filter rule
+     *
+     * @param zimbraMailAdminSieveScriptAfter new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2091)
+    public Map<String,Object> setMailAdminSieveScriptAfter(String zimbraMailAdminSieveScriptAfter, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailAdminSieveScriptAfter, zimbraMailAdminSieveScriptAfter);
+        return attrs;
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptAfter. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied after the end
+     * user filter rule
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2091)
+    public void unsetMailAdminSieveScriptAfter() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailAdminSieveScriptAfter, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptAfter. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied after the end
+     * user filter rule
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2091)
+    public Map<String,Object> unsetMailAdminSieveScriptAfter(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailAdminSieveScriptAfter, "");
+        return attrs;
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptBefore. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied before the end
+     * user filter rule
+     *
+     * @return zimbraMailAdminSieveScriptBefore, or null if unset
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2090)
+    public String getMailAdminSieveScriptBefore() {
+        return getAttr(Provisioning.A_zimbraMailAdminSieveScriptBefore, null, true);
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptBefore. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied before the end
+     * user filter rule
+     *
+     * @param zimbraMailAdminSieveScriptBefore new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2090)
+    public void setMailAdminSieveScriptBefore(String zimbraMailAdminSieveScriptBefore) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailAdminSieveScriptBefore, zimbraMailAdminSieveScriptBefore);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptBefore. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied before the end
+     * user filter rule
+     *
+     * @param zimbraMailAdminSieveScriptBefore new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2090)
+    public Map<String,Object> setMailAdminSieveScriptBefore(String zimbraMailAdminSieveScriptBefore, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailAdminSieveScriptBefore, zimbraMailAdminSieveScriptBefore);
+        return attrs;
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptBefore. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied before the end
+     * user filter rule
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2090)
+    public void unsetMailAdminSieveScriptBefore() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailAdminSieveScriptBefore, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraAdminSieveScriptBefore. Orig desc: sieve script defined by admin
+     * (not able to edit and view from the end user) applied before the end
+     * user filter rule
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2090)
+    public Map<String,Object> unsetMailAdminSieveScriptBefore(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailAdminSieveScriptBefore, "");
+        return attrs;
+    }
+
+    /**
      * interface address on which HTTP server should listen; if empty, binds
      * to all interfaces
      *
@@ -17700,108 +18048,6 @@ public abstract class ZAttrServer extends NamedEntry {
     public Map<String,Object> unsetMailSSLProxyPort(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraMailSSLProxyPort, "");
-        return attrs;
-    }
-
-    /**
-     * Deprecated since: 8.7.9. deprecated in favor of
-     * zimbraSieveNotifyActionRFCCompliant, which can be used at account
-     * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
-     * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
-     * based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS
-     * treats the &#039;notify&#039; action parameters with Zimbra specific
-     * format
-     *
-     * @return zimbraMailSieveNotifyActionRFCCompliant, or false if unset
-     *
-     * @since ZCS 8.7.8
-     */
-    @ZAttr(id=2095)
-    public boolean isMailSieveNotifyActionRFCCompliant() {
-        return getBooleanAttr(Provisioning.A_zimbraMailSieveNotifyActionRFCCompliant, false, true);
-    }
-
-    /**
-     * Deprecated since: 8.7.9. deprecated in favor of
-     * zimbraSieveNotifyActionRFCCompliant, which can be used at account
-     * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
-     * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
-     * based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS
-     * treats the &#039;notify&#039; action parameters with Zimbra specific
-     * format
-     *
-     * @param zimbraMailSieveNotifyActionRFCCompliant new value
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 8.7.8
-     */
-    @ZAttr(id=2095)
-    public void setMailSieveNotifyActionRFCCompliant(boolean zimbraMailSieveNotifyActionRFCCompliant) throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraMailSieveNotifyActionRFCCompliant, zimbraMailSieveNotifyActionRFCCompliant ? Provisioning.TRUE : Provisioning.FALSE);
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Deprecated since: 8.7.9. deprecated in favor of
-     * zimbraSieveNotifyActionRFCCompliant, which can be used at account
-     * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
-     * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
-     * based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS
-     * treats the &#039;notify&#039; action parameters with Zimbra specific
-     * format
-     *
-     * @param zimbraMailSieveNotifyActionRFCCompliant new value
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 8.7.8
-     */
-    @ZAttr(id=2095)
-    public Map<String,Object> setMailSieveNotifyActionRFCCompliant(boolean zimbraMailSieveNotifyActionRFCCompliant, Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraMailSieveNotifyActionRFCCompliant, zimbraMailSieveNotifyActionRFCCompliant ? Provisioning.TRUE : Provisioning.FALSE);
-        return attrs;
-    }
-
-    /**
-     * Deprecated since: 8.7.9. deprecated in favor of
-     * zimbraSieveNotifyActionRFCCompliant, which can be used at account
-     * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
-     * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
-     * based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS
-     * treats the &#039;notify&#039; action parameters with Zimbra specific
-     * format
-     *
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 8.7.8
-     */
-    @ZAttr(id=2095)
-    public void unsetMailSieveNotifyActionRFCCompliant() throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraMailSieveNotifyActionRFCCompliant, "");
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Deprecated since: 8.7.9. deprecated in favor of
-     * zimbraSieveNotifyActionRFCCompliant, which can be used at account
-     * level. Orig desc: Whether the RFC compliant &#039;notify&#039; is
-     * used. If TRUE, ZCS parses the &#039;notify&#039; action parameters
-     * based on the syntax defined by the RFC 5435 and 5436. If FALSE, ZCS
-     * treats the &#039;notify&#039; action parameters with Zimbra specific
-     * format
-     *
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 8.7.8
-     */
-    @ZAttr(id=2095)
-    public Map<String,Object> unsetMailSieveNotifyActionRFCCompliant(Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraMailSieveNotifyActionRFCCompliant, "");
         return attrs;
     }
 
@@ -46913,14 +47159,14 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Deprecated since: 8.7.9. deprecated in favor of
+     * Deprecated since: 8.7.8. deprecated in favor of
      * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
      * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
      * RFC 5429.
      *
      * @return zimbraSieveRejectEnabled, or true if unset
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2094)
     public boolean isSieveRejectEnabled() {
@@ -46928,7 +47174,7 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Deprecated since: 8.7.9. deprecated in favor of
+     * Deprecated since: 8.7.8. deprecated in favor of
      * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
      * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
      * RFC 5429.
@@ -46936,7 +47182,7 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param zimbraSieveRejectEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2094)
     public void setSieveRejectEnabled(boolean zimbraSieveRejectEnabled) throws com.zimbra.common.service.ServiceException {
@@ -46946,7 +47192,7 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Deprecated since: 8.7.9. deprecated in favor of
+     * Deprecated since: 8.7.8. deprecated in favor of
      * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
      * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
      * RFC 5429.
@@ -46955,7 +47201,7 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2094)
     public Map<String,Object> setSieveRejectEnabled(boolean zimbraSieveRejectEnabled, Map<String,Object> attrs) {
@@ -46965,14 +47211,14 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Deprecated since: 8.7.9. deprecated in favor of
+     * Deprecated since: 8.7.8. deprecated in favor of
      * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
      * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
      * RFC 5429.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2094)
     public void unsetSieveRejectEnabled() throws com.zimbra.common.service.ServiceException {
@@ -46982,7 +47228,7 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Deprecated since: 8.7.9. deprecated in favor of
+     * Deprecated since: 8.7.8. deprecated in favor of
      * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
      * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
      * RFC 5429.
@@ -46990,7 +47236,7 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.7.8
+     * @since ZCS 8.7.6
      */
     @ZAttr(id=2094)
     public Map<String,Object> unsetSieveRejectEnabled(Map<String,Object> attrs) {

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -47161,6 +47161,93 @@ public abstract class ZAttrServer extends NamedEntry {
     /**
      * Deprecated since: 8.7.8. deprecated in favor of
      * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;Variables&quot; extension
+     * defined in RFC 5229 in the user-defined sieve rule.
+     *
+     * @return zimbraSieveFeatureVariablesEnabled, or false if unset
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2096)
+    public boolean isSieveFeatureVariablesEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraSieveFeatureVariablesEnabled, false, true);
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;Variables&quot; extension
+     * defined in RFC 5229 in the user-defined sieve rule.
+     *
+     * @param zimbraSieveFeatureVariablesEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2096)
+    public void setSieveFeatureVariablesEnabled(boolean zimbraSieveFeatureVariablesEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveFeatureVariablesEnabled, zimbraSieveFeatureVariablesEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;Variables&quot; extension
+     * defined in RFC 5229 in the user-defined sieve rule.
+     *
+     * @param zimbraSieveFeatureVariablesEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2096)
+    public Map<String,Object> setSieveFeatureVariablesEnabled(boolean zimbraSieveFeatureVariablesEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveFeatureVariablesEnabled, zimbraSieveFeatureVariablesEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;Variables&quot; extension
+     * defined in RFC 5229 in the user-defined sieve rule.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2096)
+    public void unsetSieveFeatureVariablesEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveFeatureVariablesEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
+     * desc: Whether to enable the Sieve &quot;Variables&quot; extension
+     * defined in RFC 5229 in the user-defined sieve rule.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2096)
+    public Map<String,Object> unsetSieveFeatureVariablesEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveFeatureVariablesEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated in favor of
+     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
      * desc: Whether to enable the Sieve &quot;reject&quot; action defined in
      * RFC 5429.
      *

--- a/store/src/java/com/zimbra/cs/filter/JsieveConfigMapHandler.java
+++ b/store/src/java/com/zimbra/cs/filter/JsieveConfigMapHandler.java
@@ -61,20 +61,8 @@ public class JsieveConfigMapHandler {
         mCommandMap.put("log", com.zimbra.cs.filter.jsieve.VariableLog.class.getName());
         //mCommandMap.put("deleteheader", com.zimbra.cs.filter.jsieve.DeleteHeader.class.getName());
 
-        if (isNotifyActionRFCCompliantAvailable()) {
-            mCommandMap.put("notify",  com.zimbra.cs.filter.jsieve.NotifyMailto.class.getName());
-            ZimbraLog.filter.info("RFC compliant 'notify' is loaded");
-        } else {
-            mCommandMap.put("notify", com.zimbra.cs.filter.jsieve.Notify.class.getName());
-            ZimbraLog.filter.debug("Zimbra 'notify' is loaded");
-        }
-
-        if (isZimbraSieveRejectEnabled()) {
-            mCommandMap.put("reject", com.zimbra.cs.filter.jsieve.Reject.class.getName());
-        } else {
-            // Disable the 'reject' action defined by the jSieve library
-            mCommandMap.remove("reject");
-        }
+        mCommandMap.put("notify",  com.zimbra.cs.filter.jsieve.NotifyMailto.class.getName());
+        mCommandMap.put("reject", com.zimbra.cs.filter.jsieve.Reject.class.getName());
 
 		mCommandMap.put("variables", com.zimbra.cs.filter.jsieve.Variables.class.getName());
 		ZimbraLog.filter.info("Variables extension is loaded");
@@ -114,14 +102,15 @@ public class JsieveConfigMapHandler {
         mTestMap.put("relational", com.zimbra.cs.filter.jsieve.RelationalTest.class.getName());
         mTestMap.put("string", com.zimbra.cs.filter.jsieve.StringTest.class.getName());
 
-        if (isNotifyActionRFCCompliantAvailable()) {
-            // The capability string associated with the 'notify' action is "enotify"; 
-            // the "enotify" is not accepted as an action name in the sieve filter body, 
-            // such as inside the 'if' body.
-            mTestMap.put("enotify", com.zimbra.cs.filter.jsieve.EnotifyTest.class.getName());
-            mTestMap.put("valid_notify_method", com.zimbra.cs.filter.jsieve.ValidNotifyMethodTest.class.getName());
-            mTestMap.put("notify_method_capability", com.zimbra.cs.filter.jsieve.NotifyMethodCapabilityTest.class.getName());
-        }
+        // The capability string associated with the 'notify' action is
+        // "enotify";
+        // the "enotify" is not accepted as an action name in the sieve filter
+        // body,
+        // such as inside the 'if' body.
+        mTestMap.put("enotify", com.zimbra.cs.filter.jsieve.EnotifyTest.class.getName());
+        mTestMap.put("valid_notify_method", com.zimbra.cs.filter.jsieve.ValidNotifyMethodTest.class.getName());
+        mTestMap.put("notify_method_capability",
+            com.zimbra.cs.filter.jsieve.NotifyMethodCapabilityTest.class.getName());
 
         return mTestMap;
     }
@@ -148,37 +137,5 @@ public class JsieveConfigMapHandler {
 
     public static Map<String, String> getTestMap(){
         return mTestMap;
-    }
-
-    /**
-     * Checks the global config attribute
-     * 'zimbraMailSieveNotifyActionRFCCompliant'.
-     *
-     * @return <tt>true</tt> if the RFC compliant notify action is allowed to
-     *         execute.
-     */
-    public static boolean isNotifyActionRFCCompliantAvailable() {
-        boolean isNotifyActionRFCCompliant = false;
-        try {
-            isNotifyActionRFCCompliant = Provisioning.getInstance().getLocalServer()
-                .isMailSieveNotifyActionRFCCompliant();
-        } catch (ServiceException e) {
-            // the legacy Zimbra specific 'notify' action is used
-        }
-        return isNotifyActionRFCCompliant;
-    }
-
-    /**
-     * Checks the global config attribute 'zimbraSieveRejectEnabled'.
-     *
-     * @return <tt>true</tt> if zimbraSieveRejectEnabled is enabled.
-     */
-    public static boolean isZimbraSieveRejectEnabled() {
-        boolean isZimbraSieveRejectEnabled = true;
-        try {
-            isZimbraSieveRejectEnabled = Provisioning.getInstance().getLocalServer().isSieveRejectEnabled();
-        } catch (ServiceException e) {
-        }
-        return isZimbraSieveRejectEnabled;
     }
 }

--- a/store/src/java/com/zimbra/cs/filter/RuleManager.java
+++ b/store/src/java/com/zimbra/cs/filter/RuleManager.java
@@ -201,8 +201,8 @@ public final class RuleManager {
                 rulesCacheKey = FILTER_RULES_CACHE_KEY;
             }
             sieveScriptAttrName      = Provisioning.A_zimbraMailSieveScript;
-            adminRuleBeforeAttrName  = Provisioning.A_zimbraMailAdminSieveScriptBefore;
-            adminRuleAfterAttrName   = Provisioning.A_zimbraMailAdminSieveScriptAfter;
+            adminRuleBeforeAttrName  = Provisioning.A_zimbraAdminSieveScriptBefore;
+            adminRuleAfterAttrName   = Provisioning.A_zimbraAdminSieveScriptAfter;
         } else {
             if (useAdminRule) {
                 rulesCacheKey = ADMIN_OUTGOING_FILTER_RULES_CACHE_KEY;
@@ -210,8 +210,8 @@ public final class RuleManager {
                 rulesCacheKey = OUTGOING_FILTER_RULES_CACHE_KEY;
             }
             sieveScriptAttrName      = Provisioning.A_zimbraMailOutgoingSieveScript;
-            adminRuleBeforeAttrName  = Provisioning.A_zimbraMailAdminOutgoingSieveScriptBefore;
-            adminRuleAfterAttrName   = Provisioning.A_zimbraMailAdminOutgoingSieveScriptAfter;
+            adminRuleBeforeAttrName  = Provisioning.A_zimbraAdminOutgoingSieveScriptBefore;
+            adminRuleAfterAttrName   = Provisioning.A_zimbraAdminOutgoingSieveScriptAfter;
         }
 
         Node node = (Node) account.getCachedData(rulesCacheKey);

--- a/store/src/java/com/zimbra/cs/filter/SoapToSieve.java
+++ b/store/src/java/com/zimbra/cs/filter/SoapToSieve.java
@@ -57,11 +57,7 @@ public final class SoapToSieve {
     public String getSieveScript() throws ServiceException {
         if (buffer == null) {
             buffer = new StringBuilder();
-            buffer.append("require [\"fileinto\", \"reject\", \"tag\", \"flag\"");
-            if (JsieveConfigMapHandler.isNotifyActionRFCCompliantAvailable()) {
-                buffer.append(", \"enotify\"");
-            }
-            buffer.append("];\n");
+            buffer.append("require [\"fileinto\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\", \"enotify\"];\n");
             for (FilterRule rule : rules) {
                 buffer.append('\n');
                 handleRule(rule);

--- a/store/src/java/com/zimbra/cs/filter/ZimbraMailAdapter.java
+++ b/store/src/java/com/zimbra/cs/filter/ZimbraMailAdapter.java
@@ -333,16 +333,14 @@ public class ZimbraMailAdapter implements MailAdapter, EnvelopeAccessors {
                     }
                 } else if (action instanceof ActionReject) {
                     ActionReject reject = (ActionReject) action;
-                    if (JsieveConfigMapHandler.isZimbraSieveRejectEnabled()) {
-	                    ZimbraLog.filter.debug("Refusing delivery of a message: %s", reject.getMessage());
-	                    try {
-	                        String msg = FilterUtil.replaceVariables(this, reject.getMessage());
-	                        handler.reject(msg, envelope);
-	                        handler.discard();
-	                    } catch (Exception e) {
-	                        ZimbraLog.filter.info("Unable to reject.", e);
-	                        keep(KeepType.EXPLICIT_KEEP);
-	                    }
+                    ZimbraLog.filter.debug("Refusing delivery of a message: %s", reject.getMessage());
+                    try {
+                        String msg = FilterUtil.replaceVariables(this, reject.getMessage());
+                        handler.reject(msg, envelope);
+                        handler.discard();
+                    } catch (Exception e) {
+                        ZimbraLog.filter.info("Unable to reject.", e);
+                        keep(KeepType.EXPLICIT_KEEP);
                     }
                 } else if (action instanceof ActionEreject) {
                     ActionEreject ereject = (ActionEreject) action;

--- a/store/src/java/com/zimbra/qa/unittest/TestFilter.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestFilter.java
@@ -161,7 +161,7 @@ public final class TestFilter {
         saveOutgoingRules(mMbox, getTestOutgoingRules());
 
         mOriginalSpamApplyUserFilters = account.getAttr(Provisioning.A_zimbraSpamApplyUserFilters);
-        mAvailableRFCCompliantNotify  = Provisioning.getInstance().getConfig().getBooleanAttr(Provisioning.A_zimbraMailSieveNotifyActionRFCCompliant, false);
+        mAvailableRFCCompliantNotify  = account.isSieveNotifyActionRFCCompliant();
     }
 
     /**
@@ -767,11 +767,11 @@ public final class TestFilter {
     /**
      * Tests the Zimbra-specifict 'notify' action format (not RFC compliant format)
      *
-     * Note: please set the global config key 'zimbraMailSieveNotifyActionRFCCompliant' to FALSE.
+     * Note: please set 'zimbraSieveNotifyActionRFCCompliant' to FALSE.
      */    
     public void testNotifyAction() throws Exception {
         if (mAvailableRFCCompliantNotify) {
-            fail("Unable to test because the global config key 'zimbraMailSieveNotifyActionRFCCompliant' is set to TRUE");
+            fail("Unable to test because 'zimbraSieveNotifyActionRFCCompliant' is set to TRUE");
             return;
         }
         List<ZFilterRule> rules = new ArrayList<ZFilterRule>();
@@ -808,7 +808,7 @@ public final class TestFilter {
     @Test
     public void testNotifyActionUseOrigHeaders() throws Exception {
         if (mAvailableRFCCompliantNotify) {
-            fail("Unable to test because the global config key 'zimbraMailSieveNotifyActionRFCCompliant' is set to TRUE");
+            fail("Unable to test because 'zimbraSieveNotifyActionRFCCompliant' is set to TRUE");
             return;
         }
         List<ZFilterRule> rules = new ArrayList<ZFilterRule>();
@@ -866,7 +866,7 @@ public final class TestFilter {
     @Test
     public void testNotifyActionCopyAllOrigHeaders() throws Exception {
         if (mAvailableRFCCompliantNotify) {
-            fail("Unable to test because the global config key 'zimbraMailSieveNotifyActionRFCCompliant' is set to TRUE");
+            fail("Unable to test because 'zimbraSieveNotifyActionRFCCompliant' is set to TRUE");
             return;
         }
         List<ZFilterRule> rules = new ArrayList<ZFilterRule>();
@@ -900,7 +900,7 @@ public final class TestFilter {
     @Test
     public void testNotifyWithDiscard() throws Exception {
         if (mAvailableRFCCompliantNotify) {
-            fail("Unable to test because the global config key 'zimbraMailSieveNotifyActionRFCCompliant' is set to TRUE");
+            fail("Unable to test because 'zimbraSieveNotifyActionRFCCompliant' is set to TRUE");
             return;
         }
         List<ZFilterRule> rules = new ArrayList<ZFilterRule>();
@@ -932,7 +932,7 @@ public final class TestFilter {
     @Test
     public void testMultipleMultilineText() throws Exception {
         if (mAvailableRFCCompliantNotify) {
-            fail("Unable to test because the global config key 'zimbraMailSieveNotifyActionRFCCompliant' is set to TRUE");
+            fail("Unable to test because 'zimbraSieveNotifyActionRFCCompliant' is set to TRUE");
             return;
         }
         List<ZFilterRule> rules;

--- a/store/src/java/com/zimbra/qa/unittest/TestFilterRFCCompliantNotify.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestFilterRFCCompliantNotify.java
@@ -47,7 +47,7 @@ public class TestFilterRFCCompliantNotify extends TestCase {
     public void testNotifyAction()
     throws Exception {
         if (!mAvailableRFCCompliantNotify) {
-            fail("Unable to test because the global config key 'zimbraMailSieveNotifyActionRFCCompliant' is set to FALSE");
+            fail("Unable to test because 'zimbraSieveNotifyActionRFCCompliant' is set to FALSE");
             return;
         }
 
@@ -114,7 +114,7 @@ public class TestFilterRFCCompliantNotify extends TestCase {
         mOriginalIncomingRules = mMbox.getIncomingFilterRules();
         saveIncomingRules(mMbox, getTestIncomingRules());
 
-        mAvailableRFCCompliantNotify  = Provisioning.getInstance().getConfig().getBooleanAttr(Provisioning.A_zimbraMailSieveNotifyActionRFCCompliant, false);
+        mAvailableRFCCompliantNotify  = account.isSieveNotifyActionRFCCompliant();
     }
 
     /**


### PR DESCRIPTION
1. Deprecated old sieve attributes with id 2090, 2091, 2091, 2093, 2094, 2095
2. Added new attributes which can be used in place of the above deprecated attributes. All the attributes are defined at account, cos and domain level.
3. Since there is confusion about the release version, right now I have kept as 8.7.8. Please let me know if that needs to be changed

Testing - 
ant test

Will send a separate pull request for automation