### PR TITLE
Bugfix/zcs 2242 Optimize the BeginTrackingIMAPRequest SOAP call

### DIFF
--- a/client/src/java/com/zimbra/client/ZGetInfoResult.java
+++ b/client/src/java/com/zimbra/client/ZGetInfoResult.java
@@ -48,7 +48,7 @@ public class ZGetInfoResult implements ToZJSONObject {
 
     private GetInfoResponse data;
     private long expiration;
-    
+
     static Map<String, List<String>> getMap(Element e, String root, String elName) {
         Map<String, List<String>> result = new HashMap<String, List<String>>();
         Element attrsEl = e.getOptionalElement(root);
@@ -214,6 +214,10 @@ public class ZGetInfoResult implements ToZJSONObject {
         return data.getBOSHURL();
     }
 
+    public Boolean getIsImapTracked() {
+        return data.getIsTrackingIMAP();
+    }
+
     @Override
     public ZJSONObject toZJSONObject() throws JSONException {
         ZJSONObject jo = new ZJSONObject();
@@ -248,7 +252,7 @@ public class ZGetInfoResult implements ToZJSONObject {
     public String getId() {
         return data.getAccountId();
     }
-    
+
     public String getVersion() {
         return data.getVersion();
     }
@@ -261,4 +265,3 @@ public class ZGetInfoResult implements ToZJSONObject {
         return new Date(timestamp);
     }
 }
-

--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -6364,7 +6364,9 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
     }
 
     public void beginTrackingImap() throws ServiceException {
-        invokeJaxb(new BeginTrackingIMAPRequest());
+        if (!getAccountInfo(false).getIsImapTracked()) {
+            invokeJaxb(new BeginTrackingIMAPRequest());
+        }
     }
 
     /**

--- a/common/src/java/com/zimbra/common/soap/AccountConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AccountConstants.java
@@ -390,6 +390,7 @@ public class AccountConstants {
     public static final String E_STORE = "store";
     public static final String E_BOSH_URL = "boshURL";
     public static final String E_SUBSCRIPTION = "sub";
+    public static final String E_IS_TRACKING_IMAP = "isTrackingIMAP";
 
     public static final String A_ACTIVE = "active";
     public static final String A_ATTRS = "attrs";

--- a/soap/src/java-test/com/zimbra/soap/account/GetInfoResponse.json
+++ b/soap/src/java-test/com/zimbra/soap/account/GetInfoResponse.json
@@ -9,6 +9,7 @@
   "attSizeLimit": 10240000,
   "rest": "http://tarka.local:7070/home/user1@tarka.local",
   "used": 7585071,
+  "isTrackingIMAP": true,
   "prevSession": 1338195526716,
   "accessed": 1338195526716,
   "recent": 222,

--- a/soap/src/java-test/com/zimbra/soap/account/GetInfoResponse.xml
+++ b/soap/src/java-test/com/zimbra/soap/account/GetInfoResponse.xml
@@ -27,6 +27,7 @@
   <adminDelegated>1</adminDelegated>
   <rest>http://tarka.local:7070/home/user1@tarka.local</rest>
   <used>7585071</used>
+  <isTrackingIMAP>1</isTrackingIMAP>
   <prevSession>1338195526716</prevSession>
   <accessed>1338195526716</accessed>
   <recent>222</recent>

--- a/soap/src/java-test/com/zimbra/soap/account/GetInfoResponseTest.java
+++ b/soap/src/java-test/com/zimbra/soap/account/GetInfoResponseTest.java
@@ -2,11 +2,11 @@
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
  * Copyright (C) 2010, 2011, 2012, 2013, 2014 Zimbra, Inc.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
  * version 2 of the License.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU General Public License for more details.
@@ -73,14 +73,15 @@ public class GetInfoResponseTest {
         //     Assert.assertTrue("Signature", sig.endsWith("signature test"));
         Assert.assertEquals("\u003Cstrong\u003Ef\u00F3\u00F3 utf8\u003C/strong\u003E signature test" , sig);
         Assert.assertTrue("Number of license attributes", 2 <= result.getLicense().getAttrs().size());
+        Assert.assertTrue("isTrackingIMAP should be 'TRUE'", result.getIsTrackingIMAP());
     }
-    
+
     @Test
     public void unmarshall() throws Exception {
         checkAsserts((GetInfoResponse) unmarshaller.unmarshal(
                         getClass().getResourceAsStream("GetInfoResponse.xml")));
     }
-    
+
     @Test
     public void jaxbUtilUnmarshall() throws Exception {
         //same as unmarshall but use JaxbUtil; this provokes/tests issues with utf8 conversion

--- a/soap/src/java-test/com/zimbra/soap/account/JaxbToElementTest.java
+++ b/soap/src/java-test/com/zimbra/soap/account/JaxbToElementTest.java
@@ -187,7 +187,7 @@ public class JaxbToElementTest {
     public static String getTestInfoResponseJson() throws IOException {
         if (getInfoResponseJSON == null) {
             try (InputStream is = JaxbToElementTest.class.getResourceAsStream("GetInfoResponse.json")) {
-                getInfoResponseJSON = streamToString(is, Charsets.UTF_8);
+                getInfoResponseJSON = streamToString(is, Charsets.UTF_8).trim();
             }
         }
         return getInfoResponseJSON;

--- a/soap/src/java/com/zimbra/soap/account/message/GetInfoResponse.java
+++ b/soap/src/java/com/zimbra/soap/account/message/GetInfoResponse.java
@@ -69,11 +69,11 @@ import com.zimbra.soap.type.ZmBoolean;
 @XmlAccessorType(XmlAccessType.NONE)
 @XmlRootElement(name=AccountConstants.E_GET_INFO_RESPONSE)
 @XmlType(propOrder = {"version", "accountId", "accountName", "crumb", "lifetime", "adminDelegated", "restUrl",
-        "quotaUsed", "previousSessionTime", "lastWriteAccessTime", "recentMessageCount", "cos", "prefs", "attrs",
+        "quotaUsed", "isTrackingIMAP", "previousSessionTime", "lastWriteAccessTime", "recentMessageCount", "cos", "prefs", "attrs",
         "zimlets", "props", "identities", "signatures", "dataSources", "childAccounts", "discoveredRights",
         "soapURL", "publicURL", "changePasswordURL", "license", "adminURL", "boshURL"})
 @JsonPropertyOrder({"version", "id", "name", "crumb", "lifetime", "adminDelegated", "docSizeLimit", "attSizeLimit",
-        "rest", "used", "prevSession", "accessed", "recent", "cos", "prefs", "attrs", "zimlets", "props", "identities",
+        "rest", "used", "isTrackingIMAP", "prevSession", "accessed", "recent", "cos", "prefs", "attrs", "zimlets", "props", "identities",
         "signatures", "dataSources", "childAccounts", "rights", "soapURL", "publicURL", "license", "adminURL", "boshURL"})
 public final class GetInfoResponse {
 
@@ -318,6 +318,14 @@ public final class GetInfoResponse {
     @XmlElement(name=AccountConstants.E_LICENSE /* license */, required=false)
     private LicenseInfo license;
 
+    /**
+     * @zm-api-field isTrackingIMAP
+     * @zm-api-field-description Boolean value denoting if this account has logged in over IMAP.
+     */
+    @XmlElement(name=AccountConstants.E_IS_TRACKING_IMAP /*isTrackingIMAP */, required=false)
+    @ZimbraJsonAttribute
+    private ZmBoolean isTrackingIMAP;
+
     public GetInfoResponse() {
     }
 
@@ -456,7 +464,7 @@ public final class GetInfoResponse {
     public Integer getRecentMessageCount() { return recentMessageCount; }
     public String getAdminURL() { return adminURL; }
     public String getBOSHURL() { return boshURL; }
-    
+
     public Cos getCos() { return cos; }
     public List<Pref> getPrefs() {
         return Collections.unmodifiableList(prefs);
@@ -504,6 +512,14 @@ public final class GetInfoResponse {
         return Prop.toMultimap(props, userPropKey);
     }
 
+    public Boolean getIsTrackingIMAP() {
+        return ZmBoolean.toBool(isTrackingIMAP, Boolean.FALSE);
+    }
+
+    public void setIsTrackingIMAP(Boolean trackingEnabled) {
+        this.isTrackingIMAP = ZmBoolean.fromBool(trackingEnabled);
+    }
+
     public Objects.ToStringHelper addToStringInfo(
                 Objects.ToStringHelper helper) {
         return helper
@@ -533,7 +549,9 @@ public final class GetInfoResponse {
             .add("publicURL", publicURL)
             .add("boshURL", boshURL)
             .add("changePasswordURL", changePasswordURL)
-            .add("license", license);
+            .add("license", license)
+            .add("isTrackingIMAP", ZmBoolean.toBool(isTrackingIMAP) ? "1": "0");
+
     }
 
     @Override

--- a/store/src/java/com/zimbra/cs/imap/ImapSessionManager.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapSessionManager.java
@@ -286,8 +286,6 @@ final class ImapSessionManager {
         // don't have a session when the folder is loaded...
         OperationContext octxt = handler.getCredentials().getContext();
 
-        imapStore.beginTrackingImap();
-
         List<ImapMessage> i4list = null;
         // *always* recalculate the contents of search folders
         if (folder instanceof SearchFolderStore) {

--- a/store/src/java/com/zimbra/cs/service/account/GetInfo.java
+++ b/store/src/java/com/zimbra/cs/service/account/GetInfo.java
@@ -173,6 +173,7 @@ public class GetInfo extends AccountDocumentHandler  {
             try {
                 Mailbox mbox = getRequestedMailbox(zsc);
                 response.addAttribute(AccountConstants.E_QUOTA_USED, mbox.getSize(), Element.Disposition.CONTENT);
+                response.addAttribute(AccountConstants.E_IS_TRACKING_IMAP, mbox.isTrackingImap(), Element.Disposition.CONTENT);
 
                 Session s = (Session) context.get(SoapEngine.ZIMBRA_SESSION);
                 if (s instanceof SoapSession) {


### PR DESCRIPTION
Currently the `BeginTrackingIMAPRequest` is issued for every:
- session creation
- folder selection

This PR:
- removes the folder selection tracking request entirely
- piggy-backs the ability to notify the caller using the GetInfoResponse of the tracking state of the user with the 'isTrackingIMAP' tag.

ZMailbox has been updated to only issue the `BeginTrackingIMAPRequest` If and only if the `isTrackingIMAP` value is '0'.
