### PR TITLE
ZMS-675 ensure session cache is updated

### DIFF
--- a/store/src/java/com/zimbra/cs/imap/ImapHandler.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapHandler.java
@@ -3975,11 +3975,10 @@ public abstract class ImapHandler {
                                         ZimbraLog.imap.info("IMAP client has flagged the item with id %d to be Deleted altertag", msg.msgId);
                                     }
                                     mbox.alterTag(getContext(), itemIds, i4flag.mName, add);
-                                } else {
-                                    // session tag; update one-by-one in memory only
-                                    for (ImapMessage i4msg : i4list) {
-                                        i4msg.setSessionFlags((short) (add ? i4msg.sflags | i4flag.mBitmask : i4msg.sflags & ~i4flag.mBitmask), i4folder);
-                                    }
+                                }
+                                // session tag; update one-by-one in memory only
+                                for (ImapMessage i4msg : i4list) {
+                                    i4msg.setSessionFlags((short) (add ? i4msg.sflags | i4flag.mBitmask : i4msg.sflags & ~i4flag.mBitmask), i4folder);
                                 }
                             }
                             boolean add = operation == StoreAction.ADD;


### PR DESCRIPTION
The in-memory cache should ALWAYS be updated even if the operation is
a permanent operation. Otherwise the two views get out of sync.

Allows the zmsoap test to complete succesfully:
`zimbra@zcs-dev-one:/home/zimbra/git/zm-mailbox/store$ zmsoap -z RunUnitTestsRequest test=TestImapClient#testDelete`

    <RunUnitTestsResponse numFailed="0" numSkipped="0" numExecuted="1" xmlns="urn:zimbraAdmin">
      <results>
        <completed name="testDelete" class="com.zimbra.qa.unittest.TestImapClient" execSeconds="0.95"/>
      </results>
    </RunUnitTestsResponse>