### PR TITLE
Bugfix/zcs 2272

### DIFF
--- a/client/src/java/com/zimbra/client/ZFolder.java
+++ b/client/src/java/com/zimbra/client/ZFolder.java
@@ -414,7 +414,7 @@ public class ZFolder implements ZItem, FolderStore, Comparable<Object>, ToZJSONO
             mFlags = fevent.getFlags(mFlags);
             mColor = fevent.getColor(mColor);
             mUnreadCount = fevent.getUnreadCount(mUnreadCount);
-            mImapUnreadCount = fevent.getImapUnreadCount(mImapUnreadCount);
+            mImapUnreadCount = fevent.getImapUnreadCount(mUnreadCount);
             mMessageCount = fevent.getMessageCount(mMessageCount);
             //SOAP returns 'i4n' only when it is different from 'n'. Therefore, fall back to mMessageCount
             mImapMessageCount = fevent.getImapMessageCount(mMessageCount);

--- a/common/src/java/com/zimbra/common/soap/MailConstants.java
+++ b/common/src/java/com/zimbra/common/soap/MailConstants.java
@@ -1244,6 +1244,7 @@ public final class MailConstants {
     public static final String A_FOLDER_INTERESTS = "folderInterests";
     public static final String A_CHANGED_FOLDERS = "changedFolders";
     public static final String A_CHANGE = "change";
+    public static final String A_CHANGE_ID = "changeid";
     public static final String E_A = "a";
     public static final String A_EXPAND = "expand";
     public static final String E_PENDING_FOLDER_MODIFICATIONS = "mods";

--- a/soap/src/java/com/zimbra/soap/type/AccountWithModifications.java
+++ b/soap/src/java/com/zimbra/soap/type/AccountWithModifications.java
@@ -43,6 +43,13 @@ public class AccountWithModifications {
     private final String id;
 
     /**
+     * @zm-api-field-tag change-id
+     * @zm-api-field-description ID of the last change
+     */
+    @XmlAttribute(name=MailConstants.A_CHANGE_ID, required=false)
+    private final int lastChangeId;
+
+    /**
      * @zm-api-field-tag mods
      * @zm-api-field-description serialized pending modifications per folder
      * TODO: instead of a string this should be a structure that contains enough data to instantiate PendingRemoteModifications 
@@ -55,28 +62,29 @@ public class AccountWithModifications {
      */
     @SuppressWarnings("unused")
     private AccountWithModifications() {
-        this((String) null, (Collection<PendingFolderModifications>)null);
+        this((String) null, (Collection<PendingFolderModifications>)null, 0);
     }
 
-    public AccountWithModifications(String id) {
-        this(id, null);
+    public AccountWithModifications(String id, int lastChangeId) {
+        this(id, null, lastChangeId);
     }
 
     public AccountWithModifications(Integer id) {
-        this(id, null);
+        this(id.toString(), null, 0);
     }
 
-    public AccountWithModifications(String id, Collection<PendingFolderModifications> mods) {
+    public AccountWithModifications(String id, Collection<PendingFolderModifications> mods, int lastChangeId) {
         this.id = id;
         this.mods = mods;
+        this.lastChangeId = lastChangeId;
     }
 
-    public AccountWithModifications(Integer id, Collection<PendingFolderModifications> mods) {
-        this(id.toString(), mods);
+    public AccountWithModifications(Integer id, Collection<PendingFolderModifications> mods, int lastChangeId) {
+        this(id.toString(), mods, lastChangeId);
     }
 
     public String getId() { return id; }
-
+    public int getLastChangeId() { return lastChangeId; }
     public Collection<PendingFolderModifications> getPendingFolderModifications() {
         return mods;
     }

--- a/store/src/java/com/zimbra/cs/imap/ImapCredentials.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapCredentials.java
@@ -116,12 +116,12 @@ public class ImapCredentials implements java.io.Serializable {
     }
 
     protected ImapMailboxStore getImapMailboxStore() throws ServiceException {
+        if(mStore != null) {
+            return mStore;
+        }
         if (mIsLocal && !LC.imap_always_use_remote_store.booleanValue() && ImapDaemon.isRunningImapInsideMailboxd()) {
             ZimbraLog.imap.debug("ImapCredentials returning local mailbox store for %s", mAccountId);
             return new LocalImapMailboxStore(MailboxManager.getInstance().getMailboxByAccountId(mAccountId));
-        }
-        if(mStore != null) {
-            return mStore;
         }
         try {
             Account acct = getAccount();

--- a/store/src/java/com/zimbra/cs/imap/ImapListener.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapListener.java
@@ -453,6 +453,7 @@ public abstract class ImapListener extends Session {
     }
 
     void handleDelete(int changeId, int id, Change chg) {
+        ZimbraLog.imap.debug("Handling a delete notification. Change id %d, item id %d", changeId, id);
         MailItem.Type type = (MailItem.Type) chg.what;
         if (id <= 0) {
             return;
@@ -632,9 +633,14 @@ public abstract class ImapListener extends Session {
     @Override
     public void notifyPendingChanges(PendingModifications pnsIn, int changeId, Session source) {
         if (!pnsIn.hasNotifications()) {
+            ZimbraLog.imap.debug("ImapListener :: did not find any pending notifications. Ignoring");
             return;
         }
-
+        if(changeId < lastChangeId) {
+            ZimbraLog.imap.debug("ImapListener :: change %d is not higher than last change %d. Ignoring", changeId, lastChangeId);
+            return;
+        }
+        ZimbraLog.imap.debug("ImapListener :: notifyPendingChanges");
         ImapHandler i4handler = handler;
         try {
             synchronized (this) {
@@ -677,6 +683,8 @@ public abstract class ImapListener extends Session {
             if (i4handler != null) {
                 i4handler.close();
             }
+        } finally {
+            lastChangeId = changeId;
         }
     }
 

--- a/store/src/java/com/zimbra/cs/imap/ImapMailboxStore.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapMailboxStore.java
@@ -60,7 +60,7 @@ public abstract class ImapMailboxStore {
             return new LocalImapMailboxStore((Mailbox) mailboxStore);
         }
         if (mailboxStore instanceof ZMailbox) {
-            ZimbraLog.imap.debug("Using local MailboxStore %s", mailboxStore);
+            ZimbraLog.imap.debug("Using remote MailboxStore %s", mailboxStore);
             return new RemoteImapMailboxStore((ZMailbox) mailboxStore, accountId);
         }
         return null;

--- a/store/src/java/com/zimbra/cs/imap/ImapRemoteSession.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapRemoteSession.java
@@ -16,31 +16,28 @@
  */
 package com.zimbra.cs.imap;
 
-import java.util.Collection;
 import java.util.TreeMap;
 
 import com.zimbra.client.ZMailbox;
 import com.zimbra.client.event.ZEventHandler;
 import com.zimbra.common.mailbox.BaseItemInfo;
 import com.zimbra.common.mailbox.MailItemType;
+import com.zimbra.common.mailbox.MailboxStore;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.session.PendingModifications;
 import com.zimbra.cs.session.PendingModifications.Change;
 import com.zimbra.cs.session.PendingRemoteModifications;
-import com.zimbra.soap.mail.type.PendingFolderModifications;
 import com.zimbra.soap.type.AccountWithModifications;
 
 public class ImapRemoteSession extends ImapListener {
     private final ZEventHandler zMailboxEventHandler = new ZEventHandler() {
         @Override
         public void handlePendingModification(int changeId, AccountWithModifications info) throws ServiceException {
-            Collection<PendingFolderModifications> mods = info.getPendingFolderModifications();
-            if(mods != null && !mods.isEmpty()) {
-                for(PendingFolderModifications folderMods : mods) {
-                    PendingRemoteModifications remoteMods = PendingRemoteModifications.fromSOAP(folderMods, folderMods.getFolderId(), info.getId());
-                    notifyPendingChanges(remoteMods, changeId, null);
-                }
+            ZimbraLog.imap.debug("Handling modification from ZMailbox");
+            MailboxStore store = getMailbox();
+            if(store != null && store instanceof ZMailbox) {
+                ImapServerListenerPool.getInstance().get((ZMailbox)store).notifyAccountChange(info);
             }
         }
     };

--- a/store/src/java/com/zimbra/cs/session/Session.java
+++ b/store/src/java/com/zimbra/cs/session/Session.java
@@ -50,6 +50,7 @@ public abstract class Session {
     private   boolean   mCleanedUp;
     private   boolean   mIsRegistered;
     private   boolean   mAddedToCache;
+    protected int lastChangeId;
 
 
     /**

--- a/store/src/java/com/zimbra/cs/session/SoapSession.java
+++ b/store/src/java/com/zimbra/cs/session/SoapSession.java
@@ -1467,8 +1467,8 @@ public class SoapSession extends Session {
         boolean hasLocalModifies = pms != null && pms.modified != null && !pms.modified.isEmpty();
         boolean hasRemoteModifies = rns != null && rns.modified != null && !rns.modified.isEmpty();
         if(SoapTransport.NotificationFormat.valueOf(zsc.getNotificationFormat()) == SoapTransport.NotificationFormat.IMAP) {
-            AccountWithModifications info = new AccountWithModifications(zsc.getAuthtokenAccountId());
             try {
+                AccountWithModifications info = new AccountWithModifications(zsc.getAuthtokenAccountId(), mbox.getLastChangeID());
                 Map<Integer, PendingFolderModifications> folderMods = PendingModifications.encodeFolderModifications(pms);
                 info.setPendingFolderModifications(folderMods.values());
                 eNotify.addUniqueElement(JaxbUtil.jaxbToElement(info, eNotify.getFactory()));

--- a/store/src/java/com/zimbra/qa/unittest/TestImapImport.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestImapImport.java
@@ -21,7 +21,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
 
 import com.zimbra.client.ZDataSource;
 import com.zimbra.client.ZFolder;
@@ -33,14 +37,20 @@ import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.Server;
 import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.soap.type.DataSource.ConnectionType;
 
-public final class TestImapImport extends TestCase {
+import static org.junit.Assert.*;
 
-    private static final String REMOTE_USER_NAME = "testimapimportremote";
-    private static final String LOCAL_USER_NAME = "testimapimportlocal";
-    private static final String NAME_PREFIX = "TestImapImport";
+public final class TestImapImport {
+
+    @Rule
+    public TestName testInfo = new TestName();
+    protected String testId;
+    private static String REMOTE_USER_NAME = null;
+    private static String LOCAL_USER_NAME = null;
+    private static String NAME_PREFIX = "TestImapImport";
     private static final String DS_FOLDER_ROOT = "/" + NAME_PREFIX;
 
     // Folder hierarchy: /TestImapImport-f1/TestImapImport-f2, /TestImapImport-f3/TestImapImport-f4
@@ -57,6 +67,7 @@ public final class TestImapImport extends TestCase {
     private static final String LOCAL_PATH_INBOX = DS_FOLDER_ROOT + "/INBOX";
     private static final String LOCAL_PATH_TRASH = DS_FOLDER_ROOT + "/Trash";
 
+    private Server localServer;
     private ZMailbox mRemoteMbox;
     private ZMailbox mLocalMbox;
     private String mOriginalCleartextValue;
@@ -64,31 +75,30 @@ public final class TestImapImport extends TestCase {
     private boolean mOriginalEnableStarttls;
     private boolean mDisplayMailFoldersOnly ;
 
-    @Override
+    @Before
     public void setUp() throws Exception {
+        testId = String.format("%s-%s-%d", this.getClass().getSimpleName(), testInfo.getMethodName(), (int)Math.abs(Math.random()*100));
+        REMOTE_USER_NAME = String.format("%s-remote", testId).toLowerCase();
+        LOCAL_USER_NAME = String.format("%s-local", testId).toLowerCase();
+
         cleanUp();
-        mDisplayMailFoldersOnly = Provisioning.getInstance().getLocalServer().isImapDisplayMailFoldersOnly();
-        Provisioning.getInstance().getLocalServer().setImapDisplayMailFoldersOnly(false);
+
+        localServer = Provisioning.getInstance().getLocalServer(); 
+        mDisplayMailFoldersOnly = localServer.isImapDisplayMailFoldersOnly();
+        localServer.setImapDisplayMailFoldersOnly(false);
         
         // Get mailbox references
-        if (!TestUtil.accountExists(LOCAL_USER_NAME)) {
-            TestUtil.createAccount(LOCAL_USER_NAME);
-        }
-        if (!TestUtil.accountExists(REMOTE_USER_NAME)) {
-            TestUtil.createAccount(REMOTE_USER_NAME);
-        }
+        TestUtil.createAccount(LOCAL_USER_NAME);
+        TestUtil.createAccount(REMOTE_USER_NAME);
         mRemoteMbox = TestUtil.getZMailbox(REMOTE_USER_NAME);
         mLocalMbox = TestUtil.getZMailbox(LOCAL_USER_NAME);
 
         // Get or create folder
-        ZFolder folder = mLocalMbox.getFolderByPath(DS_FOLDER_ROOT);
-        if (folder == null) {
-            folder = TestUtil.createFolder(mLocalMbox, NAME_PREFIX);
-        }
+        ZFolder folder = TestUtil.createFolder(mLocalMbox, NAME_PREFIX);
 
         // Create data source
         int port = Integer.parseInt(TestUtil.getServerAttr(Provisioning.A_zimbraImapBindPort));
-        mDataSource = new ZImapDataSource(NAME_PREFIX, true, "localhost",
+        mDataSource = new ZImapDataSource(NAME_PREFIX, true, localServer.getServiceHostname(),
             port, REMOTE_USER_NAME, TestUtil.DEFAULT_PASSWORD, folder.getId(), ConnectionType.cleartext);
         String id = mLocalMbox.createDataSource(mDataSource);
         mDataSource = null;
@@ -108,6 +118,7 @@ public final class TestImapImport extends TestCase {
         LC.javamail_imap_enable_starttls.setDefault(Boolean.toString(false));
     }
 
+    @Test
     public void testImapImport() throws Exception {
         List<ZMessage> msgs;
         ZMessage msg;
@@ -159,7 +170,6 @@ public final class TestImapImport extends TestCase {
 
         compare();
 
-
         // Remote: move to trash
         ZimbraLog.test.info("Testing remote move to trash.");
         mRemoteMbox.trashMessage(remoteId);
@@ -168,7 +178,6 @@ public final class TestImapImport extends TestCase {
         importImap();
         checkMsgCount(mLocalMbox, "in:" + DS_FOLDER_ROOT + "/Trash", 1);
         compare();
-
 
         // Create folders on both sides
         ZimbraLog.test.info("Testing folder creation.");
@@ -352,22 +361,18 @@ public final class TestImapImport extends TestCase {
         }
     }
 
-    @Override
+    @After
     public void tearDown() throws Exception {
         cleanUp();
-        Provisioning.getInstance().getLocalServer().setImapDisplayMailFoldersOnly(mDisplayMailFoldersOnly);
+        localServer.setImapDisplayMailFoldersOnly(mDisplayMailFoldersOnly);
 
         TestUtil.setServerAttr(Provisioning.A_zimbraImapCleartextLoginEnabled, mOriginalCleartextValue);
         LC.javamail_imap_enable_starttls.setDefault(Boolean.toString(mOriginalEnableStarttls));
     }
 
     public void cleanUp() throws Exception {
-        if (TestUtil.accountExists(REMOTE_USER_NAME)) {
-            TestUtil.deleteAccount(REMOTE_USER_NAME);
-        }
-        if (TestUtil.accountExists(LOCAL_USER_NAME)) {
-            TestUtil.deleteAccount(LOCAL_USER_NAME);
-        }
+        TestUtil.deleteAccountIfExists(REMOTE_USER_NAME);
+        TestUtil.deleteAccountIfExists(LOCAL_USER_NAME);
     }
 
     public static void main(String[] args) throws Exception {

--- a/store/src/java/com/zimbra/qa/unittest/TestZClient.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestZClient.java
@@ -968,13 +968,13 @@ public class TestZClient {
         ZMailbox zmbox = TestUtil.getZMailbox(USER_NAME);
         Mailbox mbox = TestUtil.getMailbox(USER_NAME);
         int firstChangeId = zmbox.getLastChangeID();
-        assertEquals("wrong change ID before adding message", mbox.getLastChangeID(), firstChangeId);
+        assertEquals(String.format("wrong change ID before adding message. Expecting %d. Got %d", mbox.getLastChangeID(), firstChangeId), mbox.getLastChangeID(), firstChangeId);
         String msgId = TestUtil.addMessage(zmbox, "testLastChangeId message");
         ZMessage msg = zmbox.getMessageById(msgId);
         assertNotNull("msg should not be NULL", msg);
         int secondChangeId = zmbox.getLastChangeID();
         assertTrue("lastChangeId should have increased", firstChangeId < secondChangeId);
-        assertEquals("wrong change ID after adding message", mbox.getLastChangeID(), secondChangeId);
+        assertEquals(String.format("wrong change ID after adding message. Expecting %d. Got %d", mbox.getLastChangeID(), secondChangeId), mbox.getLastChangeID(), secondChangeId);
     }
 
     public boolean waitForFlag(int msgId, Mailbox mbox, String getterName, boolean expected, int maxtimeout) throws Exception {


### PR DESCRIPTION
This pull requests includes multiple changes that together enable updates to be passed to multiple IMAP clients connected to the same IMAPd. 
Major fixes:
 1. Update cached folder data when NOOP or STATUS commands are called. This fixes some of the failures of IMAP compliance tests that expect to get updated message counts in response to NOOP and STATUS commands on additional IMAP clients.
 2. When a notification comes to IMAPd via SOAP headers, pass it through ImapServerListener in order to notify any other ImapListener that is subscribed to changes for the affected folders
 3. In order to avoid applying the same pending modification twice, use lastChangeID to track the last applied change. Per-mailbox last change ID is now passed in (Admin)WaitSetResponse and SOAP headers. Previously it was passed only in SOAP headers and was ignored by IMAPd.
4. Fix unread count returned by IMAPd when a folder has been updated after an IMAP session started. Folder SOAP will contain only 'unread' and will not contain 'imap unread' when both values are the same. Therefore, fall back to 'unread' when updating 'imap unread'

I ran IMAP compliance suite with these changes and got 18 failed test groups with IMAPd (vs 21 on 'develop' branch). I did not get any new failures on local IMAP. Local IMAP still gets 13 failed test groups. 

I am not adding any more unit tests for 2 reasons:
1) @tmclane has already added a SOAP test for checking that 2d IMAP connection gets notifications
2) IMAP compliance tests also provide coverage for behaviors fixed in this pull request