### PR TITLE
ZCS-1286:Regression-ModifyOutgoingFilterRulesRequest fails

### DIFF
--- a/store/src/java/com/zimbra/cs/filter/RuleManager.java
+++ b/store/src/java/com/zimbra/cs/filter/RuleManager.java
@@ -440,7 +440,7 @@ public final class RuleManager {
 
     private static void setXMLRules(Account account,List<FilterRule> rules, String sieveScriptAttrName,
             String rulesCacheKey) throws ServiceException {
-        SoapToSieve soapToSieve = new SoapToSieve(rules, account);
+        SoapToSieve soapToSieve = new SoapToSieve(rules);
         String script = soapToSieve.getSieveScript();
         setRules(account, script, sieveScriptAttrName, rulesCacheKey);
     }
@@ -668,7 +668,7 @@ public final class RuleManager {
                 List<String> ruleNames = getRuleNames(script);
                 SieveToSoap sieveToSoap = new SieveToSoap(ruleNames);
                 sieveToSoap.accept(node);
-                SoapToSieve soapToSieve = new SoapToSieve(sieveToSoap.toFilterRules(), account);
+                SoapToSieve soapToSieve = new SoapToSieve(sieveToSoap.toFilterRules());
                 String newScript = soapToSieve.getSieveScript();
                 setRules(account, newScript, sieveScriptAttrName, rulesCacheKey);
                 ZimbraLog.filter.info("Updated %s due to folder move or rename from %s to %s.",
@@ -709,7 +709,7 @@ public final class RuleManager {
                 List<String> ruleNames = getRuleNames(script);
                 SieveToSoap sieveToSoap = new SieveToSoap(ruleNames);
                 sieveToSoap.accept(node);
-                SoapToSieve soapToSieve = new SoapToSieve(sieveToSoap.toFilterRules(), account);
+                SoapToSieve soapToSieve = new SoapToSieve(sieveToSoap.toFilterRules());
                 String newScript = soapToSieve.getSieveScript();
                 setRules(account, newScript, sieveScriptAttrName, rulesCacheKey);
                 ZimbraLog.filter.info("Updated %s filter rules after folder %s was deleted.", sieveScriptAttrName, originalPath);
@@ -770,7 +770,7 @@ public final class RuleManager {
                 List<String> ruleNames = getRuleNames(script);
                 SieveToSoap sieveToSoap = new SieveToSoap(ruleNames);
                 sieveToSoap.accept(node);
-                SoapToSieve soapToSieve = new SoapToSieve(sieveToSoap.toFilterRules(), account);
+                SoapToSieve soapToSieve = new SoapToSieve(sieveToSoap.toFilterRules());
                 String newScript = soapToSieve.getSieveScript();
                 setRules(account, newScript, sieveScriptAttrName, rulesCacheKey);
                 ZimbraLog.filter.info("Updated %s after tag %s was deleted.", sieveScriptAttrName, tagName);


### PR DESCRIPTION
Removing changes related to bug ZCS-540

After changes of ZCS-540, the existence of the folder is always checked and if not present, the filter doesn't get activated.
But, the folder gets created at runtime (if they do not exist) for fileinto action.
So, ZCS-540 does not need to be fixed.