### PR TITLE
pick up changes in message counts in folders

### DIFF
--- a/client/src/java/com/zimbra/client/ZFolder.java
+++ b/client/src/java/com/zimbra/client/ZFolder.java
@@ -272,6 +272,7 @@ public class ZFolder implements ZItem, FolderStore, Comparable<Object>, ToZJSONO
         mUnreadCount = (int) e.getAttributeLong(MailConstants.A_UNREAD, 0);
         mImapUnreadCount = (int) e.getAttributeLong(MailConstants.A_IMAP_UNREAD, mUnreadCount);
         mMessageCount = (int) e.getAttributeLong(MailConstants.A_NUM, 0);
+        //SOAP returns 'i4n' only when it is different from 'n'. Therefore, fall back to mMessageCount
         mImapMessageCount = (int) e.getAttributeLong(MailConstants.A_IMAP_NUM, mMessageCount);
         mDefaultView = View.fromString(e.getAttribute(MailConstants.A_DEFAULT_VIEW, null));
         mModifiedSequence = (int) e.getAttributeLong(MailConstants.A_MODIFIED_SEQUENCE, -1);
@@ -332,6 +333,7 @@ public class ZFolder implements ZItem, FolderStore, Comparable<Object>, ToZJSONO
         mUnreadCount = SystemUtil.coalesce(f.getUnreadCount(), 0);
         mImapUnreadCount = SystemUtil.coalesce(f.getImapUnreadCount(), mUnreadCount);
         mMessageCount = SystemUtil.coalesce(f.getItemCount(), 0);
+        //SOAP returns 'i4n' only when it is different from 'n'. Therefore, fall back to mMessageCount
         mImapMessageCount = SystemUtil.coalesce(f.getImapItemCount(), mMessageCount);
         mDeletable = SystemUtil.coalesce(f.isDeletable(), mDeletable);
         mAbsolutePath = SystemUtil.coalesce(f.getAbsoluteFolderPath(), mAbsolutePath);
@@ -411,7 +413,8 @@ public class ZFolder implements ZItem, FolderStore, Comparable<Object>, ToZJSONO
             mUnreadCount = fevent.getUnreadCount(mUnreadCount);
             mImapUnreadCount = fevent.getImapUnreadCount(mImapUnreadCount);
             mMessageCount = fevent.getMessageCount(mMessageCount);
-            mImapMessageCount = fevent.getImapMessageCount(mImapMessageCount);
+            //SOAP returns 'i4n' only when it is different from 'n'. Therefore, fall back to mMessageCount
+            mImapMessageCount = fevent.getImapMessageCount(mMessageCount);
             mDefaultView = fevent.getDefaultView(mDefaultView);
             mModifiedSequence = fevent.getModifiedSequence(mModifiedSequence);
             mContentSequence = fevent.getContentSequence(mContentSequence);

--- a/store/src/java/com/zimbra/qa/unittest/SharedImapTests.java
+++ b/store/src/java/com/zimbra/qa/unittest/SharedImapTests.java
@@ -607,6 +607,24 @@ public abstract class SharedImapTests extends ImapTestBase {
     }
 
     @Test(timeout=100000)
+    public void testAppendAndCount() throws Exception {
+        connection = connectAndSelectInbox();
+        Date date = new Date(System.currentTimeMillis());
+        Literal msg = message(100000);
+        try {
+            MailboxInfo mi = connection.status("Sent", "MESSAGES", "UIDNEXT", "UIDVALIDITY", "UNSEEN", "HIGHESTMODSEQ");
+            long oldCount = mi.getExists();
+            AppendResult res = connection.append("SENT", null, date, msg);
+            assertNotNull("result of append command should not be null", res);
+            mi = connection.status("Sent", "MESSAGES", "UIDNEXT", "UIDVALIDITY", "UNSEEN", "HIGHESTMODSEQ");
+            long newCount = mi.getExists();
+            assertEquals("message count should have increased by one", oldCount, newCount - 1);
+        } finally {
+            msg.dispose();
+        }
+    }
+
+    @Test(timeout=100000)
     public void testAppendFlags() throws Exception {
         connection = connectAndSelectInbox();
         assertTrue("expecting UIDPLUS capability", connection.hasCapability("UIDPLUS"));


### PR DESCRIPTION
added a test that appends a message to Sent folder and checks message count right after. This is how Apple Mail behaves. The test fails before the fix and passes after the fix on all 3 IMAP services (local, remote embedded, remote daemon).
The code change makes ZFolder handle SOAP with notifications similar to how it handles initial SOAP.