### PR TITLE
ZCS-777 : Fix possible XXE [CWE-611] Issues

### DIFF
--- a/common/src/java-test/com/zimbra/common/soap/W3cDomUtilTest.java
+++ b/common/src/java-test/com/zimbra/common/soap/W3cDomUtilTest.java
@@ -1,0 +1,60 @@
+package com.zimbra.common.soap;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.transform.TransformerFactory;
+
+import org.dom4j.io.SAXReader;
+import org.junit.Test;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
+
+import com.zimbra.common.util.Constants;
+
+import junit.framework.Assert;
+
+public class W3cDomUtilTest {
+    @Test
+    public void testMakeDocumentBuilderFactory() throws ParserConfigurationException {
+        DocumentBuilderFactory dbf = W3cDomUtil.makeDocumentBuilderFactory();
+        Assert.assertTrue(dbf.isNamespaceAware());
+        Assert.assertTrue(dbf.isIgnoringComments());
+        Assert.assertFalse(dbf.isXIncludeAware());
+        Assert.assertFalse(dbf.isExpandEntityReferences());
+        Assert.assertTrue(dbf.getFeature(Constants.DISALLOW_DOCTYPE_DECL));
+        Assert.assertFalse(dbf.getFeature(Constants.EXTERNAL_GENERAL_ENTITIES));
+        Assert.assertFalse(dbf.getFeature(Constants.EXTERNAL_PARAMETER_ENTITIES));
+        Assert.assertFalse(dbf.getFeature(Constants.LOAD_EXTERNAL_DTD));
+    }
+
+    @Test
+    public void testMakeSAXParserFactory() throws XmlParseException, SAXNotRecognizedException, SAXNotSupportedException, ParserConfigurationException {
+        SAXParserFactory sf = W3cDomUtil.makeSAXParserFactory();
+        Assert.assertTrue(sf.isNamespaceAware());
+        Assert.assertFalse(sf.isXIncludeAware());
+        Assert.assertFalse(sf.isValidating());
+        Assert.assertTrue(sf.getFeature(XMLConstants.FEATURE_SECURE_PROCESSING));
+        Assert.assertTrue(sf.getFeature(Constants.DISALLOW_DOCTYPE_DECL));
+        Assert.assertFalse(sf.getFeature(Constants.EXTERNAL_GENERAL_ENTITIES));
+        Assert.assertFalse(sf.getFeature(Constants.EXTERNAL_PARAMETER_ENTITIES));
+        Assert.assertFalse(sf.getFeature(Constants.LOAD_EXTERNAL_DTD));
+    }
+
+    @Test
+    public void testGetDom4jSAXReaderWhichUsesSecureProcessing() throws XmlParseException, SAXException {
+        SAXReader reader = W3cDomUtil.getDom4jSAXReaderWhichUsesSecureProcessing();
+        Assert.assertTrue(reader.getXMLReader().getFeature(Constants.DISALLOW_DOCTYPE_DECL));
+        Assert.assertFalse(reader.getXMLReader().getFeature(Constants.EXTERNAL_GENERAL_ENTITIES));
+        Assert.assertFalse(reader.getXMLReader().getFeature(Constants.EXTERNAL_PARAMETER_ENTITIES));
+    }
+
+    @Test
+    public void testMakeTransformerFactory() {
+        TransformerFactory factory = W3cDomUtil.makeTransformerFactory();
+        Assert.assertEquals("", factory.getAttribute(XMLConstants.ACCESS_EXTERNAL_DTD));
+        Assert.assertEquals("", factory.getAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET));
+    }
+}

--- a/common/src/java-test/com/zimbra/common/util/QuotedTextUtilTest.java
+++ b/common/src/java-test/com/zimbra/common/util/QuotedTextUtilTest.java
@@ -17,9 +17,12 @@
 
 package com.zimbra.common.util;
 
-import junit.framework.Assert;
+import javax.xml.XMLConstants;
+import javax.xml.transform.TransformerFactory;
 
 import org.junit.Test;
