### PR TITLE
ZCS-1571 ZMailbox::getFolderById exception with invalid id

### DIFF
--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -2956,9 +2956,16 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
             /* sometimes when working on behalf of, we're getting just by item id but the
              * cache has fully qualified keys.
              */
-            String ident = new ItemIdentifier(id, this.getAccountId()).toString();
-            if (!id.equals(ident)) {
-                item = mItemCache.getById(ident);
+            try {
+                String ident = new ItemIdentifier(id, this.getAccountId()).toString();
+                if (!id.equals(ident)) {
+                    item = mItemCache.getById(ident);
+                }
+            } catch (ServiceException e) {
+                // This can be raised when constructing an ItemIdentifier with a folder name; e.g., "INBOX"
+                if (!(e.getCause() instanceof NumberFormatException)) {
+                    throw e;
+                }
             }
         }
         if (!(item instanceof ZFolder)) {


### PR DESCRIPTION
Part of the work done for ZCS-1571 changed the behavior of the
`getFolderById` method. Prior to the changes done for that ticket
the `getFolderById` function would return `null` if called
with an argument that was not a folder id; e.g., "INBOX".

More aggressive cache checking created a new behavior that would
instead result in a ServiceException when the method was
called in a similar fashion.