### PR TITLE
ZMS-212: Fixed AppendMessage::store behavior with RemoteImapMailboxStore

### DIFF
--- a/store/src/java/com/zimbra/cs/imap/AppendMessage.java
+++ b/store/src/java/com/zimbra/cs/imap/AppendMessage.java
@@ -32,6 +32,7 @@ import javax.mail.internet.InternetHeaders;
 import javax.mail.internet.MailDateFormat;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Joiner;
 import com.google.common.collect.Sets;
 import com.zimbra.common.mailbox.FolderStore;
 import com.zimbra.common.mime.shim.JavaMailInternetAddress;
@@ -215,11 +216,11 @@ final class AppendMessage {
             return msg == null ? -1 : msg.getId();
         }
         if (mboxStore instanceof RemoteImapMailboxStore) {
-            /* TODO: For new IMAP, may need to do more here to get, e.g. the flags correct. */
             String id;
             try (InputStream is = content.getInputStream()) {
+                String tagStr = tags.isEmpty() ? null : Joiner.on(",").join(tags);
                 id = ((RemoteImapMailboxStore) mboxStore).getZMailbox().addMessage(folderStore.getFolderIdAsString(),
-                        Flag.toString(flags), null, date.getTime(), is, content.getRawSize(), true);
+                        Flag.toString(flags), tagStr, date.getTime(), is, content.getRawSize(), true);
             }
             return new ItemId(id, mboxStore.getAccountId()).getId();
         }

--- a/store/src/java/com/zimbra/qa/unittest/TestRemoteImapShared.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestRemoteImapShared.java
@@ -68,12 +68,6 @@ public class TestRemoteImapShared extends SharedImapTests {
 
     @Override
     @Ignore ("failing on remote imap for now")
-    public void testAppend() throws Exception {
-
-    }
-
-    @Override
-    @Ignore ("failing on remote imap for now")
     public void testAppendTags() throws Exception {
 
     }


### PR DESCRIPTION
The only thing missing from AppendMessage::store behavior when using remote IMAP is proper handling of message tags. This PR fixes this.

It should be noted that although the current ZMailbox behavior requires message tags to be specified by ID, they are returned in the fetch response by name.

The _testAppend_ unit test in SharedImapTests has been updated to set a custom tag on the message, as well as verify that the flags and tags are set on the fetched message. To facilitate this, the _fetchBody_ utility method in SharedImapTests have been split into _fetchMessage_ and _getBody_.
