### PR TITLE
ZMS-357: local/embedded/remote IMAP notification tests

### DIFF
--- a/store/src/java/com/zimbra/qa/unittest/ImapTestBase.java
+++ b/store/src/java/com/zimbra/qa/unittest/ImapTestBase.java
@@ -1,0 +1,109 @@
+package com.zimbra.qa.unittest;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.dom4j.DocumentException;
+import org.junit.Rule;
+import org.junit.rules.TestName;
+
+import com.zimbra.common.localconfig.ConfigException;
+import com.zimbra.common.localconfig.LC;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.Log;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.Server;
+import com.zimbra.cs.mailclient.imap.ImapConfig;
+import com.zimbra.cs.mailclient.imap.ImapConnection;
+
+public abstract class ImapTestBase {
+
+    @Rule
+    public TestName testInfo = new TestName();
+    protected static String USER = null;
+    protected static final String PASS = "test123";
+    protected static Server imapServer = null;
+    protected ImapConnection connection;
+    protected static boolean mIMAPDisplayMailFoldersOnly;
+    protected final int LOOP_LIMIT = LC.imap_throttle_command_limit.intValue();
+    protected static String imapHostname;
+    protected static int imapPort;
+    protected String testId;
+
+    private static boolean saved_imap_always_use_remote_store;
+    private static String[] saved_imap_servers = null;
+
+    protected abstract int getImapPort();
+
+    /** expect this to be called by subclass @Before method */
+    protected void sharedSetUp() throws ServiceException, IOException  {
+        testId = String.format("%s-%s", this.getClass().getName(), testInfo.getMethodName());
+        USER = String.format("%s-user", testId).toLowerCase();
+        getLocalServer();
+        mIMAPDisplayMailFoldersOnly = imapServer.isImapDisplayMailFoldersOnly();
+        imapServer.setImapDisplayMailFoldersOnly(false);
+        sharedCleanup();
+        Account acc = TestUtil.createAccount(USER);
+        Provisioning.getInstance().setPassword(acc, PASS);
+        //find out what hostname or IP IMAP server is listening on
+        List<String> addrs = Arrays.asList(imapServer.getImapBindAddress());
+        if(addrs.isEmpty()) {
+            imapHostname = imapServer.getServiceHostname();
+        } else {
+            imapHostname = addrs.get(0);
+        }
+        imapPort = getImapPort();
+    }
+
+    /** expect this to be called by subclass @After method */
+    protected void sharedTearDown() throws ServiceException  {
+        sharedCleanup();
+        if (imapServer != null) {
+            imapServer.setImapDisplayMailFoldersOnly(mIMAPDisplayMailFoldersOnly);
+        }
+    }
+
+    private void sharedCleanup() throws ServiceException {
+        TestUtil.deleteAccountIfExists(USER);
+        if (connection != null) {
+            connection.close();
+        }
+    }
+
+    protected static Server getLocalServer() throws ServiceException {
+        if (imapServer == null) {
+            imapServer = Provisioning.getInstance().getLocalServer();
+        }
+        return imapServer;
+    }
+
+    /** expect this to be called by subclass @Before method */
+    public static void saveImapConfigSettings()
+    throws ServiceException, DocumentException, ConfigException, IOException {
+        getLocalServer();
+        saved_imap_always_use_remote_store = LC.imap_always_use_remote_store.booleanValue();
+        saved_imap_servers = imapServer.getReverseProxyUpstreamImapServers();
+    }
+
+    /** expect this to be called by subclass @After method */
+    public static void restoreImapConfigSettings()
+    throws ServiceException, DocumentException, ConfigException, IOException {
+        getLocalServer();
+        if (imapServer != null) {
+            imapServer.setReverseProxyUpstreamImapServers(saved_imap_servers);
+        }
+        TestUtil.setLCValue(LC.imap_always_use_remote_store, String.valueOf(saved_imap_always_use_remote_store));
+    }
+
+    protected ImapConnection connect() throws IOException {
+        ImapConfig config = new ImapConfig(imapHostname);
+        config.setPort(imapPort);
+        config.setAuthenticationId(USER);
+        config.getLogger().setLevel(Log.Level.trace);
+        ImapConnection conn = new ImapConnection(config);
+        conn.connect();
+        return conn;
+    }
+}

