### PR TITLE
ZCS-1378:SIEVE:Reset variables before user/admin-after filter

### DIFF
--- a/store/src/java-test/com/zimbra/cs/filter/RuleManagerAdminFilterTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/RuleManagerAdminFilterTest.java
@@ -186,17 +186,22 @@ public final class RuleManagerAdminFilterTest {
     String[] variableScripts = {
             // admin-before
               "require [\"tag\", \"log\", \"variables\"];"
-            + "set \"var\" \"foo\";"
-            + "tag \"before-${var}\";",
+            + "set \"beforevar\" \"foo\";"
+            + "tag \"admin-before1-${beforevar}\";",
             // enduser
               "require [\"tag\", \"log\", \"variables\"];"
-            + "tag \"enduser-${var}\";",
+            + "set \"uservar\" \"bar\";"
+            + "tag \"enduser1-${beforevar}\";"
+            + "tag \"enduser2-${uservar}\";",
             // admin-after
               "require [\"tag\", \"log\", \"variables\"];"
-            + "tag \"after-${var}\";"};
+            + "set \"aftervar\" \"baz\";"
+            + "tag \"admin-after1-${beforevar}\";"
+            + "tag \"admin-after2-${uservar}\";"
+            + "tag \"admin-after3-${aftervar}\";"};
 
-/*    @Test
-    public void variableAdminOnUserOff() throws Exception {
+    @Test
+    public void resetVariables() throws Exception {
         Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
         RuleManager.clearCachedRules(account);
 
@@ -206,13 +211,13 @@ public final class RuleManagerAdminFilterTest {
 
         Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
-        account.unsetMailAdminSieveScriptBefore();
+        account.unsetAdminSieveScriptBefore();
         account.unsetMailSieveScript();
-        account.unsetMailAdminSieveScriptAfter();
+        account.unsetAdminSieveScriptAfter();
 
-        account.setMailAdminSieveScriptBefore(variableScripts[0]);
+        account.setAdminSieveScriptBefore(variableScripts[0]);
         account.setMailSieveScript(variableScripts[1]);
-        account.setMailAdminSieveScriptAfter(variableScripts[2]);
+        account.setAdminSieveScriptAfter(variableScripts[2]);
 
         List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox),
                 mbox, new ParsedMessage(message.getBytes(), false),
@@ -220,13 +225,16 @@ public final class RuleManagerAdminFilterTest {
         Assert.assertEquals(1, ids.size());
         Message msg = mbox.getMessageById(null, ids.get(0).getId());
         String[] tags = msg.getTags();
-        Assert.assertEquals(3, tags.length);
-        Assert.assertEquals("before-foo", tags[0]);    // ${var} has a defined value
-        Assert.assertEquals("enduser-${var}", tags[1]);// Variable feature is off
-        Assert.assertEquals("after-", tags[2]);        // Variable feature is on but no definition of ${var}
+        Assert.assertEquals(6, tags.length);
+        Assert.assertEquals("admin-before1-foo", tags[0]);
+        Assert.assertEquals("enduser1-", tags[1]);
+        Assert.assertEquals("enduser2-bar", tags[2]);
+        Assert.assertEquals("admin-after1-", tags[3]);
+        Assert.assertEquals("admin-after2-", tags[4]);
+        Assert.assertEquals("admin-after3-baz", tags[5]);
     }
 
-    @Test
+/*  @Test
     public void variableAdminOnUserOn() throws Exception {
         Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
         RuleManager.clearCachedRules(account);
@@ -386,7 +394,7 @@ public final class RuleManagerAdminFilterTest {
     }
 
     // Verification for the ZCS-272
-    @Test
+/*  @Test
     public void deleteHeaderInAdminBefore() throws Exception {
         String adminBefore = "require [\"editheader\",\"log\"];\n"
                            + "deleteheader :matches \"X-Test-Header\" \"Ran*\";\n";
@@ -501,6 +509,7 @@ public final class RuleManagerAdminFilterTest {
         }
         Assert.assertTrue(headerDeleted);
     }
+*/
 
     /* Verification for the ZCS-611
      */

