### PR TITLE
ZCS-1429: Append-related unit tests

### DIFF
--- a/store/src/java/com/zimbra/cs/imap/AppendMessage.java
+++ b/store/src/java/com/zimbra/cs/imap/AppendMessage.java
@@ -34,6 +34,7 @@ import javax.mail.internet.MailDateFormat;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Sets;
+import com.zimbra.client.ZMailbox.TagSpecifier;
 import com.zimbra.common.mailbox.FolderStore;
 import com.zimbra.common.mime.shim.JavaMailInternetAddress;
 import com.zimbra.common.mime.shim.JavaMailInternetHeaders;
@@ -218,10 +219,10 @@ final class AppendMessage {
         if (mboxStore instanceof RemoteImapMailboxStore) {
             String id;
             try (InputStream is = content.getInputStream()) {
-                String tagStr = tags.isEmpty() ? null : Joiner.on(",").join(tags);
-                long dateTime = (null != date) ? date.getTime() : 0;
+                TagSpecifier tagSpec = tags.isEmpty() ? null : TagSpecifier.tagByName(Joiner.on(",").join(tags));
+                long receivedDate = date != null ? date.getTime() : 0;
                 id = ((RemoteImapMailboxStore) mboxStore).getZMailbox().addMessage(folderStore.getFolderIdAsString(),
-                        Flag.toString(flags), tagStr, dateTime, is, content.getRawSize(), true);
+                        Flag.toString(flags), tagSpec, receivedDate, is, content.getRawSize(), true);
             }
             return new ItemId(id, mboxStore.getAccountId()).getId();
         }

--- a/store/src/java/com/zimbra/cs/imap/ImapMessage.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapMessage.java
@@ -398,6 +398,12 @@ public class ImapMessage implements Comparable<ImapMessage>, java.io.Serializabl
                     if (other == null || other == i4flag) {
                         result.append(result.length() == empty ? "" : " ").append(i4flag);
                     }
+                } else {
+                    // this is not a visible tag; perform the conflict check and return anyways
+                    ImapFlag other = i4folder.getFlagByName(tag);
+                    if (other == null) {
+                        result.append(result.length() == empty ? "" : " ").append(tag);
+                    }
                 }
             }
         }

