### PR TITLE
ZCS-1841:Add attribute to turn enable/disable edit header functionality

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -15341,6 +15341,16 @@ public class ZAttrProvisioning {
     public static final String A_zimbraShortTermGranteeCacheSize = "zimbraShortTermGranteeCacheSize";
 
     /**
+     * Whether edit header commands in admin sieve scripts are enabled or
+     * disabled. If TRUE, the addheader, deleteheader and replaceheader
+     * commands will be executed during admin sieve script execution.
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2120)
+    public static final String A_zimbraSieveEditHeaderEnabled = "zimbraSieveEditHeaderEnabled";
+
+    /**
      * Deprecated since: 8.7.8. Variable feature is always enabled, hence
      * this attribute has been deprecated. Orig desc: Whether to enable the
      * Sieve &quot;Variables&quot; extension defined in RFC 5229 in the
@@ -15394,7 +15404,7 @@ public class ZAttrProvisioning {
      *
      * @since ZCS 8.7.8
      */
-    @ZAttr(id=2118)
+    @ZAttr(id=2119)
     public static final String A_zimbraSieveRequireControlEnabled = "zimbraSieveRequireControlEnabled";
 
     /**

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9507,5 +9507,9 @@ TODO: delete them permanently from here
 <desc>Whether the declaration of the Sieve extension feature is mandatory by the 'require' control. If TRUE, before ZCS evaluates a Sieve extension test or action, it checks the corresponding capability string at 'require' control; and if the capability string is not declared in the 'require', the entire Sieve filter execution will be failed. If FALSE, any Sieve extensions can be used without declaring the capability string in the 'require' control.</desc>
 </attr>
 
+<attr id="2120" name="zimbraSieveEditHeaderEnabled" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.8.0">
+<defaultCOSValue>FALSE</defaultCOSValue>
+<desc>Whether edit header commands in admin sieve scripts are enabled or disabled. If TRUE, the addheader, deleteheader and replaceheader commands will be executed during admin sieve script execution.</desc>
+</attr>
 </attrs>
 

--- a/store/src/java-test/com/zimbra/cs/filter/AddHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/AddHeaderTest.java
@@ -99,6 +99,10 @@ public class AddHeaderTest {
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
         prov.createAccount("test2@zimbra.com", "secret", attrs);
 
+        attrs = Maps.newHashMap();
+        attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        prov.createAccount("test3@zimbra.com", "secret", attrs);
+
         // this MailboxManager does everything except actually send mail
         MailboxManager.setInstance(new DirectInsertionMailboxManager());
 
@@ -125,8 +129,8 @@ public class AddHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -164,8 +168,8 @@ public class AddHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -200,8 +204,8 @@ public class AddHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -243,8 +247,8 @@ public class AddHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -284,8 +288,8 @@ public class AddHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -333,8 +337,8 @@ public class AddHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -377,7 +381,8 @@ public class AddHeaderTest {
             Account account = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
             RuleManager.clearCachedRules(account);
-            account.setMailSieveScript(filterScript);
+            account.setSieveEditHeaderEnabled(true);
+            account.setAdminSieveScriptBefore(filterScript);
             List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox), mbox,
                     new ParsedMessage(triggeringMsg.toString().getBytes(), false), 0,
@@ -416,8 +421,8 @@ public class AddHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -446,7 +451,8 @@ public class AddHeaderTest {
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
             RuleManager.clearCachedRules(acct1);
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -475,7 +481,8 @@ public class AddHeaderTest {
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
             RuleManager.clearCachedRules(acct1);
-            acct1.setMailSieveScript(filterScript);
+            acct1.setAdminSieveScriptBefore(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -504,7 +511,8 @@ public class AddHeaderTest {
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
             RuleManager.clearCachedRules(acct1);
-            acct1.setMailSieveScript(filterScript);
+            acct1.setAdminSieveScriptBefore(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -535,7 +543,8 @@ public class AddHeaderTest {
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
             RuleManager.clearCachedRules(acct1);
-            acct1.setMailSieveScript(filterScript);
+            acct1.setAdminSieveScriptBefore(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -561,8 +570,8 @@ public class AddHeaderTest {
                 + "from: test2@zimbra.com\n"
                 + "to: test@zimbra.com\n";
 
-        String filterAdminBefore = "tag \"tag-admin-before\";";
-        String filterScriptUser = "require [\"editheader\", \"variables\"];\n"
+        String filterScriptUser = "tag \"tag-user\";";
+        String filterAdminBefore = "require [\"editheader\", \"variables\"];\n"
                 + "if header :matches \"Subject\" \"*\" {\n"
                 + " tag \"tag-${1}1\";\n"
                 + " addheader \"my-new-header\" \"${1}\";\n"
@@ -582,7 +591,7 @@ public class AddHeaderTest {
             acct1.setAdminSieveScriptBefore(filterAdminBefore);
             acct1.setMailSieveScript(filterScriptUser);
             acct1.setAdminSieveScriptAfter(filterAdminAfter);
-
+            acct1.setSieveEditHeaderEnabled(true);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -601,9 +610,9 @@ public class AddHeaderTest {
             Assert.assertTrue(isAdded);
             String[] tags = mdnMsg.getTags();
             Assert.assertEquals(4, tags.length);
-            Assert.assertEquals("tag-admin-before", tags[0]);
-            Assert.assertEquals("tag-example1", tags[1]);
-            Assert.assertEquals("tag-example2", tags[2]);
+            Assert.assertEquals("tag-example1", tags[0]);
+            Assert.assertEquals("tag-example2", tags[1]);
+            Assert.assertEquals("tag-user", tags[2]);
             Assert.assertEquals("tag-admin-after", tags[3]);
         } catch (Exception e) {
             fail("No exception should be thrown: " + e.getMessage());
@@ -633,8 +642,8 @@ public class AddHeaderTest {
             acct1.unsetAdminSieveScriptBefore();
             acct1.unsetMailSieveScript();
             acct1.unsetAdminSieveScriptAfter();
-
-            acct1.setMailSieveScript(filterScriptUser);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScriptUser);
 
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
@@ -662,6 +671,106 @@ public class AddHeaderTest {
             Assert.assertEquals(2, tags.length);
             Assert.assertEquals("tag-example1", tags[0]);
             Assert.assertEquals("tag-example2", tags[1]);
+        } catch (Exception e) {
+            fail("No exception should be thrown: " + e.getMessage());
+        }
+    }
+
+    /*
+     * Try adding new header in admin script when the SieveEditHeaderEnabled attribute is true
+     */
+    @Test
+    public void addHeaderSieveEditHeaderEnabledTrue() {
+        try {
+            String filterScript = "require [\"editheader\"];\n"
+                + "addheader \"X-New-Header\" \"my-new-header-value\";";
+            Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+            Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
+            RuleManager.clearCachedRules(acct1);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
+            RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox1), mbox1,
+                new ParsedMessage(sampleBaseMsg.getBytes(), false), 0, acct1.getName(), null,
+                new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
+            Integer itemId = mbox1.getItemIds(null, Mailbox.ID_FOLDER_INBOX)
+                .getIds(MailItem.Type.MESSAGE).get(0);
+            Message mdnMsg = mbox1.getMessageById(null, itemId);
+            boolean matchFound = false;
+            for (Enumeration<Header> e = mdnMsg.getMimeMessage().getAllHeaders(); e
+                .hasMoreElements();) {
+                Header temp = e.nextElement();
+                if (temp.getName().equals("X-New-Header")) {
+                    matchFound = true;
+                    Assert.assertEquals("my-new-header-value", temp.getValue());
+                }
+            }
+            Assert.assertTrue(matchFound);
+        } catch (Exception e) {
+            fail("No exception should be thrown: " + e.getMessage());
+        }
+    }
+
+    /*
+     * Try adding new header in admin script when the SieveEditHeaderEnabled attribute is false
+     */
+    @Test
+    public void addHeaderSieveEditHeaderEnabledFalse() {
+        try {
+            String filterScript = "require [\"editheader\"];\n"
+                + "addheader \"X-New-Header\" \"my-new-header-value\";";
+            Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+            Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
+            RuleManager.clearCachedRules(acct1);
+            acct1.setSieveEditHeaderEnabled(false);
+            acct1.setAdminSieveScriptBefore(filterScript);
+            RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox1), mbox1,
+                new ParsedMessage(sampleBaseMsg.getBytes(), false), 0, acct1.getName(), null,
+                new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
+            Integer itemId = mbox1.getItemIds(null, Mailbox.ID_FOLDER_INBOX)
+                .getIds(MailItem.Type.MESSAGE).get(0);
+            Message mdnMsg = mbox1.getMessageById(null, itemId);
+            boolean matchFound = false;
+            for (Enumeration<Header> e = mdnMsg.getMimeMessage().getAllHeaders(); e
+                .hasMoreElements();) {
+                Header temp = e.nextElement();
+                if (temp.getName().equals("X-New-Header")) {
+                    matchFound = true;
+                }
+            }
+            Assert.assertFalse(matchFound);
+        } catch (Exception e) {
+            fail("No exception should be thrown: " + e.getMessage());
+        }
+    }
+
+    /*
+     * Try adding new header in user script
+     */
+    @Test
+    public void addHeaderUserSieveScript() {
+        try {
+            String filterScript = "require [\"editheader\"];\n"
+                + "addheader \"X-New-Header\" \"my-new-header-value\";";
+            Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test3@zimbra.com");
+            Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
+            RuleManager.clearCachedRules(acct1);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setMailSieveScript(filterScript);
+            RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox1), mbox1,
+                new ParsedMessage(sampleBaseMsg.getBytes(), false), 0, acct1.getName(), null,
+                new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
+            Integer itemId = mbox1.getItemIds(null, Mailbox.ID_FOLDER_INBOX)
+                .getIds(MailItem.Type.MESSAGE).get(0);
+            Message mdnMsg = mbox1.getMessageById(null, itemId);
+            boolean matchFound = false;
+            for (Enumeration<Header> e = mdnMsg.getMimeMessage().getAllHeaders(); e
+                .hasMoreElements();) {
+                Header temp = e.nextElement();
+                if (temp.getName().equals("X-New-Header")) {
+                    matchFound = true;
+                }
+            }
+            Assert.assertFalse(matchFound);
         } catch (Exception e) {
             fail("No exception should be thrown: " + e.getMessage());
         }

