### PR TITLE
ZCS-1670: IMAP notifications in response headers

### DIFF
--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -553,6 +553,7 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
     private final ZMailboxLock lock;
     private int lastChangeId = 0;
     private NotificationFormat mNotificationFormat = NotificationFormat.DEFAULT;
+    private String mCurWaitSetID = null;
 
     private final List<ZEventHandler> mHandlers = new ArrayList<ZEventHandler>();
 
@@ -863,7 +864,7 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
                 if(nosession) {
                     return mTransport.invoke(request, false, nosession, requestedAccountId);
                 } else {
-                    return mTransport.invoke(request, nosession, requestedAccountId, this.mNotificationFormat);
+                    return mTransport.invoke(request, nosession, requestedAccountId, this.mNotificationFormat, this.mCurWaitSetID);
                 }
             } catch (SoapFaultException e) {
                 throw e; // for now, later, try to map to more specific exception
@@ -6368,5 +6369,13 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
                 el.addAttribute(isIds ? MailConstants.A_TAGS : MailConstants.A_TAG_NAMES, identifier);
             }
         }
+    }
+
+    public void setCurWaitSetID(String id) {
+        mCurWaitSetID = id;
+    }
+
+    public void unsetCurWaitSetID() {
+        mCurWaitSetID = null;
     }
 }

