### PR TITLE
ZCS-1169:mandate "require" for Sieve extension

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -15375,6 +15375,21 @@ public class ZAttrProvisioning {
     public static final String A_zimbraSieveRejectMailEnabled = "zimbraSieveRejectMailEnabled";
 
     /**
+     * Whether the declaration of the Sieve extension feature is mandatory by
+     * the &#039;require&#039; control. If TRUE, before ZCS evaluates a Sieve
+     * extension test or action, it checks the corresponding capability
+     * string at &#039;require&#039; control; and if the capability string is
+     * not declared in the &#039;require&#039;, the entire Sieve filter
+     * execution will be failed. If FALSE, any Sieve extensions can be used
+     * without declaring the capability string in the &#039;require&#039;
+     * control.
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2118)
+    public static final String A_zimbraSieveRequireControlRFCCompliant = "zimbraSieveRequireControlRFCCompliant";
+
+    /**
      * Unique ID for an signature
      */
     @ZAttr(id=490)

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -15387,7 +15387,7 @@ public class ZAttrProvisioning {
      * @since ZCS 8.7.8
      */
     @ZAttr(id=2118)
-    public static final String A_zimbraSieveRequireControlRFCCompliant = "zimbraSieveRequireControlRFCCompliant";
+    public static final String A_zimbraSieveRequireControlEnabled = "zimbraSieveRequireControlEnabled";
 
     /**
      * Unique ID for an signature

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9496,5 +9496,10 @@ TODO: delete them permanently from here
   <globalConfigValue>TRUE</globalConfigValue>
   <desc>Whether to enable zimbra network next generation modules.</desc>
 </attr>
+
+<attr id="2118" name="zimbraSieveRequireControlRFCCompliant" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.8">
+<defaultCOSValue>FALSE</defaultCOSValue>
+<desc>Whether the declaration of the Sieve extension feature is mandatory by the 'require' control. If TRUE, before ZCS evaluates a Sieve extension test or action, it checks the corresponding capability string at 'require' control; and if the capability string is not declared in the 'require', the entire Sieve filter execution will be failed. If FALSE, any Sieve extensions can be used without declaring the capability string in the 'require' control.</desc>
+</attr>
 </attrs>
 

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9497,8 +9497,8 @@ TODO: delete them permanently from here
   <desc>Whether to enable zimbra network next generation modules.</desc>
 </attr>
 
-<attr id="2118" name="zimbraSieveRequireControlRFCCompliant" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.8">
-<defaultCOSValue>FALSE</defaultCOSValue>
+<attr id="2118" name="zimbraSieveRequireControlEnabled" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.8">
+<defaultCOSValue>TRUE</defaultCOSValue>
 <desc>Whether the declaration of the Sieve extension feature is mandatory by the 'require' control. If TRUE, before ZCS evaluates a Sieve extension test or action, it checks the corresponding capability string at 'require' control; and if the capability string is not declared in the 'require', the entire Sieve filter execution will be failed. If FALSE, any Sieve extensions can be used without declaring the capability string in the 'require' control.</desc>
 </attr>
 </attrs>

--- a/store/src/java-test/com/zimbra/cs/filter/AddHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/AddHeaderTest.java
@@ -324,7 +324,7 @@ public class AddHeaderTest {
                 + "from: test2@zimbra.com\n"
                 + "to: test@zimbra.com\n";
 
-        String filterScript = "require [\"editheader\"];\n"
+        String filterScript = "require [\"editheader\", \"variables\"];\n"
                 + "if header :matches \"Subject\" \"*\" {\n"
                 + " addheader \"my-new-header\" \"${1}\";\n"
                 + "}";

--- a/store/src/java-test/com/zimbra/cs/filter/EnvelopeTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/EnvelopeTest.java
@@ -55,8 +55,7 @@ public class EnvelopeTest {
     public static void init() throws Exception {
         MailboxTestUtil.initServer();
         Provisioning prov = Provisioning.getInstance();
-        Account account = prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
-        account.setSieveRequireControlRFCCompliant(true);
+        prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
         prov.createAccount("original@zimbra.com", "secret", new HashMap<String, Object>());
     }
 

--- a/store/src/java-test/com/zimbra/cs/filter/EnvelopeTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/EnvelopeTest.java
@@ -55,7 +55,8 @@ public class EnvelopeTest {
     public static void init() throws Exception {
         MailboxTestUtil.initServer();
         Provisioning prov = Provisioning.getInstance();
-        prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
+        Account account = prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
+        account.setSieveRequireControlRFCCompliant(true);
         prov.createAccount("original@zimbra.com", "secret", new HashMap<String, Object>());
     }
 
@@ -434,7 +435,7 @@ public class EnvelopeTest {
 
     @Ignore
     public void testVariable1() {
-        String filterScript = "require \"envelope\";\n"
+        String filterScript = "require [\"variables\", \"envelope\"];\n"
                 + "if envelope :matches [\"from\"] \"*\" {\n"
                 + "  tag \"env_${1}\";\n"
                 + "}\n"
@@ -461,7 +462,7 @@ public class EnvelopeTest {
      */
     @Ignore
     public void testVariable2() {
-        String filterScript = "require \"envelope\";\n"
+        String filterScript = "require [\"variables\", \"envelope\"];\n"
                 + "if envelope :matches [\"from\"] \"*\" {\n"
                 + "  tag \"env_${1}\";\n"
                 + "}\n"
@@ -652,7 +653,7 @@ public class EnvelopeTest {
 
     @Test
     public void testTo_Alias() {
-        String filterScript = "require \"envelope\";\n"
+        String filterScript = "require [\"variables\", \"envelope\"];\n"
                 + "set \"rcptto\" \"unknown\";\n"
                 + "if envelope :all :matches \"to\" \"*\" {\n"
                 + "  set \"rcptto\" \"${1}\";\n"

--- a/store/src/java-test/com/zimbra/cs/filter/FileIntoCopyTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/FileIntoCopyTest.java
@@ -51,7 +51,6 @@ public class FileIntoCopyTest {
         Provisioning prov = Provisioning.getInstance();
         Account acct = prov.createAccount("test@zimbra.com", "secret",
             new HashMap<String, Object>());
-        acct.setSieveRequireControlRFCCompliant(true);
         Server server = Provisioning.getInstance().getServer(acct);
     }
 
@@ -520,7 +519,7 @@ public class FileIntoCopyTest {
                 + "\n" + "Hello World.";
 
             // Capability string is mandatory ==> :copy extension will be failed
-            account.setSieveRequireControlRFCCompliant(true);
+            account.setSieveRequireControlEnabled(true);
             List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox),
                 mbox, new ParsedMessage(raw.getBytes(), false), 0, account.getName(),
                 new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
@@ -529,7 +528,7 @@ public class FileIntoCopyTest {
             Assert.assertEquals(Mailbox.ID_FOLDER_INBOX, msg.getFolderId());
 
             // Capability string is optional ==> :copy extension should be available
-            account.setSieveRequireControlRFCCompliant(false);
+            account.setSieveRequireControlEnabled(false);
             ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox),
                 mbox, new ParsedMessage(raw.getBytes(), false), 0, account.getName(),
                 new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);

--- a/store/src/java-test/com/zimbra/cs/filter/FilterUtilTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/FilterUtilTest.java
@@ -40,6 +40,8 @@ import com.zimbra.cs.mailbox.MailboxTestUtil;
 import com.zimbra.cs.mailbox.OperationContext;
 import com.zimbra.cs.mime.ParsedMessage;
 
+import static com.zimbra.cs.filter.JsieveConfigMapHandler.CAPABILITY_VARIABLES;
+
 /**
  * Unit tests for {@link FilterUtil}.
  */
@@ -94,6 +96,7 @@ public class FilterUtilTest {
      */
     private ZimbraMailAdapter initZimbraMailAdapter() throws ServiceException {
         Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        account.setSieveRequireControlRFCCompliant(true);
         RuleManager.clearCachedRules(account);
         Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
@@ -121,6 +124,7 @@ public class FilterUtilTest {
 
             // Variable feature: ON
             mailAdapter.setVariablesExtAvailable(ZimbraMailAdapter.VARIABLEFEATURETYPE.AVAILABLE);
+            mailAdapter.addCapabilities(CAPABILITY_VARIABLES);
 
             String varValue = FilterUtil.replaceVariables(mailAdapter, "${var}");
             Assert.assertEquals("hello", varValue);
@@ -191,6 +195,7 @@ public class FilterUtilTest {
         try {
             ZimbraMailAdapter mailAdapter = initZimbraMailAdapter();
             mailAdapter.setVariablesExtAvailable(ZimbraMailAdapter.VARIABLEFEATURETYPE.AVAILABLE);
+            mailAdapter.addCapabilities(CAPABILITY_VARIABLES);
 
             String varValue = FilterUtil.replaceVariables(mailAdapter, "${va\\r}");
             Assert.assertEquals("hello", varValue);

--- a/store/src/java-test/com/zimbra/cs/filter/FilterUtilTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/FilterUtilTest.java
@@ -96,7 +96,6 @@ public class FilterUtilTest {
      */
     private ZimbraMailAdapter initZimbraMailAdapter() throws ServiceException {
         Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
-        account.setSieveRequireControlRFCCompliant(true);
         RuleManager.clearCachedRules(account);
         Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 

--- a/store/src/java-test/com/zimbra/cs/filter/GetFilterRulesTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/GetFilterRulesTest.java
@@ -42,8 +42,7 @@ public class GetFilterRulesTest {
     public static void init() throws Exception {
         MailboxTestUtil.initServer();
         Provisioning prov = Provisioning.getInstance();
-        Account account = prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
-        account.setSieveRequireControlRFCCompliant(true);
+        prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
     }
 
     @Before

--- a/store/src/java-test/com/zimbra/cs/filter/GetFilterRulesTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/GetFilterRulesTest.java
@@ -42,7 +42,8 @@ public class GetFilterRulesTest {
     public static void init() throws Exception {
         MailboxTestUtil.initServer();
         Provisioning prov = Provisioning.getInstance();
-        prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
+        Account account = prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
+        account.setSieveRequireControlRFCCompliant(true);
     }
 
     @Before
@@ -55,7 +56,7 @@ public class GetFilterRulesTest {
         try {
             // - no 'allof' 'anyof' tests
             String filterScript
-            = "require \"tag\";"
+            = "require \"fileinto\";"
                     + "if header :comparator \"i;ascii-casemap\" :matches \"Subject\" \"*\" {"
                     + "  fileinto \"if-block\";"
                     + "}";
@@ -91,7 +92,7 @@ public class GetFilterRulesTest {
         try {
             // - 'allof' and 'anyof' tests
             String filterScript
-            = "require \"tag\";"
+            = "require \"fileinto\";"
                     + "if allof (header :comparator \"i;ascii-casemap\" :matches \"Subject\" \"*\") {"
                     + "  fileinto \"if-block1\";"
                     + "}"
@@ -139,7 +140,7 @@ public class GetFilterRulesTest {
             // - no 'allof' 'anyof' tests
             // - nested if
             String filterScript
-            = "require \"tag\";"
+            = "require \"fileinto\";"
                     + "if header :comparator \"i;ascii-casemap\" :matches \"Subject\" \"*\" {"
                     + "  if header :matches \"From\" \"*\" {"
                     + "    fileinto \"nested-if-block\";"
@@ -184,7 +185,7 @@ public class GetFilterRulesTest {
             // - no 'allof' and 'anyof' test for the outer if block
             // - 'anyof' test for the inner if block
             String filterScript
-            = "require \"tag\";"
+            = "require \"fileinto\";"
                     + "if header :comparator \"i;ascii-casemap\" :matches \"Subject\" \"*\" {"
                     + "  if anyof (header :matches \"From\" \"*\","
                     + "            header :matches \"To\"   \"*\") {"
@@ -229,7 +230,7 @@ public class GetFilterRulesTest {
         try {
             // - no if block
             String filterScript
-            = "require \"tag\";"
+            = "require \"fileinto\";"
                     + "fileinto \"no-if-block\";";
             Account account = Provisioning.getInstance().getAccount(
                     MockProvisioning.DEFAULT_ACCOUNT_ID);
@@ -263,7 +264,7 @@ public class GetFilterRulesTest {
         try {
             // - multiple no if block
             String filterScript
-            = "require \"tag\";"
+            = "require \"fileinto\";"
                     + "fileinto \"no-if-block1\";"
                     + "fileinto \"no-if-block2\";";
 
@@ -300,7 +301,7 @@ public class GetFilterRulesTest {
         try {
             // - no if block, then nested if without allof/anyof
             String filterScript
-            = "require \"tag\";"
+            = "require \"fileinto\";"
                     + "fileinto \"no-if-block\";"
                     + "if header :comparator \"i;ascii-casemap\" :matches \"Subject\" \"*\" {"
                     + "  if header :matches \"From\" \"*\" {"
@@ -353,7 +354,7 @@ public class GetFilterRulesTest {
         try {
             // - nested if without allof/anyof, then no if block
             String filterScript
-            = "require \"tag\";"
+            = "require \"fileinto\";"
                     + "if header :comparator \"i;ascii-casemap\" :matches \"Subject\" \"*\" {"
                     + "  if header :matches \"From\" \"*\" {"
                     + "    fileinto \"nested-if-block\";"
@@ -406,7 +407,7 @@ public class GetFilterRulesTest {
         try {
             // - combination of nested if without allof/anyof, and no if block
             String filterScript
-            = "require \"tag\";"
+            = "require \"fileinto\";"
                     + "fileinto \"no-if-block1\";"
                     + "if header :comparator \"i;ascii-casemap\" :matches \"Subject\" \"*\" {"
                     + "  if header :matches \"From\" \"*\" {"

--- a/store/src/java-test/com/zimbra/cs/filter/HeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/HeaderTest.java
@@ -261,8 +261,8 @@ public class HeaderTest {
      */
     @Test
     public void testBackslash() throws Exception {
-        String script =
-            "if header :matches \"X-Header1\" \"sample\\\\pattern\"             { tag \"01\"; }"
+        String script = "require [\"variables\"];\n"
+          + "if header :matches \"X-Header1\" \"sample\\\\pattern\"             { tag \"01\"; }"
           + "if header :matches \"X-Header2\" \"sample\\\\\\\\pattern\"         { tag \"02\"; }"
           + "if header :matches \"X-Header3\" \"sample\\\\\\\\\\\\pattern\"     { tag \"03\"; }"
           + "if header :matches \"X-Header4\" \"sample\\\\\\\\\\\\\\\\pattern\" { tag \"04\"; }"
@@ -330,8 +330,8 @@ public class HeaderTest {
 
     @Test
     public void testHeaderMatchWithItself() throws Exception {
-        String script =
-                "if header :matches \"X-Header1\" \"*\" {"
+        String script = "require [\"variables\"];\n"
+                + "if header :matches \"X-Header1\" \"*\" {"
                 + "    if header :matches \"X-Header1\" \"${1}\" {"
                 + "        tag \"01\";"
                 + "    }"

--- a/store/src/java-test/com/zimbra/cs/filter/NotifyMailtoTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/NotifyMailtoTest.java
@@ -68,8 +68,7 @@ public class NotifyMailtoTest {
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
         attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "TRUE");
-        Account account = prov.createAccount("test1@zimbra.com", "secret", attrs);
-        account.setSieveRequireControlRFCCompliant(true);
+        prov.createAccount("test1@zimbra.com", "secret", attrs);
 
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());

--- a/store/src/java-test/com/zimbra/cs/filter/RedirectCopyTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/RedirectCopyTest.java
@@ -50,8 +50,7 @@ public class RedirectCopyTest {
         prov.createDomain("zimbra.com", attrs);
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
-        Account account = prov.createAccount("test1@zimbra.com", "secret", attrs);
-        account.setSieveRequireControlRFCCompliant(true);
+        prov.createAccount("test1@zimbra.com", "secret", attrs);
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
         Account acct = prov.createAccount("test2@zimbra.com", "secret", attrs);

--- a/store/src/java-test/com/zimbra/cs/filter/RedirectCopyTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/RedirectCopyTest.java
@@ -50,7 +50,8 @@ public class RedirectCopyTest {
         prov.createDomain("zimbra.com", attrs);
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
-        prov.createAccount("test1@zimbra.com", "secret", attrs);
+        Account account = prov.createAccount("test1@zimbra.com", "secret", attrs);
+        account.setSieveRequireControlRFCCompliant(true);
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
         Account acct = prov.createAccount("test2@zimbra.com", "secret", attrs);

--- a/store/src/java-test/com/zimbra/cs/filter/ReplaceHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/ReplaceHeaderTest.java
@@ -187,8 +187,7 @@ public class ReplaceHeaderTest {
 
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
-        Account acct = prov.createAccount("test@zimbra.com", "secret", attrs);
-        acct.setSieveRequireControlRFCCompliant(true);
+        prov.createAccount("test@zimbra.com", "secret", attrs);
 
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());

--- a/store/src/java-test/com/zimbra/cs/filter/ReplaceHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/ReplaceHeaderTest.java
@@ -188,6 +188,7 @@ public class ReplaceHeaderTest {
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
         Account acct = prov.createAccount("test@zimbra.com", "secret", attrs);
+        acct.setSieveRequireControlRFCCompliant(true);
 
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
@@ -808,7 +809,7 @@ public class ReplaceHeaderTest {
     @Test
     public void testReplaceHeaderNonAscii() {
         try {
-           String filterScript = "require [\"editheader\"];\n"
+           String filterScript = "require [\"editheader\", \"variables\"];\n"
                     + "replaceheader :newvalue \"[追加]${1}\" :matches \"Subject\" \"*\";";
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
 
@@ -845,7 +846,7 @@ public class ReplaceHeaderTest {
     @Test
     public void testReplaceHeaderNonAsciiVariables() {
         try {
-           String filterScript = "require [\"editheader\"];\n"
+           String filterScript = "require [\"editheader\", \"variables\"];\n"
                     + "replaceheader :newvalue \"[追加]${1}\" :matches \"Subject\" \"これは複数行に渡る*\";";
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
 

--- a/store/src/java-test/com/zimbra/cs/filter/ReplyTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/ReplyTest.java
@@ -59,7 +59,7 @@ public class ReplyTest {
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
         attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "FALSE");
-        attrs.put(Provisioning.A_zimbraSieveRequireControlRFCCompliant, "TRUE");
+        attrs.put(Provisioning.A_zimbraSieveRequireControlEnabled, "TRUE");
         prov.createAccount("test@zimbra.com", "secret", attrs);
 
         attrs = Maps.newHashMap();

--- a/store/src/java-test/com/zimbra/cs/filter/ReplyTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/ReplyTest.java
@@ -59,6 +59,7 @@ public class ReplyTest {
         attrs = Maps.newHashMap();
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
         attrs.put(Provisioning.A_zimbraSieveNotifyActionRFCCompliant, "FALSE");
+        attrs.put(Provisioning.A_zimbraSieveRequireControlRFCCompliant, "TRUE");
         prov.createAccount("test@zimbra.com", "secret", attrs);
 
         attrs = Maps.newHashMap();
@@ -118,7 +119,8 @@ public class ReplyTest {
             Mailbox mbox2 = MailboxManager.getInstance().getMailboxByAccount(acct2);
 
             RuleManager.clearCachedRules(acct1);
-            String filterScript = "set \"var\" \"World\";\n"
+            String filterScript = "require \"variables\";\n"
+                + "set \"var\" \"World\";\n"
                 + "if anyof (true) { reply \"${Subject} ${var}\"" + "    stop;" + "}";
             acct1.setMailSieveScript(filterScript);
             List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox1),

--- a/store/src/java-test/com/zimbra/cs/filter/RequireTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/RequireTest.java
@@ -49,8 +49,7 @@ public class RequireTest {
     public static void init() throws Exception {
         MailboxTestUtil.initServer();
         Provisioning prov = Provisioning.getInstance();
-        Account account = prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
-        account.setSieveRequireControlRFCCompliant(true);
+        prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
     }
 
     @Before
@@ -109,7 +108,7 @@ public class RequireTest {
                        + "Hello World.";
 
             // 'require' control is mandatory
-            account.setSieveRequireControlRFCCompliant(true);
+            account.setSieveRequireControlEnabled(true);
             List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox), mbox,
                     new ParsedMessage(raw.getBytes(), false), 0, account.getName(), new DeliveryContext(),
                     Mailbox.ID_FOLDER_INBOX, true);
@@ -117,7 +116,7 @@ public class RequireTest {
             Assert.assertEquals(null, ArrayUtil.getFirstElement(msg.getTags()));
 
             // 'require' control is optional
-            account.setSieveRequireControlRFCCompliant(false);
+            account.setSieveRequireControlEnabled(false);
             ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox), mbox,
                     new ParsedMessage(raw.getBytes(), false), 0, account.getName(), new DeliveryContext(),
                     Mailbox.ID_FOLDER_INBOX, true);

--- a/store/src/java-test/com/zimbra/cs/filter/RequireTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/RequireTest.java
@@ -16,6 +16,8 @@
  */
 package com.zimbra.cs.filter;
 
+import static org.junit.Assert.fail;
+
 import java.util.HashMap;
 import java.util.List;
 
@@ -26,24 +28,29 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.zimbra.common.util.ArrayUtil;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.MockProvisioning;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.filter.RuleManager.AdminFilterType;
 import com.zimbra.cs.filter.RuleManager.FilterType;
 import com.zimbra.cs.mailbox.DeliveryContext;
+import com.zimbra.cs.mailbox.Folder;
 import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.MailboxManager;
 import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.mailbox.Message;
 import com.zimbra.cs.mailbox.OperationContext;
 import com.zimbra.cs.mime.ParsedMessage;
+import com.zimbra.cs.service.util.ItemId;
 
 public class RequireTest {
     @BeforeClass
     public static void init() throws Exception {
         MailboxTestUtil.initServer();
         Provisioning prov = Provisioning.getInstance();
-        prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
+        Account account = prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
+        account.setSieveRequireControlRFCCompliant(true);
     }
 
     @Before
@@ -81,5 +88,44 @@ public class RequireTest {
         Assert.assertEquals(requires.get(0), "tag");
         Assert.assertEquals(requires.get(1), "log");
         Assert.assertEquals(requires.get(2), "enotify");
+    }
+
+    @Test
+    public void testRequireDeclaration() {
+        try {
+            Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+            RuleManager.clearCachedRules(account);
+            Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
+            // No "variable" require
+            String filterScript = "set \"var\" \"hello\";\n"
+                         + "if header :matches \"Subject\" \"*\" {\n"
+                         + "  tag \"${var}\";\n"
+                         + "}\n";
+            account.setMailSieveScript(filterScript);
+            String raw = "From: sender@zimbra.com\n"
+                       + "To: test1@zimbra.com\n"
+                       + "Subject: Test\n"
+                       + "\n"
+                       + "Hello World.";
+
+            // 'require' control is mandatory
+            account.setSieveRequireControlRFCCompliant(true);
+            List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox), mbox,
+                    new ParsedMessage(raw.getBytes(), false), 0, account.getName(), new DeliveryContext(),
+                    Mailbox.ID_FOLDER_INBOX, true);
+            Message msg = mbox.getMessageById(null, ids.get(0).getId());
+            Assert.assertEquals(null, ArrayUtil.getFirstElement(msg.getTags()));
+
+            // 'require' control is optional
+            account.setSieveRequireControlRFCCompliant(false);
+            ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox), mbox,
+                    new ParsedMessage(raw.getBytes(), false), 0, account.getName(), new DeliveryContext(),
+                    Mailbox.ID_FOLDER_INBOX, true);
+            msg = mbox.getMessageById(null, ids.get(0).getId());
+            Assert.assertEquals("hello", ArrayUtil.getFirstElement(msg.getTags()));
+
+        } catch (Exception e) {
+            fail("No exception should be thrown: " + e);
+        }
     }
 }

--- a/store/src/java-test/com/zimbra/cs/filter/RuleManagerAdminFilterTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/RuleManagerAdminFilterTest.java
@@ -83,7 +83,8 @@ public final class RuleManagerAdminFilterTest {
     public static void init() throws Exception {
         MailboxTestUtil.initServer();
         Provisioning prov = Provisioning.getInstance();
-        prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
+        Account account = prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
+        account.setSieveRequireControlRFCCompliant(true);
     }
 
     @Before
@@ -379,7 +380,7 @@ public final class RuleManagerAdminFilterTest {
 
     @Test
     public void fileintoAtAdminBefore() throws Exception {
-        String adminBefore = "fileinto \"foo\";";
+        String adminBefore = "require \"fileinto\"; fileinto \"foo\";";
         String enduser     = "tag \"enduser\";";
         String adminAfter  = "tag \"after\";";
 

--- a/store/src/java-test/com/zimbra/cs/filter/RuleManagerAdminFilterTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/RuleManagerAdminFilterTest.java
@@ -83,8 +83,7 @@ public final class RuleManagerAdminFilterTest {
     public static void init() throws Exception {
         MailboxTestUtil.initServer();
         Provisioning prov = Provisioning.getInstance();
-        Account account = prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
-        account.setSieveRequireControlRFCCompliant(true);
+        prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
     }
 
     @Before

--- a/store/src/java-test/com/zimbra/cs/filter/RuleManagerTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/RuleManagerTest.java
@@ -48,7 +48,8 @@ public final class RuleManagerTest {
     public static void init() throws Exception {
         MailboxTestUtil.initServer();
         Provisioning prov = Provisioning.getInstance();
-        prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
+        Account account = prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
+        account.setSieveRequireControlRFCCompliant(true);
     }
 
     @Before
@@ -62,7 +63,7 @@ public final class RuleManagerTest {
         Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
         RuleManager.clearCachedRules(account);
-        account.setMailSieveScript("if socialcast { tag \"priority\"; fileinto \"socialcast\"; }");
+        account.setMailSieveScript("require \"fileinto\"; if socialcast { tag \"priority\"; fileinto \"socialcast\"; }");
         List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox), mbox, new ParsedMessage(
                 "From: do-not-reply@socialcast.com\nReply-To: share@socialcast.com\nSubject: test".getBytes(), false),
                 0, account.getName(), new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
@@ -72,7 +73,7 @@ public final class RuleManagerTest {
         Assert.assertEquals("priority", ArrayUtil.getFirstElement(msg.getTags()));
 
         RuleManager.clearCachedRules(account);
-        account.setMailSieveScript("if socialcast { tag \"priority\"; }\n" +
+        account.setMailSieveScript("require \"fileinto\"; if socialcast { tag \"priority\"; }\n" +
                 "if header :contains [\"Subject\"] [\"Zimbra\"] { fileinto \"zimbra\"; }");
         ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox), mbox, new ParsedMessage(
                 "From: do-not-reply@socialcast.com\nReply-To: share@socialcast.com\nSubject: Zimbra".getBytes(), false),

--- a/store/src/java-test/com/zimbra/cs/filter/RuleManagerTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/RuleManagerTest.java
@@ -48,8 +48,7 @@ public final class RuleManagerTest {
     public static void init() throws Exception {
         MailboxTestUtil.initServer();
         Provisioning prov = Provisioning.getInstance();
-        Account account = prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
-        account.setSieveRequireControlRFCCompliant(true);
+        prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
     }
 
     @Before

--- a/store/src/java-test/com/zimbra/cs/filter/SetVariableTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/SetVariableTest.java
@@ -64,7 +64,6 @@ public class SetVariableTest {
         MailboxTestUtil.initServer();
         Provisioning prov = Provisioning.getInstance();
         Account acct = prov.createAccount("test1@zimbra.com", "secret", new HashMap<String, Object>());
-        acct.setSieveRequireControlRFCCompliant(true);
         Server server = Provisioning.getInstance().getServer(acct);
     }
 

--- a/store/src/java-test/com/zimbra/cs/filter/TagTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/TagTest.java
@@ -44,7 +44,8 @@ public class TagTest {
     public static void init() throws Exception {
         MailboxTestUtil.initServer();
         Provisioning prov = Provisioning.getInstance();
-        prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
+        Account account = prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
+        account.setSieveRequireControlRFCCompliant(true);
     }
 
     @Before
@@ -84,7 +85,7 @@ public class TagTest {
         try {
             Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
             RuleManager.clearCachedRules(account);
-            account.setMailSieveScript("tag \"${subject} World\";");
+            account.setMailSieveScript("require \"variables\"; tag \"${subject} World\";");
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
             List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox), mbox,

--- a/store/src/java-test/com/zimbra/cs/filter/TagTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/TagTest.java
@@ -44,8 +44,7 @@ public class TagTest {
     public static void init() throws Exception {
         MailboxTestUtil.initServer();
         Provisioning prov = Provisioning.getInstance();
-        Account account = prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
-        account.setSieveRequireControlRFCCompliant(true);
+        prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
     }
 
     @Before

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -55626,6 +55626,113 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * Whether the declaration of the Sieve extension feature is mandatory by
+     * the &#039;require&#039; control. If TRUE, before ZCS evaluates a Sieve
+     * extension test or action, it checks the corresponding capability
+     * string at &#039;require&#039; control; and if the capability string is
+     * not declared in the &#039;require&#039;, the entire Sieve filter
+     * execution will be failed. If FALSE, any Sieve extensions can be used
+     * without declaring the capability string in the &#039;require&#039;
+     * control.
+     *
+     * @return zimbraSieveRequireControlRFCCompliant, or false if unset
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2118)
+    public boolean isSieveRequireControlRFCCompliant() {
+        return getBooleanAttr(Provisioning.A_zimbraSieveRequireControlRFCCompliant, false, true);
+    }
+
+    /**
+     * Whether the declaration of the Sieve extension feature is mandatory by
+     * the &#039;require&#039; control. If TRUE, before ZCS evaluates a Sieve
+     * extension test or action, it checks the corresponding capability
+     * string at &#039;require&#039; control; and if the capability string is
+     * not declared in the &#039;require&#039;, the entire Sieve filter
+     * execution will be failed. If FALSE, any Sieve extensions can be used
+     * without declaring the capability string in the &#039;require&#039;
+     * control.
+     *
+     * @param zimbraSieveRequireControlRFCCompliant new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2118)
+    public void setSieveRequireControlRFCCompliant(boolean zimbraSieveRequireControlRFCCompliant) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRequireControlRFCCompliant, zimbraSieveRequireControlRFCCompliant ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether the declaration of the Sieve extension feature is mandatory by
+     * the &#039;require&#039; control. If TRUE, before ZCS evaluates a Sieve
+     * extension test or action, it checks the corresponding capability
+     * string at &#039;require&#039; control; and if the capability string is
+     * not declared in the &#039;require&#039;, the entire Sieve filter
+     * execution will be failed. If FALSE, any Sieve extensions can be used
+     * without declaring the capability string in the &#039;require&#039;
+     * control.
+     *
+     * @param zimbraSieveRequireControlRFCCompliant new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2118)
+    public Map<String,Object> setSieveRequireControlRFCCompliant(boolean zimbraSieveRequireControlRFCCompliant, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRequireControlRFCCompliant, zimbraSieveRequireControlRFCCompliant ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether the declaration of the Sieve extension feature is mandatory by
+     * the &#039;require&#039; control. If TRUE, before ZCS evaluates a Sieve
+     * extension test or action, it checks the corresponding capability
+     * string at &#039;require&#039; control; and if the capability string is
+     * not declared in the &#039;require&#039;, the entire Sieve filter
+     * execution will be failed. If FALSE, any Sieve extensions can be used
+     * without declaring the capability string in the &#039;require&#039;
+     * control.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2118)
+    public void unsetSieveRequireControlRFCCompliant() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRequireControlRFCCompliant, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether the declaration of the Sieve extension feature is mandatory by
+     * the &#039;require&#039; control. If TRUE, before ZCS evaluates a Sieve
+     * extension test or action, it checks the corresponding capability
+     * string at &#039;require&#039; control; and if the capability string is
+     * not declared in the &#039;require&#039;, the entire Sieve filter
+     * execution will be failed. If FALSE, any Sieve extensions can be used
+     * without declaring the capability string in the &#039;require&#039;
+     * control.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2118)
+    public Map<String,Object> unsetSieveRequireControlRFCCompliant(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRequireControlRFCCompliant, "");
+        return attrs;
+    }
+
+    /**
      * Unique ID for an signature
      *
      * @return zimbraSignatureId, or null if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -55635,13 +55635,13 @@ public abstract class ZAttrAccount  extends MailTarget {
      * without declaring the capability string in the &#039;require&#039;
      * control.
      *
-     * @return zimbraSieveRequireControlRFCCompliant, or false if unset
+     * @return zimbraSieveRequireControlEnabled, or true if unset
      *
      * @since ZCS 8.7.8
      */
     @ZAttr(id=2118)
-    public boolean isSieveRequireControlRFCCompliant() {
-        return getBooleanAttr(Provisioning.A_zimbraSieveRequireControlRFCCompliant, false, true);
+    public boolean isSieveRequireControlEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraSieveRequireControlEnabled, true, true);
     }
 
     /**
@@ -55654,15 +55654,15 @@ public abstract class ZAttrAccount  extends MailTarget {
      * without declaring the capability string in the &#039;require&#039;
      * control.
      *
-     * @param zimbraSieveRequireControlRFCCompliant new value
+     * @param zimbraSieveRequireControlEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
      * @since ZCS 8.7.8
      */
     @ZAttr(id=2118)
-    public void setSieveRequireControlRFCCompliant(boolean zimbraSieveRequireControlRFCCompliant) throws com.zimbra.common.service.ServiceException {
+    public void setSieveRequireControlEnabled(boolean zimbraSieveRequireControlEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraSieveRequireControlRFCCompliant, zimbraSieveRequireControlRFCCompliant ? Provisioning.TRUE : Provisioning.FALSE);
+        attrs.put(Provisioning.A_zimbraSieveRequireControlEnabled, zimbraSieveRequireControlEnabled ? Provisioning.TRUE : Provisioning.FALSE);
         getProvisioning().modifyAttrs(this, attrs);
     }
 
@@ -55676,16 +55676,16 @@ public abstract class ZAttrAccount  extends MailTarget {
      * without declaring the capability string in the &#039;require&#039;
      * control.
      *
-     * @param zimbraSieveRequireControlRFCCompliant new value
+     * @param zimbraSieveRequireControlEnabled new value
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
      * @since ZCS 8.7.8
      */
     @ZAttr(id=2118)
-    public Map<String,Object> setSieveRequireControlRFCCompliant(boolean zimbraSieveRequireControlRFCCompliant, Map<String,Object> attrs) {
+    public Map<String,Object> setSieveRequireControlEnabled(boolean zimbraSieveRequireControlEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraSieveRequireControlRFCCompliant, zimbraSieveRequireControlRFCCompliant ? Provisioning.TRUE : Provisioning.FALSE);
+        attrs.put(Provisioning.A_zimbraSieveRequireControlEnabled, zimbraSieveRequireControlEnabled ? Provisioning.TRUE : Provisioning.FALSE);
         return attrs;
     }
 
@@ -55704,9 +55704,9 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @since ZCS 8.7.8
      */
     @ZAttr(id=2118)
-    public void unsetSieveRequireControlRFCCompliant() throws com.zimbra.common.service.ServiceException {
+    public void unsetSieveRequireControlEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraSieveRequireControlRFCCompliant, "");
+        attrs.put(Provisioning.A_zimbraSieveRequireControlEnabled, "");
         getProvisioning().modifyAttrs(this, attrs);
     }
 
@@ -55726,9 +55726,9 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @since ZCS 8.7.8
      */
     @ZAttr(id=2118)
-    public Map<String,Object> unsetSieveRequireControlRFCCompliant(Map<String,Object> attrs) {
+    public Map<String,Object> unsetSieveRequireControlEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraSieveRequireControlRFCCompliant, "");
+        attrs.put(Provisioning.A_zimbraSieveRequireControlEnabled, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -43026,13 +43026,13 @@ public abstract class ZAttrCos extends NamedEntry {
      * without declaring the capability string in the &#039;require&#039;
      * control.
      *
-     * @return zimbraSieveRequireControlRFCCompliant, or false if unset
+     * @return zimbraSieveRequireControlEnabled, or true if unset
      *
      * @since ZCS 8.7.8
      */
     @ZAttr(id=2118)
-    public boolean isSieveRequireControlRFCCompliant() {
-        return getBooleanAttr(Provisioning.A_zimbraSieveRequireControlRFCCompliant, false, true);
+    public boolean isSieveRequireControlEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraSieveRequireControlEnabled, true, true);
     }
 
     /**
@@ -43045,15 +43045,15 @@ public abstract class ZAttrCos extends NamedEntry {
      * without declaring the capability string in the &#039;require&#039;
      * control.
      *
-     * @param zimbraSieveRequireControlRFCCompliant new value
+     * @param zimbraSieveRequireControlEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
      * @since ZCS 8.7.8
      */
     @ZAttr(id=2118)
-    public void setSieveRequireControlRFCCompliant(boolean zimbraSieveRequireControlRFCCompliant) throws com.zimbra.common.service.ServiceException {
+    public void setSieveRequireControlEnabled(boolean zimbraSieveRequireControlEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraSieveRequireControlRFCCompliant, zimbraSieveRequireControlRFCCompliant ? Provisioning.TRUE : Provisioning.FALSE);
+        attrs.put(Provisioning.A_zimbraSieveRequireControlEnabled, zimbraSieveRequireControlEnabled ? Provisioning.TRUE : Provisioning.FALSE);
         getProvisioning().modifyAttrs(this, attrs);
     }
 
@@ -43067,16 +43067,16 @@ public abstract class ZAttrCos extends NamedEntry {
      * without declaring the capability string in the &#039;require&#039;
      * control.
      *
-     * @param zimbraSieveRequireControlRFCCompliant new value
+     * @param zimbraSieveRequireControlEnabled new value
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
      * @since ZCS 8.7.8
      */
     @ZAttr(id=2118)
-    public Map<String,Object> setSieveRequireControlRFCCompliant(boolean zimbraSieveRequireControlRFCCompliant, Map<String,Object> attrs) {
+    public Map<String,Object> setSieveRequireControlEnabled(boolean zimbraSieveRequireControlEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraSieveRequireControlRFCCompliant, zimbraSieveRequireControlRFCCompliant ? Provisioning.TRUE : Provisioning.FALSE);
+        attrs.put(Provisioning.A_zimbraSieveRequireControlEnabled, zimbraSieveRequireControlEnabled ? Provisioning.TRUE : Provisioning.FALSE);
         return attrs;
     }
 
@@ -43095,9 +43095,9 @@ public abstract class ZAttrCos extends NamedEntry {
      * @since ZCS 8.7.8
      */
     @ZAttr(id=2118)
-    public void unsetSieveRequireControlRFCCompliant() throws com.zimbra.common.service.ServiceException {
+    public void unsetSieveRequireControlEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraSieveRequireControlRFCCompliant, "");
+        attrs.put(Provisioning.A_zimbraSieveRequireControlEnabled, "");
         getProvisioning().modifyAttrs(this, attrs);
     }
 
@@ -43117,9 +43117,9 @@ public abstract class ZAttrCos extends NamedEntry {
      * @since ZCS 8.7.8
      */
     @ZAttr(id=2118)
-    public Map<String,Object> unsetSieveRequireControlRFCCompliant(Map<String,Object> attrs) {
+    public Map<String,Object> unsetSieveRequireControlEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraSieveRequireControlRFCCompliant, "");
+        attrs.put(Provisioning.A_zimbraSieveRequireControlEnabled, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -43017,6 +43017,113 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * Whether the declaration of the Sieve extension feature is mandatory by
+     * the &#039;require&#039; control. If TRUE, before ZCS evaluates a Sieve
+     * extension test or action, it checks the corresponding capability
+     * string at &#039;require&#039; control; and if the capability string is
+     * not declared in the &#039;require&#039;, the entire Sieve filter
+     * execution will be failed. If FALSE, any Sieve extensions can be used
+     * without declaring the capability string in the &#039;require&#039;
+     * control.
+     *
+     * @return zimbraSieveRequireControlRFCCompliant, or false if unset
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2118)
+    public boolean isSieveRequireControlRFCCompliant() {
+        return getBooleanAttr(Provisioning.A_zimbraSieveRequireControlRFCCompliant, false, true);
+    }
+
+    /**
+     * Whether the declaration of the Sieve extension feature is mandatory by
+     * the &#039;require&#039; control. If TRUE, before ZCS evaluates a Sieve
+     * extension test or action, it checks the corresponding capability
+     * string at &#039;require&#039; control; and if the capability string is
+     * not declared in the &#039;require&#039;, the entire Sieve filter
+     * execution will be failed. If FALSE, any Sieve extensions can be used
+     * without declaring the capability string in the &#039;require&#039;
+     * control.
+     *
+     * @param zimbraSieveRequireControlRFCCompliant new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2118)
+    public void setSieveRequireControlRFCCompliant(boolean zimbraSieveRequireControlRFCCompliant) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRequireControlRFCCompliant, zimbraSieveRequireControlRFCCompliant ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether the declaration of the Sieve extension feature is mandatory by
+     * the &#039;require&#039; control. If TRUE, before ZCS evaluates a Sieve
+     * extension test or action, it checks the corresponding capability
+     * string at &#039;require&#039; control; and if the capability string is
+     * not declared in the &#039;require&#039;, the entire Sieve filter
+     * execution will be failed. If FALSE, any Sieve extensions can be used
+     * without declaring the capability string in the &#039;require&#039;
+     * control.
+     *
+     * @param zimbraSieveRequireControlRFCCompliant new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2118)
+    public Map<String,Object> setSieveRequireControlRFCCompliant(boolean zimbraSieveRequireControlRFCCompliant, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRequireControlRFCCompliant, zimbraSieveRequireControlRFCCompliant ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether the declaration of the Sieve extension feature is mandatory by
+     * the &#039;require&#039; control. If TRUE, before ZCS evaluates a Sieve
+     * extension test or action, it checks the corresponding capability
+     * string at &#039;require&#039; control; and if the capability string is
+     * not declared in the &#039;require&#039;, the entire Sieve filter
+     * execution will be failed. If FALSE, any Sieve extensions can be used
+     * without declaring the capability string in the &#039;require&#039;
+     * control.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2118)
+    public void unsetSieveRequireControlRFCCompliant() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRequireControlRFCCompliant, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether the declaration of the Sieve extension feature is mandatory by
+     * the &#039;require&#039; control. If TRUE, before ZCS evaluates a Sieve
+     * extension test or action, it checks the corresponding capability
+     * string at &#039;require&#039; control; and if the capability string is
+     * not declared in the &#039;require&#039;, the entire Sieve filter
+     * execution will be failed. If FALSE, any Sieve extensions can be used
+     * without declaring the capability string in the &#039;require&#039;
+     * control.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2118)
+    public Map<String,Object> unsetSieveRequireControlRFCCompliant(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRequireControlRFCCompliant, "");
+        return attrs;
+    }
+
+    /**
      * maximum number of signatures allowed on an account
      *
      * @return zimbraSignatureMaxNumEntries, or 20 if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -20525,13 +20525,13 @@ public abstract class ZAttrDomain extends NamedEntry {
      * without declaring the capability string in the &#039;require&#039;
      * control.
      *
-     * @return zimbraSieveRequireControlRFCCompliant, or false if unset
+     * @return zimbraSieveRequireControlEnabled, or false if unset
      *
      * @since ZCS 8.7.8
      */
     @ZAttr(id=2118)
-    public boolean isSieveRequireControlRFCCompliant() {
-        return getBooleanAttr(Provisioning.A_zimbraSieveRequireControlRFCCompliant, false, true);
+    public boolean isSieveRequireControlEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraSieveRequireControlEnabled, false, true);
     }
 
     /**
@@ -20544,15 +20544,15 @@ public abstract class ZAttrDomain extends NamedEntry {
      * without declaring the capability string in the &#039;require&#039;
      * control.
      *
-     * @param zimbraSieveRequireControlRFCCompliant new value
+     * @param zimbraSieveRequireControlEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
      * @since ZCS 8.7.8
      */
     @ZAttr(id=2118)
-    public void setSieveRequireControlRFCCompliant(boolean zimbraSieveRequireControlRFCCompliant) throws com.zimbra.common.service.ServiceException {
+    public void setSieveRequireControlEnabled(boolean zimbraSieveRequireControlEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraSieveRequireControlRFCCompliant, zimbraSieveRequireControlRFCCompliant ? Provisioning.TRUE : Provisioning.FALSE);
+        attrs.put(Provisioning.A_zimbraSieveRequireControlEnabled, zimbraSieveRequireControlEnabled ? Provisioning.TRUE : Provisioning.FALSE);
         getProvisioning().modifyAttrs(this, attrs);
     }
 
@@ -20566,16 +20566,16 @@ public abstract class ZAttrDomain extends NamedEntry {
      * without declaring the capability string in the &#039;require&#039;
      * control.
      *
-     * @param zimbraSieveRequireControlRFCCompliant new value
+     * @param zimbraSieveRequireControlEnabled new value
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
      * @since ZCS 8.7.8
      */
     @ZAttr(id=2118)
-    public Map<String,Object> setSieveRequireControlRFCCompliant(boolean zimbraSieveRequireControlRFCCompliant, Map<String,Object> attrs) {
+    public Map<String,Object> setSieveRequireControlEnabled(boolean zimbraSieveRequireControlEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraSieveRequireControlRFCCompliant, zimbraSieveRequireControlRFCCompliant ? Provisioning.TRUE : Provisioning.FALSE);
+        attrs.put(Provisioning.A_zimbraSieveRequireControlEnabled, zimbraSieveRequireControlEnabled ? Provisioning.TRUE : Provisioning.FALSE);
         return attrs;
     }
 
@@ -20594,9 +20594,9 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @since ZCS 8.7.8
      */
     @ZAttr(id=2118)
-    public void unsetSieveRequireControlRFCCompliant() throws com.zimbra.common.service.ServiceException {
+    public void unsetSieveRequireControlEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraSieveRequireControlRFCCompliant, "");
+        attrs.put(Provisioning.A_zimbraSieveRequireControlEnabled, "");
         getProvisioning().modifyAttrs(this, attrs);
     }
 
@@ -20616,9 +20616,9 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @since ZCS 8.7.8
      */
     @ZAttr(id=2118)
-    public Map<String,Object> unsetSieveRequireControlRFCCompliant(Map<String,Object> attrs) {
+    public Map<String,Object> unsetSieveRequireControlEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraSieveRequireControlRFCCompliant, "");
+        attrs.put(Provisioning.A_zimbraSieveRequireControlEnabled, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -20516,6 +20516,113 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
+     * Whether the declaration of the Sieve extension feature is mandatory by
+     * the &#039;require&#039; control. If TRUE, before ZCS evaluates a Sieve
+     * extension test or action, it checks the corresponding capability
+     * string at &#039;require&#039; control; and if the capability string is
+     * not declared in the &#039;require&#039;, the entire Sieve filter
+     * execution will be failed. If FALSE, any Sieve extensions can be used
+     * without declaring the capability string in the &#039;require&#039;
+     * control.
+     *
+     * @return zimbraSieveRequireControlRFCCompliant, or false if unset
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2118)
+    public boolean isSieveRequireControlRFCCompliant() {
+        return getBooleanAttr(Provisioning.A_zimbraSieveRequireControlRFCCompliant, false, true);
+    }
+
+    /**
+     * Whether the declaration of the Sieve extension feature is mandatory by
+     * the &#039;require&#039; control. If TRUE, before ZCS evaluates a Sieve
+     * extension test or action, it checks the corresponding capability
+     * string at &#039;require&#039; control; and if the capability string is
+     * not declared in the &#039;require&#039;, the entire Sieve filter
+     * execution will be failed. If FALSE, any Sieve extensions can be used
+     * without declaring the capability string in the &#039;require&#039;
+     * control.
+     *
+     * @param zimbraSieveRequireControlRFCCompliant new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2118)
+    public void setSieveRequireControlRFCCompliant(boolean zimbraSieveRequireControlRFCCompliant) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRequireControlRFCCompliant, zimbraSieveRequireControlRFCCompliant ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether the declaration of the Sieve extension feature is mandatory by
+     * the &#039;require&#039; control. If TRUE, before ZCS evaluates a Sieve
+     * extension test or action, it checks the corresponding capability
+     * string at &#039;require&#039; control; and if the capability string is
+     * not declared in the &#039;require&#039;, the entire Sieve filter
+     * execution will be failed. If FALSE, any Sieve extensions can be used
+     * without declaring the capability string in the &#039;require&#039;
+     * control.
+     *
+     * @param zimbraSieveRequireControlRFCCompliant new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2118)
+    public Map<String,Object> setSieveRequireControlRFCCompliant(boolean zimbraSieveRequireControlRFCCompliant, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRequireControlRFCCompliant, zimbraSieveRequireControlRFCCompliant ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether the declaration of the Sieve extension feature is mandatory by
+     * the &#039;require&#039; control. If TRUE, before ZCS evaluates a Sieve
+     * extension test or action, it checks the corresponding capability
+     * string at &#039;require&#039; control; and if the capability string is
+     * not declared in the &#039;require&#039;, the entire Sieve filter
+     * execution will be failed. If FALSE, any Sieve extensions can be used
+     * without declaring the capability string in the &#039;require&#039;
+     * control.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2118)
+    public void unsetSieveRequireControlRFCCompliant() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRequireControlRFCCompliant, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether the declaration of the Sieve extension feature is mandatory by
+     * the &#039;require&#039; control. If TRUE, before ZCS evaluates a Sieve
+     * extension test or action, it checks the corresponding capability
+     * string at &#039;require&#039; control; and if the capability string is
+     * not declared in the &#039;require&#039;, the entire Sieve filter
+     * execution will be failed. If FALSE, any Sieve extensions can be used
+     * without declaring the capability string in the &#039;require&#039;
+     * control.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.8
+     */
+    @ZAttr(id=2118)
+    public Map<String,Object> unsetSieveRequireControlRFCCompliant(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveRequireControlRFCCompliant, "");
+        return attrs;
+    }
+
+    /**
      * background color for chameleon skin for the domain
      *
      * @return zimbraSkinBackgroundColor, or null if unset

--- a/store/src/java/com/zimbra/cs/filter/FilterUtil.java
+++ b/store/src/java/com/zimbra/cs/filter/FilterUtil.java
@@ -16,6 +16,8 @@
  */
 package com.zimbra.cs.filter;
 
+import static com.zimbra.cs.filter.JsieveConfigMapHandler.CAPABILITY_VARIABLES;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -67,6 +69,7 @@ import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.AuthToken;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.filter.jsieve.ActionFlag;
+import com.zimbra.cs.filter.jsieve.Require;
 import com.zimbra.cs.filter.jsieve.SetVariable;
 import com.zimbra.cs.lmtpserver.LmtpEnvelope;
 import com.zimbra.cs.mailbox.DeliveryContext;
@@ -857,6 +860,14 @@ public final class FilterUtil {
             return sourceStr;
         }
         validateVariableIndex(sourceStr);
+        
+        try {
+            Require.checkCapability(mailAdapter, CAPABILITY_VARIABLES);
+        } catch (SyntaxException e) {
+            ZimbraLog.filter.info("\"variables\" capability is not declared. No variables won't be replaced");
+            return sourceStr;
+        }
+
         Map<String, String> variables = mailAdapter.getVariables();
         List<String> matchedVariables = mailAdapter.getMatchedValues();
         ZimbraLog.filter.debug("Variable: %s " , sourceStr);

--- a/store/src/java/com/zimbra/cs/filter/FilterUtil.java
+++ b/store/src/java/com/zimbra/cs/filter/FilterUtil.java
@@ -864,7 +864,7 @@ public final class FilterUtil {
         try {
             Require.checkCapability(mailAdapter, CAPABILITY_VARIABLES);
         } catch (SyntaxException e) {
-            ZimbraLog.filter.info("\"variables\" capability is not declared. No variables won't be replaced");
+            ZimbraLog.filter.info("\"variables\" capability is not declared. No variables will be replaced");
             return sourceStr;
         }
 

--- a/store/src/java/com/zimbra/cs/filter/JsieveConfigMapHandler.java
+++ b/store/src/java/com/zimbra/cs/filter/JsieveConfigMapHandler.java
@@ -29,6 +29,16 @@ import com.zimbra.cs.account.Provisioning;
  * These are registered to Configuration Manger to create sieve factory.
  */
 public class JsieveConfigMapHandler {
+    public static final String CAPABILITY_ENVELOPE   = "envelope";
+    public static final String CAPABILITY_FILEINTO   = "fileinto";
+    public static final String CAPABILITY_COPY       = "copy";
+    public static final String CAPABILITY_BODY       = "body";
+    public static final String CAPABILITY_VARIABLES  = "variables";
+    public static final String CAPABILITY_RELATIONAL = "relational";
+    public static final String CAPABILITY_DATE       = "date";
+    public static final String CAPABILITY_EREJECT    = "ereject";
+    public static final String CAPABILITY_REJECT     = "reject";
+    public static final String CAPABILITY_ENOTIFY    = "enotify";
 
     /*
      * jSieve's command map
@@ -49,15 +59,15 @@ public class JsieveConfigMapHandler {
         mCommandMap.put("flag", com.zimbra.cs.filter.jsieve.Flag.class.getName());
         mCommandMap.put("reply", com.zimbra.cs.filter.jsieve.Reply.class.getName());
         mCommandMap.put("discard", com.zimbra.cs.filter.jsieve.Discard.class.getName());
-        mCommandMap.put("ereject", com.zimbra.cs.filter.jsieve.Ereject.class.getName());
+        mCommandMap.put(CAPABILITY_EREJECT, com.zimbra.cs.filter.jsieve.Ereject.class.getName());
         mCommandMap.put("set", com.zimbra.cs.filter.jsieve.SetVariable.class.getName());
         mCommandMap.put("variables", com.zimbra.cs.filter.jsieve.Variables.class.getName());
         //mCommandMap.put("editheader", com.zimbra.cs.filter.jsieve.EditHeader.class.getName());
         //mCommandMap.put("addheader", com.zimbra.cs.filter.jsieve.AddHeader.class.getName());
         //mCommandMap.put("replaceheader", com.zimbra.cs.filter.jsieve.ReplaceHeader.class.getName());
-        mCommandMap.put("fileinto", com.zimbra.cs.filter.jsieve.FileInto.class.getName());
+        mCommandMap.put(CAPABILITY_FILEINTO, com.zimbra.cs.filter.jsieve.FileInto.class.getName());
         mCommandMap.put("redirect", com.zimbra.cs.filter.jsieve.Redirect.class.getName());
-        mCommandMap.put("copy", com.zimbra.cs.filter.jsieve.Copy.class.getName());
+        mCommandMap.put(CAPABILITY_COPY, com.zimbra.cs.filter.jsieve.Copy.class.getName());
         mCommandMap.put("log", com.zimbra.cs.filter.jsieve.VariableLog.class.getName());
         //mCommandMap.put("deleteheader", com.zimbra.cs.filter.jsieve.DeleteHeader.class.getName());
         mCommandMap.put("zimbravariablesctrl", com.zimbra.cs.filter.jsieve.ZimbraVariablesCtrl.class.getName());
@@ -66,9 +76,9 @@ public class JsieveConfigMapHandler {
         mCommandMap.put("keep", com.zimbra.cs.filter.jsieve.Keep.class.getName());
 
         mCommandMap.put("notify",  com.zimbra.cs.filter.jsieve.NotifyMailto.class.getName());
-        mCommandMap.put("reject", com.zimbra.cs.filter.jsieve.Reject.class.getName());
+        mCommandMap.put(CAPABILITY_REJECT, com.zimbra.cs.filter.jsieve.Reject.class.getName());
 
-		mCommandMap.put("variables", com.zimbra.cs.filter.jsieve.Variables.class.getName());
+        mCommandMap.put(CAPABILITY_VARIABLES, com.zimbra.cs.filter.jsieve.Variables.class.getName());
 		ZimbraLog.filter.info("Variables extension is loaded");
 
         return mCommandMap;
@@ -80,9 +90,9 @@ public class JsieveConfigMapHandler {
                 Collections.synchronizedMap(new HashMap<String, String>());
         mTestMap.put("header", com.zimbra.cs.filter.jsieve.HeaderTest.class.getName());
         mTestMap.put("address", com.zimbra.cs.filter.jsieve.AddressTest.class.getName());
-        mTestMap.put("envelope", com.zimbra.cs.filter.jsieve.EnvelopeTest.class.getName());
-        mTestMap.put("date", com.zimbra.cs.filter.jsieve.DateTest.class.getName());
-        mTestMap.put("body", com.zimbra.cs.filter.jsieve.BodyTest.class.getName());
+        mTestMap.put(CAPABILITY_ENVELOPE, com.zimbra.cs.filter.jsieve.EnvelopeTest.class.getName());
+        mTestMap.put(CAPABILITY_DATE, com.zimbra.cs.filter.jsieve.DateTest.class.getName());
+        mTestMap.put(CAPABILITY_BODY, com.zimbra.cs.filter.jsieve.BodyTest.class.getName());
         mTestMap.put("attachment", com.zimbra.cs.filter.jsieve.AttachmentTest.class.getName());
         mTestMap.put("addressbook", com.zimbra.cs.filter.jsieve.AddressBookTest.class.getName());
         mTestMap.put("contact_ranking", com.zimbra.cs.filter.jsieve.ContactRankingTest.class.getName());
@@ -103,7 +113,7 @@ public class JsieveConfigMapHandler {
         mTestMap.put("community_connections", com.zimbra.cs.filter.jsieve.CommunityConnectionsTest.class.getName());
         mTestMap.put("community_requests", com.zimbra.cs.filter.jsieve.CommunityRequestsTest.class.getName());
         mTestMap.put("community_content", com.zimbra.cs.filter.jsieve.CommunityContentTest.class.getName());
-        mTestMap.put("relational", com.zimbra.cs.filter.jsieve.RelationalTest.class.getName());
+        mTestMap.put(CAPABILITY_RELATIONAL, com.zimbra.cs.filter.jsieve.RelationalTest.class.getName());
         mTestMap.put("string", com.zimbra.cs.filter.jsieve.StringTest.class.getName());
 
         // The capability string associated with the 'notify' action is
@@ -111,7 +121,7 @@ public class JsieveConfigMapHandler {
         // the "enotify" is not accepted as an action name in the sieve filter
         // body,
         // such as inside the 'if' body.
-        mTestMap.put("enotify", com.zimbra.cs.filter.jsieve.EnotifyTest.class.getName());
+        mTestMap.put(CAPABILITY_ENOTIFY, com.zimbra.cs.filter.jsieve.EnotifyTest.class.getName());
         mTestMap.put("valid_notify_method", com.zimbra.cs.filter.jsieve.ValidNotifyMethodTest.class.getName());
         mTestMap.put("notify_method_capability",
             com.zimbra.cs.filter.jsieve.NotifyMethodCapabilityTest.class.getName());

--- a/store/src/java/com/zimbra/cs/filter/SoapToSieve.java
+++ b/store/src/java/com/zimbra/cs/filter/SoapToSieve.java
@@ -56,7 +56,7 @@ public final class SoapToSieve {
     public String getSieveScript() throws ServiceException {
         if (buffer == null) {
             buffer = new StringBuilder();
-            buffer.append("require [\"fileinto\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\", \"enotify\"]" + END_OF_LINE);
+            buffer.append("require [\"fileinto\", \"copy\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\", \"enotify\"]" + END_OF_LINE);
             for (FilterRule rule : rules) {
                 buffer.append('\n');
                 handleRule(rule);

--- a/store/src/java/com/zimbra/cs/filter/ZimbraMailAdapter.java
+++ b/store/src/java/com/zimbra/cs/filter/ZimbraMailAdapter.java
@@ -952,6 +952,10 @@ public class ZimbraMailAdapter implements MailAdapter, EnvelopeAccessors {
         this.capabilities.clear();
     }
 
+    public boolean isCapable(String capability) {
+        return this.capabilities.contains(capability);
+    }
+
     public boolean isImplicitKeep () {
         return fieldImplicitKeep;
     }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/FileInto.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/FileInto.java
@@ -16,6 +16,9 @@
  */
 package com.zimbra.cs.filter.jsieve;
 
+import static com.zimbra.cs.filter.JsieveConfigMapHandler.CAPABILITY_FILEINTO;
+import static com.zimbra.cs.filter.JsieveConfigMapHandler.CAPABILITY_COPY;
+
 import java.util.List;
 import org.apache.jsieve.Argument;
 import org.apache.jsieve.Arguments;
@@ -40,6 +43,8 @@ public class FileInto extends org.apache.jsieve.commands.optional.FileInto {
         }
         ZimbraMailAdapter mailAdapter = (ZimbraMailAdapter) mail;
 
+        Require.checkCapability(mailAdapter, CAPABILITY_FILEINTO);
+
         List<Argument> args = arguments.getArgumentList();
         if (args.size() == 1) {
             String folderPath = ((StringListArgument) arguments.getArgumentList().get(0)).getList()
@@ -47,6 +52,7 @@ public class FileInto extends org.apache.jsieve.commands.optional.FileInto {
             folderPath = FilterUtil.replaceVariables(mailAdapter, folderPath);
             mail.addAction(new ActionFileInto(folderPath));
         } else {
+            Require.checkCapability(mailAdapter, CAPABILITY_COPY);
             String folderPath = ((StringListArgument) arguments.getArgumentList().get(1)).getList()
                 .get(0);
             folderPath = FilterUtil.replaceVariables(mailAdapter, folderPath);

--- a/store/src/java/com/zimbra/cs/filter/jsieve/NotifyMailto.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/NotifyMailto.java
@@ -34,6 +34,8 @@ import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.filter.FilterUtil;
 import com.zimbra.cs.filter.ZimbraMailAdapter;
 
+import static com.zimbra.cs.filter.JsieveConfigMapHandler.CAPABILITY_ENOTIFY;
+
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -78,11 +80,13 @@ public class NotifyMailto extends Notify {
         return null;
     }
 
-    private boolean useRFCCompliantNotify(MailAdapter mail) {
+    private boolean useRFCCompliantNotify(MailAdapter mail) throws SieveException {
         if (!(mail instanceof ZimbraMailAdapter)) {
             return false;
         }
         ZimbraMailAdapter mailAdapter = (ZimbraMailAdapter) mail;
+        Require.checkCapability(mailAdapter, CAPABILITY_ENOTIFY);
+
         try {
             return mailAdapter.getMailbox().getAccount().isSieveNotifyActionRFCCompliant();
         } catch (ServiceException e) {

--- a/store/src/java/com/zimbra/cs/filter/jsieve/NotifyMethodCapabilityTest.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/NotifyMethodCapabilityTest.java
@@ -16,6 +16,13 @@
  */
 package com.zimbra.cs.filter.jsieve;
 
+import static com.zimbra.cs.filter.jsieve.ComparatorName.ASCII_NUMERIC_COMPARATOR;
+import static com.zimbra.cs.filter.jsieve.MatchRelationalOperators.EQ_OP;
+import static com.zimbra.cs.filter.jsieve.MatchRelationalOperators.GE_OP;
+import static com.zimbra.cs.filter.jsieve.MatchRelationalOperators.GT_OP;
+import static com.zimbra.cs.filter.jsieve.MatchRelationalOperators.LE_OP;
+import static com.zimbra.cs.filter.jsieve.MatchRelationalOperators.LT_OP;
+import static com.zimbra.cs.filter.jsieve.MatchRelationalOperators.NE_OP;
 import static com.zimbra.cs.filter.jsieve.MatchTypeTags.COUNT_TAG;
 import static com.zimbra.cs.filter.jsieve.MatchTypeTags.VALUE_TAG;
 import static org.apache.jsieve.comparators.ComparatorNames.ASCII_CASEMAP_COMPARATOR;
@@ -25,6 +32,7 @@ import static org.apache.jsieve.comparators.MatchTypeTags.MATCHES_TAG;
 import static org.apache.jsieve.tests.ComparatorTags.COMPARATOR_TAG;
 
 import java.net.URL;
+import java.util.Arrays;
 import java.util.List;
 import java.util.ListIterator;
 
@@ -33,9 +41,14 @@ import org.apache.jsieve.Arguments;
 import org.apache.jsieve.SieveContext;
 import org.apache.jsieve.StringListArgument;
 import org.apache.jsieve.TagArgument;
+import org.apache.jsieve.exception.FeatureException;
+import org.apache.jsieve.exception.LookupException;
 import org.apache.jsieve.exception.SieveException;
 import org.apache.jsieve.mail.MailAdapter;
 import org.apache.jsieve.tests.AbstractTest;
+
+import com.zimbra.cs.filter.ZimbraComparatorManagerImpl;
+import com.zimbra.cs.filter.ZimbraComparatorUtils;
 
 public class NotifyMethodCapabilityTest extends AbstractTest {
 
@@ -48,11 +61,13 @@ public class NotifyMethodCapabilityTest extends AbstractTest {
     @Override
     protected boolean executeBasic(MailAdapter mail, Arguments arguments, SieveContext context)
             throws SieveException {
-        String comparator = ASCII_CASEMAP_COMPARATOR;
-        String matchType = IS_TAG;
+        String comparator = null;
+        String matchType = null;
         String uri = null;
         String capability = null;
         List<String> keys = null;
+        String operator = null;
+        boolean nextArgumentIsRelationalSign = false;
 
         ListIterator<Argument> argumentsIter = arguments.getArgumentList().listIterator();
         boolean stop = false;
@@ -92,17 +107,34 @@ public class NotifyMethodCapabilityTest extends AbstractTest {
                         && (IS_TAG.equalsIgnoreCase(tag)
                             || CONTAINS_TAG.equalsIgnoreCase(tag)
                             || MATCHES_TAG.equalsIgnoreCase(tag)
-                            || COUNT_TAG.equalsIgnoreCase(tag)
-                            || VALUE_TAG.equalsIgnoreCase(tag))) {
+                            || COUNT_TAG.equalsIgnoreCase(tag))) {
                     matchType = tag;
+                    nextArgumentIsRelationalSign = true;
                 } else {
                     throw context.getCoordinate().syntaxException(
                             "Found unexpected TagArgument: \"" + tag + "\"");
                 }
             } else {
-                // Stop when a non-tag argument is encountered
-                argumentsIter.previous();
-                stop = true;
+                if (nextArgumentIsRelationalSign && argument instanceof StringListArgument) {
+                    String symbol = ((StringListArgument) argument).getList().get(0);
+                    if (matchType != null
+                            && (GT_OP.equalsIgnoreCase(symbol)
+                                || GE_OP.equalsIgnoreCase(symbol)
+                                || LT_OP.equalsIgnoreCase(symbol)
+                                || LE_OP.equalsIgnoreCase(symbol)
+                                || EQ_OP.equalsIgnoreCase(symbol)
+                                || NE_OP.equalsIgnoreCase(symbol))) {
+                        operator = symbol;
+                    } else {
+                        argumentsIter.previous();
+                        stop = true;
+                    }
+                    nextArgumentIsRelationalSign = false;
+                } else {
+                    // Stop when a non-tag argument is encountered
+                    argumentsIter.previous();
+                    stop = true;
+                }
             }
         }
 
@@ -137,10 +169,21 @@ public class NotifyMethodCapabilityTest extends AbstractTest {
                 keys = ((StringListArgument) argument).getList();
             }
         }
-        if (null == keys) {
+
+        if (null == comparator) {
+            if (COUNT_TAG.equalsIgnoreCase(matchType)) {
+                comparator = ASCII_NUMERIC_COMPARATOR;
+            } else {
+                comparator = ASCII_CASEMAP_COMPARATOR;
+            }
+        }
+        if (null == matchType) {
+            matchType = IS_TAG;
+        }
+        if (null == keys || null == matchType) {
             throw context.getCoordinate().syntaxException(
                     "Expecting a StringList of keys");
-        } else {
+        } else if (!COUNT_TAG.equalsIgnoreCase(matchType)) {
             for (String key : keys) {
                 if (!CAPABILITY_YES.equalsIgnoreCase(key) &&
                     !CAPABILITY_NO.equalsIgnoreCase(key) &&
@@ -150,12 +193,16 @@ public class NotifyMethodCapabilityTest extends AbstractTest {
                 }
             }
         }
+        if (COUNT_TAG.equalsIgnoreCase(matchType) && null == operator) {
+            throw context.getCoordinate().syntaxException(
+                    "Expecting a String of operator");
+        }
 
         if (argumentsIter.hasNext()) {
             throw context.getCoordinate().syntaxException(
                     "Found unexpected arguments");
         }
-        return test(comparator, matchType, uri, capability, keys);
+        return test(comparator, matchType, operator, uri, capability, keys, context);
     }
 
     @Override
@@ -163,7 +210,8 @@ public class NotifyMethodCapabilityTest extends AbstractTest {
         // override validation -- it's already done in executeBasic above
     }
 
-    private boolean test(String comparator, String matchType, String uri, String capability, List<String> keys) {
+    private boolean test(String comparator, String matchType, String operator,
+            String uri, String capability, List<String> keys, SieveContext context) throws SieveException {
         if (null == uri || null == capability) {
             return false;
         }
@@ -177,6 +225,9 @@ public class NotifyMethodCapabilityTest extends AbstractTest {
             return false;
         }
 
+        if (COUNT_TAG.equalsIgnoreCase(matchType)) {
+            return testCount(keys, comparator, operator, context);
+        }
         // There is no way to detect the online/offline status of the recipient.
         // The test always returns "maybe" for the "mailto" notification method
         // (See RFC 5435 Section 5. and RFC 5436 Section 2.2. for more details).
@@ -188,4 +239,18 @@ public class NotifyMethodCapabilityTest extends AbstractTest {
         }
         return false;
     }
+
+    private boolean testCount(List<String> keys, String comparator, String operator, SieveContext context) throws SieveException {
+        List<String> values = Arrays.asList(CAPABILITY_MAYBE);
+        boolean isMatched = false;
+        for (String key : keys) {
+            isMatched = ZimbraComparatorUtils.counts(comparator,
+                operator, values, key, context);
+            if (isMatched) {
+                break;
+            }
+        }
+        return isMatched;
+    }
+
 }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/Redirect.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/Redirect.java
@@ -16,6 +16,8 @@
  */
 package com.zimbra.cs.filter.jsieve;
 
+import static com.zimbra.cs.filter.JsieveConfigMapHandler.CAPABILITY_COPY;
+
 import java.util.List;
 import org.apache.jsieve.Argument;
 import org.apache.jsieve.Arguments;
@@ -45,6 +47,7 @@ public class Redirect extends org.apache.jsieve.commands.Redirect {
                     ((StringListArgument) arguments.getArgumentList().get(0)).getList().get(0));
             mail.addAction(new ActionRedirect(address));
         } else {
+            Require.checkCapability(mailAdapter, CAPABILITY_COPY);
             String address = FilterUtil.replaceVariables(mailAdapter,
                     ((StringListArgument) arguments.getArgumentList().get(1)).getList().get(0));
             mail.addAction(new ActionRedirect(address, true));

--- a/store/src/java/com/zimbra/cs/filter/jsieve/Require.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/Require.java
@@ -83,7 +83,7 @@ public class Require extends org.apache.jsieve.commands.Require {
         }
         ZimbraMailAdapter mailAdapter = (ZimbraMailAdapter) mail;
         try {
-            return mailAdapter.getMailbox().getAccount().isSieveRequireControlRFCCompliant();
+            return mailAdapter.getMailbox().getAccount().isSieveRequireControlEnabled();
         } catch (ServiceException e) {
             ZimbraLog.filter.warn("Exception in checking Require Control RFC compliance", e);
             return false;


### PR DESCRIPTION
[Related issue]
ZCS-168

[Fix]
* Before executing the Sieve extension test or action, ZCS will check whether the corresponding capability string is declared in the "require" control.  If it is declared, such Sieve extension will be executed.  If it is not declared, the entire sieve filter will be failed and no filter will be applied to the message (message will be stored in the default folder (Inbox or Sent)).
* This ticket covers the following Sieve extension:
  - "fileinto" (RFC 5228) : "fileinto" action
  - "copy" (RFC 3894) : "fileinto" and "redirect" actions
  - "variables" (RFC 5229) : "set" action, ":encodeurl" argument for the notify action.
      (note: if "variables" is not declared, ${n} will be appeared as is)
  - "enotify" (RFC 5435) : "notify" action, "notify_method_capability" test, and "valid_notify_method" test.
* For the backward compatibility "zimbraSieveRequireControlRFCCompliant" attribute (account,cos,domain) is introduced.
  - FALSE (default) - Backword compatibility mode. The "require" control is optional. Sieve extension can be used without "require" control.
  - TRUE - RFC compliant mode. The "require" control is mandatory for the Sieve extension.

[test]
* All unit tests under /store/src/java-test/com/zimbra/cs/filter/ are PASS