### PR TITLE
ZMS-366: Remote IMAP Tag Rename Handling

### DIFF
--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -2861,6 +2861,11 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
     public ZFolder getFolderById(String id) throws ServiceException {
         populateFolderCache();
         ZItem item = mItemCache.getById(id);
+        if (item == null && mUserRoot != null) {
+            // try rebuilding folder cache
+            addIdMappings(mUserRoot);
+        }
+        item = mItemCache.getById(id);
         if (!(item instanceof ZFolder)) {
             return null;
         }

--- a/store/src/java/com/zimbra/cs/imap/ImapFolder.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapFolder.java
@@ -52,7 +52,6 @@ import com.zimbra.cs.mailbox.Flag;
 import com.zimbra.cs.mailbox.Folder;
 import com.zimbra.cs.mailbox.MailItem;
 import com.zimbra.cs.mailbox.Mailbox;
-import com.zimbra.cs.mailbox.OperationContext;
 import com.zimbra.cs.session.PendingModifications.Change;
 
 /**
@@ -482,8 +481,12 @@ public final class ImapFolder implements ImapListener.ImapFolderData, java.io.Se
             for (String tag : i4msg.tags) {
                 if (tags.getByZimbraName(tag) == null) {
                     try {
-                        tags.cache(mailboxStore.getTagByName(tag));
-                        setTagsDirty(true);
+                        ImapFlag flag = mailboxStore.getTagByName(tag);
+                        if (flag != null) {
+                            // null means that the tag was changed while the folder was paged out
+                            tags.cache(flag);
+                            setTagsDirty(true);
+                        }
                     } catch (ServiceException e) {
                         ZimbraLog.imap.warn("could not fetch listed tag: %s", tag, e);
                     }

--- a/store/src/java/com/zimbra/cs/imap/RemoteImapMailboxStore.java
+++ b/store/src/java/com/zimbra/cs/imap/RemoteImapMailboxStore.java
@@ -82,7 +82,7 @@ public class RemoteImapMailboxStore extends ImapMailboxStore {
     @Override
     public ImapFlag getTagByName(String tag) throws ServiceException {
         ZTag ztag = zMailbox.getTagByName(tag);
-        return new ImapFlag(ztag);
+        return ztag == null ? null : new ImapFlag(ztag);
     }
 
     @Override

--- a/store/src/java/com/zimbra/cs/session/ModificationItem.java
+++ b/store/src/java/com/zimbra/cs/session/ModificationItem.java
@@ -45,6 +45,7 @@ public class ModificationItem implements BaseItemInfo, BaseFolderInfo, ZimbraTag
     private ModificationItem(int tagId, String tagName) {
         this.tagId = tagId;
         this.tagName = tagName;
+        this.type = MailItemType.TAG;
     }
 
     private ModificationItem(int id, String path, String acctId) {
@@ -53,6 +54,7 @@ public class ModificationItem implements BaseItemInfo, BaseFolderInfo, ZimbraTag
         this.path = path;
         this.type = MailItemType.FOLDER;
     }
+
     private ModificationItem(ImapMessageInfo msg, int folderId, String acctId) {
         this.acctId = acctId;
         this.flags = msg.getFlags();

--- a/store/src/java/com/zimbra/cs/session/PendingLocalModifications.java
+++ b/store/src/java/com/zimbra/cs/session/PendingLocalModifications.java
@@ -45,7 +45,7 @@ public final class PendingLocalModifications extends PendingModifications<MailIt
     @Override
     PendingModifications<MailItem> add(PendingModifications<MailItem> other) {
         changedTypes.addAll(other.changedTypes);
-        addChangedFolderIds(other.getChangedFolders());
+        addChangedParentFolderIds(other.getChangedParentFolders());
 
         if (other.deleted != null) {
             for (Map.Entry<PendingModifications.ModificationKey, PendingModifications.Change> entry : other.deleted
@@ -85,7 +85,7 @@ public final class PendingLocalModifications extends PendingModifications<MailIt
         }
         changedTypes.add(MailItem.Type.fromCommon(item.getMailItemType()));
         try {
-            addChangedFolderId(item.getFolderIdInMailbox());
+            addChangedParentFolderId(item.getFolderIdInMailbox());
         } catch (ServiceException e) {
             ZimbraLog.mailbox.warn("error getting folder ID for modified item");
         }
@@ -97,7 +97,7 @@ public final class PendingLocalModifications extends PendingModifications<MailIt
         MailItem.Type type = MailItem.Type.fromCommon(itemSnapshot.getMailItemType());
         changedTypes.add(type);
         try {
-            addChangedFolderId(itemSnapshot.getFolderIdInMailbox());
+            addChangedParentFolderId(itemSnapshot.getFolderIdInMailbox());
         } catch (ServiceException e) {
             ZimbraLog.mailbox.warn("error getting folder ID for modified item");
         }
@@ -123,9 +123,16 @@ public final class PendingLocalModifications extends PendingModifications<MailIt
         MailItem.Type type = MailItem.Type.fromCommon(item.getMailItemType());
         changedTypes.add(type);
         try {
-            addChangedFolderId(item.getFolderIdInMailbox());
+            addChangedParentFolderId(item.getFolderIdInMailbox());
         } catch (ServiceException e) {
             ZimbraLog.mailbox.warn("error getting folder ID for modified item");
+        }
+        if (type == MailItem.Type.FOLDER) {
+            try {
+                addChangedFolderId(item.getIdInMailbox());
+            } catch (ServiceException e) {
+                ZimbraLog.mailbox.warn("error getting ID for modified item");
+            }
         }
         recordModified(new ModificationKey(item), item, reason, null, true);
     }
@@ -135,9 +142,16 @@ public final class PendingLocalModifications extends PendingModifications<MailIt
         MailItem.Type type = MailItem.Type.fromCommon(item.getMailItemType());
         changedTypes.add(type);
         try {
-            addChangedFolderId(item.getFolderIdInMailbox());
+            addChangedParentFolderId(item.getFolderIdInMailbox());
         } catch (ServiceException e) {
             ZimbraLog.mailbox.warn("error getting folder ID for modified item");
+        }
+        if (type == MailItem.Type.FOLDER) {
+            try {
+                addChangedFolderId(item.getIdInMailbox());
+            } catch (ServiceException e) {
+                ZimbraLog.mailbox.warn("error getting ID for modified item");
+            }
         }
         recordModified(new ModificationKey(item), item, reason, preModifyItem, false);
     }
@@ -245,7 +259,7 @@ public final class PendingLocalModifications extends PendingModifications<MailIt
         PendingLocalModifications pms = new PendingLocalModifications();
         try (ObjectInputStream ois = new ObjectInputStream(bis)) {
             pms.changedTypes = (Set<Type>) ois.readObject();
-            pms.addChangedFolderIds((Set<Integer>) ois.readObject());
+            pms.addChangedParentFolderIds((Set<Integer>) ois.readObject());
 
             LinkedHashMap<ModificationKeyMeta, String> metaCreated = (LinkedHashMap<ModificationKeyMeta, String>) ois
                     .readObject();

--- a/store/src/java/com/zimbra/cs/session/SoapSession.java
+++ b/store/src/java/com/zimbra/cs/session/SoapSession.java
@@ -236,7 +236,7 @@ public class SoapSession extends Session {
             OperationContext octxt = new OperationContext(getAuthenticatedAccountId());
             PendingLocalModifications filtered = new PendingLocalModifications();
             filtered.changedTypes = pms.changedTypes;
-            filtered.addChangedFolderIds(pms.getChangedFolders());  // Not 100% sure this is best but it is conservative
+            filtered.addChangedParentFolderIds(pms.getChangedParentFolders());  // Not 100% sure this is best but it is conservative
             if (pms.deleted != null && !pms.deleted.isEmpty()) {
                 filtered.recordDeleted(pms.deleted);
             }

--- a/store/src/java/com/zimbra/cs/session/WaitSetSession.java
+++ b/store/src/java/com/zimbra/cs/session/WaitSetSession.java
@@ -98,7 +98,7 @@ public class WaitSetSession extends Session {
         boolean trace = ZimbraLog.session.isTraceEnabled();
         if (trace) {
             ZimbraLog.session.trace("Notifying WaitSetSession %s: change id=%s changedFolders=%s changesTypes='%s'",
-                    this, changeId, pns.getChangedFolders(), pns.changedTypes);
+                    this, changeId, pns.getAllChangedFolders(), pns.changedTypes);
         }
         if (changeId > mHighestChangeId) {
             mHighestChangeId = changeId;
@@ -119,11 +119,11 @@ public class WaitSetSession extends Session {
             return;
         }
         if ((folderInterest != null) && !folderInterest.isEmpty() &&
-                Sets.intersection(folderInterest, pns.getChangedFolders()).isEmpty()) {
+         Sets.intersection(folderInterest, pns.getAllChangedFolders()).isEmpty()) {
             if (trace) {
                 ZimbraLog.session.trace(
                         "Not signaling waitset; changes not in folders waitset is interested in %s changed=%s",
-                        this.folderInterest, pns.getChangedFolders());
+                        this.folderInterest, pns.getAllChangedFolders());
             }
             return;
         }


### PR DESCRIPTION
When a tag is renamed, two types of notifications are triggered on the server:
 - the renamed tag is notified
 - all non-empty folders are notified

Some changes had to be made in order for these changes to trigger a waitset:
#### Folder Interests
Prior to this change, a waitset was triggered on a folder when an action was taken on an item in the folder. When a tag is renamed, however, the folders themselves should be notified, as opposed to their parents. In order for this to be recognized by the waitset, the _folderInterest_ mechanism had to be updated to be triggered when a change occurs on the folder itself. To this end, the _PendingModifications_ now contains two integer sets:
 - _changedParentFolders_ replaced what used to be called _changedFolders_
 - _changedFolders_ now tracks IDs of folders in the scenario that the folder itself was somehow affected (such as during a tag rename operation)
Waitsets are triggered if a folder interest intersects with _either_ of the these sets.

#### Tag Modifications
Tag modifications have to be treated differently than other modifications because it is unknown which folder contains items that need to be re-tagged. To this end, the _ModifyNotification_ loop in _WaitSetRequest_ first iterates over all the changes and aggregates all tag changes in a single array of _ModifyTagNotifications_. It then iterates over the changes again, this time setting the tag changes on each non-empty folder that was notified. This way, the IMAP server can iterate over the messages in each folder and update their tags appropriately.

#### ZMailbox Changes
_ZMailbox::getFolderById_ had to be modified to rebuild the item cache from the known folder hierarchy in the event of a cache miss. The _getFolderById_ method looks for the folder in the item cache, which can be overwritten by the tag update.

#### Paged Folders
Finally, in order for this to work on paged folders, _ImapFolder_ and _RemoteImapMailboxStore_ classes had to be updated to do a null check when loading tags. This is necessary because when a paged folder is loaded, it attempts to restore the last-known item tags from the cache; however, renamed tags will no longer be there, leading to a null value.

#### Unit Tests
Two new unit tests have been added to _TestRemoteImapNotications_: _testRenameTagNotificationActiveFolder_ and _testRenameTagNotificationCachedFolder_. 