### PR TITLE
ZCS-164 : SIEVE: Description of zimbraSpamApplyUserFilters should mention the admin-defined filter attribute as well

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -15741,8 +15741,8 @@ public class ZAttrProvisioning {
     public static final String A_zimbraSocialcastURL = "zimbraSocialcastURL";
 
     /**
-     * If TRUE, spam messages will be affected by user mail filters instead
-     * of being automatically filed into the Junk folder.
+     * If TRUE, spam messages will be affected by user and admin mail filters
+     * instead of being automatically filed into the Junk folder.
      *
      * @since ZCS 5.0.2
      */

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -3201,7 +3201,7 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
 
 <attr id="604" name="zimbraSpamApplyUserFilters" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="5.0.2">
   <defaultCOSValue>FALSE</defaultCOSValue>
-  <desc>If TRUE, spam messages will be affected by user mail filters instead of
+  <desc>If TRUE, spam messages will be affected by user and admin mail filters instead of
         being automatically filed into the Junk folder.</desc>
 </attr>
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -56110,8 +56110,8 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * If TRUE, spam messages will be affected by user mail filters instead
-     * of being automatically filed into the Junk folder.
+     * If TRUE, spam messages will be affected by user and admin mail filters
+     * instead of being automatically filed into the Junk folder.
      *
      * @return zimbraSpamApplyUserFilters, or false if unset
      *
@@ -56123,8 +56123,8 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * If TRUE, spam messages will be affected by user mail filters instead
-     * of being automatically filed into the Junk folder.
+     * If TRUE, spam messages will be affected by user and admin mail filters
+     * instead of being automatically filed into the Junk folder.
      *
      * @param zimbraSpamApplyUserFilters new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -56139,8 +56139,8 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * If TRUE, spam messages will be affected by user mail filters instead
-     * of being automatically filed into the Junk folder.
+     * If TRUE, spam messages will be affected by user and admin mail filters
+     * instead of being automatically filed into the Junk folder.
      *
      * @param zimbraSpamApplyUserFilters new value
      * @param attrs existing map to populate, or null to create a new map
@@ -56156,8 +56156,8 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * If TRUE, spam messages will be affected by user mail filters instead
-     * of being automatically filed into the Junk folder.
+     * If TRUE, spam messages will be affected by user and admin mail filters
+     * instead of being automatically filed into the Junk folder.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -56171,8 +56171,8 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * If TRUE, spam messages will be affected by user mail filters instead
-     * of being automatically filed into the Junk folder.
+     * If TRUE, spam messages will be affected by user and admin mail filters
+     * instead of being automatically filed into the Junk folder.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -43377,8 +43377,8 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * If TRUE, spam messages will be affected by user mail filters instead
-     * of being automatically filed into the Junk folder.
+     * If TRUE, spam messages will be affected by user and admin mail filters
+     * instead of being automatically filed into the Junk folder.
      *
      * @return zimbraSpamApplyUserFilters, or false if unset
      *
@@ -43390,8 +43390,8 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * If TRUE, spam messages will be affected by user mail filters instead
-     * of being automatically filed into the Junk folder.
+     * If TRUE, spam messages will be affected by user and admin mail filters
+     * instead of being automatically filed into the Junk folder.
      *
      * @param zimbraSpamApplyUserFilters new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -43406,8 +43406,8 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * If TRUE, spam messages will be affected by user mail filters instead
-     * of being automatically filed into the Junk folder.
+     * If TRUE, spam messages will be affected by user and admin mail filters
+     * instead of being automatically filed into the Junk folder.
      *
      * @param zimbraSpamApplyUserFilters new value
      * @param attrs existing map to populate, or null to create a new map
@@ -43423,8 +43423,8 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * If TRUE, spam messages will be affected by user mail filters instead
-     * of being automatically filed into the Junk folder.
+     * If TRUE, spam messages will be affected by user and admin mail filters
+     * instead of being automatically filed into the Junk folder.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -43438,8 +43438,8 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * If TRUE, spam messages will be affected by user mail filters instead
-     * of being automatically filed into the Junk folder.
+     * If TRUE, spam messages will be affected by user and admin mail filters
+     * instead of being automatically filed into the Junk folder.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs


### PR DESCRIPTION
Problem : Update description of zimbraSpamApplyUserFilters attribute.

Fix : Updated description of zimbraSpamApplyUserFilters attribute.

Testing done : Upgrade zcs version and one can see the updated description in "zmprov desc -a zimbraSpamApplyUserFilters"

Testing to be done by QA : Fresh install and upgrade ZCS to see updated description of zimbraSpamApplyUserFilters