### PR TITLE
allow recent cutoff to be zero for remote IMAP

### DIFF
--- a/client/src/java/com/zimbra/client/ZFolder.java
+++ b/client/src/java/com/zimbra/client/ZFolder.java
@@ -735,11 +735,10 @@ public class ZFolder implements ZItem, FolderStore, Comparable<Object>, ToZJSONO
 
     public int getImapRECENTCutoff(boolean inWritableSession) {
         try {
-            if (inWritableSession || mImapRECENTCutoff == 0) {
+            if (inWritableSession) {
                 mImapRECENTCutoff = mMailbox.getLastItemIdInMailbox();
             }
-        }
-        catch (ServiceException e) {
+        } catch (ServiceException e) {
             ZimbraLog.imap.warn("Error retrieving last item ID in mailbox", e);
         }
         return mImapRECENTCutoff;

--- a/store/src/java/com/zimbra/qa/unittest/SharedImapTests.java
+++ b/store/src/java/com/zimbra/qa/unittest/SharedImapTests.java
@@ -26,7 +26,6 @@ import java.util.regex.Pattern;
 import javax.mail.MessagingException;
 
 import org.apache.commons.lang.StringUtils;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.google.common.collect.Lists;
@@ -761,7 +760,7 @@ public abstract class SharedImapTests extends ImapTestBase {
         assertTrue("should have \\Deleted flag", flags.isDeleted());
     }
 
-    @Ignore
+    @Test
     public void testZCS1776() throws Exception {
         ZMailbox mbox = TestUtil.getZMailbox(USER);
         TestUtil.addMessage(mbox, "test for ZCS-1776");


### PR DESCRIPTION
This fix addresses one specific scenario where RECENT is not reporting correct number of items after IMAP client selects a folder.