### PR TITLE
ZCS-1287:Regression-Variables not replaced in notify

### DIFF
--- a/store/src/java-test/com/zimbra/cs/filter/TagTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/TagTest.java
@@ -78,4 +78,24 @@ public class TagTest {
             fail("No exception should be thrown");
         }
     }
+
+    @Test
+    public void testMimeVariable() throws Exception {
+        try {
+            Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+            RuleManager.clearCachedRules(account);
+            account.setMailSieveScript("tag \"${subject} World\";");
+            Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
+
+            List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox), mbox,
+                    new ParsedMessage("From: sender@zimbra.com\nSubject: Hello".getBytes(), false),
+                    0, account.getName(), new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
+            Assert.assertEquals(1, ids.size());
+            Tag tag = mbox.getTagByName(null, "Hello World");
+            Assert.assertTrue(tag.isListed());
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("No exception should be thrown");
+        }
+    }
 }

--- a/store/src/java-test/com/zimbra/cs/mailbox/MailboxTestUtil.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/MailboxTestUtil.java
@@ -34,6 +34,7 @@ import org.apache.commons.httpclient.HttpMethod;
 import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.methods.DeleteMethod;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
 
 import com.google.common.base.Strings;
 import com.zimbra.common.calendar.ZCalendar.ZVCalendar;
@@ -87,7 +88,12 @@ public final class MailboxTestUtil {
         zimbraServerDir = Strings.nullToEmpty(zimbraServerDir);
         System.setProperty("log4j.configuration", "log4j-test.properties");
         // Don't load from /opt/zimbra/conf
-        System.setProperty("zimbra.config", zimbraServerDir + "/src/java-test/localconfig-test.xml");
+        String pathPrefix = "/";
+        // If zimbraServerDir is empty, use relative path to localconfig-test.xml
+        if (StringUtils.isEmpty(zimbraServerDir)) {
+            pathPrefix = "";
+        }
+        System.setProperty("zimbra.config", zimbraServerDir + pathPrefix + "src/java-test/localconfig-test.xml");
         LC.reload();
         if (Strings.isNullOrEmpty(zimbraServerDir)) {
             zimbraServerDir = System.getProperty("user.dir");

--- a/store/src/java/com/zimbra/cs/filter/ZimbraMailAdapter.java
+++ b/store/src/java/com/zimbra/cs/filter/ZimbraMailAdapter.java
@@ -60,7 +60,6 @@ import com.zimbra.common.util.Pair;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.IDNUtil;
-import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.filter.jsieve.ActionEreject;
 import com.zimbra.cs.filter.jsieve.ActionFileInto;
 import com.zimbra.cs.filter.jsieve.ActionFlag;
@@ -321,7 +320,6 @@ public class ZimbraMailAdapter implements MailAdapter, EnvelopeAccessors {
                     ActionNotify notify = (ActionNotify) action;
                     ZimbraLog.filter.debug("Sending notification message to %s.", notify.getEmailAddr());
                     try {
-                    	
                         handler.notify(FilterUtil.replaceVariables(this, notify.getEmailAddr()),
                                 FilterUtil.replaceVariables(this, notify.getSubjectTemplate()),
                                 FilterUtil.replaceVariables(this, notify.getBodyTemplate()),
@@ -811,6 +809,17 @@ public class ZimbraMailAdapter implements MailAdapter, EnvelopeAccessors {
 
     public Map<String, String> getVariables() {
         return variables;
+    }
+
+    public Map<String, String> getMimeVariables() {
+        Map<String, String> headerVars = null;
+        try {
+            headerVars = FilterUtil.getVarsMap(mailbox,
+                handler.getParsedMessage(), handler.getMimeMessage());
+        } catch (MessagingException | ServiceException e) {
+            ZimbraLog.filter.error("Unable to read header variables.", e);
+        }
+        return headerVars;
     }
 
     public void updateIncomingBlob() {


### PR DESCRIPTION
Issue:
Header names as variables names if used in the script, were not being replaced with it's corresponding value in mime message. 

Fix:
If no variable with given header name is already declared(with 'set' action), the variable is now being replaced with header value.
If not present in mime header list as well, it should replace with empty string. If present in both, precedence is given to "set" action.

Added junit test for notify.
Executed existing automation MailClient/FilterRules/FilterNotifyReplyAction.xml