--- a/store/src/java-test/com/zimbra/cs/filter/DeleteHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/DeleteHeaderTest.java
@@ -97,6 +97,10 @@ public class DeleteHeaderTest {
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
         prov.createAccount("test3@zimbra.com", "secret", attrs);
 
+        attrs = Maps.newHashMap();
+        attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        prov.createAccount("test4@zimbra.com", "secret", attrs);
+
         // this MailboxManager does everything except actually send mail
         MailboxManager.setInstance(new DirectInsertionMailboxManager());
 
@@ -148,8 +152,8 @@ public class DeleteHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -202,8 +206,8 @@ public class DeleteHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -238,8 +242,8 @@ public class DeleteHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -277,8 +281,8 @@ public class DeleteHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -318,8 +322,8 @@ public class DeleteHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -355,8 +359,8 @@ public class DeleteHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -392,8 +396,8 @@ public class DeleteHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -429,8 +433,8 @@ public class DeleteHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -466,8 +470,8 @@ public class DeleteHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -503,8 +507,8 @@ public class DeleteHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -542,8 +546,8 @@ public class DeleteHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -589,8 +593,8 @@ public class DeleteHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -636,8 +640,8 @@ public class DeleteHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -686,8 +690,8 @@ public class DeleteHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -722,8 +726,8 @@ public class DeleteHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -758,8 +762,8 @@ public class DeleteHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -808,8 +812,8 @@ public class DeleteHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -843,8 +847,8 @@ public class DeleteHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -879,8 +883,8 @@ public class DeleteHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -916,8 +920,8 @@ public class DeleteHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -952,7 +956,8 @@ public class DeleteHeaderTest {
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
             RuleManager.clearCachedRules(acct1);
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -991,8 +996,8 @@ public class DeleteHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -1022,8 +1027,8 @@ public class DeleteHeaderTest {
                 + "to: test@zimbra.com\n"
                 + "X-Test-Header: test1";
 
-        String filterAdminBefore = "tag \"tag-admin-before\";";
-        String filterScriptUser = "require [\"editheader\"];\n"
+        String filterScriptUser = "tag \"tag-user\";";
+        String filterAdminBefore = "require [\"editheader\"];\n"
                 + "tag \"tag-user1\";\n"
                 + "deleteheader \"X-Test-Header\";\n"
                 + "tag \"tag-user2\";\n";
@@ -1034,7 +1039,7 @@ public class DeleteHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
+            acct1.setSieveEditHeaderEnabled(true);
             acct1.setAdminSieveScriptBefore(filterAdminBefore);
             acct1.setMailSieveScript(filterScriptUser);
             acct1.setAdminSieveScriptAfter(filterAdminAfter);
@@ -1056,9 +1061,9 @@ public class DeleteHeaderTest {
             Assert.assertTrue(isDeleted);
             String[] tags = mdnMsg.getTags();
             Assert.assertEquals(4, tags.length);
-            Assert.assertEquals("tag-admin-before", tags[0]);
-            Assert.assertEquals("tag-user1", tags[1]);
-            Assert.assertEquals("tag-user2", tags[2]);
+            Assert.assertEquals("tag-user1", tags[0]);
+            Assert.assertEquals("tag-user2", tags[1]);
+            Assert.assertEquals("tag-user", tags[2]);
             Assert.assertEquals("tag-admin-after", tags[3]);
         } catch (Exception e) {
             fail("No exception should be thrown: " + e.getMessage());
@@ -1081,7 +1086,8 @@ public class DeleteHeaderTest {
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
             RuleManager.clearCachedRules(acct1);
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox1), mbox1,
                 new ParsedMessage(sampleBaseMsg.getBytes(), false), 0, acct1.getName(), null,
                 new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
@@ -1098,6 +1104,105 @@ public class DeleteHeaderTest {
                 }
             }
             Assert.assertFalse(matchFound);
+        } catch (Exception e) {
+            fail("No exception should be thrown: " + e.getMessage());
+        }
+    }
+
+    /*
+     * Try deleting a header in admin script when the SieveEditHeaderEnabled attribute is true
+     */
+    @Test
+    public void deleteHeaderSieveEditHeaderEnabledTrue() {
+        try {
+            String filterScript = "require [\"editheader\"];\n"
+                + "deleteheader \"Subject\";";
+            Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+            Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
+            RuleManager.clearCachedRules(acct1);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
+            RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox1), mbox1,
+                new ParsedMessage(sampleBaseMsg.getBytes(), false), 0, acct1.getName(), null,
+                new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
+            Integer itemId = mbox1.getItemIds(null, Mailbox.ID_FOLDER_INBOX)
+                .getIds(MailItem.Type.MESSAGE).get(0);
+            Message mdnMsg = mbox1.getMessageById(null, itemId);
+            boolean matchFound = false;
+            for (Enumeration<Header> e = mdnMsg.getMimeMessage().getAllHeaders(); e
+                .hasMoreElements();) {
+                Header temp = e.nextElement();
+                if (temp.getName().equals("Subject")) {
+                    matchFound = true;
+                }
+            }
+            Assert.assertFalse(matchFound);
+        } catch (Exception e) {
+            fail("No exception should be thrown: " + e.getMessage());
+        }
+    }
+
+    /*
+     * Try deleting a header in admin script when the SieveEditHeaderEnabled attribute is false
+     */
+    @Test
+    public void deleteHeaderSieveEditHeaderEnabledFalse() {
+        try {
+            String filterScript = "require [\"editheader\"];\n"
+                + "deleteheader \"Subject\";";
+            Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+            Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
+            RuleManager.clearCachedRules(acct1);
+            acct1.setSieveEditHeaderEnabled(false);
+            acct1.setAdminSieveScriptBefore(filterScript);
+            RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox1), mbox1,
+                new ParsedMessage(sampleBaseMsg.getBytes(), false), 0, acct1.getName(), null,
+                new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
+            Integer itemId = mbox1.getItemIds(null, Mailbox.ID_FOLDER_INBOX)
+                .getIds(MailItem.Type.MESSAGE).get(0);
+            Message mdnMsg = mbox1.getMessageById(null, itemId);
+            boolean matchFound = false;
+            for (Enumeration<Header> e = mdnMsg.getMimeMessage().getAllHeaders(); e
+                .hasMoreElements();) {
+                Header temp = e.nextElement();
+                if (temp.getName().equals("Subject")) {
+                    matchFound = true;
+                }
+            }
+            Assert.assertTrue(matchFound);
+        } catch (Exception e) {
+            fail("No exception should be thrown: " + e.getMessage());
+        }
+    }
+
+    /*
+     * Try deleting a header in user script
+     */
+    @Test
+    public void deleteHeaderUserSieveScript() {
+        try {
+            String filterScript = "require [\"editheader\"];\n"
+                + "deleteheader \"Subject\";";
+            Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test4@zimbra.com");
+            Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
+            RuleManager.clearCachedRules(acct1);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setMailSieveScript(filterScript);
+            RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox1), mbox1,
+                new ParsedMessage(sampleBaseMsg.getBytes(), false), 0, acct1.getName(), null,
+                new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
+            Integer itemId = mbox1.getItemIds(null, Mailbox.ID_FOLDER_INBOX)
+                .getIds(MailItem.Type.MESSAGE).get(0);
+            Message mdnMsg = mbox1.getMessageById(null, itemId);
+            boolean matchFound = false;
+            for (Enumeration<Header> e = mdnMsg.getMimeMessage().getAllHeaders(); e
+                .hasMoreElements();) {
+                Header temp = e.nextElement();
+                if (temp.getName().equals("Subject")) {
+                    matchFound = true;
+                }
+            }
+            Assert.assertTrue(matchFound);
         } catch (Exception e) {
             fail("No exception should be thrown: " + e.getMessage());
         }

