### PR TITLE
ImapHandlerTest - do not use Ehcache

### DIFF
--- a/store/src/java-test/com/zimbra/cs/imap/ImapHandlerTest.java
+++ b/store/src/java-test/com/zimbra/cs/imap/ImapHandlerTest.java
@@ -12,6 +12,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.mailbox.FolderStore;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.Account;
@@ -34,6 +35,7 @@ public class ImapHandlerTest {
 
     @BeforeClass
     public static void init() throws Exception {
+        LC.imap_use_ehcache.setDefault(false);
         MailboxTestUtil.initServer();
         String[] hosts = {"localhost", "127.0.0.1"};
         ServerThrottle.configureThrottle(new ImapConfig(false).getProtocol(), 100, 100, Arrays.asList(hosts), Arrays.asList(hosts));


### PR DESCRIPTION
Found that ImapHandlerTest was hanging if mailboxd was running when
one ran this unit test.  Issue was in EhcacheManager/1.  When it
initializes the cache it was using the same persistence file that
mailboxd uses.  By setting the LC value `imap_use_ehcache` to
false, the ImapSessionManager uses DiskImapCache and there is no
conflict.