### PR TITLE
ZCS-1281:NPE for delete folder action for user account having elsif c…

### DIFF
--- a/store/src/java/com/zimbra/cs/filter/SieveVisitor.java
+++ b/store/src/java/com/zimbra/cs/filter/SieveVisitor.java
@@ -234,7 +234,7 @@ public abstract class SieveVisitor {
     protected void visitStopAction(Node node, VisitPhase phase, RuleProperties props) throws ServiceException {
     }
 
-    private static final Set<String> RULE_NODE_NAMES = ImmutableSet.of("if", "disabled_if");
+    private static final Set<String> RULE_NODE_NAMES = ImmutableSet.of("if", "disabled_if", "elsif");
 
     public class RuleProperties {
         boolean isEnabled = true;


### PR DESCRIPTION
Issue:
NullPointerException for delete folder action for user account having elsif condition sieve script

Fix:
Added literal elsif to RULE_NODE_NAMES so that isRuleNode() returns true for elsif in SieveVisitor