### PR TITLE
ZCS-168:Sieve:mandatory require control

### DIFF
--- a/store/src/java-test/com/zimbra/cs/filter/RequireTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/RequireTest.java
@@ -1,0 +1,85 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2017 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.filter;
+
+import java.util.HashMap;
+import java.util.List;
+
+import org.apache.jsieve.SieveFactory;
+import org.apache.jsieve.parser.generated.Node;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.MockProvisioning;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.filter.RuleManager.AdminFilterType;
+import com.zimbra.cs.filter.RuleManager.FilterType;
+import com.zimbra.cs.mailbox.DeliveryContext;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.mailbox.OperationContext;
+import com.zimbra.cs.mime.ParsedMessage;
+
+public class RequireTest {
+    @BeforeClass
+    public static void init() throws Exception {
+        MailboxTestUtil.initServer();
+        Provisioning prov = Provisioning.getInstance();
+        prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        MailboxTestUtil.clearData();
+    }
+
+    @Test
+    public void requiresList() throws Exception {
+        Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        RuleManager.clearCachedRules(account);
+        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
+
+        RuleManager.clearCachedRules(account);
+        account.unsetAdminSieveScriptBefore();
+        account.unsetMailSieveScript();
+        account.unsetAdminSieveScriptAfter();
+
+        account.setAdminSieveScriptBefore("require [\"tag\", \"log\"]; require \"enotify\";");
+
+        IncomingMessageHandler handler = new IncomingMessageHandler(
+                new OperationContext(mbox), new DeliveryContext(),
+                mbox, "test@zimbra.com",
+                new ParsedMessage("From: test1@zimbra.com".getBytes(), false),
+                0, Mailbox.ID_FOLDER_INBOX, true);
+        ZimbraMailAdapter mailAdapter = new ZimbraMailAdapter(mbox, handler);
+
+        String filter = RuleManager.getAdminScriptCacheKey(FilterType.INCOMING, AdminFilterType.BEFORE);
+        Node node = RuleManager.getRulesNode(account, filter);
+        SieveFactory SIEVE_FACTORY = RuleManager.getSieveFactory();
+        SIEVE_FACTORY.evaluate(mailAdapter, node);
+
+        List<String> requires = mailAdapter.getCapabilities();
+        Assert.assertEquals(3, requires.size());
+        Assert.assertEquals(requires.get(0), "tag");
+        Assert.assertEquals(requires.get(1), "log");
+        Assert.assertEquals(requires.get(2), "enotify");
+    }
+}

