### PR TITLE
ZCS-777 :  Fix possible XXE [CWE-611] Issues

### DIFF
--- a/common/src/java/com/zimbra/common/soap/W3cDomUtil.java
+++ b/common/src/java/com/zimbra/common/soap/W3cDomUtil.java
@@ -86,17 +86,13 @@ public class W3cDomUtil {
         dbf.setIgnoringComments(true);
         // protect against recursive entity expansion DOS attack and perhaps other things
         dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-        try {
-            // XXE attack prevention
-            dbf.setFeature(Constants.DISALLOW_DOCTYPE_DECL, true);
-            dbf.setFeature(Constants.EXTERNAL_GENERAL_ENTITIES, false);
-            dbf.setFeature(Constants.EXTERNAL_PARAMETER_ENTITIES, false);
-            dbf.setFeature(Constants.LOAD_EXTERNAL_DTD, false);
-            dbf.setXIncludeAware(false);
-            dbf.setExpandEntityReferences(false);
-        } catch (IllegalArgumentException iae) {
-            ZimbraLog.misc.debug("Disabling doctype-decl not supported", iae);
-        }
+        // XXE attack prevention
+        dbf.setFeature(Constants.DISALLOW_DOCTYPE_DECL, true);
+        dbf.setFeature(Constants.EXTERNAL_PARAMETER_ENTITIES, false);
+        dbf.setFeature(Constants.LOAD_EXTERNAL_DTD, false);
+        dbf.setXIncludeAware(false);
+        dbf.setExpandEntityReferences(false);
+        dbf.setFeature(Constants.EXTERNAL_GENERAL_ENTITIES, false);
         return dbf;
     }
 


### PR DESCRIPTION
Removing extra try-catch block.

This PR is in continuation of PR 239 (https://github.com/Zimbra/zm-mailbox/pull/239) to accommodate suggested review changes requested after closing PR.

**NOTE : UNIT TESTS FOR THIS JIRA TICKET ARE ALREADY SUBMITTED UNDER PR 239**

**Requested changes by @plobbes are as below**
(Sorry for the late review) A few questions here...
1) Should we allow the disabling of doctype-decl failure to fall through and return dbf still? That seems ill advised, but perhaps I'm missing something.
2) In addition, is the IllegalArgumentException specific to doctype-decl only? I'm guessing no and perhaps it's more just any setFeature or setXIncludeAware request which can throw this, and we didn't update the debug message appropriately.
3) Does the order of lines 91-95 matter? Per Q1 above, If we're allowing a failure to successfully follow through, shouldn't we try each setFeature in a separate try/catch block in case only one of those attempts fails but the others can still succeed? Or is the assumption if one fails, they will all fail?

**Response**
1) IllegalArgumentException is removed
2) ParserConfigurationException is already added as throws, which is the only exception thrown by setFeature() method.
3) Reply to point 3 - Googled around the order and try-catching separately but i did not see try-catching separately anywhere.