### PR TITLE
zcs-2140: revert code change that always forced updating session flags

### DIFF
--- a/store/src/java/com/zimbra/cs/imap/ImapHandler.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapHandler.java
@@ -4075,10 +4075,11 @@ public abstract class ImapHandler {
                                         ZimbraLog.imap.info("IMAP client has flagged the item with id %d to be Deleted altertag", msg.msgId);
                                     }
                                     mbox.alterTag(getContext(), itemIds, i4flag.mName, add);
-                                }
-                                // session tag; update one-by-one in memory only
-                                for (ImapMessage i4msg : i4list) {
-                                    i4msg.setSessionFlags((short) (add ? i4msg.sflags | i4flag.mBitmask : i4msg.sflags & ~i4flag.mBitmask), i4folder);
+                                } else {
+                                    // session tag; update one-by-one in memory only
+                                    for (ImapMessage i4msg : i4list) {
+                                        i4msg.setSessionFlags((short) (add ? i4msg.sflags | i4flag.mBitmask : i4msg.sflags & ~i4flag.mBitmask), i4folder);
+                                    }
                                 }
                             }
                             boolean add = operation == StoreAction.ADD;


### PR DESCRIPTION
I checked that with this change compliance tests give same results on local IMAP as on 'develop' branch and that there are no new test failures on this branch.