--- a/store/src/java/com/zimbra/cs/filter/JsieveConfigMapHandler.java
+++ b/store/src/java/com/zimbra/cs/filter/JsieveConfigMapHandler.java
@@ -61,6 +61,9 @@ public class JsieveConfigMapHandler {
         mCommandMap.put("log", com.zimbra.cs.filter.jsieve.VariableLog.class.getName());
         //mCommandMap.put("deleteheader", com.zimbra.cs.filter.jsieve.DeleteHeader.class.getName());
         mCommandMap.put("zimbravariablesctrl", com.zimbra.cs.filter.jsieve.ZimbraVariablesCtrl.class.getName());
+        mCommandMap.put("stop", com.zimbra.cs.filter.jsieve.Stop.class.getName());
+        mCommandMap.put("require", com.zimbra.cs.filter.jsieve.Require.class.getName());
+        mCommandMap.put("keep", com.zimbra.cs.filter.jsieve.Keep.class.getName());
 
         mCommandMap.put("notify",  com.zimbra.cs.filter.jsieve.NotifyMailto.class.getName());
         mCommandMap.put("reject", com.zimbra.cs.filter.jsieve.Reject.class.getName());

--- a/store/src/java/com/zimbra/cs/filter/RuleManager.java
+++ b/store/src/java/com/zimbra/cs/filter/RuleManager.java
@@ -69,12 +69,8 @@ public final class RuleManager {
      */
     private static final String FILTER_RULES_CACHE_KEY =
         RuleManager.class.getSimpleName() + ".FILTER_RULES_CACHE";
-    private static final String ADMIN_FILTER_RULES_CACHE_KEY =
-            RuleManager.class.getSimpleName() + ".ADMIN_FILTER_RULES_CACHE";
     private static final String OUTGOING_FILTER_RULES_CACHE_KEY =
         RuleManager.class.getSimpleName() + ".OUTGOING_FILTER_RULES_CACHE";
-    private static final String ADMIN_OUTGOING_FILTER_RULES_CACHE_KEY =
-            RuleManager.class.getSimpleName() + ".ADMIN_OUTGOING_FILTER_RULES_CACHE";
     private static final String ADMIN_FILTER_RULES_BEFORE_CACHE_KEY =
             RuleManager.class.getSimpleName() + ".ADMIN_FILTER_RULES_BEFORE_CACHE";
     private static final String ADMIN_FILTER_RULES_AFTER_CACHE_KEY =
@@ -174,8 +170,10 @@ public final class RuleManager {
     public static void clearCachedRules(Account account) {
         account.setCachedData(FILTER_RULES_CACHE_KEY, null);
         account.setCachedData(OUTGOING_FILTER_RULES_CACHE_KEY, null);
-        account.setCachedData(ADMIN_FILTER_RULES_CACHE_KEY, null);
-        account.setCachedData(ADMIN_OUTGOING_FILTER_RULES_CACHE_KEY, null);
+        account.setCachedData(ADMIN_FILTER_RULES_BEFORE_CACHE_KEY, null);
+        account.setCachedData(ADMIN_FILTER_RULES_AFTER_CACHE_KEY, null);
+        account.setCachedData(ADMIN_OUTGOING_FILTER_RULES_BEFORE_CACHE_KEY, null);
+        account.setCachedData(ADMIN_OUTGOING_FILTER_RULES_AFTER_CACHE_KEY, null);
     }
 
     /**
@@ -202,153 +200,30 @@ public final class RuleManager {
      * {@link #getRules(com.zimbra.cs.account.Account, String)} and caches the result on the <tt>Account</tt>.
      *
      * @param account the owner account of the filter rule
-     * @param filterType <tt>FilterType.INCOMING</tt> or <tt>FilterType.OUTGOING</tt>
-     * @param useAdminRule TRUE to return a combined sieve rule of admin sieve(s) and user defined rule.  FALSE to return only a user defined rule.
+     * @param rulesCacheKey key name for the rule node cache
      *
      * @see Account#setCachedData(String, Object)
      * @throws ParseException if there was an error while parsing the Sieve script
      */
-    private static Node getRulesNode(Account account, FilterType filterType, boolean useAdminRule)
+    public static Node getRulesNode(Account account, String rulesCacheKey)
         throws ParseException {
-        String rulesCacheKey = null;
 
-        // user-defined sieve rule
-        String sieveScriptAttrName = null;
-
-        // admin-defined sieve rule applied before and after user sieve
-        String adminRuleBeforeAttrName = null;
-        String adminRuleAfterAttrName  = null;
-
-        if (filterType == FilterType.INCOMING) {
-            if (useAdminRule) {
-                rulesCacheKey = ADMIN_FILTER_RULES_CACHE_KEY;
-            } else {
-                rulesCacheKey = FILTER_RULES_CACHE_KEY;
-            }
-            sieveScriptAttrName      = Provisioning.A_zimbraMailSieveScript;
-            adminRuleBeforeAttrName  = Provisioning.A_zimbraAdminSieveScriptBefore;
-            adminRuleAfterAttrName   = Provisioning.A_zimbraAdminSieveScriptAfter;
-        } else {
-            if (useAdminRule) {
-                rulesCacheKey = ADMIN_OUTGOING_FILTER_RULES_CACHE_KEY;
-            } else {
-                rulesCacheKey = OUTGOING_FILTER_RULES_CACHE_KEY;
-            }
-            sieveScriptAttrName      = Provisioning.A_zimbraMailOutgoingSieveScript;
-            adminRuleBeforeAttrName  = Provisioning.A_zimbraAdminOutgoingSieveScriptBefore;
-            adminRuleAfterAttrName   = Provisioning.A_zimbraAdminOutgoingSieveScriptAfter;
-        }
+        String sieveScriptAttrName = getScriptAttributeName(rulesCacheKey);
 
         Node node = (Node) account.getCachedData(rulesCacheKey);
-        if (node == null) {
+        if (null == node) {
             String script = getRules(account, sieveScriptAttrName);
-            String debugScript = script;
-            if (useAdminRule) {
-                /*
-                 * Sandwitches the user-defined sieve rule
-                 * between the admin-defined rules.
-                 */
-                StringBuilder requiresPart = new StringBuilder();
-                String adminRuleBefore = getRules(account, adminRuleBeforeAttrName);
-                String adminRuleAfter  = getRules(account, adminRuleAfterAttrName);
-                String debugAdminRuleBefore = adminRuleBefore;
-                String debugAdminRuleAfter  = adminRuleAfter;
 
-                if (adminRuleBefore == null) {
-                    debugAdminRuleBefore = "";
-                    adminRuleBefore = "";
-                } else {
-                    List<String> splits = splitScript(adminRuleBefore);
-                    requiresPart.append(splits.get(0));
-                    debugAdminRuleBefore = adminRuleBefore = splits.get(1);
-                }
-                if (script == null) {
-                    debugScript = "";
-                    script = "";
-                } else {
-                    List<String> splits = splitScript(script);
-                    requiresPart.append(splits.get(0));
-                    script = "\nzimbravariablesctrl :reset;\n" + splits.get(1);
-                    debugScript = splits.get(1);
-                }
-                if (adminRuleAfter == null) {
-                    debugAdminRuleAfter = "";
-                    adminRuleAfter = "";
-                } else {
-                    List<String> splits = splitScript(adminRuleAfter);
-                    requiresPart.append(splits.get(0));
-                    adminRuleAfter = "\nzimbravariablesctrl :reset;\n" + splits.get(1);
-                    debugAdminRuleAfter = splits.get(1);
-                }
-                /*
-                 * Since "require" is only allowed before other commands,
-                 * the "require" part at the beginning of each sieve rule
-                 * text will be cut, and pasted into the very top of the
-                 * combined rule. RFC-wise, it is okay to declare the
-                 * "require" commands multiple times.
-                 */
-                script = requiresPart.toString() + adminRuleBefore + script + adminRuleAfter;
-                debugScript = requiresPart.toString() + "\n# AdminBefore script\n" + debugAdminRuleBefore + "\n# End user script\n" + debugScript + "\n# AdminAfter script\n" + debugAdminRuleAfter;
+            if (null == script) {
+                script  = "";
             }
-            if (script == null) {
-                script = "";
-            }
-            ZimbraLog.filter.debug("filterType[%s] useAdminRule[%s] rule[%s]", filterType == FilterType.INCOMING ? "incoming" : "outgoing", useAdminRule ? "true" : "false", debugScript);
+
+            ZimbraLog.filter.debug("attrName[%s] rule[%s]", sieveScriptAttrName, script);
+
             node = parse(script);
             account.setCachedData(rulesCacheKey, node);
         }
         return node;
-    }
-
-    /**
-     * Splits the given sieve rule to the "require" commands parts and others
-     *
-     * @param script target sieve rule text
-     * @return String list contains [0]: "require" commands part [1]: sieve rule bug "require" commands
-     */
-    private static List<String> splitScript(String script) {
-        /*
-         * This method collects the "require" commands only existing before
-         * other commands.
-         * As it is expected that all the "require" commands are put at the
-         * top of the script, if some "require" command is remained in the
-         * middle of the sieve rule text, sooner or later it has to be
-         * handled as a parse error.
-         */
-        StringBuilder requires = new StringBuilder();
-        StringBuilder others = new StringBuilder();
-
-        int startIdx = script.indexOf("require");
-        int endIdx = 0;
-        if (startIdx >= 0) {
-            others.append(script.substring(0, startIdx));
-        }
-
-        while(startIdx >= 0) {
-            int doubleQ = script.indexOf("\"", startIdx);
-            int startRequireIdx = startIdx;
-            if (doubleQ >= 0) {
-                startIdx = script.indexOf("\"", doubleQ + 1);
-            }
-            endIdx = script.indexOf(";", startIdx) + 1;
-            requires.append(script.substring(startRequireIdx, endIdx));
-            startIdx = script.indexOf("require", endIdx);
-            if (startIdx >= 0) {
-                if (script.substring(endIdx, startIdx).trim().length() > 0) {
-                    // This "require" is not the action name, but the value
-                    // for other action. Stop finding the "require" action.
-                    break;
-                }
-                others.append(script.substring(endIdx, startIdx));
-            }
-        }
-        requires.append("\n");
-        others.append(script.substring(endIdx, script.length()));
-
-        List<String> result = new ArrayList<String>();
-        result.add(requires.toString());
-        result.add(others.toString());
-        return result;
     }
 
     /**
@@ -372,18 +247,19 @@ public final class RuleManager {
     private static List<FilterRule> getRulesAsXML(Account account, FilterType filterType)
         throws ServiceException {
         Node node;
+        String sieveScriptAttrName = null;
         try {
-            node = getRulesNode(account, filterType, false);
+            if (filterType == FilterType.INCOMING) {
+                node = getRulesNode(account, FILTER_RULES_CACHE_KEY);
+                sieveScriptAttrName = Provisioning.A_zimbraMailSieveScript;
+            } else {
+                node = getRulesNode(account, OUTGOING_FILTER_RULES_CACHE_KEY);
+                sieveScriptAttrName = Provisioning.A_zimbraMailOutgoingSieveScript;
+            }
         } catch (ParseException e) {
             throw ServiceException.PARSE_ERROR("parsing Sieve script", e);
         } catch (TokenMgrError e) {
             throw ServiceException.PARSE_ERROR("parsing Sieve script", e);
-        }
-        String sieveScriptAttrName = null;
-        if (filterType == FilterType.INCOMING) {
-            sieveScriptAttrName = Provisioning.A_zimbraMailSieveScript;
-        } else {
-            sieveScriptAttrName = Provisioning.A_zimbraMailOutgoingSieveScript;
         }
         SieveToSoap sieveToSoap = new SieveToSoap(getRuleNames(account.getAttr(sieveScriptAttrName)));
         sieveToSoap.accept(node);
@@ -517,37 +393,48 @@ public final class RuleManager {
         mailAdapter.setEnvelope(env);
         mailAdapter.setAllowFilterToMountpoint(allowFilterToMountpoint);
 
+        String [] filters = {ADMIN_FILTER_RULES_BEFORE_CACHE_KEY,
+                FILTER_RULES_CACHE_KEY,
+                ADMIN_FILTER_RULES_AFTER_CACHE_KEY
+        };
 
         try {
             Account account = mailbox.getAccount();
-            Node node = getRulesNode(account, FilterType.INCOMING, true);
+            for (String filter : filters) {
+                // Determine whether to apply rules
+                boolean applyRules = true;
+                Node node = getRulesNode(account, filter);
 
-            // Determine whether to apply rules
-            boolean applyRules = true;
-            if (node == null) {
-                applyRules = false;
-            }
-            if (SpamHandler.isSpam(handler.getMimeMessage()) &&
-                    !account.getBooleanAttr(Provisioning.A_zimbraSpamApplyUserFilters, false)) {
-                // Don't apply user filters to spam by default
-                applyRules = false;
-            }
+                if (null == node) {
+                    applyRules = false;
+                }
+                if (SpamHandler.isSpam(handler.getMimeMessage()) &&
+                        !account.getBooleanAttr(Provisioning.A_zimbraSpamApplyUserFilters, false)) {
+                    // Don't apply user filters to spam by default
+                    applyRules = false;
+                }
 
-            if (applyRules) {
-                SIEVE_FACTORY.evaluate(mailAdapter, node);
-                // multiple fileinto may result in multiple copies of the messages in different folders
-                addedMessageIds = mailAdapter.getAddedMessageIds();
+                if (applyRules) {
+                    SIEVE_FACTORY.evaluate(mailAdapter, node);
+                    if (mailAdapter.isStop()) {
+                        break;
+                    }
+                    mailAdapter.resetValues();
+                    mailAdapter.resetCapabilities();
+                }
             }
+            mailAdapter.executeAllActions();
+            addedMessageIds = mailAdapter.getAddedMessageIds();
         } catch (ErejectException ex) {
             throw DeliveryServiceException.DELIVERY_REJECTED(ex.getMessage(), ex);
         } catch (Exception e) {
             ZimbraLog.filter.warn("An error occurred while processing filter rules. Filing message to %s.",
-                handler.getDefaultFolderPath(), e);
+                    handler.getDefaultFolderPath(), e);
         } catch (TokenMgrError e) {
             // Workaround for bug 19576.  Certain parse errors can cause JavaCC to throw an Error
             // instead of an Exception.  Woo.
             ZimbraLog.filter.warn("An error occurred while processing filter rules. Filing message to %s.",
-                handler.getDefaultFolderPath(), e);
+                    handler.getDefaultFolderPath(), e);
         }
         if (addedMessageIds == null) {
             // Filter rules were not processed.  File to the default folder.
@@ -568,14 +455,26 @@ public final class RuleManager {
             mailbox, pm, sentFolderId, noICal, flags, tags, convId, octxt);
         ZimbraMailAdapter mailAdapter = new ZimbraMailAdapter(mailbox, handler);
 
+        String[] filters = {ADMIN_OUTGOING_FILTER_RULES_BEFORE_CACHE_KEY, 
+                OUTGOING_FILTER_RULES_CACHE_KEY,
+                ADMIN_OUTGOING_FILTER_RULES_AFTER_CACHE_KEY};
+
         try {
             Account account = mailbox.getAccount();
-            Node node = getRulesNode(account, FilterType.OUTGOING, true);
-            if (node != null) {
-                SIEVE_FACTORY.evaluate(mailAdapter, node);
-                // multiple fileinto may result in multiple copies of the messages in different folders
-                addedMessageIds = mailAdapter.getAddedMessageIds();
+            for (String filter : filters) {
+                Node node = getRulesNode(account, filter);
+                if (null != node) {
+                    SIEVE_FACTORY.evaluate(mailAdapter, node);
+                    if (mailAdapter.isStop()) {
+                        break;
+                    }
+                    mailAdapter.resetValues();
+                    mailAdapter.resetCapabilities();
+                }
             }
+            mailAdapter.executeAllActions();
+            // multiple fileinto may result in multiple copies of the messages in different folders
+            addedMessageIds = mailAdapter.getAddedMessageIds();
         } catch (Exception e) {
             ZimbraLog.filter.warn("An error occurred while processing filter rules. Filing message to %s.",
                 handler.getDefaultFolderPath(), e);
@@ -600,6 +499,7 @@ public final class RuleManager {
 
         try {
             SIEVE_FACTORY.evaluate(mailAdapter, node);
+            mailAdapter.executeAllActions();
         } catch (SieveException e) {
             throw ServiceException.FAILURE("Unable to evaluate script", e);
         }
@@ -806,6 +706,26 @@ public final class RuleManager {
         }
     }
 
+    private static String getScriptAttributeName(String rulesCacheKey) throws ServiceException {
+        if (ADMIN_FILTER_RULES_BEFORE_CACHE_KEY.equalsIgnoreCase(rulesCacheKey)) {
+            return getAdminScriptAttributeName(FilterType.INCOMING,  AdminFilterType.BEFORE);
+        } else if (ADMIN_FILTER_RULES_AFTER_CACHE_KEY.equalsIgnoreCase(rulesCacheKey)) {
+            return getAdminScriptAttributeName(FilterType.INCOMING,  AdminFilterType.AFTER);
+        } else if (ADMIN_OUTGOING_FILTER_RULES_BEFORE_CACHE_KEY.equalsIgnoreCase(rulesCacheKey)) {
+            return getAdminScriptAttributeName(FilterType.OUTGOING,  AdminFilterType.BEFORE);
+        } else if (ADMIN_OUTGOING_FILTER_RULES_AFTER_CACHE_KEY.equalsIgnoreCase(rulesCacheKey)) {
+            return getAdminScriptAttributeName(FilterType.OUTGOING,  AdminFilterType.AFTER);
+        } else if (FILTER_RULES_CACHE_KEY.equalsIgnoreCase(rulesCacheKey)) {
+            return Provisioning.A_zimbraMailSieveScript;
+        } else if (OUTGOING_FILTER_RULES_CACHE_KEY.equalsIgnoreCase(rulesCacheKey)) {
+            return Provisioning.A_zimbraMailOutgoingSieveScript;
+        } else {
+            StringBuilder msg = new StringBuilder();
+            msg.append("FilterKey: ").append(rulesCacheKey).append(" is invalid");
+            throw ServiceException.INVALID_REQUEST(msg.toString(), null);
+        }
+    }
+
     private static String getAdminScriptAttributeName(FilterType filterType, AdminFilterType afType) throws ServiceException {
         if (filterType == FilterType.INCOMING && afType == AdminFilterType.BEFORE) {
             return Provisioning.A_zimbraAdminSieveScriptBefore;
@@ -822,7 +742,7 @@ public final class RuleManager {
         }
     }
 
-    private static String getAdminScriptCacheKey(FilterType filterType, AdminFilterType afType) throws ServiceException {
+    public static String getAdminScriptCacheKey(FilterType filterType, AdminFilterType afType) throws ServiceException {
         if (filterType == FilterType.INCOMING && afType == AdminFilterType.BEFORE) {
             return ADMIN_FILTER_RULES_BEFORE_CACHE_KEY;
         } else if (filterType == FilterType.INCOMING && afType == AdminFilterType.AFTER) {
@@ -870,32 +790,14 @@ public final class RuleManager {
         String adminRuleAttrName = getAdminScriptAttributeName(filterType, afType);
 
         Node node = (Node) entry.getCachedData(rulesCacheKey);
-        if (node == null) {
-            String script = null;
-            String debugScript = null;
-            StringBuilder requiresPart = new StringBuilder();
+        if (null == node) {
             String adminRule = entry.getAttr(adminRuleAttrName);
-            String debugAdminRule  = adminRule;
 
-            if (adminRule == null) {
-                debugAdminRule = "";
+            if (null == adminRule) {
                 adminRule = "";
-            } else {
-                List<String> splits = splitScript(adminRule);
-                requiresPart.append(splits.get(0));
-                debugAdminRule = splits.get(1);
             }
-            /*
-             * Since "require" is only allowed before other commands,
-             * the "require" part at the beginning of each sieve rule
-             * text will be cut, and pasted into the very top of the
-             * combined rule. RFC-wise, it is okay to declare the
-             * "require" commands multiple times.
-             */
-            script = requiresPart.toString() + adminRule;
-            debugScript = requiresPart.toString() + "\n# " + adminRuleAttrName + " script\n" + debugAdminRule;
-            ZimbraLog.filter.debug("filterType[%s] rule[%s]", filterType == FilterType.INCOMING ? "incoming" : "outgoing", debugScript);
-            node = parse(script);
+            ZimbraLog.filter.debug("filterType[%s] rule[%s]", filterType == FilterType.INCOMING ? "incoming" : "outgoing", adminRule);
+            node = parse(adminRule);
             entry.setCachedData(rulesCacheKey, node);
         }
         return node;

--- a/store/src/java/com/zimbra/cs/filter/RuleManager.java
+++ b/store/src/java/com/zimbra/cs/filter/RuleManager.java
@@ -204,9 +204,10 @@ public final class RuleManager {
      *
      * @see Account#setCachedData(String, Object)
      * @throws ParseException if there was an error while parsing the Sieve script
+     * @throws ServiceException
      */
     public static Node getRulesNode(Account account, String rulesCacheKey)
-        throws ParseException {
+        throws ParseException, ServiceException {
 
         String sieveScriptAttrName = getScriptAttributeName(rulesCacheKey);
 

--- a/store/src/java/com/zimbra/cs/filter/jsieve/ActionExplicitKeep.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/ActionExplicitKeep.java
@@ -26,7 +26,4 @@ import org.apache.jsieve.mail.Action;
  */
 public class ActionExplicitKeep implements Action {
 
-    public ActionExplicitKeep() {
-        super();
-    }
 }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/ActionExplicitKeep.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/ActionExplicitKeep.java
@@ -1,0 +1,32 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2017 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.filter.jsieve;
+
+import org.apache.jsieve.mail.Action;
+
+/**
+ * Class ActionKeep encapsulates the information required to keep a mail. See
+ * RFC 5228, Section 4.3.
+ * This class will be called when the "keep" action is explicitly specified from
+ * the sieve script.
+ */
+public class ActionExplicitKeep implements Action {
+
+    public ActionExplicitKeep() {
+        super();
+    }
+}

--- a/store/src/java/com/zimbra/cs/filter/jsieve/FileInto.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/FileInto.java
@@ -26,20 +26,30 @@ import org.apache.jsieve.exception.SieveException;
 import org.apache.jsieve.exception.SyntaxException;
 import org.apache.jsieve.mail.MailAdapter;
 
+import com.zimbra.cs.filter.FilterUtil;
+import com.zimbra.cs.filter.ZimbraMailAdapter;
+
 
 public class FileInto extends org.apache.jsieve.commands.optional.FileInto {
 	
     @Override
     protected Object executeBasic(MailAdapter mail, Arguments arguments, Block block,
         SieveContext context) throws SieveException {
+        if (!(mail instanceof ZimbraMailAdapter)) {
+            return null;
+        }
+        ZimbraMailAdapter mailAdapter = (ZimbraMailAdapter) mail;
+
         List<Argument> args = arguments.getArgumentList();
         if (args.size() == 1) {
             String folderPath = ((StringListArgument) arguments.getArgumentList().get(0)).getList()
                 .get(0);
+            folderPath = FilterUtil.replaceVariables(mailAdapter, folderPath);
             mail.addAction(new ActionFileInto(folderPath));
         } else {
             String folderPath = ((StringListArgument) arguments.getArgumentList().get(1)).getList()
                 .get(0);
+            folderPath = FilterUtil.replaceVariables(mailAdapter, folderPath);
             mail.addAction(new ActionFileInto(folderPath, true));
         }
         return null;

--- a/store/src/java/com/zimbra/cs/filter/jsieve/HeaderTest.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/HeaderTest.java
@@ -378,7 +378,7 @@ public class HeaderTest extends Header {
                     Matcher matcher = Pattern.compile(regex, Pattern.CASE_INSENSITIVE).matcher(sourceStr);
                     int grpCount = matcher.groupCount();
                     if (matcher.find() && grpCount > 0) {
-                        mailAdapter.clearMatchedValues();
+                        mailAdapter.resetMatchedValues();
                         if (firstMatchedInputSubsequence == null) {
                             // The varValues holds the substring from the source value
                             // that the corresponding wildcard expands to. Although RFC 5229 says that

--- a/store/src/java/com/zimbra/cs/filter/jsieve/Keep.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/Keep.java
@@ -1,0 +1,37 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2017 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.filter.jsieve;
+
+import org.apache.jsieve.Arguments;
+import org.apache.jsieve.Block;
+import org.apache.jsieve.SieveContext;
+import org.apache.jsieve.exception.SieveException;
+import org.apache.jsieve.mail.MailAdapter;
+
+/**
+ * Class Keep implements the explicit Keep Command which is explicitly
+ * specified in the sieve script.
+ */
+public class Keep extends org.apache.jsieve.commands.Keep {
+
+    @Override
+    protected Object executeBasic(MailAdapter mail, Arguments arguments,
+            Block block, SieveContext context) throws SieveException {
+        mail.addAction(new ActionExplicitKeep());
+        return null;
+    }
+}

--- a/store/src/java/com/zimbra/cs/filter/jsieve/Notify.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/Notify.java
@@ -29,7 +29,9 @@ import org.apache.jsieve.exception.SyntaxException;
 import org.apache.jsieve.mail.MailAdapter;
 
 import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.filter.FilterUtil;
 import com.zimbra.cs.filter.JsieveConfigMapHandler;
+import com.zimbra.cs.filter.ZimbraMailAdapter;
 
 import java.util.List;
 
@@ -38,6 +40,11 @@ public class Notify extends AbstractActionCommand {
     @Override
     protected Object executeBasic(MailAdapter mail, Arguments arguments, Block block, SieveContext context)
             throws SieveException {
+        if (!(mail instanceof ZimbraMailAdapter)) {
+            return null;
+        }
+        ZimbraMailAdapter mailAdapter = (ZimbraMailAdapter) mail;
+
         List<Argument> args = arguments.getArgumentList();
         if (args.size() < 3)
             throw new SyntaxException("Missing arguments");
@@ -48,7 +55,7 @@ public class Notify extends AbstractActionCommand {
         List<String> list = ((StringListArgument) nextArg).getList();
         if (list.size() != 1)
             throw new SyntaxException("Expected exactly one email address");
-        String emailAddr = list.get(0);
+        String emailAddr = FilterUtil.replaceVariables(mailAdapter, list.get(0));
 
         nextArg = args.get(1);
         if (!(nextArg instanceof StringListArgument))
@@ -56,7 +63,7 @@ public class Notify extends AbstractActionCommand {
         list = ((StringListArgument) nextArg).getList();
         if (list.size() != 1)
             throw new SyntaxException("Expected exactly one subject");
-        String subjectTemplate = list.get(0);
+        String subjectTemplate = FilterUtil.replaceVariables(mailAdapter, list.get(0));
 
         nextArg = args.get(2);
         if (!(nextArg instanceof StringListArgument))
@@ -64,7 +71,7 @@ public class Notify extends AbstractActionCommand {
         list = ((StringListArgument) nextArg).getList();
         if (list.size() != 1)
             throw new SyntaxException("Expected exactly one body");
-        String bodyTemplate = list.get(0);
+        String bodyTemplate = FilterUtil.replaceVariables(mailAdapter, list.get(0));
 
         int maxBodyBytes = -1;
         List<String> origHeaders = null;

--- a/store/src/java/com/zimbra/cs/filter/jsieve/Redirect.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/Redirect.java
@@ -26,19 +26,27 @@ import org.apache.jsieve.exception.SieveException;
 import org.apache.jsieve.exception.SyntaxException;
 import org.apache.jsieve.mail.MailAdapter;
 
+import com.zimbra.cs.filter.FilterUtil;
+import com.zimbra.cs.filter.ZimbraMailAdapter;
+
 public class Redirect extends org.apache.jsieve.commands.Redirect {
 
     @Override
     protected Object executeBasic(MailAdapter mail, Arguments arguments, Block block,
         SieveContext context) throws SieveException {
+        if (!(mail instanceof ZimbraMailAdapter)) {
+            return null;
+        }
+        ZimbraMailAdapter mailAdapter = (ZimbraMailAdapter) mail;
+
         List<Argument> args = arguments.getArgumentList();
         if (args.size() == 1) {
-            String address = ((StringListArgument) arguments.getArgumentList().get(0)).getList()
-                .get(0);
+            String address = FilterUtil.replaceVariables(mailAdapter,
+                    ((StringListArgument) arguments.getArgumentList().get(0)).getList().get(0));
             mail.addAction(new ActionRedirect(address));
         } else {
-            String address = ((StringListArgument) arguments.getArgumentList().get(1)).getList()
-                .get(0);
+            String address = FilterUtil.replaceVariables(mailAdapter,
+                    ((StringListArgument) arguments.getArgumentList().get(1)).getList().get(0));
             mail.addAction(new ActionRedirect(address, true));
         }
         return null;

--- a/store/src/java/com/zimbra/cs/filter/jsieve/Reject.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/Reject.java
@@ -19,13 +19,16 @@ package com.zimbra.cs.filter.jsieve;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
+import com.zimbra.cs.filter.FilterUtil;
 import com.zimbra.cs.filter.ZimbraMailAdapter;
 
 import org.apache.jsieve.Arguments;
 import org.apache.jsieve.Block;
 import org.apache.jsieve.SieveContext;
+import org.apache.jsieve.StringListArgument;
 import org.apache.jsieve.exception.SieveException;
 import org.apache.jsieve.mail.ActionKeep;
+import org.apache.jsieve.mail.ActionReject;
 import org.apache.jsieve.mail.MailAdapter;
 
 /**
@@ -46,7 +49,10 @@ public class Reject extends org.apache.jsieve.commands.optional.Reject {
             account = mailAdapter.getMailbox().getAccount();
             if (account.isSieveRejectMailEnabled()) {
                 mailAdapter.setDiscardActionPresent();
-                return super.executeBasic(mail, arguments, block, context);
+                final String message = FilterUtil.replaceVariables((ZimbraMailAdapter) mailAdapter,
+                        ((StringListArgument) arguments
+                        .getArgumentList().get(0)).getList().get(0));
+                mail.addAction(new ActionReject(message));
             } else {
                 mail.addAction(new ActionKeep());
             }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/Require.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/Require.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2009, 2010, 2011, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2017 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -14,25 +14,23 @@
  * If not, see <https://www.gnu.org/licenses/>.
  * ***** END LICENSE BLOCK *****
  */
-
 package com.zimbra.cs.filter.jsieve;
 
-import org.apache.jsieve.Argument;
+import java.util.List;
+
 import org.apache.jsieve.Arguments;
 import org.apache.jsieve.Block;
 import org.apache.jsieve.SieveContext;
 import org.apache.jsieve.StringListArgument;
-import org.apache.jsieve.commands.AbstractActionCommand;
 import org.apache.jsieve.exception.SieveException;
-import org.apache.jsieve.exception.SyntaxException;
 import org.apache.jsieve.mail.MailAdapter;
 
-import com.zimbra.cs.filter.FilterUtil;
 import com.zimbra.cs.filter.ZimbraMailAdapter;
 
-import java.util.List;
-
-public class Reply extends AbstractActionCommand {
+/**
+ * Class Require implements the Require control as defined in RFC 5228, section 3.2.
+ */
+public class Require extends org.apache.jsieve.commands.Require {
 
     @Override
     protected Object executeBasic(MailAdapter mail, Arguments arguments, Block block, SieveContext context)
@@ -42,24 +40,13 @@ public class Reply extends AbstractActionCommand {
         }
         ZimbraMailAdapter mailAdapter = (ZimbraMailAdapter) mail;
 
-        String bodyTemplate = FilterUtil.replaceVariables(mailAdapter,
-                ((StringListArgument) arguments.getArgumentList().get(0)).getList().get(0));
-        mail.addAction(new ActionReply(bodyTemplate));
+        final List<String> stringArgumentList = ((StringListArgument) arguments
+                .getArgumentList().get(0)).getList();
+        for (String stringArgument: stringArgumentList) {
+            validateFeature(stringArgument, mail, context);
+            mailAdapter.addCapabilities(stringArgument);
+        }
         return null;
     }
 
-    @Override
-    protected void validateArguments(Arguments arguments, SieveContext context)
-            throws SieveException {
-        List<Argument> args = arguments.getArgumentList();
-        if (args.size() != 1)
-            throw new SyntaxException("Exactly 1 argument permitted. Found " + args.size());
-
-        Argument argument = args.get(0);
-        if (!(argument instanceof StringListArgument))
-            throw new SyntaxException("Expected text");
-
-        if (((StringListArgument) argument).getList().size() != 1)
-            throw new SyntaxException("Expected exactly one text");
-    }
 }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/Stop.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/Stop.java
@@ -1,0 +1,27 @@
+package com.zimbra.cs.filter.jsieve;
+
+import org.apache.jsieve.Arguments;
+import org.apache.jsieve.Block;
+import org.apache.jsieve.SieveContext;
+import org.apache.jsieve.exception.SieveException;
+import org.apache.jsieve.mail.MailAdapter;
+
+import com.zimbra.cs.filter.ZimbraMailAdapter;
+
+/**
+ * Class Stop implements the stop control as defined in RFC 5228, section 3.3.
+ */
+public class Stop extends org.apache.jsieve.commands.Stop {
+
+    @Override
+    protected Object executeBasic(MailAdapter mail, Arguments arguments, Block block, SieveContext context)
+            throws SieveException {
+        if (!(mail instanceof ZimbraMailAdapter)) {
+            return null;
+        }
+        ZimbraMailAdapter mailAdapter = (ZimbraMailAdapter) mail;
+        mailAdapter.setStop(true);
+        return super.executeBasic(mail, arguments, block, context);
+    }
+
+}

--- a/store/src/java/com/zimbra/cs/filter/jsieve/ZimbraVariablesCtrl.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/ZimbraVariablesCtrl.java
@@ -59,7 +59,7 @@ public class ZimbraVariablesCtrl extends AbstractCommand {
                 TagArgument tag = (TagArgument) arg;
                 String tagValue = tag.getTag();
                 if (RESET.equalsIgnoreCase(tagValue)) {
-                    mailAdapter.clearValues();
+                    mailAdapter.resetValues();
                 } else {
                     throw new SyntaxException("Invalid tag: [" + tagValue + "]");
                 }


### PR DESCRIPTION
[bug]
Any Sieve extension command or test must be declared in
the "require" control before it is called in the rule.
Currently a Sieve rule can call any extension command or
 test without the declaration of the "require" control.

[fix]
This ticket (zcs-168) covers to fix the behaviour of
"require" control, and introduces a list of capability
strings which each extension command and test can refer
to during the execution.
previously the admin-defined filters and user-defined
filter were combined into one script and evaluated.
Now each filter script is evaluated separately.
If an action is evaluated as executable, such action’s
executeBasic() method stacks the Action object into the
ZimbraMailAdapter.actions list.  If the currently processing
filter ends up to “stop” action, stop further evaluation.
After the evaluation of three filters are all completed
(or stopped), then RuleManager.applyRulesToIncomingMessage()
calls a new method to execute the evaluated actions.

[test]
Unit test: All tests under the /zcs/zm-mailbox/store/src/java-test/com/zimbra/cs/filter/ folder were PASS
Automation test: All tests under the /git/zm-qa/data/soapvalidator/MailClient/Filters/ folder were PASS (except bug107381-0067,0076,0085 which have been failed before fix of zcs-168)