### PR TITLE
change "since" to 8.8.1 for new IMAP-related attrs

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -11694,7 +11694,7 @@ public class ZAttrProvisioning {
      * The max number of IMAP messages returned by OpenImapFolderRequest
      * before pagination begins
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3012)
     public static final String A_zimbraOpenImapFolderRequestChunkSize = "zimbraOpenImapFolderRequestChunkSize";
@@ -14014,7 +14014,7 @@ public class ZAttrProvisioning {
     /**
      * port number on which the remote IMAP server should listen
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3015)
     public static final String A_zimbraRemoteImapBindPort = "zimbraRemoteImapBindPort";
@@ -14024,7 +14024,7 @@ public class ZAttrProvisioning {
      * server. See also zimbraRemoteImapSSLServerEnabled and
      * zimbraReverseProxyUpstreamImapServers.
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3013)
     public static final String A_zimbraRemoteImapServerEnabled = "zimbraRemoteImapServerEnabled";
@@ -14032,7 +14032,7 @@ public class ZAttrProvisioning {
     /**
      * port number on which the remote IMAP SSL server should listen
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3016)
     public static final String A_zimbraRemoteImapSSLBindPort = "zimbraRemoteImapSSLBindPort";
@@ -14042,7 +14042,7 @@ public class ZAttrProvisioning {
      * See also zimbraRemoteImapServerEnabled and
      * zimbraReverseProxyUpstreamImapServers.
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3014)
     public static final String A_zimbraRemoteImapSSLServerEnabled = "zimbraRemoteImapSSLServerEnabled";

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9501,27 +9501,27 @@ TODO: delete them permanently from here
   <desc>Specifies the amount of time a thread will wait for a JedisPool resource. A value of 0 will cause the thread to block indefinitely.</desc>
 </attr>
 
-<attr id="3012" name="zimbraOpenImapFolderRequestChunkSize" type="integer" cardinality="single" optionalIn="server,globalConfig" flags="serverInherited" since="8.8.0">
+<attr id="3012" name="zimbraOpenImapFolderRequestChunkSize" type="integer" cardinality="single" optionalIn="server,globalConfig" flags="serverInherited" since="8.8.1">
   <globalConfigValue>1000</globalConfigValue>
   <desc>The max number of IMAP messages returned by OpenImapFolderRequest before pagination begins</desc>
 </attr>
 
-<attr id="3013" name="zimbraRemoteImapServerEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="8.8.0">
+<attr id="3013" name="zimbraRemoteImapServerEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="8.8.1">
   <globalConfigValue>FALSE</globalConfigValue>
   <desc>Controls if the remote IMAP (non-SSL) service is enabled for a given server. See also zimbraRemoteImapSSLServerEnabled and zimbraReverseProxyUpstreamImapServers.</desc>
 </attr>
 
-<attr id="3014" name="zimbraRemoteImapSSLServerEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="8.8.0">
+<attr id="3014" name="zimbraRemoteImapSSLServerEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="8.8.1">
   <globalConfigValue>FALSE</globalConfigValue>
   <desc>Controls if the remote IMAP SSL server is enabled for a given server. See also zimbraRemoteImapServerEnabled and zimbraReverseProxyUpstreamImapServers.</desc>
 </attr>
 
-<attr id="3015" name="zimbraRemoteImapBindPort" type="port" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="8.8.0" callback="CheckPortConflict">
+<attr id="3015" name="zimbraRemoteImapBindPort" type="port" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="8.8.1" callback="CheckPortConflict">
   <globalConfigValue>8143</globalConfigValue>
   <desc>port number on which the remote IMAP server should listen</desc>
 </attr>
 
-<attr id="3016" name="zimbraRemoteImapSSLBindPort" type="port" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="8.8.0" callback="CheckPortConflict">
+<attr id="3016" name="zimbraRemoteImapSSLBindPort" type="port" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="8.8.1" callback="CheckPortConflict">
   <globalConfigValue>8993</globalConfigValue>
   <desc>port number on which the remote IMAP SSL server should listen</desc>
 </attr>

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -48218,7 +48218,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @return zimbraOpenImapFolderRequestChunkSize, or 1000 if unset
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3012)
     public int getOpenImapFolderRequestChunkSize() {
@@ -48232,7 +48232,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param zimbraOpenImapFolderRequestChunkSize new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3012)
     public void setOpenImapFolderRequestChunkSize(int zimbraOpenImapFolderRequestChunkSize) throws com.zimbra.common.service.ServiceException {
@@ -48249,7 +48249,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3012)
     public Map<String,Object> setOpenImapFolderRequestChunkSize(int zimbraOpenImapFolderRequestChunkSize, Map<String,Object> attrs) {
@@ -48264,7 +48264,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3012)
     public void unsetOpenImapFolderRequestChunkSize() throws com.zimbra.common.service.ServiceException {
@@ -48280,7 +48280,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3012)
     public Map<String,Object> unsetOpenImapFolderRequestChunkSize(Map<String,Object> attrs) {
@@ -51035,7 +51035,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @return zimbraRemoteImapBindPort, or 8143 if unset
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3015)
     public int getRemoteImapBindPort() {
@@ -51047,7 +51047,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @return zimbraRemoteImapBindPort, or "8143" if unset
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3015)
     public String getRemoteImapBindPortAsString() {
@@ -51060,7 +51060,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param zimbraRemoteImapBindPort new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3015)
     public void setRemoteImapBindPort(int zimbraRemoteImapBindPort) throws com.zimbra.common.service.ServiceException {
@@ -51076,7 +51076,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3015)
     public Map<String,Object> setRemoteImapBindPort(int zimbraRemoteImapBindPort, Map<String,Object> attrs) {
@@ -51091,7 +51091,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param zimbraRemoteImapBindPort new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3015)
     public void setRemoteImapBindPortAsString(String zimbraRemoteImapBindPort) throws com.zimbra.common.service.ServiceException {
@@ -51107,7 +51107,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3015)
     public Map<String,Object> setRemoteImapBindPortAsString(String zimbraRemoteImapBindPort, Map<String,Object> attrs) {
@@ -51121,7 +51121,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3015)
     public void unsetRemoteImapBindPort() throws com.zimbra.common.service.ServiceException {
@@ -51136,7 +51136,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3015)
     public Map<String,Object> unsetRemoteImapBindPort(Map<String,Object> attrs) {
@@ -51154,7 +51154,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @return zimbraRemoteImapSSLBindPort, or 8993 if unset
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3016)
     public int getRemoteImapSSLBindPort() {
@@ -51166,7 +51166,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @return zimbraRemoteImapSSLBindPort, or "8993" if unset
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3016)
     public String getRemoteImapSSLBindPortAsString() {
@@ -51179,7 +51179,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param zimbraRemoteImapSSLBindPort new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3016)
     public void setRemoteImapSSLBindPort(int zimbraRemoteImapSSLBindPort) throws com.zimbra.common.service.ServiceException {
@@ -51195,7 +51195,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3016)
     public Map<String,Object> setRemoteImapSSLBindPort(int zimbraRemoteImapSSLBindPort, Map<String,Object> attrs) {
@@ -51210,7 +51210,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param zimbraRemoteImapSSLBindPort new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3016)
     public void setRemoteImapSSLBindPortAsString(String zimbraRemoteImapSSLBindPort) throws com.zimbra.common.service.ServiceException {
@@ -51226,7 +51226,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3016)
     public Map<String,Object> setRemoteImapSSLBindPortAsString(String zimbraRemoteImapSSLBindPort, Map<String,Object> attrs) {
@@ -51240,7 +51240,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3016)
     public void unsetRemoteImapSSLBindPort() throws com.zimbra.common.service.ServiceException {
@@ -51255,7 +51255,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3016)
     public Map<String,Object> unsetRemoteImapSSLBindPort(Map<String,Object> attrs) {
@@ -51271,7 +51271,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @return zimbraRemoteImapSSLServerEnabled, or false if unset
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3014)
     public boolean isRemoteImapSSLServerEnabled() {
@@ -51286,7 +51286,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param zimbraRemoteImapSSLServerEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3014)
     public void setRemoteImapSSLServerEnabled(boolean zimbraRemoteImapSSLServerEnabled) throws com.zimbra.common.service.ServiceException {
@@ -51304,7 +51304,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3014)
     public Map<String,Object> setRemoteImapSSLServerEnabled(boolean zimbraRemoteImapSSLServerEnabled, Map<String,Object> attrs) {
@@ -51320,7 +51320,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3014)
     public void unsetRemoteImapSSLServerEnabled() throws com.zimbra.common.service.ServiceException {
@@ -51337,7 +51337,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3014)
     public Map<String,Object> unsetRemoteImapSSLServerEnabled(Map<String,Object> attrs) {
@@ -51353,7 +51353,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @return zimbraRemoteImapServerEnabled, or false if unset
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3013)
     public boolean isRemoteImapServerEnabled() {
@@ -51368,7 +51368,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param zimbraRemoteImapServerEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3013)
     public void setRemoteImapServerEnabled(boolean zimbraRemoteImapServerEnabled) throws com.zimbra.common.service.ServiceException {
@@ -51386,7 +51386,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3013)
     public Map<String,Object> setRemoteImapServerEnabled(boolean zimbraRemoteImapServerEnabled, Map<String,Object> attrs) {
@@ -51402,7 +51402,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3013)
     public void unsetRemoteImapServerEnabled() throws com.zimbra.common.service.ServiceException {
@@ -51419,7 +51419,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3013)
     public Map<String,Object> unsetRemoteImapServerEnabled(Map<String,Object> attrs) {

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -36119,7 +36119,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @return zimbraOpenImapFolderRequestChunkSize, or 1000 if unset
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3012)
     public int getOpenImapFolderRequestChunkSize() {
@@ -36133,7 +36133,7 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param zimbraOpenImapFolderRequestChunkSize new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3012)
     public void setOpenImapFolderRequestChunkSize(int zimbraOpenImapFolderRequestChunkSize) throws com.zimbra.common.service.ServiceException {
@@ -36150,7 +36150,7 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3012)
     public Map<String,Object> setOpenImapFolderRequestChunkSize(int zimbraOpenImapFolderRequestChunkSize, Map<String,Object> attrs) {
@@ -36165,7 +36165,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3012)
     public void unsetOpenImapFolderRequestChunkSize() throws com.zimbra.common.service.ServiceException {
@@ -36181,7 +36181,7 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3012)
     public Map<String,Object> unsetOpenImapFolderRequestChunkSize(Map<String,Object> attrs) {
@@ -38486,7 +38486,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @return zimbraRemoteImapBindPort, or 8143 if unset
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3015)
     public int getRemoteImapBindPort() {
@@ -38498,7 +38498,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @return zimbraRemoteImapBindPort, or "8143" if unset
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3015)
     public String getRemoteImapBindPortAsString() {
@@ -38511,7 +38511,7 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param zimbraRemoteImapBindPort new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3015)
     public void setRemoteImapBindPort(int zimbraRemoteImapBindPort) throws com.zimbra.common.service.ServiceException {
@@ -38527,7 +38527,7 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3015)
     public Map<String,Object> setRemoteImapBindPort(int zimbraRemoteImapBindPort, Map<String,Object> attrs) {
@@ -38542,7 +38542,7 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param zimbraRemoteImapBindPort new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3015)
     public void setRemoteImapBindPortAsString(String zimbraRemoteImapBindPort) throws com.zimbra.common.service.ServiceException {
@@ -38558,7 +38558,7 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3015)
     public Map<String,Object> setRemoteImapBindPortAsString(String zimbraRemoteImapBindPort, Map<String,Object> attrs) {
@@ -38572,7 +38572,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3015)
     public void unsetRemoteImapBindPort() throws com.zimbra.common.service.ServiceException {
@@ -38587,7 +38587,7 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3015)
     public Map<String,Object> unsetRemoteImapBindPort(Map<String,Object> attrs) {
@@ -38605,7 +38605,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @return zimbraRemoteImapSSLBindPort, or 8993 if unset
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3016)
     public int getRemoteImapSSLBindPort() {
@@ -38617,7 +38617,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @return zimbraRemoteImapSSLBindPort, or "8993" if unset
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3016)
     public String getRemoteImapSSLBindPortAsString() {
@@ -38630,7 +38630,7 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param zimbraRemoteImapSSLBindPort new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3016)
     public void setRemoteImapSSLBindPort(int zimbraRemoteImapSSLBindPort) throws com.zimbra.common.service.ServiceException {
@@ -38646,7 +38646,7 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3016)
     public Map<String,Object> setRemoteImapSSLBindPort(int zimbraRemoteImapSSLBindPort, Map<String,Object> attrs) {
@@ -38661,7 +38661,7 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param zimbraRemoteImapSSLBindPort new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3016)
     public void setRemoteImapSSLBindPortAsString(String zimbraRemoteImapSSLBindPort) throws com.zimbra.common.service.ServiceException {
@@ -38677,7 +38677,7 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3016)
     public Map<String,Object> setRemoteImapSSLBindPortAsString(String zimbraRemoteImapSSLBindPort, Map<String,Object> attrs) {
@@ -38691,7 +38691,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3016)
     public void unsetRemoteImapSSLBindPort() throws com.zimbra.common.service.ServiceException {
@@ -38706,7 +38706,7 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3016)
     public Map<String,Object> unsetRemoteImapSSLBindPort(Map<String,Object> attrs) {
@@ -38722,7 +38722,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @return zimbraRemoteImapSSLServerEnabled, or false if unset
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3014)
     public boolean isRemoteImapSSLServerEnabled() {
@@ -38737,7 +38737,7 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param zimbraRemoteImapSSLServerEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3014)
     public void setRemoteImapSSLServerEnabled(boolean zimbraRemoteImapSSLServerEnabled) throws com.zimbra.common.service.ServiceException {
@@ -38755,7 +38755,7 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3014)
     public Map<String,Object> setRemoteImapSSLServerEnabled(boolean zimbraRemoteImapSSLServerEnabled, Map<String,Object> attrs) {
@@ -38771,7 +38771,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3014)
     public void unsetRemoteImapSSLServerEnabled() throws com.zimbra.common.service.ServiceException {
@@ -38788,7 +38788,7 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3014)
     public Map<String,Object> unsetRemoteImapSSLServerEnabled(Map<String,Object> attrs) {
@@ -38804,7 +38804,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @return zimbraRemoteImapServerEnabled, or false if unset
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3013)
     public boolean isRemoteImapServerEnabled() {
@@ -38819,7 +38819,7 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param zimbraRemoteImapServerEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3013)
     public void setRemoteImapServerEnabled(boolean zimbraRemoteImapServerEnabled) throws com.zimbra.common.service.ServiceException {
@@ -38837,7 +38837,7 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3013)
     public Map<String,Object> setRemoteImapServerEnabled(boolean zimbraRemoteImapServerEnabled, Map<String,Object> attrs) {
@@ -38853,7 +38853,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3013)
     public void unsetRemoteImapServerEnabled() throws com.zimbra.common.service.ServiceException {
@@ -38870,7 +38870,7 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.8.0
+     * @since ZCS 8.8.1
      */
     @ZAttr(id=3013)
     public Map<String,Object> unsetRemoteImapServerEnabled(Map<String,Object> attrs) {


### PR DESCRIPTION
New IMAP code will be released as a preview in 8.8.1_BETA1 out-of-band and before 8.8.0_GA becomes available. After that, we will merge new IMAP code and zExtras-related changes on "develop" and release both as 8.8.1_BETA2 or 8.8.1_GA.