### PR TITLE
ZCS-1597: child folder path updated after parent rename

### DIFF
--- a/store/src/java/com/zimbra/qa/unittest/SharedImapTests.java
+++ b/store/src/java/com/zimbra/qa/unittest/SharedImapTests.java
@@ -1546,6 +1546,40 @@ public abstract class SharedImapTests extends ImapTestBase {
     }
 
 
+    @Test
+    public void testRenameParentFolder() throws Exception {
+        String parentFolder = "parent";
+        String childFolder1 = parentFolder + "/child1";
+        String childFolder2 = childFolder1 + "/child2";
+        connection = connect();
+        connection.login(PASS);
+        connection.create(childFolder2);
+        List<ListData> listResult = connection.list("", "*");
+        assertTrue(listContains(listResult, parentFolder));
+        assertTrue(listContains(listResult, childFolder1));
+        assertTrue(listContains(listResult, childFolder2));
+        String newParentFolder = "renamed";
+        String newChildFolder1 = newParentFolder + "/child1";
+        String newChildFolder2 = newChildFolder1 + "/child2";
+        connection.rename(parentFolder, newParentFolder);
+        listResult = connection.list("", "*");
+        assertTrue(listContains(listResult, newParentFolder));
+        assertTrue(listContains(listResult, newChildFolder1));
+        assertTrue(listContains(listResult, newChildFolder2));
+        assertFalse(listContains(listResult, parentFolder));
+        assertFalse(listContains(listResult, childFolder1));
+        assertFalse(listContains(listResult, childFolder2));
+    }
+
+    private boolean listContains(List<ListData> listData, String folderName) {
+        for (ListData ld: listData) {
+            if (ld.getMailbox().equalsIgnoreCase(folderName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private MessageData fetchMessage(long uid) throws IOException {
         MessageData md = connection.uidFetch(uid, "(FLAGS BODY.PEEK[])");
         assertNotNull("message not found", md);


### PR DESCRIPTION
This bug was caused by the _ZMailbox_ not updating subfolder paths in its folder cache when receiving a _ZModifyFolderEvent_. More specifically, _ZFolder.getPath()_ returns the _mAbsolutePath_ field if it is set, falling back to determining the path based on the parent folder otherwise. To fix this, I added a method _ZFolder.refreshAbsolutePath()_ that recalculates the absolute path based on the parent folder; this also happens recursively for all subfolders. This method is called in _ZFolder.modifyNotification()_, only if the folder name is modified.

A new test method _testRenameParentFolder_ has been added to _SharedImapTests_. The test creates a parent folder with two layers of children, renames the parent folder, and verifies that the children have been renamed accordingly.

EDIT:

renamed _refreshAbsolutePath_ to _updateAbsolutePaths_ and added a method _updateAbsolutePathOfSubfolders_ for clarity. As per a suggestion by Travis, the name of the parent folder is now passed to these methods on the child folder so that nested folders don't have to keep re-calculating the parent folder names.