### PR TITLE
ZCS-886: same exception message format if header name has a non-ascii…

### DIFF
--- a/store/src/java-test/com/zimbra/cs/filter/ReplaceHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/ReplaceHeaderTest.java
@@ -25,6 +25,7 @@ import java.util.UUID;
 
 import javax.mail.Header;
 
+import org.apache.jsieve.exception.SyntaxException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -34,6 +35,7 @@ import com.google.common.collect.Maps;
 import com.zimbra.common.account.Key;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.filter.jsieve.EditHeaderExtension;
 import com.zimbra.cs.mailbox.DeliveryContext;
 import com.zimbra.cs.mailbox.MailItem;
 import com.zimbra.cs.mailbox.Mailbox;
@@ -1476,6 +1478,30 @@ public class ReplaceHeaderTest {
             Assert.assertEquals("New Value", subjectValue);
         } catch (Exception e) {
             fail("No exception should be thrown: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testNonAsciiHeaderName() {
+        EditHeaderExtension ext = new EditHeaderExtension();
+        ext.setKey("日本語ヘッダ名");
+        try {
+            ext.commonValidation("ReplaceHeader");
+        } catch (SyntaxException e) {
+            Assert.assertEquals("ReplaceHeader:Header name must be printable ASCII only.", e.getMessage());
+            
+        }
+    }
+
+    @Test
+    public void testNonAsciiHeaderNameWithoutOperation() {
+        EditHeaderExtension ext = new EditHeaderExtension();
+        ext.setKey("日本語ヘッダ名");
+        try {
+            ext.commonValidation(null);
+        } catch (SyntaxException e) {
+            Assert.assertEquals("EditHeaderExtension:Header name must be printable ASCII only.", e.getMessage());
+            
         }
     }
 }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/DeleteHeader.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/DeleteHeader.java
@@ -143,6 +143,6 @@ public class DeleteHeader extends AbstractCommand {
         if (ehe.getKey() == null) {
             throw new SyntaxException("deleteheader : key not found.");
         }
-        ehe.commonValidation();
+        ehe.commonValidation("DeleteHeader");
     }
 }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/EditHeaderExtension.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/EditHeaderExtension.java
@@ -486,13 +486,17 @@ public class EditHeaderExtension {
      * Common validation for replaceheader and deleteheader
      * @throws SyntaxException
      */
-    public void commonValidation() throws SyntaxException {
+    public void commonValidation(String operation) throws SyntaxException {
+        if(StringUtil.isNullOrEmpty(operation)) {
+            operation = "EditHeaderExtension";
+        }
+
         if (!StringUtil.isNullOrEmpty(this.key)) {
             if (!CharsetUtil.US_ASCII.equals(CharsetUtil.checkCharset(this.key, CharsetUtil.US_ASCII))) {
-                throw new SyntaxException("key must be printable ASCII only.");
+                throw new SyntaxException(operation +":Header name must be printable ASCII only.");
             }
         } else {
-            throw new SyntaxException("EditHeaderExtension:Header name must be present.");
+            throw new SyntaxException(operation +":Header name must be present.");
         }
         // relation comparator must be valid
         if (this.relationalComparator != null) {
@@ -502,7 +506,7 @@ public class EditHeaderExtension {
                     || this.relationalComparator.equals(MatchRelationalOperators.LE_OP)
                     || this.relationalComparator.equals(MatchRelationalOperators.EQ_OP)
                     || this.relationalComparator.equals(MatchRelationalOperators.NE_OP))) {
-                throw new SyntaxException("Invalid relational comparator provided.");
+                throw new SyntaxException(operation +":Invalid relational comparator provided.");
             }
         }
         // comparator must be valid and if not set, then set to default i.e. ComparatorNames.ASCII_CASEMAP_COMPARATOR
@@ -511,7 +515,7 @@ public class EditHeaderExtension {
                     || this.comparator.equals(ComparatorNames.OCTET_COMPARATOR)
                     || this.comparator.equals(ComparatorNames.ASCII_CASEMAP_COMPARATOR)
                     )) {
-                throw new SyntaxException("Invalid comparator type provided");
+                throw new SyntaxException(operation +":Invalid comparator type provided");
             }
         } else {
             this.comparator = ComparatorNames.ASCII_CASEMAP_COMPARATOR;
@@ -519,7 +523,7 @@ public class EditHeaderExtension {
         }
         // relational comparator must be available with numeric comparison
         if (this.comparator.equals(I_ASCII_NUMERIC) && !(this.countTag || this.valueTag || this.is)) {
-            throw new SyntaxException("No valid comparator (:value, :count or :is) found for numeric operation.");
+            throw new SyntaxException(operation +":No valid comparator (:value, :count or :is) found for numeric operation.");
         }
         // set index 0 if last tag argument is provided. So that, correct index can be calculated.
         if (this.index == null && this.last) {

--- a/store/src/java/com/zimbra/cs/filter/jsieve/ReplaceHeader.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/ReplaceHeader.java
@@ -185,6 +185,6 @@ public class ReplaceHeader extends AbstractCommand {
         if (ehe.getNewValue() != null) {
             ZimbraLog.filter.debug("replaceheader: new header vlaue in sieve script = %s", ehe.getNewValue());
         }
-        ehe.commonValidation();
+        ehe.commonValidation("ReplaceHeader");
     }
 }


### PR DESCRIPTION
Exception message should be the same format among addheader/deleteheader/replaceheader if header name has a non-ascii character.
Added Unit test.