### PR TITLE
ZCS-1842:Edit header should modify the headers only for a user with EditHeader Sieve script

### DIFF
--- a/store/src/java-test/com/zimbra/cs/filter/ZimbraMailAdapterTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/ZimbraMailAdapterTest.java
@@ -1,0 +1,59 @@
+package com.zimbra.cs.filter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.zimbra.cs.mailbox.DeliveryContext;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.mime.ParsedMessage;
+
+import junit.framework.Assert;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ IncomingMessageHandler.class, Mailbox.class})
+public class ZimbraMailAdapterTest {
+
+    @BeforeClass
+    public static void init() throws Exception {
+        MailboxTestUtil.initServer();
+    }
+
+    @Test
+    public void testUpdateIncomingBlob() throws Exception{
+        int mboxId = 10;
+
+        Mailbox mbox = PowerMockito.mock(Mailbox.class);
+        Mockito.when(mbox.getId()).thenReturn(mboxId);
+
+        List<Integer> targetMailboxIds = new ArrayList<Integer>(1);
+        targetMailboxIds.add(mboxId);
+        DeliveryContext sharedDeliveryCtxt = new DeliveryContext(true, targetMailboxIds);
+
+        String testStr = "test";
+        ParsedMessage pm = new ParsedMessage(testStr.getBytes(), false);
+        IncomingMessageHandler handler = PowerMockito.mock(IncomingMessageHandler.class);
+        Mockito.when(handler.getDeliveryContext()).thenReturn(sharedDeliveryCtxt);
+        Mockito.when(handler.getParsedMessage()).thenReturn(pm);
+        ZimbraMailAdapter mailAdapter = new ZimbraMailAdapter(mbox, handler);
+        mailAdapter.updateIncomingBlob();
+
+        Assert.assertNotNull(sharedDeliveryCtxt.getMailBoxSpecificBlob(mboxId));
+        Assert.assertNull(sharedDeliveryCtxt.getIncomingBlob());
+
+        DeliveryContext nonSharedDeliveryCtxt = new DeliveryContext(false, targetMailboxIds);
+        Mockito.when(handler.getDeliveryContext()).thenReturn(nonSharedDeliveryCtxt);
+        mailAdapter.updateIncomingBlob();
+
+        Assert.assertNull(nonSharedDeliveryCtxt.getMailBoxSpecificBlob(mboxId));
+        Assert.assertNotNull(nonSharedDeliveryCtxt.getIncomingBlob());
+    }
+}

--- a/store/src/java/com/zimbra/cs/filter/IncomingMessageHandler.java
+++ b/store/src/java/com/zimbra/cs/filter/IncomingMessageHandler.java
@@ -198,4 +198,8 @@ public final class IncomingMessageHandler implements FilterHandler {
     public DeliveryContext getDeliveryContext() {
         return dctxt;
     }
+
+    public void setParsedMessage(ParsedMessage pm) {
+        this.parsedMessage = pm;
+    }
 }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/AddHeader.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/AddHeader.java
@@ -17,6 +17,7 @@
 package com.zimbra.cs.filter.jsieve;
 
 import static com.zimbra.cs.filter.JsieveConfigMapHandler.CAPABILITY_EDITHEADER;
+
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -40,6 +41,7 @@ import org.apache.jsieve.exception.SieveException;
 import org.apache.jsieve.exception.SyntaxException;
 import org.apache.jsieve.mail.MailAdapter;
 
+import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.CharsetUtil;
 import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
@@ -75,10 +77,17 @@ public class AddHeader extends AbstractCommand {
             ZimbraLog.filter.info("addheader: %s is immutable header, so exiting silently.", headerName);
             return null;
         }
+
         if (mailAdapter.getEditHeaderParseStatus() == PARSESTATUS.MIMEMALFORMED) {
             ZimbraLog.filter.debug("addheader: Triggering message is malformed MIME");
             return null;
         }
