### PR TITLE
ZCS-1547: IMAP notifications for unlisted tags

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -2782,8 +2782,9 @@ public class Mailbox implements MailboxStore {
                     }
                     snapshot.recordCreated(snapshotted);
                 } else if (item instanceof Tag) {
-                    if (((Tag) item).isListed()) {
-                        snapshot.recordCreated(snapshotItem((Tag) item));
+                    Tag tag = (Tag) item;
+                    if (tag.isListed() || tag.isImapVisible()) {
+                        snapshot.recordCreated(snapshotItem(tag));
                     }
                 } else if (item instanceof MailItem){
                     MailItem mi = (MailItem) item;

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -6730,7 +6730,7 @@ public class Mailbox implements MailboxStore {
                 if (tagName.startsWith(Tag.FLAG_NAME_PREFIX)) {
                     throw nsie;
                 }
-                Tag.NormalizedTags ntags = new NormalizedTags(this, new String[] { tagName }, addTag);
+                Tag.NormalizedTags ntags = new NormalizedTags(this, new String[] { tagName }, addTag, true);
                 if (ntags.getTags().length == 0) {
                     success = true;
                     return;
@@ -6808,7 +6808,7 @@ public class Mailbox implements MailboxStore {
             }
             Flag unreadFlag = getFlagById(Flag.ID_UNREAD);
 
-            Tag.NormalizedTags ntags = tags == MailItem.TAG_UNCHANGED ? null : new Tag.NormalizedTags(this, tags);
+            Tag.NormalizedTags ntags = tags == MailItem.TAG_UNCHANGED ? null : new Tag.NormalizedTags(this, tags, true, true);
 
             for (MailItem item : items) {
                 if (item == null) {

--- a/store/src/java/com/zimbra/cs/mailbox/Tag.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Tag.java
@@ -50,6 +50,10 @@ public class Tag extends MailItem implements ZimbraTag {
         }
 
         NormalizedTags(Mailbox mbox, String[] tagsFromClient, boolean create) throws ServiceException {
+            this(mbox, tagsFromClient, create, false);
+        }
+
+        NormalizedTags(Mailbox mbox, String[] tagsFromClient, boolean create, boolean imapVisible) throws ServiceException {
             assert mbox.isTransactionActive() : "cannot instantiate NormalizedTags outside of a transaction";
 
             if (ArrayUtil.isEmpty(tagsFromClient)) {
@@ -64,7 +68,11 @@ public class Tag extends MailItem implements ZimbraTag {
 
                     if (create) {
                         try {
-                            tlist.add(mbox.createTagInternal(Mailbox.ID_AUTO_INCREMENT, tag, new Color(DEFAULT_COLOR), false));
+                            Tag newTag = mbox.createTagInternal(Mailbox.ID_AUTO_INCREMENT, tag, new Color(DEFAULT_COLOR), false);
+                            if (imapVisible) {
+                                newTag.setIsImapVisible(true);
+                            }
+                            tlist.add(newTag);
                             continue;
                         } catch (ServiceException e) {
                             if (!e.getCode().equals(MailServiceException.ALREADY_EXISTS)) {
@@ -106,6 +114,10 @@ public class Tag extends MailItem implements ZimbraTag {
     public static final int NONEXISTENT_TAG = -32;
 
     private boolean isListed;
+
+    // If this is true, an a newly-created unlisted tag will still be returned as a pending remote modification
+    private boolean isImapVisible = false;
+
     private RetentionPolicy retentionPolicy;
 
     Tag(Mailbox mbox, UnderlyingData ud) throws ServiceException {
@@ -424,5 +436,13 @@ public class Tag extends MailItem implements ZimbraTag {
     @Override
     public String getTagName() {
         return getName();
+    }
+
+    public void setIsImapVisible(boolean visible) {
+        isImapVisible = visible;
+    }
+
+    public boolean isImapVisible()  {
+        return isImapVisible;
     }
 }

--- a/store/src/java/com/zimbra/qa/unittest/SharedImapTests.java
+++ b/store/src/java/com/zimbra/qa/unittest/SharedImapTests.java
@@ -866,7 +866,7 @@ public abstract class SharedImapTests {
         data = connection.fetch(seq+"", "FLAGS");
         assertEquals(1, data.size());
         seq = data.keySet().iterator().next();
-        assertTrue("flags unexpectedly set after STORE on message in "+folderName, data.get(seq).getFlags().isEmpty());
+        assertFalse("flag unexpectedly set after STORE on message in "+folderName, data.get(seq).getFlags().isSet(tagName3));
 
         info = connection.select("INBOX");
         assertTrue("old tag not set in new folder", info.getFlags().isSet(tagName));


### PR DESCRIPTION
Prior to this change, unlisted tags were not returned in the notification response headers. This resulted in IMAP clients not being notified of tag changes if the tags were not explicitly created on the mailbox first. This change adds a new boolean field _Tag.isImapVisible_ that is set to _true_ if the tag is created by _NormalizedTags_, provided the new _imapVisible_ constructor argument is used. This only happens via the _Mailbox::alterTag_ and _Mailbox::setTags_ methods.

one of the assertions in SharedImapTests.testStoreTags() has been updated to check the absence of the target tag as opposed to checking that the flag list is empty, since the \Seen flag can be set on the message.