### PR TITLE
ZCS-1488: IMAP selecting folders created by non-IMAP clients

### DIFF
--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -3951,6 +3951,7 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
      *
      * @throws ServiceException on error
      */
+    @Override
     public void noOp() throws ServiceException {
         invoke(newRequestElement(MailConstants.NO_OP_REQUEST));
     }

--- a/common/src/java/com/zimbra/common/mailbox/MailboxStore.java
+++ b/common/src/java/com/zimbra/common/mailbox/MailboxStore.java
@@ -86,4 +86,5 @@ public interface MailboxStore {
      */
     public int getLastChangeID();
     public List<Integer> resetImapUid(OpContext octxt, List<Integer> itemIds) throws ServiceException;
+    public void noOp() throws ServiceException;
 }

--- a/store/src/java/com/zimbra/cs/imap/ImapPath.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapPath.java
@@ -354,6 +354,12 @@ public class ImapPath implements Comparable<ImapPath> {
             }
             folder = mboxStore.getFolderByPath(getContext(), asZimbraPath());
             if (folder == null) {
+                // If the folder is not found, it's possible that it was created
+                // by a non-imap client. Issue a noOp request to get latest changes and try again.
+                mboxStore.noOp();
+                folder = mboxStore.getFolderByPath(getContext(), asZimbraPath());
+            }
+            if (folder == null) {
                 throw MailServiceException.NO_SUCH_FOLDER(asImapPath());
             }
             mItemId = new ItemId(folder.getFolderIdAsString(), accountIdFromCredentials());

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -10357,4 +10357,9 @@ public class Mailbox implements MailboxStore {
         return new LocalQueryHitResults(zqr);
     }
 
+    @Override
+    public void noOp() throws ServiceException {
+        // do nothing
+    }
+
 }

--- a/store/src/java/com/zimbra/qa/unittest/SharedImapTests.java
+++ b/store/src/java/com/zimbra/qa/unittest/SharedImapTests.java
@@ -959,16 +959,6 @@ public abstract class SharedImapTests {
         req.sendCheckStatus();
     }
 
-    /**
-     * This method is needed for testAppendTags because folders created with a non-IMAP
-     * client are currently not reflected on the IMAP server in some scenarios.
-     * In the remote case, the ZMailbox instance used to create the folder should be
-     * the same one used by the IMAP listener ({@Link TestRemoteImapShared#getImapZMailbox()}.
-     * In the local case, the instance returned by {@Link TestUtil#getZMailbox(String)} suffices.
-     * When this issue is resolved, this workaround can be removed.
-     */
-    protected abstract ZMailbox getImapZMailbox() throws Exception;
-
     @Test
     public void testAppendTags() throws Exception {
         connection = connectAndSelectInbox();
@@ -986,7 +976,7 @@ public abstract class SharedImapTests {
         }
 
         //should not have created a visible tag
-        ZMailbox mbox = getImapZMailbox();
+        ZMailbox mbox = TestUtil.getZMailbox(USER);
         List<ZTag> tags = mbox.getAllTags();
         Assert.assertTrue("APPEND created new visible tag", tags == null || tags.size() == 0);
 
@@ -1546,6 +1536,18 @@ public abstract class SharedImapTests {
         } catch (CommandFailedException e) {
             Assert.assertTrue("expecting connection to be closed", connection.isClosed());
         }
+    }
+
+    @Test
+    public void testCreateFolder() throws Exception {
+        // test that a folder created by a non-IMAP client can be immediately selected by an IMAP client
+        String folderName = "newFolder";
+        ZMailbox zmbox = TestUtil.getZMailbox(USER);
+        connection = connect(imapServer);
+        connection.login(PASS);
+        TestUtil.createFolder(zmbox, folderName);
+        MailboxInfo info = connection.select(folderName);
+        assertEquals(folderName, info.getName());
     }
 
     private String url(String mbox, AppendResult res) {

--- a/store/src/java/com/zimbra/qa/unittest/TestLocalImap.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestLocalImap.java
@@ -35,9 +35,4 @@ public class TestLocalImap extends SharedImapTests {
         super.sharedTearDown();
         TestUtil.setLCValue(LC.imap_always_use_remote_store, String.valueOf(saved_imap_always_use_remote_store));
     }
-
-    @Override
-    protected ZMailbox getImapZMailbox() throws Exception {
-        return TestUtil.getZMailbox(USER);
-    }
 }

--- a/store/src/java/com/zimbra/qa/unittest/TestRemoteImapShared.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestRemoteImapShared.java
@@ -1,20 +1,15 @@
 package com.zimbra.qa.unittest;
 
 import java.io.IOException;
-import java.util.Set;
 
 import org.dom4j.DocumentException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 
-import com.zimbra.client.ZMailbox;
 import com.zimbra.common.localconfig.ConfigException;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
-import com.zimbra.cs.imap.ImapRemoteSession;
-import com.zimbra.cs.imap.ImapServerListener;
-import com.zimbra.cs.imap.ImapServerListenerPool;
 
 /**
  * This is a shell test for Remote IMAP tests that does the necessary configuration to select
@@ -39,17 +34,6 @@ public class TestRemoteImapShared extends SharedImapTests {
     public void tearDown() throws ServiceException, DocumentException, ConfigException, IOException  {
         super.sharedTearDown();
         TestUtil.setLCValue(LC.imap_always_use_remote_store, String.valueOf(saved_imap_always_use_remote_store));
-    }
-
-    @Override
-    protected ZMailbox getImapZMailbox() throws Exception {
-        // return the ZMailbox instance used by the imap listener
-        ZMailbox mbox = TestUtil.getZMailbox(USER);
-        ImapServerListener listener = ImapServerListenerPool.getInstance().get(mbox);
-        Set<ImapRemoteSession> sessions = listener.getListeners(mbox.getAccountId(), 2);
-        ImapRemoteSession session = sessions.iterator().next();
-        ZMailbox zmbox = (ZMailbox) session.getMailbox();
-        return zmbox;
     }
 
     @Override


### PR DESCRIPTION
If a folder is created by a non-IMAP client and an IMAP client attempts to select it, the error is thrown from the _ImapPath_ class as it attempts to retrieve the _ZFolder_ instance from the _ZMailbox_. Since this does not yet exist in the _ZMailbox_ cache, a NO_SUCH_FOLDER exception is thrown.
The easiest way to resolve this is to issue a noOp request in the _ImapPath.getFolder()_ method in the event that the specified folder cannot be found, and trying again. If the folder cannot be found a second time, then the exception can be thrown as before.

In order to avoid checking whether the server is remote, a _noOp()_ method has been added to the MailboxStore interface.

This fix allows us to remove the _SharedImapTests.getImapZMailbox()_ method added as part of ZCS-1429, as that was a workaround for newly-created folders not being registered with the IMAP listener.