### PR TITLE
Feature/zms 346

### DIFF
--- a/store/src/java/com/zimbra/cs/imap/ImapHandler.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapHandler.java
@@ -1039,7 +1039,7 @@ public abstract class ImapHandler {
     }
 
     boolean canContinue(ServiceException e) {
-        return e.getCode().equals(MailServiceException.MAINTENANCE) ? false : true;
+        return e.getCode().equals(MailServiceException.MAINTENANCE) || e.getCode().equals(ServiceException.TEMPORARILY_UNAVAILABLE) ? false : true;
     }
 
     OperationContext getContext() throws ServiceException {

--- a/store/src/java/com/zimbra/cs/imap/ImapPath.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapPath.java
@@ -560,6 +560,10 @@ public class ImapPath implements Comparable<ImapPath> {
 
     boolean isVisible() throws ServiceException {
         boolean isMailFolders = Provisioning.getInstance().getLocalServer().isImapDisplayMailFoldersOnly();
+        if(folder == null) {
+            ZimbraLog.imap.error("ImapFolderStore is null. This session was likely terminated.");
+            throw ServiceException.TEMPORARILY_UNAVAILABLE();
+        }
         // check the folder type before hitting a remote server if it's a mountpoint
         if (!(folder.isVisibleInImap(isMailFolders))) {
             return false;

--- a/store/src/java/com/zimbra/cs/imap/ImapServerListener.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapServerListener.java
@@ -25,18 +25,21 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.commons.httpclient.HttpStatus;
 import org.apache.http.HttpResponse;
 import org.apache.http.concurrent.FutureCallback;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.SoapFaultException;
 import com.zimbra.common.soap.SoapProtocol;
 import com.zimbra.common.soap.W3cDomUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.soap.SoapProvisioning;
 import com.zimbra.cs.httpclient.URLUtil;
+import com.zimbra.cs.service.admin.AdminServiceException;
 import com.zimbra.cs.session.PendingRemoteModifications;
 import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.admin.message.AdminCreateWaitSetRequest;
@@ -148,7 +151,49 @@ public class ImapServerListener {
         return lastSequence.intValue();
     }
 
-    private void initWaitSet(String accountId, boolean alreadyListening) throws ServiceException {
+    private synchronized void restoreWaitSet() throws ServiceException {
+        ZimbraLog.imap.debug("Attempting to restore admin waitset for all registered listeners.");
+        if(wsID != null) {
+            ZimbraLog.imap.debug("Another thread has already restored waitset.");
+            return; //another thread has already restored waitset
+        }
+        cancelPendingRequest();
+        AdminCreateWaitSetRequest req = new AdminCreateWaitSetRequest("all", false);
+        checkAuth();
+        AdminCreateWaitSetResponse resp;
+        resp = soapProv.invokeJaxbAsAdminWithRetry(req, server);
+        if(resp == null) {
+            throw ServiceException.FAILURE("Received null response from AdminCreateWaitSetRequest", null);
+        }
+        wsID = resp.getWaitSetId();
+        lastSequence.set(resp.getSequence());
+        ZimbraLog.imap.debug("Created new waitset to replace lost or cancelled one. WaitSet ID: %s", wsID);
+        //send non-blocking synchronous WaitSetRequest. This way the caller has certainty that listeners were added on remote server
+        AdminWaitSetRequest waitSetReq = new AdminWaitSetRequest(wsID, lastSequence.toString());
+        waitSetReq.setBlock(false);
+        waitSetReq.setExpand(true);
+        Enumeration<String> accountIds = this.sessionMap.keys();
+        while(accountIds.hasMoreElements()) {
+            String accountId = accountIds.nextElement();
+            WaitSetAddSpec updateOrAdd = new WaitSetAddSpec();
+            updateOrAdd.setId(accountId);
+            Enumeration<Integer> folderIDs = this.sessionMap.get(accountId).keys();
+            while(folderIDs.hasMoreElements()) {
+                updateOrAdd.addFolderInterest(folderIDs.nextElement());
+                ZimbraLog.imap.debug("Adding account %s to waitset %s", accountId, wsID);
+                waitSetReq.addAddAccount(updateOrAdd);
+            }
+        }
+        ZimbraLog.imap.debug("Sending initial AdminWaitSetRequest. WaitSet ID: %s", wsID);
+        AdminWaitSetResponse wsResp = soapProv.invokeJaxbAsAdminWithRetry(waitSetReq, server);
+        try {
+            processAdminWaitSetResponse(wsResp);
+        } catch (Exception e) {
+            throw ServiceException.FAILURE("Failed to process initial AdminWaitSetResponse", e);
+        }
+    }
+
+    private synchronized void initWaitSet(String accountId, boolean alreadyListening) throws ServiceException {
         if(wsID == null && this.sessionMap.containsKey(accountId)) {
             AdminCreateWaitSetRequest req = new AdminCreateWaitSetRequest("all", false);
             checkAuth();
@@ -189,7 +234,6 @@ public class ImapServerListener {
         AdminWaitSetResponse wsResp = soapProv.invokeJaxbAsAdminWithRetry(waitSetReq, server);
         try {
             processAdminWaitSetResponse(wsResp);
-            continueWaitSet();
         } catch (Exception e) {
             throw ServiceException.FAILURE("Failed to process initial AdminWaitSetResponse", e);
         }
@@ -203,7 +247,15 @@ public class ImapServerListener {
             checkAuth();
             try {
                 synchronized(soapProv) {
-                    soapProv.invokeJaxbAsAdminWithRetry(req);
+                    try {
+                        soapProv.invokeJaxbAsAdminWithRetry(req);
+                    } catch (SoapFaultException ex) {
+                        if(AdminServiceException.NO_SUCH_WAITSET.equalsIgnoreCase(ex.getCode())) {
+                            ZimbraLog.imap.debug("Caught NO_SUCH_WAITSET exception trying to delete a waitset. Waitset may have been deleted by sweeper. Ignoring.");
+                        }
+                    } catch (ServiceException e) {
+                        ZimbraLog.imap.error("Caught unexpected exception trying to delete a waitset.", e);
+                    }
                 }
             } finally {
                 wsID = null;
@@ -255,10 +307,9 @@ public class ImapServerListener {
         }
         if(wsResp.getCanceled() != null && wsResp.getCanceled().booleanValue() && wsID.equalsIgnoreCase(respWSId)) {
             //this waitset was canceled
-            //TODO: figure out what to do with listeners if they are still registered
-            wsID = null;
-            lastSequence.set(0);
-            ZimbraLog.imap.debug("AdminWaitSet %s was canceled", respWSId);
+            ZimbraLog.imap.warn("AdminWaitSet %s was cancelled", respWSId);
+            deleteWaitSet();
+            restoreWaitSet();
         } else {
             String seqNum = wsResp.getSeqNo();
             int modSeq = 0;
@@ -289,13 +340,14 @@ public class ImapServerListener {
                     }
                 }
             }
+            continueWaitSet();
         }
     }
     private final FutureCallback<HttpResponse> cb = new FutureCallback<HttpResponse>() {
         @Override
         public void completed(final HttpResponse response) {
             int respCode = response.getStatusLine().getStatusCode();
-            if(respCode == 200) {
+            if(respCode == HttpStatus.SC_OK) {
                 Element envelope;
                 try {
                     envelope = W3cDomUtil.parseXML(response.getEntity().getContent());
@@ -306,15 +358,41 @@ public class ImapServerListener {
                 } catch (Exception e) {
                     ZimbraLog.imap.error("Exception thrown while handling WaitSetResponse. ", e);
                 }
+            } else if (respCode == HttpStatus.SC_INTERNAL_SERVER_ERROR){
+                Element envelope;
+                try {
+                    envelope = W3cDomUtil.parseXML(response.getEntity().getContent());
+                    SoapProtocol proto = SoapProtocol.determineProtocol(envelope);
+                    if(proto.hasFault(envelope)) {
+                        Element doc = proto.getBodyElement(envelope);
+                        if(proto.isFault(doc)) {
+                            SoapFaultException ex = proto.soapFault(doc);
+                            if(AdminServiceException.NO_SUCH_WAITSET.equalsIgnoreCase(ex.getCode())) {
+                                //waitset is gone. Create a new one
+                                ZimbraLog.imap.warn("AdminWaitSet %s does not exist anymore", wsID);
+                                wsID = null;
+                                lastSequence.set(0);
+                                restoreWaitSet();
+                            }
+                        }
+                    } else {
+                        ZimbraLog.imap.error("Mailbox server returned error 500 w/o a SOAP exception. %s", envelope);
+                        //TODO: figure out what to do with listeners. Drop IMAP sessions?
+                    }
+                } catch (Exception e) {
+                    ZimbraLog.imap.error("Exception thrown while handling WaitSetResponse. ", e);
+                    //TODO: figure out what to do with listeners. Drop IMAP sessions?
+                }
             } else {
                 ZimbraLog.imap.error("WaitSetRequest failed with response code %d ", respCode);
+                //TODO: figure out what to do with listeners. Drop IMAP sessions?
             }
-            continueWaitSet();
         }
 
         @Override
         public void failed(final Exception ex) {
             ZimbraLog.imap.error("WaitSetRequest failed ", ex);
+            //TODO: figure out what to do with listeners. Drop IMAP sessions?
         }
 
         @Override

--- a/store/src/java/com/zimbra/qa/unittest/TestImapServerListener.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestImapServerListener.java
@@ -515,7 +515,6 @@ public class TestImapServerListener {
         assertNull("Should not have a waitset after shutting down ImapServerListener", remoteListener.getWSId());
     }
 
-    //TODO: when I run this test several times consequently, it sometimes fails to add folder interests possibly because of session sweeper.
     @Test
     public void testRemoveFolderInterest() throws Exception {
         Assume.assumeNotNull(remoteServer);
@@ -640,7 +639,6 @@ public class TestImapServerListener {
         public CountDownLatch doneSignal;
         MockImapListener(ImapMailboxStore store, ImapFolder i4folder, ImapHandler handler) throws ServiceException {
             super(store, i4folder, handler);
-            // TODO Auto-generated constructor stub
         }
 
         public boolean wasTriggered() {


### PR DESCRIPTION
In addition to new SOAP tests, I've also tested remote IMAP server with apple mail. When mailbox server gets disconnected (tried ifdown/ifup on mailbox server), remote IMAP is able to continue communication after mailbox server connects back. When mailboxd on mailbox server restarts, remote IMAP recreates waitsets. When mailbox server stops responding, remote IMAP drops IMAP sessions for users on the non-responding mailbox server. When mailbox server comes back up, apple mail sends an AUTHENTICATE request and communication between IMAP client and IMAP server gets restored.