### PR TITLE
ZCS-541:Tasks causing slowness from ZWC and consuming CPU resources

### DIFF
--- a/store/src/java-test/com/zimbra/cs/mailbox/RecurringTaskTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/RecurringTaskTest.java
@@ -1,0 +1,89 @@
+package com.zimbra.cs.mailbox;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.common.collect.Maps;
+import com.zimbra.common.account.Key;
+import com.zimbra.common.calendar.ZCalendar.ZCalendarBuilder;
+import com.zimbra.common.calendar.ZCalendar.ZVCalendar;
+import com.zimbra.common.mime.MimeConstants;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.calendar.IcsImportParseHandler.ImportInviteVisitor;
+import com.zimbra.cs.mailbox.calendar.Invite;
+import com.zimbra.cs.mailbox.calendar.Recurrence;
+
+public class RecurringTaskTest {
+
+    @BeforeClass
+    public static void init() throws Exception {
+        MailboxTestUtil.initServer();
+
+        Provisioning prov = Provisioning.getInstance();
+        prov.createAccount("test@zimbra.com", "secret", Maps.<String, Object>newHashMap());
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        MailboxTestUtil.clearData();
+    }
+
+    @Test
+    public void testTaskRecurrenceDuration() throws ServiceException, UnsupportedEncodingException {
+        Account acct = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+
+        String task = "BEGIN:VCALENDAR\n"
+                    + "PRODID:Zimbra-Calendar-Provider\n"
+                    + "VERSION:2.0\n"
+                    + "METHOD:PUBLISH\n"
+                    + "BEGIN:VTIMEZONE\n"
+                    + "TZID:Africa/Harare\n"
+                    + "BEGIN:STANDARD\n"
+                    + "DTSTART:16010101T000000\n"
+                    + "TZOFFSETTO:+0200\n"
+                    + "TZOFFSETFROM:+0200\n"
+                    + "TZNAME:CAT\n"
+                    + "END:STANDARD\n"
+                    + "END:VTIMEZONE\n"
+                    + "BEGIN:VTODO\n"
+                    + "UID:93077c29_ab51_41ad_aaa8_f63a68f963a6_migwiz\n"
+                    + "RRULE:FREQ=MONTHLY;INTERVAL=1;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=5\n"
+                    + "SUMMARY:Test Recurring Task\n"
+                    + "ATTENDEE;CN=User Test;CUTYPE=RESOURCE;ROLE=NON-PARTICIPANT;PARTSTAT=NEEDS-ACTION:mailto:testuser@zimbra.com\n"
+                    + "ATTENDEE;CN=User Test;ROLE=OPT-PARTICIPANT;PARTSTAT=NEEDS-ACTION:mailto:testuser@zimbra.com\n"
+                    + "PRIORITY:5\n"
+                    + "PERCENT-COMPLETE:0\n"
+                    + "ORGANIZER:mailto:admin@zimbra.com\n"
+                    + "DTSTART;VALUE=DATE:20120831\n"
+                    + "DUE;VALUE=DATE:20440709\n"
+                    + "STATUS:NEEDS-ACTION\n"
+                    + "CLASS:PUBLIC\n"
+                    + "LAST-MODIFIED:20131125T135454Z\n"
+                    + "DTSTAMP:20131125T135454Z\n"
+                    + "SEQUENCE:0\n"
+                    + "END:VTODO\n"
+                    + "END:VCALENDAR";
+
+        OperationContext octxt = new OperationContext(acct);
+        Folder taskFolder = mbox.getFolderById(octxt, 15);
+        String charset = MimeConstants.P_CHARSET_UTF8;
+        InputStream is = new ByteArrayInputStream(task.getBytes(charset));
+        List<ZVCalendar> icals = ZCalendarBuilder.buildMulti(is, charset);
+        ImportInviteVisitor visitor = new ImportInviteVisitor(octxt, taskFolder, false);
+        List<Invite> invites = Invite.createFromCalendar(acct, null, icals, true, false, visitor);
+        Recurrence.IRecurrence recur =  invites.get(0).getRecurrence();
+        Metadata meta = recur.encodeMetadata();
+        assertEquals("P1D", meta.get("duration"));
+    }
+}

--- a/store/src/java/com/zimbra/cs/mailbox/calendar/Invite.java
+++ b/store/src/java/com/zimbra/cs/mailbox/calendar/Invite.java
@@ -2050,11 +2050,12 @@ public class Invite {
                         newInv.validateDuration();
 
                         ParsedDuration duration = newInv.getDuration();
-
+                        boolean durationCalculated = false;
                         if (duration == null) {
                             ParsedDateTime end = newInv.getEndTime();
                             if (end != null && newInv.getStartTime() != null) {
                                 duration = end.difference(newInv.getStartTime());
+                                durationCalculated = true;
                             }
                         }
 
@@ -2072,6 +2073,13 @@ public class Invite {
                                 } else {
                                     // Both DTSTART and DTEND are unspecified.  Recurrence makes no sense!
                                     throw ServiceException.INVALID_REQUEST("recurrence used without DTSTART", null);
+                                }
+                            }
+                            if (durationCalculated && newInv.getItemType() == MailItem.Type.TASK) {
+                                if (newInv.getStartTime() != null && !newInv.getStartTime().hasTime()) {
+                                    duration = ParsedDuration.ONE_DAY;
+                                } else {
+                                    duration = ParsedDuration.ONE_SECOND;
                                 }
                             }
                         }


### PR DESCRIPTION
when recurring task is imported, duration is calculated as (due date -start date), which exceeds the recurrence range. Due to this when task tab is opened, the search operation takes forever as it enters a while loop which goes on forever if the due date is after several years. Ideally such task should not be created, the client should handle that, but in this case task is imported, so we set the duration to 1day to avoid this problem.

Tested by importing ics files from customers and the tasks were shown properly in web client.