### PR TITLE
feature/zms-38 updates

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -14004,6 +14004,42 @@ public class ZAttrProvisioning {
     public static final String A_zimbraRegexMaxAccessesWhenMatching = "zimbraRegexMaxAccessesWhenMatching";
 
     /**
+     * port number on which the remote IMAP server should listen
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3015)
+    public static final String A_zimbraRemoteImapBindPort = "zimbraRemoteImapBindPort";
+
+    /**
+     * Controls if the remote IMAP (non-SSL) service is enabled for a given
+     * server. See also zimbraRemoteImapSSLServerEnabled and
+     * zimbraReverseProxyUpstreamImapServers.
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3013)
+    public static final String A_zimbraRemoteImapServerEnabled = "zimbraRemoteImapServerEnabled";
+
+    /**
+     * port number on which the remote IMAP SSL server should listen
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3016)
+    public static final String A_zimbraRemoteImapSSLBindPort = "zimbraRemoteImapSSLBindPort";
+
+    /**
+     * Controls if the remote IMAP SSL server is enabled for a given server.
+     * See also zimbraRemoteImapServerEnabled and
+     * zimbraReverseProxyUpstreamImapServers.
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3014)
+    public static final String A_zimbraRemoteImapSSLServerEnabled = "zimbraRemoteImapSSLServerEnabled";
+
+    /**
      * Path to remote management command to execute on this server
      */
     @ZAttr(id=336)

--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -728,6 +728,17 @@ public final class LC {
     public static final KnownKey imap_throttle_fetch = KnownKey.newKey(true);
     public static final KnownKey data_source_imap_reuse_connections = KnownKey.newKey(false);
 
+    @Supported
+    public static final KnownKey imapd_keystore = KnownKey.newKey("/opt/zimbra/conf/imapd.keystore");
+    @Supported
+    public static final KnownKey imapd_keystore_password = KnownKey.newKey("${mailboxd_keystore_password}");
+    @Supported
+    public static final KnownKey imapd_java_options = KnownKey.newKey("");
+    @Supported
+    public static final KnownKey imapd_java_heap_size = KnownKey.newKey("");
+    @Supported
+    public static final KnownKey imapd_java_heap_new_size_percent = KnownKey.newKey("${mailboxd_java_heap_new_size_percent}");
+
     public static final KnownKey pop3_write_timeout = KnownKey.newKey(10);
     public static final KnownKey pop3_thread_keep_alive_time = KnownKey.newKey(60);
     public static final KnownKey pop3_max_idle_time = KnownKey.newKey(60);

--- a/store-conf/conf/imapd.log4j.properties
+++ b/store-conf/conf/imapd.log4j.properties
@@ -1,0 +1,53 @@
+# An example log4j configuration file that outputs to System.out.  The
+# output information consists of relative time, log level, thread
+# name, logger name, nested diagnostic context and the message in that
+# order.
+
+# For the general syntax of property based configuration files see the
+# documenation of org.apache.log4j.PropertyConfigurator.
+
+log4j.threshhold=OFF
+
+log4j.rootLogger=INFO,LOGFILE
+#log4j.rootLogger=INFO,LOGFILE,SYSLOG
+
+# Appender LOGFILE writes to the file "/opt/zimbra/log/imapd.log".
+# Daily rolling policy with compressing the old log file while rotating!!
+# The archived log files location can be changed using FileNamePattern value
+log4j.appender.LOGFILE=org.apache.log4j.rolling.RollingFileAppender
+log4j.appender.LOGFILE.RollingPolicy=org.apache.log4j.rolling.TimeBasedRollingPolicy
+log4j.appender.LOGFILE.RollingPolicy.FileNamePattern=/opt/zimbra/log/imapd.log.%d{yyyy-MM-dd}
+log4j.appender.LOGFILE.File=/opt/zimbra/log/imapd.log
+log4j.appender.LOGFILE.layout=com.zimbra.common.util.ZimbraPatternLayout
+log4j.appender.LOGFILE.layout.ConversionPattern=%d %-5p [%t] [%z] %c{1} - %m%n
+
+# Appender AUDIT writes to the file "imapd-audit.log".
+log4j.appender.AUDIT=org.apache.log4j.rolling.RollingFileAppender
+log4j.appender.AUDIT.RollingPolicy=org.apache.log4j.rolling.TimeBasedRollingPolicy
+log4j.appender.AUDIT.RollingPolicy.FileNamePattern=/opt/zimbra/log/imapd-audit.log.%d{yyyy-MM-dd}
+log4j.appender.AUDIT.File=/opt/zimbra/log/imapd-audit.log
+log4j.appender.AUDIT.layout=com.zimbra.common.util.ZimbraPatternLayout
+log4j.appender.AUDIT.layout.ConversionPattern=%d %-5p [%t] [%z] %c{1} - %m%n
+
+# Save zimbra.security to AUDIT appender 
+log4j.additivity.zimbra.security=false
+log4j.logger.zimbra.security=INFO,AUDIT
+
+# Syslog appender
+log4j.appender.SYSLOG=org.apache.log4j.net.SyslogAppender
+log4j.appender.SYSLOG.SyslogHost=localhost
+log4j.appender.SYSLOG.Facility=LOCAL0
+log4j.appender.SYSLOG.layout=com.zimbra.common.util.ZimbraPatternLayout
+log4j.appender.SYSLOG.layout.ConversionPattern=imap: %-5p [%t] [%z] %c{1} - %m
+
+
+# HttpMethodBase spews out too many WARN on the badly formatted cookies.
+log4j.logger.org.apache.commons.httpclient.HttpMethodBase=ERROR
+
+# spymemcached is too verbose at INFO level.
+log4j.logger.net.spy.memcached=WARN
+
+log4j.logger.zimbra=INFO
+log4j.logger.zimbra.op=WARN
+log4j.logger.com.zimbra=INFO
+

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9497,4 +9497,24 @@ TODO: delete them permanently from here
   <desc>The max number of IMAP messages returned by OpenImapFolderRequest before pagination begins</desc>
 </attr>
 
+<attr id="3013" name="zimbraRemoteImapServerEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="8.8.0">
+  <globalConfigValue>FALSE</globalConfigValue>
+  <desc>Controls if the remote IMAP (non-SSL) service is enabled for a given server. See also zimbraRemoteImapSSLServerEnabled and zimbraReverseProxyUpstreamImapServers.</desc>
+</attr>
+
+<attr id="3014" name="zimbraRemoteImapSSLServerEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="8.8.0">
+  <globalConfigValue>FALSE</globalConfigValue>
+  <desc>Controls if the remote IMAP SSL server is enabled for a given server. See also zimbraRemoteImapServerEnabled and zimbraReverseProxyUpstreamImapServers.</desc>
+</attr>
+
+<attr id="3015" name="zimbraRemoteImapBindPort" type="port" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="8.8.0" callback="CheckPortConflict">
+  <globalConfigValue>8143</globalConfigValue>
+  <desc>port number on which the remote IMAP server should listen</desc>
+</attr>
+
+<attr id="3016" name="zimbraRemoteImapSSLBindPort" type="port" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="8.8.0" callback="CheckPortConflict">
+  <globalConfigValue>8993</globalConfigValue>
+  <desc>port number on which the remote IMAP SSL server should listen</desc>
+</attr>
+
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -50955,6 +50955,408 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * port number on which the remote IMAP server should listen
+     *
+     * <p>Use getRemoteImapBindPortAsString to access value as a string.
+     *
+     * @see #getRemoteImapBindPortAsString()
+     *
+     * @return zimbraRemoteImapBindPort, or 8143 if unset
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3015)
+    public int getRemoteImapBindPort() {
+        return getIntAttr(Provisioning.A_zimbraRemoteImapBindPort, 8143, true);
+    }
+
+    /**
+     * port number on which the remote IMAP server should listen
+     *
+     * @return zimbraRemoteImapBindPort, or "8143" if unset
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3015)
+    public String getRemoteImapBindPortAsString() {
+        return getAttr(Provisioning.A_zimbraRemoteImapBindPort, "8143", true);
+    }
+
+    /**
+     * port number on which the remote IMAP server should listen
+     *
+     * @param zimbraRemoteImapBindPort new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3015)
+    public void setRemoteImapBindPort(int zimbraRemoteImapBindPort) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapBindPort, Integer.toString(zimbraRemoteImapBindPort));
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * port number on which the remote IMAP server should listen
+     *
+     * @param zimbraRemoteImapBindPort new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3015)
+    public Map<String,Object> setRemoteImapBindPort(int zimbraRemoteImapBindPort, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapBindPort, Integer.toString(zimbraRemoteImapBindPort));
+        return attrs;
+    }
+
+    /**
+     * port number on which the remote IMAP server should listen
+     *
+     * @param zimbraRemoteImapBindPort new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3015)
+    public void setRemoteImapBindPortAsString(String zimbraRemoteImapBindPort) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapBindPort, zimbraRemoteImapBindPort);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * port number on which the remote IMAP server should listen
+     *
+     * @param zimbraRemoteImapBindPort new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3015)
+    public Map<String,Object> setRemoteImapBindPortAsString(String zimbraRemoteImapBindPort, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapBindPort, zimbraRemoteImapBindPort);
+        return attrs;
+    }
+
+    /**
+     * port number on which the remote IMAP server should listen
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3015)
+    public void unsetRemoteImapBindPort() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapBindPort, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * port number on which the remote IMAP server should listen
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3015)
+    public Map<String,Object> unsetRemoteImapBindPort(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapBindPort, "");
+        return attrs;
+    }
+
+    /**
+     * port number on which the remote IMAP SSL server should listen
+     *
+     * <p>Use getRemoteImapSSLBindPortAsString to access value as a string.
+     *
+     * @see #getRemoteImapSSLBindPortAsString()
+     *
+     * @return zimbraRemoteImapSSLBindPort, or 8993 if unset
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3016)
+    public int getRemoteImapSSLBindPort() {
+        return getIntAttr(Provisioning.A_zimbraRemoteImapSSLBindPort, 8993, true);
+    }
+
+    /**
+     * port number on which the remote IMAP SSL server should listen
+     *
+     * @return zimbraRemoteImapSSLBindPort, or "8993" if unset
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3016)
+    public String getRemoteImapSSLBindPortAsString() {
+        return getAttr(Provisioning.A_zimbraRemoteImapSSLBindPort, "8993", true);
+    }
+
+    /**
+     * port number on which the remote IMAP SSL server should listen
+     *
+     * @param zimbraRemoteImapSSLBindPort new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3016)
+    public void setRemoteImapSSLBindPort(int zimbraRemoteImapSSLBindPort) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapSSLBindPort, Integer.toString(zimbraRemoteImapSSLBindPort));
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * port number on which the remote IMAP SSL server should listen
+     *
+     * @param zimbraRemoteImapSSLBindPort new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3016)
+    public Map<String,Object> setRemoteImapSSLBindPort(int zimbraRemoteImapSSLBindPort, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapSSLBindPort, Integer.toString(zimbraRemoteImapSSLBindPort));
+        return attrs;
+    }
+
+    /**
+     * port number on which the remote IMAP SSL server should listen
+     *
+     * @param zimbraRemoteImapSSLBindPort new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3016)
+    public void setRemoteImapSSLBindPortAsString(String zimbraRemoteImapSSLBindPort) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapSSLBindPort, zimbraRemoteImapSSLBindPort);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * port number on which the remote IMAP SSL server should listen
+     *
+     * @param zimbraRemoteImapSSLBindPort new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3016)
+    public Map<String,Object> setRemoteImapSSLBindPortAsString(String zimbraRemoteImapSSLBindPort, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapSSLBindPort, zimbraRemoteImapSSLBindPort);
+        return attrs;
+    }
+
+    /**
+     * port number on which the remote IMAP SSL server should listen
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3016)
+    public void unsetRemoteImapSSLBindPort() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapSSLBindPort, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * port number on which the remote IMAP SSL server should listen
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3016)
+    public Map<String,Object> unsetRemoteImapSSLBindPort(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapSSLBindPort, "");
+        return attrs;
+    }
+
+    /**
+     * Controls if the remote IMAP SSL server is enabled for a given server.
+     * See also zimbraRemoteImapServerEnabled and
+     * zimbraReverseProxyUpstreamImapServers.
+     *
+     * @return zimbraRemoteImapSSLServerEnabled, or false if unset
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3014)
+    public boolean isRemoteImapSSLServerEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraRemoteImapSSLServerEnabled, false, true);
+    }
+
+    /**
+     * Controls if the remote IMAP SSL server is enabled for a given server.
+     * See also zimbraRemoteImapServerEnabled and
+     * zimbraReverseProxyUpstreamImapServers.
+     *
+     * @param zimbraRemoteImapSSLServerEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3014)
+    public void setRemoteImapSSLServerEnabled(boolean zimbraRemoteImapSSLServerEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapSSLServerEnabled, zimbraRemoteImapSSLServerEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Controls if the remote IMAP SSL server is enabled for a given server.
+     * See also zimbraRemoteImapServerEnabled and
+     * zimbraReverseProxyUpstreamImapServers.
+     *
+     * @param zimbraRemoteImapSSLServerEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3014)
+    public Map<String,Object> setRemoteImapSSLServerEnabled(boolean zimbraRemoteImapSSLServerEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapSSLServerEnabled, zimbraRemoteImapSSLServerEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Controls if the remote IMAP SSL server is enabled for a given server.
+     * See also zimbraRemoteImapServerEnabled and
+     * zimbraReverseProxyUpstreamImapServers.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3014)
+    public void unsetRemoteImapSSLServerEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapSSLServerEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Controls if the remote IMAP SSL server is enabled for a given server.
+     * See also zimbraRemoteImapServerEnabled and
+     * zimbraReverseProxyUpstreamImapServers.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3014)
+    public Map<String,Object> unsetRemoteImapSSLServerEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapSSLServerEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * Controls if the remote IMAP (non-SSL) service is enabled for a given
+     * server. See also zimbraRemoteImapSSLServerEnabled and
+     * zimbraReverseProxyUpstreamImapServers.
+     *
+     * @return zimbraRemoteImapServerEnabled, or false if unset
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3013)
+    public boolean isRemoteImapServerEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraRemoteImapServerEnabled, false, true);
+    }
+
+    /**
+     * Controls if the remote IMAP (non-SSL) service is enabled for a given
+     * server. See also zimbraRemoteImapSSLServerEnabled and
+     * zimbraReverseProxyUpstreamImapServers.
+     *
+     * @param zimbraRemoteImapServerEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3013)
+    public void setRemoteImapServerEnabled(boolean zimbraRemoteImapServerEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapServerEnabled, zimbraRemoteImapServerEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Controls if the remote IMAP (non-SSL) service is enabled for a given
+     * server. See also zimbraRemoteImapSSLServerEnabled and
+     * zimbraReverseProxyUpstreamImapServers.
+     *
+     * @param zimbraRemoteImapServerEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3013)
+    public Map<String,Object> setRemoteImapServerEnabled(boolean zimbraRemoteImapServerEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapServerEnabled, zimbraRemoteImapServerEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Controls if the remote IMAP (non-SSL) service is enabled for a given
+     * server. See also zimbraRemoteImapSSLServerEnabled and
+     * zimbraReverseProxyUpstreamImapServers.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3013)
+    public void unsetRemoteImapServerEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapServerEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Controls if the remote IMAP (non-SSL) service is enabled for a given
+     * server. See also zimbraRemoteImapSSLServerEnabled and
+     * zimbraReverseProxyUpstreamImapServers.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3013)
+    public Map<String,Object> unsetRemoteImapServerEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapServerEnabled, "");
+        return attrs;
+    }
+
+    /**
      * Path to remote management command to execute on this server
      *
      * @return zimbraRemoteManagementCommand, or "/opt/zimbra/libexec/zmrcd" if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -38406,6 +38406,408 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
+     * port number on which the remote IMAP server should listen
+     *
+     * <p>Use getRemoteImapBindPortAsString to access value as a string.
+     *
+     * @see #getRemoteImapBindPortAsString()
+     *
+     * @return zimbraRemoteImapBindPort, or 8143 if unset
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3015)
+    public int getRemoteImapBindPort() {
+        return getIntAttr(Provisioning.A_zimbraRemoteImapBindPort, 8143, true);
+    }
+
+    /**
+     * port number on which the remote IMAP server should listen
+     *
+     * @return zimbraRemoteImapBindPort, or "8143" if unset
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3015)
+    public String getRemoteImapBindPortAsString() {
+        return getAttr(Provisioning.A_zimbraRemoteImapBindPort, "8143", true);
+    }
+
+    /**
+     * port number on which the remote IMAP server should listen
+     *
+     * @param zimbraRemoteImapBindPort new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3015)
+    public void setRemoteImapBindPort(int zimbraRemoteImapBindPort) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapBindPort, Integer.toString(zimbraRemoteImapBindPort));
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * port number on which the remote IMAP server should listen
+     *
+     * @param zimbraRemoteImapBindPort new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3015)
+    public Map<String,Object> setRemoteImapBindPort(int zimbraRemoteImapBindPort, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapBindPort, Integer.toString(zimbraRemoteImapBindPort));
+        return attrs;
+    }
+
+    /**
+     * port number on which the remote IMAP server should listen
+     *
+     * @param zimbraRemoteImapBindPort new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3015)
+    public void setRemoteImapBindPortAsString(String zimbraRemoteImapBindPort) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapBindPort, zimbraRemoteImapBindPort);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * port number on which the remote IMAP server should listen
+     *
+     * @param zimbraRemoteImapBindPort new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3015)
+    public Map<String,Object> setRemoteImapBindPortAsString(String zimbraRemoteImapBindPort, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapBindPort, zimbraRemoteImapBindPort);
+        return attrs;
+    }
+
+    /**
+     * port number on which the remote IMAP server should listen
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3015)
+    public void unsetRemoteImapBindPort() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapBindPort, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * port number on which the remote IMAP server should listen
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3015)
+    public Map<String,Object> unsetRemoteImapBindPort(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapBindPort, "");
+        return attrs;
+    }
+
+    /**
+     * port number on which the remote IMAP SSL server should listen
+     *
+     * <p>Use getRemoteImapSSLBindPortAsString to access value as a string.
+     *
+     * @see #getRemoteImapSSLBindPortAsString()
+     *
+     * @return zimbraRemoteImapSSLBindPort, or 8993 if unset
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3016)
+    public int getRemoteImapSSLBindPort() {
+        return getIntAttr(Provisioning.A_zimbraRemoteImapSSLBindPort, 8993, true);
+    }
+
+    /**
+     * port number on which the remote IMAP SSL server should listen
+     *
+     * @return zimbraRemoteImapSSLBindPort, or "8993" if unset
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3016)
+    public String getRemoteImapSSLBindPortAsString() {
+        return getAttr(Provisioning.A_zimbraRemoteImapSSLBindPort, "8993", true);
+    }
+
+    /**
+     * port number on which the remote IMAP SSL server should listen
+     *
+     * @param zimbraRemoteImapSSLBindPort new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3016)
+    public void setRemoteImapSSLBindPort(int zimbraRemoteImapSSLBindPort) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapSSLBindPort, Integer.toString(zimbraRemoteImapSSLBindPort));
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * port number on which the remote IMAP SSL server should listen
+     *
+     * @param zimbraRemoteImapSSLBindPort new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3016)
+    public Map<String,Object> setRemoteImapSSLBindPort(int zimbraRemoteImapSSLBindPort, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapSSLBindPort, Integer.toString(zimbraRemoteImapSSLBindPort));
+        return attrs;
+    }
+
+    /**
+     * port number on which the remote IMAP SSL server should listen
+     *
+     * @param zimbraRemoteImapSSLBindPort new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3016)
+    public void setRemoteImapSSLBindPortAsString(String zimbraRemoteImapSSLBindPort) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapSSLBindPort, zimbraRemoteImapSSLBindPort);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * port number on which the remote IMAP SSL server should listen
+     *
+     * @param zimbraRemoteImapSSLBindPort new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3016)
+    public Map<String,Object> setRemoteImapSSLBindPortAsString(String zimbraRemoteImapSSLBindPort, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapSSLBindPort, zimbraRemoteImapSSLBindPort);
+        return attrs;
+    }
+
+    /**
+     * port number on which the remote IMAP SSL server should listen
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3016)
+    public void unsetRemoteImapSSLBindPort() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapSSLBindPort, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * port number on which the remote IMAP SSL server should listen
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3016)
+    public Map<String,Object> unsetRemoteImapSSLBindPort(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapSSLBindPort, "");
+        return attrs;
+    }
+
+    /**
+     * Controls if the remote IMAP SSL server is enabled for a given server.
+     * See also zimbraRemoteImapServerEnabled and
+     * zimbraReverseProxyUpstreamImapServers.
+     *
+     * @return zimbraRemoteImapSSLServerEnabled, or false if unset
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3014)
+    public boolean isRemoteImapSSLServerEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraRemoteImapSSLServerEnabled, false, true);
+    }
+
+    /**
+     * Controls if the remote IMAP SSL server is enabled for a given server.
+     * See also zimbraRemoteImapServerEnabled and
+     * zimbraReverseProxyUpstreamImapServers.
+     *
+     * @param zimbraRemoteImapSSLServerEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3014)
+    public void setRemoteImapSSLServerEnabled(boolean zimbraRemoteImapSSLServerEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapSSLServerEnabled, zimbraRemoteImapSSLServerEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Controls if the remote IMAP SSL server is enabled for a given server.
+     * See also zimbraRemoteImapServerEnabled and
+     * zimbraReverseProxyUpstreamImapServers.
+     *
+     * @param zimbraRemoteImapSSLServerEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3014)
+    public Map<String,Object> setRemoteImapSSLServerEnabled(boolean zimbraRemoteImapSSLServerEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapSSLServerEnabled, zimbraRemoteImapSSLServerEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Controls if the remote IMAP SSL server is enabled for a given server.
+     * See also zimbraRemoteImapServerEnabled and
+     * zimbraReverseProxyUpstreamImapServers.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3014)
+    public void unsetRemoteImapSSLServerEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapSSLServerEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Controls if the remote IMAP SSL server is enabled for a given server.
+     * See also zimbraRemoteImapServerEnabled and
+     * zimbraReverseProxyUpstreamImapServers.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3014)
+    public Map<String,Object> unsetRemoteImapSSLServerEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapSSLServerEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * Controls if the remote IMAP (non-SSL) service is enabled for a given
+     * server. See also zimbraRemoteImapSSLServerEnabled and
+     * zimbraReverseProxyUpstreamImapServers.
+     *
+     * @return zimbraRemoteImapServerEnabled, or false if unset
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3013)
+    public boolean isRemoteImapServerEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraRemoteImapServerEnabled, false, true);
+    }
+
+    /**
+     * Controls if the remote IMAP (non-SSL) service is enabled for a given
+     * server. See also zimbraRemoteImapSSLServerEnabled and
+     * zimbraReverseProxyUpstreamImapServers.
+     *
+     * @param zimbraRemoteImapServerEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3013)
+    public void setRemoteImapServerEnabled(boolean zimbraRemoteImapServerEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapServerEnabled, zimbraRemoteImapServerEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Controls if the remote IMAP (non-SSL) service is enabled for a given
+     * server. See also zimbraRemoteImapSSLServerEnabled and
+     * zimbraReverseProxyUpstreamImapServers.
+     *
+     * @param zimbraRemoteImapServerEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3013)
+    public Map<String,Object> setRemoteImapServerEnabled(boolean zimbraRemoteImapServerEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapServerEnabled, zimbraRemoteImapServerEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Controls if the remote IMAP (non-SSL) service is enabled for a given
+     * server. See also zimbraRemoteImapSSLServerEnabled and
+     * zimbraReverseProxyUpstreamImapServers.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3013)
+    public void unsetRemoteImapServerEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapServerEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Controls if the remote IMAP (non-SSL) service is enabled for a given
+     * server. See also zimbraRemoteImapSSLServerEnabled and
+     * zimbraReverseProxyUpstreamImapServers.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=3013)
+    public Map<String,Object> unsetRemoteImapServerEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRemoteImapServerEnabled, "");
+        return attrs;
+    }
+
+    /**
      * Path to remote management command to execute on this server
      *
      * @return zimbraRemoteManagementCommand, or "/opt/zimbra/libexec/zmrcd" if unset

--- a/store/src/java/com/zimbra/cs/imap/EhcacheImapCache.java
+++ b/store/src/java/com/zimbra/cs/imap/EhcacheImapCache.java
@@ -45,7 +45,12 @@ final class EhcacheImapCache implements ImapSessionManager.Cache<String, ImapFol
 
     @SuppressWarnings("serial")
     EhcacheImapCache(String name, boolean active) {
-        ehcache = EhcacheManager.getInstance().getEhcache(name);
+        // If running inside mailboxd, share mailboxd cache, else use separate imap cache.  This avoids issues when running
+        // decoupled IMAP service on same host as mailbox.
+        EhcacheManager.Service service = System.getProperty(ImapDaemon.IMAP_SERVER_EMBEDDED, "true").equals("false")
+                ? EhcacheManager.Service.IMAP
+                : EhcacheManager.Service.MAILBOX;
+        ehcache = EhcacheManager.getInstance(service).getEhcache(name);
         this.active = active;
         if (active) {
             activeCacheUpdateTimes = new LinkedHashMap<String, Long>(ACTIVE_CACHE_THRESHOLD, 0.75f, true) {

--- a/store/src/java/com/zimbra/cs/imap/ImapDaemon.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapDaemon.java
@@ -1,0 +1,148 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.imap;
+
+import java.io.FileInputStream;
+import java.util.Properties;
+
+import org.apache.log4j.PropertyConfigurator;
+
+import com.zimbra.common.localconfig.LC;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.common.util.ZimbraLog;
+
+
+public class ImapDaemon {
+
+    public static final String IMAPD_LOG4J_CONFIG = "/opt/zimbra/conf/imapd.log4j.properties";
+    /**
+     * When starting IMAP(S) from ImapDaemon, a System property with the following key will
+     * be set with a value of "false".  This is referenced by the EhcacheImapCache to determine
+     * how the cache is initialized.
+     */
+    public static final String IMAP_SERVER_EMBEDDED = "imap.server.embedded";
+
+    private ImapServer imapServer, imapSSLServer;
+
+    private ImapServer startImapServer(boolean ssl) throws ServiceException {
+        RemoteImapConfig config = new RemoteImapConfig(ssl);
+        ZimbraLog.imap.info("Starting IMAP server, port=%d", config.getBindPort());
+        ImapServer server = LC.nio_imap_enabled.booleanValue() ?
+            new NioImapServer(config) : new TcpImapServer(config);
+        server.start();
+        return server;
+    }
+
+    private int startServers() throws ServiceException {
+        System.setProperty(IMAP_SERVER_EMBEDDED, "false");
+        int cnt = 0;
+        if (isEnabled(Provisioning.A_zimbraRemoteImapServerEnabled)) {
+            imapServer = startImapServer(false);
+            cnt += 1;
+        } else {
+            ZimbraLog.imap.info("%s is FALSE", Provisioning.A_zimbraRemoteImapServerEnabled);
+        }
+        if (isEnabled(Provisioning.A_zimbraRemoteImapSSLServerEnabled)) {
+            imapSSLServer = startImapServer(true);
+            cnt += 1;
+        } else {
+            ZimbraLog.imap.info("%s is FALSE", Provisioning.A_zimbraRemoteImapSSLServerEnabled);
+        }
+
+        return cnt;
+    }
+
+    private void stopServer(ImapServer server) {
+        try {
+            if(server != null) {
+                ZimbraLog.imap.info("Stopping IMAP server, port=%d", server.getConfig().getBindPort());
+                server.stop(10); // TODO configure wait time
+            }
+        } catch(ServiceException e) {
+            ZimbraLog.imap.error("stopServer", e);
+        }
+    }
+
+    private void stopServers() {
+        stopServer(imapServer);
+        stopServer(imapSSLServer);
+    }
+
+    public static void main(String[] args) {
+        try {
+            Properties props = new Properties();
+            props.load(new FileInputStream(IMAPD_LOG4J_CONFIG));
+            PropertyConfigurator.configure(props);
+
+            if(isZimbraImapEnabled()) {
+                ImapDaemon daemon = new ImapDaemon();
+                int numStarted = daemon.startServers();
+                if(numStarted > 0) {
+                    Runtime.getRuntime().addShutdownHook(new Thread() {
+                        @Override
+                        public void run() {
+                              ZimbraLog.imap.info("Shutting down servers");
+                              daemon.stopServers();
+                          }
+                        });
+                } else {
+                    errorExit("ImapDaemon: No servers started. Check zimbraRemoteImapServerEnabled and zimbraRemoteImapSSLServerEnabled");
+                }
+                if(!isMemberOfPool()) {
+                    errorExit("ImapDaemon: This server not member of pool. Check zimbraReverseProxyUpstreamImapServers.");
+                }
+            } else {
+                errorExit("ImapDaemon: imapd service is not enabled on this server. Check zimbraServiceEnabled.");
+            }
+        } catch (Exception e) {
+            System.err.println("ImapDaemon: " + e);
+        }
+    }
+
+    private static void errorExit(String msg) {
+        ZimbraLog.imap.warn(msg);
+        System.err.println(msg);
+        System.exit(1);
+    }
+
+    private static boolean isEnabled(String key) throws ServiceException {
+        return Provisioning.getInstance().getLocalServer().getBooleanAttr(key, false);
+    }
+
+    private static boolean isMemberOfPool() throws ServiceException {
+        String localServer = Provisioning.getInstance().getLocalServer().getName();
+        String[] imapServers = Provisioning.getInstance().getLocalServer().getReverseProxyUpstreamImapServers();
+        for(String server: imapServers) {
+            if(localServer.equals(server)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isZimbraImapEnabled() throws ServiceException {
+        String[] enabledServices = Provisioning.getInstance().getLocalServer().getMultiAttr(Provisioning.A_zimbraServiceEnabled);
+        for(String service: enabledServices) {
+            if(service.equals("imapd")) {
+                return true;
+            }
+        }
+        return false;
+   }
+}

--- a/store/src/java/com/zimbra/cs/imap/RemoteImapConfig.java
+++ b/store/src/java/com/zimbra/cs/imap/RemoteImapConfig.java
@@ -1,0 +1,50 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2017 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.imap;
+
+import static com.zimbra.common.account.ZAttrProvisioning.A_zimbraRemoteImapBindPort;
+import static com.zimbra.common.account.ZAttrProvisioning.A_zimbraRemoteImapSSLBindPort;
+
+import com.zimbra.common.localconfig.LC;
+
+
+public class RemoteImapConfig extends ImapConfig {
+    public static final int D_REMOTE_IMAP_BIND_PORT = 8143;
+    public static final int D_REMOTE_IMAP_SSL_BIND_PORT = 8993;
+
+    public RemoteImapConfig(boolean ssl) {
+        super(ssl);
+    }
+
+    @Override
+    public int getBindPort() {
+        return isSslEnabled() ?
+            getIntAttr(A_zimbraRemoteImapSSLBindPort, D_REMOTE_IMAP_SSL_BIND_PORT) :
+            getIntAttr(A_zimbraRemoteImapBindPort, D_REMOTE_IMAP_BIND_PORT);
+    }
+
+    @Override
+    public String getKeystorePath() {
+        return LC.imapd_keystore.value();
+    }
+
+    @Override
+    public String getKeystorePassword() {
+        return LC.imapd_keystore_password.value();
+    }
+}

--- a/store/src/java/com/zimbra/cs/server/NioServer.java
+++ b/store/src/java/com/zimbra/cs/server/NioServer.java
@@ -96,10 +96,10 @@ public abstract class NioServer implements Server {
         FILTERS.put(server, filter);
     }
 
-    private static synchronized SSLContext getSSLContext() {
+    private static synchronized SSLContext getSSLContext(ServerConfig config) {
         if (sslContext == null) {
             try {
-                sslContext = initSSLContext();
+                sslContext = initSSLContext(config);
             } catch (Exception e) {
                 Zimbra.halt("exception initializing SSL context", e);
             }
@@ -107,12 +107,12 @@ public abstract class NioServer implements Server {
         return sslContext;
     }
 
-    private static SSLContext initSSLContext() throws Exception {
+    private static SSLContext initSSLContext(ServerConfig config) throws Exception {
         FileInputStream fis = null;
         try {
 	        KeyStore ks = KeyStore.getInstance("JKS");
-	        char[] pass = LC.mailboxd_keystore_password.value().toCharArray();
-	        fis = new FileInputStream(LC.mailboxd_keystore.value());
+	        char[] pass = config.getKeystorePassword().toCharArray();
+	        fis = new FileInputStream(config.getKeystorePath());
 	        ks.load(fis, pass);
 	        KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
 	        kmf.init(ks, pass);
@@ -185,7 +185,7 @@ public abstract class NioServer implements Server {
     }
 
     public ZimbraSslFilter newSSLFilter() {
-        SSLContext sslCtxt = getSSLContext();
+        SSLContext sslCtxt = getSSLContext(getConfig());
         ZimbraSslFilter sslFilter = new ZimbraSslFilter(sslCtxt);
         String[] sslProtocols = config.getMailboxdSslProtocols();
         if (sslProtocols != null && sslProtocols.length > 0) {

--- a/store/src/java/com/zimbra/cs/server/ServerConfig.java
+++ b/store/src/java/com/zimbra/cs/server/ServerConfig.java
@@ -236,6 +236,14 @@ public abstract class ServerConfig {
 
     }
 
+    public String getKeystorePath() {
+        return LC.mailboxd_keystore.value();
+    }
+
+    public String getKeystorePassword() {
+        return LC.mailboxd_keystore_password.value();
+    }
+
     public static String[] getAddrListCsv(String[] addrCsvs) {
         ArrayList<String> addrList = new ArrayList<String>(addrCsvs.length);
         for (String addrCsv : addrCsvs) {

--- a/store/src/java/com/zimbra/cs/util/EhcacheManager.java
+++ b/store/src/java/com/zimbra/cs/util/EhcacheManager.java
@@ -46,7 +46,7 @@ import com.zimbra.cs.memcached.MemcachedConnector;
  * @author ysasaki
  */
 public final class EhcacheManager {
-    private static final EhcacheManager SINGLETON = new EhcacheManager();
+    private static EhcacheManager SINGLETON = null;
 
     private CacheManager cacheManager;
 
@@ -54,9 +54,9 @@ public final class EhcacheManager {
     public static final String IMAP_INACTIVE_SESSION_CACHE = "imap-inactive-session-cache";
     public static final String SYNC_STATE_ITEM_CACHE = "sync-state-item-cache";
 
-    private EhcacheManager() {
+    private EhcacheManager(Service service) {
         cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
-                .with(CacheManagerBuilder.persistence(LC.zimbra_home.value() + File.separator + "data" + File.separator + "mailboxd"))
+                .with(CacheManagerBuilder.persistence(LC.zimbra_home.value() + File.separator + "data" + File.separator + service.val))
                 .withCache(IMAP_ACTIVE_SESSION_CACHE, createImapActiveSessionCache())
                 .build(true);
 
@@ -69,6 +69,13 @@ public final class EhcacheManager {
     }
 
     public static EhcacheManager getInstance() {
+        return getInstance(Service.MAILBOX);
+    }
+
+    public synchronized static EhcacheManager getInstance(Service service) {
+        if(SINGLETON == null) {
+            SINGLETON = new EhcacheManager(service);
+        }
         return SINGLETON;
     }
 
@@ -151,12 +158,22 @@ public final class EhcacheManager {
     public Cache<String, ImapFolder> getEhcache(String cacheName) {
         return cacheManager.getCache(cacheName, String.class, ImapFolder.class);
     }
-    
+
     public Cache<String, String> getSyncStateEhcache() {
         return cacheManager.getCache(SYNC_STATE_ITEM_CACHE, String.class, String.class);
     }
 
     public void shutdown() {
         cacheManager.close();
+    }
+
+    public static enum Service {
+        MAILBOX("mailboxd"),
+        IMAP("imap");
+        private String val;
+
+        private Service(String val) {
+            this.val = val;
+        }
     }
 }


### PR DESCRIPTION
## zm-mailbox

### Ehcache

Update Ehcache initialization as follows:

1. When IMAP is running inside of _mailboxd_, initialize the
   persistence layer of Ehcache as before; that it, share the
   same file for persisting cache data as _mailboxd_.
2. When IMAP is not running inside of _mailboxd_, use a different
   file for persisting cache data.  This prevents issues when
   running a decoupled IMAP server on the same host as
   mailboxd.
   
### New LDAP Attributes

The following new LDAP Attributes determine with IMAP servers get started by _zimbra-imap_:

* For IMAP: `zimbraRemoteImapServerEnabled1`
* For IMAPS: `zimbraRemoteImapSSLServerEnabled`

They are equivalent to the settings that control IMAP(S) for _mailboxd_:

* `zimbraImapServerEnabled`
* `zimbraImapSSLServerEnabled`

These new LDAP attributes determine the backend ports that the IMAP(S) servers will use:

* For IMAP: `zimbraRemoteImapBindPort`
* For IMAPS: `zimbraRemoteImapSSLBindPort`

### ImapDaemon

The _zimbra-imap_ service uses a bash script defined in the `zm-core-util` repo called `zmimapdctl` to construct the appropriate JVM options and start the _ImapDaemon_.  The _ImapDaemon_ initializes logging and starts up the IMAP(S) server(s).

### imap.log4j.properties

This file is installed into `/opt/zimbra/conf` and is used by the _ImapDaemon_ to initialize logging.

### RemoteImapConfig

The _RemoteImapConfig_ class is used by the _ImapDaemon_ when initializing the IMAP(S) server(s).  It supports the alternate port bindings defined by the following LDAP attributes:

* For IMAP: `zimbraRemoteImapBindPort`
* For IMAPS: `zimbraRemoteImapSSLBindPort`


Please also see related pull requests for:

* `zm-zcs-lib`
* `zm-nginx-lookup-store`
* `zm-core-utils`
* `zm-build`

