### PR TITLE
ZCS-759 : Icalendar notification not sent if owner of shared calendar is on an other store

### DIFF
--- a/store/src/java/com/zimbra/cs/dav/caldav/AutoScheduler.java
+++ b/store/src/java/com/zimbra/cs/dav/caldav/AutoScheduler.java
@@ -33,6 +33,7 @@ import com.zimbra.common.calendar.ZCalendar.ZVCalendar;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.dav.DavContext;
 import com.zimbra.cs.dav.DavProtocol;
 import com.zimbra.cs.dav.resource.DavResource;
@@ -291,7 +292,10 @@ public abstract class AutoScheduler {
                 String descHtml = friendlyDesc.getAsHtml();
                 String uid = msgInvite.getUid();
                 ZVCalendar cal = msgInvite.newToICalendar(true);
-                Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(ctxt.getAuthAccount());
+                Account acct = Provisioning.getInstance().getAccountByName(ctxt.getUser());
+                if (acct == null)
+                    throw ServiceException.FAILURE("Could not load account for "+ctxt.getUser(), null);
+                Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
                 MimeMessage mm = CalendarMailSender.createCalendarMessage(ctxt.getAuthAccount(), from, sender,
                         recipients, subject, desc, descHtml, uid, cal, msgInvite.getIcalendarAttaches(), true);
                 mbox.getMailSender().setSendPartial(true).sendMimeMessage(

--- a/store/src/java/com/zimbra/cs/dav/caldav/AutoScheduler.java
+++ b/store/src/java/com/zimbra/cs/dav/caldav/AutoScheduler.java
@@ -293,8 +293,9 @@ public abstract class AutoScheduler {
                 String uid = msgInvite.getUid();
                 ZVCalendar cal = msgInvite.newToICalendar(true);
                 Account acct = Provisioning.getInstance().getAccountByName(ctxt.getUser());
-                if (acct == null)
+                if (acct == null) {
                     throw ServiceException.FAILURE("Could not load account for "+ctxt.getUser(), null);
+                }
                 Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
                 MimeMessage mm = CalendarMailSender.createCalendarMessage(ctxt.getAuthAccount(), from, sender,
                         recipients, subject, desc, descHtml, uid, cal, msgInvite.getIcalendarAttaches(), true);


### PR DESCRIPTION
Problem : When sharer is on different mail store and if sharee creates appointment in shared calendar using caldav client, WRONG_HOST exception is thrown in logs for sharer and attendee  do not receive calendar invitation.

Fix : Get user from context using ctxt.getUser() and not ctxt.getAuthAccount()

Testing done :
Case 1
=====
1) User "a" is on store1 and user "b" is on store2
2) User a shares his calendar with user b, user b has set caldav client configured
3) User b creates appointment using caldav client on users a's shared calendar and send invitation to user c
Result - No exception is thrown, user c receives calendar invite with from user a and sent by user b

Case 2
=====
1) User "a" is on store1 and user "b" is also on store1
2) User a shares his calendar with user b, user b has set caldav client configured
3) User b creates appointment using caldav client on users a's shared calendar and send invitation to user c
Result - No exception is thrown, user c receives calendar invite with from user a and sent by user b

Case 3
=====
1) User "a" is on store1 and user "b" is on store2
2) User a shares his calendar with user b, user b has set caldav client configured
3) User a creates appointment on the same calendar and invites user c
Result - No exception is thrown, user c receives calendar invite. Appointment is synced successfully on user b's caldav client