### PR TITLE
ZCS-2150: don't issue FLUSHCACHE if empty cache type

### DIFF
--- a/store/src/java/com/zimbra/cs/service/admin/FlushCache.java
+++ b/store/src/java/com/zimbra/cs/service/admin/FlushCache.java
@@ -299,11 +299,13 @@ public class FlushCache extends AdminDocumentHandler {
         }
         try {
             String imapTypes = sanitizeImapCacheTypes(cacheTypes);
-            if (entries == null || entries.length == 0) {
-                ZimbraLog.imap.debug("issuing X-ZIMBRA-FLUSHCACHE request to imapd server '%s'", server.getServiceHostname());
-                connection.flushCache(imapTypes);
-            } else {
-                connection.flushCache(imapTypes, entries);
+            if (imapTypes != null) {
+                ZimbraLog.imap.debug("issuing X-ZIMBRA-FLUSHCACHE request to imapd server '%s' for cache types '%s'", server.getServiceHostname(), imapTypes);
+                if (entries == null || entries.length == 0) {
+                    connection.flushCache(imapTypes);
+                } else {
+                    connection.flushCache(imapTypes, entries);
+                }
             }
         } catch (IOException e) {
             ZimbraLog.imap.warn("unable to issue X-ZIMBRA-FLUSHCACHE request to imapd server '%s'", server.getServiceHostname(), e);
@@ -325,6 +327,6 @@ public class FlushCache extends AdminDocumentHandler {
                 //shouldn't encounter invalid cache types
             }
         }
-        return Joiner.on(",").join(imapTypes);
+        return imapTypes.isEmpty() ? null : Joiner.on(",").join(imapTypes);
     }
 }


### PR DESCRIPTION
The previous fix to ZCS-2150 did not properly handle the case when _all_ of the provided cache types were filtered out as being not imap-compatible. In that case, X-ZIMBRA-FLUSHCACHE was issued anyways, with an empty string as the cache type, which caused a parse error on the imapd side. This fix updates the _FlushCache_ SOAP handler to not issue the IMAP command if no relevant cache types remain.