### PR TITLE
ZCS-296:Wildcard :matches does not work if target string contains CRLF

### DIFF
--- a/store/src/java-test/com/zimbra/cs/filter/NotifyMailtoTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/NotifyMailtoTest.java
@@ -1019,6 +1019,7 @@ public class NotifyMailtoTest {
               + "if header   :matches  \"Date\"    \"*\" {set \"dateheader\"    \"${1}\";}\n"
               + "if header   :matches  \"From\"    \"*\" {set \"fromheader\"    \"${1}\";}\n"
               + "if header   :matches  \"Subject\" \"*\" {set \"subjectheader\" \"${1}\";}\n"
+              + "if header   :matches  \"X-Header-With-Control-Chars\" \"*\" {set \"xheader\" \"${1}\";}\n"
               + "if anyof(not envelope :is [\"From\"] \"\") {\n"
               + "  set \"subjectparam\" \"Notification\";\n"
               + "  set \"bodyparam\" text:\r\n"
@@ -1027,6 +1028,7 @@ public class NotifyMailtoTest {
               + "Sent: ${dateheader}\n"
               + "From: ${fromheader}\n"
               + "Subject: ${subjectheader}\r\n"
+              + "X-Header-With-Control-Chars: ${xheader}\r\n"
               + ".\r\n"
               + ";\n"
               + "  notify :message \"${subjectparam}\"\n"
@@ -1039,13 +1041,15 @@ public class NotifyMailtoTest {
                 + "Date: Tue, 11 Oct 2016 12:01:37 +0900\n"
                 + "Subject: [acme-users] [fwd] version 1.0 is out\n"
                 + "to: foo@example.com, baz@example.com\n"
-                + "cc: qux@example.com\n";
+                + "cc: qux@example.com\n"
+                + "X-Header-With-Control-Chars: =?utf-8?B?dGVzdCBIVAkgVlQLIEVUWAMgQkVMByBCUwggbnVsbAAgYWZ0ZXIgbnVsbA0K?=\n";
 
-        String expectedNotifyMsg = "Hello test1@zimbra.com,\n"
-                + "A new massage has arrived.\n"
-                + "Sent: Tue, 11 Oct 2016 12:01:37  0900\n"
-                + "From: xyz@example.com\n"
-                + "Subject: [acme-users] [fwd] version 1.0 is out";
+        String expectedNotifyMsg = "Hello test1@zimbra.com,\r\n"
+                + "A new massage has arrived.\r\n"
+                + "Sent: Tue, 11 Oct 2016 12:01:37  0900\r\n"
+                + "From: xyz@example.com\r\n"
+                + "Subject: [acme-users] [fwd] version 1.0 is out\r\n"
+                + "X-Header-With-Control-Chars: test HT\t VT\u000b ETX\u0003 BEL\u0007 BS\u0008 null\u0000 after null";
 
         try {
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test1@zimbra.com");

--- a/store/src/java/com/zimbra/cs/filter/ZimbraAsciiCasemap.java
+++ b/store/src/java/com/zimbra/cs/filter/ZimbraAsciiCasemap.java
@@ -24,14 +24,14 @@ import static com.zimbra.cs.filter.jsieve.MatchRelationalOperators.LT_OP;
 import static com.zimbra.cs.filter.jsieve.MatchRelationalOperators.NE_OP;
 
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import org.apache.jsieve.comparators.AsciiCasemap;
 import org.apache.jsieve.comparators.ComparatorUtils;
 import org.apache.jsieve.exception.FeatureException;
 import org.apache.jsieve.exception.SievePatternException;
-import org.apache.jsieve.mail.MailAdapter;
-
-import com.zimbra.cs.filter.jsieve.Values;
 
 /**
  * Class ZimbraAsciiCasecomp enhances the jsieve's AsciiCasemap class to
@@ -69,8 +69,13 @@ public class ZimbraAsciiCasemap extends AsciiCasemap implements ZimbraComparator
      */
     public boolean matches(String string, String glob)
             throws SievePatternException {
-        return ZimbraComparatorUtils
-                .matches(string.toUpperCase(), glob.toUpperCase());
+        try {
+            String regex = FilterUtil.sieveToJavaRegex(glob.toUpperCase());
+            final Matcher matcher = Pattern.compile(regex, Pattern.CASE_INSENSITIVE | Pattern.DOTALL).matcher(string.toUpperCase());
+            return matcher.matches();
+        } catch (PatternSyntaxException e) {
+            throw new SievePatternException(e.getMessage());
+        }
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/filter/jsieve/EditHeaderExtension.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/EditHeaderExtension.java
@@ -559,7 +559,7 @@ public class EditHeaderExtension {
      */
     private boolean matchValue(String regex, String value) {
         regex = ComparatorUtils.sieveToJavaRegex(regex);
-        Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+        Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
         Matcher matcher = pattern.matcher(value);
         return matcher.matches();
     }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/HeaderTest.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/HeaderTest.java
@@ -375,7 +375,7 @@ public class HeaderTest extends Header {
                 for (Object key : keys) {
                     String keyStr = ((String) key);
                     String regex = FilterUtil.sieveToJavaRegex(keyStr);
-                    Matcher matcher = Pattern.compile(regex, Pattern.CASE_INSENSITIVE).matcher(sourceStr);
+                    Matcher matcher = Pattern.compile(regex, Pattern.CASE_INSENSITIVE | Pattern.DOTALL).matcher(sourceStr);
                     int grpCount = matcher.groupCount();
                     if (matcher.find() && grpCount > 0) {
                         mailAdapter.resetMatchedValues();


### PR DESCRIPTION
Wildcard :matches does not work if target string contains CRLF and is base64 encoded