### PR TITLE
ZCS-2150: restrict flushing cache types on imapd

### DIFF
--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -1391,6 +1391,7 @@ public final class AdminConstants {
 
     // flush cache
     public static final String A_ALLSERVERS = "allServers";
+    public static final String A_IMAPSERVERS = "imapServers";
 
     public static final String A_SYNCHRONOUS = "synchronous";
 

--- a/soap/src/java/com/zimbra/soap/admin/type/CacheSelector.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/CacheSelector.java
@@ -55,6 +55,19 @@ public final class CacheSelector {
     @XmlAttribute(name=AdminConstants.A_ALLSERVERS /* allServers */, required=false)
     private ZmBoolean allServers;
 
+
+    /**
+     * @zm-api-field-tag imap-servers
+     * @zm-api-field-description
+     * <table>
+     * <tr> <td> <b>0 (false)</b> </td> <td> don't issue X-ZIMBRA-FLUSHCACHE IMAP command to upstream IMAP servers </td> </tr>
+     * <tr> <td> <b>1 (true) [default]</b> </td>
+     *      <td> flush cache on servers listed in zimbraReverseProxyUpstreamImapServers for the current server via X-ZIMBRA-FLUSHCACHE</td> </tr>
+     * </table>
+     */
+    @XmlAttribute(name=AdminConstants.A_IMAPSERVERS /* imapServers */, required=false)
+    private ZmBoolean imapServers;
+
     /**
      * @zm-api-field-description Cache entry selectors
      */
@@ -95,4 +108,6 @@ public final class CacheSelector {
     public List<CacheEntrySelector> getEntries() {
         return Collections.unmodifiableList(entries);
     }
+    public void setIncludeImapServers(boolean bool) { imapServers = ZmBoolean.fromBool(bool); }
+    public boolean isIncludeImapServers() { return ZmBoolean.toBool(imapServers, true); }
 }

--- a/store/docs/soap-admin.txt
+++ b/store/docs/soap-admin.txt
@@ -2269,7 +2269,7 @@ in soap-waitset.txt
 # Flush memory cache for specified LDAP or directory scan type/entries
 
 <FlushCacheRequest>
-  <cache type="skin|locale|account|cos|domain|server|zimlet" [allServers="1|0"]>
+  <cache type="skin|locale|account|cos|domain|server|zimlet" [allServers="1|0"] [imapServers="1|0">
     [<entry by={id|name}>value</entry>+]
   </cache>
 </FlushCacheRequest>
@@ -2278,7 +2278,10 @@ in soap-waitset.txt
       0 (default) = flush cache only on the local server
       1           = flush cache on all servers (this can take on systems with lots of servers)
 
-
+  imapServers:
+      0           = don't send X-ZIMBRA-FLUSHCACHE IMAP commands to associated imapd servers
+      1 (default) = send X-ZIMBRA-FLUSHCACHE IMAP commands to imapd servers listed in
+                    the zimbraReverseProxyUpstreamImapServers attribute for the local server
   Directory scan caches(source of data is on local disk of the server):
       skin|locale
 

--- a/store/src/java/com/zimbra/cs/account/ProvUtil.java
+++ b/store/src/java/com/zimbra/cs/account/ProvUtil.java
@@ -117,6 +117,7 @@ import com.zimbra.cs.account.soap.SoapProvisioning.MemcachedClientConfig;
 import com.zimbra.cs.account.soap.SoapProvisioning.QuotaUsage;
 import com.zimbra.cs.account.soap.SoapProvisioning.ReIndexBy;
 import com.zimbra.cs.account.soap.SoapProvisioning.ReIndexInfo;
+import com.zimbra.cs.ephemeral.EphemeralStore;
 import com.zimbra.cs.extension.ExtensionDispatcherServlet;
 import com.zimbra.cs.fb.FbCli;
 import com.zimbra.cs.httpclient.URLUtil;
@@ -517,74 +518,74 @@ public class ProvUtil implements HttpDebugListener {
     }
 
     public enum Command {
-        ADD_ACCOUNT_ALIAS("addAccountAlias", "aaa", "{name@domain|id} {alias@domain}", Category.ACCOUNT, 2, 2), 
+        ADD_ACCOUNT_ALIAS("addAccountAlias", "aaa", "{name@domain|id} {alias@domain}", Category.ACCOUNT, 2, 2),
         ADD_ACCOUNT_LOGGER(
                 "addAccountLogger", "aal",
                 "[-s/--server hostname] {name@domain|id} {logging-category} {trace|debug|info|warn|error}",
                 Category.LOG, 3, 5),
-        ADD_DISTRIBUTION_LIST_ALIAS("addDistributionListAlias", "adla", "{list@domain|id} {alias@domain}", 
-                Category.LIST, 2, 2), 
-        ADD_DISTRIBUTION_LIST_MEMBER("addDistributionListMember", "adlm", "{list@domain|id} {member@domain}+", 
-                Category.LIST, 2, Integer.MAX_VALUE), 
-        AUTO_COMPLETE_GAL("autoCompleteGal", "acg", "{domain} {name}", Category.SEARCH, 2, 2), 
-        AUTO_PROV_CONTROL("autoProvControl", "apc", "{start|status|stop}", Category.COMMANDS, 1, 1), 
-        CHECK_PASSWORD_STRENGTH("checkPasswordStrength", "cps", "{name@domain|id} {password}", Category.ACCOUNT, 2, 2), 
-        CHECK_RIGHT("checkRight","ckr", 
+        ADD_DISTRIBUTION_LIST_ALIAS("addDistributionListAlias", "adla", "{list@domain|id} {alias@domain}",
+                Category.LIST, 2, 2),
+        ADD_DISTRIBUTION_LIST_MEMBER("addDistributionListMember", "adlm", "{list@domain|id} {member@domain}+",
+                Category.LIST, 2, Integer.MAX_VALUE),
+        AUTO_COMPLETE_GAL("autoCompleteGal", "acg", "{domain} {name}", Category.SEARCH, 2, 2),
+        AUTO_PROV_CONTROL("autoProvControl", "apc", "{start|status|stop}", Category.COMMANDS, 1, 1),
+        CHECK_PASSWORD_STRENGTH("checkPasswordStrength", "cps", "{name@domain|id} {password}", Category.ACCOUNT, 2, 2),
+        CHECK_RIGHT("checkRight","ckr",
                 "{target-type} [{target-id|target-name}] {grantee-id|grantee-name (note:can only check internal user)} {right}",
-                Category.RIGHT, 3, 4, null, new RightCommandHelp(false, false, true)), 
-        COPY_COS("copyCos", "cpc", "{src-cos-name|id} {dest-cos-name}", Category.COS, 2, 2), 
-        COUNT_ACCOUNT("countAccount", "cta", "{domain|id}", Category.DOMAIN, 1, 1), 
-        COUNT_OBJECTS("countObjects", "cto", "{" 
-                + CountObjectsType.names("|") + "} [-d {domain|id}] [-u {UCService|id}]", Category.MISC, 1, 4), 
-        CREATE_ACCOUNT("createAccount", "ca", 
-                "{name@domain} {password} [attr1 value1 [attr2 value2...]]", Category.ACCOUNT, 2, Integer.MAX_VALUE), 
-        CREATE_ALIAS_DOMAIN("createAliasDomain", "cad", 
+                Category.RIGHT, 3, 4, null, new RightCommandHelp(false, false, true)),
+        COPY_COS("copyCos", "cpc", "{src-cos-name|id} {dest-cos-name}", Category.COS, 2, 2),
+        COUNT_ACCOUNT("countAccount", "cta", "{domain|id}", Category.DOMAIN, 1, 1),
+        COUNT_OBJECTS("countObjects", "cto", "{"
+                + CountObjectsType.names("|") + "} [-d {domain|id}] [-u {UCService|id}]", Category.MISC, 1, 4),
+        CREATE_ACCOUNT("createAccount", "ca",
+                "{name@domain} {password} [attr1 value1 [attr2 value2...]]", Category.ACCOUNT, 2, Integer.MAX_VALUE),
+        CREATE_ALIAS_DOMAIN("createAliasDomain", "cad",
                 "{alias-domain-name} {local-domain-name|id} [attr1 value1 [attr2 value2...]]", Category.DOMAIN, 2,
-                Integer.MAX_VALUE), 
+                Integer.MAX_VALUE),
         CREATE_ALWAYSONCLUSTER("createAlwaysOnCluster", "caoc",
-                "{name} [attr1 value1 [attr2 value2...]]", Category.ALWAYSONCLUSTER, 1, Integer.MAX_VALUE), 
+                "{name} [attr1 value1 [attr2 value2...]]", Category.ALWAYSONCLUSTER, 1, Integer.MAX_VALUE),
         CREATE_BULK_ACCOUNTS(
                 "createBulkAccounts", "cabulk", "{domain} {namemask} {number of accounts to create}", Category.MISC, 3,
-                3), 
+                3),
         CREATE_CALENDAR_RESOURCE("createCalendarResource", "ccr",
-                "{name@domain} {password} [attr1 value1 [attr2 value2...]]", Category.CALENDAR, 2, Integer.MAX_VALUE), 
+                "{name@domain} {password} [attr1 value1 [attr2 value2...]]", Category.CALENDAR, 2, Integer.MAX_VALUE),
         CREATE_COS(
-                "createCos", "cc", "{name} [attr1 value1 [attr2 value2...]]", Category.COS, 1, Integer.MAX_VALUE), 
+                "createCos", "cc", "{name} [attr1 value1 [attr2 value2...]]", Category.COS, 1, Integer.MAX_VALUE),
         CREATE_DATA_SOURCE(
                 "createDataSource",
                 "cds",
                 "{name@domain} {ds-type} {ds-name} zimbraDataSourceEnabled {TRUE|FALSE} zimbraDataSourceFolderId {folder-id} [attr1 value1 [attr2 value2...]]",
-                Category.ACCOUNT, 3, Integer.MAX_VALUE), 
+                Category.ACCOUNT, 3, Integer.MAX_VALUE),
         CREATE_DISTRIBUTION_LIST("createDistributionList", "cdl",
-                "{list@domain}", Category.LIST, 1, Integer.MAX_VALUE), 
+                "{list@domain}", Category.LIST, 1, Integer.MAX_VALUE),
         CREATE_DYNAMIC_DISTRIBUTION_LIST(
-                "createDynamicDistributionList", "cddl", "{list@domain}", Category.LIST, 1, Integer.MAX_VALUE), 
+                "createDynamicDistributionList", "cddl", "{list@domain}", Category.LIST, 1, Integer.MAX_VALUE),
         CREATE_DISTRIBUTION_LISTS_BULK(
-                "createDistributionListsBulk", "cdlbulk"), 
+                "createDistributionListsBulk", "cdlbulk"),
         CREATE_DOMAIN("createDomain", "cd",
-                "{domain} [attr1 value1 [attr2 value2...]]", Category.DOMAIN, 1, Integer.MAX_VALUE), 
+                "{domain} [attr1 value1 [attr2 value2...]]", Category.DOMAIN, 1, Integer.MAX_VALUE),
         CREATE_SERVER(
-                "createServer", "cs", "{name} [attr1 value1 [attr2 value2...]]", Category.SERVER, 1, Integer.MAX_VALUE), 
+                "createServer", "cs", "{name} [attr1 value1 [attr2 value2...]]", Category.SERVER, 1, Integer.MAX_VALUE),
         CREATE_UC_SERVICE(
                 "createUCService", "cucs", "{name} [attr1 value1 [attr2 value2...]]", Category.UCSERVICE, 1,
-                Integer.MAX_VALUE), 
+                Integer.MAX_VALUE),
         CREATE_IDENTITY("createIdentity", "cid",
                 "{name@domain} {identity-name} [attr1 value1 [attr2 value2...]]", Category.ACCOUNT, 2,
-                Integer.MAX_VALUE), 
+                Integer.MAX_VALUE),
         CREATE_SIGNATURE("createSignature", "csig",
                 "{name@domain} {signature-name} [attr1 value1 [attr2 value2...]]", Category.ACCOUNT, 2,
-                Integer.MAX_VALUE), 
+                Integer.MAX_VALUE),
         CREATE_XMPP_COMPONENT("createXMPPComponent", "cxc",
                 "{short-name} {domain}  {server} {classname} {category} {type} [attr value1 [attr2 value2...]]",
-                Category.CONFIG, 6, Integer.MAX_VALUE), 
+                Category.CONFIG, 6, Integer.MAX_VALUE),
         DELETE_ACCOUNT("deleteAccount", "da", "{name@domain|id}",
-                Category.ACCOUNT, 1, 1), 
+                Category.ACCOUNT, 1, 1),
         DELETE_ALWAYSONCLUSTER("deleteAlwaysOnCluster", "daoc", "{name|id}",
-                Category.ALWAYSONCLUSTER, 1, 1), 
+                Category.ALWAYSONCLUSTER, 1, 1),
         DELETE_CALENDAR_RESOURCE("deleteCalendarResource", "dcr",
                 "{name@domain|id}", Category.CALENDAR, 1, 1),
         DELETE_COS("deleteCos", "dc", "{name|id}", Category.COS,
-                1, 1), 
+                1, 1),
         DELETE_DATA_SOURCE("deleteDataSource", "dds", "{name@domain|id} {ds-name|ds-id}",
                 Category.ACCOUNT, 2, 2),
         DELETE_DISTRIBUTION_LIST("deleteDistributionList", "ddl", "{list@domain|id}",
@@ -1017,6 +1018,7 @@ public class ProvUtil implements HttpDebugListener {
                 sp.soapZimbraAdminAuthenticate();
             }
             prov = sp;
+            EphemeralStore.setAutoloadExtensions(false);
         }
     }
 
