### PR TITLE
ZCS-1390 Support for filter variables in nested rule

### DIFF
--- a/soap/src/java/com/zimbra/soap/mail/type/NestedRule.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/NestedRule.java
@@ -37,9 +37,17 @@ import com.zimbra.soap.json.jackson.annotate.ZimbraJsonArrayForWrapper;
 
 // JsonPropertyOrder added to make sure JaxbToJsonTest.bug65572_BooleanAndXmlElements passes
 @XmlAccessorType(XmlAccessType.NONE)
-@XmlType(propOrder = {"tests", "actions","child"})
-@JsonPropertyOrder({ "tests", "actions","child"})
+@XmlType(propOrder = {"filterVariables", "tests", "actions","child"})
+@JsonPropertyOrder({"filterVariables", "tests", "actions","child"})
 public final class NestedRule {
+
+    /**
+     * @zm-api-field-tag variables
+     * @zm-api-field-description Filter Variables
+     */
+    @ZimbraJsonArrayForWrapper
+    @XmlElement(name=MailConstants.E_FILTER_VARIABLES /* filterVariables */, required=false)
+    private FilterVariables filterVariables;
 
     /**
      * @zm-api-field-description Filter tests
@@ -89,6 +97,7 @@ public final class NestedRule {
     public NestedRule(FilterTests tests) {
         this.tests = tests;
         this.actions = null;
+        this.filterVariables = null;
     }
     public void setFilterTests(FilterTests value) {
         tests = value;
@@ -127,6 +136,20 @@ public final class NestedRule {
         return Collections.unmodifiableList(actions);
     }
 
+    /**
+     * @param variables
+     */
+    public void setFilterVariables(FilterVariables filterVariables) {
+        this.filterVariables = filterVariables;
+    }
+
+    /**
+     * @return variables
+     */
+    public FilterVariables getFilterVariables() {
+        return this.filterVariables;
+    }
+
     public int getActionCount() {
         if(actions == null){
             return 0;
@@ -147,6 +170,7 @@ public final class NestedRule {
     @Override
     public String toString() {
         return Objects.toStringHelper(this)
+            .add("filterVariables", filterVariables)
             .add("tests", tests)
             .add("actions", actions)
             .add("child", child)

--- a/store/src/java/com/zimbra/cs/filter/SieveToSoap.java
+++ b/store/src/java/com/zimbra/cs/filter/SieveToSoap.java
@@ -44,7 +44,7 @@ public final class SieveToSoap extends SieveVisitor {
     private final List<String> ruleNames;
     private FilterRule currentRule;
     private int currentRuleIndex = 0;
-    private int nunOfIfProcessingStarted = 0; // For counting num of started If processings
+    private int numOfIfProcessingStarted = 0; // For counting num of started If processings
     private int numOfIfProcessingDone = 0; // For counting num of finished If processings
     private NestedRule currentNestedRule; // keep the pointer to nested rule being processed
     private List<FilterVariable> currentVariables = null;
@@ -73,12 +73,12 @@ public final class SieveToSoap extends SieveVisitor {
 
         if (!isNestedRule()){
             currentRule = new FilterRule(getCurrentRuleName(), props.isEnabled);
-            if (currentVariables != null) {
-                if(currentRule.getFilterVariables() == null) {
-                    currentRule.setFilterVariables(new FilterVariables());
-                }
-                currentRule.getFilterVariables().setVariables(currentVariables);
+            if (currentVariables != null && !currentVariables.isEmpty()) {
+                currentRule.setFilterVariables(new FilterVariables(currentVariables));
                 currentVariables = null;
+            }
+            if (actionVariables != null && !actionVariables.isEmpty()) {
+                currentRule.addFilterAction(new FilterVariables(actionVariables));
             }
             currentRule.setFilterTests(new FilterTests(props.condition.toString()));
             rules.add(currentRule);
@@ -91,18 +91,33 @@ public final class SieveToSoap extends SieveVisitor {
             if(currentNestedRule != null){  // some nested rule has been already processed
                 // set it as child of previous one
                 currentNestedRule.setChild(nestedRule);
+                if (currentVariables != null && !currentVariables.isEmpty()) {
+                    currentNestedRule.setFilterVariables(new FilterVariables(currentVariables));
+                    currentVariables = null;
+                }
+                if (actionVariables != null && !actionVariables.isEmpty()) {
+                    currentNestedRule.addFilterAction(new FilterVariables(actionVariables));
+                }
             } else {               // first nested rule
                 // set it as child of root rule
                 currentRule.setChild(nestedRule);
+                if (currentVariables != null && !currentVariables.isEmpty()) {
+                    currentRule.setFilterVariables(new FilterVariables(currentVariables));
+                    currentVariables = null;
+                }
+                if (actionVariables != null && !actionVariables.isEmpty()) {
+                    currentRule.addFilterAction(new FilterVariables(actionVariables));
+                }
             }
             currentNestedRule = nestedRule;
+            actionVariables = null;
         }
     }
 
     @Override
     protected void visitVariable(Node ruleNode, VisitPhase phase, RuleProperties props, String name, String value) {
         if (phase == VisitPhase.begin) {
-            if (isNestedRule()) {
+            if (numOfIfProcessingStarted > numOfIfProcessingDone) {
                 if (actionVariables == null) {
                     actionVariables = Lists.newArrayList();
                 }
@@ -127,15 +142,12 @@ public final class SieveToSoap extends SieveVisitor {
             }
             return;
         }
-        nunOfIfProcessingStarted++;   // number of if for which process is started.
+        numOfIfProcessingStarted++;   // number of if for which process is started.
     }
 
     private boolean isNestedRule(){
         // in non nested case, only one process is started but not done.
-        if(nunOfIfProcessingStarted == numOfIfProcessingDone+1){
-            return false;
-        }
-        return true;
+        return !(numOfIfProcessingStarted == numOfIfProcessingDone+1);
     }
 
     private <T extends FilterTest> T addTest(T test, RuleProperties props) {

--- a/store/src/java/com/zimbra/cs/filter/SoapToSieve.java
+++ b/store/src/java/com/zimbra/cs/filter/SoapToSieve.java
@@ -70,21 +70,8 @@ public final class SoapToSieve {
         buffer.append("# ").append(name).append('\n');
 
         FilterVariables filterVariables = rule.getFilterVariables();
-        if (filterVariables != null) {
-            List<FilterVariable> variables = filterVariables.getVariables();
-            if (variables != null && !variables.isEmpty()) {
-                for (FilterVariable filterVariable : variables) {
-                    String varName = filterVariable.getName();
-                    String varValue = filterVariable.getValue();
-                    if (!StringUtil.isNullOrEmpty(varName) && !StringUtil.isNullOrEmpty(varValue)) {
-                        buffer.append("set \"").append(varName).append("\" \"").append(varValue).append("\";\n");
-                    } else {
-                        ZimbraLog.filter.debug("Ignoring problem in filterVariable with name or value");
-                    }
-                }
-            }
-        } else {
-            ZimbraLog.filter.debug("No filterVariables found in filterRule in rule %s", name);
+        if (filterVariables != null && filterVariables.getVariables() != null && !filterVariables.getVariables().isEmpty()) {
+            buffer.append(handleVariables(filterVariables, null)).append(";\n");
         }
 
         FilterTests tests = rule.getFilterTests();
@@ -111,36 +98,42 @@ public final class SoapToSieve {
         Joiner.on(",\n  ").appendTo(buffer, index2test.values());
         buffer.append(") {\n");
 
-        // Handle nested rule
+        // Handle actions
+        Map<Integer, String> index2action = new TreeMap<Integer, String>(); // sort by index
+        List<FilterAction> filterActions = rule.getFilterActions();
+
+        String variables = "";
+        if (filterActions != null) {
+            for (FilterAction action : filterActions) {
+                if (action instanceof FilterVariables) {
+                    FilterVariables var = (FilterVariables) action;
+                    variables = handleVariables(var, "    ");
+                } else {
+                    String result = handleAction(action);
+                    if (result != null) {
+                        FilterUtil.addToMap(index2action, action.getIndex(), result);
+                    }
+                }
+            }
+            for (String action : index2action.values()) {
+                buffer.append("    ").append(action).append(";\n");
+            }
+            if (!variables.isEmpty()) {
+                buffer.append(variables).append(";\n");
+            }
+        }
+
         NestedRule child = rule.getChild();
+        // Handle nested rule
         if(child!=null){
             // first nested block's indent is "    "
             String nestedRuleBlock = handleNest("    ", child);
             buffer.append(nestedRuleBlock);
         }
 
-        // Handle actions
-        Map<Integer, String> index2action = new TreeMap<Integer, String>(); // sort by index
-        List<FilterAction> filterActions = rule.getFilterActions();
-        if ( filterActions == null) {   // if there is no action in this rule, filterActions is supposed to be null.
-            if (child == null) {
+        if ( filterActions == null && child == null) {   // if there is no action in this rule, filterActions is supposed to be null.
                 // If there is no more nested rule, there should be at least one action.
                 throw ServiceException.INVALID_REQUEST("Missing action", null);
-            } else {
-                // If there is no action in this rule and there have been no exception thrown so far,
-                // then there should be one in nested rules. So just close "if" block here.
-                buffer.append("}\n");
-                return;
-            }
-        }
-        for (FilterAction action : filterActions) {
-            String result = handleAction(action);
-            if (result != null) {
-                FilterUtil.addToMap(index2action, action.getIndex(), result);
-            }
-        }
-        for (String action : index2action.values()) {
-            buffer.append("    ").append(action).append(";\n");
         }
         buffer.append("}\n");
     }
@@ -149,7 +142,11 @@ public final class SoapToSieve {
     private String handleNest(String baseIndents, NestedRule currentNestedRule) throws ServiceException {
 
         StringBuilder nestedIfBlock = new StringBuilder();
-        nestedIfBlock.append(baseIndents);
+
+        FilterVariables filterVariables = currentNestedRule.getFilterVariables();
+        if (filterVariables != null && filterVariables.getVariables() != null && !filterVariables.getVariables().isEmpty()) {
+            nestedIfBlock.append(handleVariables(filterVariables, baseIndents)).append(";\n");
+        }
 
         Sieve.Condition childCondition =
                 Sieve.Condition.fromString(currentNestedRule.getFilterTests().getCondition());
@@ -158,7 +155,7 @@ public final class SoapToSieve {
         }
 
         // assuming no disabled_if for child tests so far
-        nestedIfBlock.append("if ");
+        nestedIfBlock.append(baseIndents).append("if ");
         nestedIfBlock.append(childCondition).append(" (");
 
         // Handle tests
@@ -172,36 +169,39 @@ public final class SoapToSieve {
         Joiner.on(",\n  "+baseIndents).appendTo(nestedIfBlock, index2childTest.values());
         nestedIfBlock.append(") {\n");
 
+        // Handle actions
+        Map<Integer, String> index2childAction = new TreeMap<Integer, String>(); // sort by index
+        List<FilterAction> childActions = currentNestedRule.getFilterActions();
+
+        String variables = "";
+        if (childActions != null) {
+            for (FilterAction childAction : childActions) {
+                if (childAction instanceof FilterVariables) {
+                    FilterVariables var = (FilterVariables) childAction;
+                    variables = handleVariables(var, baseIndents + "    ");
+                } else {
+                    String childResult = handleAction(childAction);
+                    if (childResult != null) {
+                        FilterUtil.addToMap(index2childAction, childAction.getIndex(), childResult);
+                    }
+                }
+            }
+            for (String childAction : index2childAction.values()) {
+                nestedIfBlock.append(baseIndents);
+                nestedIfBlock.append("    ").append(childAction).append(";\n");
+            }
+            if (!variables.isEmpty()) {
+                nestedIfBlock.append(variables).append(";\n");
+            }
+        }
         // Handle nest
         if(currentNestedRule.getChild() != null){
             nestedIfBlock.append(handleNest(baseIndents + "    ", currentNestedRule.getChild()));
         }
 
-        // Handle actions
-        Map<Integer, String> index2childAction = new TreeMap<Integer, String>(); // sort by index
-        List<FilterAction> childActions = currentNestedRule.getFilterActions();
-        if (childActions == null) { // if there is no action in this rule, childActions is supposed to be null.
-            if (currentNestedRule.getChild() == null) {
+        if (childActions == null && currentNestedRule.getChild() == null) { // if there is no action in this rule, childActions is supposed to be null.
                 // If there is no more nested rule, there should be at least one action.
                 throw ServiceException.INVALID_REQUEST("Missing action", null);
-            } else {
-                // If there is no action in this rule and there have been no exception thrown,
-                // then there should be one in nested rules. So just close "if" block here.
-                nestedIfBlock.append(baseIndents);
-                nestedIfBlock.append("}\n");
-
-                return nestedIfBlock.toString();
-            }
-        }
-        for (FilterAction childAction : childActions) {
-            String childResult = handleAction(childAction);
-            if (childResult != null) {
-                FilterUtil.addToMap(index2childAction, childAction.getIndex(), childResult);
-            }
-        }
-        for (String childAction : index2childAction.values()) {
-            nestedIfBlock.append(baseIndents);
-            nestedIfBlock.append("    ").append(childAction).append(";\n");
         }
 
         nestedIfBlock.append(baseIndents);
@@ -594,29 +594,6 @@ public final class SoapToSieve {
             return filter.toString();
         } else if (action instanceof FilterAction.StopAction) {
             return "stop";
-        } else if (action instanceof FilterVariables) {
-            StringBuilder sb = new StringBuilder();
-            FilterVariables filterVariables = (FilterVariables) action;
-            if (filterVariables != null) {
-                List<FilterVariable> variables = filterVariables.getVariables();
-                if (variables != null && !variables.isEmpty()) {
-                    Iterator<FilterVariable> iterator = variables.iterator();
-                    while(iterator.hasNext()) {
-                        FilterVariable filterVariable = iterator.next();
-                        String varName = filterVariable.getName();
-                        String varValue = filterVariable.getValue();
-                        if (!StringUtil.isNullOrEmpty(varName) && !StringUtil.isNullOrEmpty(varValue)) {
-                            sb.append("set \"").append(varName).append("\" \"").append(varValue).append("\"");
-                        } else {
-                            ZimbraLog.filter.debug("Ignoring problem in filterVariable with name or value");
-                        }
-                        if (iterator.hasNext()) {
-                            sb.append(";\n");
-                        }
-                    }
-                }
-                return sb.toString();
-            }
         } else if (action instanceof FilterAction.RejectAction) {
             FilterAction.RejectAction rejectAction = (FilterAction.RejectAction)action;
             return handleRejectAction(rejectAction);
@@ -662,6 +639,33 @@ public final class SoapToSieve {
             String message = "Empty " + act + " action";
             throw ServiceException.PARSE_ERROR(message, null);
         }
+    }
+
+    private static String handleVariables(FilterVariables filterVariables, String indent) {
+        StringBuilder sb = new StringBuilder();
+        if (filterVariables != null) {
+            List<FilterVariable> variables = filterVariables.getVariables();
+            if (variables != null && !variables.isEmpty()) {
+                Iterator<FilterVariable> iterator = variables.iterator();
+                while(iterator.hasNext()) {
+                    FilterVariable filterVariable = iterator.next();
+                    String varName = filterVariable.getName();
+                    String varValue = filterVariable.getValue();
+                    if (!StringUtil.isNullOrEmpty(varName) && !StringUtil.isNullOrEmpty(varValue)) {
+                            if (indent != null) {
+                                sb.append(indent);
+                            }
+                            sb.append("set \"").append(varName).append("\" \"").append(varValue).append("\"");
+                    } else {
+                        ZimbraLog.filter.debug("Ignoring problem in filterVariable with name or value");
+                    }
+                    if (iterator.hasNext()) {
+                        sb.append(";\n");
+                    }
+                }
+            }
+        }
+        return sb.toString();
     }
 
     private static boolean containsSubjectHeader(String origHeaders) {


### PR DESCRIPTION
[ZCS-1390]
FilterVariables should be supported in nested rule

[Fix]

    Extracted handleVariables method in SoapToSieve to convert filterVariables objects into sieve
    Added FilterVariables in NestedRule soap type
    Changed SieveToSoap and SieveVisitor to convert set command into filterVariable object
    Add fix for zcs-1281 in SieveVisitor

[Testing]

    Added junits for GetFilterRulesRequest and ModifyFilterRulesRequest
    Manual testing for soap sieve and vice versa with the following sieve scripts -

[A]
set "var" "testTag";
set "var_new" "${var}";
if anyof (header :contains ["subject"] "test") {
tag "${var_new}";
set "v1" "blah blah";
set "v2" "${v1}";
set "t1" "ttttt";
if anyof (header :contains ["subject"] "abc") {
tag "${v2}";
tag "${t1}";
set "v3" "bbbbbbbbbbbb";
set "v4" "${v3}";
set "v5" "${v4}";
}
}

[B]

set "var" "testTag";
set "var_new" "${var}";
if anyof (header :contains ["subject"] "test") {
tag "${var_new}";
set "v1" "blah blah";
set "v2" "${v1}";
set "t1" "ttttt";
if anyof (header :contains ["subject"] "abc") {
tag "${v2}";
tag "${t1}";
set "v3" "bbbbbbbbbbbb";
if anyof (header :contains ["subject"] "def") {
set "v4" "${v3}";
if anyof (header :contains ["subject"] "def") {
set "v5" "${v4}";
}
}
}
}

[C]

set "var" "testTag";
set "var_new" "${var}";
if anyof (header :contains ["subject"] "test") {
tag "${var_new}";
set "v1" "blah blah";
set "v2" "${v1}";
set "v3" "${v2}";
}