### PR TITLE
zcs-1678

### DIFF
--- a/store/src/java-test/com/zimbra/cs/imap/ImapPathTest.java
+++ b/store/src/java-test/com/zimbra/cs/imap/ImapPathTest.java
@@ -43,7 +43,7 @@ public class ImapPathTest {
         ImapPath i4Path = new ImapPath("*", credentials, ImapPath.Scope.UNPARSED);
         Assert.assertNotNull("Should be able to instantiate ImapPath for '*'", i4Path);
         String owner = i4Path.getOwner();
-        Assert.assertNull("owner part of the path should be null", owner);
+        Assert.assertNull("owner part of the path should be null. Was " + owner, owner);
         Assert.assertTrue("belongsTo should return TRUE with same credentials as were passed to the constructor", i4Path.belongsTo(credentials));
         Assert.assertEquals("Incorrect owner account", acct, i4Path.getOwnerAccount());
         Assert.assertEquals("Incorrect UTF7-encoded path", "\"*\"", i4Path.asUtf7String());
@@ -55,7 +55,7 @@ public class ImapPathTest {
         ImapPath i4Path = new ImapPath("%", credentials, ImapPath.Scope.UNPARSED);
         Assert.assertNotNull("Should be able to instantiate ImapPath for '*'", i4Path);
         String owner = i4Path.getOwner();
-        Assert.assertNull("owner part of the path should be null", owner);
+        Assert.assertNull("owner part of the path should be null. Was " + owner, owner);
         Assert.assertTrue("belongsTo should return TRUE with same credentials as were passed to the constructor", i4Path.belongsTo(credentials));
         Assert.assertEquals("Incorrect owner account", acct, i4Path.getOwnerAccount());
         Assert.assertEquals("Incorrect UTF7-encoded path", "\"%\"", i4Path.asUtf7String());
@@ -67,9 +67,45 @@ public class ImapPathTest {
         ImapPath i4Path = new ImapPath("%/%", credentials, ImapPath.Scope.UNPARSED);
         Assert.assertNotNull("Should be able to instantiate ImapPath for '*'", i4Path);
         String owner = i4Path.getOwner();
-        Assert.assertNull("owner part of the path should be null", owner);
+        Assert.assertNull("owner part of the path should be null. Was " + owner, owner);
         Assert.assertTrue("belongsTo should return TRUE with same credentials as were passed to the constructor", i4Path.belongsTo(credentials));
         Assert.assertEquals("Incorrect owner account", acct, i4Path.getOwnerAccount());
         Assert.assertEquals("Incorrect UTF7-encoded path", "\"%/%\"", i4Path.asUtf7String());
+    }
+
+    @Test
+    public void testHomeWildCard() throws Exception {
+        ImapCredentials credentials = new ImapCredentials(acct, ImapCredentials.EnabledHack.NONE);
+        ImapPath i4Path = new ImapPath("/home/*", credentials, ImapPath.Scope.UNPARSED);
+        Assert.assertNotNull("Should be able to instantiate ImapPath for '/home/*'", i4Path);
+        String owner = i4Path.getOwner();
+        Assert.assertNull("owner part of the path should be null. Was " + owner, owner);
+        Assert.assertTrue("belongsTo should return TRUE with same credentials as were passed to the constructor", i4Path.belongsTo(credentials));
+        Assert.assertEquals("Incorrect owner account", acct, i4Path.getOwnerAccount());
+        Assert.assertEquals("Incorrect UTF7-encoded path", "\"home/*\"", i4Path.asUtf7String());
+    }
+
+    @Test
+    public void testHomePercent() throws Exception {
+        ImapCredentials credentials = new ImapCredentials(acct, ImapCredentials.EnabledHack.NONE);
+        ImapPath i4Path = new ImapPath("/home/%", credentials, ImapPath.Scope.UNPARSED);
+        Assert.assertNotNull("Should be able to instantiate ImapPath for '/home/%'", i4Path);
+        String owner = i4Path.getOwner();
+        Assert.assertNull("owner part of the path should be null. Was " + owner, owner);
+        Assert.assertTrue("belongsTo should return TRUE with same credentials as were passed to the constructor", i4Path.belongsTo(credentials));
+        Assert.assertEquals("Incorrect owner account", acct, i4Path.getOwnerAccount());
+        Assert.assertEquals("Incorrect UTF7-encoded path", "\"home/%\"", i4Path.asUtf7String());
+    }
+
+    @Test
+    public void testHomePercent2() throws Exception {
+        ImapCredentials credentials = new ImapCredentials(acct, ImapCredentials.EnabledHack.NONE);
+        ImapPath i4Path = new ImapPath("/home/%/%", credentials, ImapPath.Scope.UNPARSED);
+        Assert.assertNotNull("Should be able to instantiate ImapPath for '/home/%/%'", i4Path);
+        String owner = i4Path.getOwner();
+        Assert.assertNull("owner part of the path should be null. Was " + owner, owner);
+        Assert.assertTrue("belongsTo should return TRUE with same credentials as were passed to the constructor", i4Path.belongsTo(credentials));
+        Assert.assertEquals("Incorrect owner account", acct, i4Path.getOwnerAccount());
+        Assert.assertEquals("Incorrect UTF7-encoded path", "\"home/%/%\"", i4Path.asUtf7String());
     }
 }

--- a/store/src/java-test/com/zimbra/cs/imap/ImapPathTest.java
+++ b/store/src/java-test/com/zimbra/cs/imap/ImapPathTest.java
@@ -1,0 +1,83 @@
+package com.zimbra.cs.imap;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.Set;
+
+import junit.framework.Assert;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.mailbox.MailItem.Type;
+
+public class ImapPathTest {
+
+    private static final String LOCAL_USER = "localimaptest@zimbra.com";
+    private Account acct = null;
+    private Mailbox mbox = null;
+
+    @BeforeClass
+    public static void init() throws Exception {
+        MailboxTestUtil.initServer();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        MailboxTestUtil.clearData();
+        Provisioning prov = Provisioning.getInstance();
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraId, "12aa345b-2b47-44e6-8cb8-7fdfa18c1a9f");
+        acct = prov.createAccount(LOCAL_USER, "secret", attrs);
+        mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        MailboxTestUtil.clearData();
+    }
+
+    @Test
+    public void testWildCardStar() throws Exception {
+        ImapCredentials credentials = new ImapCredentials(acct, ImapCredentials.EnabledHack.NONE);
+        ImapPath i4Path = new ImapPath("*", credentials, ImapPath.Scope.UNPARSED);
+        Assert.assertNotNull("Should be able to instantiate ImapPath for '*'", i4Path);
+        String owner = i4Path.getOwner();
+        Assert.assertNull("owner part of the path should be null", owner);
+        Assert.assertTrue("belongsTo should return TRUE with same credentials as were passed to the constructor", i4Path.belongsTo(credentials));
+        Assert.assertEquals("Incorrect owner account", acct, i4Path.getOwnerAccount());
+        Assert.assertEquals("Incorrect UTF7-encoded path", "\"*\"", i4Path.asUtf7String());
+    }
+
+    @Test
+    public void testWildCardPercent() throws Exception {
+        ImapCredentials credentials = new ImapCredentials(acct, ImapCredentials.EnabledHack.NONE);
+        ImapPath i4Path = new ImapPath("%", credentials, ImapPath.Scope.UNPARSED);
+        Assert.assertNotNull("Should be able to instantiate ImapPath for '*'", i4Path);
+        String owner = i4Path.getOwner();
+        Assert.assertNull("owner part of the path should be null", owner);
+        Assert.assertTrue("belongsTo should return TRUE with same credentials as were passed to the constructor", i4Path.belongsTo(credentials));
+        Assert.assertEquals("Incorrect owner account", acct, i4Path.getOwnerAccount());
+        Assert.assertEquals("Incorrect UTF7-encoded path", "\"%\"", i4Path.asUtf7String());
+    }
+
+    @Test
+    public void testWildCardPercent2() throws Exception {
+        ImapCredentials credentials = new ImapCredentials(acct, ImapCredentials.EnabledHack.NONE);
+        ImapPath i4Path = new ImapPath("%/%", credentials, ImapPath.Scope.UNPARSED);
+        Assert.assertNotNull("Should be able to instantiate ImapPath for '*'", i4Path);
+        String owner = i4Path.getOwner();
+        Assert.assertNull("owner part of the path should be null", owner);
+        Assert.assertTrue("belongsTo should return TRUE with same credentials as were passed to the constructor", i4Path.belongsTo(credentials));
+        Assert.assertEquals("Incorrect owner account", acct, i4Path.getOwnerAccount());
+        Assert.assertEquals("Incorrect UTF7-encoded path", "\"%/%\"", i4Path.asUtf7String());
+    }
+}

