### PR TITLE
ZCS-128: auto accept/decline not sent from resource on appointment update

### DIFF
--- a/store/src/java-test/com/zimbra/cs/mailbox/calendar/ZAttendeeTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/calendar/ZAttendeeTest.java
@@ -1,0 +1,39 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2017 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.mailbox.calendar;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.zimbra.common.calendar.ZCalendar.ICalTok;
+import com.zimbra.common.calendar.ZCalendar.ZParameter;
+import com.zimbra.common.calendar.ZCalendar.ZProperty;
+import com.zimbra.common.service.ServiceException;
+
+public class ZAttendeeTest {
+
+    @Test
+    public void resourceRsvpTest() throws ServiceException {
+        ZAttendee attendee = new ZAttendee ("test-resource@zimbra.com", "testResource", null, null, null, "RES", "NON", "AC", Boolean.TRUE,
+                                            null, null, null, null);
+        ZProperty prop = new ZProperty("ATTENDEE");
+        attendee.setProperty(prop);
+        ZParameter rsvpParam = prop.getParameter(ICalTok.RSVP);
+        Assert.assertTrue(Boolean.parseBoolean(rsvpParam.getValue()));
+    }
+
+}

--- a/store/src/java/com/zimbra/cs/mailbox/calendar/ZAttendee.java
+++ b/store/src/java/com/zimbra/cs/mailbox/calendar/ZAttendee.java
@@ -210,7 +210,7 @@ public class ZAttendee extends CalendarUser {
         if (hasRsvp()) {
             // Apple Mac Calendar thinks a reply is still required if RSVP is set.  Suppress this if the PARTSTAT
             // isn't NEEDS-ACTION
-            if (IcalXmlStrMap.PARTSTAT_NEEDS_ACTION.equals(getPartStat())) {
+            if (IcalXmlStrMap.PARTSTAT_NEEDS_ACTION.equals(getPartStat()) || IcalXmlStrMap.CUTYPE_RESOURCE.equals(getCUType())) {
                 prop.addParameter(new ZParameter(ICalTok.RSVP, getRsvp()));
             }
         }


### PR DESCRIPTION
When appointment was updated, auto response from resource was not sent as to send the auto response, RSVP should be true for the resource attendee. The rsvp check was added as fix for bug 39404. 
But in fix for bug 84830, check was added to set RSVP true only if the parstat for attendee is needs-action. 
I have modified the above check to set RSVP true for resource irrespective of the parstat value.
Verified that for resource attendee, accept response is correctly displayed in sierra calendar app configured through CalDAV(in bug 84830 this was not working).
