### PR TITLE
ZCS-887:Add "Auto-Submitted" to zimbraSieveImmutableHeaders

### DIFF
--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9551,7 +9551,7 @@ TODO: delete them permanently from here
 </attr>
 
 <attr id="2121" name="zimbraSieveImmutableHeaders" type="string" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.8.0">
-  <defaultCOSValue>Received,DKIM-Signature,Authentication-Results,Received-SPF,Message-ID,Content-Type,Content-Disposition,Content-Transfer-Encoding,MIME-Version</defaultCOSValue>
+  <defaultCOSValue>Received,DKIM-Signature,Authentication-Results,Received-SPF,Message-ID,Content-Type,Content-Disposition,Content-Transfer-Encoding,MIME-Version,Auto-Submitted</defaultCOSValue>
   <desc>Comma separated list of sieve immutable headers</desc>
 </attr>
 </attrs>

--- a/store/src/java-test/com/zimbra/cs/filter/DeleteHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/DeleteHeaderTest.java
@@ -1121,7 +1121,8 @@ public class DeleteHeaderTest {
                 + "Content-Type: text/plain; charset=\"ISO-2022-JP\"\n"
                 + "MIME-Version: 1.0\n"
                 + "Content-Transfer-Encoding: 7bit\n"
-                + "Content-Disposition: inline";
+                + "Content-Disposition: inline\n"
+                + "Auto-Submitted: auto-generated\n";
         String filterScript = "require [\"editheader\"];\n"
                 + "tag \"tag-example1\";\n"
                 + "if exists \"Subject\" {\n"
@@ -1129,6 +1130,7 @@ public class DeleteHeaderTest {
                 + "  deleteheader \"MIME-Version\" \"1.0\";\n"
                 + "  deleteheader \"Content-Transfer-Encoding\" \"7bit\";\n"
                 + "  deleteheader \"Content-Disposition\" \"inline\";\n"
+                + "  deleteheader \"Auto-Submitted\" \"auto-generated\";\n"
                 + "}\n"
                 + "tag \"tag-example2\";\n";
         try {
@@ -1151,6 +1153,7 @@ public class DeleteHeaderTest {
             boolean mimeVersionMatchFound = false;
             boolean contentTransferEncodingMatchFound = false;
             boolean contentDispositionMatchFound = false;
+            boolean autoSubmittedMatchFound = false;
             for (Enumeration<Header> enumeration = message.getMimeMessage().getAllHeaders(); enumeration.hasMoreElements();) {
                 Header header = enumeration.nextElement();
                 if ("Content-Type".equals(header.getName())) {
@@ -1165,11 +1168,15 @@ public class DeleteHeaderTest {
                 if ("Content-Disposition".equals(header.getName())) {
                     contentDispositionMatchFound = true;
                 }
+                if ("Auto-Submitted".equals(header.getName())) {
+                    autoSubmittedMatchFound = true;
+                }
             }
             Assert.assertTrue(contentTypeMatchFound);
             Assert.assertTrue(mimeVersionMatchFound);
             Assert.assertTrue(contentTransferEncodingMatchFound);
             Assert.assertTrue(contentDispositionMatchFound);
+            Assert.assertTrue(autoSubmittedMatchFound);
             String[] tags = message.getTags();
             Assert.assertEquals(2, tags.length);
             Assert.assertEquals("tag-example1", tags[0]);

--- a/store/src/java-test/com/zimbra/cs/filter/ReplaceHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/ReplaceHeaderTest.java
@@ -1411,7 +1411,8 @@ public class ReplaceHeaderTest {
                 + "Content-Type: text/plain; charset=\"ISO-2022-JP\"\n"
                 + "MIME-Version: 1.0\n"
                 + "Content-Transfer-Encoding: 7bit\n"
-                + "Content-Disposition: inline";
+                + "Content-Disposition: inline\n"
+                + "Auto-Submitted: auto-generated\n";
 
         String filterScriptUser = "require [\"editheader\", \"variables\"];\n"
                 + "if exists \"Content-Type\" {\n"
@@ -1419,6 +1420,7 @@ public class ReplaceHeaderTest {
                 + "  replaceheader :newvalue \"2.0\" :matches \"MIME-Version\" \"*\";\n"
                 + "  replaceheader :newvalue \"8bit\" :matches \"Content-Transfer-Encoding\" \"*\";\n"
                 + "  replaceheader :newvalue \"attachment\" :matches \"Content-Disposition\" \"*\";\n"
+                + "  replaceheader :newvalue \"auto-replied\" :matches \"Auto-Submitted\" \"*\";\n"
                 + "}\n";
 
         try {
@@ -1449,6 +1451,9 @@ public class ReplaceHeaderTest {
                 }
                 if ("Content-Disposition".equals(header.getName())) {
                     Assert.assertEquals("inline", header.getValue());
+                }
+                if ("Auto-Submitted".equals(header.getName())) {
+                    Assert.assertEquals("auto-generated", header.getValue());
                 }
             }
         } catch (Exception e) {

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -55546,13 +55546,13 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * Comma separated list of sieve immutable headers
      *
-     * @return zimbraSieveImmutableHeaders, or "Received,DKIM-Signature,Authentication-Results,Received-SPF,Message-ID,Content-Type,Content-Disposition,Content-Transfer-Encoding,MIME-Version" if unset
+     * @return zimbraSieveImmutableHeaders, or "Received,DKIM-Signature,Authentication-Results,Received-SPF,Message-ID,Content-Type,Content-Disposition,Content-Transfer-Encoding,MIME-Version,Auto-Submitted" if unset
      *
      * @since ZCS 8.8.0
      */
     @ZAttr(id=2121)
     public String getSieveImmutableHeaders() {
-        return getAttr(Provisioning.A_zimbraSieveImmutableHeaders, "Received,DKIM-Signature,Authentication-Results,Received-SPF,Message-ID,Content-Type,Content-Disposition,Content-Transfer-Encoding,MIME-Version", true);
+        return getAttr(Provisioning.A_zimbraSieveImmutableHeaders, "Received,DKIM-Signature,Authentication-Results,Received-SPF,Message-ID,Content-Type,Content-Disposition,Content-Transfer-Encoding,MIME-Version,Auto-Submitted", true);
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -42937,13 +42937,13 @@ public abstract class ZAttrCos extends NamedEntry {
     /**
      * Comma separated list of sieve immutable headers
      *
-     * @return zimbraSieveImmutableHeaders, or "Received,DKIM-Signature,Authentication-Results,Received-SPF,Message-ID,Content-Type,Content-Disposition,Content-Transfer-Encoding,MIME-Version" if unset
+     * @return zimbraSieveImmutableHeaders, or "Received,DKIM-Signature,Authentication-Results,Received-SPF,Message-ID,Content-Type,Content-Disposition,Content-Transfer-Encoding,MIME-Version,Auto-Submitted" if unset
      *
      * @since ZCS 8.8.0
      */
     @ZAttr(id=2121)
     public String getSieveImmutableHeaders() {
-        return getAttr(Provisioning.A_zimbraSieveImmutableHeaders, "Received,DKIM-Signature,Authentication-Results,Received-SPF,Message-ID,Content-Type,Content-Disposition,Content-Transfer-Encoding,MIME-Version", true);
+        return getAttr(Provisioning.A_zimbraSieveImmutableHeaders, "Received,DKIM-Signature,Authentication-Results,Received-SPF,Message-ID,Content-Type,Content-Disposition,Content-Transfer-Encoding,MIME-Version,Auto-Submitted", true);
     }
 
     /**


### PR DESCRIPTION
Added "Auto-Submitted" header name to the zimbraSieveImmutableHeaders
attribute value for the sake of the compatibility with RFC 5293.