### PR TITLE
ZMS-227: ZMailbox::searchImap

### DIFF
--- a/client/src/java/com/zimbra/client/ZIdHit.java
+++ b/client/src/java/com/zimbra/client/ZIdHit.java
@@ -3,11 +3,13 @@ package com.zimbra.client;
 import org.json.JSONException;
 
 import com.zimbra.client.event.ZModifyEvent;
+import com.zimbra.common.mailbox.ItemIdentifier;
+import com.zimbra.common.mailbox.MailItemType;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.MailConstants;
 
-public class ZIdHit implements ZSearchHit {
+public class ZIdHit implements ZImapSearchHit {
 
     private String id;
     private String sortField;
@@ -38,4 +40,38 @@ public class ZIdHit implements ZSearchHit {
     @Override
     public void modifyNotification(ZModifyEvent event) throws ServiceException {}
 
+    @Override
+    public int getItemId() throws ServiceException {
+        return new ItemIdentifier(id, null).id;
+    }
+
+    @Override
+    public int getParentId() throws ServiceException {
+        return -1;
+    }
+
+    @Override
+    public int getModifiedSequence() throws ServiceException {
+        return -1;
+    }
+
+    @Override
+    public MailItemType getMailItemType() throws ServiceException {
+        return null;
+    }
+
+    @Override
+    public int getImapUid() throws ServiceException {
+        return -1;
+    }
+
+    @Override
+    public int getFlagBitmask() throws ServiceException {
+        return -1;
+    }
+
+    @Override
+    public String[] getTags() throws ServiceException {
+        return null;
+    }
 }

--- a/client/src/java/com/zimbra/client/ZImapSearchHit.java
+++ b/client/src/java/com/zimbra/client/ZImapSearchHit.java
@@ -1,0 +1,7 @@
+package com.zimbra.client;
+
+import com.zimbra.common.mailbox.ZimbraQueryHit;
+
+public interface ZImapSearchHit extends ZSearchHit, ZimbraQueryHit {
+
+}

--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -6157,17 +6157,10 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
     }
 
     @Override
-    public ZimbraQueryHitResults search(OpContext octx, ZimbraSearchParams params)
+    public ZimbraQueryHitResults searchImap(OpContext octx, ZimbraSearchParams params)
     throws ServiceException {
-        // Mailbox does:
-        //     ZimbraQueryResults zqr = this.index.search(SoapProtocol.Soap12, octx, (SearchParams) params);
-        //     return new LocalZimbraQueryHitResults(zqr);
-        // Note that existing ZSearchHit doesn't have ZimbraQueryHit methods:
-        //     public int getItemId() throws ServiceException;  (maybe easily derivable from String getId())
-        //     public int getParentId() throws ServiceException;
-        //     public int getModifiedSequence() throws ServiceException;
-        // so may not be totally trivial to implement
-        throw new UnsupportedOperationException("ZMailbox method not supported yet");
+        ZSearchResult result = search((ZSearchParams) params);
+        return new ZRemoteQueryHitResults(result);
     }
 
 

--- a/client/src/java/com/zimbra/client/ZRemoteQueryHitResults.java
+++ b/client/src/java/com/zimbra/client/ZRemoteQueryHitResults.java
@@ -1,0 +1,23 @@
+package com.zimbra.client;
+import java.io.IOException;
+import java.util.Iterator;
+
+import com.zimbra.common.mailbox.ZimbraQueryHit;
+import com.zimbra.common.mailbox.ZimbraQueryHitResults;
+import com.zimbra.common.service.ServiceException;
+
+public class ZRemoteQueryHitResults implements ZimbraQueryHitResults {
+
+    private Iterator<ZImapSearchHit> hits;
+    public ZRemoteQueryHitResults(ZSearchResult result) {
+        this.hits = result.getImapHits().iterator();
+    }
+
+    @Override
+    public ZimbraQueryHit getNext() throws ServiceException {
+        return hits.hasNext() ? hits.next() : null;
+    }
+
+    @Override
+    public void close() throws IOException {}
+}

--- a/client/src/java/com/zimbra/client/ZSearchResult.java
+++ b/client/src/java/com/zimbra/client/ZSearchResult.java
@@ -34,6 +34,7 @@ import com.zimbra.common.soap.VoiceConstants;
 public class ZSearchResult implements ToZJSONObject {
 
     private List<ZSearchHit> hits;
+    private List<ZImapSearchHit> imapHits;
     private ZConversationSummary convSummary;
     private boolean hasMore;
     private String sortBy;
@@ -63,13 +64,18 @@ public class ZSearchResult implements ToZJSONObject {
         hasMore = resp.getAttributeBool(MailConstants.A_QUERY_MORE);
         offset = (int) resp.getAttributeLong(MailConstants.A_QUERY_OFFSET, -1);
         hits = new ArrayList<ZSearchHit>();
+        imapHits = new ArrayList<ZImapSearchHit>();
         for (Element h : el.listElements()) {
             if (h.getName().equals(MailConstants.E_CONV)) {
                 hits.add(new ZConversationHit(h));
             } else if (h.getName().equals(MailConstants.E_MSG)) {
-                hits.add(new ZMessageHit(h));
+                ZMessageHit hit = new ZMessageHit(h);
+                hits.add(hit);
+                imapHits.add(hit);
             } else if (h.getName().equals(MailConstants.E_CONTACT)) {
-                hits.add(new ZContactHit(h));
+                ZContactHit hit = new ZContactHit(h);
+                hits.add(hit);
+                imapHits.add(hit);
             } else if (h.getName().equals(MailConstants.E_APPOINTMENT)) {
                 ZAppointmentHit.addInstances(h, hits, tz, false);
             } else if (h.getName().equals(MailConstants.E_TASK)) {
@@ -83,7 +89,9 @@ public class ZSearchResult implements ToZJSONObject {
             } else if (h.getName().equals(VoiceConstants.E_CALLLOG)) {
                 hits.add(new ZCallHit(h));
             } else if (h.getName().equals(MailConstants.E_HIT)) {
-                hits.add(new ZIdHit(h));
+                ZIdHit hit = new ZIdHit(h);
+                hits.add(hit);
+                imapHits.add(hit);
             }
         }
     }
@@ -93,6 +101,10 @@ public class ZSearchResult implements ToZJSONObject {
      */
     public List<ZSearchHit> getHits() {
         return hits;
+    }
+
+    public List<ZImapSearchHit> getImapHits() {
+        return imapHits;
     }
 
     public ZConversationSummary getConversationSummary() {

--- a/common/src/java/com/zimbra/common/mailbox/MailboxStore.java
+++ b/common/src/java/com/zimbra/common/mailbox/MailboxStore.java
@@ -69,7 +69,6 @@ public interface MailboxStore {
             throws ServiceException;
     /**
      * @return the item with the specified ID.
-     * @throws NoSuchItemException if the item does not exist
      */
     public ZimbraMailItem getItemById(OpContext octxt, ItemIdentifier id, MailItemType type) throws ServiceException;
     public void flagItemAsRead(OpContext octxt, ItemIdentifier itemId, MailItemType type) throws ServiceException;
@@ -79,7 +78,7 @@ public interface MailboxStore {
     public void setTags(OpContext octxt, Collection<ItemIdentifier> itemIds, int flags, Collection<String> tags)
             throws ServiceException;
     public ZimbraSearchParams createSearchParams(String queryString);
-    public ZimbraQueryHitResults search(OpContext octx, ZimbraSearchParams params) throws ServiceException;
+    public ZimbraQueryHitResults searchImap(OpContext octx, ZimbraSearchParams params) throws ServiceException;
     /**
      * Returns the change sequence number for the most recent transaction.  This will be either the change number
      * for the current transaction or, if no database changes have yet been made in this transaction, the sequence

--- a/store/src/java/com/zimbra/cs/imap/ImapHandler.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapHandler.java
@@ -3370,7 +3370,7 @@ public abstract class ImapHandler {
         params.setPrefetch(false);
         params.setZimbraFetchMode(fetch.toZimbraFetchMode());
         params.setTimeZone(tz);
-        return mbox.search(getContext(), params);
+        return mbox.searchImap(getContext(), params);
     }
 
     boolean doTHREAD(String tag, ImapSearch i4search, boolean byUID) throws IOException, ImapException {

--- a/store/src/java/com/zimbra/cs/imap/ImapSessionManager.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapSessionManager.java
@@ -380,7 +380,7 @@ final class ImapSessionManager {
         params.setLimit(1000);
         params.setZimbraFetchMode(ZimbraFetchMode.IMAP);
         try {
-            ZimbraQueryHitResults zqr = mbox.search(octxt, params);
+            ZimbraQueryHitResults zqr = mbox.searchImap(octxt, params);
             try {
                 for (ZimbraQueryHit hit = zqr.getNext(); hit != null; hit = zqr.getNext()) {
                     i4list.add(new ImapMessage(hit));

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -10348,7 +10348,7 @@ public class Mailbox implements MailboxStore {
 
     @SuppressWarnings("resource")
     @Override
-    public ZimbraQueryHitResults search(OpContext octx, ZimbraSearchParams params)
+    public ZimbraQueryHitResults searchImap(OpContext octx, ZimbraSearchParams params)
     throws ServiceException {
         ZimbraQueryResults zqr =
                 index.search(SoapProtocol.Soap12, OperationContext.asOperationContext(octx), (SearchParams) params);

--- a/store/src/java/com/zimbra/cs/service/mail/SearchResponse.java
+++ b/store/src/java/com/zimbra/cs/service/mail/SearchResponse.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.List;
 
 import com.zimbra.common.localconfig.LC;
+import com.zimbra.common.mailbox.ZimbraFetchMode;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.MailConstants;
@@ -52,6 +53,7 @@ import com.zimbra.cs.service.mail.ToXML.EmailType;
 import com.zimbra.cs.service.util.ItemId;
 import com.zimbra.cs.service.util.ItemIdFormatter;
 import com.zimbra.cs.session.PendingModifications;
+import com.zimbra.cs.session.PendingModifications.Change;
 import com.zimbra.soap.DocumentHandler;
 import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.mail.type.ConversationMsgHitInfo;
@@ -256,13 +258,18 @@ final class SearchResponse {
         }
 
         Element el;
+        int fields;
+        if (params.isQuick()) {
+            fields = PendingModifications.Change.CONTENT;
+        } else {
+            fields = getFieldBitmask();
+        }
         if (expandMsg) {
             el = ToXML.encodeMessageAsMP(element, ifmt, octxt, msg, null, params.getMaxInlinedLength(),
                     params.getWantHtml(), params.getNeuterImages(), params.getInlinedHeaders(), true,
-                    params.getWantExpandGroupInfo(), LC.mime_encode_missing_blob.booleanValue(), params.getWantContent());
+                    params.getWantExpandGroupInfo(), LC.mime_encode_missing_blob.booleanValue(), params.getWantContent(), fields);
         } else {
-            el = ToXML.encodeMessageSummary(element, ifmt, octxt, msg, params.getWantRecipients(),
-                    params.isQuick() ? PendingModifications.Change.CONTENT : ToXML.NOTIFY_FIELDS);
+            el = ToXML.encodeMessageSummary(element, ifmt, octxt, msg, params.getWantRecipients(), fields);
         }
 
         el.addAttribute(MailConstants.A_CONTENTMATCHED, true);
@@ -305,8 +312,19 @@ final class SearchResponse {
         return el;
     }
 
+    private int getFieldBitmask() {
+        int fields = ToXML.NOTIFY_FIELDS;
+        ZimbraFetchMode fetchMode = params.getZimbraFetchMode();
+        if (fetchMode == ZimbraFetchMode.MODSEQ) {
+            fields |= Change.MODSEQ;
+        } else if (fetchMode == ZimbraFetchMode.IMAP) {
+            fields |= (Change.MODSEQ | Change.IMAP_UID);
+        }
+        return fields;
+    }
+
     private Element add(ContactHit hit) throws ServiceException {
-        return ToXML.encodeContact(element, ifmt, octxt, hit.getContact(), true, null);
+        return ToXML.encodeContact(element, ifmt, octxt, hit.getContact(), true, null, getFieldBitmask());
     }
 
     private Element add(NoteHit hit) throws ServiceException {

--- a/store/src/java/com/zimbra/cs/session/PendingModifications.java
+++ b/store/src/java/com/zimbra/cs/session/PendingModifications.java
@@ -39,8 +39,8 @@ import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.Pair;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.mailbox.MailItem;
-import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.MailItem.Type;
+import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.util.TypedIdList;
 
 
@@ -78,6 +78,7 @@ public abstract class PendingModifications<T extends ZimbraMailItem> {
         public static final int RETENTION_POLICY = 0x02000000;
         public static final int DISABLE_ACTIVESYNC = 0x04000000;
         public static final int INTERNAL_ONLY    = 0x10000000;
+        public static final int MODSEQ           = 0x20000000;
         public static final int ALL_FIELDS       = ~0;
 
         public Object what;

--- a/store/src/java/com/zimbra/qa/unittest/TestRemoteImapShared.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestRemoteImapShared.java
@@ -35,118 +35,70 @@ public class TestRemoteImapShared extends SharedImapTests {
         super.sharedTearDown();
         TestUtil.setLCValue(LC.imap_always_use_remote_store, String.valueOf(saved_imap_always_use_remote_store));
     }
-    
+
     @Override
     @Ignore ("failing on remote imap for now")
     public void testMultiappendNoLiteralPlus() throws Exception {
-        
+
     }
 
     @Override
     @Ignore ("failing on remote imap for now")
     public void testMultiappend() throws Exception {
-        
+
     }
 
     @Override
     @Ignore ("failing on remote imap for now")
     public void testCatenateUrl() throws Exception {
-        
+
     }
 
     @Override
     @Ignore ("failing on remote imap for now")
     public void testCatenateSimpleNoLiteralPlus() throws Exception {
-        
+
     }
 
     @Override
     @Ignore ("failing on remote imap for now")
     public void testCatenateSimple() throws Exception {
-        
+
     }
 
     @Override
     @Ignore ("failing on remote imap for now")
     public void testAppend() throws Exception {
-        
+
     }
 
     @Override
     @Ignore ("failing on remote imap for now")
     public void testAppendTags() throws Exception {
-        
+
     }
 
     @Override
     @Ignore ("failing on remote imap for now")
     public void testStoreTagsDirty() throws Exception {
-        
+
     }
 
     @Override
     @Ignore ("failing on remote imap for now")
     public void testStoreInvalidSystemFlag() throws Exception {
-        
+
     }
 
     @Override
     @Ignore ("failing on remote imap for now")
     public void testStoreTags() throws Exception {
-        
+
     }
 
     @Override
     @Ignore ("failing on remote imap for now")
     public void testAppendNoLiteralPlus() throws Exception {
-        
-    }
 
-    @Override
-    @Ignore ("failing on remote imap for now")
-    public void testDeepNestedAndSearch() throws Exception {
-        
-    }
-
-    @Override
-    @Ignore ("failing on remote imap for now")
-    public void testTooDeepNestedAndSearch() throws Exception {
-        
-    }
-
-    @Override
-    @Ignore ("failing on remote imap for now")
-    public void testDeepNestedOrSearch() throws Exception {
-        
-    }
-
-    @Override
-    @Ignore ("failing on remote imap for now")
-    public void testOrSearch() throws Exception {
-        
-    }
-
-    @Override
-    @Ignore ("failing on remote imap for now")
-    public void testAndSearch() throws Exception {
-        
-    }
-
-    @Override
-    @Ignore ("failing on remote imap for now")
-    public void testNotSearch() throws Exception {
-        
-    }
-
-    @Override
-    @Ignore ("failing on remote imap for now")
-    public void testBadOrSearch() throws Exception {
-        
-    }
-
-    @Override
-    @Ignore ("failing on remote imap for now")
-    public void testSubClauseAndSearch() throws Exception {
-        
     }
 }

--- a/store/src/java/com/zimbra/qa/unittest/TestZClient.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestZClient.java
@@ -43,6 +43,7 @@ import com.zimbra.client.ZFolder;
 import com.zimbra.client.ZGetInfoResult;
 import com.zimbra.client.ZIdHit;
 import com.zimbra.client.ZMailbox;
+import com.zimbra.client.ZMailbox.Fetch;
 import com.zimbra.client.ZMailbox.OpenIMAPFolderParams;
 import com.zimbra.client.ZMailbox.Options;
 import com.zimbra.client.ZMailbox.ZAppointmentResult;
@@ -55,12 +56,15 @@ import com.zimbra.client.ZSearchParams;
 import com.zimbra.client.ZSearchResult;
 import com.zimbra.client.ZSignature;
 import com.zimbra.client.ZTag;
+import com.zimbra.client.ZTag.Color;
 import com.zimbra.common.account.Key.AccountBy;
 import com.zimbra.common.mailbox.ItemIdentifier;
 import com.zimbra.common.mailbox.MailItemType;
 import com.zimbra.common.mailbox.OpContext;
 import com.zimbra.common.mailbox.ZimbraFetchMode;
 import com.zimbra.common.mailbox.ZimbraMailItem;
+import com.zimbra.common.mailbox.ZimbraQueryHit;
+import com.zimbra.common.mailbox.ZimbraQueryHitResults;
 import com.zimbra.common.mailbox.ZimbraSortBy;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.SoapFaultException;
@@ -76,6 +80,7 @@ import com.zimbra.cs.mailbox.Flag;
 import com.zimbra.cs.mailbox.Flag.FlagInfo;
 import com.zimbra.cs.mailbox.Folder;
 import com.zimbra.cs.mailbox.MailItem;
+import com.zimbra.cs.mailbox.MailItem.Type;
 import com.zimbra.cs.mailbox.MailServiceException;
 import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.Message;
@@ -880,6 +885,76 @@ public class TestZClient extends TestCase {
         results = zmbox.search(params).getHits();
         assertEquals(1, results.size());
         assertTrue(results.get(0) instanceof ZIdHit);
+    }
+
+    @Test
+    public void testImapSearch() throws Exception {
+        ZMailbox zmbox = TestUtil.getZMailbox(USER_NAME);
+        Mailbox mbox = TestUtil.getMailbox(USER_NAME);
+        ZTag tag = zmbox.createTag("testImapSearch tag", Color.blue);
+        int msgId = Integer.valueOf(TestUtil.addMessage(zmbox, "testImapSearch message"));
+        mbox.alterTag(null, msgId, Type.MESSAGE, FlagInfo.UNREAD, false, null);
+        mbox.alterTag(null, msgId, Type.MESSAGE, tag.getName(), true, null);
+        ZSearchParams params = new ZSearchParams("testImapSearch");
+        params.setMailItemTypes(Sets.newHashSet(MailItemType.MESSAGE));
+        params.setFetch(Fetch.all);
+        params.setZimbraFetchMode(ZimbraFetchMode.IMAP);
+        ZimbraQueryHitResults results = zmbox.searchImap(null, params);
+        Message msg = mbox.getMessageById(null, msgId);
+        verifyImapSearchResults(results, msgId, msg.getImapUid(), msg.getParentId(), msg.getModifiedSequence(),
+                MailItemType.MESSAGE, msg.getFlagBitmask(), new String[] {tag.getId()});
+        params.setZimbraFetchMode(ZimbraFetchMode.MODSEQ);
+        results = zmbox.searchImap(null, params);
+        verifyImapSearchResults(results, msgId, -1, msg.getParentId(), msg.getModifiedSequence(),
+                MailItemType.MESSAGE, msg.getFlagBitmask(), new String[] {tag.getId()});
+        params.setZimbraFetchMode(ZimbraFetchMode.IDS);
+        results = zmbox.searchImap(null, params);
+        verifyImapSearchResults(results, msgId, -1, -1, -1, null, -1, null);
+
+        //verify that setting the expandResult parameter also returns the necessary fields
+        params.setFetch(Fetch.all);
+        params.setZimbraFetchMode(ZimbraFetchMode.IMAP);
+        results = zmbox.searchImap(null, params);
+        verifyImapSearchResults(results, msgId, msg.getImapUid(), msg.getParentId(), msg.getModifiedSequence(),
+                MailItemType.MESSAGE, msg.getFlagBitmask(), new String[] {tag.getId()});
+    }
+
+    @Test
+    public void testImapSearchContact() throws Exception {
+        ZMailbox zmbox = TestUtil.getZMailbox(USER_NAME);
+        Mailbox mbox = TestUtil.getMailbox(USER_NAME);
+        ZTag tag = zmbox.createTag("testImapSearch tag", Color.blue);
+        ZFolder folder = TestUtil.createFolder(zmbox, "/testImapSearch", ZFolder.View.contact);
+        Contact contact = TestUtil.createContact(mbox, folder.getFolderIdInOwnerMailbox(), "testImapSearch@test.local");
+        int contactId = contact.getId();
+        mbox.alterTag(null, contactId, Type.CONTACT, FlagInfo.FLAGGED, true, null);
+        mbox.alterTag(null, contactId, Type.CONTACT, tag.getName(), true, null);
+        ZSearchParams params = new ZSearchParams("testImapSearch");
+        params.setMailItemTypes(Sets.newHashSet(MailItemType.CONTACT));
+        params.setZimbraFetchMode(ZimbraFetchMode.IMAP);
+        ZimbraQueryHitResults results = zmbox.searchImap(null, params);
+        verifyImapSearchResults(results, contactId, contact.getImapUid(), contact.getParentId(), contact.getModifiedSequence(),
+                MailItemType.CONTACT, contact.getFlagBitmask(), new String[] {tag.getId()});
+        params.setZimbraFetchMode(ZimbraFetchMode.MODSEQ);
+        results = zmbox.searchImap(null, params);
+        verifyImapSearchResults(results, contactId, -1, contact.getParentId(), contact.getModifiedSequence(),
+                MailItemType.CONTACT, contact.getFlagBitmask(), new String[] {tag.getId()});
+        params.setZimbraFetchMode(ZimbraFetchMode.IDS);
+        results = zmbox.searchImap(null, params);
+        verifyImapSearchResults(results, contactId, -1, -1, -1, null, -1, null);
+    }
+
+    private void verifyImapSearchResults(ZimbraQueryHitResults results, int id, int imapUid, int parentId, int modSeq,
+            MailItemType type, int flags, String[] tags) throws ServiceException {
+        ZimbraQueryHit hit = results.getNext();
+        assertNotNull(hit);
+        assertEquals(id, hit.getItemId());
+        assertEquals(parentId, hit.getParentId());
+        assertEquals(imapUid, hit.getImapUid());
+        assertEquals(modSeq, hit.getModifiedSequence());
+        assertEquals(type, hit.getMailItemType());
+        assertEquals(flags, hit.getFlagBitmask());
+        org.junit.Assert.assertArrayEquals(tags, hit.getTags());
     }
 
     private void compareMsgAndZMsg(String testname, Message msg, ZMessage zmsg) throws IOException, ServiceException {


### PR DESCRIPTION
For clarity, I renamed this interface method from "search" to "searchImap" since it is only used by the IMAP server and only returns IMAP-compatible results.

### Client changes
 - A new interface _ZImapSearchHit_ is introduced. This interface combines _ZSearchHit_ (the base for all client-side search results) and _ZimbraQueryHit_ (returned by _ZimbraQueryHitResults_). Three search hit classes now implement _ZImapSearchHit_:
   - _ZMessageHit_ has new _imapUid_ and _modSeq_ fields that default to -1 unless _resultMode_ is set IMAP or MODSEQ.
   - _ZContactHit_ has new _imapUid_ and _modSeq_ fields like _ZMessageHit_, but always returns -1 for the parent ID. To get the _getFlagBitmask_ method to work, the _ZContact.Flag_ enum had to be updated with a method to convert the string to a bitmask, similar to the Flag class in zm-store.
   - _ZIdHit_ returns -1 or null for all _ZImapSearchHit_ methods except for _getItemId()_.
 - _ZSearchResult_ has a new field _imapHits_, exposed via _getImapHits()_, which is a list of _ZImapSearchHit_ objects returned in the search response.
 - A new class _ZRemoteQueryHitResults_ implements _ZimbraQueryHitResults_ by iterating over the imapHits described above. _Zmailbox::searchImap_ returns a _ZRemoteQueryHitResults_ instance.

### Server changes
In order for this to work, the server had to be updated to return the _modSeq_ and _imapUid_ values in the search response for messages and contacts. The following changes were made:
 - New MODSEQ bitmask in _PendingModifications.Change_
 - Updated _ToXML.NOTIFY_FIELDS_ bitmask to not include MODSEQ and IMAP_UID
 - Updated _SearchResponse_ class to add the MODSEQ and/or IMAP_UID masks to the _field_ bitmask when appropriate (both if _resultMode_ is IMAP; MODSEQ only if _resultMode_ is MODSEQ)
 - Added new _ToXML::encodeContact_ method signature to be able to pass in a field bitmask
 - Updated _ToXML::encodeContact_ and _ToXML::encodeMessageCommon_ to add the new fields when necessary

### Unit Tests
 - Added _testImapSearch_ and _testImapSearchContact_ tests in _TestZClient_. These tests compare the fields present in the response from _ZClient::searchImap_ to the values on the actual message/contact object. This is done for _resultMode_=IMAP, MODSEQ, and ID.
 - Re-activated the search unit tests in _TestRemoteImapShared_; they all pass.
