### PR TITLE
ZCS-1580 - Append command does not work with Remote IMAP/IMAPS

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -738,6 +738,10 @@ public final class LC {
     public static final KnownKey imapd_java_heap_size = KnownKey.newKey("");
     @Supported
     public static final KnownKey imapd_java_heap_new_size_percent = KnownKey.newKey("${mailboxd_java_heap_new_size_percent}");
+    @Supported
+    public static final KnownKey imapd_tmp_directory = KnownKey.newKey("${zimbra_tmp_directory}/imapd");
+    @Supported
+    public static final KnownKey imapd_class_store = KnownKey.newKey("com.zimbra.cs.store.external.ImapTransientStoreManager");
 
     public static final KnownKey pop3_write_timeout = KnownKey.newKey(10);
     public static final KnownKey pop3_thread_keep_alive_time = KnownKey.newKey(60);

--- a/store/src/java-test/com/zimbra/cs/store/external/ImapTransientStoreManagerTest.java
+++ b/store/src/java-test/com/zimbra/cs/store/external/ImapTransientStoreManagerTest.java
@@ -1,0 +1,27 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2017 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.store.external;
+
+import com.zimbra.cs.store.StoreManager;
+
+public class ImapTransientStoreManagerTest extends AbstractExternalStoreManagerTest {
+
+    @Override
+    protected StoreManager getStoreManager() {
+        return new ImapTransientStoreManager();
+    }
+}

--- a/store/src/java/com/zimbra/cs/imap/NioImapRequest.java
+++ b/store/src/java/com/zimbra/cs/imap/NioImapRequest.java
@@ -33,6 +33,8 @@ final class NioImapRequest extends ImapRequest {
     boolean parse(Object obj) throws IOException, ProtocolDecoderException {
         if (literal != null) {
             parseLiteral((byte[]) obj);
+        } else if (obj instanceof byte[]) {
+            parseCommand(new String((byte []) obj));
         } else {
             parseCommand((String) obj);
         }

--- a/store/src/java/com/zimbra/cs/store/StoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/StoreManager.java
@@ -25,6 +25,7 @@ import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.Server;
 import com.zimbra.cs.extension.ExtensionUtil;
+import com.zimbra.cs.imap.ImapDaemon;
 import com.zimbra.cs.mailbox.MailItem;
 import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.store.file.FileBlobStore;
@@ -33,15 +34,23 @@ import com.zimbra.cs.util.Zimbra;
 public abstract class StoreManager {
 
     private static StoreManager sInstance;
+    private static Integer diskStreamingThreshold;
 
-    public static StoreManager getInstance() {
+    public static StoreManager getInstance () {
+        if(ImapDaemon.isRunningImapInsideMailboxd()) {
+            return getInstance(LC.zimbra_class_store.value());
+        } else {
+            return getInstance(LC.imapd_class_store.value());
+        }
+    }
+
+    public static StoreManager getInstance(String className) {
         if (sInstance == null) {
             synchronized (StoreManager.class) {
                 if (sInstance != null) {
                     return sInstance;
                 }
 
-                String className = LC.zimbra_class_store.value();
                 try {
                     if (className != null && !className.equals("")) {
                         try {
@@ -67,8 +76,6 @@ public abstract class StoreManager {
         ZimbraLog.store.info("Setting StoreManager to " + instance.getClass().getName());
         sInstance = instance;
     }
-
-    private static Integer diskStreamingThreshold;
 
     public static int getDiskStreamingThreshold() throws ServiceException {
         if (diskStreamingThreshold == null)

--- a/store/src/java/com/zimbra/cs/store/external/ImapTransientStoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/external/ImapTransientStoreManager.java
@@ -1,0 +1,89 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2017 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.store.external;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import com.zimbra.common.localconfig.LC;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.FileUtil;
+import com.zimbra.cs.mailbox.Mailbox;
+
+/**
+ * Simple ExternalStoreManager implementation that is intended for use in storing
+ * transient blobs.
+ *
+ * <p>This StoreManager is used by the {@link com.zimbra.cs.imap.ImapDaemon} while
+ * constructing blobs for an APPEND operation.  The blobs are deleted when the
+ * APPEND is finalized.
+ *
+ */
+public class ImapTransientStoreManager extends ExternalStoreManager {
+
+    protected File baseDirectory;
+
+    @Override
+    public void startup() throws IOException, ServiceException {
+        startup(LC.imapd_tmp_directory.value());
+    }
+
+    public void startup(String baseDirectoryPath) throws IOException, ServiceException {
+        super.startup();
+        baseDirectory = new File(baseDirectoryPath);
+        FileUtil.mkdirs(baseDirectory);
+    }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
+    }
+
+    @Override
+    public String writeStreamToStore(InputStream in, long actualSize, Mailbox mbox)
+            throws IOException, ServiceException {
+        File destFile = createBlobFile(mbox);
+        FileUtil.copy(in, false, destFile);
+        return destFile.getCanonicalPath();
+    }
+
+    @Override
+    public InputStream readStreamFromStore(String locator, Mailbox mbox) throws IOException {
+        return new FileInputStream(locator);
+    }
+
+    @Override
+    public boolean deleteFromStore(String locator, Mailbox mbox) throws IOException {
+        File deleteFile = new File(locator);
+        return deleteFile.delete();
+    }
+
+    @Override
+    public boolean supports(StoreFeature feature) {
+        return feature == StoreFeature.CENTRALIZED ? false : super.supports(feature);
+    }
+
+    private File createBlobFile(Mailbox mbox) throws IOException {
+        synchronized (this) {
+            return File.createTempFile(mbox.getAccountId(), ".msg", baseDirectory);
+        }
+    }
+
+}


### PR DESCRIPTION
### Overview
 
Updates to enable `APPEND` command to function properly with both embedded and remote IMAP(S)
 
### Notes
 
In the parsing of the `APPEND` command...
 
    NioImapRequest.parseCommand/1 ->
    Literal.newInstance/2 ->
    BlobLiteral/1 ->
    StoreManager.getInstance().getBlobBuilder()
 
...we end up initializing the `StoreManager`.
 
`StoreManager.getInstance/0` was using the `zimbra_class_store` LC value.  It will still use that now, if not running from the `zimbra-imapd` process.  If it is, is uses a new LC value `imapd_class_store`.  The interesting part is that, at least for the `APPEND` command, it doesn't actually store anything on disk.
 
The new `ImapTransientStoreManager` is now what is being initialized for the remote IMAP(S) servers to use.  As the name implies, it really is for transient blobs that do not need to be replicated.  We may decide at some point in the future to optionally spool large transient information to disk and this would be a suitable candidate for handling that.
 
As to why adding a new `StoreManager`at all: The default configured one is `FileBlobStore`.  This requires access to a `DbPool`.  This is not a problem when the `zimbra-imapd` server is running on a mailbox server node, where MariaDB is available, but is a problem when running as a stand-alone service.
