### PR TITLE
Added percent quota used to the response returned

### DIFF
--- a/store/src/java/com/zimbra/cs/service/admin/GetQuotaUsage.java
+++ b/store/src/java/com/zimbra/cs/service/admin/GetQuotaUsage.java
@@ -187,6 +187,7 @@ public class GetQuotaUsage extends AdminDocumentHandler {
                         quota.id = accountElt.getAttribute(AdminConstants.A_ID);
                         quota.quotaUsed = accountElt.getAttributeLong(AdminConstants.A_QUOTA_USED);
                         quota.quotaLimit = accountElt.getAttributeLong(AdminConstants.A_QUOTA_LIMIT);
+                        quota.percentQuotaUsed = quota.quotaLimit > 0 ? (quota.quotaUsed / (float)quota.quotaLimit) : 0;
                         retList.add(quota);
                     }
                     return retList;


### PR DESCRIPTION
This issues happens in a multi node environment when the quota usage is fetched from all the servers. In the The AccountQuota object 'percentQuotaUsed' field was not populated, hence the data was not properly sorted when you clicked on 'Quota Used' in admin console ("Configure" -> "Domains" -> "pccwglobal.com" -> "Mailbox Quota"). It used be on descending on per server basis.

Fixed by populating the 'percentQuotaUsed'

Testing
Installed the jar with the fix in a multi node environment and verified that the when sorted by 'Quota Used'  it is in descending order of high usage mailbox irrespective of the server they belong.