### PR TITLE
ZCS-1790: Ability to flush cache / reload LC on imapd servers

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -13836,6 +13836,14 @@ public class ZAttrProvisioning {
     public static final String A_zimbraPrevFoldersToTrackMax = "zimbraPrevFoldersToTrackMax";
 
     /**
+     * URL of the previous ephemeral storage backend
+     *
+     * @since ZCS 8.8.1
+     */
+    @ZAttr(id=3018)
+    public static final String A_zimbraPreviousEphemeralBackendURL = "zimbraPreviousEphemeralBackendURL";
+
+    /**
      * whether this instance of Zimbra is running ZCS or some other
      * derivative product
      *

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9535,4 +9535,8 @@ TODO: delete them permanently from here
   <globalConfigValue>32</globalConfigValue>
   <desc>Configures the 'upstream_fair_shm_size' value used by Nginx to set the size of shared memory for storing information about the busy-ness of backends. Values are in kilobytes.</desc>
 </attr>
+
+<attr id="3018" name="zimbraPreviousEphemeralBackendURL" type="string" cardinality="single" optionalIn="globalConfig" immutable="1" since="8.8.1">
+  <desc>URL of the previous ephemeral storage backend</desc>
+</attr>
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/Provisioning.java
+++ b/store/src/java/com/zimbra/cs/account/Provisioning.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.cs.account;
 
-import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1220,6 +1219,7 @@ public abstract class Provisioning extends ZAttrProvisioning {
     public static final String SERVICE_ADMINCLIENT = "zimbraAdmin";
     public static final String SERVICE_ZIMLET = "zimlet";
     public static final String SERVICE_MAILCLIENT = "service";
+    public static final String SERVICE_IMAP = "imapd";
 
     public abstract List<Account> getAllAdminAccounts()  throws ServiceException;
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -49814,6 +49814,78 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * URL of the previous ephemeral storage backend
+     *
+     * @return zimbraPreviousEphemeralBackendURL, or null if unset
+     *
+     * @since ZCS 8.8.1
+     */
+    @ZAttr(id=3018)
+    public String getPreviousEphemeralBackendURL() {
+        return getAttr(Provisioning.A_zimbraPreviousEphemeralBackendURL, null, true);
+    }
+
+    /**
+     * URL of the previous ephemeral storage backend
+     *
+     * @param zimbraPreviousEphemeralBackendURL new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.1
+     */
+    @ZAttr(id=3018)
+    public void setPreviousEphemeralBackendURL(String zimbraPreviousEphemeralBackendURL) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPreviousEphemeralBackendURL, zimbraPreviousEphemeralBackendURL);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * URL of the previous ephemeral storage backend
+     *
+     * @param zimbraPreviousEphemeralBackendURL new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.1
+     */
+    @ZAttr(id=3018)
+    public Map<String,Object> setPreviousEphemeralBackendURL(String zimbraPreviousEphemeralBackendURL, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPreviousEphemeralBackendURL, zimbraPreviousEphemeralBackendURL);
+        return attrs;
+    }
+
+    /**
+     * URL of the previous ephemeral storage backend
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.1
+     */
+    @ZAttr(id=3018)
+    public void unsetPreviousEphemeralBackendURL() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPreviousEphemeralBackendURL, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * URL of the previous ephemeral storage backend
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.1
+     */
+    @ZAttr(id=3018)
+    public Map<String,Object> unsetPreviousEphemeralBackendURL(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPreviousEphemeralBackendURL, "");
+        return attrs;
+    }
+
+    /**
      * whether this instance of Zimbra is running ZCS or some other
      * derivative product
      *

--- a/store/src/java/com/zimbra/cs/account/ZimbraAuthToken.java
+++ b/store/src/java/com/zimbra/cs/account/ZimbraAuthToken.java
@@ -45,8 +45,13 @@ import com.zimbra.common.util.LogFactory;
 import com.zimbra.common.util.MapUtil;
 import com.zimbra.common.util.ZimbraCookie;
 import com.zimbra.cs.account.auth.AuthMechanism.AuthMech;
+import com.zimbra.cs.ephemeral.EphemeralInput;
 import com.zimbra.cs.ephemeral.EphemeralInput.AbsoluteExpiration;
 import com.zimbra.cs.ephemeral.EphemeralInput.Expiration;
+import com.zimbra.cs.ephemeral.EphemeralKey;
+import com.zimbra.cs.ephemeral.EphemeralLocation;
+import com.zimbra.cs.ephemeral.EphemeralStore;
+import com.zimbra.cs.ephemeral.LdapEntryLocation;
 
 /**
  * @since May 30, 2004
@@ -693,6 +698,19 @@ public class ZimbraAuthToken extends AuthToken implements Cloneable {
     @Override
     public ZimbraAuthToken clone() throws CloneNotSupportedException {
         return (ZimbraAuthToken)super.clone();
+    }
+
+    /*
+     * Used when the auth token needs to be registered with a non-default
+     * ephemeral backend
+     */
+    public void registerWithEphemeralStore(EphemeralStore store) throws ServiceException {
+        Account acct = Provisioning.getInstance().get(AccountBy.id, accountId);
+        Expiration expiration = new AbsoluteExpiration(this.expires);
+        EphemeralLocation location = new LdapEntryLocation(acct);
+        EphemeralKey key = new EphemeralKey(Provisioning.A_zimbraAuthTokens, String.valueOf(tokenID));
+        EphemeralInput input = new EphemeralInput(key, server_version, expiration);
+        store.update(input, location);
     }
 
     public static void main(String args[]) throws ServiceException, AuthTokenException {

--- a/store/src/java/com/zimbra/cs/account/callback/CallbackContext.java
+++ b/store/src/java/com/zimbra/cs/account/callback/CallbackContext.java
@@ -30,48 +30,49 @@ public class CallbackContext {
         CREATE,
         MODIFY;
     };
-    
+
     public enum DataKey {
         MAX_SIGNATURE_LEN,
         MAIL_FORWARDING_ADDRESS_MAX_LEN,
         MAIL_FORWARDING_ADDRESS_MAX_NUM_ADDRS,
         MAIL_WHITELIST_MAX_NUM_ENTRIES,
         MAIL_BLACKLIST_MAX_NUM_ENTRIES,
+        PREV_EPHEMERAL_BACKEND_URL;
     };
 
     // whether the entry is being created
     private final Op op;
-    
+
     // named of the entry being created
     private String creatingEntryName;
-    
+
     // set of AttributeCallback marked themselves done
     private Set<Class<? extends AttributeCallback>> done = Sets.newHashSet();
-    
+
     // data map
     private Map<DataKey, String> dataMap = Maps.newHashMap();
-    
+
     public CallbackContext(Op op) {
         this.op = op;
     }
-    
+
     public boolean isCreate() {
         return op == Op.CREATE;
     }
-    
+
     public void setCreatingEntryName(String name) {
         creatingEntryName = name;
     }
-    
+
     // name of the entry being creating
     public String getCreatingEntryName() {
         return creatingEntryName;
     }
-    
+
     private void setDone(Class<? extends AttributeCallback> callback) {
         done.add(callback);
     }
-    
+
     public boolean isDoneAndSetIfNot(Class<? extends AttributeCallback> callback) {
         boolean isDone = done.contains(callback);
         if (!isDone) {
@@ -79,13 +80,13 @@ public class CallbackContext {
         }
         return isDone;
     }
-    
+
     public void setData(DataKey key, String value) {
         dataMap.put(key, value);
     }
-    
+
     public String getData(DataKey key) {
         return dataMap.get(key);
     }
-    
+
 }

--- a/store/src/java/com/zimbra/cs/account/callback/EphemeralBackendCheck.java
+++ b/store/src/java/com/zimbra/cs/account/callback/EphemeralBackendCheck.java
@@ -2,12 +2,15 @@ package com.zimbra.cs.account.callback;
 
 import java.util.Map;
 
+import com.google.common.base.Strings;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.Log.Level;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.AttributeCallback;
+import com.zimbra.cs.account.Config;
 import com.zimbra.cs.account.Entry;
 import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.callback.CallbackContext.DataKey;
 import com.zimbra.cs.ephemeral.EphemeralStore;
 import com.zimbra.cs.ephemeral.EphemeralStore.Factory;
 import com.zimbra.cs.ephemeral.migrate.AttributeMigration;
@@ -25,6 +28,7 @@ public class EphemeralBackendCheck extends AttributeCallback {
             if (tokens != null && tokens.length > 0) {
                 String backend = tokens[0];
                 if (backend.equalsIgnoreCase("ldap")) {
+                    savePreviousUrl(context, entry);
                     EphemeralStore.clearFactory();
                     return;
                 }
@@ -58,11 +62,25 @@ public class EphemeralBackendCheck extends AttributeCallback {
                 throw ServiceException.FAILURE(String.format(
                         "unable to modify %s; no ephemeral backend specified", attrName), null);
             }
+            savePreviousUrl(context, entry);
+        }
+    }
+
+    private void savePreviousUrl(CallbackContext context, Entry entry) {
+        String prevUrl = ((Config) entry).getEphemeralBackendURL();
+        if (!Strings.isNullOrEmpty(prevUrl)) {
+            context.setData(DataKey.PREV_EPHEMERAL_BACKEND_URL, prevUrl);
         }
     }
 
     @Override
     public void postModify(CallbackContext context, String attrName, Entry entry) {
+        String prevUrl = context.getData(DataKey.PREV_EPHEMERAL_BACKEND_URL);
+        try {
+            ((Config) entry).setPreviousEphemeralBackendURL(prevUrl);
+        } catch (ServiceException e) {
+            ZimbraLog.ephemeral.error("unable to set zimbraPreviousEphemeralBackendURL to %s", prevUrl, e);
+        }
         AttributeMigration.clearConfigCacheOnAllServers(false);
     }
 

--- a/store/src/java/com/zimbra/cs/ephemeral/FallbackEphemeralStore.java
+++ b/store/src/java/com/zimbra/cs/ephemeral/FallbackEphemeralStore.java
@@ -72,7 +72,7 @@ public class FallbackEphemeralStore extends EphemeralStore {
         return secondary;
     }
 
-    public static class Factory implements EphemeralStore.Factory {
+    public static class Factory extends EphemeralStore.Factory {
 
         private EphemeralStore.Factory primaryFactory;
         private EphemeralStore.Factory fallbackFactory;

--- a/store/src/java/com/zimbra/cs/ephemeral/InMemoryEphemeralStore.java
+++ b/store/src/java/com/zimbra/cs/ephemeral/InMemoryEphemeralStore.java
@@ -103,7 +103,7 @@ public class InMemoryEphemeralStore extends EphemeralStore {
         return store;
     }
 
-    public static class Factory implements EphemeralStore.Factory {
+    public static class Factory extends EphemeralStore.Factory {
 
         private static InMemoryEphemeralStore instance;
 

--- a/store/src/java/com/zimbra/cs/ephemeral/LdapEphemeralStore.java
+++ b/store/src/java/com/zimbra/cs/ephemeral/LdapEphemeralStore.java
@@ -102,7 +102,7 @@ public class LdapEphemeralStore extends EphemeralStore {
         // is handled by LdapProvisioning
     }
 
-    public static class Factory implements EphemeralStore.Factory {
+    public static class Factory extends EphemeralStore.Factory {
 
         @Override
         public EphemeralStore getStore() {

--- a/store/src/java/com/zimbra/cs/ephemeral/migrate/AttributeMigration.java
+++ b/store/src/java/com/zimbra/cs/ephemeral/migrate/AttributeMigration.java
@@ -47,6 +47,7 @@ import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.SearchDirectoryOptions;
 import com.zimbra.cs.account.SearchDirectoryOptions.ObjectType;
 import com.zimbra.cs.account.Server;
+import com.zimbra.cs.account.ZimbraAuthToken;
 import com.zimbra.cs.account.ldap.LdapProvisioning;
 import com.zimbra.cs.account.soap.SoapProvisioning;
 import com.zimbra.cs.ephemeral.EphemeralInput;
@@ -54,12 +55,15 @@ import com.zimbra.cs.ephemeral.EphemeralKey;
 import com.zimbra.cs.ephemeral.EphemeralLocation;
 import com.zimbra.cs.ephemeral.EphemeralResult;
 import com.zimbra.cs.ephemeral.EphemeralStore;
+import com.zimbra.cs.ephemeral.EphemeralStore.BackendType;
 import com.zimbra.cs.ephemeral.FallbackEphemeralStore;
 import com.zimbra.cs.ephemeral.LdapEntryLocation;
 import com.zimbra.cs.ephemeral.LdapEphemeralStore;
 import com.zimbra.cs.httpclient.URLUtil;
 import com.zimbra.cs.ldap.ZLdapFilter;
 import com.zimbra.cs.ldap.ZLdapFilterFactory;
+import com.zimbra.cs.service.AuthProvider;
+import com.zimbra.cs.service.admin.FlushCache;
 import com.zimbra.soap.admin.type.CacheEntryType;
 
 /**
@@ -883,11 +887,17 @@ public class AttributeMigration {
     public static void clearConfigCacheOnAllServers(boolean includeLocal) {
         ExecutorService executor = newCachedThreadPool(newDaemonThreadFactory("ClearEphemeralConfigCache"));
         List<Server> servers = null;
+        List<Server> imapServers = null;
         try {
             servers = Provisioning.getInstance().getAllMailClientServers();
         } catch (ServiceException e) {
             ZimbraLog.account.warn("cannot fetch list of servers");
             return;
+        }
+        try {
+            imapServers = Provisioning.getInstance().getAllServers(Provisioning.SERVICE_IMAP);
+        } catch (ServiceException e) {
+            ZimbraLog.account.warn("cannot fetch list of imapd servers");
         }
         for (Server server: servers) {
             try {
@@ -924,9 +934,45 @@ public class AttributeMigration {
             });
 
         }
+
+        /* To flush the cache on imapd servers via the FLUSHCACHE command, the auth token needs to be registered
+         * with the previous ephemeral backend, if one exists. This is because the imapd server may still be using
+         * the previous backend.
+         */
+        EphemeralStore.Factory previousEphemeralFactory = null;
+        if (imapServers != null && imapServers.size() > 0) {
+            try {
+                previousEphemeralFactory = EphemeralStore.getNewFactory(BackendType.previous);
+            } catch (ServiceException e) {
+                ZimbraLog.ephemeral.error("could not instantiate previous EphemeralStore; cannot flush cache on imapd servers", e);
+            }
+            if (previousEphemeralFactory != null) {
+                EphemeralStore previousEphemeralStore = previousEphemeralFactory.getStore();
+                for (Server server: imapServers) {
+                    executor.submit(new Runnable() {
+
+                        @Override
+                        public void run() {
+                            try {
+                                ZimbraAuthToken token = (ZimbraAuthToken) AuthProvider.getAdminAuthToken();
+                                token.registerWithEphemeralStore(previousEphemeralStore);
+                                FlushCache.flushCacheOnImapDaemon(server, "config", null, LC.zimbra_ldap_user.value(), token);
+                                ZimbraLog.ephemeral.debug("sent FLUSHCACHE IMAP request to imapd server %s", server.getServiceHostname());
+                            } catch (ServiceException e) {
+                                ZimbraLog.ephemeral.error("cannot send FLUSHCACHE IMAP request to imapd server %s", server.getServiceHostname(), e);
+                            }
+                        }
+
+                    });
+                }
+            }
+        }
         executor.shutdown();
         try {
             executor.awaitTermination(10, TimeUnit.SECONDS);
         } catch (InterruptedException e) {}
+        if (previousEphemeralFactory != null) {
+            previousEphemeralFactory.shutdown();
+        }
     }
 }

--- a/store/src/java/com/zimbra/cs/imap/ImapDaemon.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapDaemon.java
@@ -25,10 +25,9 @@ import org.apache.log4j.PropertyConfigurator;
 
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
-import com.zimbra.cs.account.Provisioning;
-import com.zimbra.cs.extension.ExtensionUtil;
-import com.zimbra.cs.store.StoreManager;
 import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.store.StoreManager;
 
 
 public class ImapDaemon {
@@ -93,8 +92,6 @@ public class ImapDaemon {
             Properties props = new Properties();
             props.load(new FileInputStream(IMAPD_LOG4J_CONFIG));
             PropertyConfigurator.configure(props);
-            maybeInitEphemeralBackendExtension();
-
             String imapdClassStore=LC.imapd_class_store.value();
             try {
                 StoreManager.getInstance(imapdClassStore).startup();
@@ -157,17 +154,6 @@ public class ImapDaemon {
             }
         }
         return false;
-    }
-
-    private static void maybeInitEphemeralBackendExtension() throws ServiceException {
-        String url = Provisioning.getInstance().getConfig().getEphemeralBackendURL();
-        if(url != null) {
-            String[] tokens = url.split(":");
-            String backendName = tokens[0];
-            if (tokens != null && tokens.length > 0 && !backendName.equalsIgnoreCase("ldap")) {
-                ExtensionUtil.initEphemeralBackendExtension(backendName);
-            }
-        }
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/mailclient/imap/CAtom.java
+++ b/store/src/java/com/zimbra/cs/mailclient/imap/CAtom.java
@@ -41,7 +41,9 @@ public enum CAtom {
     F_FLAGGED("\\Flagged"), F_DELETED("\\Deleted"), F_SEEN("\\Seen"),
     F_DRAFT("\\Draft"), F_RECENT("\\Recent"), F_NOINFERIORS("\\Noinferiors"),
     F_NOSELECT("\\Noselect"), F_MARKED("\\Marked"), F_UNMARKED("\\Unmarked"),
-    F_STAR("\\*"), UNKNOWN("");
+    F_STAR("\\*"), UNKNOWN(""),
+    /* zimbra-specific commands */
+    ZIMBRA_FLUSHCACHE("X-ZIMBRA-FLUSHCACHE"), ZIMBRA_RELOADLC("X-ZIMBRA-RELOADLC");
 
     private final Atom atom;
 

--- a/store/src/java/com/zimbra/cs/security/sasl/Authenticator.java
+++ b/store/src/java/com/zimbra/cs/security/sasl/Authenticator.java
@@ -17,15 +17,9 @@
 
 package com.zimbra.cs.security.sasl;
 
-import com.zimbra.common.account.Key;
-import com.zimbra.common.service.ServiceException;
-import com.zimbra.common.util.Log;
-import com.zimbra.common.util.ZimbraLog;
-import com.zimbra.cs.account.AccessManager;
-import com.zimbra.cs.account.Account;
-import com.zimbra.cs.account.Provisioning;
-import com.zimbra.cs.account.auth.AuthContext;
-
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.InetAddress;
 import java.util.Collection;
 import java.util.Collections;
@@ -34,9 +28,14 @@ import java.util.Map;
 
 import javax.security.sasl.SaslServer;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import com.zimbra.common.account.Key;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.Log;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.AccessManager;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.auth.AuthContext;
 
 public abstract class Authenticator {
     static interface AuthenticatorFactory {
@@ -168,11 +167,11 @@ public abstract class Authenticator {
     protected Log getLog() {
         return mAuthUser.getLog();
     }
-    
+
     protected boolean isProtocolEnabled(Account authAccount, AuthContext.Protocol protocol) {
         if (protocol == null)
             return true;
-        
+
         switch (protocol) {
         case imap:
             return authAccount.isImapEnabled();
@@ -198,6 +197,10 @@ public abstract class Authenticator {
 
         Provisioning prov = Provisioning.getInstance();
         Account userAcct = prov.get(Key.AccountBy.name, username);
+        if (userAcct == null && asAdmin) {
+            //try to get by admin name
+            userAcct = prov.get(Key.AccountBy.adminName, username);
+        }
         if (userAcct == null) {
             // if username not found, check username again using the domain associated with the authorization account
             int i = username.indexOf('@');

--- a/store/src/java/com/zimbra/cs/service/admin/ReloadLocalConfig.java
+++ b/store/src/java/com/zimbra/cs/service/admin/ReloadLocalConfig.java
@@ -16,6 +16,8 @@
  */
 package com.zimbra.cs.service.admin;
 
+import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 import org.dom4j.DocumentException;
@@ -25,6 +27,10 @@ import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.Server;
+import com.zimbra.cs.mailclient.imap.ImapConnection;
+import com.zimbra.cs.service.AuthProvider;
 import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.admin.message.ReloadLocalConfigResponse;
 
@@ -53,9 +59,40 @@ public final class ReloadLocalConfig extends AdminDocumentHandler {
             throw AdminServiceException.FAILURE("Failed to reload LocalConfig", e);
         }
         ZimbraLog.misc.info("LocalConfig reloaded");
-
+        reloadLCOnAllImapDaemons();
         ZimbraSoapContext zsc = getZimbraSoapContext(context);
         return zsc.jaxbToElement(new ReloadLocalConfigResponse());
+    }
+
+    private void reloadLCOnAllImapDaemons() {
+        Provisioning prov = Provisioning.getInstance();
+        List<Server> imapServers;
+        try {
+            imapServers = prov.getAllServers(Provisioning.SERVICE_IMAP);
+        } catch (ServiceException e) {
+            ZimbraLog.imap.warn("unable to fetch list of imapd servers", e);
+            return;
+        }
+        for (Server server: imapServers) {
+            reloadImapDaemonLC(server);
+        }
+    }
+    private void reloadImapDaemonLC(Server server) {
+        ImapConnection connection = null;
+        try {
+            connection = ImapConnection.getZimbraConnection(server, LC.zimbra_ldap_user.value(), AuthProvider.getAdminAuthToken());
+        } catch (ServiceException e) {
+            ZimbraLog.imap.warn("unable to connect to IMAP server '%s'", server.getServiceHostname(), e);
+            return;
+        }
+        try {
+            ZimbraLog.imap.debug("issuing RELOADLC request to imapd server '%s'", server.getServiceHostname());
+            connection.reloadLocalConfig();
+        } catch (IOException e) {
+            ZimbraLog.imap.warn("unable to issue RELOADLC request to IMAP server '%s'", server.getServiceHostname(), e);
+        } finally {
+            connection.close();
+        }
     }
 
 }

--- a/store/src/java/com/zimbra/qa/unittest/ImapTestBase.java
+++ b/store/src/java/com/zimbra/qa/unittest/ImapTestBase.java
@@ -15,8 +15,12 @@ import com.zimbra.common.util.Log;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.Server;
+import com.zimbra.cs.imap.ImapProxy.ZimbraClientAuthenticator;
+import com.zimbra.cs.mailclient.auth.AuthenticatorFactory;
 import com.zimbra.cs.mailclient.imap.ImapConfig;
 import com.zimbra.cs.mailclient.imap.ImapConnection;
+import com.zimbra.cs.security.sasl.ZimbraAuthenticator;
+import com.zimbra.cs.service.AuthProvider;
 
 public abstract class ImapTestBase {
 
@@ -76,8 +80,10 @@ public abstract class ImapTestBase {
             otherConnection.close();
             otherConnection = null;
         }
-        TestUtil.deleteAccountIfExists(USER);
-        TestUtil.deleteAccountIfExists(SHAREE);
+        if (USER != null) {
+            TestUtil.deleteAccountIfExists(USER);
+            TestUtil.deleteAccountIfExists(SHAREE);
+        }
     }
 
     protected static Server getLocalServer() throws ServiceException {
@@ -134,5 +140,21 @@ public abstract class ImapTestBase {
     protected ImapConnection connectAndSelectInbox() throws IOException {
         return connectAndSelectInbox(USER);
     }
+
+    protected ImapConnection getAdminConnection() throws Exception {
+        AuthenticatorFactory authFactory = new AuthenticatorFactory();
+        authFactory.register(ZimbraAuthenticator.MECHANISM, ZimbraClientAuthenticator.class);
+        ImapConfig config = new ImapConfig(imapServer.getServiceHostname());
+        config.setMechanism(ZimbraAuthenticator.MECHANISM);
+        config.setAuthenticatorFactory(authFactory);
+        config.setPort(imapPort);
+        config.setAuthenticationId(LC.zimbra_ldap_user.value());
+        config.getLogger().setLevel(Log.Level.trace);
+        ImapConnection conn = new ImapConnection(config);
+        conn.connect();
+        conn.authenticate(AuthProvider.getAdminAuthToken().getEncoded());
+        return conn;
+    }
+
 
 }

--- a/store/src/java/com/zimbra/qa/unittest/SharedImapTests.java
+++ b/store/src/java/com/zimbra/qa/unittest/SharedImapTests.java
@@ -541,6 +541,7 @@ public abstract class SharedImapTests extends ImapTestBase {
         String folderName = "newfolder1";
         mbox.createFolder(Mailbox.ID_FOLDER_USER_ROOT+"", folderName, ZFolder.View.unknown, ZFolder.Color.DEFAULTCOLOR, null, null);
         Provisioning.getInstance().getLocalServer().setImapDisplayMailFoldersOnly(true);
+        flushCacheIfNecessary();
         connection = connectAndSelectInbox();
         List<ListData> listResult = connection.list("", "*");
         assertNotNull("list result should not be null", listResult);
@@ -2049,5 +2050,9 @@ public abstract class SharedImapTests extends ImapTestBase {
         } catch (AccessBoundedRegex.TooManyAccessesToMatchTargetException se) {
             assertTrue("Throwing exception considered OK", timeoutOk);
         }
+    }
+
+    protected void flushCacheIfNecessary() throws Exception {
+        // overridden by tests running against imapd
     }
 }

--- a/store/src/java/com/zimbra/qa/unittest/TestImapClient.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestImapClient.java
@@ -104,6 +104,7 @@ public class TestImapClient {
     private static int imapPort;
     private static int imapSSLPort;
     private static String imapHostname;
+    private static boolean isImapDaemon = false;
 
     private static final String MESSAGE =
         "Return-Path: dac@zimbra.com\r\n" +
@@ -138,6 +139,7 @@ public class TestImapClient {
         if(homeServer.isRemoteImapServerEnabled()) {
             ZimbraLog.test.debug("Connecting to IMAPd");
             imapPort = homeServer.getRemoteImapBindPort();
+            isImapDaemon = true;
         } else {
             ZimbraLog.test.debug("Connecting to embedded IMAP");
             imapPort = homeServer.getImapBindPort();
@@ -179,6 +181,9 @@ public class TestImapClient {
         connection = null;
         if(TestUtil.accountExists(USER)) {
             TestUtil.deleteAccount(USER);
+        }
+        if (isImapDaemon) {
+            TestUtil.flushImapDaemonCache(homeServer);
         }
     }
 

--- a/store/src/java/com/zimbra/qa/unittest/TestImapDaemonNotifications.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestImapDaemonNotifications.java
@@ -1,33 +1,31 @@
 package com.zimbra.qa.unittest;
 
-import java.io.IOException;
-
-import org.dom4j.DocumentException;
 import org.junit.After;
 import org.junit.Before;
 
 import com.zimbra.client.ZFolder;
 import com.zimbra.client.ZMailbox;
-import com.zimbra.common.localconfig.ConfigException;
 import com.zimbra.common.localconfig.LC;
-import com.zimbra.common.service.ServiceException;
 
 public class TestImapDaemonNotifications extends SharedImapNotificationTests {
 
     @Before
-    public void setUp() throws ServiceException, IOException, DocumentException, ConfigException  {
+    public void setUp() throws Exception  {
+        getLocalServer();
+        TestUtil.assumeTrue("remoteImapServerEnabled false for this server", imapServer.isRemoteImapServerEnabled());
         saveImapConfigSettings();
         TestUtil.setLCValue(LC.imap_always_use_remote_store, String.valueOf(false));
-        getLocalServer();
         imapServer.setReverseProxyUpstreamImapServers(new String[] {imapServer.getServiceHostname()});
         super.sharedSetUp();
-        TestUtil.assumeTrue("remoteImapServerEnabled false for this server", imapServer.isRemoteImapServerEnabled());
+        TestUtil.flushImapDaemonCache(imapServer);
     }
 
     @After
-    public void tearDown() throws ServiceException, DocumentException, ConfigException, IOException  {
+    public void tearDown() throws Exception  {
         super.sharedTearDown();
         restoreImapConfigSettings();
+        TestUtil.flushImapDaemonCache(imapServer);
+        getAdminConnection().reloadLocalConfig();
     }
 
     @Override

--- a/store/src/java/com/zimbra/qa/unittest/TestImapViaImapDaemon.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestImapViaImapDaemon.java
@@ -1,14 +1,26 @@
 package com.zimbra.qa.unittest;
 
-import java.io.IOException;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
-import org.dom4j.DocumentException;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
 
-import com.zimbra.common.localconfig.ConfigException;
+import com.zimbra.common.account.Key.CacheEntryBy;
 import com.zimbra.common.localconfig.LC;
-import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.localconfig.LocalConfig;
+import com.zimbra.common.util.Log;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning.CacheEntry;
+import com.zimbra.cs.imap.ImapProxy.ZimbraClientAuthenticator;
+import com.zimbra.cs.mailclient.CommandFailedException;
+import com.zimbra.cs.mailclient.auth.AuthenticatorFactory;
+import com.zimbra.cs.mailclient.imap.ImapConfig;
+import com.zimbra.cs.mailclient.imap.ImapConnection;
+import com.zimbra.cs.security.sasl.ZimbraAuthenticator;
+import com.zimbra.cs.service.AuthProvider;
+import com.zimbra.soap.admin.type.CacheEntryType;
 
 /**
  * Test the IMAP server provided by the IMAP daemon, doing the necessary configuration to make it work.
@@ -20,23 +32,191 @@ import com.zimbra.common.service.ServiceException;
 public class TestImapViaImapDaemon extends SharedImapTests {
 
     @Before
-    public void setUp() throws ServiceException, IOException, DocumentException, ConfigException  {
+    public void setUp() throws Exception  {
+        getLocalServer();
+        TestUtil.assumeTrue("remoteImapServerEnabled false for this server", imapServer.isRemoteImapServerEnabled());
         saveImapConfigSettings();
         TestUtil.setLCValue(LC.imap_always_use_remote_store, String.valueOf(false));
-        getLocalServer();
         imapServer.setReverseProxyUpstreamImapServers(new String[] {imapServer.getServiceHostname()});
         super.sharedSetUp();
-        TestUtil.assumeTrue("remoteImapServerEnabled false for this server", imapServer.isRemoteImapServerEnabled());
+        TestUtil.flushImapDaemonCache(imapServer);
     }
 
     @After
-    public void tearDown() throws ServiceException, DocumentException, ConfigException, IOException  {
+    public void tearDown() throws Exception {
         super.sharedTearDown();
-        restoreImapConfigSettings();
+        if (imapHostname != null) {
+            restoreImapConfigSettings();
+            TestUtil.flushImapDaemonCache(imapServer);
+            getAdminConnection().reloadLocalConfig();
+        }
     }
 
     @Override
     protected int getImapPort() {
         return imapServer.getRemoteImapBindPort();
+    }
+
+    @Override
+    protected void flushCacheIfNecessary() throws Exception {
+        TestUtil.flushImapDaemonCache(imapServer);
+    }
+
+    @Test
+    public void testClearDaemonCacheWrongAuthenticator() throws Exception {
+        connection = connect();
+        try {
+            connection.flushCache(CacheEntryType.config.toString());
+            fail("should not be able to flush the cache without authenticating");
+        } catch (CommandFailedException cfe) {
+            assertEquals("must be in AUTHENTICATED or SELECTED state", cfe.getError());
+        }
+        connection.login(PASS);
+        try {
+            connection.flushCache(CacheEntryType.config.toString());
+            fail("should not be able to flush the cache without using X-ZIMBRA auth mechanism");
+        } catch (CommandFailedException cfe) {
+            assertEquals("must be authenticated as admin with X-ZIMBRA auth mechanism", cfe.getError());
+        }
+    }
+
+    private void tryConnect(boolean shouldSucceed, String message) throws Exception {
+        try {
+            connection = connect(USER);
+            connection.login(PASS);
+            if (!shouldSucceed) {
+                fail(message);
+            }
+        } catch (CommandFailedException e) {
+            if (shouldSucceed) {
+                fail(message);
+            }
+        }
+    }
+
+    private void enableImapAndCheckCachedValue(Account acct) throws Exception {
+        acct.setImapEnabled(true);
+        tryConnect(false, "should not be able to log in since imapd has old value of zimbraImapEnabled=FALSE");
+    }
+
+    private void disableImapAndCheckCachedValue(Account acct) throws Exception {
+        acct.setImapEnabled(false);
+        tryConnect(true, "should be able to log in since imapd has old value of zimbraImapEnabled=TRUE");
+    }
+
+    @Test
+    public void testClearDaemonCache() throws Exception {
+        tryConnect(true, "should be able to log in initially"); //loads the account into the imapd cache
+
+        Account acct = TestUtil.getAccount(USER);
+        CacheEntry acctByName = new CacheEntry(CacheEntryBy.name, acct.getName());
+        CacheEntry acctById = new CacheEntry(CacheEntryBy.id, acct.getId());
+        ImapConnection adminConn = getAdminConnection();
+
+        //verify that we can flush an account cache by name
+        disableImapAndCheckCachedValue(acct);
+        adminConn.flushCache("account", new CacheEntry[] { acctByName });
+        tryConnect(false, "should not be able to log in after flushing LDAP cache by account name");
+
+        //verify that we can flush an account cache by ID
+        enableImapAndCheckCachedValue(acct);
+        adminConn.flushCache("account", new CacheEntry[] { acctById });
+        tryConnect(true, "should be able to log in after flushing LDAP cache by account ID");
+
+        //verify that we can flush an account cache with multiple CacheEntries
+        disableImapAndCheckCachedValue(acct);
+        adminConn.flushCache("account", new CacheEntry[] { acctByName, acctById });
+        tryConnect(false, "should not be able to log in after flushing LDAP cache by account name and ID");
+
+        //verify that we can flush an account cache without a CacheEntry value
+        enableImapAndCheckCachedValue(acct);
+        adminConn.flushCache("account");
+        tryConnect(true, "should be able to log in after flushing entire LDAP account cache");
+
+        //verify that we can flush multiple cache types at once
+        disableImapAndCheckCachedValue(acct);
+        adminConn.flushCache("config,account");
+        tryConnect(false, "should not be able to log in after flushing multiple cache types");
+
+        //verify that we can flush all caches
+        enableImapAndCheckCachedValue(acct);
+        adminConn.flushCache("all");
+        tryConnect(true, "should be able to log in after flushing all caches");
+    }
+
+    @Test
+    public void testReloadLocalConfig() throws Exception {
+        //to test this, we set imap_max_consecutive_error to 1 and make sure imapd disconnects after
+        //the first failure
+        ImapConnection adminConn = getAdminConnection();
+        int savedMaxConsecutiveError = LC.imap_max_consecutive_error.intValue();
+
+        //don't use TestUtil.setLCValue, since it issues a ReloadLocalConfigRequest, which will
+        //send out its own RELOADLC request
+        LocalConfig lc = new LocalConfig(null);
+        lc.set(LC.imap_max_consecutive_error.key(), "1");
+        lc.save();
+
+        connection = connect(USER);
+        connection.login(PASS);
+        try {
+            //sanity check: even though the LC value is changed, imapd should still be using the old value
+            for (int i = 0; i < savedMaxConsecutiveError; i++) {
+                try {
+                    connection.select("BAD");
+                } catch (CommandFailedException e) {
+                    assertEquals("expected 'SELECT failed' error", "SELECT failed", e.getError());
+                }
+            }
+            try {
+                connection.select("INBOX");
+                fail("session should be disconnected due to too many consecutive errors");
+            } catch (CommandFailedException e) {}
+
+            //reload LC and reconnect; imapd should now be using the new value
+            adminConn.reloadLocalConfig();
+            connection = connect(USER);
+            connection.login(PASS);
+            try {
+                connection.select("BAD");
+            } catch (CommandFailedException e) {
+                assertEquals("expected 'SELECT failed' error", "SELECT failed", e.getError());
+            }
+            try {
+                connection.select("INBOX");
+                fail("session should be disconnected after 1 error");
+            } catch (CommandFailedException e) {}
+        } finally {
+            TestUtil.setLCValue(LC.imap_max_consecutive_error, String.valueOf(savedMaxConsecutiveError));
+            adminConn.reloadLocalConfig();
+        }
+    }
+
+    @Test
+    public void testZimbraCommandsNonAdminUser() throws Exception {
+        Account acct = TestUtil.getAccount(USER);
+        AuthenticatorFactory authFactory = new AuthenticatorFactory();
+        authFactory.register(ZimbraAuthenticator.MECHANISM, ZimbraClientAuthenticator.class);
+        ImapConfig config = new ImapConfig(imapHostname);
+        config.setMechanism(ZimbraAuthenticator.MECHANISM);
+        config.setAuthenticatorFactory(authFactory);
+        config.setPort(imapPort);
+        config.setAuthenticationId(acct.getName());
+        config.getLogger().setLevel(Log.Level.trace);
+        ImapConnection conn = new ImapConnection(config);
+        conn.connect();
+        conn.authenticate(AuthProvider.getAuthToken(acct).getEncoded());
+        try {
+            conn.reloadLocalConfig();
+            fail("should not be able to run X-ZIMBRA-RELOADLC command with a non-admin auth token");
+        } catch (CommandFailedException cfe) {
+            assertEquals("must be authenticated as admin with X-ZIMBRA auth mechanism", cfe.getError());
+        }
+        try {
+            conn.flushCache("all");
+            fail("should not be able to run X-ZIMBRA-FLUSHCACHE command with a non-admin auth token");
+        } catch (CommandFailedException cfe) {
+            assertEquals("must be authenticated as admin with X-ZIMBRA auth mechanism", cfe.getError());
+        }
     }
 }

--- a/store/src/java/com/zimbra/qa/unittest/TestUtil.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestUtil.java
@@ -38,6 +38,8 @@ import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 import javax.mail.util.SharedByteArrayInputStream;
 
+import junit.framework.Assert;
+
 import org.dom4j.DocumentException;
 import org.junit.internal.AssumptionViolatedException;
 import org.junit.runner.JUnitCore;
@@ -148,6 +150,7 @@ import com.zimbra.cs.rmgmt.RemoteCommands;
 import com.zimbra.cs.rmgmt.RemoteMailQueue;
 import com.zimbra.cs.rmgmt.RemoteMailQueue.QueueAttr;
 import com.zimbra.cs.rmgmt.RemoteManager;
+import com.zimbra.cs.service.admin.FlushCache;
 import com.zimbra.cs.store.StoreManager;
 import com.zimbra.cs.store.file.FileBlobStore;
 import com.zimbra.cs.util.BuildInfo;
@@ -175,8 +178,6 @@ import com.zimbra.soap.admin.type.WaitSetSessionInfo;
 import com.zimbra.soap.type.AccountSelector;
 import com.zimbra.soap.type.TargetBy;
 import com.zimbra.soap.type.TargetType;
-
-import junit.framework.Assert;
 
 
 /**
@@ -1634,5 +1635,9 @@ public class TestUtil extends Assert {
         } catch (AssumptionViolatedException ave) {
             throw new AssumptionViolatedException(missive, null);
         }
+    }
+
+    public static void flushImapDaemonCache(Server imapd) throws Exception {
+        FlushCache.flushCacheOnImapDaemon(imapd, "all", null);
     }
 }


### PR DESCRIPTION
This PR adds two new zimbra-only IMAP operations and updates the server to make use of those operations where necessary.

### New IMAP commands

#### FLUSHCACHE 
The `FLUSHCACHE` imap command is used to flush the specified cache. It is equivalent to _FlushCacheRequest_, except that it does not support an _allServers_ parameter. The syntax is as follows:
  - `FLUSHCACHE <cacheTypes>` flushes the entire cache of the specified comma-separated cache types, such as `FLUSHCACHE account` or `FLUSHCACHE server,config`.
  - `FLUSHCACHE <cacheTypes> (<id|name> <entry id or name> ... )` flushes the cache entries specified in the parameters list. For example, a single account can be flushed with `FLUSHCACHE account (id <accountId>)`

#### RELOADLC
The `RELOADLC` imap command forces the imapd server to reload its LocalConfig instance. It is equivalent to _ReloadLocalConfigRequest_. This command has no other parameters.

Both `FLUSHCACHE` and `RELOADLC` _must_ be run from a session authenticated with the X-ZIMBRA auth mechanism. In other words, only a client that can generate a valid auth token can use these commands. An error will be thrown if these commands are used without proper authentication.

Since these commands are issued by a ZCS server to an imapd server, these commands are authenticated with an admin auth token for the internal _zimbra_ account. In order for this to work, several small changes had to be made to make the zimbra user compatible with the imap server:
 - The _ZimbraAuthenticator_ class now supports admin users
 - _ZimbraAuthenticator_ doesn't call _authorize()_ when dealing with the _zimbra_ user. The _Authenticator::authorize_ method doesn't currently fetch admin accounts, but if it did, it would succeed in this case because both the _authAccount_ and _username_ params are the _zimbra_ user.
 - ImapHandler::startSession doesn't begin tracking IMAP if the user is _zimbra_. This is because the _zimbra_ user doesn't have a server associated with it, and to avoid unnecessary work.
  
### Server changes

1. The _FlushCache_ SOAP handler has several new methods:
    - _flushCacheOnImapDaemon_ issues a FLUSHCACHE imap command to the specified server for the given cache types and entries, using the provided auth token.
    - _flushCacheOnAllImapDaemons_ calls the above method for all servers that have the "imapd" service enabled. Note that this may include servers that are not part of the _zimbraReverseProxyUpstreamImapServers_ pool, but given that this attribute is both server- and config-level, this seemed more straightforward than trying to aggregate the exact list of current imap servers.
    - If a _FlushCacheRequest_ has _allServers=true_, the handler will call _flushCacheOnAllImapDaemons_ in addition to forwarding the SOAP request to other mailbox servers.

2. The _ReloadLocalConfig_ SOAP handler sends out a `RELOADLC` command to all imapd servers. Both _ReloadLocalConfig_ and _FlushCache_ handlers make use of the new static utility method _ImapConnection::getAdminConnection_.

3. In order to clear imapd caches when changing _zimbraEphemeralBackendURL_, the auth token used to authenticate the IMAP session needs to be registered with the *previous* ephemeral backend. This is because the token is generated on a server which is aware of the new backend, but validated on a server which is not. To this end:
    - A new LDAP attribute zimbraPreviousEphemeralBackendURL keeps track of the previous ephemeral store. This attribute is immutable, and is changed by the callback attached to _zimbraEphemeralBackendURL_.
    - _EphemeralStore_ has a new enum _BackendType_ {primary, previous} and a new method _getNewFactory_ that can return a new _Factory_ instance for a given BackendType, without setting it as the singleton. This value of _BackendType_ is also set on the factory itself; the new protected method _getURL()_ uses this to return either the current or previous ephemeral backend URL. Subclasses of _EphemeralStore_ need to use _getURL()_ to access the backend configuration instead of assuming _zimbraEphemeralBackendURL_.
    - _ZimbraAuthToken_ has a new method _registerWithEphemeralStore_ that bypasses the normal _ZAttrAccount::addAuthTokens_ code path and registers the auth token with the provided backend.
    - _AttributeMigration::clearConfigCacheOnAllServers_ flushes the cache on all imapd servers asynchronously. Prior to doing so, the auth token is registered with the previous ephemeral backend so that imapd can validate it. Note that this may not be necessary - this method is also called before/after attribute migration, at which point imapd will already be aware of the new backend.
    - _EphemeralStore_ loads the ephemeral backend extensions as needed, instead of relying on the extension being initialized previously. imapd used to only initialize the extension associated with the current backend URL, which caused problems when the backend is changed.

### Testing

 - New tests _testClearDaemonCache_, _testReloadLocalConfig_, and _testClearDaemonCacheWrongAuthenticator_ in _TestImapViaImapDaemon_
 - New test _testPreviousEphemeralBackendURL_ in _TestChangeEphemeralStore_.
 - _TestUtil_ has a new method _flushImapDaemonCache_. This method is added to the _setUp_ and _tearDown_ methods of _TestImapViaImapDaemon_ and _TestImapDaemonNotifications_, as well as to _TestImapClient::cleanup_. 
 - new empty method _SharedImapTests::flushCacheIfNecessary_ that is overridden by _TestImapViaImapDaemon_. This is used by _testMailfoldersOnlyList_ to force the imapd to pick up the change to _zimbraImapDisplayMailFoldersOnly_.

The changes to _TestUtil_ allow ImapDaemon tests to run consecutively without the LOGIN errors seen before, since the account cache is now flushed before each test run. It also fixes the test failures caused by imapd not picking up attribute changes. On my environment, all tests in _TestImapClient_, _TestImapVia*_, and _TestImap*Notifications_ passed.

I also tested changing the ephemeral backend and running an attribute migration while logged into imapd:
 - If an IMAP command is issued after a change to the ephemeral backend but prior to migration, the session is disconnected since the auth token is no longer valid.
 - If an attribute migration is run first, the session continues normally.


#### Updates from Feedback:
 - The new imap commands have been renamed to `X-ZIMBRA-FLUSHCACHE` and `X-ZIMBRA-RELOADLC`
 - removed the special-case logic in _ZimbraAuthenticator_ in lieu of updating _Authenticator::authenticate_ method to handle admin accounts
 - _FlushCache_ SOAP handler uses the the same account name and auth token to flush imapd caches as was used to authenticate the request
 - ImapHandler checks whether the authenticated user has admin rights to flush the cache
 - The new IMAP commands require _ZimbraAuthenticator_ to be authenticated with an admin auth token; added new test _testZimbraCommandsNonAdminUser_ to verify this
 - Changed `X-ZIMBRA-FLUSHCACHE` command signature to specify multiple cache types in parentheses instead of CSV
