### PR TITLE
feature/zms 180

### DIFF
--- a/client/src/java/com/zimbra/client/ZFolder.java
+++ b/client/src/java/com/zimbra/client/ZFolder.java
@@ -97,6 +97,7 @@ public class ZFolder implements ZItem, FolderStore, Comparable<Object>, ToZJSONO
     private final ZMailbox mMailbox;
     private RetentionPolicy mRetentionPolicy = new RetentionPolicy();
     private boolean mActiveSyncDisabled;
+    private boolean mDeletable;
     private int mImapRECENTCutoff;
 
 
@@ -280,6 +281,7 @@ public class ZFolder implements ZItem, FolderStore, Comparable<Object>, ToZJSONO
         mEffectivePerms = e.getAttribute(MailConstants.A_RIGHTS, null);
         mSize = e.getAttributeLong(MailConstants.A_SIZE, 0);
         mActiveSyncDisabled = e.getAttributeBool(MailConstants.A_ACTIVESYNC_DISABLED, false);
+        mDeletable = e.getAttributeBool(MailConstants.A_DELETABLE, true);
 
         mGrants = new ArrayList<ZGrant>();
         mSubFolders = new ArrayList<ZFolder>();
@@ -505,7 +507,7 @@ public class ZFolder implements ZItem, FolderStore, Comparable<Object>, ToZJSONO
 
     @Override
     public boolean isDeletable() {
-        throw new UnsupportedOperationException("ZFolder method not supported yet");
+        return mDeletable;
     }
 
     /**

--- a/client/src/java/com/zimbra/client/ZFolder.java
+++ b/client/src/java/com/zimbra/client/ZFolder.java
@@ -98,7 +98,7 @@ public class ZFolder implements ZItem, FolderStore, Comparable<Object>, ToZJSONO
     private final ZMailbox mMailbox;
     private RetentionPolicy mRetentionPolicy = new RetentionPolicy();
     private boolean mActiveSyncDisabled;
-    private boolean mDeletable;
+    private Boolean mDeletable;
     private int mImapRECENTCutoff;
 
 
@@ -333,8 +333,8 @@ public class ZFolder implements ZItem, FolderStore, Comparable<Object>, ToZJSONO
         mImapUnreadCount = SystemUtil.coalesce(f.getImapUnreadCount(), mUnreadCount);
         mMessageCount = SystemUtil.coalesce(f.getItemCount(), 0);
         mImapMessageCount = SystemUtil.coalesce(f.getImapItemCount(), mMessageCount);
-        mDeletable = f.isDeletable();
-        mAbsolutePath = f.getAbsoluteFolderPath();
+        mDeletable = SystemUtil.coalesce(f.isDeletable(), mDeletable);
+        mAbsolutePath = SystemUtil.coalesce(f.getAbsoluteFolderPath(), mAbsolutePath);
 
         mDefaultView = View.conversation;
         if (f.getView() != null) {

--- a/client/src/java/com/zimbra/client/ZFolder.java
+++ b/client/src/java/com/zimbra/client/ZFolder.java
@@ -40,7 +40,6 @@ import com.zimbra.common.soap.MailConstants;
 import com.zimbra.common.util.SystemUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.common.zclient.ZClientException;
-import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.mail.type.Acl;
 import com.zimbra.soap.mail.type.Folder;
 import com.zimbra.soap.mail.type.Grant;

--- a/client/src/java/com/zimbra/client/event/ZModifyFolderEvent.java
+++ b/client/src/java/com/zimbra/client/event/ZModifyFolderEvent.java
@@ -202,6 +202,14 @@ public class ZModifyFolderEvent implements ZModifyItemEvent, ToZJSONObject {
 
     /**
      * @param defaultValue value to return if unchanged
+     * @return new absolute path or defaultValue if unchanged
+     */
+    public String getAbsolutePath(String defaultValue) {
+        return mFolderEl.getAttribute(MailConstants.A_ABS_FOLDER_PATH, defaultValue);
+    }
+
+    /**
+     * @param defaultValue value to return if unchanged
      * @return grants or defaultValue if unchanged
      * @throws com.zimbra.common.service.ServiceException on error
      */