--- a/store/src/java-test/com/zimbra/cs/filter/ReplaceHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/ReplaceHeaderTest.java
@@ -197,6 +197,10 @@ public class ReplaceHeaderTest {
         attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
         prov.createAccount("test3@zimbra.com", "secret", attrs);
 
+        attrs = Maps.newHashMap();
+        attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        prov.createAccount("test4@zimbra.com", "secret", attrs);
+
         // this MailboxManager does everything except actually send mail
         MailboxManager.setInstance(new DirectInsertionMailboxManager());
 
@@ -222,8 +226,8 @@ public class ReplaceHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -259,8 +263,8 @@ public class ReplaceHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -298,8 +302,8 @@ public class ReplaceHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -337,8 +341,8 @@ public class ReplaceHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -376,8 +380,8 @@ public class ReplaceHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -414,8 +418,8 @@ public class ReplaceHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -449,8 +453,8 @@ public class ReplaceHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -484,8 +488,8 @@ public class ReplaceHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -519,8 +523,8 @@ public class ReplaceHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -554,8 +558,8 @@ public class ReplaceHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -595,8 +599,8 @@ public class ReplaceHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -630,8 +634,8 @@ public class ReplaceHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg2.getBytes(), false), 0, acct1.getName(),
@@ -671,12 +675,12 @@ public class ReplaceHeaderTest {
                     + "tag \"tag7-${7}\";"
                     + "tag \"tag8-${8}\";"
                     + "tag \"tag9-${9}\";";
-            Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+            Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test4@zimbra.com");
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg3.getBytes(), false), 0, acct1.getName(),
@@ -735,8 +739,8 @@ public class ReplaceHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg4.getBytes(), false), 0, acct1.getName(),
@@ -771,8 +775,8 @@ public class ReplaceHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg5.getBytes(), false), 0, acct1.getName(),
@@ -815,8 +819,8 @@ public class ReplaceHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -852,8 +856,8 @@ public class ReplaceHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg6.getBytes(), false), 0, acct1.getName(),
@@ -899,7 +903,8 @@ public class ReplaceHeaderTest {
             Account account = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
             RuleManager.clearCachedRules(account);
-            account.setMailSieveScript(filterScript);
+            account.setSieveEditHeaderEnabled(true);
+            account.setAdminSieveScriptBefore(filterScript);
             List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox), mbox,
                     new ParsedMessage(triggeringMsg.toString().getBytes(), false), 0,
