### PR TITLE
ZCS-1144: remove dependency on /opt/zimbra/conf folder from Junit tests

### DIFF
--- a/store/src/java-test/com/zimbra/cs/db/DbVolumeBlobsTest.java
+++ b/store/src/java-test/com/zimbra/cs/db/DbVolumeBlobsTest.java
@@ -26,13 +26,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-import junit.framework.Assert;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
@@ -55,6 +54,8 @@ import com.zimbra.cs.store.file.FileBlobStore;
 import com.zimbra.cs.util.SpoolingCache;
 import com.zimbra.cs.volume.Volume;
 import com.zimbra.cs.volume.VolumeManager;
+
+import junit.framework.Assert;
 
 public class DbVolumeBlobsTest {
 
@@ -84,6 +85,7 @@ public class DbVolumeBlobsTest {
         conn = DbPool.getConnection();
         originalStoreManager = StoreManager.getInstance();
         originalVolume = VolumeManager.getInstance().getCurrentMessageVolume();
+        LC.zimbra_tmp_directory.setDefault(System.getProperty("user.dir") + "/build/tmp");
         StoreManager.setInstance(new FileBlobStore());
         StoreManager.getInstance().startup();
 

--- a/store/src/java-test/com/zimbra/cs/mailbox/MailboxTestUtil.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/MailboxTestUtil.java
@@ -18,6 +18,7 @@
 package com.zimbra.cs.mailbox;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
 
@@ -86,12 +87,19 @@ public final class MailboxTestUtil {
         zimbraServerDir = Strings.nullToEmpty(zimbraServerDir);
         System.setProperty("log4j.configuration", "log4j-test.properties");
         // Don't load from /opt/zimbra/conf
-        System.setProperty("zimbra.config", zimbraServerDir + "src/java-test/localconfig-test.xml");
+        System.setProperty("zimbra.config", zimbraServerDir + "/src/java-test/localconfig-test.xml");
         LC.reload();
-        LC.zimbra_attrs_directory.setDefault(zimbraHome + "conf/attrs");
-        LC.zimbra_rights_directory.setDefault(zimbraHome + "conf/rights");
-        LC.timezone_file.setDefault(zimbraHome + "conf/timezones.ics");
-
+        if (Strings.isNullOrEmpty(zimbraServerDir)) {
+            zimbraServerDir = System.getProperty("user.dir");
+        }
+        String timezonefilePath = zimbraServerDir + "/../../zm-timezones/" + "conf/timezones.ics";
+        File d = new File(timezonefilePath);
+        if (!d.exists()) {
+            throw new FileNotFoundException("zm-timezones repository not found. Please clone this repo in same directory as zm-mailbox before running this test.");
+        }
+        LC.timezone_file.setDefault(timezonefilePath);
+        LC.zimbra_rights_directory.setDefault(zimbraServerDir +"-conf" + "/conf/rights");
+        LC.zimbra_attrs_directory.setDefault(zimbraServerDir + "/conf/attrs");
         // default MIME handlers are now set up in MockProvisioning constructor
         Provisioning.setInstance(new MockProvisioning());
     }

--- a/store/src/java-test/com/zimbra/cs/util/ParseMailboxIDTest.java
+++ b/store/src/java-test/com/zimbra/cs/util/ParseMailboxIDTest.java
@@ -23,6 +23,7 @@ import junit.framework.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.MockProvisioning;
 import com.zimbra.cs.account.Provisioning;
@@ -37,6 +38,7 @@ public class ParseMailboxIDTest {
 
     @BeforeClass
     public static void init() throws Exception {
+        LC.zimbra_attrs_directory.setDefault(System.getProperty("user.dir") + "/conf/attrs");
         MockProvisioning prov = new MockProvisioning();
         prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
         Provisioning.setInstance(prov);


### PR DESCRIPTION
required files will now be accessed from the repo itself instead of /opt/zimbra/conf folder.
All the tests in repos of zm-mailbox which were failing due to absence of /opt/zimbra/conf folder are passing now.