### PR TITLE
ZCS-1248 : add attribute which was there in 877 and deprecate it as it is not used anymore. corrected deprecateDesc for one of the attributes

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -3053,6 +3053,17 @@ public class ZAttrProvisioning {
     public static final String A_zimbraAdminSavedSearches = "zimbraAdminSavedSearches";
 
     /**
+     * Deprecated since: 8.7.8. deprecated as this attribute is not used
+     * anymore and variable feature is availabe to use for all.. Orig desc:
+     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
+     * RFC 5229 in the admin-defined sieve rules.
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2098)
+    public static final String A_zimbraAdminSieveFeatureVariablesEnabled = "zimbraAdminSieveFeatureVariablesEnabled";
+
+    /**
      * sieve script defined by admin (not able to edit and view from the end
      * user) applied after the end user filter rule
      *
@@ -15314,10 +15325,10 @@ public class ZAttrProvisioning {
     public static final String A_zimbraShortTermGranteeCacheSize = "zimbraShortTermGranteeCacheSize";
 
     /**
-     * Deprecated since: 8.7.8. deprecated in favor of
-     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
-     * desc: Whether to enable the Sieve &quot;Variables&quot; extension
-     * defined in RFC 5229 in the user-defined sieve rule.
+     * Deprecated since: 8.7.8. deprecated as this attribute is not used
+     * anymore and variable feature is availabe to use for all.. Orig desc:
+     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
+     * RFC 5229 in the user-defined sieve rule.
      *
      * @since ZCS 8.7.6
      */

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -3053,10 +3053,10 @@ public class ZAttrProvisioning {
     public static final String A_zimbraAdminSavedSearches = "zimbraAdminSavedSearches";
 
     /**
-     * Deprecated since: 8.7.8. deprecated as this attribute is not used
-     * anymore and variable feature is availabe to use for all.. Orig desc:
-     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
-     * RFC 5229 in the admin-defined sieve rules.
+     * Deprecated since: 8.7.8. Variable feature is always enabled, hence
+     * this attribute has been deprecated. Orig desc: Whether to enable the
+     * Sieve &quot;Variables&quot; extension defined in RFC 5229 in the
+     * admin-defined sieve rules.
      *
      * @since ZCS 8.7.6
      */
@@ -15325,10 +15325,10 @@ public class ZAttrProvisioning {
     public static final String A_zimbraShortTermGranteeCacheSize = "zimbraShortTermGranteeCacheSize";
 
     /**
-     * Deprecated since: 8.7.8. deprecated as this attribute is not used
-     * anymore and variable feature is availabe to use for all.. Orig desc:
-     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
-     * RFC 5229 in the user-defined sieve rule.
+     * Deprecated since: 8.7.8. Variable feature is always enabled, hence
+     * this attribute has been deprecated. Orig desc: Whether to enable the
+     * Sieve &quot;Variables&quot; extension defined in RFC 5229 in the
+     * user-defined sieve rule.
      *
      * @since ZCS 8.7.6
      */

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9262,12 +9262,18 @@ TODO: delete them permanently from here
 <attr id="2096" name="zimbraSieveFeatureVariablesEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mailbox" since="8.7.6" deprecatedSince="8.7.8">
   <globalConfigValue>FALSE</globalConfigValue>
   <desc>Whether to enable the Sieve "Variables" extension defined in RFC 5229 in the user-defined sieve rule.</desc>
-  <deprecateDesc>deprecated in favor of zimbraSieveRejectMailEnabled, which can be used at account level</deprecateDesc>
+  <deprecateDesc>deprecated as this attribute is not used anymore and variable feature is availabe to use for all.</deprecateDesc>
 </attr>
 
 <attr id="2097" name="zimbraGalSyncSizeLimit" type="integer" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited" since="8.7.2">
   <globalConfigValue>30000</globalConfigValue>
   <desc>Page size control for SyncGalRequest. By default not more than 30000 entries will be returned for every SyncGalRequest</desc>
+</attr>
+
+<attr id="2098" name="zimbraAdminSieveFeatureVariablesEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mailbox" since="8.7.6" deprecatedSince="8.7.8">
+  <globalConfigValue>TRUE</globalConfigValue>
+  <desc>Whether to enable the Sieve "Variables" extension defined in RFC 5229 in the admin-defined sieve rules.</desc>
+  <deprecateDesc>deprecated as this attribute is not used anymore and variable feature is availabe to use for all.</deprecateDesc>
 </attr>
 
 <attr id="2099" name="zimbraSmimeUserCertificateExtensions" type="string" cardinality="multi" optionalIn="globalConfig" flags="accountInfo" since="8.7.5">

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9262,7 +9262,7 @@ TODO: delete them permanently from here
 <attr id="2096" name="zimbraSieveFeatureVariablesEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mailbox" since="8.7.6" deprecatedSince="8.7.8">
   <globalConfigValue>FALSE</globalConfigValue>
   <desc>Whether to enable the Sieve "Variables" extension defined in RFC 5229 in the user-defined sieve rule.</desc>
-  <deprecateDesc>deprecated as this attribute is not used anymore and variable feature is availabe to use for all.</deprecateDesc>
+  <deprecateDesc>Variable feature is always enabled, hence this attribute has been deprecated</deprecateDesc>
 </attr>
 
 <attr id="2097" name="zimbraGalSyncSizeLimit" type="integer" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited" since="8.7.2">
@@ -9273,7 +9273,7 @@ TODO: delete them permanently from here
 <attr id="2098" name="zimbraAdminSieveFeatureVariablesEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mailbox" since="8.7.6" deprecatedSince="8.7.8">
   <globalConfigValue>TRUE</globalConfigValue>
   <desc>Whether to enable the Sieve "Variables" extension defined in RFC 5229 in the admin-defined sieve rules.</desc>
-  <deprecateDesc>deprecated as this attribute is not used anymore and variable feature is availabe to use for all.</deprecateDesc>
+  <deprecateDesc>Variable feature is always enabled, hence this attribute has been deprecated</deprecateDesc>
 </attr>
 
 <attr id="2099" name="zimbraSmimeUserCertificateExtensions" type="string" cardinality="multi" optionalIn="globalConfig" flags="accountInfo" since="8.7.5">

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -2074,6 +2074,93 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Deprecated since: 8.7.8. deprecated as this attribute is not used
+     * anymore and variable feature is availabe to use for all.. Orig desc:
+     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
+     * RFC 5229 in the admin-defined sieve rules.
+     *
+     * @return zimbraAdminSieveFeatureVariablesEnabled, or true if unset
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2098)
+    public boolean isAdminSieveFeatureVariablesEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraAdminSieveFeatureVariablesEnabled, true, true);
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated as this attribute is not used
+     * anymore and variable feature is availabe to use for all.. Orig desc:
+     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
+     * RFC 5229 in the admin-defined sieve rules.
+     *
+     * @param zimbraAdminSieveFeatureVariablesEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2098)
+    public void setAdminSieveFeatureVariablesEnabled(boolean zimbraAdminSieveFeatureVariablesEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveFeatureVariablesEnabled, zimbraAdminSieveFeatureVariablesEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated as this attribute is not used
+     * anymore and variable feature is availabe to use for all.. Orig desc:
+     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
+     * RFC 5229 in the admin-defined sieve rules.
+     *
+     * @param zimbraAdminSieveFeatureVariablesEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2098)
+    public Map<String,Object> setAdminSieveFeatureVariablesEnabled(boolean zimbraAdminSieveFeatureVariablesEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveFeatureVariablesEnabled, zimbraAdminSieveFeatureVariablesEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated as this attribute is not used
+     * anymore and variable feature is availabe to use for all.. Orig desc:
+     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
+     * RFC 5229 in the admin-defined sieve rules.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2098)
+    public void unsetAdminSieveFeatureVariablesEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveFeatureVariablesEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated as this attribute is not used
+     * anymore and variable feature is availabe to use for all.. Orig desc:
+     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
+     * RFC 5229 in the admin-defined sieve rules.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2098)
+    public Map<String,Object> unsetAdminSieveFeatureVariablesEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveFeatureVariablesEnabled, "");
+        return attrs;
+    }
+
+    /**
      * URL prefix for where the zimbraAdmin app resides on this server
      *
      * @return zimbraAdminURL, or "/zimbraAdmin" if unset
@@ -65301,10 +65388,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Deprecated since: 8.7.8. deprecated in favor of
-     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
-     * desc: Whether to enable the Sieve &quot;Variables&quot; extension
-     * defined in RFC 5229 in the user-defined sieve rule.
+     * Deprecated since: 8.7.8. deprecated as this attribute is not used
+     * anymore and variable feature is availabe to use for all.. Orig desc:
+     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
+     * RFC 5229 in the user-defined sieve rule.
      *
      * @return zimbraSieveFeatureVariablesEnabled, or false if unset
      *
@@ -65316,10 +65403,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Deprecated since: 8.7.8. deprecated in favor of
-     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
-     * desc: Whether to enable the Sieve &quot;Variables&quot; extension
-     * defined in RFC 5229 in the user-defined sieve rule.
+     * Deprecated since: 8.7.8. deprecated as this attribute is not used
+     * anymore and variable feature is availabe to use for all.. Orig desc:
+     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
+     * RFC 5229 in the user-defined sieve rule.
      *
      * @param zimbraSieveFeatureVariablesEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -65334,10 +65421,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Deprecated since: 8.7.8. deprecated in favor of
-     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
-     * desc: Whether to enable the Sieve &quot;Variables&quot; extension
-     * defined in RFC 5229 in the user-defined sieve rule.
+     * Deprecated since: 8.7.8. deprecated as this attribute is not used
+     * anymore and variable feature is availabe to use for all.. Orig desc:
+     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
+     * RFC 5229 in the user-defined sieve rule.
      *
      * @param zimbraSieveFeatureVariablesEnabled new value
      * @param attrs existing map to populate, or null to create a new map
@@ -65353,10 +65440,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Deprecated since: 8.7.8. deprecated in favor of
-     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
-     * desc: Whether to enable the Sieve &quot;Variables&quot; extension
-     * defined in RFC 5229 in the user-defined sieve rule.
+     * Deprecated since: 8.7.8. deprecated as this attribute is not used
+     * anymore and variable feature is availabe to use for all.. Orig desc:
+     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
+     * RFC 5229 in the user-defined sieve rule.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -65370,10 +65457,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Deprecated since: 8.7.8. deprecated in favor of
-     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
-     * desc: Whether to enable the Sieve &quot;Variables&quot; extension
-     * defined in RFC 5229 in the user-defined sieve rule.
+     * Deprecated since: 8.7.8. deprecated as this attribute is not used
+     * anymore and variable feature is availabe to use for all.. Orig desc:
+     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
+     * RFC 5229 in the user-defined sieve rule.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -2074,10 +2074,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Deprecated since: 8.7.8. deprecated as this attribute is not used
-     * anymore and variable feature is availabe to use for all.. Orig desc:
-     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
-     * RFC 5229 in the admin-defined sieve rules.
+     * Deprecated since: 8.7.8. Variable feature is always enabled, hence
+     * this attribute has been deprecated. Orig desc: Whether to enable the
+     * Sieve &quot;Variables&quot; extension defined in RFC 5229 in the
+     * admin-defined sieve rules.
      *
      * @return zimbraAdminSieveFeatureVariablesEnabled, or true if unset
      *
@@ -2089,10 +2089,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Deprecated since: 8.7.8. deprecated as this attribute is not used
-     * anymore and variable feature is availabe to use for all.. Orig desc:
-     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
-     * RFC 5229 in the admin-defined sieve rules.
+     * Deprecated since: 8.7.8. Variable feature is always enabled, hence
+     * this attribute has been deprecated. Orig desc: Whether to enable the
+     * Sieve &quot;Variables&quot; extension defined in RFC 5229 in the
+     * admin-defined sieve rules.
      *
      * @param zimbraAdminSieveFeatureVariablesEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -2107,10 +2107,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Deprecated since: 8.7.8. deprecated as this attribute is not used
-     * anymore and variable feature is availabe to use for all.. Orig desc:
-     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
-     * RFC 5229 in the admin-defined sieve rules.
+     * Deprecated since: 8.7.8. Variable feature is always enabled, hence
+     * this attribute has been deprecated. Orig desc: Whether to enable the
+     * Sieve &quot;Variables&quot; extension defined in RFC 5229 in the
+     * admin-defined sieve rules.
      *
      * @param zimbraAdminSieveFeatureVariablesEnabled new value
      * @param attrs existing map to populate, or null to create a new map
@@ -2126,10 +2126,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Deprecated since: 8.7.8. deprecated as this attribute is not used
-     * anymore and variable feature is availabe to use for all.. Orig desc:
-     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
-     * RFC 5229 in the admin-defined sieve rules.
+     * Deprecated since: 8.7.8. Variable feature is always enabled, hence
+     * this attribute has been deprecated. Orig desc: Whether to enable the
+     * Sieve &quot;Variables&quot; extension defined in RFC 5229 in the
+     * admin-defined sieve rules.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -2143,10 +2143,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Deprecated since: 8.7.8. deprecated as this attribute is not used
-     * anymore and variable feature is availabe to use for all.. Orig desc:
-     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
-     * RFC 5229 in the admin-defined sieve rules.
+     * Deprecated since: 8.7.8. Variable feature is always enabled, hence
+     * this attribute has been deprecated. Orig desc: Whether to enable the
+     * Sieve &quot;Variables&quot; extension defined in RFC 5229 in the
+     * admin-defined sieve rules.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
@@ -65388,10 +65388,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Deprecated since: 8.7.8. deprecated as this attribute is not used
-     * anymore and variable feature is availabe to use for all.. Orig desc:
-     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
-     * RFC 5229 in the user-defined sieve rule.
+     * Deprecated since: 8.7.8. Variable feature is always enabled, hence
+     * this attribute has been deprecated. Orig desc: Whether to enable the
+     * Sieve &quot;Variables&quot; extension defined in RFC 5229 in the
+     * user-defined sieve rule.
      *
      * @return zimbraSieveFeatureVariablesEnabled, or false if unset
      *
@@ -65403,10 +65403,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Deprecated since: 8.7.8. deprecated as this attribute is not used
-     * anymore and variable feature is availabe to use for all.. Orig desc:
-     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
-     * RFC 5229 in the user-defined sieve rule.
+     * Deprecated since: 8.7.8. Variable feature is always enabled, hence
+     * this attribute has been deprecated. Orig desc: Whether to enable the
+     * Sieve &quot;Variables&quot; extension defined in RFC 5229 in the
+     * user-defined sieve rule.
      *
      * @param zimbraSieveFeatureVariablesEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -65421,10 +65421,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Deprecated since: 8.7.8. deprecated as this attribute is not used
-     * anymore and variable feature is availabe to use for all.. Orig desc:
-     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
-     * RFC 5229 in the user-defined sieve rule.
+     * Deprecated since: 8.7.8. Variable feature is always enabled, hence
+     * this attribute has been deprecated. Orig desc: Whether to enable the
+     * Sieve &quot;Variables&quot; extension defined in RFC 5229 in the
+     * user-defined sieve rule.
      *
      * @param zimbraSieveFeatureVariablesEnabled new value
      * @param attrs existing map to populate, or null to create a new map
@@ -65440,10 +65440,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Deprecated since: 8.7.8. deprecated as this attribute is not used
-     * anymore and variable feature is availabe to use for all.. Orig desc:
-     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
-     * RFC 5229 in the user-defined sieve rule.
+     * Deprecated since: 8.7.8. Variable feature is always enabled, hence
+     * this attribute has been deprecated. Orig desc: Whether to enable the
+     * Sieve &quot;Variables&quot; extension defined in RFC 5229 in the
+     * user-defined sieve rule.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -65457,10 +65457,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Deprecated since: 8.7.8. deprecated as this attribute is not used
-     * anymore and variable feature is availabe to use for all.. Orig desc:
-     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
-     * RFC 5229 in the user-defined sieve rule.
+     * Deprecated since: 8.7.8. Variable feature is always enabled, hence
+     * this attribute has been deprecated. Orig desc: Whether to enable the
+     * Sieve &quot;Variables&quot; extension defined in RFC 5229 in the
+     * user-defined sieve rule.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -1096,6 +1096,93 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
+     * Deprecated since: 8.7.8. deprecated as this attribute is not used
+     * anymore and variable feature is availabe to use for all.. Orig desc:
+     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
+     * RFC 5229 in the admin-defined sieve rules.
+     *
+     * @return zimbraAdminSieveFeatureVariablesEnabled, or true if unset
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2098)
+    public boolean isAdminSieveFeatureVariablesEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraAdminSieveFeatureVariablesEnabled, true, true);
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated as this attribute is not used
+     * anymore and variable feature is availabe to use for all.. Orig desc:
+     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
+     * RFC 5229 in the admin-defined sieve rules.
+     *
+     * @param zimbraAdminSieveFeatureVariablesEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2098)
+    public void setAdminSieveFeatureVariablesEnabled(boolean zimbraAdminSieveFeatureVariablesEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveFeatureVariablesEnabled, zimbraAdminSieveFeatureVariablesEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated as this attribute is not used
+     * anymore and variable feature is availabe to use for all.. Orig desc:
+     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
+     * RFC 5229 in the admin-defined sieve rules.
+     *
+     * @param zimbraAdminSieveFeatureVariablesEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2098)
+    public Map<String,Object> setAdminSieveFeatureVariablesEnabled(boolean zimbraAdminSieveFeatureVariablesEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveFeatureVariablesEnabled, zimbraAdminSieveFeatureVariablesEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated as this attribute is not used
+     * anymore and variable feature is availabe to use for all.. Orig desc:
+     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
+     * RFC 5229 in the admin-defined sieve rules.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2098)
+    public void unsetAdminSieveFeatureVariablesEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveFeatureVariablesEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Deprecated since: 8.7.8. deprecated as this attribute is not used
+     * anymore and variable feature is availabe to use for all.. Orig desc:
+     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
+     * RFC 5229 in the admin-defined sieve rules.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.6
+     */
+    @ZAttr(id=2098)
+    public Map<String,Object> unsetAdminSieveFeatureVariablesEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminSieveFeatureVariablesEnabled, "");
+        return attrs;
+    }
+
+    /**
      * URL prefix for where the zimbraAdmin app resides on this server
      *
      * @return zimbraAdminURL, or "/zimbraAdmin" if unset
@@ -47159,10 +47246,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Deprecated since: 8.7.8. deprecated in favor of
-     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
-     * desc: Whether to enable the Sieve &quot;Variables&quot; extension
-     * defined in RFC 5229 in the user-defined sieve rule.
+     * Deprecated since: 8.7.8. deprecated as this attribute is not used
+     * anymore and variable feature is availabe to use for all.. Orig desc:
+     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
+     * RFC 5229 in the user-defined sieve rule.
      *
      * @return zimbraSieveFeatureVariablesEnabled, or false if unset
      *
@@ -47174,10 +47261,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Deprecated since: 8.7.8. deprecated in favor of
-     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
-     * desc: Whether to enable the Sieve &quot;Variables&quot; extension
-     * defined in RFC 5229 in the user-defined sieve rule.
+     * Deprecated since: 8.7.8. deprecated as this attribute is not used
+     * anymore and variable feature is availabe to use for all.. Orig desc:
+     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
+     * RFC 5229 in the user-defined sieve rule.
      *
      * @param zimbraSieveFeatureVariablesEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -47192,10 +47279,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Deprecated since: 8.7.8. deprecated in favor of
-     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
-     * desc: Whether to enable the Sieve &quot;Variables&quot; extension
-     * defined in RFC 5229 in the user-defined sieve rule.
+     * Deprecated since: 8.7.8. deprecated as this attribute is not used
+     * anymore and variable feature is availabe to use for all.. Orig desc:
+     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
+     * RFC 5229 in the user-defined sieve rule.
      *
      * @param zimbraSieveFeatureVariablesEnabled new value
      * @param attrs existing map to populate, or null to create a new map
@@ -47211,10 +47298,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Deprecated since: 8.7.8. deprecated in favor of
-     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
-     * desc: Whether to enable the Sieve &quot;Variables&quot; extension
-     * defined in RFC 5229 in the user-defined sieve rule.
+     * Deprecated since: 8.7.8. deprecated as this attribute is not used
+     * anymore and variable feature is availabe to use for all.. Orig desc:
+     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
+     * RFC 5229 in the user-defined sieve rule.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -47228,10 +47315,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Deprecated since: 8.7.8. deprecated in favor of
-     * zimbraSieveRejectMailEnabled, which can be used at account level. Orig
-     * desc: Whether to enable the Sieve &quot;Variables&quot; extension
-     * defined in RFC 5229 in the user-defined sieve rule.
+     * Deprecated since: 8.7.8. deprecated as this attribute is not used
+     * anymore and variable feature is availabe to use for all.. Orig desc:
+     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
+     * RFC 5229 in the user-defined sieve rule.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -1096,10 +1096,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Deprecated since: 8.7.8. deprecated as this attribute is not used
-     * anymore and variable feature is availabe to use for all.. Orig desc:
-     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
-     * RFC 5229 in the admin-defined sieve rules.
+     * Deprecated since: 8.7.8. Variable feature is always enabled, hence
+     * this attribute has been deprecated. Orig desc: Whether to enable the
+     * Sieve &quot;Variables&quot; extension defined in RFC 5229 in the
+     * admin-defined sieve rules.
      *
      * @return zimbraAdminSieveFeatureVariablesEnabled, or true if unset
      *
@@ -1111,10 +1111,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Deprecated since: 8.7.8. deprecated as this attribute is not used
-     * anymore and variable feature is availabe to use for all.. Orig desc:
-     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
-     * RFC 5229 in the admin-defined sieve rules.
+     * Deprecated since: 8.7.8. Variable feature is always enabled, hence
+     * this attribute has been deprecated. Orig desc: Whether to enable the
+     * Sieve &quot;Variables&quot; extension defined in RFC 5229 in the
+     * admin-defined sieve rules.
      *
      * @param zimbraAdminSieveFeatureVariablesEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -1129,10 +1129,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Deprecated since: 8.7.8. deprecated as this attribute is not used
-     * anymore and variable feature is availabe to use for all.. Orig desc:
-     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
-     * RFC 5229 in the admin-defined sieve rules.
+     * Deprecated since: 8.7.8. Variable feature is always enabled, hence
+     * this attribute has been deprecated. Orig desc: Whether to enable the
+     * Sieve &quot;Variables&quot; extension defined in RFC 5229 in the
+     * admin-defined sieve rules.
      *
      * @param zimbraAdminSieveFeatureVariablesEnabled new value
      * @param attrs existing map to populate, or null to create a new map
@@ -1148,10 +1148,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Deprecated since: 8.7.8. deprecated as this attribute is not used
-     * anymore and variable feature is availabe to use for all.. Orig desc:
-     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
-     * RFC 5229 in the admin-defined sieve rules.
+     * Deprecated since: 8.7.8. Variable feature is always enabled, hence
+     * this attribute has been deprecated. Orig desc: Whether to enable the
+     * Sieve &quot;Variables&quot; extension defined in RFC 5229 in the
+     * admin-defined sieve rules.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -1165,10 +1165,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Deprecated since: 8.7.8. deprecated as this attribute is not used
-     * anymore and variable feature is availabe to use for all.. Orig desc:
-     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
-     * RFC 5229 in the admin-defined sieve rules.
+     * Deprecated since: 8.7.8. Variable feature is always enabled, hence
+     * this attribute has been deprecated. Orig desc: Whether to enable the
+     * Sieve &quot;Variables&quot; extension defined in RFC 5229 in the
+     * admin-defined sieve rules.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
@@ -47246,10 +47246,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Deprecated since: 8.7.8. deprecated as this attribute is not used
-     * anymore and variable feature is availabe to use for all.. Orig desc:
-     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
-     * RFC 5229 in the user-defined sieve rule.
+     * Deprecated since: 8.7.8. Variable feature is always enabled, hence
+     * this attribute has been deprecated. Orig desc: Whether to enable the
+     * Sieve &quot;Variables&quot; extension defined in RFC 5229 in the
+     * user-defined sieve rule.
      *
      * @return zimbraSieveFeatureVariablesEnabled, or false if unset
      *
@@ -47261,10 +47261,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Deprecated since: 8.7.8. deprecated as this attribute is not used
-     * anymore and variable feature is availabe to use for all.. Orig desc:
-     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
-     * RFC 5229 in the user-defined sieve rule.
+     * Deprecated since: 8.7.8. Variable feature is always enabled, hence
+     * this attribute has been deprecated. Orig desc: Whether to enable the
+     * Sieve &quot;Variables&quot; extension defined in RFC 5229 in the
+     * user-defined sieve rule.
      *
      * @param zimbraSieveFeatureVariablesEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -47279,10 +47279,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Deprecated since: 8.7.8. deprecated as this attribute is not used
-     * anymore and variable feature is availabe to use for all.. Orig desc:
-     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
-     * RFC 5229 in the user-defined sieve rule.
+     * Deprecated since: 8.7.8. Variable feature is always enabled, hence
+     * this attribute has been deprecated. Orig desc: Whether to enable the
+     * Sieve &quot;Variables&quot; extension defined in RFC 5229 in the
+     * user-defined sieve rule.
      *
      * @param zimbraSieveFeatureVariablesEnabled new value
      * @param attrs existing map to populate, or null to create a new map
@@ -47298,10 +47298,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Deprecated since: 8.7.8. deprecated as this attribute is not used
-     * anymore and variable feature is availabe to use for all.. Orig desc:
-     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
-     * RFC 5229 in the user-defined sieve rule.
+     * Deprecated since: 8.7.8. Variable feature is always enabled, hence
+     * this attribute has been deprecated. Orig desc: Whether to enable the
+     * Sieve &quot;Variables&quot; extension defined in RFC 5229 in the
+     * user-defined sieve rule.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -47315,10 +47315,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Deprecated since: 8.7.8. deprecated as this attribute is not used
-     * anymore and variable feature is availabe to use for all.. Orig desc:
-     * Whether to enable the Sieve &quot;Variables&quot; extension defined in
-     * RFC 5229 in the user-defined sieve rule.
+     * Deprecated since: 8.7.8. Variable feature is always enabled, hence
+     * this attribute has been deprecated. Orig desc: Whether to enable the
+     * Sieve &quot;Variables&quot; extension defined in RFC 5229 in the
+     * user-defined sieve rule.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs


### PR DESCRIPTION
Changes done:
===========
1) added zimbraAdminSieveFeatureVariablesEnabled ldap attribute which was there in 877
2) deprecated the same, as it is not used anymore
3) corrected deprecateDesc for zimbraSieveFeatureVariablesEnabled

Testing done:
==========
1) zimbraAdminSieveFeatureVariablesEnabled comes as deprecated in "zmprov desc -a zimbraAdminSieveFeatureVariablesEnabled"
2) zimbraSieveFeatureVariablesEnabled comes as deprecated with new description in "zmprov desc -a zimbraSieveFeatureVariablesEnabled"