+
+import junit.framework.Assert;
 
 public class QuotedTextUtilTest {
 
@@ -117,5 +120,12 @@ public class QuotedTextUtilTest {
             + "<DIV dir=\"ltr\">This is my reply<BR>\n<DIV>\n<DIV class=\"gmail_extra\">\n"
             + "<BR>\n</DIV>\n</DIV>\n</DIV>\n</BODY>\n</HTML>\n";
         Assert.assertEquals(expected, originalContent);
+    }
+
+    @Test
+    public void testMakeTransformerFactory() {
+        TransformerFactory factory = QuotedTextUtil.makeTransformerFactory();
+        Assert.assertEquals("", factory.getAttribute(XMLConstants.ACCESS_EXTERNAL_DTD));
+        Assert.assertEquals("", factory.getAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET));
     }
 }

--- a/common/src/java/com/zimbra/common/soap/W3cDomUtil.java
+++ b/common/src/java/com/zimbra/common/soap/W3cDomUtil.java
@@ -34,6 +34,7 @@ import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.TransformerFactoryConfigurationError;
@@ -57,6 +58,7 @@ import com.google.common.base.Strings;
 import com.google.common.io.Closeables;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element.ElementFactory;
+import com.zimbra.common.util.Constants;
 import com.zimbra.common.util.Log;
 import com.zimbra.common.util.ZimbraLog;
 
