### PR TITLE
ZMS-339 catch exceptions and return 'BAD' response to client

### DIFF
--- a/store/src/java-test/com/zimbra/cs/imap/ImapLoadBalancingMechanismTest.java
+++ b/store/src/java-test/com/zimbra/cs/imap/ImapLoadBalancingMechanismTest.java
@@ -84,6 +84,10 @@ public final class ImapLoadBalancingMechanismTest {
         Assert.assertEquals(s1, mech.getImapServerFromPool(req, pool));
         headers.put(ImapLoadBalancingMechanism.ClientIpHashMechanism.CLIENT_IP, "127.0.0.4");
         Assert.assertEquals(s2, mech.getImapServerFromPool(req, pool));
+        headers.put(ImapLoadBalancingMechanism.ClientIpHashMechanism.CLIENT_IP, "192.168.56.1");
+        req = new MockHttpServletRequest(null, null, null, 123, "127.0.0.1", headers);
+        Assert.assertEquals("Expected address 192.168.56.1 to hash to s1", s1, mech.getImapServerFromPool(req, pool));
+
 
 		/* Verify we get the same results using IPV6 */
         headers.put(ImapLoadBalancingMechanism.ClientIpHashMechanism.CLIENT_IP, "::FFFF:127.0.0.2");
@@ -92,6 +96,8 @@ public final class ImapLoadBalancingMechanismTest {
         Assert.assertEquals(s1, mech.getImapServerFromPool(req, pool));
         headers.put(ImapLoadBalancingMechanism.ClientIpHashMechanism.CLIENT_IP, "::FFFF:127.0.0.4");
         Assert.assertEquals(s2, mech.getImapServerFromPool(req, pool));
+        headers.put(ImapLoadBalancingMechanism.ClientIpHashMechanism.CLIENT_IP, "2001:db8:cafe:f9::6");
+        Assert.assertEquals("Expected address 2001:db8:cafe:f9::6 to hash to s2", s2, mech.getImapServerFromPool(req, pool));
     }
 
     @Test

--- a/store/src/java/com/zimbra/cs/imap/ImapLoadBalancingMechanism.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapLoadBalancingMechanism.java
@@ -181,6 +181,8 @@ public abstract class ImapLoadBalancingMechanism {
             try {
                 pool.sort(serverComparator);
                 int clientIpHash = InetAddress.getByName(httpReq.getHeader(CLIENT_IP)).hashCode();
+                if (clientIpHash < 0)
+                    clientIpHash = -clientIpHash;
                 int serverPoolIdx = clientIpHash % pool.size();
                 ZimbraLog.imap.debug(
                     "ClientIpHashMechanism.getImapServerFromPool: CLIENT_IP=%s, Server.pool.size=%d, clientIpHash=%d, serverPoolIdx=%d",

--- a/store/src/java/com/zimbra/cs/imap/TcpImapHandler.java
+++ b/store/src/java/com/zimbra/cs/imap/TcpImapHandler.java
@@ -145,6 +145,10 @@ final class TcpImapHandler extends ProtocolHandler {
                 return false;
             }
             throw e;
+        } catch (Exception e) {
+            ZimbraLog.imap.error("unexpected exception", e);
+            delegate.sendBAD("Unknown Error");
+            return false;
         } finally {
             if (complete) {
                 clearRequest();


### PR DESCRIPTION
Add similar exception handling code as was added previously to NioImapHandler.java in 
https://github.com/Zimbra/zm-mailbox/pull/59/commits/4da976e98e503d7441caf6ee4b3de20975ef2054