### PR TITLE
ZCS-1482: NO_SUCH_CONTACT -> NO_SUCH_MSG error fix

### DIFF
--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -2718,7 +2718,7 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
             return getMessageById(itemId.toString(), raw, max);
         } catch (SoapFaultException sfe) {
             if (sfe.getMessage().startsWith("no such message")) {
-                throw ZClientException.NO_SUCH_CONTACT(itemId.id, sfe);
+                throw ZClientException.NO_SUCH_MSG(itemId.id, sfe);
             }
             throw sfe;
         }


### PR DESCRIPTION
When _ZMailbox::getMessageById_ receives a "no such message" SOAP exception, it was erroneously throwing _ZClientException.NO_SUCH_CONTACT_, resulting in misleading log entries. This fix changes that to throw _NO_SUCH_MSG_ instead.

No unit test is provided, as this is a trivial change.