@@ -70,19 +72,7 @@ public class W3cDomUtil {
             @Override
             protected javax.xml.parsers.DocumentBuilder initialValue() {
                 try {
-                    DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-                    dbf.setNamespaceAware(true);
-                    dbf.setIgnoringComments(true);
-                    // Prevent external entity reference attack.
-                    dbf.setExpandEntityReferences(false);
-                    dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
-                    // protect against recursive entity expansion DOS attack and perhaps other things
-                    dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-                    try {
-                        dbf.setAttribute("http://apache.org/xml/features/disallow-doctype-decl", true);
-                    } catch (IllegalArgumentException iae) {
-                        ZimbraLog.misc.debug("Disabling doctype-decl not supported", iae);
-                    }
+                    DocumentBuilderFactory dbf = makeDocumentBuilderFactory();
                     return dbf.newDocumentBuilder();
                 } catch (javax.xml.parsers.ParserConfigurationException pce) {
                     ZimbraLog.misc.error("Problem setting up w3c DOM builder", pce);
@@ -91,22 +81,32 @@ public class W3cDomUtil {
             }
     };
 
+    public static DocumentBuilderFactory makeDocumentBuilderFactory() throws ParserConfigurationException {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(true);
+        dbf.setIgnoringComments(true);
+        // protect against recursive entity expansion DOS attack and perhaps other things
+        dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        try {
+            // XXE attack prevention
+            dbf.setFeature(Constants.DISALLOW_DOCTYPE_DECL, true);
+            dbf.setFeature(Constants.EXTERNAL_GENERAL_ENTITIES, false);
+            dbf.setFeature(Constants.EXTERNAL_PARAMETER_ENTITIES, false);
+            dbf.setFeature(Constants.LOAD_EXTERNAL_DTD, false);
+            dbf.setXIncludeAware(false);
+            dbf.setExpandEntityReferences(false);
+        } catch (IllegalArgumentException iae) {
+            ZimbraLog.misc.debug("Disabling doctype-decl not supported", iae);
+        }
+        return dbf;
+    }
+
     public static DocumentBuilder getBuilder() {
         return w3DomBuilderTL.get();
     }
 
     public static SAXParser getDom4jSAXParserWhichUsesSecureProcessing() throws XmlParseException {
-        SAXParserFactory factory = SAXParserFactory.newInstance();
-        factory.setNamespaceAware(true);
-        factory.setXIncludeAware(false);
-        factory.setValidating(false);
-        try {
-            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-        } catch (SAXNotRecognizedException | SAXNotSupportedException | ParserConfigurationException ex) {
-            ZimbraLog.misc.error("Problem setting up SAXParser which supports secure XML processing", ex);
-            throw XmlParseException.PARSE_ERROR();
-        }
+        SAXParserFactory factory = makeSAXParserFactory();
         try {
             return factory.newSAXParser();
         } catch (ParserConfigurationException | SAXException e) {
@@ -114,6 +114,25 @@ public class W3cDomUtil {
             throw XmlParseException.PARSE_ERROR();
         }
     };
+
+    public static SAXParserFactory makeSAXParserFactory() throws XmlParseException {
+        SAXParserFactory factory = SAXParserFactory.newInstance();
+        factory.setNamespaceAware(true);
+        factory.setXIncludeAware(false);
+        factory.setValidating(false);
+        try {
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            // XXE attack prevention
+            factory.setFeature(Constants.DISALLOW_DOCTYPE_DECL, true);
+            factory.setFeature(Constants.EXTERNAL_GENERAL_ENTITIES, false);
+            factory.setFeature(Constants.EXTERNAL_PARAMETER_ENTITIES, false);
+            factory.setFeature(Constants.LOAD_EXTERNAL_DTD, false);
+        } catch (SAXNotRecognizedException | SAXNotSupportedException | ParserConfigurationException ex) {
+            ZimbraLog.misc.error("Problem setting up SAXParser which supports secure XML processing", ex);
+            throw XmlParseException.PARSE_ERROR();
+        }
+        return factory;
+    }
 
     public static SAXReader getDom4jSAXReaderWhichUsesSecureProcessing()
     throws XmlParseException, SAXException {
@@ -123,6 +142,9 @@ public class W3cDomUtil {
     public static SAXReader getDom4jSAXReaderWhichUsesSecureProcessing(DocumentFactory fact)
     throws XmlParseException, SAXException {
         SAXReader dom4jSAXReader = new SAXReader(getDom4jSAXParserWhichUsesSecureProcessing().getXMLReader());
+        dom4jSAXReader.setFeature(Constants.DISALLOW_DOCTYPE_DECL, true);
+        dom4jSAXReader.setFeature(Constants.EXTERNAL_GENERAL_ENTITIES, false);
+        dom4jSAXReader.setFeature(Constants.EXTERNAL_PARAMETER_ENTITIES, false);
         if (null != fact) {
             dom4jSAXReader.setDocumentFactory(fact);
         }
@@ -134,7 +156,7 @@ public class W3cDomUtil {
         @Override
         protected Transformer initialValue() {
             try {
-                TransformerFactory transformerFactory = TransformerFactory.newInstance();
+                TransformerFactory transformerFactory = makeTransformerFactory();
                 Transformer transformer = transformerFactory.newTransformer();
                 transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
                 return transformer;
@@ -146,6 +168,13 @@ public class W3cDomUtil {
             return null;
         }
     };
+
+    public static TransformerFactory makeTransformerFactory() {
+        TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+        return transformerFactory;
+    }
 
     /**
      * Return a pretty view of the XML fragment represented by {@code node}

--- a/common/src/java/com/zimbra/common/soap/W3cDomUtil.java
+++ b/common/src/java/com/zimbra/common/soap/W3cDomUtil.java
@@ -34,7 +34,6 @@ import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.TransformerFactoryConfigurationError;

--- a/common/src/java/com/zimbra/common/util/Constants.java
+++ b/common/src/java/com/zimbra/common/util/Constants.java
@@ -38,4 +38,9 @@ public class Constants {
 
     public static final String CSRF_TOKEN = "X-Zimbra-Csrf-Token";
     public static final String ERROR_CODE_NO_SUCH_DOMAIN = "account.NO_SUCH_DOMAIN";
+
+    public static final String DISALLOW_DOCTYPE_DECL = "http://apache.org/xml/features/disallow-doctype-decl";
+    public static final String EXTERNAL_GENERAL_ENTITIES = "http://xml.org/sax/features/external-general-entities";
+    public static final String EXTERNAL_PARAMETER_ENTITIES = "http://xml.org/sax/features/external-parameter-entities";
+    public static final String LOAD_EXTERNAL_DTD = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
 }

--- a/common/src/java/com/zimbra/common/util/QuotedTextUtil.java
+++ b/common/src/java/com/zimbra/common/util/QuotedTextUtil.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.xml.XMLConstants;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
@@ -766,7 +767,7 @@ public class QuotedTextUtil {
         try {
             StringWriter writer = new StringWriter();
             StreamResult result = new StreamResult(writer);
-            TransformerFactory factory = TransformerFactory.newInstance();
+            TransformerFactory factory = makeTransformerFactory();
             Transformer transformer = factory.newTransformer();
             transformer.transform(new DOMSource(document), result);
             return writer.toString();
@@ -774,5 +775,12 @@ public class QuotedTextUtil {
             ZimbraLog.soap.warn("Exception in converting DOM to html", e);
         }
         return null;
+    }
+
+    public static TransformerFactory makeTransformerFactory() {
+        TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+        return transformerFactory;
     }
 }

--- a/soap/src/java-test/com/zimbra/soap/util/XsdCleanerTest.java
+++ b/soap/src/java-test/com/zimbra/soap/util/XsdCleanerTest.java
@@ -1,0 +1,34 @@
+package com.zimbra.soap.util;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerFactory;
+
+import org.junit.Test;
+
+import com.zimbra.common.util.Constants;
+
+import junit.framework.Assert;
+
+public class XsdCleanerTest {
+    @Test
+    public void testMakeDocumentBuilderFactory() throws ParserConfigurationException {
+        DocumentBuilderFactory dbf = XsdCleaner.makeDocumentBuilderFactory();
+        Assert.assertTrue(dbf.isNamespaceAware());
+        Assert.assertTrue(dbf.isIgnoringComments());
+        Assert.assertFalse(dbf.isXIncludeAware());
+        Assert.assertFalse(dbf.isExpandEntityReferences());
+        Assert.assertTrue(dbf.getFeature(Constants.DISALLOW_DOCTYPE_DECL));
+        Assert.assertFalse(dbf.getFeature(Constants.EXTERNAL_GENERAL_ENTITIES));
+        Assert.assertFalse(dbf.getFeature(Constants.EXTERNAL_PARAMETER_ENTITIES));
+        Assert.assertFalse(dbf.getFeature(Constants.LOAD_EXTERNAL_DTD));
+    }
+
+    @Test
+    public void testMakeTransformerFactory() {
+        TransformerFactory factory = XsdCleaner.makeTransformerFactory();
+        Assert.assertEquals("", factory.getAttribute(XMLConstants.ACCESS_EXTERNAL_DTD));
+        Assert.assertEquals("", factory.getAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET));
+    }
+}

--- a/store/src/java-test/com/zimbra/cs/html/XHtmlDefangTest.java
+++ b/store/src/java-test/com/zimbra/cs/html/XHtmlDefangTest.java
@@ -1,0 +1,27 @@
+package com.zimbra.cs.html;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParserFactory;
+
+import org.junit.Test;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
+
+import com.zimbra.common.soap.XmlParseException;
+import com.zimbra.common.util.Constants;
+
+import junit.framework.Assert;
+
+public class XHtmlDefangTest {
+    @Test
+    public void testMakeSAXParserFactory() throws XmlParseException, SAXNotRecognizedException, SAXNotSupportedException, ParserConfigurationException {
+        SAXParserFactory sf = XHtmlDefang.makeSAXParserFactory();
+        Assert.assertTrue(sf.getFeature(XMLConstants.FEATURE_SECURE_PROCESSING));
+        Assert.assertTrue(sf.getFeature(Constants.DISALLOW_DOCTYPE_DECL));
+        Assert.assertFalse(sf.getFeature(Constants.EXTERNAL_GENERAL_ENTITIES));
+        Assert.assertFalse(sf.getFeature(Constants.EXTERNAL_PARAMETER_ENTITIES));
+        Assert.assertFalse(sf.getFeature(Constants.LOAD_EXTERNAL_DTD));
+    }
+
+}

--- a/store/src/java-test/com/zimbra/cs/service/AutoDiscoverServletTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/AutoDiscoverServletTest.java
@@ -17,9 +17,16 @@
 
 package com.zimbra.cs.service;
 
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerFactory;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import com.zimbra.common.util.Constants;
 
 
 /**
@@ -49,4 +56,20 @@ public class AutoDiscoverServletTest {
         Assert.assertTrue(result);
     }
 
+    @Test
+    public void testMakeDocumentBuilderFactory() throws ParserConfigurationException {
+        DocumentBuilderFactory dbf = AutoDiscoverServlet.makeDocumentBuilderFactory();
+        Assert.assertTrue(dbf.isNamespaceAware());
+        Assert.assertTrue(dbf.getFeature(Constants.DISALLOW_DOCTYPE_DECL));
+        Assert.assertFalse(dbf.getFeature(Constants.EXTERNAL_GENERAL_ENTITIES));
+        Assert.assertFalse(dbf.getFeature(Constants.EXTERNAL_PARAMETER_ENTITIES));
+        Assert.assertFalse(dbf.getFeature(Constants.LOAD_EXTERNAL_DTD));
+    }
+
+    @Test
+    public void testMakeTransformerFactory() {
+        TransformerFactory factory = AutoDiscoverServlet.makeTransformerFactory();
+        Assert.assertEquals("", factory.getAttribute(XMLConstants.ACCESS_EXTERNAL_DTD));
+        Assert.assertEquals("", factory.getAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET));
+    }
 }

--- a/store/src/java/com/zimbra/cs/html/XHtmlDefang.java
+++ b/store/src/java/com/zimbra/cs/html/XHtmlDefang.java
@@ -21,12 +21,17 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.io.Writer;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
+
+import com.zimbra.common.util.Constants;
 
 /**
  * Makes xhtml and svg content safe for display
@@ -51,11 +56,9 @@ public class XHtmlDefang extends AbstractDefang{
 
     protected void defang(InputSource is, boolean neuterImages, Writer out)
             throws IOException {
-        //get a factory
-        SAXParserFactory spf = SAXParserFactory.newInstance();
         try {
-            spf.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            spf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            //get a factory
+            SAXParserFactory spf = makeSAXParserFactory();
             //get a new instance of parser            
             SAXParser sp = spf.newSAXParser();
             
@@ -74,6 +77,15 @@ public class XHtmlDefang extends AbstractDefang{
         
     }
 
-
-    
+    public static SAXParserFactory makeSAXParserFactory() throws SAXNotRecognizedException, SAXNotSupportedException, ParserConfigurationException {
+        //get a factory
+        SAXParserFactory factory = SAXParserFactory.newInstance();
+        // XXE attack prevention
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setFeature(Constants.DISALLOW_DOCTYPE_DECL, true);
+        factory.setFeature(Constants.EXTERNAL_GENERAL_ENTITIES, false);
+        factory.setFeature(Constants.EXTERNAL_PARAMETER_ENTITIES, false);
+        factory.setFeature(Constants.LOAD_EXTERNAL_DTD, false);
+        return factory;
+    }
 }


### PR DESCRIPTION
Problem : possible XXE

Fix : applied fixes on factory classes as per XXE prevention cheat sheet (Ref. : https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet)

Testing done : 
1) Unit tests to verify applied changes
2) ant test in zm-wsdl-test repo(no failures because of current changes)
3) Verified EWS.wsdl and ZimbraService.wsdl, none of them are using any includes or any external entities

Testing to be done by QA :
1) full soap/ews automation run and sanity testing around category and outbound messages in EWS