--- a/store/src/java/com/zimbra/cs/filter/JsieveConfigMapHandler.java
+++ b/store/src/java/com/zimbra/cs/filter/JsieveConfigMapHandler.java
@@ -60,6 +60,7 @@ public class JsieveConfigMapHandler {
         mCommandMap.put("copy", com.zimbra.cs.filter.jsieve.Copy.class.getName());
         mCommandMap.put("log", com.zimbra.cs.filter.jsieve.VariableLog.class.getName());
         //mCommandMap.put("deleteheader", com.zimbra.cs.filter.jsieve.DeleteHeader.class.getName());
+        mCommandMap.put("zimbravariablesctrl", com.zimbra.cs.filter.jsieve.ZimbraVariablesCtrl.class.getName());
 
         mCommandMap.put("notify",  com.zimbra.cs.filter.jsieve.NotifyMailto.class.getName());
         mCommandMap.put("reject", com.zimbra.cs.filter.jsieve.Reject.class.getName());

--- a/store/src/java/com/zimbra/cs/filter/RuleManager.java
+++ b/store/src/java/com/zimbra/cs/filter/RuleManager.java
@@ -243,7 +243,8 @@ public final class RuleManager {
                 } else {
                     List<String> splits = splitScript(script);
                     requiresPart.append(splits.get(0));
-                    debugScript = script = splits.get(1);
+                    script = "\nzimbravariablesctrl :reset;\n" + splits.get(1);
+                    debugScript = splits.get(1);
                 }
                 if (adminRuleAfter == null) {
                     debugAdminRuleAfter = "";
@@ -251,7 +252,8 @@ public final class RuleManager {
                 } else {
                     List<String> splits = splitScript(adminRuleAfter);
                     requiresPart.append(splits.get(0));
-                    debugAdminRuleAfter = adminRuleAfter = splits.get(1);
+                    adminRuleAfter = "\nzimbravariablesctrl :reset;\n" + splits.get(1);
+                    debugAdminRuleAfter = splits.get(1);
                 }
                 /*
                  * Since "require" is only allowed before other commands,

--- a/store/src/java/com/zimbra/cs/filter/jsieve/ZimbraVariablesCtrl.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/ZimbraVariablesCtrl.java
@@ -1,0 +1,98 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2017 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.filter.jsieve;
+
+import java.util.List;
+
+import org.apache.jsieve.Argument;
+import org.apache.jsieve.Arguments;
+import org.apache.jsieve.Block;
+import org.apache.jsieve.SieveContext;
+import org.apache.jsieve.StringListArgument;
+import org.apache.jsieve.TagArgument;
+import org.apache.jsieve.commands.AbstractCommand;
+import org.apache.jsieve.exception.SieveException;
+import org.apache.jsieve.exception.SyntaxException;
+import org.apache.jsieve.mail.MailAdapter;
+
+import com.zimbra.cs.filter.ZimbraMailAdapter;
+
+/**
+ * SIEVE command for controlling the Variables functionality
+ * <p>
+ * Internal-use-only built-in command for resetting the variable data.
+ * <p>
+ * {@code zimbravariablesctrl [:reset]}
+ * <ul>
+ *  <li>{@code :reset} Reset the variable data which is stored in the
+ *  ZimbraMailAdapter object. Both name-based variable ("${abc}") and
+ *  number-based variable ("${1}") will be reset.
+ * </ul>
+ */
+public class ZimbraVariablesCtrl extends AbstractCommand {
+    static final String RESET = ":reset";
+
+    @Override
+    protected Object executeBasic(MailAdapter mail, Arguments arguments, Block block, SieveContext context)
+            throws SieveException {
+        if (!(mail instanceof ZimbraMailAdapter)) {
+            return null;
+        }
+        ZimbraMailAdapter mailAdapter = (ZimbraMailAdapter) mail;
+
+        for (Argument arg: arguments.getArgumentList()) {
+            if (arg instanceof TagArgument) {
+                TagArgument tag = (TagArgument) arg;
+                String tagValue = tag.getTag();
+                if (RESET.equalsIgnoreCase(tagValue)) {
+                    mailAdapter.clearValues();
+                } else {
+                    throw new SyntaxException("Invalid tag: [" + tagValue + "]");
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    protected void validateArguments(Arguments arguments, SieveContext context)
+    throws SieveException
+    {
+        List<Argument> args = arguments.getArgumentList();
+        if (args.size() > 1) {
+            throw new SyntaxException(
+                "More than one argument found (" + args.size() + ")");
+        }
+
+        for (Argument arg: arguments.getArgumentList()) {
+            if (arg instanceof TagArgument) {
+                TagArgument tag = (TagArgument) arg;
+                String tagValue = tag.getTag();
+                if (!RESET.equalsIgnoreCase(tagValue)) {
+                    throw new SyntaxException("Invalid tag: [" + tagValue + "]");
+                }
+            } else {
+                if (arg instanceof StringListArgument) {
+                    String argument = ((StringListArgument) arg).getList().get(0);
+                    throw new SyntaxException("Invalid argument: [" + argument + "]");
+                } else {
+                    throw new SyntaxException("Invalid argument");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
[Bug]
The variables that are assigned in the admin-before script are
mistakenly accessible from the subsequent scripts. If the end
user sets some text of "${var}" in the zimbraMailSieveScript,
it may be replaced by either the value assigned by the admin-before
rule; from the end user viewpoint, the text "${var}" should be
handled based on the setting within the zimbraMailSieveScript.

The mechanism for resetting the variables defined in another filter
rule set has been implemented by introducing the internal Sieve
action "zimbravariablectrl" under the Bug 104912
(https://bugzilla.zimbra.com/show_bug.cgi?id=104912#c24), but it was
backed out by zcs-806.

[Fix]
* The "zimbravariablesctrl" action is rescued from the source code
  before zcs-806.  The zimbravariablesctrl action with ":reset"
  parameter is now invisibility inserted between the admin-before
  and user-defined rules, and user-defined and admin-after rules.
  This action resets the variable caches stored in the ZimbraMailAdapter.

* Added an unit test RuleManagerAdminFilterTest.resetVariables().
* Commented out the test cases which use "deleteheader" action
  in the RuleManagerAdminFilterTest class.

[Test]
* All unit tests in RuleManagerAdminFilterTest: PASS