### PR TITLE
ZMS-228: Various ZSearchParams Methods

### DIFF
--- a/client/src/java/com/zimbra/client/ZIdHit.java
+++ b/client/src/java/com/zimbra/client/ZIdHit.java
@@ -1,0 +1,41 @@
+package com.zimbra.client;
+
+import org.json.JSONException;
+
+import com.zimbra.client.event.ZModifyEvent;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.MailConstants;
+
+public class ZIdHit implements ZSearchHit {
+
+    private String id;
+    private String sortField;
+
+    public ZIdHit(Element e) throws ServiceException {
+        id = e.getAttribute(MailConstants.A_ID);
+        sortField = e.getAttribute(MailConstants.A_SORT_FIELD, null);
+    }
+
+    @Override
+    public ZJSONObject toZJSONObject() throws JSONException {
+        ZJSONObject zjo = new ZJSONObject();
+        zjo.put("id", id);
+        zjo.put("sortField", sortField);
+        return zjo;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public String getSortField() {
+        return sortField;
+    }
+
+    @Override
+    public void modifyNotification(ZModifyEvent event) throws ServiceException {}
+
+}

--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -3711,6 +3711,15 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
         if (params.getInDumpster()) {
             req.addAttribute(MailConstants.A_IN_DUMPSTER, true);
         }
+        if (params.getIncludeTagDeleted()) {
+            req.addAttribute(MailConstants.A_INCLUDE_TAG_DELETED, true);
+        }
+        if (params.getZimbraFetchMode() != null) {
+            req.addAttribute(MailConstants.A_RESULT_MODE, params.getZimbraFetchMode().toString());
+        }
+        if (!params.getPrefetch()) {
+            req.addAttribute(MailConstants.A_PREFETCH, false);
+        }
 
         req.addAttribute(MailConstants.E_QUERY, params.getQuery(), Element.Disposition.CONTENT);
 

--- a/client/src/java/com/zimbra/client/ZSearchParams.java
+++ b/client/src/java/com/zimbra/client/ZSearchParams.java
@@ -18,11 +18,14 @@
 package com.zimbra.client;
 
 
+import java.util.EnumSet;
 import java.util.Set;
 import java.util.TimeZone;
 
 import org.json.JSONException;
 
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
 import com.zimbra.common.mailbox.MailItemType;
 import com.zimbra.common.mailbox.ZimbraFetchMode;
 import com.zimbra.common.mailbox.ZimbraSearchParams;
@@ -159,6 +162,15 @@ public class ZSearchParams implements ToZJSONObject, ZimbraSearchParams {
      */
     private boolean mInDumpster;
 
+    /**
+     * If false, items with the \Deleted tag set are not returned.
+     */
+    private boolean includeTagDeleted = false;
+
+    private ZimbraFetchMode resultMode = ZimbraFetchMode.NORMAL;
+
+    private boolean prefetch = true;
+
     @Override
     public int hashCode() {
         if (mConvId != null)
@@ -219,6 +231,7 @@ public class ZSearchParams implements ToZJSONObject, ZimbraSearchParams {
         this.mCalExpandInstStart = that.mCalExpandInstStart;
         this.mTimeZone = that.mTimeZone;
         this.mInDumpster = that.mInDumpster;
+        this.includeTagDeleted = that.includeTagDeleted;
     }
 
     public ZSearchParams(String query) {
@@ -378,6 +391,7 @@ public class ZSearchParams implements ToZJSONObject, ZimbraSearchParams {
         if (mTimeZone != null) zjo.put("timeZone", mTimeZone.getID());
         if (mCursor != null) zjo.put("cursor", mCursor);
         if (mInDumpster) zjo.put("inDumpster", true);
+        if (includeTagDeleted) zjo.put("includeTagDeleted", true);
         return zjo;
     }
 
@@ -468,12 +482,12 @@ public class ZSearchParams implements ToZJSONObject, ZimbraSearchParams {
 
     @Override
     public boolean getIncludeTagDeleted() {
-        throw new UnsupportedOperationException("ZSearchParams method not supported yet");
+        return includeTagDeleted;
     }
 
     @Override
     public void setIncludeTagDeleted(boolean value) {
-        throw new UnsupportedOperationException("ZSearchParams method not supported yet");
+        includeTagDeleted = value;
     }
 
     @Override
@@ -488,41 +502,53 @@ public class ZSearchParams implements ToZJSONObject, ZimbraSearchParams {
 
     @Override
     public Set<MailItemType> getMailItemTypes() {
-        throw new UnsupportedOperationException("ZSearchParams method not supported yet");
+        Set<MailItemType> result = EnumSet.noneOf(MailItemType.class);
+        for (String token : Splitter.on(',').trimResults().split(mTypes)) {
+            MailItemType type = MailItemType.valueOf(token.toUpperCase());
+            if (type != MailItemType.UNKNOWN) {
+                result.add(type);
+            } else {
+                throw new IllegalArgumentException("cannot specify UNKNOWN mailitem type");
+            }
+        }
+        return result;
     }
 
     @Override
     public ZimbraSearchParams setMailItemTypes(Set<MailItemType> values) {
-        throw new UnsupportedOperationException("ZSearchParams method not supported yet");
+        mTypes = Joiner.on(",").join(values);
+        return this;
     }
 
     @Override
     public ZimbraSortBy getZimbraSortBy() {
-        throw new UnsupportedOperationException("ZSearchParams method not supported yet");
+        return mSortBy == null ? null : mSortBy.toZimbraSortBy();
     }
 
     @Override
     public ZimbraSearchParams setZimbraSortBy(ZimbraSortBy value) {
-        throw new UnsupportedOperationException("ZSearchParams method not supported yet");
+        mSortBy = SearchSortBy.fromZimbraSortBy(value);
+        return this;
     }
 
     @Override
     public ZimbraFetchMode getZimbraFetchMode() {
-        throw new UnsupportedOperationException("ZSearchParams method not supported yet");
+        return resultMode;
     }
 
     @Override
     public ZimbraSearchParams setZimbraFetchMode(ZimbraFetchMode value) {
-        throw new UnsupportedOperationException("ZSearchParams method not supported yet");
+        this.resultMode = value;
+        return this;
     }
 
     @Override
     public boolean getPrefetch() {
-        throw new UnsupportedOperationException("ZSearchParams method not supported yet");
+        return prefetch;
     }
 
     @Override
     public void setPrefetch(boolean value) {
-        throw new UnsupportedOperationException("ZSearchParams method not supported yet");
+        prefetch = value;
     }
 }

--- a/client/src/java/com/zimbra/client/ZSearchResult.java
+++ b/client/src/java/com/zimbra/client/ZSearchResult.java
@@ -17,18 +17,19 @@
 
 package com.zimbra.client;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TimeZone;
+
+import org.json.JSONException;
+
 import com.google.common.base.Objects;
+import com.zimbra.client.event.ZModifyConversationEvent;
+import com.zimbra.client.event.ZModifyEvent;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.MailConstants;
 import com.zimbra.common.soap.VoiceConstants;
-import com.zimbra.client.event.ZModifyConversationEvent;
-import com.zimbra.client.event.ZModifyEvent;
-import org.json.JSONException;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.TimeZone;
 
 public class ZSearchResult implements ToZJSONObject {
 
@@ -81,6 +82,8 @@ public class ZSearchResult implements ToZJSONObject {
                 hits.add(new ZVoiceMailItemHit(h));
             } else if (h.getName().equals(VoiceConstants.E_CALLLOG)) {
                 hits.add(new ZCallHit(h));
+            } else if (h.getName().equals(MailConstants.E_HIT)) {
+                hits.add(new ZIdHit(h));
             }
         }
     }

--- a/common/src/java/com/zimbra/common/soap/MailConstants.java
+++ b/common/src/java/com/zimbra/common/soap/MailConstants.java
@@ -853,6 +853,7 @@ public final class MailConstants {
     public static final String A_WARMUP = "warmup";
     public static final String A_QUICK = "quick";
     public static final String A_SCORE = "score";
+    public static final String E_HIT = "hit";
 
     // search-result paging
     public static final String E_CURSOR = "cursor";

--- a/soap/src/java/com/zimbra/soap/type/SearchSortBy.java
+++ b/soap/src/java/com/zimbra/soap/type/SearchSortBy.java
@@ -21,14 +21,52 @@ import java.util.Arrays;
 
 import javax.xml.bind.annotation.XmlEnum;
 
+import com.zimbra.common.mailbox.ZimbraSortBy;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.zclient.ZClientException;
 
 @XmlEnum
 public enum SearchSortBy {
     // case must match protocol
-    dateDesc, dateAsc, subjDesc, subjAsc, nameDesc, nameAsc, durDesc, durAsc, none,
-    taskDueAsc, taskDueDesc, taskStatusAsc, taskStatusDesc, taskPercCompletedAsc, taskPercCompletedDesc, rcptAsc, rcptDesc;
+    dateDesc(ZimbraSortBy.dateDesc),
+    dateAsc(ZimbraSortBy.dateAsc),
+    subjDesc(ZimbraSortBy.subjDesc),
+    subjAsc(ZimbraSortBy.subjAsc),
+    nameDesc(ZimbraSortBy.nameDesc),
+    nameAsc(ZimbraSortBy.nameAsc),
+    durDesc(ZimbraSortBy.durDesc),
+    durAsc(ZimbraSortBy.durAsc),
+    none(ZimbraSortBy.none),
+    taskDueAsc(ZimbraSortBy.taskDueAsc),
+    taskDueDesc(ZimbraSortBy.taskDueDesc),
+    taskStatusAsc(ZimbraSortBy.taskStatusAsc),
+    taskStatusDesc(ZimbraSortBy.taskStatusDesc),
+    taskPercCompletedAsc(ZimbraSortBy.taskPercCompletedAsc),
+    taskPercCompletedDesc(ZimbraSortBy.taskPercCompletedDesc),
+    rcptAsc(ZimbraSortBy.rcptAsc),
+    rcptDesc(ZimbraSortBy.rcptDesc);
+
+    private ZimbraSortBy zsb;
+
+    private SearchSortBy(ZimbraSortBy zsb) {
+        this.zsb = zsb;
+    }
+
+    public ZimbraSortBy toZimbraSortBy() {
+        return zsb;
+    }
+
+    public static SearchSortBy fromZimbraSortBy(ZimbraSortBy zsb) {
+        if (zsb == null) {
+            return null;
+        }
+        for (SearchSortBy val :SearchSortBy.values()) {
+            if (val.zsb == zsb) {
+                return val;
+            }
+        }
+        throw new IllegalArgumentException("Unrecognised ZimbraSortBy:" + zsb);
+    }
 
     public static SearchSortBy fromString(String s)
     throws ServiceException {

--- a/store/src/java/com/zimbra/cs/service/mail/SearchResponse.java
+++ b/store/src/java/com/zimbra/cs/service/mail/SearchResponse.java
@@ -138,7 +138,7 @@ final class SearchResponse {
      */
     void add(ZimbraHit zimbraHit) throws ServiceException{
 		add(zimbraHit,false);
-		
+
 	}
     /* We need to pass in a boolean signifying whether to expand the message or not (bug 75990)
     */
@@ -147,10 +147,10 @@ final class SearchResponse {
         if (params.getFetchMode() == SearchParams.Fetch.IDS) {
             if (hit instanceof ConversationHit) {
                 // need to expand the contained messages
-                el = element.addElement("hit");
+                el = element.addElement(MailConstants.E_HIT);
                 el.addAttribute(MailConstants.A_ID, ifmt.formatItemId(hit.getParsedItemID()));
             } else {
-                el = element.addElement("hit");
+                el = element.addElement(MailConstants.E_HIT);
                 el.addAttribute(MailConstants.A_ID, ifmt.formatItemId(hit.getParsedItemID()));
             }
         } else if (hit instanceof ProxiedHit) {


### PR DESCRIPTION
Support for five search parameters in ZSearchParams:
- ZMS-229: ZSearchParams::getIncludeTagDeleted/setIncludeTagDeleted
  - implemented the ZSearchParams methods and added support in ZMailbox
  - added TestZClient::testZSearchParamsIncludeTagDeleted unit test

- ZMS-230: ZSearchParams::getMailItemTypes/setMailItemTypes
  - implemented the ZSearchParams methods
  - added TestZClient::testZSearchParamsMailItemTypes unit test

- ZMS-231: ZSearchParams::setZimbraSortBy / getZimbraSortBy
  - implemented the ZSearchParams methods
  - added a mapping between SearchSortBy and ZimbraSortBy enums
  - added TestZClient::testZSearchParamsZimbraSortBy unit test

- ZMS-232: ZSearchParams::setZimbraFetchMode/getZimbraFetchMode
  - implemented the ZSearchParams methods
  - added an E_HIT="hit" constant in MailConstants (SearchResponse class was using raw string)
  - added ZIdHit class to wrap response when resultMode="id" (previously, this fetch mode would result in empty search response)
  - added TestZClient::testZSearchParamsFetchMode unit test

- ZMS-233: ZSearchParams::setPrefetch/getPrefetch
  - implemented the ZSearchParams methods and added support in ZMailbox
  - no SOAP test, since "prefetch" is an optimization parameter that does not result in any change in the SearchResponse
