### PR TITLE
resolve only the xerces#xercesImpl;2.9.1-patch-01 dependency form redhat repository

### DIFF
--- a/build-ivysettings.xml
+++ b/build-ivysettings.xml
@@ -8,7 +8,7 @@
         <artifact pattern= "${dev.home}/.zcs-deps/[organisation]/[module]/[module]-[revision].[ext]" />
         <artifact pattern= "${dev.home}/.zcs-deps/[organisation]-[revision].[ext]" />
         <artifact pattern= "${dev.home}/.zcs-deps/[organisation].[ext]" />
-        
+
       </filesystem>
       <ibiblio name="maven" m2compatible="true" usepoms="false"/>
       <ibiblio name="maven-redhat" root="https://maven.repository.redhat.com/ga/" pattern="[organisation]/[module]/[revision]/[module]-[revision].[ext]"/>
@@ -27,6 +27,6 @@
     </filesystem>
   </resolvers>
      <modules>
-      <module organisation="xerces" resolver="maven-redhat"/>
+      <module organisation="xerces" name="xercesImpl" revision="2.9.1-patch-01" resolver="maven-redhat"/>
     </modules>
 </ivysettings>


### PR DESCRIPTION
Currently building the master branch of this repository is broken. Because the zm-mailbox dependency `xerces#xmlParserAPIs;2.6.2` is 404ing (https://maven.repository.redhat.com/ga/xerces/xmlParserAPIs/2.6.2/xmlParserAPIs-2.6.2.jar). It does not exist in the Redhat Maven repo being used to resolve xerces JARs. I narrowed the build configuration so that only the `xerces#xercesImpl;2.9.1-patch-01` dependency is resolved to the Redhat maven repository.

Redhat Maven repo was added in https://github.com/Zimbra/zm-mailbox/pull/189/files#diff-34e3400bfbe00e937202f79eff0c6b33L30

```
[ivy:resolve]
[ivy:resolve] :: problems summary ::
[ivy:resolve] :::: WARNINGS
[ivy:resolve] 		module not found: xerces#xmlParserAPIs;2.6.2
[ivy:resolve] 	==== maven-redhat: tried
[ivy:resolve] 	  -- artifact xerces#xmlParserAPIs;2.6.2!xmlParserAPIs.jar:
[ivy:resolve] 	  https://maven.repository.redhat.com/ga/xerces/xmlParserAPIs/2.6.2/xmlParserAPIs-2.6.2.jar
[ivy:resolve] 		::::::::::::::::::::::::::::::::::::::::::::::
[ivy:resolve] 		::          UNRESOLVED DEPENDENCIES         ::
[ivy:resolve] 		::::::::::::::::::::::::::::::::::::::::::::::
[ivy:resolve] 		:: xerces#xmlParserAPIs;2.6.2: not found
[ivy:resolve] 		::::::::::::::::::::::::::::::::::::::::::::::
[ivy:resolve]
[ivy:resolve] :: USE VERBOSE OR DEBUG MESSAGE LEVEL FOR MORE DETAILS

BUILD FAILED
/tmp/zm-mailbox/build.xml:12: The following error occurred while executing this line:
/tmp/zm-mailbox/build-common.xml:46: impossible to resolve dependencies:
	resolve failed - see output for details

Total time: 17 seconds
```

After this change the build output is.

```
[ivy:resolve] 	found xerces#xercesImpl;2.9.1-patch-01 in maven-redhat
[ivy:resolve] 	found xerces#xmlParserAPIs;2.6.2 in maven
[ivy:resolve] 	found commons-httpclient#commons-httpclient;3.1 in maven
[ivy:resolve] 	found commons-codec#commons-codec;1.7 in maven
[ivy:resolve] 	found commons-cli#commons-cli;1.2 in maven
[ivy:resolve] 	found org.freemarker#freemarker;2.3.23 in maven
[ivy:resolve] 	found log4j#log4j;1.2.16 in maven
[ivy:resolve] 	found org.codehaus.jackson#jackson-core-asl;1.9.2 in maven
[ivy:resolve] 	found org.codehaus.jackson#jackson-mapper-asl;1.9.2 in maven
[ivy:resolve] 	found org.codehaus.jackson#jackson-xc;1.9.2 in maven
[ivy:resolve] 	found zimbra#zm-common;8.7.6.1497485751 in local
[ivy:resolve] 	[8.7.6.1497485751] zimbra#zm-common;latest.integration
[ivy:resolve] downloading http://repo1.maven.org/maven2/xmlunit/xmlunit/1.6/xmlunit-1.6.jar ...
[ivy:resolve] ............................ (98kB)
[ivy:resolve] .. (0kB)
[ivy:resolve] 	[SUCCESSFUL ] xmlunit#xmlunit;1.6!xmlunit.jar (109ms)
[ivy:resolve] downloading http://repo1.maven.org/maven2/xerces/xmlParserAPIs/2.6.2/xmlParserAPIs-2.6.2.jar ...
[ivy:resolve] ................................. (121kB)
[ivy:resolve] .. (0kB)
[ivy:resolve] 	[SUCCESSFUL ] xerces#xmlParserAPIs;2.6.2!xmlParserAPIs.jar (83ms)
```