@@ -3305,7 +3307,7 @@ public class ProvUtil implements HttpDebugListener {
         } else {
             /*
              * oops, do not apply default, and we are SoapProvisioning
-             * 
+             *
              * This a bit awkward because the applyDefault is controlled at the Entry.getAttrs, not at the provisioning
              * interface. But for SOAP, this needs to be passed to the get(AccountBy) method so it can set the flag in
              * SOAP. We do not want to add a provisioning method for this. Instead, we make it a SOAPProvisioning only
@@ -4206,7 +4208,7 @@ public class ProvUtil implements HttpDebugListener {
         /*
          * -only is *not* a documented option, we could expose it if we want, handy for engineering tasks, not as useful
          * for users
-         * 
+         *
          * console.println("zmprov desc -only globalConfig");
          * console.println("    print attribute name of all attributes that are on global config only" + "\n");
          */
@@ -5479,7 +5481,7 @@ public class ProvUtil implements HttpDebugListener {
      * divides it into two parts instead of treating as one parameter of the '-' and attribute name.
      * <p>
      * This method detects such decapitated attribute, and recombines those two into one attribute name with '-'.
-     * 
+     *
      * @param parsedArgs
      *            [cmd-args] which are parsed by PosixParser
      * @param options
@@ -5520,6 +5522,6 @@ public class ProvUtil implements HttpDebugListener {
                 newArgs.add(arg);
             }
         }
-        return (String[]) newArgs.toArray(new String[newArgs.size()]);
+        return newArgs.toArray(new String[newArgs.size()]);
     }
 }

