### PR TITLE
bugfix/ZCS-1128 TestGetMsg

### DIFF
--- a/store/src/java/com/zimbra/qa/unittest/TestGetMsg.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestGetMsg.java
@@ -35,11 +35,10 @@ import org.junit.rules.TestName;
 
 public class TestGetMsg{
 	
-	@Rule
-	public TestName testInfo = new TestName();
+    @Rule
+    public TestName testInfo = new TestName();
     private static String USER_NAME = null;
-	private static final String NAME_PREFIX = TestGetMsg.class.getSimpleName();
-    
+    private static final String NAME_PREFIX = TestGetMsg.class.getSimpleName();
     private String mOriginalContentMaxSize;
 	
     @Before
@@ -48,6 +47,7 @@ public class TestGetMsg{
 		String prefix = NAME_PREFIX + "-" + testInfo.getMethodName() + "-";
 		USER_NAME = prefix + "user";
         cleanUp();
+        TestUtil.createAccount(USER_NAME);
         mOriginalContentMaxSize = TestUtil.getServerAttr(Provisioning.A_zimbraMailContentMaxSize);
     }
     @Test
@@ -68,7 +68,6 @@ public class TestGetMsg{
     }
     private void doTestMessageContent(String contentType, String body)
     throws Exception {
-		TestUtil.createAccount(USER_NAME);
         ZMailbox mbox = TestUtil.getZMailbox(USER_NAME);
         MessageBuilder mb = new MessageBuilder();
         

--- a/store/src/java/com/zimbra/qa/unittest/TestGetMsg.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestGetMsg.java
@@ -26,38 +26,49 @@ import com.zimbra.client.ZMessage;
 import com.zimbra.client.ZMessage.ZMimePart;
 import com.zimbra.common.mime.MimeConstants;
 
-public class TestGetMsg
-extends TestCase {
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
 
-    private static final String USER_NAME = "user1";
-    private static final String NAME_PREFIX = TestGetMsg.class.getSimpleName();
+public class TestGetMsg{
+	
+	@Rule
+	public TestName testInfo = new TestName();
+    private static String USER_NAME = null;
+	private static final String NAME_PREFIX = TestGetMsg.class.getSimpleName();
     
     private String mOriginalContentMaxSize;
-    
+	
+    @Before
     public void setUp()
     throws Exception {
+		String prefix = NAME_PREFIX + "-" + testInfo.getMethodName() + "-";
+		USER_NAME = prefix + "user";
         cleanUp();
         mOriginalContentMaxSize = TestUtil.getServerAttr(Provisioning.A_zimbraMailContentMaxSize);
     }
-    
+    @Test
     public void testPlainMessageContent()
     throws Exception {
         doTestMessageContent(MimeConstants.CT_TEXT_PLAIN, "This is the body of a plain message.");
     }
-    
+    @Test
     public void testHtmlMessageContent()
     throws Exception {
         doTestMessageContent(MimeConstants.CT_TEXT_HTML, "<html><head></head><body>HTML message</body></html>");
     }
-    
+    @Test
     public void testEnrichedMessageContent()
     throws Exception {
         doTestMessageContent(MimeConstants.CT_TEXT_ENRICHED,
             "<color><param>red</param>Blood</color> is <bold>thicker</bold> than<color><param>blue</param>water</color>.");
     }
-    
     private void doTestMessageContent(String contentType, String body)
     throws Exception {
+		TestUtil.createAccount(USER_NAME);
         ZMailbox mbox = TestUtil.getZMailbox(USER_NAME);
         MessageBuilder mb = new MessageBuilder();
         
@@ -91,7 +102,7 @@ extends TestCase {
         ZMessage msg = mbox.getMessage(params);
         ZMimePart mp = msg.getMimeStructure();
 
-        assertEquals(expectedTruncated, mp.wasTruncated());
+        Assert.assertEquals(expectedTruncated, mp.wasTruncated());
         String expected = body;
         if (expectedLength != null) {
             expected = body.substring(0, expectedLength);
@@ -101,13 +112,13 @@ extends TestCase {
             // HTML conversion in TextEnrichedHandler will drop trailing
             // characters when the enriched data is malformed (tags not
             // closed, etc.).
-            assertTrue(mp.getContent().length() > 0);
-            assertTrue(expected.startsWith(mp.getContent()));
+            Assert.assertTrue(mp.getContent().length() > 0);
+            Assert.assertTrue(expected.startsWith(mp.getContent()));
         } else {
-            assertEquals(expected, mp.getContent());
+            Assert.assertEquals(expected, mp.getContent());
         }
     }
-    
+    @After
     public void tearDown()
     throws Exception {
         cleanUp();
@@ -116,7 +127,7 @@ extends TestCase {
     
     private void cleanUp()
     throws Exception {
-        TestUtil.deleteTestData(USER_NAME, NAME_PREFIX);
+        TestUtil.deleteAccountIfExists(USER_NAME);
     }
 
     public static void main(String[] args)

--- a/store/src/java/com/zimbra/qa/unittest/TestGetMsg.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestGetMsg.java
@@ -16,16 +16,6 @@
  */
 package com.zimbra.qa.unittest;
 
-import junit.framework.TestCase;
-
-import com.zimbra.cs.account.Provisioning;
-import com.zimbra.cs.mime.handler.TextEnrichedHandler;
-import com.zimbra.client.ZGetMessageParams;
-import com.zimbra.client.ZMailbox;
-import com.zimbra.client.ZMessage;
-import com.zimbra.client.ZMessage.ZMimePart;
-import com.zimbra.common.mime.MimeConstants;
-
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -33,63 +23,75 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 
+import com.zimbra.client.ZGetMessageParams;
+import com.zimbra.client.ZMailbox;
+import com.zimbra.client.ZMessage;
+import com.zimbra.client.ZMessage.ZMimePart;
+import com.zimbra.common.mime.MimeConstants;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mime.handler.TextEnrichedHandler;
+
 public class TestGetMsg{
-	
+
     @Rule
     public TestName testInfo = new TestName();
     private static String USER_NAME = null;
     private static final String NAME_PREFIX = TestGetMsg.class.getSimpleName();
     private String mOriginalContentMaxSize;
-	
+
     @Before
     public void setUp()
     throws Exception {
-		String prefix = NAME_PREFIX + "-" + testInfo.getMethodName() + "-";
-		USER_NAME = prefix + "user";
+        String prefix = NAME_PREFIX + "-" + testInfo.getMethodName() + "-";
+        USER_NAME = prefix + "user";
         cleanUp();
         TestUtil.createAccount(USER_NAME);
         mOriginalContentMaxSize = TestUtil.getServerAttr(Provisioning.A_zimbraMailContentMaxSize);
     }
+
     @Test
     public void testPlainMessageContent()
     throws Exception {
         doTestMessageContent(MimeConstants.CT_TEXT_PLAIN, "This is the body of a plain message.");
     }
+
     @Test
     public void testHtmlMessageContent()
     throws Exception {
         doTestMessageContent(MimeConstants.CT_TEXT_HTML, "<html><head></head><body>HTML message</body></html>");
     }
+
     @Test
     public void testEnrichedMessageContent()
     throws Exception {
         doTestMessageContent(MimeConstants.CT_TEXT_ENRICHED,
             "<color><param>red</param>Blood</color> is <bold>thicker</bold> than<color><param>blue</param>water</color>.");
     }
+
     private void doTestMessageContent(String contentType, String body)
     throws Exception {
         ZMailbox mbox = TestUtil.getZMailbox(USER_NAME);
         MessageBuilder mb = new MessageBuilder();
-        
+
         String subject = NAME_PREFIX + " testMessageContent " + contentType;
         String raw = mb.withSubject(subject).withBody(body).withContentType(contentType).create();
         String msgId = TestUtil.addRawMessage(mbox, raw);
         if (contentType.equals(MimeConstants.CT_TEXT_ENRICHED)) {
             body = TextEnrichedHandler.convertToHTML(body);
         }
-        
+
         verifyMessageContent(mbox, msgId, false, null, null, false, body, contentType);
         verifyMessageContent(mbox, msgId, true, null, null, false, body, contentType);
         verifyMessageContent(mbox, msgId, false, 24, 24, true, body, contentType);
         verifyMessageContent(mbox, msgId, true, 24, 24, true, body, contentType);
-        
+
         // Set zimbraMailMaxContentLength and confirm that the content
         // gets truncated.
         TestUtil.setServerAttr(Provisioning.A_zimbraMailContentMaxSize, "24");
         verifyMessageContent(mbox, msgId, false, null, 24, true, body, contentType);
         verifyMessageContent(mbox, msgId, true, null, 24, true, body, contentType);
     }
-    
+
     private void verifyMessageContent(ZMailbox mbox, String msgId, boolean wantHtml,
                                       Integer requestMaxLength, Integer expectedLength,
                                       boolean expectedTruncated, String body, String contentType)
@@ -117,13 +119,14 @@ public class TestGetMsg{
             Assert.assertEquals(expected, mp.getContent());
         }
     }
+
     @After
     public void tearDown()
     throws Exception {
         cleanUp();
         TestUtil.setServerAttr(Provisioning.A_zimbraMailContentMaxSize, mOriginalContentMaxSize);
     }
-    
+
     private void cleanUp()
     throws Exception {
         TestUtil.deleteAccountIfExists(USER_NAME);

--- a/store/src/java/com/zimbra/qa/unittest/TestStoreManager.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestStoreManager.java
@@ -22,8 +22,13 @@ import javax.mail.internet.MimeMessage;
 import junit.framework.TestCase;
 
 import org.apache.commons.lang.RandomStringUtils;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
+
 
 import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mime.Mime;
@@ -34,9 +39,14 @@ import com.zimbra.cs.store.StagedBlob;
 import com.zimbra.cs.store.StoreManager;
 import com.zimbra.cs.util.JMSession;
 
-public class TestStoreManager extends TestCase {
 
-    private static final String USER_NAME = "user1";
+
+public class TestStoreManager {
+
+    @Rule
+    public TestName testInfo = new TestName();
+    private static String USER_NAME = null;
+    private static final String NAME_PREFIX = TestStoreManager.class.getSimpleName();
 
     public static ParsedMessage getMessage() throws Exception {
         MimeMessage mm = new Mime.FixedMimeMessage(JMSession.getSession());
@@ -47,7 +57,27 @@ public class TestStoreManager extends TestCase {
         mm.setText("nothing to see here" + RandomStringUtils.random(1024));
         return new ParsedMessage(mm, false);
     }
+	
+    @Before
+    public void setUp()
+    throws Exception {
+        String prefix = NAME_PREFIX + "-" + testInfo.getMethodName() + "-";
+        USER_NAME = prefix + "user";
+        cleanUp();
+        TestUtil.createAccount(USER_NAME);
+    }
+	
+    @After
+    public void tearDown()
+    throws Exception {
+        cleanUp();
+    }
 
+    private void cleanUp() 
+	throws Exception{
+        TestUtil.deleteAccountIfExists(USER_NAME);
+    }
+	
     @Test
     public void testStore() throws Exception {
         ParsedMessage pm = getMessage();


### PR DESCRIPTION
zimbra@mail130:/root$ zmsoap -z
RunUnitTestsRequest/test=com.zimbra.qa.unittest.TestGetMsg
<RunUnitTestsResponse numFailed="0" numSkipped="0" numExecuted="3"
xmlns="urn:zimbraAdmin">
<results>
<completed name="testPlainMessageContent"
class="com.zimbra.qa.unittest.TestGetMsg" execSeconds="18.57"/>
<completed name="testHtmlMessageContent"
class="com.zimbra.qa.unittest.TestGetMsg" execSeconds="1.19"/>
<completed name="testEnrichedMessageContent"
class="com.zimbra.qa.unittest.TestGetMsg" execSeconds="0.63"/>
</results>
</RunUnitTestsResponse>
zimbra@mail130:/root$