@@ -941,7 +946,8 @@ public class ReplaceHeaderTest {
             Account account = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
             RuleManager.clearCachedRules(account);
-            account.setMailSieveScript(filterScript);
+            account.setSieveEditHeaderEnabled(true);
+            account.setAdminSieveScriptBefore(filterScript);
             List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox), mbox,
                     new ParsedMessage(triggeringMsg.toString().getBytes(), false), 0,
@@ -983,8 +989,8 @@ public class ReplaceHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg8.getBytes(), false), 0, acct1.getName(),
@@ -1019,8 +1025,8 @@ public class ReplaceHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -1056,8 +1062,8 @@ public class ReplaceHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -1093,8 +1099,8 @@ public class ReplaceHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -1129,7 +1135,8 @@ public class ReplaceHeaderTest {
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
             RuleManager.clearCachedRules(acct1);
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -1164,7 +1171,8 @@ public class ReplaceHeaderTest {
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
             RuleManager.clearCachedRules(acct1);
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -1199,7 +1207,8 @@ public class ReplaceHeaderTest {
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
             RuleManager.clearCachedRules(acct1);
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -1234,7 +1243,8 @@ public class ReplaceHeaderTest {
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
             RuleManager.clearCachedRules(acct1);
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -1269,8 +1279,8 @@ public class ReplaceHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -1314,8 +1324,8 @@ public class ReplaceHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
-            acct1.setMailSieveScript(filterScript);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
                             sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
@@ -1348,8 +1358,8 @@ public class ReplaceHeaderTest {
                 + "from: test2@zimbra.com\n"
                 + "to: test@zimbra.com\n";
 
-        String filterAdminBefore = "tag \"tag-admin-before\";";
-        String filterScriptUser = "require [\"editheader\", \"variables\"];\n"
+        String filterScriptUser = "tag \"tag-user\";";
+        String filterAdminBefore = "require [\"editheader\", \"variables\"];\n"
                 + "if exists \"Subject\" {\n"
                 + "  tag \"tag-user1\";\n"
                 + "  replaceheader :newvalue \"[SPAM]${1}\" :matches \"Subject\" \"*\";\n"
@@ -1362,7 +1372,7 @@ public class ReplaceHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-
+            acct1.setSieveEditHeaderEnabled(true);
             acct1.setAdminSieveScriptBefore(filterAdminBefore);
             acct1.setMailSieveScript(filterScriptUser);
             acct1.setAdminSieveScriptAfter(filterAdminAfter);
@@ -1383,9 +1393,9 @@ public class ReplaceHeaderTest {
             }
             String[] tags = message.getTags();
             Assert.assertEquals(4, tags.length);
-            Assert.assertEquals("tag-admin-before", tags[0]);
-            Assert.assertEquals("tag-user1", tags[1]);
-            Assert.assertEquals("tag-user2", tags[2]);
+            Assert.assertEquals("tag-user1", tags[0]);
+            Assert.assertEquals("tag-user2", tags[1]);
+            Assert.assertEquals("tag-user", tags[2]);
             Assert.assertEquals("tag-admin-after", tags[3]);
         } catch (Exception e) {
             fail("No exception should be thrown: " + e.getMessage());
@@ -1414,7 +1424,8 @@ public class ReplaceHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
 
             RuleManager.clearCachedRules(acct1);
-            acct1.setMailSieveScript(filterScriptUser);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScriptUser);
 
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
@@ -1459,7 +1470,7 @@ public class ReplaceHeaderTest {
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
             RuleManager.clearCachedRules(acct1);
-            acct1.setMailSieveScript(filterScript);
+            acct1.setAdminSieveScriptBefore(filterScript);
             RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox1), mbox1,
                 new ParsedMessage(sampleBaseMsg.getBytes(), false), 0, acct1.getName(), null,
                 new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
@@ -1502,6 +1513,108 @@ public class ReplaceHeaderTest {
         } catch (SyntaxException e) {
             Assert.assertEquals("EditHeaderExtension:Header name must be printable ASCII only.", e.getMessage());
             
+        }
+    }
+
+    /*
+     * Try replacing a header value in admin script when the SieveEditHeaderEnabled attribute is true
+     */
+    @Test
+    public void replaceHeaderSieveEditHeaderEnabledTrue() {
+        try {
+            String filterScript = "require [\"editheader\"];\n"
+                + "replaceheader :newvalue \"my subject\" :contains \"Subject\" \"example\";";
+            Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+            Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
+            RuleManager.clearCachedRules(acct1);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setAdminSieveScriptBefore(filterScript);
+            RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox1), mbox1,
+                new ParsedMessage(sampleBaseMsg.getBytes(), false), 0, acct1.getName(), null,
+                new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
+            Integer itemId = mbox1.getItemIds(null, Mailbox.ID_FOLDER_INBOX)
+                .getIds(MailItem.Type.MESSAGE).get(0);
+            Message mdnMsg = mbox1.getMessageById(null, itemId);
+            boolean matchFound = false;
+            for (Enumeration<Header> e = mdnMsg.getMimeMessage().getAllHeaders(); e
+                .hasMoreElements();) {
+                Header temp = e.nextElement();
+                if (temp.getName().equals("Subject")) {
+                    matchFound = true;
+                    Assert.assertEquals("my subject", temp.getValue());
+                }
+            }
+            Assert.assertTrue(matchFound);
+        } catch (Exception e) {
+            fail("No exception should be thrown: " + e.getMessage());
+        }
+    }
+
+    /*
+     * Try replacing a header in admin script when the SieveEditHeaderEnabled attribute is false
+     */
+    @Test
+    public void replaceHeaderSieveEditHeaderEnabledFalse() {
+        try {
+            String filterScript = "require [\"editheader\"];\n"
+                + "replaceheader :newvalue \"my subject\" :contains \"Subject\" \"example\"";
+            Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+            Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
+            RuleManager.clearCachedRules(acct1);
+            acct1.setSieveEditHeaderEnabled(false);
+            acct1.setAdminSieveScriptBefore(filterScript);
+            RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox1), mbox1,
+                new ParsedMessage(sampleBaseMsg.getBytes(), false), 0, acct1.getName(), null,
+                new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
+            Integer itemId = mbox1.getItemIds(null, Mailbox.ID_FOLDER_INBOX)
+                .getIds(MailItem.Type.MESSAGE).get(0);
+            Message mdnMsg = mbox1.getMessageById(null, itemId);
+            boolean matchFound = false;
+            for (Enumeration<Header> e = mdnMsg.getMimeMessage().getAllHeaders(); e
+                .hasMoreElements();) {
+                Header temp = e.nextElement();
+                if (temp.getName().equals("Subject")) {
+                    matchFound = true;
+                    Assert.assertEquals("example", temp.getValue());
+                }
+            }
+            Assert.assertTrue(matchFound);
+        } catch (Exception e) {
+            fail("No exception should be thrown: " + e.getMessage());
+        }
+    }
+
+    /*
+     * Try replacing a header in user script
+     */
+    @Test
+    public void replaceHeaderUserSieveScript() {
+        try {
+            String filterScript = "require [\"editheader\"];\n"
+                + "addheader \"X-New-Header\" \"my-new-header-value\";";
+            Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+            Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
+            RuleManager.clearCachedRules(acct1);
+            acct1.setSieveEditHeaderEnabled(true);
+            acct1.setMailSieveScript(filterScript);
+            RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox1), mbox1,
+                new ParsedMessage(sampleBaseMsg.getBytes(), false), 0, acct1.getName(), null,
+                new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
+            Integer itemId = mbox1.getItemIds(null, Mailbox.ID_FOLDER_INBOX)
+                .getIds(MailItem.Type.MESSAGE).get(0);
+            Message mdnMsg = mbox1.getMessageById(null, itemId);
+            boolean matchFound = false;
+            for (Enumeration<Header> e = mdnMsg.getMimeMessage().getAllHeaders(); e
+                .hasMoreElements();) {
+                Header temp = e.nextElement();
+                if (temp.getName().equals("Subject")) {
+                    matchFound = true;
+                    Assert.assertEquals("example", temp.getValue());
+                }
+            }
+            Assert.assertTrue(matchFound);
+        } catch (Exception e) {
+            fail("No exception should be thrown: " + e.getMessage());
         }
     }
 }

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -55462,6 +55462,88 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * Whether edit header commands in admin sieve scripts are enabled or
+     * disabled. If TRUE, the addheader, deleteheader and replaceheader
+     * commands will be executed during admin sieve script execution.
+     *
+     * @return zimbraSieveEditHeaderEnabled, or false if unset
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2120)
+    public boolean isSieveEditHeaderEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraSieveEditHeaderEnabled, false, true);
+    }
+
+    /**
+     * Whether edit header commands in admin sieve scripts are enabled or
+     * disabled. If TRUE, the addheader, deleteheader and replaceheader
+     * commands will be executed during admin sieve script execution.
+     *
+     * @param zimbraSieveEditHeaderEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2120)
+    public void setSieveEditHeaderEnabled(boolean zimbraSieveEditHeaderEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveEditHeaderEnabled, zimbraSieveEditHeaderEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether edit header commands in admin sieve scripts are enabled or
+     * disabled. If TRUE, the addheader, deleteheader and replaceheader
+     * commands will be executed during admin sieve script execution.
+     *
+     * @param zimbraSieveEditHeaderEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2120)
+    public Map<String,Object> setSieveEditHeaderEnabled(boolean zimbraSieveEditHeaderEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveEditHeaderEnabled, zimbraSieveEditHeaderEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether edit header commands in admin sieve scripts are enabled or
+     * disabled. If TRUE, the addheader, deleteheader and replaceheader
+     * commands will be executed during admin sieve script execution.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2120)
+    public void unsetSieveEditHeaderEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveEditHeaderEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether edit header commands in admin sieve scripts are enabled or
+     * disabled. If TRUE, the addheader, deleteheader and replaceheader
+     * commands will be executed during admin sieve script execution.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2120)
+    public Map<String,Object> unsetSieveEditHeaderEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveEditHeaderEnabled, "");
+        return attrs;
+    }
+
+    /**
      * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
      * parses the &#039;notify&#039; action parameters based on the syntax
      * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
@@ -55639,7 +55721,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 8.7.8
      */
