### PR TITLE
ZCS-543 : Updating response of a meeting from Decline to Accept does not sync it to device

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/CalendarItem.java
+++ b/store/src/java/com/zimbra/cs/mailbox/CalendarItem.java
@@ -1488,19 +1488,32 @@ public abstract class CalendarItem extends MailItem {
         return processNewInvite(pm, invite, folderId, CalendarItem.NEXT_ALARM_KEEP_CURRENT, true, replaceExistingInvites);
     }
 
+    boolean processNewInvite(ParsedMessage pm, Invite invite,
+            int folderId, long nextAlarm,
+            boolean preserveAlarms, boolean replaceExistingInvites)
+        throws ServiceException {
+        return processNewInvite(pm, invite, folderId, nextAlarm, preserveAlarms, replaceExistingInvites, false);
+    }
+
     /**
      * A new Invite has come in, take a look at it and see what needs to happen.
      * Maybe we need to send updates out. Maybe we need to modify the
      * CalendarItem table.
      *
+     * @param pm
      * @param invite
+     * @param folderId
+     * @param nextAlarm
+     * @param replaceExistingInvites
+     * @param updatePrevFolders
      * @return
      *            TRUE if an update calendar was written, FALSE if the CalendarItem is
      *            unchanged or deleted
      */
     boolean processNewInvite(ParsedMessage pm, Invite invite,
                              int folderId, long nextAlarm,
-                             boolean preserveAlarms, boolean replaceExistingInvites)
+                             boolean preserveAlarms, boolean replaceExistingInvites,
+                             boolean updatePrevFolders)
     throws ServiceException {
         invite.setHasAttachment(pm != null ? pm.hasAttachments() : false);
 
@@ -1511,7 +1524,7 @@ public abstract class CalendarItem extends MailItem {
             return processNewInviteRequestOrCancel(pm, invite, folderId, nextAlarm,
                                                    preserveAlarms, replaceExistingInvites, false);
         } else if (method.equals(ICalTok.REPLY.toString())) {
-            return processNewInviteReply(invite, null);
+            return processNewInviteReply(invite, null, updatePrevFolders);
         } else if (method.equals(ICalTok.COUNTER.toString())) {
             return processNewInviteReply(invite, pm.getSender());
         }
@@ -3282,11 +3295,12 @@ public abstract class CalendarItem extends MailItem {
         saveMetadata();
     }
 
-    private boolean updatePrevFolders = false;
-    public void setUpdatePrevFolders (boolean updatePrevFolders) {
-        this.updatePrevFolders = updatePrevFolders;
-    }
     boolean processNewInviteReply(Invite reply, String sender)
+    throws ServiceException {
+        return processNewInviteReply(reply, sender, false);
+    }
+
+    boolean processNewInviteReply(Invite reply, String sender, boolean updatePrevFolders)
     throws ServiceException {
         List<ZAttendee> attendees = reply.getAttendees();
 
@@ -3395,9 +3409,8 @@ public abstract class CalendarItem extends MailItem {
         } else {
             createPseudoExceptionForSingleInstanceReplyIfNecessary(reply);
         }
-        if (this.updatePrevFolders) {
+        if (updatePrevFolders) {
             performSetPrevFoldersOperation(octxt);
-            this.setUpdatePrevFolders(false);
         }
         saveMetadata();
         return true;

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -5426,7 +5426,13 @@ public class Mailbox {
     public AddInviteData addInvite(OperationContext octxt, Invite inv, int folderId)
             throws ServiceException {
         boolean addRevision = true;  // Always rev the calendar item.
-        return addInvite(octxt, inv, folderId, null, false, false, addRevision);
+        return addInvite(octxt, inv, folderId, null, false, false, addRevision, false);
+    }
+
+    public AddInviteData addInvite(OperationContext octxt, Invite inv, int folderId, boolean updatePrevFolders)
+            throws ServiceException {
+        boolean addRevision = true;  // Always rev the calendar item.
+        return addInvite(octxt, inv, folderId, null, false, false, addRevision, updatePrevFolders);
     }
 
     public AddInviteData addInvite(OperationContext octxt, Invite inv, int folderId, ParsedMessage pm)
@@ -5435,28 +5441,41 @@ public class Mailbox {
         return addInvite(octxt, inv, folderId, pm, false, false, addRevision);
     }
 
+    public AddInviteData addInvite(OperationContext octxt, Invite inv, int folderId, ParsedMessage pm, boolean updatePrevFolders)
+            throws ServiceException {
+        boolean addRevision = true;  // Always rev the calendar item.
+        return addInvite(octxt, inv, folderId, pm, false, false, addRevision, updatePrevFolders);
+    }
+
     public AddInviteData addInvite(OperationContext octxt, Invite inv, int folderId, boolean preserveExistingAlarms,
             boolean addRevision) throws ServiceException {
         return addInvite(octxt, inv, folderId, null, preserveExistingAlarms, false, addRevision);
     }
 
+    public AddInviteData addInvite(OperationContext octxt, Invite inv, int folderId, ParsedMessage pm,
+            boolean preserveExistingAlarms, boolean discardExistingInvites, boolean addRevision)
+            throws ServiceException {
+        return addInvite(octxt, inv, folderId, pm, preserveExistingAlarms, discardExistingInvites, addRevision, false);
+    }
     /**
      * Directly add an Invite into the system...this process also gets triggered when we add a Message
      * that has a text/calendar Mime part: but this API is useful when you don't want to add a corresponding
      * message.
      * @param octxt
      * @param inv
+     * @param folderId
      * @param pm NULL is OK here
      * @param preserveExistingAlarms
      * @param discardExistingInvites
      * @param addRevision if true and revisioning is enabled and calendar item exists already, add a revision
      *                    with current snapshot of the calendar item
-     *
+     * @param updatePrevFolders
      * @return AddInviteData
      * @throws ServiceException
      */
     public AddInviteData addInvite(OperationContext octxt, Invite inv, int folderId, ParsedMessage pm,
-            boolean preserveExistingAlarms, boolean discardExistingInvites, boolean addRevision)
+            boolean preserveExistingAlarms, boolean discardExistingInvites, boolean addRevision,
+            boolean updatePrevFolders)
             throws ServiceException {
         if (pm == null) {
             inv.setDontIndexMimeMessage(true); // the MimeMessage is fake, so we don't need to index it
@@ -5517,7 +5536,7 @@ public class Mailbox {
                     calItem.snapshotRevision();
                 }
                 processed = calItem.processNewInvite(pm, inv, folderId, CalendarItem.NEXT_ALARM_KEEP_CURRENT,
-                        preserveExistingAlarms, discardExistingInvites);
+                        preserveExistingAlarms, discardExistingInvites, updatePrevFolders);
             }
 
             if (Invite.isOrganizerMethod(inv.getMethod())) { // Don't update the index for replies. (bug 55317)

--- a/store/src/java/com/zimbra/cs/service/mail/SendInviteReply.java
+++ b/store/src/java/com/zimbra/cs/service/mail/SendInviteReply.java
@@ -386,9 +386,10 @@ public class SendInviteReply extends CalendarRequest {
                 MailSendQueue sendQueue = new MailSendQueue();
                 try {
                     if (stat != null && IcalXmlStrMap.PARTSTAT_DECLINED.equals(stat) && !CalendarMailSender.VERB_DECLINE.equals(verb)) {
-                        calItem.setUpdatePrevFolders(true);
+                        sendCalendarMessage(zsc, octxt, apptFolderId, acct, mbox, csd, response, sendQueue, true/*set previous folder*/);
+                    } else {
+                        sendCalendarMessage(zsc, octxt, apptFolderId, acct, mbox, csd, response, sendQueue);
                     }
-                    sendCalendarMessage(zsc, octxt, apptFolderId, acct, mbox, csd, response, sendQueue);
                 } finally {
                     sendQueue.send();
                 }

--- a/store/src/java/com/zimbra/cs/service/mail/SendInviteReply.java
+++ b/store/src/java/com/zimbra/cs/service/mail/SendInviteReply.java
@@ -119,6 +119,7 @@ public class SendInviteReply extends CalendarRequest {
         int inviteMsgId;
         CalendarItem calItem = null;
         boolean wasInTrash = false;
+        String stat = null;
 
         // the user could be accepting EITHER the original-mail-item (id="nnn") OR the
         // calendar item (id="aaaa-nnnn") --- work in both cases
@@ -317,6 +318,7 @@ public class SendInviteReply extends CalendarRequest {
                 oldInv = calItem.getInvite(new RecurId(exceptDt, RecurId.RANGE_NONE));
             }
 
+            stat = oldInv.getMatchingAttendee(mbox.getAccount()).getPartStat();
             if (updateOrg && oldInv.hasOrganizer()) {
                 Locale locale;
                 Account organizer = oldInv.getOrganizerAccount();
@@ -383,6 +385,9 @@ public class SendInviteReply extends CalendarRequest {
                     apptFolderId = oldInv.isTodo() ? Mailbox.ID_FOLDER_TASKS : Mailbox.ID_FOLDER_CALENDAR;
                 MailSendQueue sendQueue = new MailSendQueue();
                 try {
+                    if (stat != null && IcalXmlStrMap.PARTSTAT_DECLINED.equals(stat) && !CalendarMailSender.VERB_DECLINE.equals(verb)) {
+                        calItem.setUpdatePrevFolders(true);
+                    }
                     sendCalendarMessage(zsc, octxt, apptFolderId, acct, mbox, csd, response, sendQueue);
                 } finally {
                     sendQueue.send();


### PR DESCRIPTION
Problem : Once appointment is declined, it's deleted from device. And when it's accepted again from ZWC, it's sent to device as a change because this appointment was previously synced. Zimbra should send it to device as "add" not "change".

Fix : While accepting the declined appointment, previous folder is set to trash, so that it's sent to device as "add".

Testing done : All below cases are tested with the bug scenario
1) Simple appointment
2) Recurring appointment as a whole series
3) Recurring appointment as an exception within the series
4) All day appointment

Testing to be done by QA :
Verify complete calendar accept/decline/tentative functionality on EAS and ZWC.