### PR TITLE
Bugfix/zcs 2173

### DIFF
--- a/store/src/java/com/zimbra/cs/imap/ImapHandler.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapHandler.java
@@ -1351,10 +1351,6 @@ public abstract class ImapHandler {
 
     boolean doLOGOUT(String tag) throws IOException {
         sendBYE();
-        if (credentials != null) {
-            ZimbraLog.imap.info("dropping connection for user " + credentials.getUsername() + " (LOGOUT)");
-            credentials.logout();
-        }
         sendOK(tag, "LOGOUT completed");
         return false;
     }
@@ -4523,5 +4519,16 @@ public abstract class ImapHandler {
 
     protected void sendResponse(String tag, String msg, boolean flush) throws IOException {
         sendLine((tag == null ? "" : tag + ' ') + (msg == null ? "" : msg), flush);
+    }
+
+    protected void logout() {
+        try {
+            if (credentials != null) {
+                ZimbraLog.imap.info("dropping connection for user " + credentials.getUsername() + " (LOGOUT)");
+                credentials.logout();
+                setCredentials(null);
+            }
+        } catch (Exception ignore) {
+        }
     }
 }

--- a/store/src/java/com/zimbra/cs/imap/NioImapHandler.java
+++ b/store/src/java/com/zimbra/cs/imap/NioImapHandler.java
@@ -171,6 +171,8 @@ final class NioImapHandler extends ImapHandler implements NioHandler {
         try {
             unsetSelectedFolder(false);
         } catch (Exception ignore) {
+        } finally {
+            logout();
         }
     }
 

--- a/store/src/java/com/zimbra/cs/imap/TcpImapHandler.java
+++ b/store/src/java/com/zimbra/cs/imap/TcpImapHandler.java
@@ -236,6 +236,8 @@ final class TcpImapHandler extends ProtocolHandler {
             try {
                 unsetSelectedFolder(false);
             } catch (Exception e) {
+            } finally {
+                logout();
             }
 
             //TODO use thread pool

--- a/store/src/java/com/zimbra/qa/unittest/TestRemoteImapSoapSessions.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestRemoteImapSoapSessions.java
@@ -98,7 +98,7 @@ public class TestRemoteImapSoapSessions extends ImapTestBase {
         Thread.sleep(500);
         Collection<Session> sessionsAfterClose = SessionCache.getSoapSessions(TestUtil.getAccount(USER).getId());
         int numSessionsAfterClose = sessionsAfterClose == null ? 0 : sessionsAfterClose.size();
-        assertEquals("SOAP session should not be dropped when IMAP client drops without logging out", numSessionsAfterLogin, numSessionsAfterClose);
+        assertEquals("SOAP session should be dropped when IMAP client drops without logging out", sessionsBeforeLogin, numSessionsAfterClose);
     }
 
     @Override

--- a/store/src/java/com/zimbra/qa/unittest/TestRemoteImapSoapSessions.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestRemoteImapSoapSessions.java
@@ -98,7 +98,7 @@ public class TestRemoteImapSoapSessions extends ImapTestBase {
         Thread.sleep(500);
         Collection<Session> sessionsAfterClose = SessionCache.getSoapSessions(TestUtil.getAccount(USER).getId());
         int numSessionsAfterClose = sessionsAfterClose == null ? 0 : sessionsAfterClose.size();
-        assertEquals("SOAP session should be dropped when IMAP client drops without logging out", sessionsBeforeLogin, numSessionsAfterClose);
+        assertEquals("SOAP session should be dropped when IMAP client drops without logging out", numSessionsBeforeLogin, numSessionsAfterClose);
     }
 
     @Override


### PR DESCRIPTION
End ZMailbox's SOAP session after IMAP connection is closed. I ran SOAP tests on feature/imap and this branch and compared the results using the tool @tmclane published in zm-dev-utils repo - no difference in SOAP test results. Also ran the IMAP scenario described in the bug via telnet and checked that no AUTH_EXPIRED exceptions are logged in imapd.log