### PR TITLE
ZCS-1787: 'invoke' method signature without nFormat and curWaitSetID args

### DIFF
--- a/common/src/java/com/zimbra/common/soap/SoapHttpTransport.java
+++ b/common/src/java/com/zimbra/common/soap/SoapHttpTransport.java
@@ -190,6 +190,12 @@ public class SoapHttpTransport extends SoapTransport {
         return invoke(document, raw, noSession, requestedAccountId, changeToken, tokenType, nFormat, curWaitSetID, null);
     }
 
+    public Element invoke(Element document, boolean raw, boolean noSession, String requestedAccountId,
+            String changeToken, String tokenType, ResponseHandler respHandler)
+            throws IOException, HttpException, ServiceException {
+        return invoke(document, raw, noSession, requestedAccountId, changeToken, tokenType, NotificationFormat.DEFAULT, null, respHandler);
+    }
+
     private String getUriWithPath(Element document) {
         String uri, query;
         int i = mUri.indexOf('?');


### PR DESCRIPTION
Reinstated a method signature for _SoapHttpTransport::invoke_ that existed prior to the introduction of _nFormat_ and _curWaitSetID_ arguments. This signature is used by the _CrossMailboxSearch_ class in zm-network-store.