### PR TITLE
ZCS-1173(5):SIEVE:filter w/o anyof & allof causes NPE

### DIFF
--- a/soap/src/java/com/zimbra/soap/mail/type/FilterTests.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/FilterTests.java
@@ -39,7 +39,7 @@ public final class FilterTests {
      * @zm-api-field-description Condition - <b>allof|anyof</b>
      */
     @XmlAttribute(name=MailConstants.A_CONDITION, required=true)
-    private final String condition;
+    private String condition;
 
     /**
      * @zm-api-field-description Tests
@@ -105,6 +105,10 @@ public final class FilterTests {
 
     public String getCondition() {
         return condition;
+    }
+
+    public void setCondition(String condition) {
+        this.condition = condition;
     }
 
     public List<FilterTest> getTests() {

--- a/store/docs/soap.txt
+++ b/store/docs/soap.txt
@@ -3168,7 +3168,7 @@ use and error handling.  The old APIs still work in ZCS 6.0, but have been remov
             <filterVariable name="{variable-name}" value="{variable-value}"/>
             ...
         </filterVariables>
-        <filterTests condition="{allof | anyof"}>
+        <filterTests [condition="{allof | anyof"}]>
         {test}
         [test]
         ...
@@ -3199,6 +3199,7 @@ use and error handling.  The old APIs still work in ZCS 6.0, but have been remov
 <ModifyFilterRulesResponse/>
 
     * Default value for "active" is 1.
+    * Default value for "condition" is "allof"
 
 Tests:
 

--- a/store/src/java-test/com/zimbra/cs/filter/GetFilterRulesTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/GetFilterRulesTest.java
@@ -1,0 +1,465 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2017 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.filter;
+
+import static org.junit.Assert.fail;
+
+import java.util.HashMap;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.MailConstants;
+
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.MockProvisioning;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.filter.RuleManager;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.service.mail.GetFilterRules;
+import com.zimbra.cs.service.mail.ServiceTestUtil;
+import com.zimbra.cs.util.XMLDiffChecker;
+
+public class GetFilterRulesTest {
+    @BeforeClass
+    public static void init() throws Exception {
+        MailboxTestUtil.initServer();
+        Provisioning prov = Provisioning.getInstance();
+        prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        MailboxTestUtil.clearData();
+    }
+
+    @Test
+    public void testIfWithoutAllof() {
+        try {
+            // - no 'allof' 'anyof' tests
+            String filterScript
+            = "require \"tag\";"
+                    + "if header :comparator \"i;ascii-casemap\" :matches \"Subject\" \"*\" {"
+                    + "  fileinto \"if-block\";"
+                    + "}";
+            Account account = Provisioning.getInstance().getAccount(
+                    MockProvisioning.DEFAULT_ACCOUNT_ID);
+            RuleManager.clearCachedRules(account);
+            account.setMailSieveScript(filterScript);
+
+            Element request = new Element.XMLElement(MailConstants.GET_FILTER_RULES_REQUEST);
+            Element response = new GetFilterRules().handle(request, ServiceTestUtil.getRequestContext(account));
+
+            String expectedSoapResponse =
+                    "<GetFilterRulesResponse xmlns=\"urn:zimbraMail\">"
+                            + "<filterRules>"
+                            + "<filterRule active=\"1\">"
+                            + "<filterTests>"
+                            + "<headerTest stringComparison=\"matches\" header=\"Subject\" index=\"0\" value=\"*\"/>"
+                            + "</filterTests>"
+                            + "<filterActions>"
+                            + "<actionFileInto folderPath=\"if-block\" index=\"0\" copy=\"0\"/>"
+                            + "</filterActions>"
+                            + "</filterRule>"
+                            + "</filterRules>"
+                            + "</GetFilterRulesResponse>";
+            XMLDiffChecker.assertXMLEquals(expectedSoapResponse, response.prettyPrint());
+        } catch (Exception e) {
+            fail("No exception should be thrown" + e);
+        }
+    }
+
+    @Test
+    public void testIfWithAllofAnyOf() {
+        try {
+            // - 'allof' and 'anyof' tests
+            String filterScript
+            = "require \"tag\";"
+                    + "if allof (header :comparator \"i;ascii-casemap\" :matches \"Subject\" \"*\") {"
+                    + "  fileinto \"if-block1\";"
+                    + "}"
+                    + "if anyof (header :comparator \"i;ascii-casemap\" :matches \"X-Header\" \"*\") {"
+                    + "  fileinto \"if-block2\";"
+                    + "}";
+            Account account = Provisioning.getInstance().getAccount(
+                    MockProvisioning.DEFAULT_ACCOUNT_ID);
+            RuleManager.clearCachedRules(account);
+            account.setMailSieveScript(filterScript);
+
+            Element request = new Element.XMLElement(MailConstants.GET_FILTER_RULES_REQUEST);
+            Element response = new GetFilterRules().handle(request, ServiceTestUtil.getRequestContext(account));
+
+            String expectedSoapResponse =
+                    "<GetFilterRulesResponse xmlns=\"urn:zimbraMail\">"
+                            + "<filterRules>"
+                            + "<filterRule active=\"1\">"
+                            + "<filterTests condition=\"allof\">"
+                            + "<headerTest stringComparison=\"matches\" header=\"Subject\" index=\"0\" value=\"*\"/>"
+                            + "</filterTests>"
+                            + "<filterActions>"
+                            + "<actionFileInto folderPath=\"if-block1\" index=\"0\" copy=\"0\"/>"
+                            + "</filterActions>"
+                            + "</filterRule>"
+                            + "<filterRule active=\"1\">"
+                            + "<filterTests condition=\"anyof\">"
+                            + "<headerTest stringComparison=\"matches\" header=\"X-Header\" index=\"0\" value=\"*\"/>"
+                            + "</filterTests>"
+                            + "<filterActions>"
+                            + "<actionFileInto folderPath=\"if-block2\" index=\"0\" copy=\"0\"/>"
+                            + "</filterActions>"
+                            + "</filterRule>"
+                            + "</filterRules>"
+                            + "</GetFilterRulesResponse>";
+            XMLDiffChecker.assertXMLEquals(expectedSoapResponse, response.prettyPrint());
+        } catch (Exception e) {
+            fail("No exception should be thrown" + e);
+        }
+    }
+
+    @Test
+    public void testNestedIfWithoutAllof() {
+        try {
+            // - no 'allof' 'anyof' tests
+            // - nested if
+            String filterScript
+            = "require \"tag\";"
+                    + "if header :comparator \"i;ascii-casemap\" :matches \"Subject\" \"*\" {"
+                    + "  if header :matches \"From\" \"*\" {"
+                    + "    fileinto \"nested-if-block\";"
+                    + "  }"
+                    + "}";
+            Account account = Provisioning.getInstance().getAccount(
+                    MockProvisioning.DEFAULT_ACCOUNT_ID);
+            RuleManager.clearCachedRules(account);
+            account.setMailSieveScript(filterScript);
+
+            Element request = new Element.XMLElement(MailConstants.GET_FILTER_RULES_REQUEST);
+            Element response = new GetFilterRules().handle(request, ServiceTestUtil.getRequestContext(account));
+
+            String expectedSoapResponse =
+                    "<GetFilterRulesResponse xmlns=\"urn:zimbraMail\">"
+                            + "<filterRules>"
+                            + "<filterRule active=\"1\">"
+                            + "<filterTests>"
+                            + "<headerTest stringComparison=\"matches\" header=\"Subject\" index=\"0\" value=\"*\"/>"
+                            + "</filterTests>"
+                            + "<nestedRule>"
+                            + "<filterTests>"
+                            + "<headerTest stringComparison=\"matches\" header=\"From\" index=\"0\" value=\"*\"/>"
+                            + "</filterTests>"
+                            + "<filterActions>"
+                            + "<actionFileInto folderPath=\"nested-if-block\" index=\"0\" copy=\"0\"/>"
+                            + "</filterActions>"
+                            + "</nestedRule>"
+                            + "</filterRule>"
+                            + "</filterRules>"
+                            + "</GetFilterRulesResponse>";
+            XMLDiffChecker.assertXMLEquals(expectedSoapResponse, response.prettyPrint());
+        } catch (Exception e) {
+            fail("No exception should be thrown" + e);
+        }
+    }
+
+    @Test
+    public void testNestedIfAllofAnyof() {
+        try {
+            // - nested if
+            // - no 'allof' and 'anyof' test for the outer if block
+            // - 'anyof' test for the inner if block
+            String filterScript
+            = "require \"tag\";"
+                    + "if header :comparator \"i;ascii-casemap\" :matches \"Subject\" \"*\" {"
+                    + "  if anyof (header :matches \"From\" \"*\","
+                    + "            header :matches \"To\"   \"*\") {"
+                    + "    fileinto \"nested-if-block\";"
+                    + "  }"
+                    + "}";
+            Account account = Provisioning.getInstance().getAccount(
+                    MockProvisioning.DEFAULT_ACCOUNT_ID);
+            RuleManager.clearCachedRules(account);
+            account.setMailSieveScript(filterScript);
+
+            Element request = new Element.XMLElement(MailConstants.GET_FILTER_RULES_REQUEST);
+            Element response = new GetFilterRules().handle(request, ServiceTestUtil.getRequestContext(account));
+
+            String expectedSoapResponse =
+                    "<GetFilterRulesResponse xmlns=\"urn:zimbraMail\">"
+                            + "<filterRules>"
+                            + "<filterRule active=\"1\">"
+                            + "<filterTests>"
+                            + "<headerTest stringComparison=\"matches\" header=\"Subject\" index=\"0\" value=\"*\"/>"
+                            + "</filterTests>"
+                            + "<nestedRule>"
+                            + "<filterTests condition=\"anyof\">"
+                            + "<headerTest stringComparison=\"matches\" header=\"From\" index=\"0\" value=\"*\"/>"
+                            + "<headerTest stringComparison=\"matches\" header=\"To\"   index=\"1\" value=\"*\"/>"
+                            + "</filterTests>"
+                            + "<filterActions>"
+                            + "<actionFileInto folderPath=\"nested-if-block\" index=\"0\" copy=\"0\"/>"
+                            + "</filterActions>"
+                            + "</nestedRule>"
+                            + "</filterRule>"
+                            + "</filterRules>"
+                            + "</GetFilterRulesResponse>";
+            XMLDiffChecker.assertXMLEquals(expectedSoapResponse, response.prettyPrint());
+        } catch (Exception e) {
+            fail("No exception should be thrown" + e);
+        }
+    }
+
+    @Test
+    public void testWithoutIfBlock1() {
+        try {
+            // - no if block
+            String filterScript
+            = "require \"tag\";"
+                    + "fileinto \"no-if-block\";";
+            Account account = Provisioning.getInstance().getAccount(
+                    MockProvisioning.DEFAULT_ACCOUNT_ID);
+            RuleManager.clearCachedRules(account);
+            account.setMailSieveScript(filterScript);
+
+            Element request = new Element.XMLElement(MailConstants.GET_FILTER_RULES_REQUEST);
+            Element response = new GetFilterRules().handle(request, ServiceTestUtil.getRequestContext(account));
+
+            String expectedSoapResponse =
+                    "<GetFilterRulesResponse xmlns=\"urn:zimbraMail\">"
+                            + "<filterRules>"
+                            + "<filterRule active=\"1\">"
+                            + "<filterTests>"
+                            + "<trueTest index=\"0\"/>"
+                            + "</filterTests>"
+                            + "<filterActions>"
+                            + "<actionFileInto folderPath=\"no-if-block\" index=\"0\" copy=\"0\"/>"
+                            + "</filterActions>"
+                            + "</filterRule>"
+                            + "</filterRules>"
+                            + "</GetFilterRulesResponse>";
+            XMLDiffChecker.assertXMLEquals(expectedSoapResponse, response.prettyPrint());
+        } catch (Exception e) {
+            fail("No exception should be thrown" + e);
+        }
+    }
+
+    @Test
+    public void testWithoutIfBlock2() {
+        try {
+            // - multiple no if block
+            String filterScript
+            = "require \"tag\";"
+                    + "fileinto \"no-if-block1\";"
+                    + "fileinto \"no-if-block2\";";
+
+            Account account = Provisioning.getInstance().getAccount(
+                    MockProvisioning.DEFAULT_ACCOUNT_ID);
+            RuleManager.clearCachedRules(account);
+            account.setMailSieveScript(filterScript);
+
+            Element request = new Element.XMLElement(MailConstants.GET_FILTER_RULES_REQUEST);
+            Element response = new GetFilterRules().handle(request, ServiceTestUtil.getRequestContext(account));
+
+            String expectedSoapResponse =
+                    "<GetFilterRulesResponse xmlns=\"urn:zimbraMail\">"
+                            + "<filterRules>"
+                            + "<filterRule active=\"1\">"
+                            + "<filterTests>"
+                            + "<trueTest index=\"0\"/>"
+                            + "</filterTests>"
+                            + "<filterActions>"
+                            + "<actionFileInto folderPath=\"no-if-block1\" index=\"0\" copy=\"0\"/>"
+                            + "<actionFileInto folderPath=\"no-if-block2\" index=\"1\" copy=\"0\"/>"
+                            + "</filterActions>"
+                            + "</filterRule>"
+                            + "</filterRules>"
+                            + "</GetFilterRulesResponse>";
+            XMLDiffChecker.assertXMLEquals(expectedSoapResponse, response.prettyPrint());
+        } catch (Exception e) {
+            fail("No exception should be thrown" + e);
+        }
+    }
+
+    @Test
+    public void testWithoutIfBlock3() {
+        try {
+            // - no if block, then nested if without allof/anyof
+            String filterScript
+            = "require \"tag\";"
+                    + "fileinto \"no-if-block\";"
+                    + "if header :comparator \"i;ascii-casemap\" :matches \"Subject\" \"*\" {"
+                    + "  if header :matches \"From\" \"*\" {"
+                    + "    fileinto \"nested-if-block\";"
+                    + "  }"
+                    + "}";
+
+            Account account = Provisioning.getInstance().getAccount(
+                    MockProvisioning.DEFAULT_ACCOUNT_ID);
+            RuleManager.clearCachedRules(account);
+            account.setMailSieveScript(filterScript);
+
+            Element request = new Element.XMLElement(MailConstants.GET_FILTER_RULES_REQUEST);
+            Element response = new GetFilterRules().handle(request, ServiceTestUtil.getRequestContext(account));
+
+            String expectedSoapResponse =
+                    "<GetFilterRulesResponse xmlns=\"urn:zimbraMail\">"
+                            + "<filterRules>"
+                            + "<filterRule active=\"1\">"
+                            + "<filterTests>"
+                            + "<trueTest index=\"0\"/>"
+                            + "</filterTests>"
+                            + "<filterActions>"
+                            + "<actionFileInto folderPath=\"no-if-block\" index=\"0\" copy=\"0\"/>"
+                            + "</filterActions>"
+                            + "</filterRule>"
+                            + "<filterRule active=\"1\">"
+                            + "<filterTests>"
+                            + "<headerTest stringComparison=\"matches\" header=\"Subject\" index=\"0\" value=\"*\"/>"
+                            + "</filterTests>"
+                            + "<nestedRule>"
+                            + "<filterTests>"
+                            + "<headerTest stringComparison=\"matches\" header=\"From\" index=\"0\" value=\"*\"/>"
+                            + "</filterTests>"
+                            + "<filterActions>"
+                            + "<actionFileInto folderPath=\"nested-if-block\" index=\"0\" copy=\"0\"/>"
+                            + "</filterActions>"
+                            + "</nestedRule>"
+                            + "</filterRule>"
+                            + "</filterRules>"
+                            + "</GetFilterRulesResponse>";
+            XMLDiffChecker.assertXMLEquals(expectedSoapResponse, response.prettyPrint());
+        } catch (Exception e) {
+            fail("No exception should be thrown" + e);
+        }
+    }
+
+    @Test
+    public void testWithoutIfBlock4() {
+        try {
+            // - nested if without allof/anyof, then no if block
+            String filterScript
+            = "require \"tag\";"
+                    + "if header :comparator \"i;ascii-casemap\" :matches \"Subject\" \"*\" {"
+                    + "  if header :matches \"From\" \"*\" {"
+                    + "    fileinto \"nested-if-block\";"
+                    + "  }"
+                    + "}"
+                    + "fileinto \"no-if-block\";";
+
+            Account account = Provisioning.getInstance().getAccount(
+                    MockProvisioning.DEFAULT_ACCOUNT_ID);
+            RuleManager.clearCachedRules(account);
+            account.setMailSieveScript(filterScript);
+
+            Element request = new Element.XMLElement(MailConstants.GET_FILTER_RULES_REQUEST);
+            Element response = new GetFilterRules().handle(request, ServiceTestUtil.getRequestContext(account));
+
+            String expectedSoapResponse =
+                    "<GetFilterRulesResponse xmlns=\"urn:zimbraMail\">"
+                            + "<filterRules>"
+                            + "<filterRule active=\"1\">"
+                            + "<filterTests>"
+                            + "<headerTest stringComparison=\"matches\" header=\"Subject\" index=\"0\" value=\"*\"/>"
+                            + "</filterTests>"
+                            + "<nestedRule>"
+                            + "<filterTests>"
+                            + "<headerTest stringComparison=\"matches\" header=\"From\" index=\"0\" value=\"*\"/>"
+                            + "</filterTests>"
+                            + "<filterActions>"
+                            + "<actionFileInto folderPath=\"nested-if-block\" index=\"0\" copy=\"0\"/>"
+                            + "</filterActions>"
+                            + "</nestedRule>"
+                            + "</filterRule>"
+                            + "<filterRule active=\"1\">"
+                            + "<filterTests>"
+                            + "<trueTest index=\"0\"/>"
+                            + "</filterTests>"
+                            + "<filterActions>"
+                            + "<actionFileInto folderPath=\"no-if-block\" index=\"0\" copy=\"0\"/>"
+                            + "</filterActions>"
+                            + "</filterRule>"
+                            + "</filterRules>"
+                            + "</GetFilterRulesResponse>";
+            XMLDiffChecker.assertXMLEquals(expectedSoapResponse, response.prettyPrint());
+        } catch (Exception e) {
+            fail("No exception should be thrown" + e);
+        }
+    }
+
+    @Test
+    public void testWithoutIfBlock5() {
+        try {
+            // - combination of nested if without allof/anyof, and no if block
+            String filterScript
+            = "require \"tag\";"
+                    + "fileinto \"no-if-block1\";"
+                    + "if header :comparator \"i;ascii-casemap\" :matches \"Subject\" \"*\" {"
+                    + "  if header :matches \"From\" \"*\" {"
+                    + "    fileinto \"nested-if-block\";"
+                    + "  }"
+                    + "}"
+                    + "fileinto \"no-if-block2\";";
+
+            Account account = Provisioning.getInstance().getAccount(
+                    MockProvisioning.DEFAULT_ACCOUNT_ID);
+            RuleManager.clearCachedRules(account);
+            account.setMailSieveScript(filterScript);
+
+            Element request = new Element.XMLElement(MailConstants.GET_FILTER_RULES_REQUEST);
+            Element response = new GetFilterRules().handle(request, ServiceTestUtil.getRequestContext(account));
+
+            String expectedSoapResponse =
+                    "<GetFilterRulesResponse xmlns=\"urn:zimbraMail\">"
+                            + "<filterRules>"
+                            + "<filterRule active=\"1\">"
+                            + "<filterTests>"
+                            + "<trueTest index=\"0\"/>"
+                            + "</filterTests>"
+                            + "<filterActions>"
+                            + "<actionFileInto folderPath=\"no-if-block1\" index=\"0\" copy=\"0\"/>"
+                            + "</filterActions>"
+                            + "</filterRule>"
+                            + "<filterRule active=\"1\">"
+                            + "<filterTests>"
+                            + "<headerTest stringComparison=\"matches\" header=\"Subject\" index=\"0\" value=\"*\"/>"
+                            + "</filterTests>"
+                            + "<nestedRule>"
+                            + "<filterTests>"
+                            + "<headerTest stringComparison=\"matches\" header=\"From\" index=\"0\" value=\"*\"/>"
+                            + "</filterTests>"
+                            + "<filterActions>"
+                            + "<actionFileInto folderPath=\"nested-if-block\" index=\"0\" copy=\"0\"/>"
+                            + "</filterActions>"
+                            + "</nestedRule>"
+                            + "</filterRule>"
+                            + "<filterRule active=\"1\">"
+                            + "<filterTests>"
+                            + "<trueTest index=\"0\"/>"
+                            + "</filterTests>"
+                            + "<filterActions>"
+                            + "<actionFileInto folderPath=\"no-if-block2\" index=\"0\" copy=\"0\"/>"
+                            + "</filterActions>"
+                            + "</filterRule>"
+                            + "</filterRules>"
+                            + "</GetFilterRulesResponse>";
+            XMLDiffChecker.assertXMLEquals(expectedSoapResponse, response.prettyPrint());
+        } catch (Exception e) {
+            fail("No exception should be thrown" + e);
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/filter/SieveVisitor.java
+++ b/store/src/java/com/zimbra/cs/filter/SieveVisitor.java
@@ -48,248 +48,333 @@ public abstract class SieveVisitor {
 
     @SuppressWarnings("unused")
     protected void visitNode(Node node, VisitPhase phase, RuleProperties props) throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitRule(Node node, VisitPhase phase, RuleProperties props) throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitVariable(Node node, VisitPhase phase, RuleProperties props, String name, String value) throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitIfControl(Node node, VisitPhase phase, RuleProperties props) throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitTest(Node node, VisitPhase phase, RuleProperties props) throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitAction(Node node, VisitPhase phase, RuleProperties props) throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitHeaderTest(Node node, VisitPhase phase, RuleProperties props, List<String> headers,
             Sieve.StringComparison comparison, boolean caseSensitive, String value) throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitHeaderTest(Node node, VisitPhase phase, RuleProperties props, List<String> headers,
             Sieve.ValueComparison comparison, boolean isCount, String value) throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitMimeHeaderTest(Node node, VisitPhase phase, RuleProperties props, List<String> headers,
             Sieve.StringComparison comparison, boolean caseSensitive, String value) throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitAddressTest(Node node, VisitPhase phase, RuleProperties props, List<String> headers,
         Sieve.AddressPart part, Sieve.StringComparison comparison, boolean caseSensitive, String value)
         throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitAddressTest(Node node, VisitPhase phase, RuleProperties props, List<String> headers,
         Sieve.AddressPart part, Sieve.ValueComparison comparison, boolean isCount, String value)
         throws ServiceException {
+        // empty method
     }
 
     protected void visitEnvelopeTest(Node node, VisitPhase phase, RuleProperties props, List<String> headers,
         Sieve.AddressPart part, Sieve.StringComparison comparison, boolean caseSensitive, String value)
         throws ServiceException {
+        // empty method
     }
 
     protected void visitEnvelopeTest(Node node, VisitPhase phase, RuleProperties props, List<String> headers,
         Sieve.AddressPart part, Sieve.ValueComparison comparison, boolean isCount, String value)
         throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitHeaderExistsTest(Node node, VisitPhase phase, RuleProperties props, String header)
             throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitSizeTest(Node node, VisitPhase phase, RuleProperties props,
             Sieve.NumberComparison comparison, int size, String sizeString) throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitDateTest(Node node, VisitPhase phase, RuleProperties props,
             Sieve.DateComparison comparison, Date date) throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitCurrentTimeTest(Node node, VisitPhase phase, RuleProperties props,
             Sieve.DateComparison comparison, String timeStr) throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitCurrentDayOfWeekTest(Node node, VisitPhase phase, RuleProperties props, List<String> days)
             throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitConversationTest(Node node, VisitPhase phase, RuleProperties props, String where)
             throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitFacebookTest(Node node, VisitPhase phase, RuleProperties props) throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitLinkedInTest(Node node, VisitPhase phase, RuleProperties props) throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitSocialcastTest(Node node, VisitPhase phase, RuleProperties props) throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitTwitterTest(Node node, VisitPhase phase, RuleProperties props) throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitListTest(Node node, VisitPhase phase, RuleProperties props) throws ServiceException {
+        // empty method
+    }
+
+    @SuppressWarnings("unused")
+    protected void visitAllOfTest(Node node, VisitPhase phase, RuleProperties props) throws ServiceException {
+        // empty method
+    }
+
+    @SuppressWarnings("unused")
+    protected void visitAnyOfTest(Node node, VisitPhase phase, RuleProperties props) throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitBulkTest(Node node, VisitPhase phase, RuleProperties props) throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitCommunityRequestsTest(Node node, VisitPhase phase, RuleProperties props) throws ServiceException {
+        // empty method
     }
+
     @SuppressWarnings("unused")
     protected void visitCommunityContentTest(Node node, VisitPhase phase, RuleProperties props) throws ServiceException {
+        // empty method
     }
+
     @SuppressWarnings("unused")
     protected void visitCommunityConnectionsTest(Node node, VisitPhase phase, RuleProperties props) throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitImportanceTest(Node node, VisitPhase phase, RuleProperties props,
             FilterTest.Importance importance) throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitFlaggedTest(Node node, VisitPhase phase, RuleProperties props, Sieve.Flag flag)
             throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitTrueTest(Node node, VisitPhase phase, RuleProperties props) throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitAddressBookTest(Node node, VisitPhase phase, RuleProperties props, String header)
             throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitContactRankingTest(Node node, VisitPhase phase, RuleProperties props, String header)
             throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitMeTest(Node node, VisitPhase phase, RuleProperties props, String header)
             throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitBodyTest(Node node, VisitPhase phase, RuleProperties props,
             boolean caseSensitive, String value) throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitAttachmentTest(Node node, VisitPhase phase, RuleProperties props) throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitInviteTest(Node node, VisitPhase phase, RuleProperties props,
             List<String> methods) throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitKeepAction(Node node, VisitPhase phase, RuleProperties props) throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitDiscardAction(Node node, VisitPhase phase, RuleProperties props) throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitFileIntoAction(Node node, VisitPhase phase, RuleProperties props, String folderPath)
         throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitFileIntoAction(Node node, VisitPhase phase, RuleProperties props, String folderPath, boolean copy)
         throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitFlagAction(Node node, VisitPhase phase, RuleProperties props, Sieve.Flag flag)
             throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitTagAction(Node node, VisitPhase phase, RuleProperties props, String tagName)
             throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitRedirectAction(Node node, VisitPhase phase, RuleProperties props, String address)
             throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitRedirectAction(Node node, VisitPhase phase, RuleProperties props, String address, boolean copy)
             throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitReplyAction(Node node, VisitPhase phase, RuleProperties props, String bodyTemplate)
             throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitNotifyAction(Node node, VisitPhase phase, RuleProperties props, String emailAddr,
             String subjectTemplate, String bodyTemplate, int maxBodyBytes, List<String> origHeaders)
-    throws ServiceException { }
+            throws ServiceException {
+        // empty method
+    }
 
     @SuppressWarnings("unused")
     protected void visitRFCCompliantNotifyAction(Node node, VisitPhase phase, RuleProperties props, String from,
             String importance, String options, String message, String method)
-        throws ServiceException { }
+        throws ServiceException {
+        // empty method
+    }
 
     @SuppressWarnings("unused")
     protected void visitStopAction(Node node, VisitPhase phase, RuleProperties props) throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitRejectAction(Node node, VisitPhase phase, RuleProperties props, String content) throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitErejectAction(Node node, VisitPhase phase, RuleProperties props, String content) throws ServiceException {
+        // empty method
     }
 
     @SuppressWarnings("unused")
     protected void visitLogAction(Node node, VisitPhase phase, RuleProperties props, FilterAction.LogAction.LogLevel logLevel, String logText) throws ServiceException {
+        // empty method
     }
 
     private static final Set<String> RULE_NODE_NAMES = ImmutableSet.of("if", "disabled_if", "elsif");
     private static final String COPY_EXT = ":copy";
 
     public class RuleProperties {
-        boolean isEnabled = true;
-        boolean isNegativeTest = false;
-        Sieve.Condition condition = Sieve.Condition.allof;
+        private boolean isEnabled = true;
+        private boolean isNegativeTest = false;
+        private Sieve.Condition condition = null;
+
+        public boolean isEnabled() {
+            return isEnabled;
+        }
+        public void setEnabled(boolean isEnabled) {
+            this.isEnabled = isEnabled;
+        }
+        public boolean isNegativeTest() {
+            return isNegativeTest;
+        }
+        public void setNegativeTest(boolean isNegativeTest) {
+            this.isNegativeTest = isNegativeTest;
+        }
+        public Sieve.Condition getCondition() {
+            return condition;
+        }
+        public void setCondition(Sieve.Condition condition) {
+            this.condition = condition;
+        }
     }
 
     public void accept(Node node) throws ServiceException {
@@ -307,7 +392,7 @@ public abstract class SieveVisitor {
                 // New rule tree or Nested if. New RuleProperties is created for each nested if
                 RuleProperties newProps = new RuleProperties();
                 if ("disabled_if".equalsIgnoreCase(getNodeName(node))) {
-                    newProps.isEnabled = false;
+                    newProps.setEnabled(false);
                 }
                 visitIfControl(node,VisitPhase.begin,newProps);
                 accept(node, newProps);
@@ -329,19 +414,19 @@ public abstract class SieveVisitor {
         String nodeName = getNodeName(node);
 
         if ("not".equalsIgnoreCase(nodeName)) {
-            props.isNegativeTest = true;
+            props.setNegativeTest(true);
             accept(node, props);
         } else {
             if ("allof".equalsIgnoreCase(nodeName)) {
-                props.condition = Sieve.Condition.allof;
-                visitRule(node, VisitPhase.begin, props);
+                props.setCondition(Sieve.Condition.allof);
+                visitAllOfTest(node, VisitPhase.begin, props);
                 accept(node, props);
-                visitRule(node, VisitPhase.end, props);
+                visitAllOfTest(node, VisitPhase.end, props);
             } else if ("anyof".equalsIgnoreCase(nodeName)) {
-                props.condition = Sieve.Condition.anyof;
-                visitRule(node, VisitPhase.begin, props);
+                props.setCondition(Sieve.Condition.anyof);
+                visitAnyOfTest(node, VisitPhase.begin, props);
                 accept(node, props);
-                visitRule(node, VisitPhase.end, props);
+                visitAnyOfTest(node, VisitPhase.end, props);
             } else if ("header".equalsIgnoreCase(nodeName) || "mime_header".equalsIgnoreCase(nodeName)) {
                 boolean caseSensitive = false;
                 List<String> headers;


### PR DESCRIPTION
**Bug**
If anyof/allof test is not specified in condition within the Sieve rule, NullPointerException occurs in mailbox.log when the rule is loaded on ZWC.
    
**Root cause**
An instance of the FilterRule and NestedRule keeps a set of Sieve test and/or logic of each rule.  It  was created only while 'anyof' or 'allof' test was processed; if a filter does not have an 'anyof' or 'allof' in the 'if' condition, or even an action is not enclosed by the if-block, the member parameter the FilterRule or NestedRule in the com.zimbra.cs.filter.SieveToSoap class remained null.
    
**Fix**
If neither the member parameter FilterRule and NestedRule are not initialized, create a FilterRule instance before being accessed. The condition parameter is set to empty as default.

When a rule is directly set to the LDAP directory, and if the rule contains one or more than one tests in the condition part of the "if" clause without "allof" or "anyof" test, GetFilterRules SOAP response will not contain the "condition=allof" or "condition=anyof" parameter in the "filterTests" tag.

_note: At the filter execution, if the rule does not contain "allof" or "anyof" test before the multiple  tests, those tests will be implicitly joined "allof" test, then will be evaluated and will be executed without any error._

**Manual/Unit test**

- Set a Sieve rule which has no 'anyof' or 'allof' test to the zimbraMailSieveScript, and accessed it from ZWC ==> PASS
 -- No NPE on the server side, no network error no the client side,
 -- the filter is shown on the ZWC (only the supported Sieve commands were displayed)
- Unit test to verify the four patterns ==> PASS
 -- Set a Sieve rule directly to the LDAP attribute, and verify it via GetFilterRules SOAP request.
 -- Modify a Sieve rule via ModifyFilterRules SOAP request, and check the LDAP attribute.