### PR TITLE
ZCS-1515 ImapDaemon init ephemeral extension

### DIFF
--- a/store/src/java-test/com/zimbra/cs/imap/ImapHandlerTest.java
+++ b/store/src/java-test/com/zimbra/cs/imap/ImapHandlerTest.java
@@ -12,6 +12,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.mailbox.FolderStore;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.Account;
@@ -34,6 +35,7 @@ public class ImapHandlerTest {
 
     @BeforeClass
     public static void init() throws Exception {
+        LC.imap_use_ehcache.setDefault(false);
         MailboxTestUtil.initServer();
         String[] hosts = {"localhost", "127.0.0.1"};
         ServerThrottle.configureThrottle(new ImapConfig(false).getProtocol(), 100, 100, Arrays.asList(hosts), Arrays.asList(hosts));

--- a/store/src/java/com/zimbra/cs/ephemeral/migrate/AttributeMigrationUtil.java
+++ b/store/src/java/com/zimbra/cs/ephemeral/migrate/AttributeMigrationUtil.java
@@ -1,6 +1,5 @@
 package com.zimbra.cs.ephemeral.migrate;
 
-import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.util.List;
 
@@ -36,7 +35,6 @@ import com.zimbra.cs.util.Zimbra;
  */
 public class AttributeMigrationUtil {
 
-    private static final PrintStream console = System.out;
     private static Options OPTIONS = new Options();
 
     static {
@@ -189,6 +187,7 @@ public class AttributeMigrationUtil {
                 store.getClass().getName());
     }
 
+    @SuppressWarnings("PMD.DoNotCallSystemExit")
     private static void usage() {
         HelpFormatter format = new HelpFormatter();
         format.printHelp(new PrintWriter(System.err, true), 80,

--- a/store/src/java/com/zimbra/cs/ephemeral/migrate/AttributeMigrationUtil.java
+++ b/store/src/java/com/zimbra/cs/ephemeral/migrate/AttributeMigrationUtil.java
@@ -16,7 +16,6 @@ import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.AttributeManager;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.ephemeral.EphemeralStore;
-import com.zimbra.cs.ephemeral.EphemeralStore.Factory;
 import com.zimbra.cs.ephemeral.migrate.AttributeMigration.AllAccountsSource;
 import com.zimbra.cs.ephemeral.migrate.AttributeMigration.DryRunMigrationCallback;
 import com.zimbra.cs.ephemeral.migrate.AttributeMigration.EntrySource;
@@ -104,7 +103,7 @@ public class AttributeMigrationUtil {
                 Zimbra.halt("no ephemeral backend specified");
                 return;
             }
-            initEphemeralBackendExtension(backendName);
+            ExtensionUtil.initEphemeralBackendExtension(backendName);
             try {
                 callback = new ZimbraMigrationCallback();
             } catch (ServiceException e) {
@@ -157,34 +156,6 @@ public class AttributeMigrationUtil {
             Zimbra.halt(String.format("error encountered during migration to ephemeral backend at %s; migration cannot proceed", url), e);
             return;
         }
-    }
-
-    private static void initEphemeralBackendExtension(String backendName) throws ServiceException {
-        Level savedExten = ZimbraLog.extensions.getLevel();
-        try {
-            if (!ZimbraLog.ephemeral.isDebugEnabled()) {
-                // cut down on noise unless enabled debug
-                ZimbraLog.extensions.setLevel(Level.error);
-            }
-            ExtensionUtil.initAllMatching(new EphemeralStore.EphemeralStoreMatcher(backendName));
-        } finally {
-            ZimbraLog.extensions.setLevel(savedExten);
-        }
-        Factory factory = EphemeralStore.getFactory(backendName);
-        if (factory == null) {
-            Zimbra.halt(String.format(
-                    "no extension class name found for backend '%s', aborting attribute migration",
-                    backendName));
-            return; // keep Eclipse happy
-        }
-        EphemeralStore store = factory.getStore();
-        if (store == null) {
-            Zimbra.halt(String.format("no store found for backend '%s', aborting attribute migration",
-                    backendName));
-            return; // keep Eclipse happy
-        }
-        ZimbraLog.ephemeral.info("Using ephemeral backend %s (%s) for attribute migration", backendName,
-                store.getClass().getName());
     }
 
     @SuppressWarnings("PMD.DoNotCallSystemExit")

--- a/store/src/java/com/zimbra/cs/extension/ExtensionUtil.java
+++ b/store/src/java/com/zimbra/cs/extension/ExtensionUtil.java
@@ -27,8 +27,13 @@ import java.util.List;
 import java.util.Map;
 
 import com.zimbra.common.localconfig.LC;
+import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.common.util.Log.Level;
+import com.zimbra.cs.ephemeral.EphemeralStore;
+import com.zimbra.cs.ephemeral.EphemeralStore.Factory;
 import com.zimbra.cs.redolog.op.RedoableOp;
+import com.zimbra.cs.util.Zimbra;
 
 public class ExtensionUtil {
 
@@ -180,6 +185,35 @@ public class ExtensionUtil {
             ZimbraLog.extensions.warn("unable to locate extension class %s, not found", className);
         }
     }
+
+    public static void initEphemeralBackendExtension(String backendName) throws ServiceException {
+        Level savedExten = ZimbraLog.extensions.getLevel();
+        try {
+            if (!ZimbraLog.ephemeral.isDebugEnabled()) {
+                // cut down on noise unless enabled debug
+                ZimbraLog.extensions.setLevel(Level.error);
+            }
+            ExtensionUtil.initAllMatching(new EphemeralStore.EphemeralStoreMatcher(backendName));
+        } finally {
+            ZimbraLog.extensions.setLevel(savedExten);
+        }
+        Factory factory = EphemeralStore.getFactory(backendName);
+        if (factory == null) {
+            Zimbra.halt(String.format(
+                    "no extension class name found for backend '%s', aborting attribute migration",
+                    backendName));
+            return; // keep Eclipse happy
+        }
+        EphemeralStore store = factory.getStore();
+        if (store == null) {
+            Zimbra.halt(String.format("no store found for backend '%s', aborting attribute migration",
+                    backendName));
+            return; // keep Eclipse happy
+        }
+        ZimbraLog.ephemeral.info("Using ephemeral backend %s (%s) for attribute migration", backendName,
+                store.getClass().getName());
+    }
+
 
     public static synchronized void postInitAll() {
         ZimbraLog.extensions.info("Post-Initializing extensions");

--- a/store/src/java/com/zimbra/cs/extension/ExtensionUtil.java
+++ b/store/src/java/com/zimbra/cs/extension/ExtensionUtil.java
@@ -22,7 +22,6 @@ import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +33,9 @@ import com.zimbra.cs.redolog.op.RedoableOp;
 public class ExtensionUtil {
 
     private static List<ZimbraExtensionClassLoader> sClassLoaders = new ArrayList<ZimbraExtensionClassLoader>();
+    private static ClassLoader sExtParentClassLoader;
+    private static Map<String, ZimbraExtension> sInitializedExtensions = new LinkedHashMap<String, ZimbraExtension>();
+
 
     public static URL[] dirListToURLs(File dir) {
         File[] files = dir.listFiles();
@@ -56,8 +58,6 @@ public class ExtensionUtil {
         return urls.toArray(new URL[0]);
     }
 
-    private static ClassLoader sExtParentClassLoader;
-
     static {
         File extCommonDir = new File(LC.zimbra_extension_common_directory.value());
         URL[] extCommonURLs = dirListToURLs(extCommonDir);
@@ -70,7 +70,7 @@ public class ExtensionUtil {
         loadAll();
     }
 
-    static synchronized void addClassLoader(ZimbraExtensionClassLoader zcl) {
+    protected static synchronized void addClassLoader(ZimbraExtensionClassLoader zcl) {
         sClassLoaders.add(zcl);
     }
 
@@ -103,8 +103,6 @@ public class ExtensionUtil {
             sClassLoaders.add(zcl);
         }
     }
-
-    private static Map<String, ZimbraExtension> sInitializedExtensions = new LinkedHashMap<String, ZimbraExtension>();
 
     public static interface ExtensionMatcher {
         public boolean matches(ZimbraExtension ext);

--- a/store/src/java/com/zimbra/cs/imap/ImapDaemon.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapDaemon.java
@@ -25,6 +25,7 @@ import org.apache.log4j.PropertyConfigurator;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.extension.ExtensionUtil;
 import com.zimbra.common.util.ZimbraLog;
 
 
@@ -90,6 +91,7 @@ public class ImapDaemon {
             Properties props = new Properties();
             props.load(new FileInputStream(IMAPD_LOG4J_CONFIG));
             PropertyConfigurator.configure(props);
+            maybeInitEphemeralBackendExtension();
 
             if(isZimbraImapEnabled()) {
                 ImapDaemon daemon = new ImapDaemon();
@@ -146,6 +148,17 @@ public class ImapDaemon {
             }
         }
         return false;
+    }
+
+    private static void maybeInitEphemeralBackendExtension() throws ServiceException {
+        String url = Provisioning.getInstance().getConfig().getEphemeralBackendURL();
+        if(url != null) {
+            String[] tokens = url.split(":");
+            String backendName = tokens[0];
+            if (tokens != null && tokens.length > 0 && !backendName.equalsIgnoreCase("ldap")) {
+                ExtensionUtil.initEphemeralBackendExtension(backendName);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Update the ImapDaemon to initialize the configured ephemeral
backend extension, based on the setting of
`zimbraEphemeralBackendURL`, if `ldap` is not the configured
backend.

### 2017-06-01 updates
* Implemented Gren's suggestion
* **Note:** This updated branch is based on top of [pull request 166](https://github.com/Zimbra/zm-mailbox/pull/166)

