### PR TITLE
ZCS-1047:S/MIME certificate not seen in Contact Properties

### DIFF
--- a/store/src/java/com/zimbra/cs/ldap/unboundid/UBIDAttributes.java
+++ b/store/src/java/com/zimbra/cs/ldap/unboundid/UBIDAttributes.java
@@ -23,7 +23,7 @@ import java.util.Set;
 import com.unboundid.ldap.sdk.Attribute;
 import com.unboundid.ldap.sdk.Entry;
 import com.unboundid.ldap.sdk.SearchResultEntry;
-
+import com.zimbra.common.mailbox.ContactConstants;
 import com.zimbra.common.util.ByteUtil;
 import com.zimbra.cs.account.AttributeManager;
 import com.zimbra.cs.ldap.LdapException;
@@ -93,7 +93,6 @@ public class UBIDAttributes extends ZAttributes {
     protected String getAttrString(String transferAttrName, boolean containsBinaryData) 
     throws LdapException {
         Attribute attr = entry.getAttribute(transferAttrName);
-        
         if (attr != null) {
             return getAttrStringInternal(attr, containsBinaryData);
         } else {
@@ -105,7 +104,11 @@ public class UBIDAttributes extends ZAttributes {
     protected String[] getMultiAttrString(String transferAttrName, boolean containsBinaryData) 
     throws LdapException {
         Attribute attr = entry.getAttribute(transferAttrName);
-        
+        // (ZCS-1047) AD sends 'userCertificate;binary' attribute as 'userCertificate' without appending ';binary' to it
+        if (attr == null && transferAttrName.startsWith(ContactConstants.A_userCertificate)) {
+            attr = entry.getAttribute(ContactConstants.A_userCertificate);
+        }
+
         if (attr != null) {
             return getMultiAttrStringInternal(attr, containsBinaryData);
         } else {


### PR DESCRIPTION
Issue:
Configure AD as external GAL on a domain in ZCS. When ZCO sends SyncGalRequest and GetContactsRequest, the ZCS does not send the userCertificate in GetContactsResponse

Root cause:
AD sends 'userCertificate;binary' attribute as 'userCertificate' without appending ';binary' to it. So, the server is not able to pick the attribute from entry data sent by AD

Fix:
If the attribute is not found by 'userCertficate;binary' name, fallback to get attribute with 'userCertificate' name.