--- a/store/src/java/com/zimbra/qa/unittest/SharedImapTests.java
+++ b/store/src/java/com/zimbra/qa/unittest/SharedImapTests.java
@@ -12,7 +12,6 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -26,26 +25,19 @@ import java.util.regex.Pattern;
 import javax.mail.MessagingException;
 
 import org.apache.commons.lang.StringUtils;
-import org.dom4j.DocumentException;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestName;
 
 import com.google.common.collect.Lists;
 import com.zimbra.client.ZFolder;
 import com.zimbra.client.ZMailbox;
 import com.zimbra.client.ZTag;
 import com.zimbra.client.ZTag.Color;
-import com.zimbra.common.localconfig.ConfigException;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.mime.MimeConstants;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.AccessBoundedRegex;
-import com.zimbra.common.util.Log;
 import com.zimbra.common.util.ZimbraLog;
-import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.Provisioning;
-import com.zimbra.cs.account.Server;
 import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailclient.CommandFailedException;
 import com.zimbra.cs.mailclient.imap.AppendMessage;
@@ -71,102 +63,11 @@ import com.zimbra.cs.service.formatter.VCard;
 /**
  * Definitions of tests used from {@Link TestLocalImapShared} and {@Link TestRemoteImapShared}
  */
-public abstract class SharedImapTests {
-    @Rule
-    public TestName testInfo = new TestName();
+public abstract class SharedImapTests extends ImapTestBase {
 
-    protected static String USER = null;
-    private static final String PASS = "test123";
-    protected static Server imapServer = null;
-    private ImapConnection connection;
-    private static boolean mIMAPDisplayMailFoldersOnly;
-    private final int LOOP_LIMIT = LC.imap_throttle_command_limit.intValue();
-    protected static String imapHostname;
-    protected static int imapPort;
-    protected String testId;
-
-    private static boolean saved_imap_always_use_remote_store;
-    private static String[] saved_imap_servers = null;
-
-    protected abstract int getImapPort();
-
-    /** expect this to be called by subclass @Before method */
-    protected void sharedSetUp() throws ServiceException, IOException  {
-        testId = String.format("%s-%s", this.getClass().getName(), testInfo.getMethodName());
-        USER = String.format("%s-user", testId).toLowerCase();
-        getLocalServer();
-        mIMAPDisplayMailFoldersOnly = imapServer.isImapDisplayMailFoldersOnly();
-        imapServer.setImapDisplayMailFoldersOnly(false);
-        sharedCleanup();
-        Account acc = TestUtil.createAccount(USER);
-        Provisioning.getInstance().setPassword(acc, PASS);
-        //find out what hostname or IP IMAP server is listening on
-        List<String> addrs = Arrays.asList(imapServer.getImapBindAddress());
-        if(addrs.isEmpty()) {
-            imapHostname = imapServer.getServiceHostname();
-        } else {
-            imapHostname = addrs.get(0);
-        }
-        imapPort = getImapPort();
-    }
-
-    /** expect this to be called by subclass @After method */
-    protected void sharedTearDown() throws ServiceException  {
-        sharedCleanup();
-        if (imapServer != null) {
-            imapServer.setImapDisplayMailFoldersOnly(mIMAPDisplayMailFoldersOnly);
-        }
-    }
-
-    private void sharedCleanup() throws ServiceException {
-        TestUtil.deleteAccountIfExists(USER);
-        if (connection != null) {
-            connection.close();
-        }
-    }
-
-    protected static Server getLocalServer() throws ServiceException {
-        if (imapServer == null) {
-            imapServer = Provisioning.getInstance().getLocalServer();
-        }
-        return imapServer;
-    }
-
-    /** expect this to be called by subclass @Before method */
-    public static void saveImapConfigSettings()
-    throws ServiceException, DocumentException, ConfigException, IOException {
-        getLocalServer();
-        saved_imap_always_use_remote_store = LC.imap_always_use_remote_store.booleanValue();
-        saved_imap_servers = imapServer.getReverseProxyUpstreamImapServers();
-    }
-
-    /** expect this to be called by subclass @After method */
-    public static void restoreImapConfigSettings()
-    throws ServiceException, DocumentException, ConfigException, IOException {
-        getLocalServer();
-        if (imapServer != null) {
-            imapServer.setReverseProxyUpstreamImapServers(saved_imap_servers);
-        }
-        TestUtil.setLCValue(LC.imap_always_use_remote_store, String.valueOf(saved_imap_always_use_remote_store));
-    }
-
-    private ImapConnection connect() throws IOException {
-        ImapConfig config = new ImapConfig(imapHostname);
-        config.setPort(imapPort);
-        config.setAuthenticationId(USER);
-        config.getLogger().setLevel(Log.Level.trace);
-        ImapConnection conn = new ImapConnection(config);
-        conn.connect();
-        return conn;
-    }
 
     private ImapConnection connectAndSelectInbox() throws IOException {
-        ImapConfig config = new ImapConfig(imapHostname);
-        config.setPort(imapPort);
-        config.setAuthenticationId(USER);
-        config.getLogger().setLevel(Log.Level.trace);
-        ImapConnection imapConn = new ImapConnection(config);
-        imapConn.connect();
+        ImapConnection imapConn = connect();
         imapConn.login(PASS);
         imapConn.select("INBOX");
         return imapConn;

--- a/store/src/java/com/zimbra/qa/unittest/TestEmbeddedRemoteImapNotificationsViaMailbox.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestEmbeddedRemoteImapNotificationsViaMailbox.java
@@ -10,14 +10,8 @@ import com.zimbra.common.localconfig.ConfigException;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 
-/**
- * Test the Embedded Remote IMAP server, doing the necessary configuration to make it work.
- *
- * Note: Currently bypasses Proxy, the tests connect directly to the embedded IMAP server's port
- *
- * The actual tests that are run are in {@link SharedImapTests}
- */
-public class TestImapViaEmbeddedRemote extends SharedImapTests {
+
+public class TestEmbeddedRemoteImapNotificationsViaMailbox extends TestImapNotificationsViaMailbox  {
 
     @Before
     public void setUp() throws ServiceException, IOException, DocumentException, ConfigException  {

--- a/store/src/java/com/zimbra/qa/unittest/TestEmbeddedRemoteImapNotificationsViaWaitsets.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestEmbeddedRemoteImapNotificationsViaWaitsets.java
@@ -10,14 +10,7 @@ import com.zimbra.common.localconfig.ConfigException;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 
-/**
- * Test the Embedded Remote IMAP server, doing the necessary configuration to make it work.
- *
- * Note: Currently bypasses Proxy, the tests connect directly to the embedded IMAP server's port
- *
- * The actual tests that are run are in {@link SharedImapTests}
- */
-public class TestImapViaEmbeddedRemote extends SharedImapTests {
+public class TestEmbeddedRemoteImapNotificationsViaWaitsets extends TestImapNotificationsViaWaitsets {
 
     @Before
     public void setUp() throws ServiceException, IOException, DocumentException, ConfigException  {

--- a/store/src/java/com/zimbra/qa/unittest/TestImapDaemonNotificationsViaMailbox.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestImapDaemonNotificationsViaMailbox.java
@@ -10,22 +10,16 @@ import com.zimbra.common.localconfig.ConfigException;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 
-/**
- * Test the Embedded Remote IMAP server, doing the necessary configuration to make it work.
- *
- * Note: Currently bypasses Proxy, the tests connect directly to the embedded IMAP server's port
- *
- * The actual tests that are run are in {@link SharedImapTests}
- */
-public class TestImapViaEmbeddedRemote extends SharedImapTests {
+public class TestImapDaemonNotificationsViaMailbox extends TestImapNotificationsViaMailbox {
 
     @Before
     public void setUp() throws ServiceException, IOException, DocumentException, ConfigException  {
         saveImapConfigSettings();
-        TestUtil.setLCValue(LC.imap_always_use_remote_store, String.valueOf(true));
-        imapServer.setReverseProxyUpstreamImapServers(new String[] {});
+        TestUtil.setLCValue(LC.imap_always_use_remote_store, String.valueOf(false));
+        getLocalServer();
+        imapServer.setReverseProxyUpstreamImapServers(new String[] {imapServer.getServiceHostname()});
         super.sharedSetUp();
-        TestUtil.assumeTrue("embedded remote IMAP server is not enabled", imapServer.isImapServerEnabled());
+        TestUtil.assumeTrue("remoteImapServerEnabled false for this server", imapServer.isRemoteImapServerEnabled());
     }
 
     @After
@@ -36,6 +30,6 @@ public class TestImapViaEmbeddedRemote extends SharedImapTests {
 
     @Override
     protected int getImapPort() {
-        return imapServer.getImapBindPort();
+        return imapServer.getRemoteImapBindPort();
     }
 }

--- a/store/src/java/com/zimbra/qa/unittest/TestImapDaemonNotificationsViaWaitsets.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestImapDaemonNotificationsViaWaitsets.java
@@ -10,22 +10,16 @@ import com.zimbra.common.localconfig.ConfigException;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 
-/**
- * Test the Embedded Remote IMAP server, doing the necessary configuration to make it work.
- *
- * Note: Currently bypasses Proxy, the tests connect directly to the embedded IMAP server's port
- *
- * The actual tests that are run are in {@link SharedImapTests}
- */
-public class TestImapViaEmbeddedRemote extends SharedImapTests {
+public class TestImapDaemonNotificationsViaWaitsets extends TestImapNotificationsViaWaitsets {
 
     @Before
     public void setUp() throws ServiceException, IOException, DocumentException, ConfigException  {
         saveImapConfigSettings();
-        TestUtil.setLCValue(LC.imap_always_use_remote_store, String.valueOf(true));
-        imapServer.setReverseProxyUpstreamImapServers(new String[] {});
+        TestUtil.setLCValue(LC.imap_always_use_remote_store, String.valueOf(false));
+        getLocalServer();
+        imapServer.setReverseProxyUpstreamImapServers(new String[] {imapServer.getServiceHostname()});
         super.sharedSetUp();
-        TestUtil.assumeTrue("embedded remote IMAP server is not enabled", imapServer.isImapServerEnabled());
+        TestUtil.assumeTrue("remoteImapServerEnabled false for this server", imapServer.isRemoteImapServerEnabled());
     }
 
     @After
@@ -36,6 +30,6 @@ public class TestImapViaEmbeddedRemote extends SharedImapTests {
 
     @Override
     protected int getImapPort() {
-        return imapServer.getImapBindPort();
+        return imapServer.getRemoteImapBindPort();
     }
 }

--- a/store/src/java/com/zimbra/qa/unittest/TestImapNotificationsViaMailbox.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestImapNotificationsViaMailbox.java
@@ -10,8 +10,7 @@ import com.zimbra.cs.imap.ImapRemoteSession;
 import com.zimbra.cs.imap.ImapServerListener;
 import com.zimbra.cs.imap.ImapServerListenerPool;
 
-public class TestRemoteImapNotificationsViaMailbox extends TestRemoteImapNotifications {
-
+public abstract class TestImapNotificationsViaMailbox extends SharedImapNotificationTests {
 
     @Override
     protected void runOp(MailboxOperation op, ZMailbox zmbox, ZFolder folder) throws Exception {

--- a/store/src/java/com/zimbra/qa/unittest/TestImapNotificationsViaWaitsets.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestImapNotificationsViaWaitsets.java
@@ -9,7 +9,7 @@ import com.zimbra.cs.imap.ImapServerListenerPool;
 import com.zimbra.cs.session.SomeAccountsWaitSet;
 import com.zimbra.cs.session.WaitSetMgr;
 
-public class TestRemoteImapNotificationsViaWaitsets extends TestRemoteImapNotifications {
+public abstract class TestImapNotificationsViaWaitsets extends SharedImapNotificationTests {
 
     @Override
     protected void runOp(MailboxOperation op, ZMailbox zmbox, ZFolder folder) throws Exception {

--- a/store/src/java/com/zimbra/qa/unittest/TestImapViaEmbeddedLocal.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestImapViaEmbeddedLocal.java
@@ -31,6 +31,7 @@ public class TestImapViaEmbeddedLocal extends SharedImapTests {
         TestUtil.setLCValue(LC.imap_always_use_remote_store, String.valueOf(false));
         imapServer.setReverseProxyUpstreamImapServers(new String[] {});
         super.sharedSetUp();
+        TestUtil.assumeTrue("local IMAP server is not enabled", imapServer.isImapServerEnabled());
     }
 
     @After

--- a/store/src/java/com/zimbra/qa/unittest/TestLocalImapNotifications.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestLocalImapNotifications.java
@@ -6,26 +6,21 @@ import org.dom4j.DocumentException;
 import org.junit.After;
 import org.junit.Before;
 
+import com.zimbra.client.ZFolder;
+import com.zimbra.client.ZMailbox;
 import com.zimbra.common.localconfig.ConfigException;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 
-/**
- * Test the Embedded Remote IMAP server, doing the necessary configuration to make it work.
- *
- * Note: Currently bypasses Proxy, the tests connect directly to the embedded IMAP server's port
- *
- * The actual tests that are run are in {@link SharedImapTests}
- */
-public class TestImapViaEmbeddedRemote extends SharedImapTests {
+public class TestLocalImapNotifications extends SharedImapNotificationTests {
 
     @Before
     public void setUp() throws ServiceException, IOException, DocumentException, ConfigException  {
         saveImapConfigSettings();
-        TestUtil.setLCValue(LC.imap_always_use_remote_store, String.valueOf(true));
+        TestUtil.setLCValue(LC.imap_always_use_remote_store, String.valueOf(false));
         imapServer.setReverseProxyUpstreamImapServers(new String[] {});
         super.sharedSetUp();
-        TestUtil.assumeTrue("embedded remote IMAP server is not enabled", imapServer.isImapServerEnabled());
+        TestUtil.assumeTrue("local IMAP server is not enabled", imapServer.isImapServerEnabled());
     }
 
     @After
@@ -37,5 +32,11 @@ public class TestImapViaEmbeddedRemote extends SharedImapTests {
     @Override
     protected int getImapPort() {
         return imapServer.getImapBindPort();
+    }
+
+    @Override
+    protected void runOp(MailboxOperation op, ZMailbox mbox, ZFolder folder)
+            throws Exception {
+        op.run(mbox);
     }
 }

--- a/store/src/java/com/zimbra/qa/unittest/ZimbraSuite.java
+++ b/store/src/java/com/zimbra/qa/unittest/ZimbraSuite.java
@@ -144,8 +144,11 @@ public class ZimbraSuite  {
         sClasses.add(TestImapClient.class);
         sClasses.add(TestImapServerListener.class);
         sClasses.add(TestTrashImapMessage.class);
-        sClasses.add(TestRemoteImapNotificationsViaWaitsets.class);
-        sClasses.add(TestRemoteImapNotificationsViaMailbox.class);
+        sClasses.add(TestEmbeddedRemoteImapNotificationsViaWaitsets.class);
+        sClasses.add(TestEmbeddedRemoteImapNotificationsViaMailbox.class);
+        sClasses.add(TestImapDaemonNotificationsViaWaitsets.class);
+        sClasses.add(TestImapDaemonNotificationsViaMailbox.class);
+        sClasses.add(TestLocalImapNotifications.class);
         sClasses.add(TestImapViaEmbeddedLocal.class);
         sClasses.add(TestImapViaEmbeddedRemote.class);
         sClasses.add(TestImapViaImapDaemon.class);


### PR DESCRIPTION
While tests exist for checking remote IMAP notifications of deleted folders, this PR moves all IMAP notification tests into a framework similar to SharedImapTests where test are defined in an abstract class and server configuration is moved to subclasses. This way, we can test IMAP notifications for the local, embedded remote, and IMAP daemon modes of operation. Since there is a lot of common code between this and SharedImapTests, a new class ImapTestBase has been introduced as a base class for both SharedImapTests and the new SharedImapNotificationTests class.

This results with the following notification test classes:
 - TestLocalImapNotifications
 - TestEmbeddedRemoteImapNotificationsViaMailbox
 - TestEmbeddedRemoteImapNotificationsViaWaitsets
 - TestImapDaemonNotificationsViaMailbox
 - TestImapDaemonNotificationsViaWaitsets

This PR is a follow-up on https://github.com/Zimbra/zm-mailbox/pull/203, which was inadvertently closed.