--- a/store/src/java-test/com/zimbra/cs/imap/ImapPathTest.java
+++ b/store/src/java-test/com/zimbra/cs/imap/ImapPathTest.java
@@ -1,9 +1,6 @@
 package com.zimbra.cs.imap;
 
-import static org.junit.Assert.*;
-
 import java.util.HashMap;
-import java.util.Set;
 
 import junit.framework.Assert;
 
@@ -14,16 +11,12 @@ import org.junit.Test;
 
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.Provisioning;
-import com.zimbra.cs.mailbox.Mailbox;
-import com.zimbra.cs.mailbox.MailboxManager;
 import com.zimbra.cs.mailbox.MailboxTestUtil;
-import com.zimbra.cs.mailbox.MailItem.Type;
 
 public class ImapPathTest {
 
     private static final String LOCAL_USER = "localimaptest@zimbra.com";
     private Account acct = null;
-    private Mailbox mbox = null;
 
     @BeforeClass
     public static void init() throws Exception {
@@ -37,7 +30,6 @@ public class ImapPathTest {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraId, "12aa345b-2b47-44e6-8cb8-7fdfa18c1a9f");
         acct = prov.createAccount(LOCAL_USER, "secret", attrs);
-        mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
     }
 
     @After

--- a/store/src/java/com/zimbra/cs/imap/ImapPath.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapPath.java
@@ -89,7 +89,7 @@ public class ImapPath implements Comparable<ImapPath> {
 
         if (imapPath.toLowerCase().startsWith(NAMESPACE_PREFIX)) {
             String imapPathNoPrefix = imapPath.substring(NAMESPACE_PREFIX.length());
-            if (imapPathNoPrefix.length() > 0 && !imapPathNoPrefix.startsWith("/")) {
+            if (imapPathNoPrefix.length() > 0 && !imapPathNoPrefix.startsWith("/") && imapPathNoPrefix.indexOf("*") < 0 && imapPathNoPrefix.indexOf("%") < 0) {
                 int slash = imapPathNoPrefix.indexOf('/');
                 mOwner = (slash == -1 ? imapPathNoPrefix : imapPathNoPrefix.substring(0, slash)).toLowerCase();
                 mPath = (slash == -1 ? "" : imapPathNoPrefix.substring(slash));
@@ -110,7 +110,7 @@ public class ImapPath implements Comparable<ImapPath> {
             mPath = "Sent" + mPath.substring(10);
         }
         //for LIST *, LIST % and LIST %/% we do not need an instance of ImapFolderStore
-        if(!mPath.startsWith("*") && !mPath.startsWith("%")) {
+        if(mPath.indexOf("*") < 0 && mPath.indexOf("%") < 0) {
             try {
                 this.imapFolderStore = getImapFolderStore();
             } catch (ServiceException e) {

--- a/store/src/java/com/zimbra/cs/imap/ImapPath.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapPath.java
@@ -109,10 +109,15 @@ public class ImapPath implements Comparable<ImapPath> {
                 lcname.startsWith("sent items") && (lcname.length() == 10 || lcname.charAt(10) == '/')) {
             mPath = "Sent" + mPath.substring(10);
         }
-        try {
-            this.imapFolderStore = getImapFolderStore();
-        } catch (ServiceException e) {
-            ZimbraLog.imap.error(e);
+        //for LIST *, LIST % and LIST %/% we do not need an instance of ImapFolderStore
+        if(!mPath.startsWith("*") && !mPath.startsWith("%")) {
+            try {
+                this.imapFolderStore = getImapFolderStore();
+            } catch (ServiceException e) {
+                ZimbraLog.imap.error("Failed to instantiate IMAP Folder Store for %s", mPath, e);
+            }
+        } else {
+            ZimbraLog.imap.debug("Wll not instantiate IMAP Folder store for %s", mPath);
         }
     }
 
@@ -212,10 +217,6 @@ public class ImapPath implements Comparable<ImapPath> {
 
     protected ImapCredentials getCredentials() {
         return mCredentials;
-    }
-
-    public ImapFolderStore getFolderStore() {
-        return imapFolderStore;
     }
 
     protected boolean belongsTo(ImapCredentials creds) throws ServiceException {
@@ -540,7 +541,7 @@ public class ImapPath implements Comparable<ImapPath> {
     }
 
     protected boolean isSelectable() throws ServiceException {
-        if (!isVisible() || imapFolderStore.isUserRootFolder() || imapFolderStore.isIMAPDeleted()) {
+        if (imapFolderStore == null || !isVisible() || imapFolderStore.isUserRootFolder() || imapFolderStore.isIMAPDeleted()) {
             return false;
         }
         return (mReferent == this ? true : mReferent.isSelectable());


### PR DESCRIPTION
The bug is that IMAP Server logs exceptions in mailbox.log/imapd.log when IMAP Client sends LIST requests with wildcards. The response of the server is correct and is the same as on 'develop' branch, but the exceptions are a new behavior. The exceptions are caused by a change that I made a while ago ( f999ccf8bc04811ffc0cdb8797caa3232aa3bcd6 (initialize ImapFolderStore to avoid NPEs. IMAP works locally now)). 
The fix is to skip initializing ImapFolderStore for folder paths that cannot be recognized by SOAP interface. To make sure that this change does not cause any NPEs, I added unit tests that check all methods of ImapPath, which are called in doLIST.