### PR TITLE
ZCS-1922 Fix travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,16 @@ script:
   - mkdir -p ${HOME}/.ivy2/cache
   - wget https://files.zimbra.com/repository/ant-contrib/ant-contrib-1.0b1.jar                           -O ${HOME}/.zcs-deps/ant-contrib-1.0b1.jar
   - wget https://files.zimbra.com/repository/ant-1.7.0-ziputil-patched/ant-1.7.0-ziputil-patched-1.0.jar -O ${HOME}/.zcs-deps/ant-1.7.0-ziputil-patched-1.0.jar
-  - ant -Dzimbra.buildinfo.version=1.1.1_GA_1000 test-all
+  - cd ..
+  - git clone https://github.com/Zimbra/zm-timezones.git
+  - cd zm-mailbox/native
+  -  ant -Dzimbra.buildinfo.version=1.1.1_GA_1000 publish-local
+  - cd ../common
+  -  ant -Dzimbra.buildinfo.version=1.1.1_GA_1000 publish-local
+  - cd ../soap
+  -  ant -Dzimbra.buildinfo.version=1.1.1_GA_1000 publish-local
+  - cd ../client
+  -  ant -Dzimbra.buildinfo.version=1.1.1_GA_1000 publish-local
+  - cd ../store
+  -  ant -Dzimbra.buildinfo.version=1.1.1_GA_1000 publish-local
+  - ant -Dzimbra.buildinfo.version=1.1.1_GA_1000 test


### PR DESCRIPTION
Came across the failures on Travis CI while working on ZCS-1922
Fixed travis script so that the unit tests pass on Travis CI

We can remove the dependency for zm-timezones later. But at this point at least the script will run to give us correct output

Testing:
The script is passing on my fork
https://travis-ci.org/rohan-ambasta/zm-mailbox