### PR TITLE
bugfix/ZCS-1481

### DIFF
--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -6108,9 +6108,11 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
          ItemActionRequest req = new ItemActionRequest(action);
          ItemActionResponse resp = invokeJaxb(req);
          ActionResult ar = resp.getAction();
-         for (String id: ar.getNonExistentIds().split(","))
-         {
-             nonExistingItems.add(Integer.parseInt(id));
+
+         for (String id: ar.getNonExistentIds().split(",")) {
+             if (id.length() > 0) {
+                 nonExistingItems.add(Integer.parseInt(id));
+             }
          }
     }
 

--- a/store/src/java/com/zimbra/qa/unittest/TestZClient.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestZClient.java
@@ -1047,6 +1047,20 @@ public class TestZClient extends TestCase {
     }
 
     @Test
+    public void testDeleteAllPresent() throws Exception {
+        ZMailbox zmbox = TestUtil.getZMailbox(USER_NAME);
+        Mailbox mbox = TestUtil.getMailbox(USER_NAME);
+        Message msg = TestUtil.addMessage(mbox, Mailbox.ID_FOLDER_INBOX, "testDelete message", System.currentTimeMillis());
+
+        List<Integer> ids = new ArrayList<Integer>(2);
+        ids.add(msg.getId());
+
+        List<Integer> nonExistentIds = new ArrayList<Integer>(1);
+        zmbox.delete(null, ids, nonExistentIds);
+        assertTrue("Non-Existent IDS should be empty: ", nonExistentIds.isEmpty());
+    }
+
+    @Test
     public void testDelete() throws Exception {
         ZMailbox zmbox = TestUtil.getZMailbox(USER_NAME);
         Mailbox mbox = TestUtil.getMailbox(USER_NAME);


### PR DESCRIPTION
* Add zmsoap test to check for proper handling of no non-existent ids when deleting mail objects.
* Update `ZMailbox.delete` to only process 'ids' that are not an empty string. i.e. have a length greater than zero.