### PR TITLE
ZCS-1845:editheader throws ParseException

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1307,7 +1307,7 @@ public final class LC {
     @Supported
     public static final KnownKey smime_truststore_password = KnownKey.newKey("${mailboxd_truststore_password}");
 
-    public static final KnownKey sieve_immutable_headers = KnownKey.newKey("Received,DKIM-Signature,Authentication-Results,Received-SPF,Message-ID");
+    public static final KnownKey sieve_immutable_headers = KnownKey.newKey("Received,DKIM-Signature,Authentication-Results,Received-SPF,Message-ID,Content-Type,Content-Disposition,Content-Transfer-Encoding,MIME-Version");
 
     static {
         // Automatically set the key name with the variable name.

--- a/store/src/java-test/com/zimbra/cs/filter/AddHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/AddHeaderTest.java
@@ -46,7 +46,6 @@ import com.zimbra.cs.mime.ParsedMessage;
 import com.zimbra.cs.service.mail.SendMsgTest.DirectInsertionMailboxManager;
 import com.zimbra.cs.service.util.ItemId;
 
-@Ignore
 public class AddHeaderTest {
 
     private static String sampleBaseMsg = "Received: from edge01e.zimbra.com ([127.0.0.1])\n"
@@ -183,7 +182,7 @@ public class AddHeaderTest {
                     break;
                 }
             }
-            Assert.assertEquals(6, index);
+            Assert.assertEquals(9, index);
         } catch (Exception e) {
             fail("No exception should be thrown: " + e.getMessage());
         }
@@ -551,6 +550,119 @@ public class AddHeaderTest {
                 Assert.assertFalse(temp.getName().equals(" X-My-Test "));
                 Assert.assertFalse(temp.getValue().equals("my-new-header-value"));
             }
+        } catch (Exception e) {
+            fail("No exception should be thrown: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testAddHeaderBadContentType() {
+        String sampleBaseMsg = "Subject: example\n"
+                + "Content-Type: text/plain;;\n"
+                + "from: test2@zimbra.com\n"
+                + "to: test@zimbra.com\n";
+
+        String filterAdminBefore = "tag \"tag-admin-before\";";
+        String filterScriptUser = "require [\"editheader\", \"variables\"];\n"
+                + "if header :matches \"Subject\" \"*\" {\n"
+                + " tag \"tag-${1}1\";\n"
+                + " addheader \"my-new-header\" \"${1}\";\n"
+                + " tag \"tag-${1}2\";"
+                + "}\n";
+        String filterAdminAfter = "tag \"tag-admin-after\";";
+
+        try {
+            Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+            Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
+
+            
+            RuleManager.clearCachedRules(acct1);
+            acct1.unsetAdminSieveScriptBefore();
+            acct1.unsetMailSieveScript();
+            acct1.unsetAdminSieveScriptAfter();
+            acct1.setAdminSieveScriptBefore(filterAdminBefore);
+            acct1.setMailSieveScript(filterScriptUser);
+            acct1.setAdminSieveScriptAfter(filterAdminAfter);
+
+            RuleManager.applyRulesToIncomingMessage(
+                    new OperationContext(mbox1), mbox1, new ParsedMessage(
+                            sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
+                            null, new DeliveryContext(),
+                            Mailbox.ID_FOLDER_INBOX, true);
+            Integer itemId = mbox1.getItemIds(null, Mailbox.ID_FOLDER_INBOX).getIds(MailItem.Type.MESSAGE).get(0);
+            Message mdnMsg = mbox1.getMessageById(null, itemId);
+            boolean isAdded = false;
+            for (Enumeration<Header> e = mdnMsg.getMimeMessage().getAllHeaders(); e.hasMoreElements();) {
+                Header temp = e.nextElement();
+                if ("my-new-header".equals(temp.getName())) {
+                    isAdded = true;
+                    break;
+                }
+            }
+            Assert.assertTrue(isAdded);
+            String[] tags = mdnMsg.getTags();
+            Assert.assertEquals(4, tags.length);
+            Assert.assertEquals("tag-admin-before", tags[0]);
+            Assert.assertEquals("tag-example1", tags[1]);
+            Assert.assertEquals("tag-example2", tags[2]);
+            Assert.assertEquals("tag-admin-after", tags[3]);
+        } catch (Exception e) {
+            fail("No exception should be thrown: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testAddHeaderImmutableHeaders() {
+        String sampleBaseMsg = "Subject: example\n"
+                + "to: test@zimbra.com\n";
+
+        String filterScriptUser = "require [\"editheader\"];\n"
+                + "tag \"tag-example1\";\n"
+                + "if exists \"Subject\" {\n"
+                + "  addheader \"Content-Type\" \"text/plain\";\n"
+                + "  addheader \"MIME-Version\" \"1.0\";\n"
+                + "  addheader \"Content-Transfer-Encoding\" \"7bit\";\n"
+                + "  addheader \"Content-Disposition\" \"inline\";\n"
+                + "}\n"
+                + "tag \"tag-example2\";\n";
+
+        try {
+            Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+            Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
+
+            RuleManager.clearCachedRules(acct1);
+            acct1.unsetAdminSieveScriptBefore();
+            acct1.unsetMailSieveScript();
+            acct1.unsetAdminSieveScriptAfter();
+
+            acct1.setMailSieveScript(filterScriptUser);
+
+            RuleManager.applyRulesToIncomingMessage(
+                    new OperationContext(mbox1), mbox1, new ParsedMessage(
+                            sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
+                            null, new DeliveryContext(),
+                            Mailbox.ID_FOLDER_INBOX, true);
+            Integer itemId = mbox1.getItemIds(null, Mailbox.ID_FOLDER_INBOX).getIds(MailItem.Type.MESSAGE).get(0);
+            Message message = mbox1.getMessageById(null, itemId);
+            for (Enumeration<Header> enumeration = message.getMimeMessage().getAllHeaders(); enumeration.hasMoreElements();) {
+                Header header = enumeration.nextElement();
+                if ("Content-Type".equals(header.getName())) {
+                    Assert.fail();
+                }
+                if ("MIME-Version".equals(header.getName())) {
+                    Assert.fail();
+                }
+                if ("Content-Transfer-Encoding".equals(header.getName())) {
+                    Assert.fail();
+                }
+                if ("Content-Disposition".equals(header.getName())) {
+                    Assert.fail();
+                }
+            }
+            String[] tags = message.getTags();
+            Assert.assertEquals(2, tags.length);
+            Assert.assertEquals("tag-example1", tags[0]);
+            Assert.assertEquals("tag-example2", tags[1]);
         } catch (Exception e) {
             fail("No exception should be thrown: " + e.getMessage());
         }

--- a/store/src/java-test/com/zimbra/cs/filter/AddHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/AddHeaderTest.java
@@ -182,7 +182,7 @@ public class AddHeaderTest {
                     break;
                 }
             }
-            Assert.assertEquals(9, index);
+            Assert.assertEquals(6, index);
         } catch (Exception e) {
             fail("No exception should be thrown: " + e.getMessage());
         }

--- a/store/src/java/com/zimbra/cs/filter/ZimbraMailAdapter.java
+++ b/store/src/java/com/zimbra/cs/filter/ZimbraMailAdapter.java
@@ -130,6 +130,12 @@ public class ZimbraMailAdapter implements MailAdapter, EnvelopeAccessors {
     private LmtpEnvelope envelope = null;
 
     /**
+     * Parse result of the triggering message (editheader actions)
+     */
+    public enum PARSESTATUS { UNKNOWN, TOLERABLE, MIMEMALFORMED };
+    private PARSESTATUS eheParseStatus = PARSESTATUS.UNKNOWN;
+
+    /**
      * List of capability strings declared by "require" control.
      */
     private List<String> capabilities = new ArrayList<String>();
@@ -958,5 +964,13 @@ public class ZimbraMailAdapter implements MailAdapter, EnvelopeAccessors {
 
     public boolean isImplicitKeep () {
         return fieldImplicitKeep;
+    }
+
+    public PARSESTATUS getEheParseStatus() {
+        return eheParseStatus;
+    }
+
+    public void setEheParseStatus(PARSESTATUS eheParseStatus) {
+        this.eheParseStatus = eheParseStatus;
     }
 }

--- a/store/src/java/com/zimbra/cs/filter/ZimbraMailAdapter.java
+++ b/store/src/java/com/zimbra/cs/filter/ZimbraMailAdapter.java
@@ -966,11 +966,11 @@ public class ZimbraMailAdapter implements MailAdapter, EnvelopeAccessors {
         return fieldImplicitKeep;
     }
 
-    public PARSESTATUS getEheParseStatus() {
+    public PARSESTATUS getEditHeaderParseStatus() {
         return eheParseStatus;
     }
 
-    public void setEheParseStatus(PARSESTATUS eheParseStatus) {
+    public void setEditHeaderParseStatus(PARSESTATUS eheParseStatus) {
         this.eheParseStatus = eheParseStatus;
     }
 }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/AddHeader.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/AddHeader.java
@@ -44,6 +44,8 @@ import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.filter.FilterUtil;
 import com.zimbra.cs.filter.ZimbraMailAdapter;
+import com.zimbra.cs.filter.ZimbraMailAdapter.PARSESTATUS;
+
 
 public class AddHeader extends AbstractCommand {
     private static final String LAST = ":last";
@@ -64,6 +66,10 @@ public class AddHeader extends AbstractCommand {
         FilterUtil.headerNameHasSpace(headerName);
         if (EditHeaderExtension.isImmutableHeaderKey(headerName)) {
             ZimbraLog.filter.info("addheader: %s is immutable header, so exiting silently.", headerName);
+            return null;
+        }
+        if (mailAdapter.getEditHeaderParseStatus() == PARSESTATUS.MIMEMALFORMED) {
+            ZimbraLog.filter.debug("addheader: Triggering message is malformed MIME");
             return null;
         }
         headerValue = FilterUtil.replaceVariables(mailAdapter, headerValue);

--- a/store/src/java/com/zimbra/cs/filter/jsieve/AddHeader.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/AddHeader.java
@@ -74,9 +74,6 @@ public class AddHeader extends AbstractCommand {
         }
 
         MimeMessage mm = mailAdapter.getMimeMessage();
-        if (!EditHeaderExtension.isTolerableFormedMessage(mailAdapter, "addheader", mm)) {
-            return null;
-        }
         if (headerName != null && headerValue != null) {
             try {
                 if (last) {

--- a/store/src/java/com/zimbra/cs/filter/jsieve/DeleteHeader.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/DeleteHeader.java
@@ -66,9 +66,6 @@ public class DeleteHeader extends AbstractCommand {
         ehe.replaceVariablesInKey(mailAdapter);
         FilterUtil.headerNameHasSpace(ehe.getKey());
         MimeMessage mm = mailAdapter.getMimeMessage();
-        if (!EditHeaderExtension.isTolerableFormedMessage(mailAdapter, "deleteheader", mm)) {
-            return null;
-        }
         Enumeration<Header> headers;
         try {
             headers = mm.getAllHeaders();

--- a/store/src/java/com/zimbra/cs/filter/jsieve/DeleteHeader.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/DeleteHeader.java
@@ -37,6 +37,7 @@ import org.apache.jsieve.mail.MailAdapter;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.filter.FilterUtil;
 import com.zimbra.cs.filter.ZimbraMailAdapter;
+import com.zimbra.cs.filter.ZimbraMailAdapter.PARSESTATUS;
 
 public class DeleteHeader extends AbstractCommand {
     private EditHeaderExtension ehe = new EditHeaderExtension();
@@ -52,14 +53,17 @@ public class DeleteHeader extends AbstractCommand {
             ZimbraLog.filter.info("deleteheader: Zimbra mail adapter not found.");
             return null;
         }
+        ZimbraMailAdapter mailAdapter = (ZimbraMailAdapter) mail;
 
         // make sure zcs do not delete immutable header
         if (EditHeaderExtension.isImmutableHeaderKey(ehe.getKey())) {
             ZimbraLog.filter.info("deleteheader: %s is immutable header, so exiting silently.", ehe.getKey());
             return null;
         }
-
-        ZimbraMailAdapter mailAdapter = (ZimbraMailAdapter) mail;
+        if (mailAdapter.getEditHeaderParseStatus() == PARSESTATUS.MIMEMALFORMED) {
+            ZimbraLog.filter.debug("deleteha: Triggering message is malformed MIME");
+            return null;
+        }
 
         // replace sieve variables
         ehe.replaceVariablesInValueList(mailAdapter);

--- a/store/src/java/com/zimbra/cs/filter/jsieve/EditHeaderExtension.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/EditHeaderExtension.java
@@ -568,9 +568,9 @@ public class EditHeaderExtension {
     }
 
     static public boolean isTolerableFormedMessage(ZimbraMailAdapter zma, String actionName, MimeMessage mm) {
-        if (zma.getEheParseStatus() == PARSESTATUS.UNKNOWN) {
+        if (zma.getEditHeaderParseStatus() == PARSESTATUS.UNKNOWN) {
             return saveChanges(zma, actionName, mm);
-        } else if (zma.getEheParseStatus() == PARSESTATUS.MIMEMALFORMED) {
+        } else if (zma.getEditHeaderParseStatus() == PARSESTATUS.MIMEMALFORMED) {
             ZimbraLog.filter.info(actionName + ": Triggering message is malformed MIME");
             return false;
         }
@@ -578,23 +578,16 @@ public class EditHeaderExtension {
     }
 
     static public boolean saveChanges(ZimbraMailAdapter zma, String actionName, MimeMessage mm) {
-        String ct = "";
-        try {
-            ct = mm.getContentType();
-        } catch (MessagingException e) {
-            ct = "(unknown)";
-        }
-
         try {
             mm.saveChanges();
         } catch (ParseException pe) {
-            ZimbraLog.filter.info(actionName + ": parse error [" + ct + "]" + pe.getMessage());
+            ZimbraLog.filter.info(actionName + ": malformed original message: " + pe.getMessage());
         } catch (Exception e) {
             ZimbraLog.filter.info(actionName + ": parse error:" + e.getMessage());
-            zma.setEheParseStatus(PARSESTATUS.MIMEMALFORMED);
+            zma.setEditHeaderParseStatus(PARSESTATUS.MIMEMALFORMED);
             return false;
         }
-        zma.setEheParseStatus(PARSESTATUS.TOLERABLE);
+        zma.setEditHeaderParseStatus(PARSESTATUS.TOLERABLE);
         return true;
     }
 }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/EditHeaderExtension.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/EditHeaderExtension.java
@@ -571,7 +571,7 @@ public class EditHeaderExtension {
         if (zma.getEditHeaderParseStatus() == PARSESTATUS.UNKNOWN) {
             return saveChanges(zma, actionName, mm);
         } else if (zma.getEditHeaderParseStatus() == PARSESTATUS.MIMEMALFORMED) {
-            ZimbraLog.filter.info(actionName + ": Triggering message is malformed MIME");
+            ZimbraLog.filter.debug(actionName + ": Triggering message is malformed MIME");
             return false;
         }
         return true;

--- a/store/src/java/com/zimbra/cs/filter/jsieve/EditHeaderExtension.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/EditHeaderExtension.java
@@ -567,27 +567,23 @@ public class EditHeaderExtension {
         return matcher.matches();
     }
 
-    static public boolean isTolerableFormedMessage(ZimbraMailAdapter zma, String actionName, MimeMessage mm) {
+    static public boolean saveChanges(ZimbraMailAdapter zma, String actionName, MimeMessage mm) {
         if (zma.getEditHeaderParseStatus() == PARSESTATUS.UNKNOWN) {
-            return saveChanges(zma, actionName, mm);
+            try {
+                mm.saveChanges();
+            } catch (ParseException pe) {
+                ZimbraLog.filter.info(actionName + ": malformed original message: " + pe.getMessage());
+            } catch (Exception e) {
+                ZimbraLog.filter.info(actionName + ": parse error:" + e.getMessage());
+                zma.setEditHeaderParseStatus(PARSESTATUS.MIMEMALFORMED);
+                return false;
+            }
+            zma.setEditHeaderParseStatus(PARSESTATUS.TOLERABLE);
+            return true;
         } else if (zma.getEditHeaderParseStatus() == PARSESTATUS.MIMEMALFORMED) {
             ZimbraLog.filter.debug(actionName + ": Triggering message is malformed MIME");
             return false;
         }
-        return true;
-    }
-
-    static public boolean saveChanges(ZimbraMailAdapter zma, String actionName, MimeMessage mm) {
-        try {
-            mm.saveChanges();
-        } catch (ParseException pe) {
-            ZimbraLog.filter.info(actionName + ": malformed original message: " + pe.getMessage());
-        } catch (Exception e) {
-            ZimbraLog.filter.info(actionName + ": parse error:" + e.getMessage());
-            zma.setEditHeaderParseStatus(PARSESTATUS.MIMEMALFORMED);
-            return false;
-        }
-        zma.setEditHeaderParseStatus(PARSESTATUS.TOLERABLE);
         return true;
     }
 }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/ReplaceHeader.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/ReplaceHeader.java
@@ -71,9 +71,6 @@ public class ReplaceHeader extends AbstractCommand {
         FilterUtil.headerNameHasSpace(ehe.getKey());
 
         MimeMessage mm = mailAdapter.getMimeMessage();
-        if (!EditHeaderExtension.isTolerableFormedMessage(mailAdapter, "replaceheader", mm)) {
-            return null;
-        }
         Enumeration<Header> headers;
         try {
             headers = mm.getAllHeaders();

--- a/store/src/java/com/zimbra/cs/filter/jsieve/ReplaceHeader.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/ReplaceHeader.java
@@ -40,6 +40,7 @@ import com.zimbra.common.util.CharsetUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.filter.FilterUtil;
 import com.zimbra.cs.filter.ZimbraMailAdapter;
+import com.zimbra.cs.filter.ZimbraMailAdapter.PARSESTATUS;
 
 public class ReplaceHeader extends AbstractCommand {
     private EditHeaderExtension ehe = new EditHeaderExtension();
@@ -55,13 +56,18 @@ public class ReplaceHeader extends AbstractCommand {
             ZimbraLog.filter.info("replaceheader: Zimbra mail adapter not found.");
             return null;
         }
+        ZimbraMailAdapter mailAdapter = (ZimbraMailAdapter) mail;
 
         // make sure zcs do not edit immutable header
         if (EditHeaderExtension.isImmutableHeaderKey(ehe.getKey())) {
             ZimbraLog.filter.info("replaceheader: %s is immutable header, so exiting silently.", ehe.getKey());
             return null;
         }
-        ZimbraMailAdapter mailAdapter = (ZimbraMailAdapter) mail;
+        if (mailAdapter.getEditHeaderParseStatus() == PARSESTATUS.MIMEMALFORMED) {
+            ZimbraLog.filter.debug("deleteha: Triggering message is malformed MIME");
+            return null;
+        }
+
         // replace sieve variables
         ehe.replaceVariablesInValueList(mailAdapter);
         ehe.replaceVariablesInKey(mailAdapter);


### PR DESCRIPTION
SIEVE: editheader throws ParseException exception if original mail's mime header violates RFC.

[Bug]
When the triggering (original) message contains any MIME header which is not compliant with RFC, the editheader action (addheader/deleteheader/replaceheader) throws the exception of "javax.mail.internet.ParseException", and entire filter execution is canceled.

For example, the Content-Type is sometimes minorly malformed, like a value contains multiple semi-colon characters at the end of the value "Content-Type: text/plain;;". When a message with such malformed Content-Type is edited, even the editheader does not edit the Content-Type header, the ParseException is thrown during the execution of the action, and the message is delivered to the Inbox without editing.

Because the addheader, deleteheader, and replaceheader actions are particularly used for the spam handling, if the filter execution is canceled due to the malformed message, end user may receive more spam messages without the SPAM label (and it may cause another security problems).

[Root Cause]
After modifying the message header, and before writing down it to the blob file, ZCS checks the consistency of the MIME headers by MimeMessage.saveChanges().  This method checks MIME headers, and if one of them is malformed, the method throws the ParseException exception.

[Fix]
* Added to call MimeMessage.saveMessages() before editing the headers to verify the format of the original message.  If the MimeMessage.saveMessages() is failed due to the ParseException, just logged it (INFO level) and continue to execute the action.
* Added the following MIME headers immutable by default so that the editheader can't change the headers which may cause any inconsistency around the MIME structure.
 - Content-Type
 - Content-Transfer-Encoding
 - Content-Disposition
 - Mime-Version
* For "addheader" command, added to check if the adding header is an immutable one.
* (Optimization) Added a flag to update the blob file only if the message was actually altered.

[Unit test]
Sieve related unit test: PASS
 - AddHeaderTest
 - DeleteHeaderTest
 - ReplaceHeaderTest