+
+        if(mailAdapter.cloneParsedMessage()) {
+            ZimbraLog.filter.debug("addheader: failed to clone parsed message, so exiting silently.");
+            return null;
+        }
+
         headerValue = FilterUtil.replaceVariables(mailAdapter, headerValue);
         try {
             headerValue = MimeUtility.fold(headerName.length() + 2, MimeUtility.encodeText(headerValue));

--- a/store/src/java/com/zimbra/cs/filter/jsieve/DeleteHeader.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/DeleteHeader.java
@@ -70,10 +70,16 @@ public class DeleteHeader extends AbstractCommand {
             return null;
         }
 
+        if(mailAdapter.cloneParsedMessage()) {
+            ZimbraLog.filter.debug("deleteHeader: failed to clone parsed message, so exiting silently.");
+            return null;
+        }
+
         // replace sieve variables
         ehe.replaceVariablesInValueList(mailAdapter);
         ehe.replaceVariablesInKey(mailAdapter);
         FilterUtil.headerNameHasSpace(ehe.getKey());
+
         MimeMessage mm = mailAdapter.getMimeMessage();
         Enumeration<Header> headers;
         try {

--- a/store/src/java/com/zimbra/cs/filter/jsieve/ReplaceHeader.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/ReplaceHeader.java
@@ -73,6 +73,11 @@ public class ReplaceHeader extends AbstractCommand {
             return null;
         }
 
+        if(mailAdapter.cloneParsedMessage()) {
+            ZimbraLog.filter.debug("replaceheader: failed to clone parsed message, so exiting silently.");
+            return null;
+        }
+
         // replace sieve variables
         ehe.replaceVariablesInValueList(mailAdapter);
         ehe.replaceVariablesInKey(mailAdapter);

--- a/store/src/java/com/zimbra/cs/mailbox/DeliveryContext.java
+++ b/store/src/java/com/zimbra/cs/mailbox/DeliveryContext.java
@@ -20,7 +20,9 @@
  */
 package com.zimbra.cs.mailbox;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.zimbra.cs.store.Blob;
 import com.zimbra.cs.store.MailboxBlob;
@@ -40,6 +42,7 @@ public class DeliveryContext {
     private MailboxBlob mMailboxBlob;
     private List<Integer> mMailboxIdList;
     private boolean mIsFirst = true;
+    private Map <Integer,Blob> mailBoxBlobMap;
 
     /**
      * Constructor for non-shared case
@@ -56,9 +59,12 @@ public class DeliveryContext {
      * @param mboxIdList list of ID of mailboxes being delivered to
      */
     public DeliveryContext(boolean shared, List<Integer> mboxIdList) {
-    	mShared = shared;
+        mShared = shared;
         mMailboxBlob = null;
         mMailboxIdList = mboxIdList;
+        if (mShared) {
+            mailBoxBlobMap =  new HashMap<Integer,Blob>();
+        }
     }
 
     public boolean getShared() {
@@ -96,5 +102,25 @@ public class DeliveryContext {
     
     public void setFirst(boolean isFirst) {
         mIsFirst = isFirst;
+    }
+
+    public void setMailBoxSpecificBlob(int id, Blob blob) {
+        if(mailBoxBlobMap != null) {
+           mailBoxBlobMap.put(id, blob);
+        }
+    }
+
+    public void clearMailBoxSpecificBlob(int id) {
+        if(mailBoxBlobMap != null) {
+            mailBoxBlobMap.remove(id);
+        }
+    }
+
+   public Blob getMailBoxSpecificBlob(int mailBoxId) {
+        if(mailBoxBlobMap != null) {
+            return mailBoxBlobMap.get(mailBoxId);
+        } else {
+            return null;
+        }
     }
 }

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -5908,8 +5908,16 @@ public class Mailbox {
             dctxt = new DeliveryContext();
         }
 
+        boolean deleteMailboxSpecificBlob = false;
         StoreManager sm = StoreManager.getInstance();
-        Blob blob = dctxt.getIncomingBlob();
+        Blob blob = dctxt.getMailBoxSpecificBlob(mId);
+        if (blob == null) {
+            blob = dctxt.getIncomingBlob();
+            ZimbraLog.filter.debug("MailBoxSpecificBlob is null for mailbox %d", mId);
+        } else {
+            deleteMailboxSpecificBlob = true;
+            ZimbraLog.filter.debug("got MailBoxSpecificBlob for mailbox %d", mId);
+        }
         boolean deleteIncoming = false;
 
         if (blob == null) {
@@ -5934,6 +5942,10 @@ public class Mailbox {
             } finally {
                 if (deleteIncoming) {
                     sm.quietDelete(dctxt.getIncomingBlob());
+                }
+                if (deleteMailboxSpecificBlob) {
+                    sm.quietDelete(dctxt.getMailBoxSpecificBlob(mId));
+                    dctxt.clearMailBoxSpecificBlob(mId);
                 }
                 sm.quietDelete(staged);
             }


### PR DESCRIPTION
EditHeader script rule changes should be applied only to recipient who has the rule configured, not to other recipients of the same mail.

Before mime is updated from Edit header classes, parsed message will be cloned if mail is for multiple recipients and all rule operation will be done on cloned message. After updating mime, updated blob is stored in deliveryContext. If the mime is shared, updated blob will be stored in  a map with key as mailbox id, otherwise incoming blob of the context will be updated.
when message is added to mail store at that time, we will check if there is updated blob for this user, if so, link will be created with updated blob, else link will be created with incoming blob. 