--- a/store/src/java/com/zimbra/cs/account/Provisioning.java
+++ b/store/src/java/com/zimbra/cs/account/Provisioning.java
@@ -1527,6 +1527,16 @@ public abstract class Provisioning extends ZAttrProvisioning {
         }
     }
 
+    public static List<Server> getIMAPDaemonServersForLocalServer() throws ServiceException {
+        Provisioning prov = getInstance();
+        String[] servers = prov.getLocalServer().getReverseProxyUpstreamImapServers();
+        List<Server> imapServers = new ArrayList<Server>();
+        for (String server: servers) {
+            imapServers.add(prov.getServerByServiceHostname(server));
+        }
+        return imapServers;
+    }
+
     private static boolean isAlwaysOn(Account account) throws ServiceException {
         return isAlwaysOn(account, null);
     }

--- a/store/src/java/com/zimbra/cs/account/soap/SoapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/soap/SoapProvisioning.java
@@ -28,9 +28,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.Future;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.Future;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.concurrent.FutureCallback;
@@ -2617,6 +2617,10 @@ public class SoapProvisioning extends Provisioning {
      * managed by Provisioning.
      */
     public void flushCache(String type, CacheEntry[] entries, boolean allServers) throws ServiceException {
+        flushCache(type, entries, allServers, true);
+    }
+
+    public void flushCache(String type, CacheEntry[] entries, boolean allServers, boolean imapDaemons) throws ServiceException {
         CacheSelector sel = new CacheSelector(allServers, type);
 
         if (entries != null) {
@@ -2626,8 +2630,10 @@ public class SoapProvisioning extends Provisioning {
                         entry.mEntryIdentity));
             }
         }
+        sel.setIncludeImapServers(imapDaemons);
         invokeJaxb(new FlushCacheRequest(sel));
     }