-    @ZAttr(id=2118)
+    @ZAttr(id=2119)
     public boolean isSieveRequireControlEnabled() {
         return getBooleanAttr(Provisioning.A_zimbraSieveRequireControlEnabled, true, true);
     }
@@ -55659,7 +55741,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 8.7.8
      */
-    @ZAttr(id=2118)
+    @ZAttr(id=2119)
     public void setSieveRequireControlEnabled(boolean zimbraSieveRequireControlEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSieveRequireControlEnabled, zimbraSieveRequireControlEnabled ? Provisioning.TRUE : Provisioning.FALSE);
@@ -55682,7 +55764,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 8.7.8
      */
-    @ZAttr(id=2118)
+    @ZAttr(id=2119)
     public Map<String,Object> setSieveRequireControlEnabled(boolean zimbraSieveRequireControlEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSieveRequireControlEnabled, zimbraSieveRequireControlEnabled ? Provisioning.TRUE : Provisioning.FALSE);
@@ -55703,7 +55785,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 8.7.8
      */
-    @ZAttr(id=2118)
+    @ZAttr(id=2119)
     public void unsetSieveRequireControlEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSieveRequireControlEnabled, "");
@@ -55725,7 +55807,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 8.7.8
      */
-    @ZAttr(id=2118)
+    @ZAttr(id=2119)
     public Map<String,Object> unsetSieveRequireControlEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSieveRequireControlEnabled, "");

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -42853,6 +42853,88 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * Whether edit header commands in admin sieve scripts are enabled or
+     * disabled. If TRUE, the addheader, deleteheader and replaceheader
+     * commands will be executed during admin sieve script execution.
+     *
+     * @return zimbraSieveEditHeaderEnabled, or false if unset
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2120)
+    public boolean isSieveEditHeaderEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraSieveEditHeaderEnabled, false, true);
+    }
+
+    /**
+     * Whether edit header commands in admin sieve scripts are enabled or
+     * disabled. If TRUE, the addheader, deleteheader and replaceheader
+     * commands will be executed during admin sieve script execution.
+     *
+     * @param zimbraSieveEditHeaderEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2120)
+    public void setSieveEditHeaderEnabled(boolean zimbraSieveEditHeaderEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveEditHeaderEnabled, zimbraSieveEditHeaderEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether edit header commands in admin sieve scripts are enabled or
+     * disabled. If TRUE, the addheader, deleteheader and replaceheader
+     * commands will be executed during admin sieve script execution.
+     *
+     * @param zimbraSieveEditHeaderEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2120)
+    public Map<String,Object> setSieveEditHeaderEnabled(boolean zimbraSieveEditHeaderEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveEditHeaderEnabled, zimbraSieveEditHeaderEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether edit header commands in admin sieve scripts are enabled or
+     * disabled. If TRUE, the addheader, deleteheader and replaceheader
+     * commands will be executed during admin sieve script execution.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2120)
+    public void unsetSieveEditHeaderEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveEditHeaderEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether edit header commands in admin sieve scripts are enabled or
+     * disabled. If TRUE, the addheader, deleteheader and replaceheader
+     * commands will be executed during admin sieve script execution.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2120)
+    public Map<String,Object> unsetSieveEditHeaderEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveEditHeaderEnabled, "");
+        return attrs;
+    }
+
+    /**
      * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
      * parses the &#039;notify&#039; action parameters based on the syntax
      * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
@@ -43030,7 +43112,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 8.7.8
      */
