### PR TITLE
ZCS-375 Add envelope test to sieve soap api

### DIFF
--- a/common/src/java/com/zimbra/common/soap/MailConstants.java
+++ b/common/src/java/com/zimbra/common/soap/MailConstants.java
@@ -589,6 +589,7 @@ public final class MailConstants {
     public static final String E_HEADER_EXISTS_TEST = "headerExistsTest";
     public static final String E_MIME_HEADER_TEST = "mimeHeaderTest";
     public static final String E_ADDRESS_TEST = "addressTest";
+    public static final String E_ENVELOPE_TEST = "envelopeTest";
     public static final String E_SIZE_TEST = "sizeTest";
     public static final String E_DATE_TEST = "dateTest";
     public static final String E_CURRENT_TIME_TEST = "currentTimeTest";

--- a/soap/src/java/com/zimbra/soap/mail/type/FilterTest.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/FilterTest.java
@@ -87,7 +87,7 @@ public class FilterTest {
     }
 
     @XmlAccessorType(XmlAccessType.NONE)
-    public static final class AddressTest extends FilterTest {
+    public static class AddressTest extends FilterTest {
 
         /**
          * @zm-api-field-tag comma-sep-header-names
@@ -210,6 +210,10 @@ public class FilterTest {
                 .add("value", value)
                 .toString();
         }
+    }
+
+    @XmlAccessorType(XmlAccessType.NONE)
+    public static class EnvelopeTest extends AddressTest {
     }
 
     @XmlAccessorType(XmlAccessType.NONE)

--- a/soap/src/java/com/zimbra/soap/mail/type/FilterTest.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/FilterTest.java
@@ -213,7 +213,7 @@ public class FilterTest {
     }
 
     @XmlAccessorType(XmlAccessType.NONE)
-    public static class EnvelopeTest extends AddressTest {
+    public static final class EnvelopeTest extends AddressTest {
     }
 
     @XmlAccessorType(XmlAccessType.NONE)

--- a/soap/src/java/com/zimbra/soap/mail/type/FilterTests.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/FilterTests.java
@@ -47,6 +47,7 @@ public final class FilterTests {
     @XmlElements({
         @XmlElement(name=MailConstants.E_ADDRESS_BOOK_TEST, type=FilterTest.AddressBookTest.class),
         @XmlElement(name=MailConstants.E_ADDRESS_TEST, type=FilterTest.AddressTest.class),
+        @XmlElement(name=MailConstants.E_ENVELOPE_TEST, type=FilterTest.EnvelopeTest.class),
         @XmlElement(name=MailConstants.E_ATTACHMENT_TEST, type=FilterTest.AttachmentTest.class),
         @XmlElement(name=MailConstants.E_BODY_TEST, type=FilterTest.BodyTest.class),
         @XmlElement(name=MailConstants.E_BULK_TEST, type=FilterTest.BulkTest.class),

--- a/store/src/java-test/com/zimbra/cs/service/mail/GetFilterRulesTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/mail/GetFilterRulesTest.java
@@ -494,4 +494,62 @@ public class GetFilterRulesTest {
 
     }
 
+    @Test
+    public void testEnvelopeTest() throws Exception {
+        Account acct = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+
+        // set One rule with one nested if
+        RuleManager.clearCachedRules(acct);
+        String filterScript = "require \"envelope\";\n"
+            + "#test\n if anyof envelope :all :is \"from\" \"tim@example.com\" {\n"
+            + "tag \"t2\";\n"
+            + "}";
+        acct.setMailSieveScript(filterScript);
+        //ZimbraLog.filter.info(acct.getMailSieveScript());
+
+        // first, test the default setup (full tree)
+        Element request = new Element.XMLElement(MailConstants.GET_FILTER_RULES_REQUEST);
+        Element response = new GetFilterRules().handle(request, ServiceTestUtil.getRequestContext(acct));
+
+
+        String expectedSoap = "<GetFilterRulesResponse xmlns=\"urn:zimbraMail\">"
+            + "<filterRules><filterRule active=\"1\"><filterTests condition=\"anyof\">"
+            + "<envelopeTest stringComparison=\"is\" part=\"all\" header=\"from\" index=\"0\" value=\"tim@example.com\"/>"
+            + "<envelopeTest index=\"1\"/></filterTests><filterActions><actionTag index=\"0\" tagName=\"t2\"/>"
+            + "</filterActions></filterRule></filterRules></GetFilterRulesResponse>";
+
+        XMLDiffChecker.assertXMLEquals(expectedSoap, response.prettyPrint());
+
+    }
+
+    @Test
+    public void testEnvelopeTestNumericComparison() throws Exception {
+        Account acct = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+
+        // set One rule with one nested if
+        RuleManager.clearCachedRules(acct);
+        String filterScript = "require \"envelope\";\n"
+            + "#test\n if anyof envelope :count \"eq\" :all \"from\" \"1\" {\n"
+            + "tag \"t2\";\n"
+            + "}";
+        acct.setMailSieveScript(filterScript);
+        //ZimbraLog.filter.info(acct.getMailSieveScript());
+
+        // first, test the default setup (full tree)
+        Element request = new Element.XMLElement(MailConstants.GET_FILTER_RULES_REQUEST);
+        Element response = new GetFilterRules().handle(request, ServiceTestUtil.getRequestContext(acct));
+
+
+        String expectedSoap = "<GetFilterRulesResponse xmlns=\"urn:zimbraMail\">"
+            + "<filterRules><filterRule active=\"1\"><filterTests condition=\"anyof\">"
+            + "<envelopeTest countComparison=\"eq\" part=\"all\" header=\"from\" index=\"0\" value=\"1\"/>"
+            + "<envelopeTest index=\"1\"/></filterTests><filterActions><actionTag index=\"0\" tagName=\"t2\"/>"
+            + "</filterActions></filterRule></filterRules></GetFilterRulesResponse>";
+
+        XMLDiffChecker.assertXMLEquals(expectedSoap, response.prettyPrint());
+
+    }
+
 }

--- a/store/src/java/com/zimbra/cs/filter/SieveToSoap.java
+++ b/store/src/java/com/zimbra/cs/filter/SieveToSoap.java
@@ -271,8 +271,34 @@ public final class SieveToSoap extends SieveVisitor {
     @Override
     protected void visitAddressTest(Node node, VisitPhase phase, RuleProperties props, List<String> headers,
             Sieve.AddressPart part, Sieve.ValueComparison comparison, boolean isCount, String value) {
-        if (phase == VisitPhase.begin) {
-            FilterTest.AddressTest test = addTest(new FilterTest.AddressTest(), props);
+        FilterTest.AddressTest test = addTest(new FilterTest.AddressTest(), props);
+        visitAddress(test, phase, props, headers, part, comparison, isCount, value);
+    }
+
+    @Override
+    protected void visitAddressTest(Node node, VisitPhase phase, RuleProperties props, List<String> headers,
+            Sieve.AddressPart part, Sieve.StringComparison comparison, boolean caseSensitive, String value) {
+        FilterTest.AddressTest test = addTest(new FilterTest.AddressTest(), props);
+        visitAddress(test, phase, props, headers, part, comparison, caseSensitive, value);
+    }
+
+    @Override
+    protected void visitEnvelopeTest(Node node, VisitPhase phase, RuleProperties props, List<String> headers,
+            Sieve.AddressPart part, Sieve.StringComparison comparison, boolean caseSensitive, String value) {
+        FilterTest.EnvelopeTest test = addTest(new FilterTest.EnvelopeTest(), props);
+        visitAddress(test, phase, props, headers, part, comparison, caseSensitive, value);
+    }
+
+    @Override
+    protected void visitEnvelopeTest(Node node, VisitPhase phase, RuleProperties props, List<String> headers,
+            Sieve.AddressPart part, Sieve.ValueComparison comparison, boolean isCount, String value) {
+        FilterTest.EnvelopeTest test = addTest(new FilterTest.EnvelopeTest(), props);
+        visitAddress(test, phase, props, headers, part, comparison, isCount, value);
+    }
+
+    private void visitAddress(FilterTest.AddressTest test, VisitPhase phase, RuleProperties props, List<String> headers, Sieve.AddressPart part,
+        Sieve.ValueComparison comparison, boolean isCount, String value) {
+        if (test != null && phase == VisitPhase.begin) {
             test.setHeader(Joiner.on(',').join(headers));
             test.setPart(part.toString());
             if (isCount) {
@@ -284,11 +310,9 @@ public final class SieveToSoap extends SieveVisitor {
         }
     }
 
-    @Override
-    protected void visitAddressTest(Node node, VisitPhase phase, RuleProperties props, List<String> headers,
-            Sieve.AddressPart part, Sieve.StringComparison comparison, boolean caseSensitive, String value) {
-        if (phase == VisitPhase.begin) {
-            FilterTest.AddressTest test = addTest(new FilterTest.AddressTest(), props);
+    private void visitAddress(FilterTest.AddressTest test, VisitPhase phase, RuleProperties props, List<String> headers, Sieve.AddressPart part,
+        Sieve.StringComparison comparison, boolean caseSensitive, String value) {
+        if (test != null && phase == VisitPhase.begin) {
             test.setHeader(Joiner.on(',').join(headers));
             test.setPart(part.toString());
             test.setStringComparison(comparison.toString());

--- a/store/src/java/com/zimbra/cs/filter/SieveVisitor.java
+++ b/store/src/java/com/zimbra/cs/filter/SieveVisitor.java
@@ -87,14 +87,24 @@ public abstract class SieveVisitor {
 
     @SuppressWarnings("unused")
     protected void visitAddressTest(Node node, VisitPhase phase, RuleProperties props, List<String> headers,
-            Sieve.AddressPart part, Sieve.StringComparison comparison, boolean caseSensitive, String value)
-            throws ServiceException {
+        Sieve.AddressPart part, Sieve.StringComparison comparison, boolean caseSensitive, String value)
+        throws ServiceException {
     }
 
     @SuppressWarnings("unused")
     protected void visitAddressTest(Node node, VisitPhase phase, RuleProperties props, List<String> headers,
-            Sieve.AddressPart part, Sieve.ValueComparison comparison, boolean isCount, String value)
-            throws ServiceException {
+        Sieve.AddressPart part, Sieve.ValueComparison comparison, boolean isCount, String value)
+        throws ServiceException {
+    }
+
+    protected void visitEnvelopeTest(Node node, VisitPhase phase, RuleProperties props, List<String> headers,
+        Sieve.AddressPart part, Sieve.StringComparison comparison, boolean caseSensitive, String value)
+        throws ServiceException {
+    }
+
+    protected void visitEnvelopeTest(Node node, VisitPhase phase, RuleProperties props, List<String> headers,
+        Sieve.AddressPart part, Sieve.ValueComparison comparison, boolean isCount, String value)
+        throws ServiceException {
     }
 
     @SuppressWarnings("unused")
@@ -401,7 +411,7 @@ public abstract class SieveVisitor {
                     accept(node, props);
                     visitMimeHeaderTest(node, VisitPhase.end, props, headers, comparison, caseSensitive, value);
                 }
-            } else if ("address".equalsIgnoreCase(nodeName)) {
+            } else if ("address".equalsIgnoreCase(nodeName) || "envelope".equalsIgnoreCase(nodeName)) {
                 Sieve.AddressPart part = Sieve.AddressPart.all;
                 Sieve.StringComparison comparison = Sieve.StringComparison.is;
                 boolean caseSensitive = false;
@@ -449,16 +459,28 @@ public abstract class SieveVisitor {
                 headers = getMultiValue(node, 0, nextArgIndex, 0);
                 value = getValue(node, 0, nextArgIndex + 1, 0, 0);
                 validateCountComparator(isCount, comparator);
-                if (valueComparison != null) { 
-                    visitAddressTest(node, VisitPhase.begin, props, headers, part, valueComparison, isCount, value);
-                    accept(node, props);
-                    visitAddressTest(node, VisitPhase.end, props, headers, part, valueComparison, isCount, value);
-                } else {
-                    visitAddressTest(node, VisitPhase.begin, props, headers, part, comparison, caseSensitive, value);
-                    accept(node, props);
-                    visitAddressTest(node, VisitPhase.end, props, headers, part, comparison, caseSensitive, value);
-                }
 
+                if ("address".equalsIgnoreCase(nodeName)) {
+                    if (valueComparison != null) {
+                        visitAddressTest(node, VisitPhase.begin, props, headers, part, valueComparison, isCount, value);
+                        accept(node, props);
+                        visitAddressTest(node, VisitPhase.end, props, headers, part, valueComparison, isCount, value);
+                    } else {
+                        visitAddressTest(node, VisitPhase.begin, props, headers, part, comparison, caseSensitive, value);
+                        accept(node, props);
+                        visitAddressTest(node, VisitPhase.end, props, headers, part, comparison, caseSensitive, value);
+                    }
+                } else if ("envelope".equalsIgnoreCase(nodeName)) {
+                    if (valueComparison != null) {
+                        visitEnvelopeTest(node, VisitPhase.begin, props, headers, part, valueComparison, isCount, value);
+                        accept(node, props);
+                        visitEnvelopeTest(node, VisitPhase.end, props, headers, part, valueComparison, isCount, value);
+                    } else {
+                        visitEnvelopeTest(node, VisitPhase.begin, props, headers, part, comparison, caseSensitive, value);
+                        accept(node, props);
+                        visitEnvelopeTest(node, VisitPhase.end, props, headers, part, comparison, caseSensitive, value);
+                    }
+                }
             } else if ("exists".equalsIgnoreCase(nodeName)) {
                 String header = getValue(node, 0, 0, 0, 0);
 

--- a/store/src/java/com/zimbra/cs/filter/SoapToSieve.java
+++ b/store/src/java/com/zimbra/cs/filter/SoapToSieve.java
@@ -408,6 +408,13 @@ public final class SoapToSieve {
     }
 
     private static String toSieve(FilterTest.AddressTest test) throws ServiceException {
+        if (test instanceof FilterTest.EnvelopeTest) {
+            return formatAddress((FilterTest.EnvelopeTest) test, "envelope");
+        }
+        return formatAddress(test, "address");
+    }
+
+    private static String formatAddress(FilterTest.AddressTest test, String testName) throws ServiceException {
         String header = getSieveHeaderList(test.getHeader());
         Sieve.AddressPart part = Sieve.AddressPart.fromString(test.getPart());
         if (part == null) {
@@ -418,19 +425,19 @@ public final class SoapToSieve {
             String value = test.getValue();
             checkValue(comp, value);
             String valueStr = null == value ? "" : FilterUtil.escape(value);
-            return String.format("address :%s :%s :comparator \"%s\" %s \"%s\"", part, comp,
+            return String.format("%s :%s :%s :comparator \"%s\" %s \"%s\"", testName, part, comp,
                     test.isCaseSensitive() ? Sieve.Comparator.ioctet : Sieve.Comparator.iasciicasemap,
                             header, valueStr);
         }
 
         if (StringUtils.isNotEmpty(test.getValueComparison())) {
             Sieve.ValueComparison comp = Sieve.ValueComparison.fromString(test.getValueComparison());
-            return toSieve("address", header, comp, test.getValue(), false, part);
+            return toSieve(testName, header, comp, test.getValue(), false, part);
         }
 
         if (StringUtils.isNotEmpty(test.getCountComparison())) {
             Sieve.ValueComparison comp = Sieve.ValueComparison.fromString(test.getCountComparison());
-            return toSieve("address", header, comp, test.getValue(), true, part);
+            return toSieve(testName, header, comp, test.getValue(), true, part);
         }
         return null;
     }


### PR DESCRIPTION
[Story] -
Add support for envelope test in zimbra soap API

[Change] -
- Added EnvelopeTest that extends AddressTest 
- Add methods to convert envelope test soap object into sieve script
- Added sieve to soap visitor methods for envelope test

[Testing] -
- Manual testing for GetFilterRulesRequest and ModifyFilterRequests for envelope test with string
and value comparison
- Added junits for the same