### PR TITLE
ZCS-107: fix the zimbraServerDir if needed while running unittest

### DIFF
--- a/store/src/java-test/com/zimbra/cs/db/HSQLDB.java
+++ b/store/src/java-test/com/zimbra/cs/db/HSQLDB.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.hsqldb.cmdline.SqlFile;
+import org.hsqldb.lib.StringUtil;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
@@ -63,6 +64,9 @@ public final class HSQLDB extends Db {
             rs = stmt.executeQuery();
             if (rs.next() && rs.getInt(1) > 0) {
                 return;  // already exists
+            }
+            if (!StringUtil.isEmpty(zimbraServerDir) && !zimbraServerDir.endsWith("/")) {
+                zimbraServerDir = zimbraServerDir + "/";
             }
             execute(conn, zimbraServerDir + "src/db/hsqldb/db.sql");
             execute(conn, zimbraServerDir + "src/db/hsqldb/create_database.sql");

--- a/store/src/java-test/com/zimbra/cs/mailbox/MailboxTestUtil.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/MailboxTestUtil.java
@@ -35,6 +35,7 @@ import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.methods.DeleteMethod;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
+import org.hsqldb.lib.StringUtil;
 
 import com.google.common.base.Strings;
 import com.zimbra.common.calendar.ZCalendar.ZVCalendar;
@@ -92,6 +93,9 @@ public final class MailboxTestUtil {
         // If zimbraServerDir is empty, use relative path to localconfig-test.xml
         if (StringUtils.isEmpty(zimbraServerDir)) {
             pathPrefix = "";
+        }
+        if (!StringUtil.isEmpty(zimbraServerDir) && !zimbraServerDir.endsWith("/")) {
+            zimbraServerDir = zimbraServerDir + "/";
         }
         System.setProperty("zimbra.config", zimbraServerDir + pathPrefix + "src/java-test/localconfig-test.xml");
         LC.reload();


### PR DESCRIPTION
MailboxTestUtil.initProvisioning() method expects the server dir without trailing "/" 
(like zm-mailbox/store) whereas HSQLDB.createDatabase() expects the serverDir ending with "/" 
(like zm-mailbox/store/). hence added code to check if trailing "/" is not present then add it.