### PR TITLE
ZMS-229: ZSearchParams::get/setIncludeTagDeleted

### DIFF
--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -3706,6 +3706,9 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
         if (params.getInDumpster()) {
             req.addAttribute(MailConstants.A_IN_DUMPSTER, true);
         }
+        if (params.getIncludeTagDeleted()) {
+            req.addAttribute(MailConstants.A_INCLUDE_TAG_DELETED, true);
+        }
 
         req.addAttribute(MailConstants.E_QUERY, params.getQuery(), Element.Disposition.CONTENT);
 

--- a/client/src/java/com/zimbra/client/ZSearchParams.java
+++ b/client/src/java/com/zimbra/client/ZSearchParams.java
@@ -159,6 +159,11 @@ public class ZSearchParams implements ToZJSONObject, ZimbraSearchParams {
      */
     private boolean mInDumpster;
 
+    /**
+     * If false, items with the \Deleted tag set are not returned.
+     */
+    private boolean includeTagDeleted = false;
+
     @Override
     public int hashCode() {
         if (mConvId != null)
@@ -219,6 +224,7 @@ public class ZSearchParams implements ToZJSONObject, ZimbraSearchParams {
         this.mCalExpandInstStart = that.mCalExpandInstStart;
         this.mTimeZone = that.mTimeZone;
         this.mInDumpster = that.mInDumpster;
+        this.includeTagDeleted = that.includeTagDeleted;
     }
 
     public ZSearchParams(String query) {
@@ -378,6 +384,7 @@ public class ZSearchParams implements ToZJSONObject, ZimbraSearchParams {
         if (mTimeZone != null) zjo.put("timeZone", mTimeZone.getID());
         if (mCursor != null) zjo.put("cursor", mCursor);
         if (mInDumpster) zjo.put("inDumpster", true);
+        if (includeTagDeleted) zjo.put("includeTagDeleted", true);
         return zjo;
     }
 
@@ -468,12 +475,12 @@ public class ZSearchParams implements ToZJSONObject, ZimbraSearchParams {
 
     @Override
     public boolean getIncludeTagDeleted() {
-        throw new UnsupportedOperationException("ZSearchParams method not supported yet");
+        return includeTagDeleted;
     }
 
     @Override
     public void setIncludeTagDeleted(boolean value) {
-        throw new UnsupportedOperationException("ZSearchParams method not supported yet");
+        includeTagDeleted = value;
     }
 
     @Override

--- a/store/src/java/com/zimbra/qa/unittest/TestZClient.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestZClient.java
@@ -44,6 +44,8 @@ import com.zimbra.client.ZMailbox.OpenIMAPFolderParams;
 import com.zimbra.client.ZMailbox.Options;
 import com.zimbra.client.ZMessage;
 import com.zimbra.client.ZPrefs;
+import com.zimbra.client.ZSearchParams;
+import com.zimbra.client.ZSearchResult;
 import com.zimbra.client.ZSignature;
 import com.zimbra.client.ZTag;
 import com.zimbra.common.account.Key.AccountBy;
@@ -62,6 +64,7 @@ import com.zimbra.cs.imap.RemoteImapMailboxStore;
 import com.zimbra.cs.mailbox.Contact;
 import com.zimbra.cs.mailbox.DeliveryOptions;
 import com.zimbra.cs.mailbox.Flag;
+import com.zimbra.cs.mailbox.Flag.FlagInfo;
 import com.zimbra.cs.mailbox.Folder;
 import com.zimbra.cs.mailbox.MailItem;
 import com.zimbra.cs.mailbox.MailServiceException;
@@ -610,6 +613,20 @@ public class TestZClient extends TestCase {
         int secondChangeId = zmbox.getLastChangeID();
         assertTrue("lastChangeId should have increased", firstChangeId < secondChangeId);
         assertEquals("wrong change ID after adding message", mbox.getLastChangeID(), secondChangeId);
+    }
+
+    @Test
+    public void testZSearchParamsIncludeTagDeleted() throws Exception {
+        ZMailbox zmbox = TestUtil.getZMailbox(USER_NAME);
+        Mailbox mbox = TestUtil.getMailbox(USER_NAME);
+        String msgId = TestUtil.addMessage(zmbox, "testZSearchParamsIncludeTagDeleted message");
+        mbox.alterTag(null, Integer.valueOf(msgId), MailItem.Type.MESSAGE, FlagInfo.DELETED, true, null);
+        ZSearchParams params = new ZSearchParams("testZSearchParamsIncludeTagDeleted");
+        ZSearchResult result = zmbox.search(params);
+        assertEquals(0, result.getHits().size());
+        params.setIncludeTagDeleted(true);
+        result = zmbox.search(params);
+        assertEquals(1, result.getHits().size());
     }
 
     private void compareMsgAndZMsg(String testname, Message msg, ZMessage zmsg) throws IOException, ServiceException {


### PR DESCRIPTION
Implemented ZSearchParams::get/setIncludeTagDeleted methods, updated ZMailbox to include this parameter in the search request, and added a unit test verifying the functionality.