### PR TITLE
ZCS-1850:Move sieve_immutable_headers to LDAP attribute

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -15362,6 +15362,14 @@ public class ZAttrProvisioning {
     public static final String A_zimbraSieveFeatureVariablesEnabled = "zimbraSieveFeatureVariablesEnabled";
 
     /**
+     * Comma separated list of sieve immutable headers
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2121)
+    public static final String A_zimbraSieveImmutableHeaders = "zimbraSieveImmutableHeaders";
+
+    /**
      * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
      * parses the &#039;notify&#039; action parameters based on the syntax
      * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the

--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1307,8 +1307,6 @@ public final class LC {
     @Supported
     public static final KnownKey smime_truststore_password = KnownKey.newKey("${mailboxd_truststore_password}");
 
-    public static final KnownKey sieve_immutable_headers = KnownKey.newKey("Received,DKIM-Signature,Authentication-Results,Received-SPF,Message-ID,Content-Type,Content-Disposition,Content-Transfer-Encoding,MIME-Version");
-
     static {
         // Automatically set the key name with the variable name.
         for (Field field : LC.class.getFields()) {

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9503,13 +9503,18 @@ TODO: delete them permanently from here
 </attr>
 
 <attr id="2119" name="zimbraSieveRequireControlEnabled" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.7.8">
-<defaultCOSValue>TRUE</defaultCOSValue>
-<desc>Whether the declaration of the Sieve extension feature is mandatory by the 'require' control. If TRUE, before ZCS evaluates a Sieve extension test or action, it checks the corresponding capability string at 'require' control; and if the capability string is not declared in the 'require', the entire Sieve filter execution will be failed. If FALSE, any Sieve extensions can be used without declaring the capability string in the 'require' control.</desc>
+  <defaultCOSValue>TRUE</defaultCOSValue>
+  <desc>Whether the declaration of the Sieve extension feature is mandatory by the 'require' control. If TRUE, before ZCS evaluates a Sieve extension test or action, it checks the corresponding capability string at 'require' control; and if the capability string is not declared in the 'require', the entire Sieve filter execution will be failed. If FALSE, any Sieve extensions can be used without declaring the capability string in the 'require' control.</desc>
 </attr>
 
 <attr id="2120" name="zimbraSieveEditHeaderEnabled" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.8.0">
-<defaultCOSValue>FALSE</defaultCOSValue>
-<desc>Whether edit header commands in admin sieve scripts are enabled or disabled. If TRUE, the addheader, deleteheader and replaceheader commands will be executed during admin sieve script execution.</desc>
+  <defaultCOSValue>FALSE</defaultCOSValue>
+  <desc>Whether edit header commands in admin sieve scripts are enabled or disabled. If TRUE, the addheader, deleteheader and replaceheader commands will be executed during admin sieve script execution.</desc>
+</attr>
+
+<attr id="2121" name="zimbraSieveImmutableHeaders" type="string" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.8.0">
+  <defaultCOSValue>Received,DKIM-Signature,Authentication-Results,Received-SPF,Message-ID,Content-Type,Content-Disposition,Content-Transfer-Encoding,MIME-Version</defaultCOSValue>
+  <desc>Comma separated list of sieve immutable headers</desc>
 </attr>
 </attrs>
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -55544,6 +55544,78 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * Comma separated list of sieve immutable headers
+     *
+     * @return zimbraSieveImmutableHeaders, or "Received,DKIM-Signature,Authentication-Results,Received-SPF,Message-ID,Content-Type,Content-Disposition,Content-Transfer-Encoding,MIME-Version" if unset
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2121)
+    public String getSieveImmutableHeaders() {
+        return getAttr(Provisioning.A_zimbraSieveImmutableHeaders, "Received,DKIM-Signature,Authentication-Results,Received-SPF,Message-ID,Content-Type,Content-Disposition,Content-Transfer-Encoding,MIME-Version", true);
+    }
+
+    /**
+     * Comma separated list of sieve immutable headers
+     *
+     * @param zimbraSieveImmutableHeaders new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2121)
+    public void setSieveImmutableHeaders(String zimbraSieveImmutableHeaders) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveImmutableHeaders, zimbraSieveImmutableHeaders);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Comma separated list of sieve immutable headers
+     *
+     * @param zimbraSieveImmutableHeaders new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2121)
+    public Map<String,Object> setSieveImmutableHeaders(String zimbraSieveImmutableHeaders, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveImmutableHeaders, zimbraSieveImmutableHeaders);
+        return attrs;
+    }
+
+    /**
+     * Comma separated list of sieve immutable headers
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2121)
+    public void unsetSieveImmutableHeaders() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveImmutableHeaders, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Comma separated list of sieve immutable headers
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2121)
+    public Map<String,Object> unsetSieveImmutableHeaders(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveImmutableHeaders, "");
+        return attrs;
+    }
+
+    /**
      * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
      * parses the &#039;notify&#039; action parameters based on the syntax
      * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -42935,6 +42935,78 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * Comma separated list of sieve immutable headers
+     *
+     * @return zimbraSieveImmutableHeaders, or "Received,DKIM-Signature,Authentication-Results,Received-SPF,Message-ID,Content-Type,Content-Disposition,Content-Transfer-Encoding,MIME-Version" if unset
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2121)
+    public String getSieveImmutableHeaders() {
+        return getAttr(Provisioning.A_zimbraSieveImmutableHeaders, "Received,DKIM-Signature,Authentication-Results,Received-SPF,Message-ID,Content-Type,Content-Disposition,Content-Transfer-Encoding,MIME-Version", true);
+    }
+
+    /**
+     * Comma separated list of sieve immutable headers
+     *
+     * @param zimbraSieveImmutableHeaders new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2121)
+    public void setSieveImmutableHeaders(String zimbraSieveImmutableHeaders) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveImmutableHeaders, zimbraSieveImmutableHeaders);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Comma separated list of sieve immutable headers
+     *
+     * @param zimbraSieveImmutableHeaders new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2121)
+    public Map<String,Object> setSieveImmutableHeaders(String zimbraSieveImmutableHeaders, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveImmutableHeaders, zimbraSieveImmutableHeaders);
+        return attrs;
+    }
+
+    /**
+     * Comma separated list of sieve immutable headers
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2121)
+    public void unsetSieveImmutableHeaders() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveImmutableHeaders, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Comma separated list of sieve immutable headers
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2121)
+    public Map<String,Object> unsetSieveImmutableHeaders(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveImmutableHeaders, "");
+        return attrs;
+    }
+
+    /**
      * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
      * parses the &#039;notify&#039; action parameters based on the syntax
      * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -20434,6 +20434,78 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
+     * Comma separated list of sieve immutable headers
+     *
+     * @return zimbraSieveImmutableHeaders, or null if unset
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2121)
+    public String getSieveImmutableHeaders() {
+        return getAttr(Provisioning.A_zimbraSieveImmutableHeaders, null, true);
+    }
+
+    /**
+     * Comma separated list of sieve immutable headers
+     *
+     * @param zimbraSieveImmutableHeaders new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2121)
+    public void setSieveImmutableHeaders(String zimbraSieveImmutableHeaders) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveImmutableHeaders, zimbraSieveImmutableHeaders);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Comma separated list of sieve immutable headers
+     *
+     * @param zimbraSieveImmutableHeaders new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2121)
+    public Map<String,Object> setSieveImmutableHeaders(String zimbraSieveImmutableHeaders, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveImmutableHeaders, zimbraSieveImmutableHeaders);
+        return attrs;
+    }
+
+    /**
+     * Comma separated list of sieve immutable headers
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2121)
+    public void unsetSieveImmutableHeaders() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveImmutableHeaders, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Comma separated list of sieve immutable headers
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.0
+     */
+    @ZAttr(id=2121)
+    public Map<String,Object> unsetSieveImmutableHeaders(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSieveImmutableHeaders, "");
+        return attrs;
+    }
+
+    /**
      * Whether the RFC compliant &#039;notify&#039; is used. If TRUE, ZCS
      * parses the &#039;notify&#039; action parameters based on the syntax
      * defined by the RFC 5435 and 5436. If FALSE, ZCS treats the

--- a/store/src/java/com/zimbra/cs/filter/jsieve/AddHeader.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/AddHeader.java
@@ -70,7 +70,8 @@ public class AddHeader extends AbstractCommand {
         }
         headerName = FilterUtil.replaceVariables(mailAdapter, headerName);
         FilterUtil.headerNameHasSpace(headerName);
-        if (EditHeaderExtension.isImmutableHeaderKey(headerName)) {
+        // make sure zcs do not add immutable header
+        if (EditHeaderExtension.isImmutableHeaderKey(headerName, mailAdapter)) {
             ZimbraLog.filter.info("addheader: %s is immutable header, so exiting silently.", headerName);
             return null;
         }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/DeleteHeader.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/DeleteHeader.java
@@ -61,7 +61,7 @@ public class DeleteHeader extends AbstractCommand {
             return null;
         }
         // make sure zcs do not delete immutable header
-        if (EditHeaderExtension.isImmutableHeaderKey(ehe.getKey())) {
+        if (EditHeaderExtension.isImmutableHeaderKey(ehe.getKey(), mailAdapter)) {
             ZimbraLog.filter.info("deleteheader: %s is immutable header, so exiting silently.", ehe.getKey());
             return null;
         }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/EditHeaderExtension.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/EditHeaderExtension.java
@@ -46,7 +46,6 @@ import org.apache.jsieve.exception.SieveException;
 import org.apache.jsieve.exception.SyntaxException;
 import org.apache.jsieve.tests.ComparatorTags;
 
-import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.util.CharsetUtil;
 import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
@@ -553,9 +552,9 @@ public class EditHeaderExtension {
      * This method verifies if the key is set for immutable header or not.
      * @return <b>true</b> if immutable header found else <b>false</b>
      */