--- a/common/src/java/com/zimbra/common/soap/MailConstants.java
+++ b/common/src/java/com/zimbra/common/soap/MailConstants.java
@@ -755,6 +755,7 @@ public final class MailConstants {
     public static final String A_FOLDER = "l";
     public static final String A_FOLDER_UUID = "luuid";
     public static final String A_VISIBLE = "visible";
+    public static final String A_DELETABLE = "deletable";
     public static final String A_URL = "url";
     public static final String A_NUM = "n";
     public static final String A_IMAP_UID ="i4uid";

--- a/soap/src/java/com/zimbra/soap/mail/type/Folder.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/Folder.java
@@ -283,7 +283,7 @@ public class Folder {
      * @zm-api-field-description whether this folder can be deleted
      */
     @XmlAttribute(name=MailConstants.A_DELETABLE /* deletable */, required=false)
-    private boolean deletable;
+    private ZmBoolean deletable;
 
     /**
      * @zm-api-field-tag metadata
@@ -331,7 +331,7 @@ public class Folder {
     public Long getChangeDate() { return changeDate; }
     public Integer getImapItemCount() { return imapItemCount; }
     public Long getTotalSize() { return totalSize; }
-    public boolean isDeletable() { return deletable; }
+    public Boolean isDeletable() { return ZmBoolean.toBool(deletable); }
 
     /**
      * Returns the {@code View}, or {@link View#UNKNOWN} if not specified.
@@ -386,7 +386,7 @@ public class Folder {
     public void setWebOfflineSyncDays(Integer webOfflineSyncDays) { this.webOfflineSyncDays = webOfflineSyncDays; }
     public void setPerm(String perm) { this.perm = perm; }
     public void setRestUrl(String restUrl) { this.restUrl = restUrl; }
-    public void setDeletable(boolean deletable) { this.deletable = deletable; }
+    public void setDeletable(Boolean deletable) { this.deletable = ZmBoolean.fromBool(deletable); }
 
     public void setSubfolders(Collection<Folder> folders) {
         subfolders.clear();

--- a/soap/src/java/com/zimbra/soap/mail/type/Folder.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/Folder.java
@@ -279,6 +279,13 @@ public class Folder {
     private String restUrl;
 
     /**
+     * @zm-api-field-tag deletable
+     * @zm-api-field-description whether this folder can be deleted
+     */
+    @XmlAttribute(name=MailConstants.A_DELETABLE /* deletable */, required=false)
+    private boolean deletable;
+
+    /**
      * @zm-api-field-tag metadata
      * @zm-api-field-description Custom metadata
      */
@@ -324,6 +331,7 @@ public class Folder {
     public Long getChangeDate() { return changeDate; }
     public Integer getImapItemCount() { return imapItemCount; }
     public Long getTotalSize() { return totalSize; }
+    public boolean isDeletable() { return deletable; }
 
     /**
      * Returns the {@code View}, or {@link View#UNKNOWN} if not specified.
@@ -378,6 +386,7 @@ public class Folder {
     public void setWebOfflineSyncDays(Integer webOfflineSyncDays) { this.webOfflineSyncDays = webOfflineSyncDays; }
     public void setPerm(String perm) { this.perm = perm; }
     public void setRestUrl(String restUrl) { this.restUrl = restUrl; }
+    public void setDeletable(boolean deletable) { this.deletable = deletable; }
 
     public void setSubfolders(Collection<Folder> folders) {
         subfolders.clear();

--- a/store/docs/soap.txt
+++ b/store/docs/soap.txt
@@ -1351,7 +1351,7 @@ Folders:
 
   <folder id="{folder-id}" name="{folder-name}" l="{parent-id}" [f="{flags}"] [color="{color}"]
        u="{unread}" [i4u="{imap-unread}"] n="{msg-count}" [i4n="{imap-count}"] s="{total-size}" [view="{default-type}"]
-       [url="{remote-url}"] [activesyncdisabled="0|1"] [perm="{effective-perms}"] [rest="{rest-url}"] [webOfflineSyncDays="num-days"]>
+       [url="{remote-url}"] [activesyncdisabled="0|1"] [deletable="0|1"] [perm="{effective-perms}"] [rest="{rest-url}"] [webOfflineSyncDays="num-days"]>
     <acl [internalGrantExpiry="{millis-since-epoch}"] [guestGrantExpiry="{millis-since-epoch}"]>
       <grant perm="{rights}" gt="{grantee-type}" zid="{zimbra-id}" [expiry="{millis-since-epoch}"] [d="{grantee-name}"] [pw="{password-for-guest}"] [key="{access-key}"]/>*
     </acl>?

--- a/store/src/java-test/com/zimbra/cs/mailbox/FlagTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/FlagTest.java
@@ -135,20 +135,4 @@ public final class FlagTest {
             }
         }
     }
-
-    @Test
-    public void consistency() throws Exception {
-        Assert.assertEquals(ZItem.Flag.FROM_ME, Flag.BITMASK_FROM_ME);
-        Assert.assertEquals(ZItem.Flag.ATTACHED, Flag.BITMASK_ATTACHED);
-        Assert.assertEquals(ZItem.Flag.REPLIED, Flag.BITMASK_REPLIED);
-        Assert.assertEquals(ZItem.Flag.FORWARDED, Flag.BITMASK_FORWARDED);
-        Assert.assertEquals(ZItem.Flag.FLAGGED, Flag.BITMASK_FLAGGED);
-        Assert.assertEquals(ZItem.Flag.DRAFT, Flag.BITMASK_DRAFT);
-        Assert.assertEquals(ZItem.Flag.DELETED, Flag.BITMASK_DELETED);
-        Assert.assertEquals(ZItem.Flag.NOTIFIED, Flag.BITMASK_NOTIFIED);
-        Assert.assertEquals(ZItem.Flag.UNREAD, Flag.BITMASK_UNREAD);
-        Assert.assertEquals(ZItem.Flag.HIGH_PRIORITY, Flag.BITMASK_HIGH_PRIORITY);
-        Assert.assertEquals(ZItem.Flag.LOW_PRIORITY, Flag.BITMASK_LOW_PRIORITY);
-        Assert.assertEquals(ZItem.Flag.NOTE, Flag.BITMASK_NOTE);
-    }
 }

--- a/store/src/java/com/zimbra/cs/service/mail/ToXML.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ToXML.java
@@ -476,6 +476,7 @@ public final class ToXML {
         int folderId = folder.getId();
         elem.addAttribute(MailConstants.A_ID, ifmt.formatItemId(folder));
         elem.addAttribute(MailConstants.A_UUID, folder.getUuid());
+        elem.addAttribute(MailConstants.A_DELETABLE, folder.isDeletable());
 
         if (folderId != Mailbox.ID_FOLDER_ROOT) {
             boolean encodedPath = false;

--- a/store/src/java/com/zimbra/qa/unittest/TestZClient.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestZClient.java
@@ -44,6 +44,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.collect.Maps;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.zimbra.client.ZContact;
 import com.zimbra.client.ZFeatures;
@@ -1259,81 +1260,24 @@ public class TestZClient {
         List<ZFolder> folders = zmbox.getAllFolders();
         assertFalse("list of folders in ZMailbox should not be empty", folders.isEmpty());
         assertEquals("Should have 12 folders", 12, folders.size());
-        boolean foundInbox = false;
-        boolean foundDrafts = false;
-        boolean foundSent = false;
-        boolean foundSpam = false;
-        boolean foundTrash = false;
-        boolean foundContacts = false;
-        boolean foundCalendar = false;
-        boolean emailedContacts = false;
-        boolean foundRoot = false;
-        boolean foundTasks = false;
-        boolean foundBriefcase = false;
-        boolean foundChats = false;
+        ArrayList<Integer> folderIds = Lists.newArrayList();
         for(ZFolder zf : folders) {
             ZimbraLog.test.debug("Found folder %s with ID: %s", zf.getPath(), zf.getId());
-            if(zf.getId().equalsIgnoreCase(Integer.toString(Mailbox.ID_FOLDER_USER_ROOT))) {
-                foundRoot = true;
-                assertFalse(String.format("Folder %s should not be deletable", zf.getPath()), zf.isDeletable());
-            }
-            if(zf.getId().equalsIgnoreCase(Integer.toString(Mailbox.ID_FOLDER_INBOX))) {
-                foundInbox = true;
-                assertFalse(String.format("Folder %s should not be deletable", zf.getPath()), zf.isDeletable());
-            }
-            if(zf.getId().equalsIgnoreCase(Integer.toString(Mailbox.ID_FOLDER_DRAFTS))) {
-                foundDrafts = true;
-                assertFalse(String.format("Folder %s should not be deletable", zf.getPath()), zf.isDeletable());
-            }
-            if(zf.getId().equalsIgnoreCase(Integer.toString(Mailbox.ID_FOLDER_SENT))) {
-                foundSent = true;
-                assertFalse(String.format("Folder %s should not be deletable", zf.getPath()), zf.isDeletable());
-            }
-            if(zf.getId().equalsIgnoreCase(Integer.toString(Mailbox.ID_FOLDER_SPAM))) {
-                foundSpam = true;
-                assertFalse(String.format("Folder %s should not be deletable", zf.getPath()), zf.isDeletable());
-            }
-            if(zf.getId().equalsIgnoreCase(Integer.toString(Mailbox.ID_FOLDER_TRASH))) {
-                foundTrash = true;
-                assertFalse(String.format("Folder %s should not be deletable", zf.getPath()), zf.isDeletable());
-            }
-            if(zf.getId().equalsIgnoreCase(Integer.toString(Mailbox.ID_FOLDER_CONTACTS))) {
-                foundContacts = true;
-                assertFalse(String.format("Folder %s should not be deletable", zf.getPath()), zf.isDeletable());
-            }
-            if(zf.getId().equalsIgnoreCase(Integer.toString(Mailbox.ID_FOLDER_CALENDAR))) {
-                foundCalendar = true;
-                assertFalse(String.format("Folder %s should not be deletable", zf.getPath()), zf.isDeletable());
-            }
-            if(zf.getId().equalsIgnoreCase(Integer.toString(Mailbox.ID_FOLDER_AUTO_CONTACTS))) {
-                emailedContacts = true;
-                assertFalse(String.format("Folder %s should not be deletable", zf.getPath()), zf.isDeletable());
-            }
-            if(zf.getId().equalsIgnoreCase(Integer.toString(Mailbox.ID_FOLDER_TASKS))) {
-                foundTasks = true;
-                assertFalse(String.format("Folder %s should not be deletable", zf.getPath()), zf.isDeletable());
-            }
-            if(zf.getId().equalsIgnoreCase(Integer.toString(Mailbox.ID_FOLDER_BRIEFCASE))) {
-                foundBriefcase = true;
-                assertFalse(String.format("Folder %s should not be deletable", zf.getPath()), zf.isDeletable());
-            }
-            if(zf.getId().equalsIgnoreCase(Integer.toString(Mailbox.ID_FOLDER_IM_LOGS))) {
-                foundChats = true;
-                assertFalse(String.format("Folder %s should not be deletable", zf.getPath()), zf.isDeletable());
-            }
+            assertFalse(String.format("Folder %s should not be deletable", zf.getPath()), zf.isDeletable());
+            folderIds.add(Integer.parseInt(zf.getId()));
         }
-        assertTrue("did not find /Calendar", foundCalendar);
-        assertTrue("did not find /Contacts", foundContacts);
-        assertTrue("did not find /Trash", foundTrash);
-        assertTrue("did not find /Junk", foundSpam);
-        assertTrue("did not find /Sent", foundSent);
-        assertTrue("did not find /Drafts", foundDrafts);
-        assertTrue("did not find /Inbox", foundInbox);
-        assertTrue("did not find /Emailed Contacts", emailedContacts);
-        assertTrue("did not find /", foundRoot);
-        assertTrue("did not find /Tasks", foundTasks);
-        assertTrue("did not find /Briefcase", foundBriefcase);
-        assertTrue("did not find /Chats", foundChats);
+        assertTrue("did not find /Calendar", folderIds.contains(Mailbox.ID_FOLDER_CALENDAR));
+        assertTrue("did not find /Contacts", folderIds.contains(Mailbox.ID_FOLDER_CONTACTS));
+        assertTrue("did not find /Trash", folderIds.contains(Mailbox.ID_FOLDER_TRASH));
+        assertTrue("did not find /Junk", folderIds.contains(Mailbox.ID_FOLDER_SPAM));
+        assertTrue("did not find /Sent", folderIds.contains(Mailbox.ID_FOLDER_SENT));
+        assertTrue("did not find /Drafts", folderIds.contains(Mailbox.ID_FOLDER_DRAFTS));
+        assertTrue("did not find /Inbox", folderIds.contains(Mailbox.ID_FOLDER_INBOX));
+        assertTrue("did not find /Emailed Contacts", folderIds.contains(Mailbox.ID_FOLDER_AUTO_CONTACTS));
+        assertTrue("did not find /",folderIds.contains( Mailbox.ID_FOLDER_USER_ROOT));
+        assertTrue("did not find /Tasks", folderIds.contains(Mailbox.ID_FOLDER_TASKS));
+        assertTrue("did not find /Briefcase", folderIds.contains(Mailbox.ID_FOLDER_BRIEFCASE));
+        assertTrue("did not find /Chats", folderIds.contains(Mailbox.ID_FOLDER_IM_LOGS));
     }
 
     @Test

--- a/store/src/java/com/zimbra/qa/unittest/TestZClient.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestZClient.java
@@ -1336,6 +1336,49 @@ public class TestZClient {
         assertTrue("did not find /Chats", foundChats);
     }
 
+    @Test
+    public void testRenameFolder() throws Exception {
+        Mailbox mbox = TestUtil.getMailbox(USER_NAME);
+        Folder.FolderOptions fopt = new Folder.FolderOptions();
+        fopt.setDefaultView(MailItem.Type.MESSAGE).setFlags(0).setColor(MailItem.DEFAULT_COLOR_RGB);
+        Folder testFolder = mbox.createFolder(null, "testRenameFolderOriginal", Mailbox.ID_FOLDER_USER_ROOT, fopt);
+        assertNotNull("testFolder (/testRenameFolderOriginal) should not be null", testFolder);
+        int folderId = testFolder.getId();
+        String szFolderId = Integer.toString(folderId);
+        assertEquals("unexpected folder name", "testRenameFolderOriginal", testFolder.getName());
+        assertEquals("unexpected folder path", "/testRenameFolderOriginal", testFolder.getPath());
+        ZMailbox zmbox = TestUtil.getZMailbox(USER_NAME);
+        ZFolder zf = zmbox.getFolderById(szFolderId);
+        assertNotNull("ZMailbox should be able to get new folder by ID", zf);
+        assertEquals("unexpected zfolder ID", szFolderId, zf.getId());
+        assertEquals("unexpected zfolder name", "testRenameFolderOriginal", zf.getName());
+        assertEquals("unexpected zfolder path", "/testRenameFolderOriginal", zf.getPath());
+
+        //rename folder using ZMailbox
+        zmbox.renameFolder(szFolderId, "testFolderRenamedOnce");
+        zf = zmbox.getFolderById(szFolderId);
+        assertNotNull("ZMailbox should be able to get renamed folder by ID", zf);
+        assertEquals("unexpected renamed zfolder ID", szFolderId, zf.getId());
+        assertEquals("unexpected renamed zfolder name", "testFolderRenamedOnce", zf.getName());
+        assertEquals("unexpected renamed zfolder path", "/testFolderRenamedOnce", zf.getPath());
+
+        //rename folder outside of ZMailbox
+        mbox.renameFolder(null, testFolder, "/testFolderRenamedTwice");
+        zf = zmbox.getFolderById(szFolderId);
+        assertNotNull("ZMailbox should be able to get renamed folder by ID", zf);
+        assertEquals("unexpected renamed zfolder ID", szFolderId, zf.getId());
+        assertEquals("zfolder should not be aware of new name yet", "testFolderRenamedOnce", zf.getName());
+        assertEquals("zfolder should not be aware of new path yet", "/testFolderRenamedOnce", zf.getPath());
+
+        //get notifications
+        zmbox.noOp();
+        zf = zmbox.getFolderById(szFolderId);
+        assertNotNull("ZMailbox should be able to get renamed folder by ID", zf);
+        assertEquals("unexpected renamed zfolder ID", szFolderId, zf.getId());
+        assertEquals("zfolder should pick up new name for renamed folder after NoOp", "testFolderRenamedTwice", zf.getName());
+        assertEquals("zfolder should pick up new path for renamed folder after NoOp", "/testFolderRenamedTwice", zf.getPath());
+    }
+
     public static void main(String[] args) throws Exception {
         TestUtil.cliSetup();
         TestUtil.runTest(TestZClient.class);


### PR DESCRIPTION
I added 'deletable' flag to Folder SOAP to be returned by default, because we currently do not have a way to request only specific attribute from GetFolderRequest. As far as I can see from the tests, this is not breaking any existing functionality. 
I also noticed that ZClient was not correctly picking up paths for top level folders. Instead ZClient was attempting to construct folder path based on internally cached folder tree. This results in ZClient returning incorrect paths when a folder is renamed outside of ZClient. I removed "TODO" comment from getPath and added implementation that relies on path returned from SOAP. This last change broke some tests that relied on old behavior where ZMailbox would construct Folder path based on internal folder tree. To address this, I added code that handles changes to folder path that are sent via context headers. I also added a test to verify how zclient handles renamed folders when folders are renamed outside of zclient and inside zclient.