+
 
     @Override
     public CountAccountResult countAccount(Domain domain) throws ServiceException {

--- a/store/src/java/com/zimbra/cs/ephemeral/EphemeralStore.java
+++ b/store/src/java/com/zimbra/cs/ephemeral/EphemeralStore.java
@@ -36,6 +36,7 @@ public abstract class EphemeralStore {
         String getStoreId();
     }
 
+    private static boolean autoloadExtensions = true;
     private static Map<String, String> factories = new HashMap<String, String>();
     private static Factory factory;
     protected AttributeEncoder encoder;
@@ -229,9 +230,13 @@ public abstract class EphemeralStore {
         return encoder.decode(key, value);
     }
 
+    public static void setAutoloadExtensions(boolean bool) {
+        autoloadExtensions = bool;
+    }
+
     private static String getFactoryClassName(String backendName) throws ServiceException {
         String factoryClassName = factories.get(backendName);
-        if (factoryClassName == null) {
+        if (factoryClassName == null && autoloadExtensions) {
             //perhaps the extension hasn't been loaded - try to find it and check again
             ExtensionUtil.initEphemeralBackendExtension(backendName);
             factoryClassName = factories.get(backendName);

--- a/store/src/java/com/zimbra/cs/extension/ExtensionUtil.java
+++ b/store/src/java/com/zimbra/cs/extension/ExtensionUtil.java
@@ -28,8 +28,8 @@ import java.util.Map;
 
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
-import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.common.util.Log.Level;
+import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.ephemeral.EphemeralStore;
 import com.zimbra.cs.ephemeral.EphemeralStore.Factory;
 import com.zimbra.cs.redolog.op.RedoableOp;
@@ -200,17 +200,17 @@ public class ExtensionUtil {
         Factory factory = EphemeralStore.getFactory(backendName);
         if (factory == null) {
             Zimbra.halt(String.format(
-                    "no extension class name found for backend '%s', aborting attribute migration",
+                    "no extension class name found for backend '%s'",
                     backendName));
             return; // keep Eclipse happy
         }
         EphemeralStore store = factory.getStore();
         if (store == null) {
-            Zimbra.halt(String.format("no store found for backend '%s', aborting attribute migration",
+            Zimbra.halt(String.format("no store found for backend '%s'",
                     backendName));
             return; // keep Eclipse happy
         }
-        ZimbraLog.ephemeral.info("Using ephemeral backend %s (%s) for attribute migration", backendName,
+        ZimbraLog.ephemeral.info("Using ephemeral backend %s (%s)", backendName,
                 store.getClass().getName());
     }
 

--- a/store/src/java/com/zimbra/cs/imap/ImapHandler.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapHandler.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -85,7 +86,6 @@ import com.zimbra.cs.account.AuthToken;
 import com.zimbra.cs.account.GuestAccount;
 import com.zimbra.cs.account.NamedEntry;
 import com.zimbra.cs.account.Provisioning;
-import com.zimbra.cs.account.Provisioning.CacheEntry;
 import com.zimbra.cs.account.Server;
 import com.zimbra.cs.account.accesscontrol.Rights.Admin;
 import com.zimbra.cs.account.auth.AuthContext;
@@ -111,11 +111,14 @@ import com.zimbra.cs.security.sasl.PlainAuthenticator;
 import com.zimbra.cs.security.sasl.ZimbraAuthenticator;
 import com.zimbra.cs.server.ServerThrottle;
 import com.zimbra.cs.service.admin.AdminAccessControl;
+import com.zimbra.cs.service.admin.FlushCache;
 import com.zimbra.cs.service.mail.FolderAction;
 import com.zimbra.cs.service.util.ItemId;
 import com.zimbra.cs.util.AccountUtil;
 import com.zimbra.cs.util.BuildInfo;
+import com.zimbra.soap.admin.type.CacheEntrySelector;
 import com.zimbra.soap.admin.type.CacheEntryType;
+import com.zimbra.soap.admin.type.CacheSelector;
 
 public abstract class ImapHandler {
     enum State { NOT_AUTHENTICATED, AUTHENTICATED, SELECTED, LOGOUT }
@@ -152,6 +155,14 @@ public abstract class ImapHandler {
     private static final Set<String> THROTTLED_COMMANDS = ImmutableSet.of(
             "APPEND", "COPY", "CREATE", "EXAMINE", "FETCH", "LIST",
             "LSUB", "UID", "SEARCH", "SELECT", "SORT", "STORE", "XLIST");
+
+    public static final Set<CacheEntryType> IMAP_CACHE_TYPES = EnumSet.of(
+            CacheEntryType.all,
+            CacheEntryType.account,
+            CacheEntryType.config,
+            CacheEntryType.cos,
+            CacheEntryType.domain,
+            CacheEntryType.server);
 
     protected ImapHandler(ImapConfig config) {
         this.config = config;
@@ -888,8 +899,8 @@ public abstract class ImapHandler {
                     return doLIST(tag, base, patterns, (byte) 0, RETURN_XLIST, (byte) 0);
                 } else if (command.equals("X-ZIMBRA-FLUSHCACHE")) {
                     req.skipSpace();
-                    CacheEntryType[] cacheTypes = req.readCacheEntryTypes();
-                    CacheEntry[] entries = req.readCacheEntries();
+                    List<CacheEntryType> cacheTypes = req.readCacheEntryTypes();
+                    List<CacheEntrySelector> entries = req.readCacheEntries();
                     checkEOF(tag, req);
                     return doFLUSHCACHE(tag, cacheTypes, entries);
                 } else if (command.equals("X-ZIMBRA-RELOADLC")) {
@@ -1355,11 +1366,16 @@ public abstract class ImapHandler {
 
     }
 
-    boolean doFLUSHCACHE(String tag, CacheEntryType[] types, CacheEntry[] entries) throws IOException {
+    boolean doFLUSHCACHE(String tag, List<CacheEntryType> types, List<CacheEntrySelector> entries) throws IOException {
         if (!checkState(tag, State.AUTHENTICATED)) {
             return true;
         } else if (!checkZimbraAdminAuth()) {
             sendNO(tag, "must be authenticated as admin with X-ZIMBRA auth mechanism");
+            return true;
+        }
+        if (types.isEmpty()) {
+            // nothing to do here
+            sendOK(tag, "FLUSHCACHE completed");
             return true;
         }
         AuthToken authToken = ((ZimbraAuthenticator) authenticator).getAuthToken();
@@ -1375,9 +1391,11 @@ public abstract class ImapHandler {
             }
             return canContinue(e);
         }
+        CacheSelector cacheSelector = new CacheSelector();
+        cacheSelector.setEntries(entries);
         for (CacheEntryType type: types) {
             try {
-                Provisioning.getInstance().flushCache(type, entries);
+                FlushCache.doFlush(null, type, cacheSelector);
             } catch (ServiceException e) {
                 ZimbraLog.imap.error("error flushing cache on IMAP server", e);
                 return canContinue(e);

--- a/store/src/java/com/zimbra/cs/service/admin/FlushCache.java
+++ b/store/src/java/com/zimbra/cs/service/admin/FlushCache.java
@@ -17,6 +17,7 @@
 package com.zimbra.cs.service.admin;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -25,6 +26,7 @@ import javax.servlet.ServletContext;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 
+import com.google.common.base.Joiner;
 import com.zimbra.common.account.Key.AccountBy;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
@@ -43,6 +45,7 @@ import com.zimbra.cs.account.accesscontrol.PermissionCache;
 import com.zimbra.cs.account.accesscontrol.Rights.Admin;
 import com.zimbra.cs.gal.GalGroup;
 import com.zimbra.cs.httpclient.URLUtil;
+import com.zimbra.cs.imap.ImapHandler;
 import com.zimbra.cs.mailclient.imap.ImapConnection;
 import com.zimbra.cs.service.AuthProvider;
 import com.zimbra.cs.util.SkinUtil;
@@ -87,6 +90,7 @@ public class FlushCache extends AdminDocumentHandler {
 
         CacheSelector cacheSelector = req.getCache();
         boolean allServers = cacheSelector.isAllServers();
+        boolean imapServers = cacheSelector.isIncludeImapServers();
         String[] types = cacheSelector.getTypes().split(",");
         for (String type : types) {
             CacheEntryType cacheType = null;
@@ -107,13 +111,15 @@ public class FlushCache extends AdminDocumentHandler {
                 }
             }
         }
+        if (imapServers) {
+            flushCacheOnImapDaemons(req, zsc);
+        }
         if (allServers) {
             flushCacheOnAllServers(zsc, req);
-            flushCacheOnAllImapDaemons(req, zsc);
         }
     }
 
-    private static void doFlush(Map<String, Object> context, CacheEntryType cacheType, CacheSelector cacheSelector)
+    public static void doFlush(Map<String, Object> context, CacheEntryType cacheType, CacheSelector cacheSelector)
     throws ServiceException {
 
         String mailURL = Provisioning.getInstance().getLocalServer().getMailURL();
@@ -251,22 +257,21 @@ public class FlushCache extends AdminDocumentHandler {
         relatedRights.add(Admin.R_flushCache);
     }
 
-    private static void flushCacheOnAllImapDaemons(FlushCacheRequest req, ZimbraSoapContext zsc) throws ServiceException {
+    private static void flushCacheOnImapDaemons(FlushCacheRequest req, ZimbraSoapContext zsc) throws ServiceException {
         CacheSelector selector = req.getCache();
         String cacheTypes = selector.getTypes();
         CacheEntry[] cacheEntries = getCacheEntries(selector);
         Account acct = Provisioning.getInstance().get(AccountBy.id, zsc.getAuthtokenAccountId(), zsc.getAuthToken());
-        flushCacheOnAllImapDaemons(cacheTypes, cacheEntries, acct.getName(), zsc.getAuthToken());
+        flushCacheOnImapDaemons(cacheTypes, cacheEntries, acct.getName(), zsc.getAuthToken());
     }
 
-    public static void flushCacheOnAllImapDaemons(String cacheTypes, CacheEntry[] entries, AuthToken authToken) {
-        flushCacheOnAllImapDaemons(cacheTypes, entries, LC.zimbra_ldap_user.value(), authToken);
+    public static void flushCacheOnImapDaemons(String cacheTypes, CacheEntry[] entries, AuthToken authToken) {
+        flushCacheOnImapDaemons(cacheTypes, entries, LC.zimbra_ldap_user.value(), authToken);
     }
-    public static void flushCacheOnAllImapDaemons(String cacheTypes, CacheEntry[] entries, String acctName, AuthToken authToken) {
-        Provisioning prov = Provisioning.getInstance();
+    public static void flushCacheOnImapDaemons(String cacheTypes, CacheEntry[] entries, String acctName, AuthToken authToken) {
         List<Server> imapServers;
         try {
-            imapServers = prov.getAllServers(Provisioning.SERVICE_IMAP);
+            imapServers = Provisioning.getIMAPDaemonServersForLocalServer();
         } catch (ServiceException e) {
             ZimbraLog.imap.warn("unable to fetch list of imapd servers", e);
             return;
@@ -280,7 +285,7 @@ public class FlushCache extends AdminDocumentHandler {
         try {
             flushCacheOnImapDaemon(server, cacheTypes, entries, LC.zimbra_ldap_user.value(), AuthProvider.getAdminAuthToken());
         } catch (ServiceException e) {
-            ZimbraLog.imap.warn("unable to generate admin auth token to issue FLUSHCACHE request to imapd server '%s'", server.getServiceHostname(), e);
+            ZimbraLog.imap.warn("unable to generate admin auth token to issue X-ZIMBRA-FLUSHCACHE request to imapd server '%s'", server.getServiceHostname(), e);
         }
     }
 
@@ -289,20 +294,37 @@ public class FlushCache extends AdminDocumentHandler {
         try {
             connection = ImapConnection.getZimbraConnection(server, userName, authToken);
         } catch (ServiceException e) {
-            ZimbraLog.imap.warn("unable to connect to imapd server '%s' to issue FLUSHCACHE request", server.getServiceHostname(), e);
+            ZimbraLog.imap.warn("unable to connect to imapd server '%s' to issue X-ZIMBRA-FLUSHCACHE request", server.getServiceHostname(), e);
             return;
         }
         try {
+            String imapTypes = sanitizeImapCacheTypes(cacheTypes);
             if (entries == null || entries.length == 0) {
-                ZimbraLog.imap.debug("issuing FLUSHCACHE request to imapd server '%s'", server.getServiceHostname());
-                connection.flushCache(cacheTypes);
+                ZimbraLog.imap.debug("issuing X-ZIMBRA-FLUSHCACHE request to imapd server '%s'", server.getServiceHostname());
+                connection.flushCache(imapTypes);
             } else {
-                connection.flushCache(cacheTypes, entries);
+                connection.flushCache(imapTypes, entries);
             }
         } catch (IOException e) {
-            ZimbraLog.imap.warn("unable to issue FLUSHCACHE request to imapd server '%s'", server.getServiceHostname(), e);
+            ZimbraLog.imap.warn("unable to issue X-ZIMBRA-FLUSHCACHE request to imapd server '%s'", server.getServiceHostname(), e);
         } finally {
             connection.close();
         }
+    }
+
+    private static String sanitizeImapCacheTypes(String cacheTypes) {
+        List<String> imapTypes = new ArrayList<String>();
+        for (String typeStr: cacheTypes.split(",")) {
+            try {
+                CacheEntryType cacheType = CacheEntryType.fromString(typeStr);
+                if (ImapHandler.IMAP_CACHE_TYPES.contains(cacheType)) {
+                    //filter out cache types that don't need to be flushed on imapd servers
+                    imapTypes.add(typeStr);
+                }
+            } catch (ServiceException e) {
+                //shouldn't encounter invalid cache types
+            }
+        }
+        return Joiner.on(",").join(imapTypes);
     }
 }

--- a/store/src/java/com/zimbra/cs/service/admin/ReloadLocalConfig.java
+++ b/store/src/java/com/zimbra/cs/service/admin/ReloadLocalConfig.java
@@ -65,10 +65,9 @@ public final class ReloadLocalConfig extends AdminDocumentHandler {
     }
 
     private void reloadLCOnAllImapDaemons() {
-        Provisioning prov = Provisioning.getInstance();
         List<Server> imapServers;
         try {
-            imapServers = prov.getAllServers(Provisioning.SERVICE_IMAP);
+            imapServers = Provisioning.getIMAPDaemonServersForLocalServer();
         } catch (ServiceException e) {
             ZimbraLog.imap.warn("unable to fetch list of imapd servers", e);
             return;

--- a/store/src/java/com/zimbra/qa/unittest/TestImapViaImapDaemon.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestImapViaImapDaemon.java
@@ -1,23 +1,26 @@
-package com.zimbra.qa.unittest;
+ package com.zimbra.qa.unittest;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
-import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-
+import com.google.common.collect.Sets;
 import com.zimbra.common.account.Key.CacheEntryBy;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.localconfig.LocalConfig;
 import com.zimbra.common.util.Log;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.Provisioning.CacheEntry;
+import com.zimbra.cs.imap.ImapHandler;
 import com.zimbra.cs.imap.ImapProxy.ZimbraClientAuthenticator;
 import com.zimbra.cs.mailclient.CommandFailedException;
 import com.zimbra.cs.mailclient.auth.AuthenticatorFactory;
@@ -27,209 +30,226 @@ import com.zimbra.cs.security.sasl.ZimbraAuthenticator;
 import com.zimbra.cs.service.AuthProvider;
 import com.zimbra.soap.admin.type.CacheEntryType;
 
-/**
- * Test the IMAP server provided by the IMAP daemon, doing the necessary configuration to make it work.
- *
- * Note: Currently bypasses Proxy, the tests connect directly to the IMAP daemon's port
- *
- * The actual tests that are run are in {@link SharedImapTests}
- */
-public class TestImapViaImapDaemon extends SharedImapTests {
+  /**
+   * Test the IMAP server provided by the IMAP daemon, doing the necessary configuration to make it work.
+   *
+   * Note: Currently bypasses Proxy, the tests connect directly to the IMAP daemon's port
+   *
+   * The actual tests that are run are in {@link SharedImapTests}
+   */
+  public class TestImapViaImapDaemon extends SharedImapTests {
 
-    @Before
-    public void setUp() throws Exception  {
-        getLocalServer();
-        TestUtil.assumeTrue("remoteImapServerEnabled false for this server", imapServer.isRemoteImapServerEnabled());
-        saveImapConfigSettings();
-        TestUtil.setLCValue(LC.imap_always_use_remote_store, String.valueOf(false));
-        imapServer.setReverseProxyUpstreamImapServers(new String[] {imapServer.getServiceHostname()});
-        super.sharedSetUp();
-        TestUtil.flushImapDaemonCache(imapServer);
-    }
+      @Before
+      public void setUp() throws Exception  {
+          getLocalServer();
+          TestUtil.assumeTrue("remoteImapServerEnabled false for this server", imapServer.isRemoteImapServerEnabled());
+          saveImapConfigSettings();
+          TestUtil.setLCValue(LC.imap_always_use_remote_store, String.valueOf(false));
+          imapServer.setReverseProxyUpstreamImapServers(new String[] {imapServer.getServiceHostname()});
+          super.sharedSetUp();
+          TestUtil.flushImapDaemonCache(imapServer);
+      }
 
-    @After
-    public void tearDown() throws Exception {
-        super.sharedTearDown();
-        if (imapHostname != null) {
-            restoreImapConfigSettings();
-            TestUtil.flushImapDaemonCache(imapServer);
-            getAdminConnection().reloadLocalConfig();
-        }
-    }
+      @After
+      public void tearDown() throws Exception {
+          super.sharedTearDown();
+          if (imapHostname != null) {
+              restoreImapConfigSettings();
+              TestUtil.flushImapDaemonCache(imapServer);
+              getAdminConnection().reloadLocalConfig();
+          }
+      }
 
-    @Override
-    protected int getImapPort() {
-        return imapServer.getRemoteImapBindPort();
-    }
+      @Override
+      protected int getImapPort() {
+          return imapServer.getRemoteImapBindPort();
+      }
 
-    @Override
-    protected void flushCacheIfNecessary() throws Exception {
-        TestUtil.flushImapDaemonCache(imapServer);
-    }
+      @Override
+      protected void flushCacheIfNecessary() throws Exception {
+          TestUtil.flushImapDaemonCache(imapServer);
+      }
 
-    @Test
-    public void testClearDaemonCacheWrongAuthenticator() throws Exception {
-        connection = connect();
-        try {
-            connection.flushCache(CacheEntryType.config.toString());
-            fail("should not be able to flush the cache without authenticating");
-        } catch (CommandFailedException cfe) {
-            assertEquals("must be in AUTHENTICATED or SELECTED state", cfe.getError());
-        }
-        connection.login(PASS);
-        try {
-            connection.flushCache(CacheEntryType.config.toString());
-            fail("should not be able to flush the cache without using X-ZIMBRA auth mechanism");
-        } catch (CommandFailedException cfe) {
-            assertEquals("must be authenticated as admin with X-ZIMBRA auth mechanism", cfe.getError());
-        }
-    }
+      @Test
+      public void testClearDaemonCacheWrongAuthenticator() throws Exception {
+          connection = connect();
+          try {
+              connection.flushCache(CacheEntryType.config.toString());
+              fail("should not be able to flush the cache without authenticating");
+          } catch (CommandFailedException cfe) {
+              assertEquals("must be in AUTHENTICATED or SELECTED state", cfe.getError());
+          }
+          connection.login(PASS);
+          try {
+              connection.flushCache(CacheEntryType.config.toString());
+              fail("should not be able to flush the cache without using X-ZIMBRA auth mechanism");
+          } catch (CommandFailedException cfe) {
+              assertEquals("must be authenticated as admin with X-ZIMBRA auth mechanism", cfe.getError());
+          }
+      }
 
-    private void tryConnect(boolean shouldSucceed, String message) throws Exception {
-        try {
-            connection = connect(USER);
-            connection.login(PASS);
-            if (!shouldSucceed) {
-                fail(message);
-            }
-        } catch (CommandFailedException e) {
-            if (shouldSucceed) {
-                fail(message);
-            }
-        }
-    }
+      private void tryConnect(boolean shouldSucceed, String message) throws Exception {
+          try {
+              connection = connect(USER);
+              connection.login(PASS);
+              if (!shouldSucceed) {
+                  fail(message);
+              }
+          } catch (CommandFailedException e) {
+              if (shouldSucceed) {
+                  fail(message);
+              }
+          }
+      }
 
-    private void enableImapAndCheckCachedValue(Account acct) throws Exception {
-        acct.setImapEnabled(true);
-        tryConnect(false, "should not be able to log in since imapd has old value of zimbraImapEnabled=FALSE");
-    }
+      private void enableImapAndCheckCachedValue(Account acct) throws Exception {
+          acct.setImapEnabled(true);
+          tryConnect(false, "should not be able to log in since imapd has old value of zimbraImapEnabled=FALSE");
+      }
 
-    private void disableImapAndCheckCachedValue(Account acct) throws Exception {
-        acct.setImapEnabled(false);
-        tryConnect(true, "should be able to log in since imapd has old value of zimbraImapEnabled=TRUE");
-    }
+      private void disableImapAndCheckCachedValue(Account acct) throws Exception {
+          acct.setImapEnabled(false);
+          tryConnect(true, "should be able to log in since imapd has old value of zimbraImapEnabled=TRUE");
+      }
 
-    @Test
-    public void testClearDaemonCache() throws Exception {
-        tryConnect(true, "should be able to log in initially"); //loads the account into the imapd cache
+      @Test
+      public void testClearDaemonCache() throws Exception {
+          tryConnect(true, "should be able to log in initially"); //loads the account into the imapd cache
 
-        Account acct = TestUtil.getAccount(USER);
-        CacheEntry acctByName = new CacheEntry(CacheEntryBy.name, acct.getName());
-        CacheEntry acctById = new CacheEntry(CacheEntryBy.id, acct.getId());
-        ImapConnection adminConn = getAdminConnection();
+          Account acct = TestUtil.getAccount(USER);
+          CacheEntry acctByName = new CacheEntry(CacheEntryBy.name, acct.getName());
+          CacheEntry acctById = new CacheEntry(CacheEntryBy.id, acct.getId());
+          ImapConnection adminConn = getAdminConnection();
 
-        //verify that we can flush an account cache by name
-        disableImapAndCheckCachedValue(acct);
-        adminConn.flushCache("account", new CacheEntry[] { acctByName });
-        tryConnect(false, "should not be able to log in after flushing LDAP cache by account name");
+          //verify that we can flush an account cache by name
+          disableImapAndCheckCachedValue(acct);
+          adminConn.flushCache("account", new CacheEntry[] { acctByName });
+          tryConnect(false, "should not be able to log in after flushing LDAP cache by account name");
 
-        //verify that we can flush an account cache by ID
-        enableImapAndCheckCachedValue(acct);
-        adminConn.flushCache("account", new CacheEntry[] { acctById });
-        tryConnect(true, "should be able to log in after flushing LDAP cache by account ID");
+          //verify that we can flush an account cache by ID
+          enableImapAndCheckCachedValue(acct);
+          adminConn.flushCache("account", new CacheEntry[] { acctById });
+          tryConnect(true, "should be able to log in after flushing LDAP cache by account ID");
 
-        //verify that we can flush an account cache with multiple CacheEntries
-        disableImapAndCheckCachedValue(acct);
-        adminConn.flushCache("account", new CacheEntry[] { acctByName, acctById });
-        tryConnect(false, "should not be able to log in after flushing LDAP cache by account name and ID");
+          //verify that we can flush an account cache with multiple CacheEntries
+          disableImapAndCheckCachedValue(acct);
+          adminConn.flushCache("account", new CacheEntry[] { acctByName, acctById });
+          tryConnect(false, "should not be able to log in after flushing LDAP cache by account name and ID");
 
-        //verify that we can flush an account cache without a CacheEntry value
-        enableImapAndCheckCachedValue(acct);
-        adminConn.flushCache("account");
-        tryConnect(true, "should be able to log in after flushing entire LDAP account cache");
+          //verify that we can flush an account cache without a CacheEntry value
+          enableImapAndCheckCachedValue(acct);
+          adminConn.flushCache("account");
+          tryConnect(true, "should be able to log in after flushing entire LDAP account cache");
 
-        //verify that we can flush multiple cache types at once
-        disableImapAndCheckCachedValue(acct);
-        adminConn.flushCache("config,account");
-        tryConnect(false, "should not be able to log in after flushing multiple cache types");
+          //verify that we can flush multiple cache types at once
+          disableImapAndCheckCachedValue(acct);
+          adminConn.flushCache("config,account");
+          tryConnect(false, "should not be able to log in after flushing multiple cache types");
 
-        //verify that we can flush all caches
-        enableImapAndCheckCachedValue(acct);
-        adminConn.flushCache("all");
-        tryConnect(true, "should be able to log in after flushing all caches");
-    }
+          //verify that we can flush all caches
+          enableImapAndCheckCachedValue(acct);
+          adminConn.flushCache("all");
+          tryConnect(true, "should be able to log in after flushing all caches");
+      }
 
-    @Test
-    public void testReloadLocalConfig() throws Exception {
-        //to test this, we set imap_max_consecutive_error to 1 and make sure imapd disconnects after
-        //the first failure
-        ImapConnection adminConn = getAdminConnection();
-        int savedMaxConsecutiveError = LC.imap_max_consecutive_error.intValue();
+      @Test
+      public void testReloadLocalConfig() throws Exception {
+          //to test this, we set imap_max_consecutive_error to 1 and make sure imapd disconnects after
+          //the first failure
+          ImapConnection adminConn = getAdminConnection();
+          int savedMaxConsecutiveError = LC.imap_max_consecutive_error.intValue();
 
-        //don't use TestUtil.setLCValue, since it issues a ReloadLocalConfigRequest, which will
-        //send out its own RELOADLC request
-        LocalConfig lc = new LocalConfig(null);
-        lc.set(LC.imap_max_consecutive_error.key(), "1");
-        lc.save();
+          //don't use TestUtil.setLCValue, since it issues a ReloadLocalConfigRequest, which will
+          //send out its own RELOADLC request
+          LocalConfig lc = new LocalConfig(null);
+          lc.set(LC.imap_max_consecutive_error.key(), "1");
+          lc.save();
 
-        connection = connect(USER);
-        connection.login(PASS);
-        try {
-            //sanity check: even though the LC value is changed, imapd should still be using the old value
-            for (int i = 0; i < savedMaxConsecutiveError; i++) {
-                try {
-                    connection.select("BAD");
-                } catch (CommandFailedException e) {
-                    assertEquals("expected 'SELECT failed' error", "SELECT failed", e.getError());
-                }
-            }
-            try {
-                connection.select("INBOX");
-                fail("session should be disconnected due to too many consecutive errors");
-            } catch (CommandFailedException e) {}
+          connection = connect(USER);
+          connection.login(PASS);
+          try {
+              //sanity check: even though the LC value is changed, imapd should still be using the old value
+              for (int i = 0; i < savedMaxConsecutiveError; i++) {
+                  try {
+                      connection.select("BAD");
+                  } catch (CommandFailedException e) {
+                      assertEquals("expected 'SELECT failed' error", "SELECT failed", e.getError());
+                  }
+              }
+              try {
+                  connection.select("INBOX");
+                  fail("session should be disconnected due to too many consecutive errors");
+              } catch (CommandFailedException e) {}
 
-            //reload LC and reconnect; imapd should now be using the new value
-            adminConn.reloadLocalConfig();
-            connection = connect(USER);
-            connection.login(PASS);
-            try {
-                connection.select("BAD");
-            } catch (CommandFailedException e) {
-                assertEquals("expected 'SELECT failed' error", "SELECT failed", e.getError());
-            }
-            try {
-                connection.select("INBOX");
-                fail("session should be disconnected after 1 error");
-            } catch (CommandFailedException e) {}
-        } finally {
-            TestUtil.setLCValue(LC.imap_max_consecutive_error, String.valueOf(savedMaxConsecutiveError));
-            adminConn.reloadLocalConfig();
-        }
-    }
+              //reload LC and reconnect; imapd should now be using the new value
+              adminConn.reloadLocalConfig();
+              connection = connect(USER);
+              connection.login(PASS);
+              try {
+                  connection.select("BAD");
+              } catch (CommandFailedException e) {
+                  assertEquals("expected 'SELECT failed' error", "SELECT failed", e.getError());
+              }
+              try {
+                  connection.select("INBOX");
+                  fail("session should be disconnected after 1 error");
+              } catch (CommandFailedException e) {}
+          } finally {
+              TestUtil.setLCValue(LC.imap_max_consecutive_error, String.valueOf(savedMaxConsecutiveError));
+              adminConn.reloadLocalConfig();
+          }
+      }
 
-    @Test
-    public void testZimbraCommandsNonAdminUser() throws Exception {
-        Account acct = TestUtil.getAccount(USER);
-        AuthenticatorFactory authFactory = new AuthenticatorFactory();
-        authFactory.register(ZimbraAuthenticator.MECHANISM, ZimbraClientAuthenticator.class);
-        ImapConfig config = new ImapConfig(imapHostname);
-        config.setMechanism(ZimbraAuthenticator.MECHANISM);
-        config.setAuthenticatorFactory(authFactory);
-        config.setPort(imapPort);
-        config.setAuthenticationId(acct.getName());
-        config.getLogger().setLevel(Log.Level.trace);
-        ImapConnection conn = new ImapConnection(config);
-        conn.connect();
-        conn.authenticate(AuthProvider.getAuthToken(acct).getEncoded());
-        try {
-            conn.reloadLocalConfig();
-            fail("should not be able to run X-ZIMBRA-RELOADLC command with a non-admin auth token");
-        } catch (CommandFailedException cfe) {
-            assertEquals("must be authenticated as admin with X-ZIMBRA auth mechanism", cfe.getError());
-        }
-        try {
-            conn.flushCache("all");
-            fail("should not be able to run X-ZIMBRA-FLUSHCACHE command with a non-admin auth token");
-        } catch (CommandFailedException cfe) {
-            assertEquals("must be authenticated as admin with X-ZIMBRA auth mechanism", cfe.getError());
-        }
-    }
+      @Test
+      public void testZimbraCommandsNonAdminUser() throws Exception {
+          Account acct = TestUtil.getAccount(USER);
+          AuthenticatorFactory authFactory = new AuthenticatorFactory();
+          authFactory.register(ZimbraAuthenticator.MECHANISM, ZimbraClientAuthenticator.class);
+          ImapConfig config = new ImapConfig(imapHostname);
+          config.setMechanism(ZimbraAuthenticator.MECHANISM);
+          config.setAuthenticatorFactory(authFactory);
+          config.setPort(imapPort);
+          config.setAuthenticationId(acct.getName());
+          config.getLogger().setLevel(Log.Level.trace);
+          ImapConnection conn = new ImapConnection(config);
+          conn.connect();
+          conn.authenticate(AuthProvider.getAuthToken(acct).getEncoded());
+          try {
+              conn.reloadLocalConfig();
+              fail("should not be able to run X-ZIMBRA-RELOADLC command with a non-admin auth token");
+          } catch (CommandFailedException cfe) {
+              assertEquals("must be authenticated as admin with X-ZIMBRA auth mechanism", cfe.getError());
+          }
+          try {
+              conn.flushCache("all");
+              fail("should not be able to run X-ZIMBRA-FLUSHCACHE command with a non-admin auth token");
+          } catch (CommandFailedException cfe) {
+              assertEquals("must be authenticated as admin with X-ZIMBRA auth mechanism", cfe.getError());
+          }
+      }
 
-    @Test
-    public void testImapdStatFile() throws Exception {
-        File testFile = new File("/opt/zimbra/zmstat/imapd.csv");
+      @Test
+      public void testImapdStatFile() throws Exception {
+          File testFile = new File("/opt/zimbra/zmstat/imapd.csv");
 
-        assertTrue("imapd.csv file does not exists", testFile.exists());
-        assertTrue("imapd.csv file is empty", testFile.length()>0);
-    }
-}
+          assertTrue("imapd.csv file does not exists", testFile.exists());
+          assertTrue("imapd.csv file is empty", testFile.length()>0);
+      }
+
+
+      @Test
+      public void testFlushNonImapCacheTypes() throws Exception {
+          //Flushing these cache types won't do anything on the imapd server, but
+          //we want to make sure that this does not fail;
+          ImapConnection adminConn = getAdminConnection();
+          Set<CacheEntryType> allTypes = new HashSet<CacheEntryType>(Arrays.asList(CacheEntryType.values()));
+          Set<CacheEntryType> nonImapTypes = Sets.difference(allTypes, ImapHandler.IMAP_CACHE_TYPES);
+          for (CacheEntryType type: nonImapTypes) {
+              try {
+                  adminConn.flushCache(CacheEntryType.license.toString());
+              } catch (CommandFailedException e) {
+                  fail("should be able issue X-ZIMBRA-FLUSHCACHE command for cache type " + type.toString());
+              }
+          }
+      }
+  }


### PR DESCRIPTION
This bug was caused by `X-ZIMBRA-FLUSHCACHE` routing all cache types to _Provisioning.flushCache_, which is incorrect since some cache types, such as _license_ require special handling.

This is fixed with the following changes:

1. Restrict which cache types are forwarded by the _FlushCache_ SOAP handler to imapd servers. Not all cache types are applicable to imapd servers, so it makes sense to only forward relevant ones to avoid unnecessary requests. The relevant caches are listed in the new public static set _ImapHander.IMAP_CACHE_TYPES_, which current consists of _account, cos, domain, server, config_, and _all_. If there are other cache types that should be included here, please comment and I will update this set.

2. Update _ImapHandler_ to ignore other cache types even if they are encountered. While this may be somewhat unnecessary since irrelevant cache types should be filtered out by step 1, it makes testing easier and prevents edge cases where caches like _uistrings_ try to be flushed on imapd, which may lead to complications due to further request forwarding.

3. Instead of simplly calling _Provisioning::flushCache_ from _ImapHandler_, use the same code path as the FlushCache SOAP handler, which allows for additional code to be executed for each cache type. To this end, _FlushCache::doFlush_ has been made public so it can be called from _ImapHandler::doFLUSHCACHE_.

A new test _TestImapViaImapDaemon.testFlushNonImapCacheTypes()_ is added to test that attempting to flush cache types not listed in _IMAP_CACHE_TYPES_ does not result in errors.


#### Updates
 - _FlushCache_ and _ReloadLocalConfig_ SOAP handlers forward their respective IMAP commands only to those servers listed in the _zimbraReverseProxyUpstreamImapServers_ attribute for the current server. For _FlushCache_, this happens regardless of the value of the _allServers_ attribute. The idea here is that we want to flush the cache on all imapd servers that serve the mailbox server receiving the _FlushCacheRequest_.
 - _FlushCacheRequest_ has a new request attribute _imapServers_ that defaults to true. If set to _false_, `X-ZIMBRA-FLUSHCACHE` will _not_ be forwarded to _zimbraReverseProxyUpstreamImapServers_. This is used by _AttributeMigration_, as it issues its own custom `X-ZIMBRA-FLUSHCACHE` commands, and needs a way to disable _FlushCache_ from doing so.
 - Autoloading of ephemeral extensions can be disabled on _EphemeralStore_. `zmprov` does this when using _SoapProvisioning_, to prevent the process from unnecessarily loading extensions and outputting logging noise to the console. This is a follow-up to work that was done for ZCS-1790, which introduced the autoloading mechanism.