-    static public boolean isImmutableHeaderKey(String key) {
-        // TODO Work on to create new ldap attribute and store all the immutable header names in that
-        List<String> immutableHeaders = Arrays.asList(LC.sieve_immutable_headers.value().split(","));
+    static public boolean isImmutableHeaderKey(String key, ZimbraMailAdapter mailAdapter) {
+        List<String> immutableHeaders = Arrays.asList(mailAdapter.getAccount().getSieveImmutableHeaders().split(","));
+        immutableHeaders.replaceAll(String::trim);
         return immutableHeaders.contains(key) ? true : false;
     }
 

--- a/store/src/java/com/zimbra/cs/filter/jsieve/ReplaceHeader.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/ReplaceHeader.java
@@ -64,7 +64,7 @@ public class ReplaceHeader extends AbstractCommand {
             return null;
         }
         // make sure zcs do not edit immutable header
-        if (EditHeaderExtension.isImmutableHeaderKey(ehe.getKey())) {
+        if (EditHeaderExtension.isImmutableHeaderKey(ehe.getKey(), mailAdapter)) {
             ZimbraLog.filter.info("replaceheader: %s is immutable header, so exiting silently.", ehe.getKey());
             return null;
         }


### PR DESCRIPTION
Moving sieve_immutable_headers LC attribute to LDAP attribute at account-cos-domain level.

Junit for add and replace header for immutable header is already in place.
Added junit for delete immutable header.