### PR TITLE
ZCS-1649 Disable extensions if zimbraNetworkModuleNGEnabled is TRUE

### DIFF
--- a/common/src/java/com/zimbra/common/service/ServiceException.java
+++ b/common/src/java/com/zimbra/common/service/ServiceException.java
@@ -69,6 +69,8 @@ public class ServiceException extends Exception {
     public static final String OPERATION_DENIED = "smime.OPERATION_DENIED";
     public static final String FEATURE_SMIME_DISABLED = "smime.FEATURE_SMIME_DISABLED";
 
+    public static final String ZIMBRA_NETWORK_MODULES_NG_ENABLED = "extension.ZIMBRA_NETWORK_MODULES_NG_ENABLED";
+
     protected String mCode;
     private List<Argument> mArgs;
     private String mId;
@@ -428,5 +430,9 @@ public class ServiceException extends Exception {
 
     public static ServiceException OPERATION_DENIED(String message) {
         return new ServiceException("operation denied: "+message, OPERATION_DENIED, SENDERS_FAULT);
+    }
+
+    public static ServiceException NETWORK_MODULES_NG_ENABLED() {
+        return new ServiceException("ZimbraNetworkModulesNGEnabled is true", ZIMBRA_NETWORK_MODULES_NG_ENABLED, RECEIVERS_FAULT);
     }
 }

--- a/store/src/java/com/zimbra/cs/extension/ExtensionUtil.java
+++ b/store/src/java/com/zimbra/cs/extension/ExtensionUtil.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.zimbra.common.localconfig.LC;
+import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.redolog.op.RedoableOp;
 
@@ -128,7 +129,7 @@ public class ExtensionUtil {
                         String extName = ext.getName();
                         ZimbraLog.extensions.info("Initialized extension %s: %s@%s", extName, name, zcl);
                         sInitializedExtensions.put(extName, ext);
-                    } catch (ExtensionException e) {
+                    } catch (ExtensionException|ServiceException e) {
                         ZimbraLog.extensions.info("Disabled '%s' %s", ext.getName(), e.getMessage());
                         ext.destroy();
                         RedoableOp.deregisterClassLoader(ext.getClass().getClassLoader());


### PR DESCRIPTION
1. Add service exception for zimbraNetworkModulesNGEnabled
2. In ExtensionUtil.java added ServiceException in catch clause because some extensions like HSM and Backup extend the deprecated ZimbraNetworkExtension
3. In GetAdminExtensionZimlets disable zimlets if zimbraNetworkModulesNGEnabled is true