-    @ZAttr(id=2118)
+    @ZAttr(id=2119)
     public boolean isSieveRequireControlEnabled() {
         return getBooleanAttr(Provisioning.A_zimbraSieveRequireControlEnabled, true, true);
     }
@@ -43050,7 +43132,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 8.7.8
      */
-    @ZAttr(id=2118)
+    @ZAttr(id=2119)
     public void setSieveRequireControlEnabled(boolean zimbraSieveRequireControlEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSieveRequireControlEnabled, zimbraSieveRequireControlEnabled ? Provisioning.TRUE : Provisioning.FALSE);
@@ -43073,7 +43155,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 8.7.8
      */
-    @ZAttr(id=2118)
+    @ZAttr(id=2119)
     public Map<String,Object> setSieveRequireControlEnabled(boolean zimbraSieveRequireControlEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSieveRequireControlEnabled, zimbraSieveRequireControlEnabled ? Provisioning.TRUE : Provisioning.FALSE);
@@ -43094,7 +43176,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 8.7.8
      */
-    @ZAttr(id=2118)
+    @ZAttr(id=2119)
     public void unsetSieveRequireControlEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSieveRequireControlEnabled, "");
@@ -43116,7 +43198,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 8.7.8
      */
-    @ZAttr(id=2118)
+    @ZAttr(id=2119)
     public Map<String,Object> unsetSieveRequireControlEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSieveRequireControlEnabled, "");

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -20352,6 +20352,88 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
+     * Whether edit header commands in admin sieve scripts are enabled or
+     * disabled. If TRUE, the addheader, deleteheader and replaceheader
+     * commands will be executed during admin sieve script execution.
+     *
+     * @return zimbraSieveEditHeaderEnabled, or false if unset
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2120)
+    public boolean isSieveEditHeaderEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraSieveEditHeaderEnabled, false, true);
+    }
+
+    /**
+     * Whether edit header commands in admin sieve scripts are enabled or
+     * disabled. If TRUE, the addheader, deleteheader and replaceheader
+     * commands will be executed during admin sieve script execution.
+     *
+     * @param zimbraSieveEditHeaderEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2120)
+    public void setSieveEditHeaderEnabled(boolean zimbraSieveEditHeaderEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveEditHeaderEnabled, zimbraSieveEditHeaderEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether edit header commands in admin sieve scripts are enabled or
+     * disabled. If TRUE, the addheader, deleteheader and replaceheader
+     * commands will be executed during admin sieve script execution.
+     *
+     * @param zimbraSieveEditHeaderEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2120)
+    public Map<String,Object> setSieveEditHeaderEnabled(boolean zimbraSieveEditHeaderEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveEditHeaderEnabled, zimbraSieveEditHeaderEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether edit header commands in admin sieve scripts are enabled or
+     * disabled. If TRUE, the addheader, deleteheader and replaceheader
+     * commands will be executed during admin sieve script execution.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2120)
+    public void unsetSieveEditHeaderEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveEditHeaderEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether edit header commands in admin sieve scripts are enabled or
+     * disabled. If TRUE, the addheader, deleteheader and replaceheader
+     * commands will be executed during admin sieve script execution.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2120)
+    public Map<String,Object> unsetSieveEditHeaderEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveEditHeaderEnabled, "");
+        return attrs;
+    }
+
+    /**
      * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
      * parses the &#039;notify&#039; action parameters based on the syntax
      * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the
@@ -20529,7 +20611,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 8.7.8
      */
-    @ZAttr(id=2118)
+    @ZAttr(id=2119)
     public boolean isSieveRequireControlEnabled() {
         return getBooleanAttr(Provisioning.A_zimbraSieveRequireControlEnabled, false, true);
     }
@@ -20549,7 +20631,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 8.7.8
      */
-    @ZAttr(id=2118)
+    @ZAttr(id=2119)
     public void setSieveRequireControlEnabled(boolean zimbraSieveRequireControlEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSieveRequireControlEnabled, zimbraSieveRequireControlEnabled ? Provisioning.TRUE : Provisioning.FALSE);
@@ -20572,7 +20654,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 8.7.8
      */
-    @ZAttr(id=2118)
+    @ZAttr(id=2119)
     public Map<String,Object> setSieveRequireControlEnabled(boolean zimbraSieveRequireControlEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSieveRequireControlEnabled, zimbraSieveRequireControlEnabled ? Provisioning.TRUE : Provisioning.FALSE);
@@ -20593,7 +20675,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 8.7.8
      */
-    @ZAttr(id=2118)
+    @ZAttr(id=2119)
     public void unsetSieveRequireControlEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSieveRequireControlEnabled, "");
@@ -20615,7 +20697,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 8.7.8
      */
-    @ZAttr(id=2118)
+    @ZAttr(id=2119)
     public Map<String,Object> unsetSieveRequireControlEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSieveRequireControlEnabled, "");