--- a/common/src/java/com/zimbra/common/soap/HeaderConstants.java
+++ b/common/src/java/com/zimbra/common/soap/HeaderConstants.java
@@ -64,6 +64,7 @@ public final class HeaderConstants {
     public static final String SESSION_ADMIN = "admin";
     public static final String E_CSRFTOKEN = "csrfToken";
     public static final String E_SOAP_ID = "soapId";
+    public static final String A_WAITSET_ID = "wsId";
 
     private HeaderConstants() {
     }

--- a/common/src/java/com/zimbra/common/soap/SoapHttpTransport.java
+++ b/common/src/java/com/zimbra/common/soap/SoapHttpTransport.java
@@ -185,9 +185,9 @@ public class SoapHttpTransport extends SoapTransport {
 
     @Override
     public Element invoke(Element document, boolean raw, boolean noSession,
-            String requestedAccountId, String changeToken, String tokenType, NotificationFormat nFormat)
+            String requestedAccountId, String changeToken, String tokenType, NotificationFormat nFormat, String curWaitSetID)
     throws IOException, HttpException, ServiceException {
-        return invoke(document, raw, noSession, requestedAccountId, changeToken, tokenType, nFormat, null);
+        return invoke(document, raw, noSession, requestedAccountId, changeToken, tokenType, nFormat, curWaitSetID, null);
     }
 
     private String getUriWithPath(Element document) {
@@ -207,7 +207,7 @@ public class SoapHttpTransport extends SoapTransport {
     }
 
     public Element invoke(Element document, boolean raw, boolean noSession, String requestedAccountId,
-            String changeToken, String tokenType, NotificationFormat nFormat, ResponseHandler respHandler)
+            String changeToken, String tokenType, NotificationFormat nFormat, String curWaitSetID, ResponseHandler respHandler)
             throws IOException, HttpException, ServiceException {
         PostMethod method = null;
 
@@ -235,7 +235,7 @@ public class SoapHttpTransport extends SoapTransport {
                     ZimbraLog.misc.debug("set remote IP header [%s] to [%s]", RemoteIP.X_ORIGINATING_IP_HEADER, getClientIp());
                 }
             }
-            Element soapReq = generateSoapMessage(document, raw, noSession, requestedAccountId, changeToken, tokenType, nFormat);
+            Element soapReq = generateSoapMessage(document, raw, noSession, requestedAccountId, changeToken, tokenType, nFormat, curWaitSetID);
             String soapMessage = SoapProtocol.toString(soapReq, getPrettyPrint());
             HttpMethodParams params = method.getParams();
 
@@ -371,7 +371,7 @@ public class SoapHttpTransport extends SoapTransport {
 
     @Override
     public Future<HttpResponse> invokeAsync(Element document, boolean raw, boolean noSession, String requestedAccountId,
-            String changeToken, String tokenType, NotificationFormat nFormat, FutureCallback<HttpResponse> cb) throws IOException {
+            String changeToken, String tokenType, NotificationFormat nFormat, String curWaitSetID, FutureCallback<HttpResponse> cb) throws IOException {
         HttpPost post = new HttpPost(getUriWithPath(document));
         // Set user agent if it's specified.
         String agentName = getUserAgentName();
@@ -399,7 +399,7 @@ public class SoapHttpTransport extends SoapTransport {
         }
 
         //SOAP message
-        Element soapReq = generateSoapMessage(document, raw, noSession, requestedAccountId, changeToken, tokenType, nFormat);
+        Element soapReq = generateSoapMessage(document, raw, noSession, requestedAccountId, changeToken, tokenType, nFormat, curWaitSetID);
         String soapMessage = SoapProtocol.toString(soapReq, getPrettyPrint());
         post.setEntity(new ByteArrayEntity(soapMessage.getBytes("UTF-8")));
         HttpClientContext context = HttpClientContext.create();

--- a/common/src/java/com/zimbra/common/soap/SoapTransport.java
+++ b/common/src/java/com/zimbra/common/soap/SoapTransport.java
@@ -278,11 +278,11 @@ public abstract class SoapTransport {
 
     protected Element generateSoapMessage(Element document, boolean raw, boolean noSession,
             String requestedAccountId, String changeToken, String tokenType) {
-            return generateSoapMessage(document, raw, noSession, requestedAccountId, changeToken, tokenType, null);
+            return generateSoapMessage(document, raw, noSession, requestedAccountId, changeToken, tokenType, null, null);
     }
 
     protected Element generateSoapMessage(Element document, boolean raw, boolean noSession,
-            String requestedAccountId, String changeToken, String tokenType, NotificationFormat nFormat) {
+            String requestedAccountId, String changeToken, String tokenType, NotificationFormat nFormat, String curWaitSetID) {
 
         if (raw) {
             if (mDebugListener != null) {
@@ -311,7 +311,7 @@ public abstract class SoapTransport {
             if (noSession) {
                 SoapUtil.disableNotificationOnCtxt(context);
             } else {
-                SoapUtil.addSessionToCtxt(context, mAuthToken == null ? null : mSessionId, mMaxNotifySeq, nFormat);
+                SoapUtil.addSessionToCtxt(context, mAuthToken == null ? null : mSessionId, mMaxNotifySeq, nFormat, curWaitSetID);
             }
             SoapUtil.addTargetAccountToCtxt(context, targetId, targetName);
             SoapUtil.addChangeTokenToCtxt(context, changeToken, tokenType);
@@ -379,12 +379,12 @@ public abstract class SoapTransport {
     }
 
     public abstract Future<HttpResponse> invokeAsync(Element document, boolean raw, boolean noSession, String requestedAccountId,
-            String changeToken, String tokenType, NotificationFormat nFormat, FutureCallback<HttpResponse> cb) throws IOException;
+            String changeToken, String tokenType, NotificationFormat nFormat, String curWaitSetID, FutureCallback<HttpResponse> cb) throws IOException;
 
     public final Future<HttpResponse> invokeAsync(Element document, boolean raw, boolean noSession, String requestedAccountId,
             String changeToken, String tokenType, FutureCallback<HttpResponse> cb) throws IOException {
         return invokeAsync(document, raw, noSession, requestedAccountId,
-                changeToken, tokenType, null, cb);
+                changeToken, tokenType, null, null, cb);
     }
 
     public final Future<HttpResponse> invokeAsync(Element document, FutureCallback<HttpResponse> cb) throws IOException {
@@ -394,7 +394,7 @@ public abstract class SoapTransport {
     public final Future<HttpResponse> invokeWithoutSessionAsync(Element document, FutureCallback<HttpResponse> cb) throws IOException {
         return invokeAsync(document, false, true, null, null, null, cb);
     }
-    
+
     /**
      * Sends the specified document as a Soap message
      * and parses the response as a Soap message. <p>
@@ -454,15 +454,16 @@ public abstract class SoapTransport {
      * a &lt;soap:Envelope&gt; element, otherwise it wraps it in an envelope/body.
      *
      * <tt>nFormat</tt> indicates the format for notifications in response header (IMAP or DEFAULT).
-     * 
+     *
      * <tt>noSession</tt> is assumed to be false.
      * @throws ServiceException
      */
-    public final Element invoke(Element document, boolean raw, String requestedAccountId, NotificationFormat nFormat) throws IOException, ServiceException {
-        return invoke(document, raw, false, requestedAccountId, null, null, nFormat);
+    public final Element invoke(Element document, boolean raw, String requestedAccountId, NotificationFormat nFormat, String curWaitSetID) throws IOException, ServiceException {
+        return invoke(document, raw, false, requestedAccountId, null, null, nFormat, curWaitSetID);
     }
 
-    public abstract Element invoke(Element document, boolean raw, boolean noSession, String requestedAccountId, String changeToken, String tokenType, NotificationFormat nFormat) throws IOException, HttpException, ServiceException;
+    public abstract Element invoke(Element document, boolean raw, boolean noSession, String requestedAccountId, String changeToken,
+            String tokenType, NotificationFormat nFormat, String curWaitSetID) throws IOException, HttpException, ServiceException;
     /**
      * Sends the specified document as a Soap message
      * and parses the response as a Soap message. <p />

--- a/common/src/java/com/zimbra/common/soap/SoapUtil.java
+++ b/common/src/java/com/zimbra/common/soap/SoapUtil.java
@@ -114,9 +114,9 @@ public final class SoapUtil {
      * @see #toCtxt
      */
     public static Element addSessionToCtxt(Element ctxt, String sessionId, long sequence) {
-        return addSessionToCtxt(ctxt, sessionId, sequence, null);
+        return addSessionToCtxt(ctxt, sessionId, sequence, null, null);
     }
-    public static Element addSessionToCtxt(Element ctxt, String sessionId, long sequence, NotificationFormat nFormat) {
+    public static Element addSessionToCtxt(Element ctxt, String sessionId, long sequence, NotificationFormat nFormat, String curWaitSetID) {
         if (ctxt == null) {
             return ctxt;
         }
@@ -135,6 +135,9 @@ public final class SoapUtil {
         }
         if(nFormat != null) {
             eSession.addAttribute(HeaderConstants.E_FORMAT, nFormat.toString());
+        }
+        if (curWaitSetID != null) {
+            eSession.addAttribute(HeaderConstants.A_WAITSET_ID, curWaitSetID);
         }
         return ctxt;
     }

--- a/store/src/java/com/zimbra/cs/mailclient/imap/ImapResponse.java
+++ b/store/src/java/com/zimbra/cs/mailclient/imap/ImapResponse.java
@@ -114,6 +114,8 @@ public final class ImapResponse {
             is.skipOptionalChar(' ');
             data = IDInfo.read(is);
             break;
+        case NOOP:
+            break;
         default:
             throw new ParseException("Unknown response code: " + code);
         }

--- a/store/src/java/com/zimbra/cs/session/WaitSetSession.java
+++ b/store/src/java/com/zimbra/cs/session/WaitSetSession.java
@@ -127,6 +127,15 @@ public class WaitSetSession extends Session {
             }
             return;
         }
+        if (source != null && source instanceof SoapSession) {
+            String curWaitSetID = ((SoapSession) source).getCurWaitSetID();
+            if (curWaitSetID != null && curWaitSetID.equals(mWs.getWaitSetId())) {
+                if (trace) {
+                    ZimbraLog.session.trace("Not signaling waitset; changes will be returned in SOAP headers");
+                }
+                return;
+            }
+        }
         if (trace) {
             ZimbraLog.session.trace("Signaling waitset");
         }

--- a/store/src/java/com/zimbra/qa/unittest/TestRemoteImapNotificationsViaMailbox.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestRemoteImapNotificationsViaMailbox.java
@@ -1,0 +1,26 @@
+package com.zimbra.qa.unittest;
+
+import static org.junit.Assert.assertFalse;
+
+import java.util.Set;
+
+import com.zimbra.client.ZFolder;
+import com.zimbra.client.ZMailbox;
+import com.zimbra.cs.imap.ImapRemoteSession;
+import com.zimbra.cs.imap.ImapServerListener;
+import com.zimbra.cs.imap.ImapServerListenerPool;
+
+public class TestRemoteImapNotificationsViaMailbox extends TestRemoteImapNotifications {
+
+
+    @Override
+    protected void runOp(MailboxOperation op, ZMailbox zmbox, ZFolder folder) throws Exception {
+        ImapServerListener listener = ImapServerListenerPool.getInstance().get(zmbox);
+        Set<ImapRemoteSession> sessions = listener.getListeners(zmbox.getAccountId(), Integer.valueOf(folder.getId()));
+        assertFalse(String.format("Folder %s does not have any IMAP listeners", folder.getPath()), sessions.isEmpty());
+        ImapRemoteSession session = sessions.iterator().next();
+        ZMailbox imapzmbox = (ZMailbox) session.getMailbox();
+        op.run(imapzmbox);
+    }
+
+}

--- a/store/src/java/com/zimbra/qa/unittest/TestRemoteImapNotificationsViaWaitsets.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestRemoteImapNotificationsViaWaitsets.java
@@ -1,0 +1,39 @@
+package com.zimbra.qa.unittest;
+
+import static org.junit.Assert.assertTrue;
+
+import com.zimbra.client.ZFolder;
+import com.zimbra.client.ZMailbox;
+import com.zimbra.cs.imap.ImapServerListener;
+import com.zimbra.cs.imap.ImapServerListenerPool;
+import com.zimbra.cs.session.SomeAccountsWaitSet;
+import com.zimbra.cs.session.WaitSetMgr;
+
+public class TestRemoteImapNotificationsViaWaitsets extends TestRemoteImapNotifications {
+
+    @Override
+    protected void runOp(MailboxOperation op, ZMailbox zmbox, ZFolder folder) throws Exception {
+
+        ImapServerListener listener = ImapServerListenerPool.getInstance().get(zmbox);
+        String wsID = listener.getWSId();
+        SomeAccountsWaitSet ws = (SomeAccountsWaitSet)(WaitSetMgr.lookup(wsID));
+        long lastSequence = ws.getCurrentSeqNo();
+        op.run(zmbox);
+        boolean applied = false;
+        int timeout = 6000;
+        while(timeout > 0) {
+            if(listener.getLastKnownSequenceNumber() > lastSequence) {
+                applied = true;
+                break;
+            }
+            timeout -= 500;
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                break;
+            }
+        }
+        assertTrue("operation not applied within 6 seconds", applied);
+    }
+
+}

--- a/store/src/java/com/zimbra/qa/unittest/ZimbraSuite.java
+++ b/store/src/java/com/zimbra/qa/unittest/ZimbraSuite.java
@@ -144,7 +144,8 @@ public class ZimbraSuite  {
         sClasses.add(TestImapClient.class);
         sClasses.add(TestImapServerListener.class);
         sClasses.add(TestTrashImapMessage.class);
-        sClasses.add(TestRemoteImapNotifications.class);
+        sClasses.add(TestRemoteImapNotificationsViaWaitsets.class);
+        sClasses.add(TestRemoteImapNotificationsViaMailbox.class);
         sClasses.add(TestImapViaEmbeddedLocal.class);
         sClasses.add(TestImapViaEmbeddedRemote.class);
         sClasses.add(TestImapViaImapDaemon.class);

--- a/store/src/java/com/zimbra/soap/DocumentHandler.java
+++ b/store/src/java/com/zimbra/soap/DocumentHandler.java
@@ -377,6 +377,12 @@ public abstract class DocumentHandler {
             } else if (s.getSessionType() != stype) {
                 // only want a session of the appropriate type
                 s = null;
+            } else if (s instanceof SoapSession) {
+                SoapSession soap = (SoapSession) s;
+                if (soap.getCurWaitSetID() != zsc.getCurWaitSetID()) {
+                    // update the waitset ID on the SOAP session
+                    soap.setCurWaitSetID(zsc.getCurWaitSetID());
+                }
             }
         }
 
@@ -404,7 +410,6 @@ public abstract class DocumentHandler {
                 s = delegate;
             }
         }
-
         return s;
     }
 

--- a/store/src/java/com/zimbra/soap/ZimbraSoapContext.java
+++ b/store/src/java/com/zimbra/soap/ZimbraSoapContext.java
@@ -152,6 +152,7 @@ public final class ZimbraSoapContext {
     private String mVia;
     private String soapRequestId;
     private String mNotificationFormat = DEFAULT_NOTIFICATION_FORMAT;
+    private String mCurWaitSetID;
     //zdsync: for parsing locally constructed soap requests
     public ZimbraSoapContext(AuthToken authToken, String accountId,
             SoapProtocol reqProtocol, SoapProtocol respProtocol) throws ServiceException {
@@ -414,6 +415,7 @@ public final class ZimbraSoapContext {
                         mSessionInfo = new SessionInfo(sessionId, (int) session.getAttributeLong(HeaderConstants.A_SEQNO, seqNo), false);
                     }
                     mNotificationFormat = session.getAttribute(HeaderConstants.E_FORMAT, DEFAULT_NOTIFICATION_FORMAT);
+                    mCurWaitSetID = session.getAttribute(HeaderConstants.A_WAITSET_ID, null);
                 }
             }
         }
@@ -455,12 +457,21 @@ public final class ZimbraSoapContext {
     }
 
     /**
-     * tells SoapSession how to format notification elements in SOAP headers. 
-     * Remote IMAP server uses IMAP format, whereas default SOAP and JSON clients use default format.  
+     * tells SoapSession how to format notification elements in SOAP headers.
+     * Remote IMAP server uses IMAP format, whereas default SOAP and JSON clients use default format.
      * @return
      */
     public String getNotificationFormat() {
         return mNotificationFormat;
+    }
+
+    /**
+     * WaitSetSession will NOT trigger a response for this Waitset, since the notifications
+     * will be returned in SOAP headers instead. This ensures that the the remote server
+     * isn't notified of the same notifications twice using different mechanisms.
+     */
+    public String getCurWaitSetID() {
+        return mCurWaitSetID;
     }
 
     /**


### PR DESCRIPTION
The current remote IMAP notification mechanism introduces race conditions that result in bugs. The race condition occurs when an IMAP operation potentially returns before the corresponding changes are propagated back to the originating IMAP server via waitsets; this causes problems when a subsequent IMAP operation sees a stale view of the IMAP data. [ZCS-1482](https://jira.corp.synacor.com/browse/ZCS-1482) is an example of this type of bug.

This PR introduces two changes to IMAP notifications:
1. All IMAP notifications are returned in the SOAP response headers.
_WaitSetRequest_ and _SoapSession_ now encode pending modifications in an identical way, using common logic. This code is now contained in the new _PendingModifications::encodeFolderModifications_ method. This method accepts an optional _folderInterests_ argument; _WaitSetRequest_ makes use of this argument, while _SoapSession_ does not.
2. A waitset is _not_ triggered if the same pending notifications are to be returned in the response headers. This is done so that IMAP servers don't receive two copies of the notifications through the two mechanisms. 
SOAP requests issued by _ZMailbox_ can include an optional waitset ID in the header. This is set/unset by the the new _ZMailbox::setCurWaitSetID_ and _ZMailbox::unsetCurWaitSetID_ methods. When _ImapServerListener_ adds an _ImapRemoteSession_ listener, it sets the current waitset ID on that remote session's ZMailbox instance. If a waitset is initialized, the new ID is propagated to all ZMailboxes in the sessionMap. Likewise, when a waitset is destroyed, the field is unset on all ZMailboxes.
On the mailbox server, this ID is  included in _ZimbraSoapContext_ and exposed by _SoapSession::getCurWaitSetID_. Since SoapSessions are cached, _DocumentHandler::getSession_ sets the waitset ID directly on the cached session if its waitset ID doesn't match that of the request. Lastly, _WaitSetSession::notifyPendingChanges_ checks whether this ID matches the ID of its waitset, and if does, does not call _signalDataReady_. In other words, an IMAP server doesn't receive waitset notifications for operations _it_ triggered, instead getting all changes in the response headers. This guarantees that all changes from an IMAP operation have taken effect by the time the operation returns.

With these changes, tests in _TestRemoteImapNotifications_ no longer have to repeatedly sleep and check if the changes have been applied. However, the tests had to be changed to make use of the same ZMailbox instance that is used by the IMAP listener, as only that instance has the ZEventHandler registered that can process IMAP notifications. This instance is accessed by the new _TestRemoteImapNotifications_:: getImapZMailboxForFolder_ method.

Finally, _ImapResponse::readUntagged_ has been updated to not throw an exception when receiving an NOOP response. This makes it easier to debug a running server, as the _ImapHandler_ sends a NOOP after 15 seconds of inactivity, which previously led to a _ParseException_.

This fix resolves [ZCS-1482](https://jira.corp.synacor.com/browse/ZCS-1482) and [ZMS-675](https://jira.corp.synacor.com/browse/ZMS-675), and potentially others.