### PR TITLE
ZCS-1390 Support for filter variables in nested rule

### DIFF
--- a/soap/src/java/com/zimbra/soap/mail/type/NestedRule.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/NestedRule.java
@@ -37,9 +37,17 @@ import com.zimbra.soap.json.jackson.annotate.ZimbraJsonArrayForWrapper;
 
 // JsonPropertyOrder added to make sure JaxbToJsonTest.bug65572_BooleanAndXmlElements passes
 @XmlAccessorType(XmlAccessType.NONE)
-@XmlType(propOrder = {"tests", "actions","child"})
-@JsonPropertyOrder({ "tests", "actions","child"})
+@XmlType(propOrder = {"filterVariables", "tests", "actions","child"})
+@JsonPropertyOrder({"filterVariables", "tests", "actions","child"})
 public final class NestedRule {
+
+    /**
+     * @zm-api-field-tag variables
+     * @zm-api-field-description Filter Variables
+     */
+    @ZimbraJsonArrayForWrapper
+    @XmlElement(name=MailConstants.E_FILTER_VARIABLES /* filterVariables */, required=false)
+    private FilterVariables filterVariables;
 
     /**
      * @zm-api-field-description Filter tests
@@ -89,6 +97,7 @@ public final class NestedRule {
     public NestedRule(FilterTests tests) {
         this.tests = tests;
         this.actions = null;
+        this.filterVariables = null;
     }
     public void setFilterTests(FilterTests value) {
         tests = value;
@@ -127,6 +136,20 @@ public final class NestedRule {
         return Collections.unmodifiableList(actions);
     }
 
+    /**
+     * @param variables
+     */
+    public void setFilterVariables(FilterVariables filterVariables) {
+        this.filterVariables = filterVariables;
+    }
+
+    /**
+     * @return variables
+     */
+    public FilterVariables getFilterVariables() {
+        return this.filterVariables;
+    }
+
     public int getActionCount() {
         if(actions == null){
             return 0;
@@ -147,6 +170,7 @@ public final class NestedRule {
     @Override
     public String toString() {
         return Objects.toStringHelper(this)
+            .add("filterVariables", filterVariables)
             .add("tests", tests)
             .add("actions", actions)
             .add("child", child)

--- a/store/src/java-test/com/zimbra/cs/service/mail/GetFilterRulesTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/mail/GetFilterRulesTest.java
@@ -552,4 +552,95 @@ public class GetFilterRulesTest {
 
     }
 
+    @Test
+    public void testFilterVariables() throws Exception {
+        Account acct = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+        RuleManager.clearCachedRules(acct);
+
+        String filterScript = "require [\"fileinto\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\", \"enotify\"];\n" +
+            "\n" +
+            "# t60\n" +
+            "set \"var\" \"testTag\";\n" +
+            "set \"var_new\" \"${var}\";\n" +
+            "if anyof (header :contains [\"subject\"] \"test\") {\n" +
+            "    tag \"${var_new}\";\n" +
+            "    set \"v1\" \"blah blah\";\n" +
+            "    set \"v2\" \"${v1}\";\n" +
+            "    set \"t1\" \"ttttt\";\n" +
+            "    if anyof (header :contains [\"subject\"] \"abc\") {\n" +
+            "        tag \"${v2}\";\n" +
+            "        tag \"${t1}\";\n" +
+            "        set \"v3\" \"bbbbbbbbbbbb\";\n" +
+            "        if anyof (header :contains [\"subject\"] \"def\") {\n" +
+            "            set \"v4\" \"${v3}\";\n" +
+            "            if anyof (header :contains [\"subject\"] \"def\") {\n" +
+            "                set \"v5\" \"${v4}\";\n" +
+            "            }\n" +
+            "        }\n" +
+            "    }\n" +
+            "}\n" +
+            "";
+        acct.setMailSieveScript(filterScript);
+
+        Element request = new Element.XMLElement(MailConstants.GET_FILTER_RULES_REQUEST);
+        Element response = new GetFilterRules().handle(request, ServiceTestUtil.getRequestContext(acct));
+
+
+        String expectedSoap = "<GetFilterRulesResponse xmlns=\"urn:zimbraMail\">\n" +
+            "  <filterRules>\n" +
+            "    <filterRule name=\"t60\" active=\"1\">\n" +
+            "      <filterVariables index=\"0\">\n" +
+            "        <filterVariable name=\"var\" value=\"testTag\"/>\n" +
+            "        <filterVariable name=\"var_new\" value=\"${var}\"/>\n" +
+            "      </filterVariables>\n" +
+            "      <filterTests condition=\"anyof\">\n" +
+            "        <headerTest stringComparison=\"contains\" header=\"subject\" index=\"0\" value=\"test\"/>\n" +
+            "      </filterTests>\n" +
+            "      <filterActions>\n" +
+            "        <actionTag index=\"0\" tagName=\"${var_new}\"/>\n" +
+            "        <filterVariables index=\"0\">\n" +
+            "          <filterVariable name=\"v1\" value=\"blah blah\"/>\n" +
+            "          <filterVariable name=\"v2\" value=\"${v1}\"/>\n" +
+            "          <filterVariable name=\"t1\" value=\"ttttt\"/>\n" +
+            "        </filterVariables>\n" +
+            "      </filterActions>\n" +
+            "      <nestedRule>\n" +
+            "        <filterTests condition=\"anyof\">\n" +
+            "          <headerTest stringComparison=\"contains\" header=\"subject\" index=\"0\" value=\"abc\"/>\n" +
+            "        </filterTests>\n" +
+            "        <filterActions>\n" +
+            "          <actionTag index=\"0\" tagName=\"${v2}\"/>\n" +
+            "          <actionTag index=\"1\" tagName=\"${t1}\"/>\n" +
+            "          <filterVariables index=\"0\">\n" +
+            "            <filterVariable name=\"v3\" value=\"bbbbbbbbbbbb\"/>\n" +
+            "          </filterVariables>\n" +
+            "        </filterActions>\n" +
+            "        <nestedRule>\n" +
+            "          <filterTests condition=\"anyof\">\n" +
+            "            <headerTest stringComparison=\"contains\" header=\"subject\" index=\"0\" value=\"def\"/>\n" +
+            "          </filterTests>\n" +
+            "          <filterActions>\n" +
+            "            <filterVariables index=\"0\">\n" +
+            "              <filterVariable name=\"v4\" value=\"${v3}\"/>\n" +
+            "            </filterVariables>\n" +
+            "          </filterActions>\n" +
+            "          <nestedRule>\n" +
+            "            <filterTests condition=\"anyof\">\n" +
+            "              <headerTest stringComparison=\"contains\" header=\"subject\" index=\"0\" value=\"def\"/>\n" +
+            "            </filterTests>\n" +
+            "            <filterActions>\n" +
+            "              <filterVariables index=\"0\">\n" +
+            "                <filterVariable name=\"v5\" value=\"${v4}\"/>\n" +
+            "              </filterVariables>\n" +
+            "            </filterActions>\n" +
+            "          </nestedRule>\n" +
+            "        </nestedRule>\n" +
+            "      </nestedRule>\n" +
+            "    </filterRule>\n" +
+            "  </filterRules>\n" +
+            "</GetFilterRulesResponse>";
+
+        XMLDiffChecker.assertXMLEquals(expectedSoap, response.prettyPrint());
+    }
+
 }

--- a/store/src/java-test/com/zimbra/cs/service/mail/ModifyFilterRulesTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/mail/ModifyFilterRulesTest.java
@@ -46,6 +46,8 @@ import com.zimbra.soap.mail.type.FilterAction;
 import com.zimbra.soap.mail.type.FilterRule;
 import com.zimbra.soap.mail.type.FilterTest;
 import com.zimbra.soap.mail.type.FilterTests;
+import com.zimbra.soap.mail.type.FilterVariable;
+import com.zimbra.soap.mail.type.FilterVariables;
 
 
 /**
@@ -442,6 +444,94 @@ public class ModifyFilterRulesTest {
             String sieve = account.getMailSieveScript();
             int result = sieve.indexOf("envelope :count \"eq\" :all :comparator \"i;ascii-numeric\" [\"to\"] \"1\"");
             Assert.assertNotSame(-1, result);
+        } catch (Exception e) {
+            fail("No exception should be thrown" + e);
+        }
+    }
+
+    @Test
+    public void testFilterVariables() {
+        try {
+            Account account = Provisioning.getInstance().getAccount(
+                    MockProvisioning.DEFAULT_ACCOUNT_ID);
+            RuleManager.clearCachedRules(account);
+
+            String xml = "<ModifyFilterRulesRequest xmlns=\"urn:zimbraMail\"><filterRules>"
+                + "<filterRule name=\"t60\" active=\"1\">"
+                + "<filterVariables index=\"0\">"
+                + "<filterVariable name=\"var\" value=\"testTag\"/>"
+                + "<filterVariable name=\"var_new\" value=\"${var}\"/>"
+                + "</filterVariables>"
+                + "<filterTests condition=\"anyof\">"
+                + "<headerTest stringComparison=\"contains\" header=\"subject\" index=\"0\" value=\"test\"/>"
+                + "</filterTests>"
+                + "<filterActions>"
+                + "<actionTag index=\"0\" tagName=\"${var_new}\"/>"
+                + "<filterVariables index=\"0\">"
+                + "<filterVariable name=\"v1\" value=\"blah blah\"/>"
+                + "<filterVariable name=\"v2\" value=\"${v1}\"/>"
+                + "<filterVariable name=\"t1\" value=\"ttttt\"/>"
+                + "</filterVariables>"
+                + "</filterActions>"
+                + "<nestedRule>"
+                + "<filterTests condition=\"anyof\"><headerTest stringComparison=\"contains\" header=\"subject\" index=\"0\" value=\"abc\"/>"
+                + "</filterTests>"
+                + "<filterActions>"
+                + "<actionTag index=\"0\" tagName=\"${v2}\"/>"
+                + "<actionTag index=\"1\" tagName=\"${t1}\"/>"
+                + "<filterVariables index=\"0\">"
+                + "<filterVariable name=\"v3\" value=\"bbbbbbbbbbbb\"/>"
+                + "</filterVariables>"
+                + "</filterActions>"
+                + "<nestedRule>"
+                + "<filterTests condition=\"anyof\"><headerTest stringComparison=\"contains\" header=\"subject\" index=\"0\" value=\"def\"/></filterTests>"
+                + "<filterActions>"
+                + "<filterVariables index=\"0\">"
+                + "<filterVariable name=\"v4\" value=\"${v3}\"/>"
+                + "</filterVariables>"
+                + "</filterActions>"
+                + "<nestedRule>"
+                + "<filterTests condition=\"anyof\"><headerTest stringComparison=\"contains\" header=\"subject\" index=\"0\" value=\"def\"/></filterTests>"
+                + "<filterActions>"
+                + "<filterVariables index=\"0\">"
+                + "<filterVariable name=\"v5\" value=\"${v4}\"/>"
+                + "</filterVariables>"
+                + "</filterActions>"
+                + "</nestedRule>"
+                + "</nestedRule>"
+                + "</nestedRule>"
+                + "</filterRule>"
+                + "</filterRules>"
+                + "</ModifyFilterRulesRequest>";
+
+            Element request = Element.parseXML(xml);
+            new ModifyFilterRules().handle(request, ServiceTestUtil.getRequestContext(account));
+
+            String expectedScript = "require [\"fileinto\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\", \"enotify\"];\n" +
+                "\n" +
+                "# t60\n" +
+                "set \"var\" \"testTag\";\n" +
+                "set \"var_new\" \"${var}\";\n" +
+                "if anyof (header :contains [\"subject\"] \"test\") {\n" +
+                "    tag \"${var_new}\";\n" +
+                "    set \"v1\" \"blah blah\";\n" +
+                "    set \"v2\" \"${v1}\";\n" +
+                "    set \"t1\" \"ttttt\";\n" +
+                "    if anyof (header :contains [\"subject\"] \"abc\") {\n" +
+                "        tag \"${v2}\";\n" +
+                "        tag \"${t1}\";\n" +
+                "        set \"v3\" \"bbbbbbbbbbbb\";\n" +
+                "        if anyof (header :contains [\"subject\"] \"def\") {\n" +
+                "            set \"v4\" \"${v3}\";\n" +
+                "            if anyof (header :contains [\"subject\"] \"def\") {\n" +
+                "                set \"v5\" \"${v4}\";\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}\n" +
+                "";
+
+            assertEquals(expectedScript, account.getMailSieveScript());
         } catch (Exception e) {
             fail("No exception should be thrown" + e);
         }

--- a/store/src/java/com/zimbra/cs/filter/SieveVisitor.java
+++ b/store/src/java/com/zimbra/cs/filter/SieveVisitor.java
@@ -283,7 +283,7 @@ public abstract class SieveVisitor {
     protected void visitLogAction(Node node, VisitPhase phase, RuleProperties props, FilterAction.LogAction.LogLevel logLevel, String logText) throws ServiceException {
     }
 
-    private static final Set<String> RULE_NODE_NAMES = ImmutableSet.of("if", "disabled_if");
+    private static final Set<String> RULE_NODE_NAMES = ImmutableSet.of("if", "disabled_if", "elsif");
     private static final String COPY_EXT = ":copy";
 
     public class RuleProperties {

--- a/store/src/java/com/zimbra/cs/filter/SoapToSieve.java
+++ b/store/src/java/com/zimbra/cs/filter/SoapToSieve.java
@@ -70,21 +70,8 @@ public final class SoapToSieve {
         buffer.append("# ").append(name).append('\n');
 
         FilterVariables filterVariables = rule.getFilterVariables();
-        if (filterVariables != null) {
-            List<FilterVariable> variables = filterVariables.getVariables();
-            if (variables != null && !variables.isEmpty()) {
-                for (FilterVariable filterVariable : variables) {
-                    String varName = filterVariable.getName();
-                    String varValue = filterVariable.getValue();
-                    if (!StringUtil.isNullOrEmpty(varName) && !StringUtil.isNullOrEmpty(varValue)) {
-                        buffer.append("set \"").append(varName).append("\" \"").append(varValue).append("\";\n");
-                    } else {
-                        ZimbraLog.filter.debug("Ignoring problem in filterVariable with name or value");
-                    }
-                }
-            }
-        } else {
-            ZimbraLog.filter.debug("No filterVariables found in filterRule in rule %s", name);
+        if (filterVariables != null && filterVariables.getVariables() != null && !filterVariables.getVariables().isEmpty()) {
+            buffer.append(handleVariables(filterVariables, null)).append(";\n");
         }
 
         FilterTests tests = rule.getFilterTests();
@@ -111,36 +98,42 @@ public final class SoapToSieve {
         Joiner.on(",\n  ").appendTo(buffer, index2test.values());
         buffer.append(") {\n");
 
-        // Handle nested rule
+        // Handle actions
+        Map<Integer, String> index2action = new TreeMap<Integer, String>(); // sort by index
+        List<FilterAction> filterActions = rule.getFilterActions();
+
+        String variables = "";
+        if (filterActions != null) {
+            for (FilterAction action : filterActions) {
+                if (action instanceof FilterVariables) {
+                    FilterVariables var = (FilterVariables) action;
+                    variables = handleVariables(var, "    ");
+                } else {
+                    String result = handleAction(action);
+                    if (result != null) {
+                        FilterUtil.addToMap(index2action, action.getIndex(), result);
+                    }
+                }
+            }
+            for (String action : index2action.values()) {
+                buffer.append("    ").append(action).append(";\n");
+            }
+            if (!variables.isEmpty()) {
+                buffer.append(variables).append(";\n");
+            }
+        }
+
         NestedRule child = rule.getChild();
+        // Handle nested rule
         if(child!=null){
             // first nested block's indent is "    "
             String nestedRuleBlock = handleNest("    ", child);
             buffer.append(nestedRuleBlock);
         }
 
-        // Handle actions
-        Map<Integer, String> index2action = new TreeMap<Integer, String>(); // sort by index
-        List<FilterAction> filterActions = rule.getFilterActions();
-        if ( filterActions == null) {   // if there is no action in this rule, filterActions is supposed to be null.
-            if (child == null) {
+        if ( filterActions == null && child == null) {   // if there is no action in this rule, filterActions is supposed to be null.
                 // If there is no more nested rule, there should be at least one action.
                 throw ServiceException.INVALID_REQUEST("Missing action", null);
-            } else {
-                // If there is no action in this rule and there have been no exception thrown so far,
-                // then there should be one in nested rules. So just close "if" block here.
-                buffer.append("}\n");
-                return;
-            }
-        }
-        for (FilterAction action : filterActions) {
-            String result = handleAction(action);
-            if (result != null) {
-                FilterUtil.addToMap(index2action, action.getIndex(), result);
-            }
-        }
-        for (String action : index2action.values()) {
-            buffer.append("    ").append(action).append(";\n");
         }
         buffer.append("}\n");
     }
@@ -149,7 +142,11 @@ public final class SoapToSieve {
     private String handleNest(String baseIndents, NestedRule currentNestedRule) throws ServiceException {
 
         StringBuilder nestedIfBlock = new StringBuilder();
-        nestedIfBlock.append(baseIndents);
+
+        FilterVariables filterVariables = currentNestedRule.getFilterVariables();
+        if (filterVariables != null && filterVariables.getVariables() != null && !filterVariables.getVariables().isEmpty()) {
+            nestedIfBlock.append(handleVariables(filterVariables, baseIndents)).append(";\n");
+        }
 
         Sieve.Condition childCondition =
                 Sieve.Condition.fromString(currentNestedRule.getFilterTests().getCondition());
@@ -158,7 +155,7 @@ public final class SoapToSieve {
         }
 
         // assuming no disabled_if for child tests so far
-        nestedIfBlock.append("if ");
+        nestedIfBlock.append(baseIndents).append("if ");
         nestedIfBlock.append(childCondition).append(" (");
 
         // Handle tests
@@ -172,36 +169,39 @@ public final class SoapToSieve {
         Joiner.on(",\n  "+baseIndents).appendTo(nestedIfBlock, index2childTest.values());
         nestedIfBlock.append(") {\n");
 
+        // Handle actions
+        Map<Integer, String> index2childAction = new TreeMap<Integer, String>(); // sort by index
+        List<FilterAction> childActions = currentNestedRule.getFilterActions();
+
+        String variables = "";
+        if (childActions != null) {
+            for (FilterAction childAction : childActions) {
+                if (childAction instanceof FilterVariables) {
+                    FilterVariables var = (FilterVariables) childAction;
+                    variables = handleVariables(var, baseIndents + "    ");
+                } else {
+                    String childResult = handleAction(childAction);
+                    if (childResult != null) {
+                        FilterUtil.addToMap(index2childAction, childAction.getIndex(), childResult);
+                    }
+                }
+            }
+            for (String childAction : index2childAction.values()) {
+                nestedIfBlock.append(baseIndents);
+                nestedIfBlock.append("    ").append(childAction).append(";\n");
+            }
+            if (!variables.isEmpty()) {
+                nestedIfBlock.append(variables).append(";\n");
+            }
+        }
         // Handle nest
         if(currentNestedRule.getChild() != null){
             nestedIfBlock.append(handleNest(baseIndents + "    ", currentNestedRule.getChild()));
         }
 
-        // Handle actions
-        Map<Integer, String> index2childAction = new TreeMap<Integer, String>(); // sort by index
-        List<FilterAction> childActions = currentNestedRule.getFilterActions();
-        if (childActions == null) { // if there is no action in this rule, childActions is supposed to be null.
-            if (currentNestedRule.getChild() == null) {
+        if (childActions == null && currentNestedRule.getChild() == null) { // if there is no action in this rule, childActions is supposed to be null.
                 // If there is no more nested rule, there should be at least one action.
                 throw ServiceException.INVALID_REQUEST("Missing action", null);
-            } else {
-                // If there is no action in this rule and there have been no exception thrown,
-                // then there should be one in nested rules. So just close "if" block here.
-                nestedIfBlock.append(baseIndents);
-                nestedIfBlock.append("}\n");
-
-                return nestedIfBlock.toString();
-            }
-        }
-        for (FilterAction childAction : childActions) {
-            String childResult = handleAction(childAction);
-            if (childResult != null) {
-                FilterUtil.addToMap(index2childAction, childAction.getIndex(), childResult);
-            }
-        }
-        for (String childAction : index2childAction.values()) {
-            nestedIfBlock.append(baseIndents);
-            nestedIfBlock.append("    ").append(childAction).append(";\n");
         }
 
         nestedIfBlock.append(baseIndents);
@@ -594,29 +594,6 @@ public final class SoapToSieve {
             return filter.toString();
         } else if (action instanceof FilterAction.StopAction) {
             return "stop";
-        } else if (action instanceof FilterVariables) {
-            StringBuilder sb = new StringBuilder();
-            FilterVariables filterVariables = (FilterVariables) action;
-            if (filterVariables != null) {
-                List<FilterVariable> variables = filterVariables.getVariables();
-                if (variables != null && !variables.isEmpty()) {
-                    Iterator<FilterVariable> iterator = variables.iterator();
-                    while(iterator.hasNext()) {
-                        FilterVariable filterVariable = iterator.next();
-                        String varName = filterVariable.getName();
-                        String varValue = filterVariable.getValue();
-                        if (!StringUtil.isNullOrEmpty(varName) && !StringUtil.isNullOrEmpty(varValue)) {
-                            sb.append("set \"").append(varName).append("\" \"").append(varValue).append("\"");
-                        } else {
-                            ZimbraLog.filter.debug("Ignoring problem in filterVariable with name or value");
-                        }
-                        if (iterator.hasNext()) {
-                            sb.append(";\n");
-                        }
-                    }
-                }
-                return sb.toString();
-            }
         } else if (action instanceof FilterAction.RejectAction) {
             FilterAction.RejectAction rejectAction = (FilterAction.RejectAction)action;
             return handleRejectAction(rejectAction);
@@ -662,6 +639,33 @@ public final class SoapToSieve {
             String message = "Empty " + act + " action";
             throw ServiceException.PARSE_ERROR(message, null);
         }
+    }
+
+    private static String handleVariables(FilterVariables filterVariables, String indent) {
+        StringBuilder sb = new StringBuilder();
+        if (filterVariables != null) {
+            List<FilterVariable> variables = filterVariables.getVariables();
+            if (variables != null && !variables.isEmpty()) {
+                Iterator<FilterVariable> iterator = variables.iterator();
+                while(iterator.hasNext()) {
+                    FilterVariable filterVariable = iterator.next();
+                    String varName = filterVariable.getName();
+                    String varValue = filterVariable.getValue();
+                    if (!StringUtil.isNullOrEmpty(varName) && !StringUtil.isNullOrEmpty(varValue)) {
+                            if (indent != null) {
+                                sb.append(indent);
+                            }
+                            sb.append("set \"").append(varName).append("\" \"").append(varValue).append("\"");
+                    } else {
+                        ZimbraLog.filter.debug("Ignoring problem in filterVariable with name or value");
+                    }
+                    if (iterator.hasNext()) {
+                        sb.append(";\n");
+                    }
+                }
+            }
+        }
+        return sb.toString();
     }
 
     private static boolean containsSubjectHeader(String origHeaders) {


### PR DESCRIPTION
[ZCS-1390]
FilterVariables should be supported in nested rule

[Fix]
1. Extracted handleVariables method in SoapToSieve to convert filterVariables objects into sieve
2. Added FilterVariables in NestedRule soap type
3. Changed SieveToSoap and SieveVisitor to convert set command into filterVariable object
4. Add fix for zcs-1281 in SieveVisitor

[Testing]
1. Added junits for GetFilterRulesRequest and ModifyFilterRulesRequest
2. Manual testing for soap sieve and vice versa with the following sieve scripts -

[A]
set "var" "testTag";
set "var_new" "${var}";
if anyof (header :contains ["subject"] "test") {
    tag "${var_new}";
    set "v1" "blah blah";
    set "v2" "${v1}";
    set "t1" "ttttt";
    if anyof (header :contains ["subject"] "abc") {
        tag "${v2}";
        tag "${t1}";
        set "v3" "bbbbbbbbbbbb";
        set "v4" "${v3}";
        set "v5" "${v4}";
    }
}

[B]

set "var" "testTag";
set "var_new" "${var}";
if anyof (header :contains ["subject"] "test") {
    tag "${var_new}";
    set "v1" "blah blah";
    set "v2" "${v1}";
    set "t1" "ttttt";
    if anyof (header :contains ["subject"] "abc") {
        tag "${v2}";
        tag "${t1}";
        set "v3" "bbbbbbbbbbbb";
        if anyof (header :contains ["subject"] "def") {
            set "v4" "${v3}";
            if anyof (header :contains ["subject"] "def") {
                set "v5" "${v4}";
            }
        }
    }
}

[C]

set "var" "testTag";
set "var_new" "${var}";
if anyof (header :contains ["subject"] "test") {
    tag "${var_new}";
    set "v1" "blah blah";
    set "v2" "${v1}";
    set "v3" "${v2}";
}