--- a/store/src/java/com/zimbra/cs/filter/JsieveConfigMapHandler.java
+++ b/store/src/java/com/zimbra/cs/filter/JsieveConfigMapHandler.java
@@ -39,6 +39,7 @@ public class JsieveConfigMapHandler {
     public static final String CAPABILITY_EREJECT    = "ereject";
     public static final String CAPABILITY_REJECT     = "reject";
     public static final String CAPABILITY_ENOTIFY    = "enotify";
+    public static final String CAPABILITY_EDITHEADER = "editheader";
 
     /*
      * jSieve's command map
@@ -62,7 +63,7 @@ public class JsieveConfigMapHandler {
         mCommandMap.put(CAPABILITY_EREJECT, com.zimbra.cs.filter.jsieve.Ereject.class.getName());
         mCommandMap.put("set", com.zimbra.cs.filter.jsieve.SetVariable.class.getName());
         mCommandMap.put("variables", com.zimbra.cs.filter.jsieve.Variables.class.getName());
-        mCommandMap.put("editheader", com.zimbra.cs.filter.jsieve.EditHeader.class.getName());
+        mCommandMap.put(CAPABILITY_EDITHEADER, com.zimbra.cs.filter.jsieve.EditHeader.class.getName());
         mCommandMap.put("addheader", com.zimbra.cs.filter.jsieve.AddHeader.class.getName());
         mCommandMap.put("replaceheader", com.zimbra.cs.filter.jsieve.ReplaceHeader.class.getName());
         mCommandMap.put(CAPABILITY_FILEINTO, com.zimbra.cs.filter.jsieve.FileInto.class.getName());

--- a/store/src/java/com/zimbra/cs/filter/ZimbraMailAdapter.java
+++ b/store/src/java/com/zimbra/cs/filter/ZimbraMailAdapter.java
@@ -93,6 +93,7 @@ import com.zimbra.cs.store.StoreManager;
  */
 public class ZimbraMailAdapter implements MailAdapter, EnvelopeAccessors {
     private Mailbox mailbox;
+    private Account account;
     private FilterHandler handler;
     private String[] tags;
     private boolean allowFilterToMountpoint = true;
@@ -143,13 +144,17 @@ public class ZimbraMailAdapter implements MailAdapter, EnvelopeAccessors {
     private boolean isStop = false;
 
     private boolean fieldImplicitKeep = true;
+    private boolean isAddHeaderPresent = false;
+    private boolean isDeleteHeaderPresent = false;
+    private boolean isReplaceHeaderPresent = false;
+    private boolean isUserScriptExecuting = false;
 
     public ZimbraMailAdapter(Mailbox mailbox, FilterHandler handler) {
         this.mailbox = mailbox;
         this.handler = handler;
 
         try {
-            Account account = getMailbox().getAccount();
+            setAccount(getMailbox().getAccount());
         } catch (ServiceException e) {
             ZimbraLog.filter.info("Error initializing the sieve variables extension.", e);
         }
@@ -930,10 +935,17 @@ public class ZimbraMailAdapter implements MailAdapter, EnvelopeAccessors {
     public void resetValues() {
         resetMatchedValues();
         resetVariables();
+        resetEditHeaderFlags();
     }
 
     public void resetMatchedValues() { matchedValues.clear(); }
     public void resetVariables() { variables.clear(); }
+    public void resetEditHeaderFlags() {
+        isAddHeaderPresent = false;
+        isDeleteHeaderPresent = false;
+        isReplaceHeaderPresent = false;
+        isUserScriptExecuting = false;
+    }
 
     public VARIABLEFEATURETYPE getVariablesExtAvailable() { return variablesExtAvailable; }
     public void setVariablesExtAvailable(VARIABLEFEATURETYPE type) { this.variablesExtAvailable = type; }
@@ -972,5 +984,45 @@ public class ZimbraMailAdapter implements MailAdapter, EnvelopeAccessors {
 
     public void setEditHeaderParseStatus(PARSESTATUS eheParseStatus) {
         this.eheParseStatus = eheParseStatus;
+    }
+
+    public boolean isAddHeaderPresent() {
+        return isAddHeaderPresent;
+    }
+
+    public void setAddHeaderPresent(boolean isAddHeaderPresent) {
+        this.isAddHeaderPresent = isAddHeaderPresent;
+    }
+
+    public boolean isDeleteHeaderPresent() {
+        return isDeleteHeaderPresent;
+    }
+
+    public void setDeleteHeaderPresent(boolean isDeleteHeaderPresent) {
+        this.isDeleteHeaderPresent = isDeleteHeaderPresent;
+    }
+
+    public boolean isReplaceHeaderPresent() {
+        return isReplaceHeaderPresent;
+    }
+
+    public void setReplaceHeaderPresent(boolean isReplaceHeaderPresent) {
+        this.isReplaceHeaderPresent = isReplaceHeaderPresent;
+    }
+
+    public Account getAccount() {
+        return account;
+    }
+
+    public void setAccount(Account account) {
+        this.account = account;
+    }
+
+    public boolean isUserScriptExecuting() {
+        return isUserScriptExecuting;
+    }
+
+    public void setUserScriptExecuting(boolean isUserScriptExecuting) {
+        this.isUserScriptExecuting = isUserScriptExecuting;
     }
 }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/AddHeader.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/AddHeader.java
@@ -16,6 +16,7 @@
  */
 package com.zimbra.cs.filter.jsieve;
 
+import static com.zimbra.cs.filter.JsieveConfigMapHandler.CAPABILITY_EDITHEADER;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -62,6 +63,11 @@ public class AddHeader extends AbstractCommand {
         }
 
         ZimbraMailAdapter mailAdapter = (ZimbraMailAdapter) mail;
+        Require.checkCapability(mailAdapter, CAPABILITY_EDITHEADER);
+        if (!mailAdapter.getAccount().isSieveEditHeaderEnabled()) {
+            mailAdapter.setAddHeaderPresent(true);
+            return null;
+        }
         headerName = FilterUtil.replaceVariables(mailAdapter, headerName);
         FilterUtil.headerNameHasSpace(headerName);
         if (EditHeaderExtension.isImmutableHeaderKey(headerName)) {

--- a/store/src/java/com/zimbra/cs/filter/jsieve/DeleteHeader.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/DeleteHeader.java
@@ -16,6 +16,7 @@
  */
 package com.zimbra.cs.filter.jsieve;
 
+import static com.zimbra.cs.filter.JsieveConfigMapHandler.CAPABILITY_EDITHEADER;
 import java.util.List;
 import java.util.Enumeration;
 import java.util.HashSet;
@@ -54,7 +55,11 @@ public class DeleteHeader extends AbstractCommand {
             return null;
         }
         ZimbraMailAdapter mailAdapter = (ZimbraMailAdapter) mail;
-
+        Require.checkCapability(mailAdapter, CAPABILITY_EDITHEADER);
+        if (!mailAdapter.getAccount().isSieveEditHeaderEnabled()) {
+            mailAdapter.setDeleteHeaderPresent(true);
+            return null;
+        }
         // make sure zcs do not delete immutable header
         if (EditHeaderExtension.isImmutableHeaderKey(ehe.getKey())) {
             ZimbraLog.filter.info("deleteheader: %s is immutable header, so exiting silently.", ehe.getKey());

--- a/store/src/java/com/zimbra/cs/filter/jsieve/NotifyMailto.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/NotifyMailto.java
@@ -28,7 +28,6 @@ import org.apache.jsieve.exception.SieveException;
 import org.apache.jsieve.exception.SyntaxException;
 import org.apache.jsieve.mail.MailAdapter;
 
-import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.filter.FilterUtil;
@@ -86,13 +85,7 @@ public class NotifyMailto extends Notify {
         }
         ZimbraMailAdapter mailAdapter = (ZimbraMailAdapter) mail;
         Require.checkCapability(mailAdapter, CAPABILITY_ENOTIFY);
-
-        try {
-            return mailAdapter.getMailbox().getAccount().isSieveNotifyActionRFCCompliant();
-        } catch (ServiceException e) {
-            ZimbraLog.filter.warn("Exception in checking NotifyAction RFC compliance", e);
-            return false;
-        }
+        return mailAdapter.getAccount().isSieveNotifyActionRFCCompliant();
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/filter/jsieve/Reject.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/Reject.java
@@ -16,8 +16,6 @@
  */
 package com.zimbra.cs.filter.jsieve;
 
-import com.zimbra.common.service.ServiceException;
-import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.filter.FilterUtil;
 import com.zimbra.cs.filter.ZimbraMailAdapter;
@@ -45,19 +43,14 @@ public class Reject extends org.apache.jsieve.commands.optional.Reject {
         }
         ZimbraMailAdapter mailAdapter = (ZimbraMailAdapter) mail;
         Account account = null;
-        try {
-            account = mailAdapter.getMailbox().getAccount();
-            if (account.isSieveRejectMailEnabled()) {
-                mailAdapter.setDiscardActionPresent();
-                final String message = FilterUtil.replaceVariables((ZimbraMailAdapter) mailAdapter,
-                        ((StringListArgument) arguments
-                        .getArgumentList().get(0)).getList().get(0));
-                mail.addAction(new ActionReject(message));
-            } else {
-                mail.addAction(new ActionKeep());
-            }
-        } catch (ServiceException e) {
-            ZimbraLog.filter.warn("Exception in executing reject action", e);
+        account = mailAdapter.getAccount();
+        if (account.isSieveRejectMailEnabled()) {
+            mailAdapter.setDiscardActionPresent();
+            final String message = FilterUtil.replaceVariables((ZimbraMailAdapter) mailAdapter,
+                ((StringListArgument) arguments.getArgumentList().get(0)).getList().get(0));
+            mail.addAction(new ActionReject(message));
+        } else {
+            mail.addAction(new ActionKeep());
         }
         return null;
     }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/ReplaceHeader.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/ReplaceHeader.java
@@ -16,6 +16,7 @@
  */
 package com.zimbra.cs.filter.jsieve;
 
+import static com.zimbra.cs.filter.JsieveConfigMapHandler.CAPABILITY_EDITHEADER;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -57,7 +58,11 @@ public class ReplaceHeader extends AbstractCommand {
             return null;
         }
         ZimbraMailAdapter mailAdapter = (ZimbraMailAdapter) mail;
-
+        Require.checkCapability(mailAdapter, CAPABILITY_EDITHEADER);
+        if (!mailAdapter.getAccount().isSieveEditHeaderEnabled()) {
+            mailAdapter.setReplaceHeaderPresent(true);
+            return null;
+        }
         // make sure zcs do not edit immutable header
         if (EditHeaderExtension.isImmutableHeaderKey(ehe.getKey())) {
             ZimbraLog.filter.info("replaceheader: %s is immutable header, so exiting silently.", ehe.getKey());

--- a/store/src/java/com/zimbra/cs/filter/jsieve/Require.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/Require.java
@@ -16,6 +16,7 @@
  */
 package com.zimbra.cs.filter.jsieve;
 
+import static com.zimbra.cs.filter.JsieveConfigMapHandler.CAPABILITY_EDITHEADER;
 import static org.apache.jsieve.Constants.COMPARATOR_PREFIX;
 import static org.apache.jsieve.Constants.COMPARATOR_PREFIX_LENGTH;
 
@@ -29,8 +30,7 @@ import org.apache.jsieve.exception.SieveException;
 import org.apache.jsieve.exception.SyntaxException;
 import org.apache.jsieve.mail.MailAdapter;
 
-import com.zimbra.common.service.ServiceException;
-import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.filter.RuleManager;
 import com.zimbra.cs.filter.ZimbraMailAdapter;
 
 /**
@@ -50,6 +50,10 @@ public class Require extends org.apache.jsieve.commands.Require {
                 .getArgumentList().get(0)).getList();
         for (String stringArgument: stringArgumentList) {
             validateFeature(stringArgument, mail, context);
+            if (CAPABILITY_EDITHEADER.equals(getCapabilityString(stringArgument))
+                && mailAdapter.isUserScriptExecuting()) {
+                throw new SieveException(RuleManager.editHeaderUserScriptError);
+            }
             mailAdapter.addCapabilities(getCapabilityString(stringArgument));
         }
         return null;
@@ -82,11 +86,6 @@ public class Require extends org.apache.jsieve.commands.Require {
             return true;
         }
         ZimbraMailAdapter mailAdapter = (ZimbraMailAdapter) mail;
-        try {
-            return mailAdapter.getMailbox().getAccount().isSieveRequireControlEnabled();
-        } catch (ServiceException e) {
-            ZimbraLog.filter.warn("Exception in checking Require Control RFC compliance", e);
-            return false;
-        }
+        return mailAdapter.getAccount().isSieveRequireControlEnabled();
     }
 }


### PR DESCRIPTION
Added a ldap attribute to enabled or disable sieve edit header feature at account-cos-domain level.
If the attribute value is false, all the edit header commands in admin scripts will be ignored.
If the attribute value is true, all the edit header commands in admin scripts will be executed.
The attribute value is by default false.

Regardless if the attribute value, user script can not have edit header commands and if they appear in the script, the entire user script will be ignored.

Added junit test for add/delete/replace header for admin as well as user script.
Since the user script can not have the edit header commands now, the existing unit tests needed to be fixed. Modified them to be in admin script.