### PR TITLE
Bugfix/zms 666

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -14827,6 +14827,16 @@ public class ZAttrProvisioning {
     public static final String A_zimbraReverseProxyUpstreamEwsServers = "zimbraReverseProxyUpstreamEwsServers";
 
     /**
+     * Configures the &#039;upstream_fair_shm_size&#039; value used by Nginx
+     * to set the size of shared memory for storing information about the
+     * busy-ness of backends. Values are in kilobytes.
+     *
+     * @since ZCS 8.8.1
+     */
+    @ZAttr(id=3017)
+    public static final String A_zimbraReverseProxyUpstreamFairShmSize = "zimbraReverseProxyUpstreamFairShmSize";
+
+    /**
      * The pool of servers that are available to the proxy for handling IMAP
      * sessions. If empty, the NginxLookupExtension will select the mailbox
      * server that hosts the account.

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9526,5 +9526,10 @@ TODO: delete them permanently from here
   <desc>port number on which the remote IMAP SSL server should listen</desc>
 </attr>
 
+<attr id="3017" name="zimbraReverseProxyUpstreamFairShmSize" type="integer" min="32" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="8.8.1" requiresRestart="nginxproxy">
+  <globalConfigValue>32</globalConfigValue>
+  <desc>Configures the 'upstream_fair_shm_size' value used by Nginx to set the size of shared memory for storing information about the busy-ness of backends. Values are in kilobytes.</desc>
+</attr>
+
 </attrs>
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -59181,6 +59181,88 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Configures the &#039;upstream_fair_shm_size&#039; value used by Nginx
+     * to set the size of shared memory for storing information about the
+     * busy-ness of backends. Values are in kilobytes.
+     *
+     * @return zimbraReverseProxyUpstreamFairShmSize, or 32 if unset
+     *
+     * @since ZCS 8.8.1
+     */
+    @ZAttr(id=3017)
+    public int getReverseProxyUpstreamFairShmSize() {
+        return getIntAttr(Provisioning.A_zimbraReverseProxyUpstreamFairShmSize, 32, true);
+    }
+
+    /**
+     * Configures the &#039;upstream_fair_shm_size&#039; value used by Nginx
+     * to set the size of shared memory for storing information about the
+     * busy-ness of backends. Values are in kilobytes.
+     *
+     * @param zimbraReverseProxyUpstreamFairShmSize new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.1
+     */
+    @ZAttr(id=3017)
+    public void setReverseProxyUpstreamFairShmSize(int zimbraReverseProxyUpstreamFairShmSize) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraReverseProxyUpstreamFairShmSize, Integer.toString(zimbraReverseProxyUpstreamFairShmSize));
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures the &#039;upstream_fair_shm_size&#039; value used by Nginx
+     * to set the size of shared memory for storing information about the
+     * busy-ness of backends. Values are in kilobytes.
+     *
+     * @param zimbraReverseProxyUpstreamFairShmSize new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.1
+     */
+    @ZAttr(id=3017)
+    public Map<String,Object> setReverseProxyUpstreamFairShmSize(int zimbraReverseProxyUpstreamFairShmSize, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraReverseProxyUpstreamFairShmSize, Integer.toString(zimbraReverseProxyUpstreamFairShmSize));
+        return attrs;
+    }
+
+    /**
+     * Configures the &#039;upstream_fair_shm_size&#039; value used by Nginx
+     * to set the size of shared memory for storing information about the
+     * busy-ness of backends. Values are in kilobytes.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.1
+     */
+    @ZAttr(id=3017)
+    public void unsetReverseProxyUpstreamFairShmSize() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraReverseProxyUpstreamFairShmSize, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures the &#039;upstream_fair_shm_size&#039; value used by Nginx
+     * to set the size of shared memory for storing information about the
+     * busy-ness of backends. Values are in kilobytes.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.1
+     */
+    @ZAttr(id=3017)
+    public Map<String,Object> unsetReverseProxyUpstreamFairShmSize(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraReverseProxyUpstreamFairShmSize, "");
+        return attrs;
+    }
+
+    /**
      * The pool of servers that are available to the proxy for handling IMAP
      * sessions. If empty, the NginxLookupExtension will select the mailbox
      * server that hosts the account.

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -43620,6 +43620,88 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
+     * Configures the &#039;upstream_fair_shm_size&#039; value used by Nginx
+     * to set the size of shared memory for storing information about the
+     * busy-ness of backends. Values are in kilobytes.
+     *
+     * @return zimbraReverseProxyUpstreamFairShmSize, or 32 if unset
+     *
+     * @since ZCS 8.8.1
+     */
+    @ZAttr(id=3017)
+    public int getReverseProxyUpstreamFairShmSize() {
+        return getIntAttr(Provisioning.A_zimbraReverseProxyUpstreamFairShmSize, 32, true);
+    }
+
+    /**
+     * Configures the &#039;upstream_fair_shm_size&#039; value used by Nginx
+     * to set the size of shared memory for storing information about the
+     * busy-ness of backends. Values are in kilobytes.
+     *
+     * @param zimbraReverseProxyUpstreamFairShmSize new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.1
+     */
+    @ZAttr(id=3017)
+    public void setReverseProxyUpstreamFairShmSize(int zimbraReverseProxyUpstreamFairShmSize) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraReverseProxyUpstreamFairShmSize, Integer.toString(zimbraReverseProxyUpstreamFairShmSize));
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures the &#039;upstream_fair_shm_size&#039; value used by Nginx
+     * to set the size of shared memory for storing information about the
+     * busy-ness of backends. Values are in kilobytes.
+     *
+     * @param zimbraReverseProxyUpstreamFairShmSize new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.1
+     */
+    @ZAttr(id=3017)
+    public Map<String,Object> setReverseProxyUpstreamFairShmSize(int zimbraReverseProxyUpstreamFairShmSize, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraReverseProxyUpstreamFairShmSize, Integer.toString(zimbraReverseProxyUpstreamFairShmSize));
+        return attrs;
+    }
+
+    /**
+     * Configures the &#039;upstream_fair_shm_size&#039; value used by Nginx
+     * to set the size of shared memory for storing information about the
+     * busy-ness of backends. Values are in kilobytes.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.1
+     */
+    @ZAttr(id=3017)
+    public void unsetReverseProxyUpstreamFairShmSize() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraReverseProxyUpstreamFairShmSize, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures the &#039;upstream_fair_shm_size&#039; value used by Nginx
+     * to set the size of shared memory for storing information about the
+     * busy-ness of backends. Values are in kilobytes.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.1
+     */
+    @ZAttr(id=3017)
+    public Map<String,Object> unsetReverseProxyUpstreamFairShmSize(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraReverseProxyUpstreamFairShmSize, "");
+        return attrs;
+    }
+
+    /**
      * The pool of servers that are available to the proxy for handling IMAP
      * sessions. If empty, the NginxLookupExtension will select the mailbox
      * server that hosts the account.

--- a/store/src/java/com/zimbra/cs/util/ProxyConfGen.java
+++ b/store/src/java/com/zimbra/cs/util/ProxyConfGen.java
@@ -488,6 +488,39 @@ class IPv6OnlyEnablerVar extends IPModeEnablerVar {
     }
 }
 
+class ProxyFairShmVar extends ProxyConfVar {
+
+    public ProxyFairShmVar() {
+        super("upstream.fair.shm.size", "zimbraReverseProxyUpstreamFairShmSize", "",
+                ProxyConfValueType.CUSTOM, ProxyConfOverride.CONFIG,
+                "Controls the 'upstream_fair_shm_size' configuration in the proxy configuration file: nginx.conf.web.template.");
+    }
+
+    @Override
+    public void update() {
+        String setting = serverSource.getAttr(Provisioning.A_zimbraReverseProxyUpstreamFairShmSize, "32");
+
+        try {
+            if (Integer.parseInt(setting) < 32)
+            {
+                setting = "32";
+            }
+        }
+        catch (NumberFormatException e)
+        {
+            mLog.info("Value provided in 'zimbraReverseProxyUpstreamFairShmSize': " + setting + " is invalid. Falling back to default value of 32.");
+            setting = "32";
+        }
+
+        mValue = setting;
+    }
+
+    @Override
+    public String format(Object o) {
+       return "upstream_fair_shm_size " + mValue + "k;";
+    }
+}
+
 class Pop3GreetingVar extends ProxyConfVar {
 
     public Pop3GreetingVar() {
@@ -2686,6 +2719,7 @@ public class ProxyConfGen
 	ProxyConfVar webSslDhParamFile = new ProxyConfVar("web.ssl.dhparam.file", null, mDefaultDhParamFile, ProxyConfValueType.STRING, ProxyConfOverride.NONE, "Filename with DH parameters for EDH ciphers to be used by the proxy");
         mConfVars.put("web.ssl.dhparam.enabled", new WebSSLDhparamEnablerVar(webSslDhParamFile));
         mConfVars.put("web.ssl.dhparam.file", webSslDhParamFile);
+        mConfVars.put("upstream.fair.shm.size", new ProxyFairShmVar());
         //Get the response headers list from globalconfig
         String[] rspHeaders = ProxyConfVar.configSource.getMultiAttr(Provisioning.A_zimbraReverseProxyResponseHeaders);
         ArrayList<String> rhdr = new ArrayList<String>();


### PR DESCRIPTION
* Adds a new LDAP attribute `zimbraReverseProxyUpstreamFairShmSize` to control the 'upstream_fair_shm_size' configuration value in the Nginx template files.
* Updates ProxyConfGen.java to process 'upstream.fair.shm.size' and replace the variable with
nothing if not present in LDAP, or with `upstream_fair_shm_size <value>k` 
   Example: `upstream_fair_shm_size 32k`

If an invalid value is placed in the attribute it is replaced with the minimum which is equal to 32k.

Note: This is based on `feature/imap`. I am unsure which branch i.e. release should be targeted at this time. If this is the wrong one per PM direction I will rebase and regenerate the getter/setters after fixing the attribute id if necessary.