--- a/store/src/java/com/zimbra/cs/imap/RemoteImapMailboxStore.java
+++ b/store/src/java/com/zimbra/cs/imap/RemoteImapMailboxStore.java
@@ -237,7 +237,7 @@ public class RemoteImapMailboxStore extends ImapMailboxStore {
     throws ImapSessionClosedException, ServiceException, IOException {
         String id;
         try (InputStream is = content.getInputStream()) {
-            id = zMailbox.addMessage(folderId, Flag.toString(msgFlags), null, date.getTime(), is,
+            id = zMailbox.addMessage(folderId, Flag.toString(msgFlags), (String) null, date.getTime(), is,
                     content.getRawSize(), true);
         }
         return new ItemId(id, accountId).getId();

--- a/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
@@ -735,7 +735,7 @@ public class ItemActionHelper {
             case MESSAGE:
                 try {
                     in = StoreManager.getInstance().getContent(item.getBlob());
-                    createdId = zmbx.addMessage(folderStr, flags, null, item.getDate(), in, item.getSize(), true);
+                    createdId = zmbx.addMessage(folderStr, flags, (String) null, item.getDate(), in, item.getSize(), true);
                 } finally {
                     ByteUtil.closeStream(in);
                 }
@@ -747,7 +747,7 @@ public class ItemActionHelper {
                     flags = (mOperation == Op.UPDATE && mFlags != null ? mFlags : msg.getFlagString());
                     try {
                         in = StoreManager.getInstance().getContent(msg.getBlob());
-                        createdId = zmbx.addMessage(folderStr, flags, null, msg.getDate(), in, msg.getSize(), true);
+                        createdId = zmbx.addMessage(folderStr, flags, (String) null, msg.getDate(), in, msg.getSize(), true);
                     } finally {
                         ByteUtil.closeStream(in);
                     }

--- a/store/src/java/com/zimbra/qa/unittest/TestLocalImap.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestLocalImap.java
@@ -6,6 +6,7 @@ import org.dom4j.DocumentException;
 import org.junit.After;
 import org.junit.Before;
 
+import com.zimbra.client.ZMailbox;
 import com.zimbra.common.localconfig.ConfigException;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
@@ -33,5 +34,10 @@ public class TestLocalImap extends SharedImapTests {
     public void tearDown() throws ServiceException, DocumentException, ConfigException, IOException  {
         super.sharedTearDown();
         TestUtil.setLCValue(LC.imap_always_use_remote_store, String.valueOf(saved_imap_always_use_remote_store));
+    }
+
+    @Override
+    protected ZMailbox getImapZMailbox() throws Exception {
+        return TestUtil.getZMailbox(USER);
     }
 }

--- a/store/src/java/com/zimbra/qa/unittest/TestRemoteImapShared.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestRemoteImapShared.java
@@ -1,15 +1,20 @@
 package com.zimbra.qa.unittest;
 
 import java.io.IOException;
+import java.util.Set;
 
 import org.dom4j.DocumentException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 
+import com.zimbra.client.ZMailbox;
 import com.zimbra.common.localconfig.ConfigException;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.imap.ImapRemoteSession;
+import com.zimbra.cs.imap.ImapServerListener;
+import com.zimbra.cs.imap.ImapServerListenerPool;
 
 /**
  * This is a shell test for Remote IMAP tests that does the necessary configuration to select
@@ -37,15 +42,14 @@ public class TestRemoteImapShared extends SharedImapTests {
     }
 
     @Override
-    @Ignore ("failing on remote imap for now")
-    public void testMultiappendNoLiteralPlus() throws Exception {
-
-    }
-
-    @Override
-    @Ignore ("failing on remote imap for now")
-    public void testMultiappend() throws Exception {
-
+    protected ZMailbox getImapZMailbox() throws Exception {
+        // return the ZMailbox instance used by the imap listener
+        ZMailbox mbox = TestUtil.getZMailbox(USER);
+        ImapServerListener listener = ImapServerListenerPool.getInstance().get(mbox);
+        Set<ImapRemoteSession> sessions = listener.getListeners(mbox.getAccountId(), 2);
+        ImapRemoteSession session = sessions.iterator().next();
+        ZMailbox zmbox = (ZMailbox) session.getMailbox();
+        return zmbox;
     }
 
     @Override
@@ -67,8 +71,13 @@ public class TestRemoteImapShared extends SharedImapTests {
     }
 
     @Override
+    public void testStoreTagsDirty() throws Exception {
+
+    }
+
+    @Override
     @Ignore ("failing on remote imap for now")
-    public void testAppendTags() throws Exception {
+    public void testStoreInvalidSystemFlag() throws Exception {
 
     }
 


### PR DESCRIPTION
This is a continuation of the work started in ZMS-212.

Changes to SharedImapTests:

- _testAppend_ has been split into _testAppend_ and _testAppendFlags_
- new _getImapZMailbox_ method lets remote IMAP tests access the _ZMailbox_ instance used by the IMAP server. This is necessary for _testAppendTags_ unit test, as folders created using a non-IMAP client are not reflected on the IMAP server in certain scenarios (ZCS-1488 addresses this).
- all append-related remote unit tests have been activated
- _fetchMessage_ method has been updated to fetch flags

Other changes:

- _ZMailbox_ has a new static inner class _TagSpecifier_ that can be used by a new _addMessage_ method signature to specify tags either by name or ID
- _AppendMessage_ uses a _TagSpecifier_ to set the tags by name (other parts of the code use tag IDs)
- null dates are properly handled by _AppendMessage_ in the remote case
- _ImapMessage.getFlags()_ can return tags that are not registered with the mailbox


