### PR TITLE
ZCS-2369 encoding test fails in ZMimeBodyPartTest

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -310,6 +310,7 @@
             <jvmarg value="-Xverify:none"/>
             <jvmarg value="-Dserver.dir=${server.dir}"/>
             <jvmarg value="-Dzimbra.config=${server.dir}/src/java-test/localconfig-test.xml"/>
+            <jvmarg value="-Dfile.encoding=UTF-8"/>
             <batchtest todir="${test.dir}/output">
                 <fileset dir="${test.src.dir}">
                     <include name="${test.pattern}"/>


### PR DESCRIPTION
Set UTF-8 encoding in build-common.xml

The encoding JUnit test passes after this fix