### PR TITLE
ZMS-358: updated tag deletion IMAP tests

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -2782,8 +2782,9 @@ public class Mailbox implements MailboxStore {
                     }
                     snapshot.recordCreated(snapshotted);
                 } else if (item instanceof Tag) {
-                    if (((Tag) item).isListed()) {
-                        snapshot.recordCreated(snapshotItem((Tag) item));
+                    Tag tag = (Tag) item;
+                    if (tag.isListed() || tag.isImapVisible()) {
+                        snapshot.recordCreated(snapshotItem(tag));
                     }
                 } else if (item instanceof MailItem){
                     MailItem mi = (MailItem) item;

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -6730,7 +6730,7 @@ public class Mailbox implements MailboxStore {
                 if (tagName.startsWith(Tag.FLAG_NAME_PREFIX)) {
                     throw nsie;
                 }
-                Tag.NormalizedTags ntags = new NormalizedTags(this, new String[] { tagName }, addTag);
+                Tag.NormalizedTags ntags = new NormalizedTags(this, new String[] { tagName }, addTag, true);
                 if (ntags.getTags().length == 0) {
                     success = true;
                     return;
@@ -6808,7 +6808,7 @@ public class Mailbox implements MailboxStore {
             }
             Flag unreadFlag = getFlagById(Flag.ID_UNREAD);
 
-            Tag.NormalizedTags ntags = tags == MailItem.TAG_UNCHANGED ? null : new Tag.NormalizedTags(this, tags);
+            Tag.NormalizedTags ntags = tags == MailItem.TAG_UNCHANGED ? null : new Tag.NormalizedTags(this, tags, true, true);
 
             for (MailItem item : items) {
                 if (item == null) {

--- a/store/src/java/com/zimbra/cs/mailbox/Tag.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Tag.java
@@ -50,6 +50,10 @@ public class Tag extends MailItem implements ZimbraTag {
         }
 
         NormalizedTags(Mailbox mbox, String[] tagsFromClient, boolean create) throws ServiceException {
+            this(mbox, tagsFromClient, create, false);
+        }
+
+        NormalizedTags(Mailbox mbox, String[] tagsFromClient, boolean create, boolean imapVisible) throws ServiceException {
             assert mbox.isTransactionActive() : "cannot instantiate NormalizedTags outside of a transaction";
 
             if (ArrayUtil.isEmpty(tagsFromClient)) {
@@ -64,7 +68,11 @@ public class Tag extends MailItem implements ZimbraTag {
 
                     if (create) {
                         try {
-                            tlist.add(mbox.createTagInternal(Mailbox.ID_AUTO_INCREMENT, tag, new Color(DEFAULT_COLOR), false));
+                            Tag newTag = mbox.createTagInternal(Mailbox.ID_AUTO_INCREMENT, tag, new Color(DEFAULT_COLOR), false);
+                            if (imapVisible) {
+                                newTag.setIsImapVisible(true);
+                            }
+                            tlist.add(newTag);
                             continue;
                         } catch (ServiceException e) {
                             if (!e.getCode().equals(MailServiceException.ALREADY_EXISTS)) {
@@ -106,6 +114,10 @@ public class Tag extends MailItem implements ZimbraTag {
     public static final int NONEXISTENT_TAG = -32;
 
     private boolean isListed;
+
+    // If this is true, an a newly-created unlisted tag will still be returned as a pending remote modification
+    private boolean isImapVisible = false;
+
     private RetentionPolicy retentionPolicy;
 
     Tag(Mailbox mbox, UnderlyingData ud) throws ServiceException {
@@ -424,5 +436,13 @@ public class Tag extends MailItem implements ZimbraTag {
     @Override
     public String getTagName() {
         return getName();
+    }
+
+    public void setIsImapVisible(boolean visible) {
+        isImapVisible = visible;
+    }
+
+    public boolean isImapVisible()  {
+        return isImapVisible;
     }
 }

--- a/store/src/java/com/zimbra/qa/unittest/SharedImapTests.java
+++ b/store/src/java/com/zimbra/qa/unittest/SharedImapTests.java
@@ -866,7 +866,7 @@ public abstract class SharedImapTests {
         data = connection.fetch(seq+"", "FLAGS");
         assertEquals(1, data.size());
         seq = data.keySet().iterator().next();
-        assertTrue("flags unexpectedly set after STORE on message in "+folderName, data.get(seq).getFlags().isEmpty());
+        assertFalse("flag unexpectedly set after STORE on message in "+folderName, data.get(seq).getFlags().isSet(tagName3));
 
         info = connection.select("INBOX");
         assertTrue("old tag not set in new folder", info.getFlags().isSet(tagName));

--- a/store/src/java/com/zimbra/qa/unittest/TestRemoteImapNotifications.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestRemoteImapNotifications.java
@@ -257,7 +257,6 @@ public class TestRemoteImapNotifications {
         assertEquals("Size of map returned by fetch 2", 1, mdMap.size());
     }
 
-    @Ignore("TODO - support for delete tag notifications")
     @Test
     public void testDeleteTagNotificationActiveFolder() throws Exception {
         String folderName = "TestRemoteImapNotifications-folder";
@@ -283,7 +282,6 @@ public class TestRemoteImapNotifications {
         assertFalse(flags.contains(new Atom(tagName)));
     }
 
-    @Ignore("TODO - support for delete tag notifications")
     @Test
     public void testDeleteTagNotificationCachedFolder() throws Exception {
         String folderName1 = "TestRemoteImapNotifications-folder";

--- a/store/src/java/com/zimbra/qa/unittest/TestRemoteImapNotifications.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestRemoteImapNotifications.java
@@ -274,12 +274,19 @@ public class TestRemoteImapNotifications {
 
         Flags flags = info.getPermanentFlags();
         assertTrue(flags.contains(new Atom(tagName)));
+        Map<Long, MessageData> mdMap = connection.fetch("1:*", "(FLAGS)");
+        Flags msgFlags = mdMap.get(1L).getFlags();
+        assertTrue(msgFlags.contains(new Atom(tagName)));
 
         imapzmbox.deleteTag(tag.getId());
 
         info = connection.select(folderName);
         flags = info.getPermanentFlags();
         assertFalse(flags.contains(new Atom(tagName)));
+
+        mdMap = connection.fetch("1:*", "(FLAGS)");
+        msgFlags = mdMap.get(1L).getFlags();
+        assertFalse(msgFlags.contains(new Atom(tagName)));
     }
 
     @Test
@@ -301,6 +308,9 @@ public class TestRemoteImapNotifications {
 
         Flags flags = info.getPermanentFlags();
         assertTrue(flags.contains(new Atom(tagName)));
+        Map<Long, MessageData> mdMap = connection.fetch("1:*", "(FLAGS)");
+        Flags msgFlags = mdMap.get(1L).getFlags();
+        assertTrue(msgFlags.contains(new Atom(tagName)));
 
         connection.select(folderName2);
 
@@ -309,6 +319,10 @@ public class TestRemoteImapNotifications {
         info = connection.select(folderName1);
         flags = info.getPermanentFlags();
         assertFalse(flags.contains(new Atom(tagName)));
+
+        mdMap = connection.fetch("1:*", "(FLAGS)");
+        msgFlags = mdMap.get(1L).getFlags();
+        assertFalse(msgFlags.contains(new Atom(tagName)));
     }
 
     @Test


### PR DESCRIPTION
Enabled IMAP notification tests for tag deletion, as well as updated them to check the presence/absence of the tag on messages themselves in addition to the folder.