### PR TITLE
ZCS-2170 Error initializing LocalConfig

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -308,6 +308,7 @@
             <formatter type="xml"/>
             <jvmarg value="-Xverify:none"/>
             <jvmarg value="-Dserver.dir=${server.dir}"/>
+            <jvmarg value="-Dzimbra.config=${server.dir}/src/java-test/localconfig-test.xml"/>
             <batchtest todir="${test.dir}/output">
                 <fileset dir="${test.src.dir}">
                     <include name="**/*Test.java"/>

--- a/common/src/java-test/com/zimbra/common/localconfig/LocalConfigTest.java
+++ b/common/src/java-test/com/zimbra/common/localconfig/LocalConfigTest.java
@@ -22,12 +22,18 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+import org.python.google.common.base.Strings;
 
 public class LocalConfigTest {
-    
+
+    private static LocalConfig localConfig;
+
     @BeforeClass
     public static void init() throws Exception {
-        System.setProperty("zimbra.config", "../store/src/java-test/localconfig-test.xml");
+        if (Strings.isNullOrEmpty(System.getProperty("zimbra.config"))) {
+            System.setProperty("zimbra.config", "../store/src/java-test/localconfig-test.xml");
+        }
+        localConfig = LocalConfig.getInstance();
     }
     
     @Rule
@@ -42,7 +48,7 @@ public class LocalConfigTest {
     }
     
     private String get(String key) throws ConfigException {
-        return LocalConfig.getInstance().get(key);
+        return localConfig.get(key);
     }
     
     private String get(KnownKey key) throws ConfigException {


### PR DESCRIPTION
[Issue]
LocalConfig initialization failed intermittently

[Fix]
Pass the path for zimbra.config from the build file.
In LocalConfigTest, fetch the zimbra.config property and initialize LocalConfig in init method

[Testing]
Executed ant test and ant test-all multiple times. The issue does not seem to be occurring now.