### PR TITLE
ZCS-126 PasswordLockoutFailureTime is updated for accounts in lockout

### DIFF
--- a/store/src/java/com/zimbra/cs/account/ldap/LdapLockoutPolicy.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapLockoutPolicy.java
@@ -208,6 +208,11 @@ public class LdapLockoutPolicy {
             ZimbraLog.security.info("Suppressed password lockout.");
             return;
         }
+        // Account is lockout or lockout expired but still there is failed login.
+        if (mIsLockedOut || mAccountStatus.equalsIgnoreCase(Provisioning.ACCOUNT_STATUS_LOCKOUT)) {
+            ZimbraLog.security.info("Account is lockout, not updating failure time.");
+            return;
+        }
         Map<String, Object> attrs = new HashMap<String,Object>();
 
         int totalFailures = login.updateFailureTimes(attrs);


### PR DESCRIPTION
[Bug]:
In case of failed login, zimbraPasswordLockoutFailureTime is updated for accounts in lockout state

[Fix]:
If the account is in lockout state, return without updating zimbraPasswordLockoutFailureTime.
This fix has been applied from the patch provided by Prashant for bug #106408

[Testing]:
Mock provisioning does not support authentication. Hence, did manual testing.
Automation needs to be done.