### PR TITLE
ZCS-1047:adding Junit

### DIFF
--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -5,6 +5,14 @@
  <info organisation="zimbra" module="zm-store" status="integration">
  </info>
  <dependencies>
+  <dependency org="org.powermock" name="powermock-module-junit4" rev="1.5.5" />
+  <dependency org="org.powermock" name="powermock-module-junit4-common" rev="1.5.5" />
+  <dependency org="org.powermock" name="powermock-api-mockito" rev="1.5.5" />
+  <dependency org="org.powermock" name="powermock-core" rev="1.5.5" />
+  <dependency org="org.powermock" name="powermock-api-support" rev="1.5.5" />
+  <dependency org="org.powermock" name="powermock-reflect" rev="1.5.5" />
+  <dependency org="org.mockito" name="mockito-all" rev="1.9.5" />
+  <dependency org="org.javassist" name="javassist" rev="3.18.2-GA" />
   <dependency org="org.slf4j" name="slf4j-api" rev="1.6.4"/>
   <dependency org="org.slf4j" name="slf4j-log4j12" rev="1.6.4"/>
   <dependency org="junit" name="junit" rev="4.8.2" />

--- a/store/src/java-test/com/zimbra/cs/ldap/unboundid/UBIDUserCertificateAttributeTest.java
+++ b/store/src/java-test/com/zimbra/cs/ldap/unboundid/UBIDUserCertificateAttributeTest.java
@@ -1,0 +1,48 @@
+package com.zimbra.cs.ldap.unboundid;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import com.unboundid.ldap.sdk.Attribute;
+import com.unboundid.ldap.sdk.Entry;
+import com.zimbra.common.mailbox.ContactConstants;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Entry.class})
+public class UBIDUserCertificateAttributeTest {
+    private String lookupAttr = ContactConstants.A_userCertificate + ";binary";
+    private String certBase64 = "MIIEfzCCA2egAwIBAgIDEAACMA0GCSqGSIb3DQEBCwUAMH8xDzANBgNVBAoTBlppbWJyYTElMCMGCSqGSIb3DQEJARYWYWRtaW5AZXhjaGFuZ2UyMDEwLmxhYjESMBAGA1UEBxMJUGFsbyBBbHRvMQswCQYDVQQIEwJDQTELMAkGA1UEBhMCVVMxFzAVBgNVBAMTDnRlc3RDb21tb25OYW1lMB4XDTE3MDUwODA3MzYzMFoXDTE4MDUwODA3MzYzMFowgYAxCzAJBgNVBAYTAlVTMQwwCgYDVQQIDANOU1cxDzANBgNVBAoMBlppbWJyYTEXMBUGA1UEAwwOdGVzdENvbW1vbk5hbWUxKDAmBgkqhkiG9w0BCQEWGXZnMUB6bWV4Y2guZW5nLnZtd2FyZS5jb20xDzANBgNVBAsMBlppbWJyYTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKeGcXq5GqfQzVMemx9ADdUfq6wlD0G9zuBQVpUvl0sI/rwWxD4Yh9uSyCb/XItMUPVMSYVCvEvW6Xopxa/+Ecj4ExRDy9eH6rub/G8umvatwx5Zx/OyzQotCJ66hEXwCOp72ye/yX+Y6RCuMhNSeNRMcdxVFc0VFRtaEtwHo9qJ9UQu/SOr9VDm8ZMUOAIBlNEeCSFJ8L6XQnlKqOWouWpsmWe80emf+Bljf+G1LOJt92Nx5Mj6ky3PWu6BWnPtTYhO1LFtIQiFY9hKZ5yLnnfn5w/QokRMluCKXuFCXFCD2mNmJD31k+zTjwwYY0BiyYTjOeYwQAsecbBQfH+kXaMCAwEAAaOCAQAwgf0wCQYDVR0TBAIwADALBgNVHQ8EBAMCBeAwJAYDVR0RBB0wG4EZdmcxQHptZXhjaC5lbmcudm13YXJlLmNvbTAdBgNVHQ4EFgQUm0eV1WZ/4A5dfvGsmRdWjVt0FCMwgZ0GA1UdIwSBlTCBkqGBhKSBgTB/MQ8wDQYDVQQKEwZaaW1icmExJTAjBgkqhkiG9w0BCQEWFmFkbWluQGV4Y2hhbmdlMjAxMC5sYWIxEjAQBgNVBAcTCVBhbG8gQWx0bzELMAkGA1UECBMCQ0ExCzAJBgNVBAYTAlVTMRcwFQYDVQQDEw50ZXN0Q29tbW9uTmFtZYIJAIP73sPIjZijMA0GCSqGSIb3DQEBCwUAA4IBAQAA0iiImrDPPND5SgJOBl/IVfrgePzztMXDkvS9mi6fIMlC7B1nmxPVm2Uch5SLN8IShKj7H4hpUjtqZBp09qF+dv/Nb8Z5WtFNUsJ81Jf2fMSl3fQbS3t7bm93XCkNt10C42ruyTLKHZWBuoANX64XUU4BNz0slas/91sAq6G3zMA3xqs2yFCc+hcwfeGijtJDxgFKZPBU8VeKnU/K1eI5suirZ3WWmT4LtyVUz1nLKoyWOB17Y1S5SN6K/hrjs+vrICHA8MPyxtvLI1TiRanzv5itOTWvN76sJ3LbKPCEtGtNnK30jUn56TlgMYunJL77hWOveXwu24b2EYR5Yso5";
+
+    @Test
+    public void getMultiAttrStringShouldReturnCertificateForAttributeNameWithBinary() {
+        Attribute attr = new Attribute(lookupAttr, certBase64);
+        Entry entry = PowerMockito.mock(Entry.class);
+        UBIDAttributes attributes = new UBIDAttributes(entry);
+        Mockito.when(entry.getAttribute(ContactConstants.A_userCertificate)).thenReturn(null);//entry does not contain "userCertificate" attribute
+        Mockito.when(entry.getAttribute(lookupAttr)).thenReturn(attr);//entry contains "userCertificate;binary" attribute
+        try {
+            assertEquals(attributes.getMultiAttrString(lookupAttr, false)[0], certBase64);
+        } catch (com.zimbra.cs.ldap.LdapException e) {
+            fail("Exception thrown");
+        }
+    }
+
+    @Test
+    public void getMultiAttrStringShouldReturnCertificateForAttributeNameWithoutBinary() {
+        Attribute attr = new Attribute(ContactConstants.A_userCertificate, certBase64);
+        Entry entry = PowerMockito.mock(Entry.class);
+        UBIDAttributes attributes = new UBIDAttributes(entry);
+        Mockito.when(entry.getAttribute(lookupAttr)).thenReturn(null);//entry does not contain "userCertificate;binary" attribute
+        Mockito.when(entry.getAttribute(ContactConstants.A_userCertificate)).thenReturn(attr);//entry contains "userCertificate" attribute
+        try {
+            assertEquals(attributes.getMultiAttrString(lookupAttr, false)[0], certBase64);
+        } catch (com.zimbra.cs.ldap.LdapException e) {
+            fail("Exception thrown");
+        }
+    }
+}


### PR DESCRIPTION
Adding Junit to test if getMultiAttrString returns certificate if the entry contains either 'userCertificate' or 'userCertificate;binary' attribute
Using powermock framework to mock ldap sdk Entry object which contains final methods. Easymock does not help mocking such object.