### PR TITLE
Bugfix/zcs 1173 SIEVE:filter w/o anyof & allof causes NPE(reopen)

### DIFF
--- a/soap/src/java/com/zimbra/soap/mail/type/FilterTests.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/FilterTests.java
@@ -39,7 +39,7 @@ public final class FilterTests {
      * @zm-api-field-description Condition - <b>allof|anyof</b>
      */
     @XmlAttribute(name=MailConstants.A_CONDITION, required=true)
-    private final String condition;
+    private String condition;
 
     /**
      * @zm-api-field-description Tests
@@ -104,6 +104,10 @@ public final class FilterTests {
 
     public String getCondition() {
         return condition;
+    }
+
+    public void setCondition(String condition) {
+        this.condition = condition;
     }
 
     public List<FilterTest> getTests() {

--- a/store/src/java-test/com/zimbra/cs/filter/GetFilterRulesTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/GetFilterRulesTest.java
@@ -49,7 +49,7 @@ public class GetFilterRulesTest {
     }
 
     @Test
-    public void testIf_Without_Allof() throws Exception {
+    public void testIfWithoutAllof() throws Exception {
         // - no 'allof' 'anyof' tests
         String filterScript
                     = "require \"tag\";"
@@ -81,7 +81,7 @@ public class GetFilterRulesTest {
     }
 
     @Test
-    public void testNestedIf_Without_Allof() throws Exception {
+    public void testNestedIfWithoutAllof() throws Exception {
         // - no 'allof' 'anyof' tests
         // - nested if
         String filterScript
@@ -117,7 +117,7 @@ public class GetFilterRulesTest {
     }
 
     @Test
-    public void testNestedIf_AllofAnyof() throws Exception {
+    public void testNestedIfAllofAnyof() throws Exception {
         // - nested if
         // - no 'allof' and 'anyof' test for the outer if block
         // - 'anyof' test in the inner if block
@@ -160,7 +160,7 @@ public class GetFilterRulesTest {
     }
 
     @Test
-    public void testWithout_if() throws Exception {
+    public void testWithoutIf() throws Exception {
         // - no if block
         String filterScript
                     = "require \"tag\";"

--- a/store/src/java-test/com/zimbra/cs/filter/GetFilterRulesTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/GetFilterRulesTest.java
@@ -323,4 +323,62 @@ public class GetFilterRulesTest {
               + "</GetFilterRulesResponse>";
         XMLDiffChecker.assertXMLEquals(expectedSoapResponse, response.prettyPrint());
     }
+
+    @Test
+    public void testWithoutIfBlock5() throws Exception {
+        // - combination of nested if without allof/anyof, and no if block
+        String filterScript
+                    = "require \"tag\";"
+                    + "fileinto \"no-if-block1\";"
+                    + "if header :comparator \"i;ascii-casemap\" :matches \"Subject\" \"*\" {"
+                    + "  if header :matches \"From\" \"*\" {"
+                    + "    fileinto \"nested-if-block\";"
+                    + "  }"
+                    + "}"
+                    + "fileinto \"no-if-block2\";";
+
+        Account account = Provisioning.getInstance().getAccount(
+                MockProvisioning.DEFAULT_ACCOUNT_ID);
+        RuleManager.clearCachedRules(account);
+        account.setMailSieveScript(filterScript);
+
+        Element request = new Element.XMLElement(MailConstants.GET_FILTER_RULES_REQUEST);
+        Element response = new GetFilterRules().handle(request, ServiceTestUtil.getRequestContext(account));
+
+        String expectedSoapResponse =
+                "<GetFilterRulesResponse xmlns=\"urn:zimbraMail\">"
+                + "<filterRules>"
+                  + "<filterRule active=\"1\">"
+                    + "<filterTests condition=\"allof\">"
+                      + "<trueTest index=\"0\"/>"
+                    + "</filterTests>"
+                    + "<filterActions>"
+                      + "<actionFileInto folderPath=\"no-if-block1\" index=\"0\"/>"
+                    + "</filterActions>"
+                  + "</filterRule>"
+                  + "<filterRule active=\"1\">"
+                    + "<filterTests condition=\"allof\">"
+                      + "<headerTest stringComparison=\"matches\" header=\"Subject\" index=\"0\" value=\"*\"/>"
+                    + "</filterTests>"
+                    + "<nestedRule>"
+                      + "<filterTests condition=\"allof\">"
+                        + "<headerTest stringComparison=\"matches\" header=\"From\" index=\"0\" value=\"*\"/>"
+                      + "</filterTests>"
+                      + "<filterActions>"
+                        + "<actionFileInto folderPath=\"nested-if-block\" index=\"0\"/>"
+                      + "</filterActions>"
+                    + "</nestedRule>"
+                  + "</filterRule>"
+                  + "<filterRule active=\"1\">"
+                    + "<filterTests condition=\"allof\">"
+                      + "<trueTest index=\"0\"/>"
+                    + "</filterTests>"
+                    + "<filterActions>"
+                      + "<actionFileInto folderPath=\"no-if-block2\" index=\"0\"/>"
+                    + "</filterActions>"
+                  + "</filterRule>"
+                + "</filterRules>"
+              + "</GetFilterRulesResponse>";
+        XMLDiffChecker.assertXMLEquals(expectedSoapResponse, response.prettyPrint());
+    }
 }

--- a/store/src/java-test/com/zimbra/cs/filter/GetFilterRulesTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/GetFilterRulesTest.java
@@ -1,0 +1,191 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2017 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.filter;
+
+import java.util.HashMap;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.MailConstants;
+
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.MockProvisioning;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.filter.RuleManager;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.service.mail.GetFilterRules;
+import com.zimbra.cs.service.mail.ServiceTestUtil;
+import com.zimbra.cs.util.XMLDiffChecker;
+
+public class GetFilterRulesTest {
+    @BeforeClass
+    public static void init() throws Exception {
+        MailboxTestUtil.initServer();
+        Provisioning prov = Provisioning.getInstance();
+        prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        MailboxTestUtil.clearData();
+    }
+
+    @Test
+    public void testIf_Without_Allof() throws Exception {
+        // - no 'allof' 'anyof' tests
+        String filterScript
+                    = "require \"tag\";"
+                    + "if header :comparator \"i;ascii-casemap\" :matches \"Subject\" \"*\" {"
+                    + "  fileinto \"if-block\";"
+                    + "}";
+        Account account = Provisioning.getInstance().getAccount(
+                MockProvisioning.DEFAULT_ACCOUNT_ID);
+        RuleManager.clearCachedRules(account);
+        account.setMailSieveScript(filterScript);
+
+        Element request = new Element.XMLElement(MailConstants.GET_FILTER_RULES_REQUEST);
+        Element response = new GetFilterRules().handle(request, ServiceTestUtil.getRequestContext(account));
+
+        String expectedSoapResponse =
+                "<GetFilterRulesResponse xmlns=\"urn:zimbraMail\">"
+                + "<filterRules>"
+                  + "<filterRule active=\"1\">"
+                    + "<filterTests condition=\"allof\">"
+                      + "<headerTest stringComparison=\"matches\" header=\"Subject\" index=\"0\" value=\"*\"/>"
+                    + "</filterTests>"
+                    + "<filterActions>"
+                      + "<actionFileInto folderPath=\"if-block\" index=\"0\"/>"
+                    + "</filterActions>"
+                  + "</filterRule>"
+                + "</filterRules>"
+              + "</GetFilterRulesResponse>";
+        XMLDiffChecker.assertXMLEquals(expectedSoapResponse, response.prettyPrint());
+    }
+
+    @Test
+    public void testNestedIf_Without_Allof() throws Exception {
+        // - no 'allof' 'anyof' tests
+        // - nested if
+        String filterScript
+                    = "require \"tag\";"
+                    + "if header :comparator \"i;ascii-casemap\" :matches \"Subject\" \"*\" {"
+                    + "  if header :matches \"From\" \"*\" {"
+                    + "    fileinto \"nested-if-block\";"
+                    + "  }"
+                    + "}";
+        Account account = Provisioning.getInstance().getAccount(
+                MockProvisioning.DEFAULT_ACCOUNT_ID);
+        RuleManager.clearCachedRules(account);
+        account.setMailSieveScript(filterScript);
+
+        Element request = new Element.XMLElement(MailConstants.GET_FILTER_RULES_REQUEST);
+        Element response = new GetFilterRules().handle(request, ServiceTestUtil.getRequestContext(account));
+
+        String expectedSoapResponse =
+              "<GetFilterRulesResponse xmlns=\"urn:zimbraMail\">"
+              + "<filterRules>"
+                + "<filterRule active=\"1\">"
+                  + "<filterTests condition=\"allof\">"
+                    + "<headerTest stringComparison=\"matches\" header=\"Subject\" index=\"0\" value=\"*\"/>"
+                    + "<headerTest stringComparison=\"matches\" header=\"From\"    index=\"1\" value=\"*\"/>"
+                  + "</filterTests>"
+                  + "<filterActions>"
+                    + "<actionFileInto folderPath=\"nested-if-block\" index=\"0\"/>"
+                  + "</filterActions>"
+                + "</filterRule>"
+              + "</filterRules>"
+            + "</GetFilterRulesResponse>";
+        XMLDiffChecker.assertXMLEquals(expectedSoapResponse, response.prettyPrint());
+    }
+
+    @Test
+    public void testNestedIf_AllofAnyof() throws Exception {
+        // - nested if
+        // - no 'allof' and 'anyof' test for the outer if block
+        // - 'anyof' test in the inner if block
+        String filterScript
+                    = "require \"tag\";"
+                    + "if header :comparator \"i;ascii-casemap\" :matches \"Subject\" \"*\" {"
+                    + "  if anyof (header :matches \"From\" \"*\","
+                    + "            header :matches \"To\"   \"*\") {"
+                    + "    fileinto \"nested-if-block\";"
+                    + "  }"
+                    + "}";
+        Account account = Provisioning.getInstance().getAccount(
+                MockProvisioning.DEFAULT_ACCOUNT_ID);
+        RuleManager.clearCachedRules(account);
+        account.setMailSieveScript(filterScript);
+
+        Element request = new Element.XMLElement(MailConstants.GET_FILTER_RULES_REQUEST);
+        Element response = new GetFilterRules().handle(request, ServiceTestUtil.getRequestContext(account));
+
+        String expectedSoapResponse =
+              "<GetFilterRulesResponse xmlns=\"urn:zimbraMail\">"
+              + "<filterRules>"
+                + "<filterRule active=\"1\">"
+                  + "<filterTests condition=\"allof\">"
+                    + "<headerTest stringComparison=\"matches\" header=\"Subject\" index=\"0\" value=\"*\"/>"
+                  + "</filterTests>"
+                  + "<nestedRule>"
+                    + "<filterTests condition=\"anyof\">"
+                      + "<headerTest stringComparison=\"matches\" header=\"From\" index=\"0\" value=\"*\"/>"
+                      + "<headerTest stringComparison=\"matches\" header=\"To\"   index=\"1\" value=\"*\"/>"
+                    + "</filterTests>"
+                    + "<filterActions>"
+                      + "<actionFileInto folderPath=\"nested-if-block\" index=\"0\"/>"
+                    + "</filterActions>"
+                  + "</nestedRule>"
+                + "</filterRule>"
+              + "</filterRules>"
+            + "</GetFilterRulesResponse>";
+        XMLDiffChecker.assertXMLEquals(expectedSoapResponse, response.prettyPrint());
+    }
+
+    @Test
+    public void testWithout_if() throws Exception {
+        // - no if block
+        String filterScript
+                    = "require \"tag\";"
+                    + "fileinto \"no-if-block\";";
+        Account account = Provisioning.getInstance().getAccount(
+                MockProvisioning.DEFAULT_ACCOUNT_ID);
+        RuleManager.clearCachedRules(account);
+        account.setMailSieveScript(filterScript);
+
+        Element request = new Element.XMLElement(MailConstants.GET_FILTER_RULES_REQUEST);
+        Element response = new GetFilterRules().handle(request, ServiceTestUtil.getRequestContext(account));
+
+        String expectedSoapResponse =
+                "<GetFilterRulesResponse xmlns=\"urn:zimbraMail\">"
+                + "<filterRules><filterRule active=\"1\">"
+                  + "<filterTests condition=\"allof\"/>"
+                    + "<filterActions>"
+                      + "<actionFileInto folderPath=\"no-if-block\" index=\"0\"/>"
+                    + "</filterActions>"
+                    + "<nestedRule>"
+                      + "<filterTests condition=\"allof\"/>"
+                    + "</nestedRule>"
+                  + "</filterRule>"
+                + "</filterRules>"
+              + "</GetFilterRulesResponse>";
+        XMLDiffChecker.assertXMLEquals(expectedSoapResponse, response.prettyPrint());
+    }
+}

--- a/store/src/java/com/zimbra/cs/filter/SieveToSoap.java
+++ b/store/src/java/com/zimbra/cs/filter/SieveToSoap.java
@@ -103,14 +103,26 @@ public final class SieveToSoap extends SieveVisitor {
     protected void visitIfControl(Node ruleNode, VisitPhase phase, RuleProperties props) {
         if (phase == VisitPhase.end) {
             numOfIfProcessingDone++; // number of if for which process is done
+            if (nunOfIfProcessingStarted == numOfIfProcessingDone) {
+                // If all the nested 'if' is completed, clean up the rule objects
+                currentRule = null;
+                currentNestedRule = null;
+            }
+            visitRule(ruleNode, VisitPhase.end, props);
             return;
         }
         nunOfIfProcessingStarted++;   // number of if for which process is started.
+        visitRule(ruleNode, VisitPhase.begin, props);
     }
 
     private boolean isNestedRule(){
         // in non nested case, only one process is started but not done.
         if(nunOfIfProcessingStarted == numOfIfProcessingDone+1){
+            return false;
+        }
+        // if an action is specified outside of the 'if' clause,
+        // the number of Started becomes equal to that of Done.
+        if (nunOfIfProcessingStarted == numOfIfProcessingDone) {
             return false;
         }
         return true;
@@ -140,7 +152,11 @@ public final class SieveToSoap extends SieveVisitor {
             currentNestedRule.addFilterAction(action);
         } else {                     // Root Rule is being processed
             if (null == currentRule) {
-                initRule(new RuleProperties());
+                // The action is specified outside the if clause.
+                // Let's set the 'true' as a dummy test.
+                RuleProperties props = new RuleProperties();
+                initRule(props);
+                addTest(new FilterTest.TrueTest(), props);
             }
             action.setIndex(currentRule.getActionCount());
             currentRule.addFilterAction(action);
@@ -373,6 +389,33 @@ public final class SieveToSoap extends SieveVisitor {
         if (phase == VisitPhase.begin) {
             addTest(new FilterTest.FlaggedTest(flag.toString()), props);
         }
+    }
+
+    @Override
+    protected void visitAllOfTest(Node ruleNode, VisitPhase phase, RuleProperties props) {
+        visitLogicalTest(ruleNode, phase, props);
+    }
+
+    @Override
+    protected void visitAnyOfTest(Node ruleNode, VisitPhase phase, RuleProperties props) {
+        visitLogicalTest(ruleNode, phase, props);
+    }
+
+    private void visitLogicalTest(Node ruleNode, VisitPhase phase, RuleProperties props) {
+        if (phase == VisitPhase.end) {
+            return;
+        }
+
+        FilterTests tests;
+        if(currentNestedRule != null){ // Nested Rule is being processed
+            tests = currentNestedRule.getFilterTests();
+        } else {                     // Root Rule is being processed
+            if (null == currentRule) {
+                initRule(props);
+            }
+            tests = currentRule.getFilterTests();
+        }
+        tests.setCondition(props.condition.toString());
     }
 
     @Override

--- a/store/src/java/com/zimbra/cs/filter/SieveVisitor.java
+++ b/store/src/java/com/zimbra/cs/filter/SieveVisitor.java
@@ -131,6 +131,14 @@ public abstract class SieveVisitor {
     }
 
     @SuppressWarnings("unused")
+    protected void visitAllOfTest(Node node, VisitPhase phase, RuleProperties props) throws ServiceException {
+    }
+
+    @SuppressWarnings("unused")
+    protected void visitAnyOfTest(Node node, VisitPhase phase, RuleProperties props) throws ServiceException {
+    }
+
+    @SuppressWarnings("unused")
     protected void visitBulkTest(Node node, VisitPhase phase, RuleProperties props) throws ServiceException {
     }
 
@@ -284,14 +292,14 @@ public abstract class SieveVisitor {
         } else {
             if ("allof".equalsIgnoreCase(nodeName)) {
                 props.condition = Sieve.Condition.allof;
-                visitRule(node, VisitPhase.begin, props);
+                visitAllOfTest(node, VisitPhase.begin, props);
                 accept(node, props);
-                visitRule(node, VisitPhase.end, props);
+                visitAllOfTest(node, VisitPhase.end, props);
             } else if ("anyof".equalsIgnoreCase(nodeName)) {
                 props.condition = Sieve.Condition.anyof;
-                visitRule(node, VisitPhase.begin, props);
+                visitAnyOfTest(node, VisitPhase.begin, props);
                 accept(node, props);
-                visitRule(node, VisitPhase.end, props);
+                visitAnyOfTest(node, VisitPhase.end, props);
             } else if ("header".equalsIgnoreCase(nodeName) || "mime_header".equalsIgnoreCase(nodeName)) {
                 Sieve.StringComparison comparison = Sieve.StringComparison.is;
                 boolean caseSensitive = false;


### PR DESCRIPTION
ZCS-1173:SIEVE:filter w/o anyof & allof causes NPE

[Bug]
If anyof/allof test is not specified in condition within the sieve rule, NullPointerException occurs in mailbox.log when the rule is loaded on ZWC.

[Root cause]
An instance of the FilterRule or NestedRule which keeps a set of Sieve test and/or actions of each rule was created only while 'anyof' or 'allof' test was processed; if a filter does not have an 'anyof' or 'allof' in the 'if' condition, or even an action is not enclosed by the if-block, the member parameter the FilterRule or NestedRule in the com.zimbra.cs.filter.SieveToSoap class remained null.

[Fix]
SieveVisitor.visitRule() method which initializes the simple/nested rule object was called when the 'allof' or 'anyof' test was processed. But it may still cause NPE when 'allof' or 'anyof' test is not specified.

- visitRule() is now called when the 'if' is started.
- Introduce visitAllOfTest() and visitAnyOfTest() methods to SieveVisitor class, and their implementations to SieveToSoap class. Each classe updates the condition of the rule condition (default: allof) when 'allof' or 'anyof' test is specified in the 'if'.

If the member parameter FilterRule nor NestedRule are not initialized, create a FilterRule instance before being accessed. By default, 'allof' test is set (As a result, the "filterTests" tag in the SOAP result has an 'allof' as a "condition" parameter).

[Manual/Unit test]

Set a Sieve rule which has no 'anyof' or 'allof' test to the zimbraMailSieveScript, and accessed it from ZWC ==> PASS (No NPE on the server side, no network error no the client side, the filter is shown on the ZWC (only the supported Sieve commands were displayed))
Unit test to verify the four patterns ==> PASS
(1) Not nested. no 'allof' 'anyof' tests
(2) Nested. no 'allof' 'anyof' tests
(3) Nested. no 'allof' and 'anyof' test for the outer if block. 'anyof' test in the inner if block.
(4) No if block. Only a Sieve action is specified.