### PR TITLE
ZCS-1781: Proper IMAP permanent flag handling in the remote case

### DIFF
--- a/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
@@ -33,6 +33,7 @@ import javax.mail.internet.MimeMessage;
 
 import org.dom4j.QName;
 
+import com.google.common.primitives.Ints;
 import com.zimbra.client.ZContact;
 import com.zimbra.client.ZFolder;
 import com.zimbra.client.ZMailbox;
@@ -517,7 +518,11 @@ public class ItemActionHelper {
                     getMailbox().move(getOpCtxt(), ids, type, mIidFolder.getId(), mTargetConstraint);
                 }
                 if (mTags != null || mFlags != null) {
-                    int flagMask = Flag.toBitmask(mFlags);
+                    //check if the flags were passed in as the bitmask
+                    Integer flagMask = Ints.tryParse(mFlags);
+                    if (flagMask == null) {
+                        flagMask = Flag.toBitmask(mFlags);
+                    }
                     if (mFlags == null) {
                         flagMask = MailItem.FLAG_UNCHANGED;
                     }

--- a/store/src/java/com/zimbra/qa/unittest/SharedImapTests.java
+++ b/store/src/java/com/zimbra/qa/unittest/SharedImapTests.java
@@ -26,7 +26,6 @@ import java.util.regex.Pattern;
 import javax.mail.MessagingException;
 
 import org.apache.commons.lang.StringUtils;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.google.common.collect.Lists;
@@ -724,7 +723,7 @@ public abstract class SharedImapTests extends ImapTestBase {
         });
     }
 
-    @Ignore
+    @Test(timeout=100000)
     public void testZCS1781() throws Exception {
         ZMailbox mbox = TestUtil.getZMailbox(USER);
         TestUtil.addMessage(mbox, "test for ZCS-1781");


### PR DESCRIPTION
The bug was caused by the fact that the ItemActionRequest API expects the flags to be passed in as a readable string, while ZMailbox sends it as the bitmask. This results in the flags not being parsed by the server correctly. The solution is to update _ItemActionHelper_ to accept a bitmask string as well as the readable form.