### PR TITLE
bugfix/ZCS-1130 TestSoapHarvest

### DIFF
--- a/store/src/java/com/zimbra/qa/unittest/TestSoapHarvest.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestSoapHarvest.java
@@ -18,9 +18,7 @@
 package com.zimbra.qa.unittest;
 
 import java.io.IOException;
-
 import junit.framework.TestCase;
-
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpException;
 import org.apache.commons.httpclient.methods.PostMethod;
@@ -31,7 +29,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
-
 import com.zimbra.client.ZMailbox;
 import com.zimbra.common.account.Key.AccountBy;
 import com.zimbra.common.httpclient.HttpClientUtil;
@@ -39,7 +36,6 @@ import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.Provisioning;
 
 public class TestSoapHarvest {
-
     @Rule
     public TestName testInfo = new TestName();
     private static String AUTH_USER_NAME = null;
@@ -104,11 +100,11 @@ public class TestSoapHarvest {
         "</soap:Body>"+
         "</soap:Envelope>";
     }
-
+	
     private String sendReq(String userId, String authToken, int expectedCode, boolean useGetInfoReq) throws HttpException, IOException {
         return sendReq(userId, authToken, expectedCode, useGetInfoReq, false);
     }
-
+	
     private String sendReq(String userId, String authToken, int expectedCode, boolean useGetInfoReq, boolean byAccountId) throws HttpException, IOException {
         HttpClient client = new HttpClient();
         PostMethod method = new PostMethod(TestUtil.getSoapUrl() + (useGetInfoReq ? "GetInfoRequest" : "NoOpRequest"));
@@ -123,12 +119,9 @@ public class TestSoapHarvest {
         ZMailbox mbox = TestUtil.getZMailbox(AUTH_USER_NAME);
         //make sure user1 exists
         Assert.assertNotNull(mbox);
-
         String response = sendReq(AUTH_USER_NAME, null, 500, false);
         Assert.assertTrue(response.indexOf("<Code>service.AUTH_REQUIRED</Code>") > -1);
         Assert.assertTrue(response.indexOf("<soap:Text>no valid authtoken present</soap:Text>") > -1);
-
-
         //now with non-existing account
         String bogusUserId = "bogus";
         try {
@@ -137,11 +130,9 @@ public class TestSoapHarvest {
         } catch (Exception e) {
             //expected
         }
-
         response = sendReq(bogusUserId, null, 500, false);
         Assert.assertTrue(response.indexOf("<Code>service.AUTH_REQUIRED</Code>") > -1);
         Assert.assertTrue(response.indexOf("<soap:Text>no valid authtoken present</soap:Text>") > -1);
-
     }
 	
     @Test
@@ -150,29 +141,24 @@ public class TestSoapHarvest {
         ZMailbox mbox = TestUtil.getZMailbox(AUTH_USER_NAME);
         //make sure user1 exists
         Assert.assertNotNull(mbox);
-
         String authToken = mbox.getAuthToken().getValue();
         String response = sendReq(AUTH_USER_NAME, authToken, 200, true);
         //make sure auth token works for normal request
-
         String userId = TARGET_USER_NAME;
         mbox = TestUtil.getZMailbox(userId);
         //make sure TARGET_USER_NAME exists
         Assert.assertNotNull(mbox);
-
         //note this fails if you've shared anything from TARGET_USER_NAME to user1. works fine in clean setup
         response = sendReq(userId, authToken, 500, true);
         Assert.assertTrue(response.indexOf("<Code>service.PERM_DENIED</Code>") > -1);
         Assert.assertTrue(response.indexOf("<soap:Text>permission denied: can not access account") > -1);
         //make sure we're not returning account id
         Assert.assertTrue(!response.contains(Provisioning.getInstance().get(AccountBy.name, userId).getId()));
-
         response = sendReq(userId, authToken, 500, false);
         Assert.assertTrue(response.indexOf("<Code>service.PERM_DENIED</Code>") > -1);
         Assert.assertTrue(response.indexOf("<soap:Text>permission denied: can not access account") > -1);
         //make sure we're not returning account id
         Assert.assertTrue(!response.contains(Provisioning.getInstance().get(AccountBy.name, userId).getId()));
-
         //make sure bogus does *not* exist
         userId = "bogus";
         try {
@@ -181,7 +167,6 @@ public class TestSoapHarvest {
         } catch (Exception e) {
             //expected
         }
-
         response = sendReq(userId, authToken, 500, true);
         Assert.assertTrue(response.indexOf("<Code>service.PERM_DENIED</Code>") > -1);
         Assert.assertTrue(response.indexOf("<soap:Text>permission denied: can not access account") > -1);
@@ -193,14 +178,12 @@ public class TestSoapHarvest {
         String authToken = mbox.getAuthToken().getValue();
         String userId = TARGET_USER_NAME;
         Account account = Provisioning.getInstance().get(AccountBy.name, userId);
-
         //note this fails if you've shared anything from TARGET_USER_NAME to user1. works fine in clean setup
         String response = sendReq(userId, authToken, 500, true, false);
         Assert.assertTrue(response.indexOf("<Code>service.PERM_DENIED</Code>") > -1);
         Assert.assertTrue(response.indexOf("<soap:Text>permission denied: can not access account") > -1);
         //make sure we're not returning account id
         Assert.assertTrue(!response.contains(account.getId()));
-
         response = sendReq(account.getId(), authToken, 500, true, true);
         Assert.assertTrue(response.indexOf("<Code>service.PERM_DENIED</Code>") > -1);
         Assert.assertTrue(response.indexOf("<soap:Text>permission denied: can not access account") > -1);
@@ -214,29 +197,24 @@ public class TestSoapHarvest {
         ZMailbox mbox = TestUtil.getZMailbox(AUTH_USER_NAME);
         //make sure user1 exists
         Assert.assertNotNull(mbox);
-
         String authToken = mbox.getAuthToken().getValue();
         String response = sendReq(AUTH_USER_NAME, authToken, 200, false);
         //make sure auth token works for normal request
-
         String userId = TARGET_USER_NAME;
         mbox = TestUtil.getZMailbox(userId);
         //make sure TARGET_USER_NAME exists
         Assert.assertNotNull(mbox);
-
         //note this fails if you've shared anything from TARGET_USER_NAME to user1.
         response = sendReq(userId, authToken, 500, true);
         Assert.assertTrue(response.indexOf("<Code>service.PERM_DENIED</Code>") > -1);
         Assert.assertTrue(response.indexOf("<soap:Text>permission denied: can not access account") > -1);
         //make sure we're not returning account id
         Assert.assertTrue(!response.contains(Provisioning.getInstance().get(AccountBy.name, userId).getId()));
-
         response = sendReq(userId, authToken, 500, false);
         Assert.assertTrue(response.indexOf("<Code>service.PERM_DENIED</Code>") > -1);
         Assert.assertTrue(response.indexOf("<soap:Text>permission denied: can not access account") > -1);
         //make sure we're not returning account id
         Assert.assertTrue(!response.contains(Provisioning.getInstance().get(AccountBy.name, userId).getId()));
-
         //make sure bogus does *not* exist
         userId = "bogus";
         try {
@@ -245,7 +223,6 @@ public class TestSoapHarvest {
         } catch (Exception e) {
             //expected
         }
-
         response = sendReq(userId, authToken, 500, false);
         Assert.assertTrue(response.indexOf("<Code>service.PERM_DENIED</Code>") > -1);
         Assert.assertTrue(response.indexOf("<soap:Text>permission denied: can not access account") > -1);
@@ -255,28 +232,23 @@ public class TestSoapHarvest {
     public void testAdminDelegation() throws Exception {
         //admin account non-admin auth token; effectively no rights
         ZMailbox mbox = TestUtil.getZMailbox("admin");
-
         String authToken = mbox.getAuthToken().getValue();
         String response = sendReq("admin", authToken, 200, false);
-
         String userId = TARGET_USER_NAME;
         mbox = TestUtil.getZMailbox(userId);
         //make sure TARGET_USER_NAME exists
         Assert.assertNotNull(mbox);
-
         //send both NoOp and GetInfo; neither should work here
         response = sendReq(userId, authToken, 500, true);
         Assert.assertTrue(response.indexOf("<Code>service.PERM_DENIED</Code>") > -1);
         Assert.assertTrue(response.indexOf("<soap:Text>permission denied: can not access account") > -1);
         //make sure we're not returning account id
         Assert.assertTrue(!response.contains(Provisioning.getInstance().get(AccountBy.name, userId).getId()));
-
         response = sendReq(userId, authToken, 500, false);
         Assert.assertTrue(response.indexOf("<Code>service.PERM_DENIED</Code>") > -1);
         Assert.assertTrue(response.indexOf("<soap:Text>permission denied: can not access account") > -1);
         //make sure we're not returning account id
         Assert.assertTrue(!response.contains(Provisioning.getInstance().get(AccountBy.name, userId).getId()));
-
         //make sure bogus does *not* exist
         userId = "bogus";
         try {
@@ -285,7 +257,6 @@ public class TestSoapHarvest {
         } catch (Exception e) {
             //expected
         }
-
         response = sendReq(userId, authToken, 500, false);
         Assert.assertTrue(response.indexOf("<Code>service.PERM_DENIED</Code>") > -1);
         Assert.assertTrue(response.indexOf("<soap:Text>permission denied: can not access account") > -1);
@@ -295,20 +266,16 @@ public class TestSoapHarvest {
     public void testAdminAuthToken() throws Exception {
         //admin account admin auth token
         ZMailbox mbox = TestUtil.getZMailboxAsAdmin("admin");
-
         String authToken = mbox.getAuthToken().getValue();
         String response = sendReq("admin", authToken, 200, false);
         //make sure auth token works for normal request
-
         String userId = TARGET_USER_NAME;
         mbox = TestUtil.getZMailbox(userId);
         //make sure TARGET_USER_NAME exists
         Assert.assertNotNull(mbox);
-
         //send both NoOp and GetInfo; both should work for admin
         response = sendReq(userId, authToken, 200, false);
         response = sendReq(userId, authToken, 200, true);
-
         //make sure bogus does *not* exist
         userId = "bogus";
         try {
@@ -317,10 +284,8 @@ public class TestSoapHarvest {
         } catch (Exception e) {
             //expected
         }
-
         response = sendReq(userId, authToken, 500, false);
         //admin is correctly allowed to receive NO_SUCH_ACCOUNT
         Assert.assertTrue(response.indexOf("<Code>account.NO_SUCH_ACCOUNT</Code>") > -1);
     }
-		
 }

--- a/store/src/java/com/zimbra/qa/unittest/TestSoapHarvest.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestSoapHarvest.java
@@ -18,7 +18,7 @@
 package com.zimbra.qa.unittest;
 
 import java.io.IOException;
-import junit.framework.TestCase;
+
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpException;
 import org.apache.commons.httpclient.methods.PostMethod;
@@ -29,6 +29,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+
 import com.zimbra.client.ZMailbox;
 import com.zimbra.common.account.Key.AccountBy;
 import com.zimbra.common.httpclient.HttpClientUtil;
@@ -57,7 +58,7 @@ public class TestSoapHarvest {
         cleanUp();
     }
 
-	private void cleanUp() throws Exception{
+    private void cleanUp() throws Exception{
         TestUtil.deleteAccountIfExists(AUTH_USER_NAME);
         TestUtil.deleteAccountIfExists(TARGET_USER_NAME);
     }

--- a/store/src/java/com/zimbra/qa/unittest/TestSoapHarvest.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestSoapHarvest.java
@@ -43,8 +43,7 @@ public class TestSoapHarvest {
     private static final String NAME_PREFIX = TestSoapHarvest.class.getSimpleName();
 
     @Before
-    public void setUp()
-    throws Exception {
+    public void setUp() throws Exception {
         String prefix = NAME_PREFIX + "-" + testInfo.getMethodName() + "-";
         AUTH_USER_NAME = prefix + "user1";
         TARGET_USER_NAME = prefix + "user3";
@@ -52,15 +51,13 @@ public class TestSoapHarvest {
         TestUtil.createAccount(AUTH_USER_NAME);
         TestUtil.createAccount(TARGET_USER_NAME);
     }
-	
+
     @After
-    public void tearDown()
-    throws Exception {
+    public void tearDown() throws Exception {
         cleanUp();
     }
 
-	private void cleanUp() 
-	throws Exception{
+	private void cleanUp() throws Exception{
         TestUtil.deleteAccountIfExists(AUTH_USER_NAME);
         TestUtil.deleteAccountIfExists(TARGET_USER_NAME);
     }
@@ -100,11 +97,11 @@ public class TestSoapHarvest {
         "</soap:Body>"+
         "</soap:Envelope>";
     }
-	
+
     private String sendReq(String userId, String authToken, int expectedCode, boolean useGetInfoReq) throws HttpException, IOException {
         return sendReq(userId, authToken, expectedCode, useGetInfoReq, false);
     }
-	
+
     private String sendReq(String userId, String authToken, int expectedCode, boolean useGetInfoReq, boolean byAccountId) throws HttpException, IOException {
         HttpClient client = new HttpClient();
         PostMethod method = new PostMethod(TestUtil.getSoapUrl() + (useGetInfoReq ? "GetInfoRequest" : "NoOpRequest"));
@@ -113,7 +110,7 @@ public class TestSoapHarvest {
         Assert.assertEquals(expectedCode, respCode);
         return method.getResponseBodyAsString();
     }
-	
+
     @Test
     public void testHarvestNoAuth() throws Exception {
         ZMailbox mbox = TestUtil.getZMailbox(AUTH_USER_NAME);
@@ -134,7 +131,7 @@ public class TestSoapHarvest {
         Assert.assertTrue(response.indexOf("<Code>service.AUTH_REQUIRED</Code>") > -1);
         Assert.assertTrue(response.indexOf("<soap:Text>no valid authtoken present</soap:Text>") > -1);
     }
-	
+
     @Test
     public void testHarvestDelegated() throws Exception {
         //test an operation that implements delegation
@@ -171,7 +168,7 @@ public class TestSoapHarvest {
         Assert.assertTrue(response.indexOf("<Code>service.PERM_DENIED</Code>") > -1);
         Assert.assertTrue(response.indexOf("<soap:Text>permission denied: can not access account") > -1);
     }
-	
+
     @Test
     public void testErrorResponses() throws Exception {
         ZMailbox mbox = TestUtil.getZMailbox(AUTH_USER_NAME);


### PR DESCRIPTION
zimbra@mail130:/root$ zmsoap -z
RunUnitTestsRequest/test=com.zimbra.qa.unittest.TestSoapHarvest
<RunUnitTestsResponse numFailed="0" numSkipped="0" numExecuted="6"
xmlns="urn:zimbraAdmin">
<results>
<completed name="testHarvestNoAuth"
class="com.zimbra.qa.unittest.TestSoapHarvest" execSeconds="1.97"/>
<completed name="testHarvestDelegated"
class="com.zimbra.qa.unittest.TestSoapHarvest" execSeconds="1.33"/>
<completed name="testErrorResponses"
class="com.zimbra.qa.unittest.TestSoapHarvest" execSeconds="0.43"/>
<completed name="testHarvestDelegatedNoOp"
class="com.zimbra.qa.unittest.TestSoapHarvest" execSeconds="1.23"/>
<completed name="testAdminDelegation"
class="com.zimbra.qa.unittest.TestSoapHarvest" execSeconds="0.82"/>
<completed name="testAdminAuthToken"
class="com.zimbra.qa.unittest.TestSoapHarvest" execSeconds="0.42"/>
</results>
</RunUnitTestsResponse>