### PR TITLE
ZCS-2462 - Build script improvements

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -1,4 +1,4 @@
-<project name="build-common" xmlns:ivy="antlib:org.apache.ivy.ant">
+<project name="build-common" xmlns:ivy="antlib:org.apache.ivy.ant" xmlns:antcontrib="antlib:net.sf.antcontrib">
     <!-- Set properties that can be used in all projects. -->
     <dirname property="zimbra.root.dir" file="${ant.file.build-common}/../"/>
     <dirname property="zm-mailbox.basedir" file="${ant.file.build-common}"/>
@@ -18,20 +18,18 @@
     <property name="ivy.publish.src.artifacts.pattern" value="build/[artifact]-[revision].[ext]" />
     <property name="ivy.deliver.ivy.pattern" value="${dev.home}/.zcs-deps/[organisation]/[module]/[module]-[revision].[ext]" />
     <property name="ivy.module" value="${ant.project.name}" />
-    <target name="download-ivy">
-      <if>
-        <not>
-          <available file="${ivy.jar.file}" type="file"/>
-        </not>
-        <then>
-          <mkdir dir="${ivy.jar.dir}"/>
-          <!-- download Ivy from web site so that it can be used even without any special installation.
-             Note, that 'get' task will not try downloading if this file is already downloaded. -->
-          <get src="https://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar"
-             dest="${ivy.jar.file}" usetimestamp="true"/>
-        </then>
-      </if>
+
+    <target name="test.if.ivy.available">
+      <condition property="ivy.installed">
+        <available file="${ivy.jar.file}" type="file"/>
+      </condition>
     </target>
+
+    <target name="download-ivy" description="Install ivy" unless="ivy.installed" depends="test.if.ivy.available">
+        <mkdir dir="${ivy.jar.dir}"/>
+        <get src="https://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar"
+             dest="${ivy.jar.file}" usetimestamp="true"/>
+     </target>
 
     <target name="init-ivy" depends="download-ivy">
       <!-- If ivy is not downloaded yet, try to load ivy here from ivy home. -->
@@ -39,13 +37,18 @@
             <fileset dir="${ivy.jar.dir}" includes="*.jar"/>
         </path>
         <taskdef resource="org/apache/ivy/ant/antlib.xml" uri="antlib:org.apache.ivy.ant" classpathref="ivy.lib.path"/>
-        <ivy:settings id="dev.settings" file="../build-ivysettings.xml"/>
     </target>
     <!-- common resolve target that should work to resolve dependencies based on ivy.xml for most projects -->
     <target name="resolve" depends="init-ivy" description="resolve dependencies">
+      <ivy:settings id="dev.settings" file="../build-ivysettings.xml"/>
       <ivy:resolve settingsRef="dev.settings" />
-      <ivy:cachepath pathid="class.path" />
     </target>
+
+    <target name="3rd-party-defines"  description="Declare 3rd party ANT tasks">
+      <ivy:cachepath pathid="class.path" />
+      <taskdef uri="antlib:net.sf.antcontrib" classpathref="class.path"/>
+    </target>
+
     <!-- Ignore the classpath from the shell running ant.  This avoids dependency
       on the user's environment and suppresses the warning about includeAntRuntime. -->
     <property name="build.sysclasspath" value="ignore"/>
@@ -167,70 +170,6 @@
         <not><os family="windows"/></not>
     </condition>
 
-    <taskdef resource="net/sf/antcontrib/antlib.xml">
-        <classpath>
-            <pathelement location="${build.deps.dir}/ant-contrib-1.0b1.jar"/>
-        </classpath>
-    </taskdef>
-
-      <!-- Build version -->
-      <tstamp/>
-      <propertyregex property="zimbra.buildinfo.majorversion"
-                     input="${zimbra.buildinfo.version}"
-                     regexp="([0-9]+)\.([0-9]+)\.([0-9]+)"
-                     select="\1"
-                     casesensitive="false" />
-
-      <propertyregex property="zimbra.buildinfo.minorversion"
-                     input="${zimbra.buildinfo.version}"
-                     regexp="([0-9]+)\.([0-9]+)\.([0-9]+)"
-                     select="\2"
-                     casesensitive="false" />
-
-      <propertyregex property="zimbra.buildinfo.microversion"
-                     input="${zimbra.buildinfo.version}"
-                     regexp="([0-9]+)\.([0-9]+)\.([0-9]+)"
-                     select="\3"
-                     casesensitive="false" />
-
-      <propertyregex property="zimbra.buildinfo.relclass"
-                     defaultValue="GA"
-                     input="${zimbra.buildinfo.version}"
-                     regexp="([0-9]+)\.([0-9]+)\.([0-9]+)_([A-Z]+)"
-                     select="\4"
-                     casesensitive="false" />
-
-      <propertyregex property="zimbra.buildinfo.buildnum"
-                     input="${zimbra.buildinfo.version}"
-                     regexp="([0-9]+)\.([0-9]+)\.([0-9]+)_([A-Z]+)_([0-9]+)"
-                     select="\5"
-                     casesensitive="false" />
-
-      <condition property="zimbra.buildinfo.relnum" value="0">
-          <not><isset property="${zimbra.buildinfo.relnum}"/></not>
-      </condition>
-
-      <condition property="zimbra.buildinfo.type" value="">
-          <not><isset property="${zimbra.buildinfo.type}"/></not>
-      </condition>
-
-      <condition property="zimbra.buildinfo.release" value="${user.name}">
-          <not><isset property="${zimbra.buildinfo.release}"/></not>
-      </condition>
-
-      <condition property="zimbra.buildinfo.date" value="${DSTAMP}-${TSTAMP}">
-          <not><isset property="${zimbra.buildinfo.date}"/></not>
-      </condition>
-
-      <condition property="zimbra.buildinfo.host" value="${zimbra.server.hostname}">
-          <not><isset property="${zimbra.buildinfo.host}"/></not>
-      </condition>
-
-      <property name="zimbra.buildinfo.microtag" value="${zimbra.buildinfo.microversion}_${zimbra.buildinfo.relclass}"/>
-
-      <property name="zimbra.buildinfo.all"
-              value="Version: ${zimbra.buildinfo.version}; Type: ${zimbra.buildinfo.type}; Release: ${zimbra.buildinfo.release}; Built: ${zimbra.buildinfo.date}; Host: ${zimbra.buildinfo.host}"/>
-
     <target name="require-version">
       <fail message="Missing build version. use ant proper ZCS version like -Dzimbra.buildinfo.version=8.7.6_GA_1001">
        <condition>
@@ -242,8 +181,8 @@
       <echo message="Using version ${zimbra.buildinfo.version}"/>
     </target>
 
-    <target name="set-dev-version" depends="require-version">
-      <if>
+    <target name="set-dev-version" depends="require-version,3rd-party-defines">
+      <antcontrib:if>
         <not>
           <isset property="jar.file"/>
         </not>
@@ -253,10 +192,69 @@
             <arg value="-1"/>
             <arg value="--pretty=format:%at"/>
           </exec>
+
+          <!-- Build version -->
+          <tstamp/>
+          <antcontrib:propertyregex property="zimbra.buildinfo.majorversion"
+                                    input="${zimbra.buildinfo.version}"
+                                    regexp="([0-9]+)\.([0-9]+)\.([0-9]+)"
+                                    select="\1"
+                                    casesensitive="false" />
+
+          <antcontrib:propertyregex property="zimbra.buildinfo.minorversion"
+                                    input="${zimbra.buildinfo.version}"
+                                    regexp="([0-9]+)\.([0-9]+)\.([0-9]+)"
+                                    select="\2"
+                                    casesensitive="false" />
+
+          <antcontrib:propertyregex property="zimbra.buildinfo.microversion"
+                                    input="${zimbra.buildinfo.version}"
+                                    regexp="([0-9]+)\.([0-9]+)\.([0-9]+)"
+                                    select="\3"
+                                    casesensitive="false" />
+
+          <antcontrib:propertyregex property="zimbra.buildinfo.relclass"
+                                    defaultValue="GA"
+                                    input="${zimbra.buildinfo.version}"
+                                    regexp="([0-9]+)\.([0-9]+)\.([0-9]+)_([A-Z]+)"
+                                    select="\4"
+                                    casesensitive="false" />
+
+          <antcontrib:propertyregex property="zimbra.buildinfo.buildnum"
+                                    input="${zimbra.buildinfo.version}"
+                                    regexp="([0-9]+)\.([0-9]+)\.([0-9]+)_([A-Z]+)_([0-9]+)"
+                                    select="\5"
+                                    casesensitive="false" />
+
+          <condition property="zimbra.buildinfo.relnum" value="0">
+            <not><isset property="${zimbra.buildinfo.relnum}"/></not>
+          </condition>
+
+          <condition property="zimbra.buildinfo.type" value="">
+            <not><isset property="${zimbra.buildinfo.type}"/></not>
+          </condition>
+
+          <condition property="zimbra.buildinfo.release" value="${user.name}">
+            <not><isset property="${zimbra.buildinfo.release}"/></not>
+          </condition>
+
+          <condition property="zimbra.buildinfo.date" value="${DSTAMP}-${TSTAMP}">
+            <not><isset property="${zimbra.buildinfo.date}"/></not>
+          </condition>
+
+          <condition property="zimbra.buildinfo.host" value="${zimbra.server.hostname}">
+            <not><isset property="${zimbra.buildinfo.host}"/></not>
+          </condition>
+
+          <property name="zimbra.buildinfo.microtag" value="${zimbra.buildinfo.microversion}_${zimbra.buildinfo.relclass}"/>
+
+          <property name="zimbra.buildinfo.all"
+                    value="Version: ${zimbra.buildinfo.version}; Type: ${zimbra.buildinfo.type}; Release: ${zimbra.buildinfo.release}; Built: ${zimbra.buildinfo.date}; Host: ${zimbra.buildinfo.host}"/>
+
           <property name="dev.version" value="${zimbra.buildinfo.majorversion}.${zimbra.buildinfo.minorversion}.${zimbra.buildinfo.microversion}.${git.timestamp}"/>
           <property name="jar.file" value="${ant.project.name}-${dev.version}.jar"/>
         </then>
-      </if>
+      </antcontrib:if>
     </target>
 
     <target name="clean">
@@ -269,29 +267,29 @@
       <mkdir dir="${dist.dir}"/>
     </target>
 
-    <target name="compile" depends="build-init,resolve" description="Compiles from src/java into build/classes.">
+    <target name="compile" depends="build-init,resolve,3rd-party-defines" description="Compiles from src/java into build/classes.">
         <mkdir dir="${build.classes.dir}" />
         <javac destdir="${build.classes.dir}" debug="true" classpathref="class.path" target="${javac.target}" encoding="utf-8">
             <src refid="all.java.path" />
         </javac>
     </target>
 
-    <target name="test-compile" depends="compile">
-      <if>
+    <target name="test-compile" depends="compile,3rd-party-defines">
+      <antcontrib:if>
         <available file="${test.src.dir}" type="dir"/>
-        <then>
+        <antcontrib:then>
           <mkdir dir="${test.classes.dir}"/>
             <javac destdir="${test.classes.dir}" srcdir="${test.src.dir}" classpathref="test.class.path"
                debug="true" target="${javac.target}" encoding="utf-8" />
             <copy todir="${test.classes.dir}">
               <fileset dir="${test.src.dir}" excludes="**/*.java"/>
             </copy>
-         </then>
-      </if>
+         </antcontrib:then>
+      </antcontrib:if>
     </target>
 
     <target name="test" depends="test-compile" description="Run unit tests">
-      <if>
+      <antcontrib:if>
         <available file="${test.src.dir}" type="dir"/>
         <then>
           <property name="test.path" refid="test.class.path"/>
@@ -409,16 +407,16 @@
             <report todir="${test.dir}/report"/>
           </junitreport>
           <echo>Test Report: ${test.dir}/report/index.html</echo>
-	  <if>
+	  <antcontrib:if>
 	    <isset property="junit.failure"/>
 	    <then><echo append="true" file="${test-results-file}" message="${test.dir} - FAILED&#xD;&#xA;"/></then>
 	    <else><echo append="true" file="${test-results-file}" message="${test.dir} - PASSED&#xD;&#xA;"/></else>
-	  </if>
+	  </antcontrib:if>
         </then>
         <else>
           <echo>${test.src.dir} not found. Will not run unit tests</echo>
         </else>
-      </if>
+      </antcontrib:if>
     </target>
 
     <target name="test-hudson" depends="test-compile" description="Run hudson unit tests">
@@ -561,11 +559,11 @@
         <fail if="junit.failure" message="Integration test failed"/>
     </target>
 
-    <target name="generate-jar-version" description="Creates the Version class that prints the version of the jarfile.  This class is the Main-Class in the jarfile's manifest.">
+    <target name="generate-jar-version" description="Creates the Version class that prints the version of the jarfile.  This class is the Main-Class in the jarfile's manifest." depends="3rd-party-defines">
         <fail unless="build.dir" />
         <fail unless="build.classes.dir" />
 
-        <if>
+        <antcontrib:if>
             <not><available file="${build.dir}/buildinfo/com/zimbra/buildinfo/Version.java"/></not>
             <then>
                 <mkdir dir="${build.dir}/buildinfo/com/zimbra/buildinfo"/>
@@ -583,41 +581,41 @@
                     }
                 </echo>
             </then>
-        </if>
+        </antcontrib:if>
         <javac destdir="${build.classes.dir}" debug="true" target="${javac.target}" srcdir="${build.dir}/buildinfo" />
     </target>
 
-    <target name="zimbra-jar" depends="generate-jar-version,set-dev-version" description="Builds a standard jar file that prints its version info when executed.  Optionally sets the Zimbra-Extension-Class attribute in the manifest if the zimbra.extension.class property is set.">
+    <target name="zimbra-jar" depends="generate-jar-version,set-dev-version,3rd-party-defines" description="Builds a standard jar file that prints its version info when executed.  Optionally sets the Zimbra-Extension-Class attribute in the manifest if the zimbra.extension.class property is set.">
         <condition property="jar.file" value="${ant.project.name}-${dev.version}.jar">
           <not><isset property="jar.file"/></not>
         </condition>
         <fail unless="implementation.title"/>
-        <if>
+        <antcontrib:if>
           <not>
             <isset property="jar.build.dir"/>
           </not>
           <then>
             <property name="jar.build.dir" value="${build.classes.dir}"/>
           </then>
-        </if>
-        <if>
+        </antcontrib:if>
+        <antcontrib:if>
           <not>
             <isset property="excludes"/>
           </not>
           <then>
             <property name="excludes" value=""/>
           </then>
-        </if>
-        <if>
+        </antcontrib:if>
+        <antcontrib:if>
           <not>
             <isset property="includes"/>
           </not>
           <then>
             <property name="includes" value=""/>
           </then>
-        </if>
+        </antcontrib:if>
         <echo>building jar from ${jar.build.dir}</echo>
-        <if>
+        <antcontrib:if>
             <isset property="zimbra.extension.class"/>
             <then>
             <jar destfile="${build.dir}/${jar.file}" basedir="${jar.build.dir}" includes="${includes}" excludes="${excludes}">
@@ -646,7 +644,7 @@
                 </manifest>
             </jar>
             </else>
-        </if>
+        </antcontrib:if>
     </target>
 
     <target name="clean-cache" description="Delete ivy cache">

--- a/client/build.xml
+++ b/client/build.xml
@@ -1,27 +1,27 @@
-<project xmlns:ivy="antlib:org.apache.ivy.ant" name="zm-client" default="jar">
+<project xmlns:ivy="antlib:org.apache.ivy.ant" xmlns:antcontrib="antlib:net.sf.antcontrib" name="zm-client" default="jar">
   <import file="../build-common.xml"/>
-  <target name="deploy-no-start" depends="jar,set-dev-version,undeploy">
+  <target name="deploy-no-start" depends="jar,set-dev-version,undeploy,3rd-party-defines">
     <ant dir="${server.dir}" target="stop-webserver" inheritAll="false"/>
     <!-- untill zm* scripts are fixed to use versioned zm* jars, we have to deploy this with jar with a fixed name -->
     <copy file="${build.dir}/${jar.file}" tofile="${common.jars.dir}/zimbraclient.jar"/>
-    <if>
+    <antcontrib:if>
       <available file="${jetty.webapps.dir}/zimbra/" type="dir" property="zimbra.webapp.installed"/>
       <then>
         <copy file="${build.dir}/${jar.file}" tofile="${jetty.webapps.dir}/zimbra/WEB-INF/lib/${jar.file}"/>
       </then>
-    </if>
-	<if>
+    </antcontrib:if>
+	<antcontrib:if>
 	  <available file="${jetty.webapps.dir}/zimbraAdmin/" type="dir" property="zimbraadmin.webapp.installed"/>
 	  <then>
         <copy file="${build.dir}/${jar.file}" tofile="${jetty.webapps.dir}/zimbraAdmin/WEB-INF/lib/${jar.file}"/>
 	  </then>
-	</if>
-    <if>
+	</antcontrib:if>
+    <antcontrib:if>
       <available file="${jetty.webapps.dir}/service/" type="dir" property="service.webapp.installed"/>
       <then>
         <copy file="${build.dir}/${jar.file}" tofile="${jetty.webapps.dir}/service/WEB-INF/lib/${jar.file}"/>
       </then>
-    </if>
+    </antcontrib:if>
   </target>
   <target name="deploy" depends="deploy-no-start">
     <antcall target="start-webserver"/>
@@ -32,30 +32,30 @@
       <fileset dir="${common.jars.dir}" includes="zm-client*.jar,zimbraclient*.jar"/>
       <fileset dir="${jetty.endorsed.jars.dir}" includes="zm-client*.jar,zimbraclient*.jar"/>
     </delete>
-    <if>
+    <antcontrib:if>
       <available file="${jetty.webapps.dir}/zimbra/" type="dir" property="zimbra.webapp.installed"/>
       <then>
         <delete verbose="true">
           <fileset dir="${jetty.webapps.dir}/zimbra/WEB-INF/lib" includes="zm-client*.jar,zimbraclient*.jar"/>
         </delete>
       </then>
-    </if>
-	<if>
+    </antcontrib:if>
+	<antcontrib:if>
 	  <available file="${jetty.webapps.dir}/zimbraAdmin/" type="dir" property="zimbraadmin.webapp.installed"/>
 	  <then>
 	    <delete verbose="true">
           <fileset dir="${jetty.webapps.dir}/zimbraAdmin/WEB-INF/lib" includes="zm-client*.jar,zimbraclient*.jar"/>
 	    </delete>
 	  </then>
-	</if>
-    <if>
+	</antcontrib:if>
+    <antcontrib:if>
       <available file="${jetty.webapps.dir}/service/" type="dir" property="service.webapp.installed"/>
       <then>
         <delete verbose="true">
           <fileset dir="${jetty.webapps.dir}/service/WEB-INF/lib" includes="zm-client*.jar,zimbraclient*.jar"/>
         </delete>
       </then>
-    </if>
+    </antcontrib:if>
   </target>
   <target name="undeploy" depends="stop-webserver">
     <antcall target="undeploy-no-stop"/>

--- a/client/ivy.xml
+++ b/client/ivy.xml
@@ -16,6 +16,7 @@
   <dependency org="commons-httpclient" name="commons-httpclient" rev="3.1" />
   <dependency org="commons-lang" name="commons-lang" rev="2.6" />
   <dependency org="zimbra" name="zm-common" rev="latest.integration" />
-  <dependency org="zimbra" name="zm-soap" rev="latest.integration" /> 
+  <dependency org="zimbra" name="zm-soap" rev="latest.integration" />
+  <dependency org="ant-contrib" name="ant-contrib" rev="1.0b3" />
  </dependencies>
 </ivy-module>

--- a/common/ivy.xml
+++ b/common/ivy.xml
@@ -30,9 +30,10 @@
   <dependency org="com.ibm.icu" name="icu4j" rev="4.8.1.1" />
   <dependency org="org.easymock" name="easymock" rev="3.0" />
   <dependency org="cglib" name="cglib" rev="2.2.2" />
-  <dependency org="asm" name="asm" rev="3.3.1" /> 
+  <dependency org="asm" name="asm" rev="3.3.1" />
   <dependency org="org.eclipse.jetty" name="jetty-rewrite" rev="9.3.5.v20151012" />
   <dependency org="org.eclipse.jetty" name="jetty-util" rev="9.3.5.v20151012" />
   <dependency org="zimbra" name="zm-native" rev="latest.integration" />
+  <dependency org="ant-contrib" name="ant-contrib" rev="1.0b3" />
  </dependencies>
 </ivy-module>

--- a/native/ivy.xml
+++ b/native/ivy.xml
@@ -4,4 +4,7 @@
  xsi:noNamespaceSchemaLocation="http://ant.apache.org/ivy/schemas/ivy.xsd">
  <info organisation="zimbra" module="zm-native" status="integration">
  </info>
+ <dependencies>
+   <dependency org="ant-contrib" name="ant-contrib" rev="1.0b3" />
+ </dependencies>
 </ivy-module>

--- a/soap/build.xml
+++ b/soap/build.xml
@@ -1,4 +1,4 @@
-<project name="zm-soap" default="jar" xmlns:ivy="antlib:org.apache.ivy.ant">
+<project name="zm-soap" default="jar" xmlns:ivy="antlib:org.apache.ivy.ant" xmlns:antcontrib="antlib:net.sf.antcontrib">
 
   <!-- Most interesting targets:
        jar                     - source package which is part of the product.
@@ -199,36 +199,36 @@
   </target>
 
   <!-- mailboxd will not start without zm-soap library, so this target does not attempt to start it -->
-  <target name="undeploy-no-stop">
+  <target name="undeploy-no-stop" depends="3rd-party-defines">
 
     <delete verbose="true">
       <fileset dir="${common.jars.dir}" includes="zm-soap*.jar,zimbrasoap*.jar"/>
       <fileset dir="${jetty.endorsed.jars.dir}" includes="zm-soap*.jar,zimbrasoap*.jar"/>
     </delete>
-    <if>
+    <antcontrib:if>
       <available file="${jetty.webapps.dir}/zimbra/" type="dir" property="zimbra.webapp.installed"/>
       <then>
         <delete verbose="true">
           <fileset dir="${jetty.webapps.dir}/zimbra/WEB-INF/lib" includes="zm-soap*.jar,zimbrasoap*.jar"/>
         </delete>
       </then>
-    </if>
-	<if>
+    </antcontrib:if>
+	<antcontrib:if>
 	  <available file="${jetty.webapps.dir}/zimbraAdmin/" type="dir" property="zimbraadmin.webapp.installed"/>
 	  <then>
 	    <delete verbose="true">
 	      <fileset dir="${jetty.webapps.dir}/zimbraAdmin/WEB-INF/lib" includes="zm-soap*.jar,zimbrasoap*.jar"/>
 	    </delete>
 	  </then>
-	</if>
-    <if>
+	</antcontrib:if>
+    <antcontrib:if>
       <available file="${jetty.webapps.dir}/service/" type="dir" property="service.webapp.installed"/>
       <then>
         <delete verbose="true">
           <fileset dir="${jetty.webapps.dir}/service/WEB-INF/lib" includes="zm-soap*.jar,zimbrasoap*.jar"/>
         </delete>
       </then>
-    </if>
+    </antcontrib:if>
   </target>
 
   <target name="undeploy" depends="stop-webserver">
@@ -236,27 +236,27 @@
   </target>
 
   <!-- relies on undeploy to stop the webserver -->
-  <target name="deploy-no-start" depends="jar,set-dev-version,undeploy" description="Deploy">
+  <target name="deploy-no-start" depends="jar,set-dev-version,undeploy,3rd-party-defines" description="Deploy">
     <!-- until zm* scripts are fixed to use versioned zm* jars, we have to deploy this jar with a fixed name -->
     <copy file="${build.dir}/${jar.file}" tofile="${common.jars.dir}/zimbrasoap.jar"/>
-    <if>
+    <antcontrib:if>
       <available file="${jetty.webapps.dir}/zimbra/" type="dir" property="zimbra.webapp.installed"/>
       <then>
         <copy file="${build.dir}/${jar.file}" tofile="${jetty.webapps.dir}/zimbra/WEB-INF/lib/${jar.file}"/>
       </then>
-    </if>
-	<if>
+    </antcontrib:if>
+	<antcontrib:if>
 	  <available file="${jetty.webapps.dir}/zimbraAdmin/" type="dir" property="zimbraadmin.webapp.installed"/>
 	  <then>
         <copy file="${build.dir}/${jar.file}" tofile="${jetty.webapps.dir}/zimbraAdmin/WEB-INF/lib/${jar.file}"/>
 	  </then>
-	</if>
-    <if>
+	</antcontrib:if>
+    <antcontrib:if>
       <available file="${jetty.webapps.dir}/service/" type="dir" property="service.webapp.installed"/>
       <then>
         <copy file="${build.dir}/${jar.file}" tofile="${jetty.webapps.dir}/service/WEB-INF/lib/${jar.file}"/>
       </then>
-    </if>
+    </antcontrib:if>
   </target>
 
   <target name="deploy" depends="deploy-no-start">

--- a/soap/ivy.xml
+++ b/soap/ivy.xml
@@ -21,5 +21,6 @@
   <dependency org="org.codehaus.jackson" name="jackson-mapper-asl" rev="1.9.2" />
   <dependency org="org.codehaus.jackson" name="jackson-xc" rev="1.9.2" />
   <dependency org="zimbra" name="zm-common" rev="latest.integration" />
+  <dependency org="ant-contrib" name="ant-contrib" rev="1.0b3" />
  </dependencies>
 </ivy-module>

--- a/store/build.xml
+++ b/store/build.xml
@@ -1,4 +1,4 @@
-<project xmlns:ivy="antlib:org.apache.ivy.ant" name="zm-store" default="jar">
+<project xmlns:ivy="antlib:org.apache.ivy.ant" xmlns:antcontrib="antlib:net.sf.antcontrib" name="zm-store" default="jar">
   <import file="../build-common.xml"/>
   <property name="service.webapp.dir" location="${jetty.webapps.dir}/service"/>
   <property name="zimbra.webapp.dir" location="${jetty.webapps.dir}/zimbra"/>
@@ -35,15 +35,16 @@
     <path refid="class.path"/>
     <pathelement location="${build.classes.dir}"/>
   </path>
-  <target name="imapd-control">
-    <if>
+
+  <target name="test.if.imapd.available">
+    <condition property="imapd.available">
       <available file="${zimbra.home.dir}/bin/zmimapdctl" type="file"/>
-      <then>
-        <exec executable="zmimapdctl">
-          <arg value="${action}"/>
-        </exec>
-      </then>
-    </if>
+    </condition>
+  </target>
+  <target name="imapd-control" if="imapd.available" depends="test.if.imapd.available">
+    <exec executable="zmimapdctl">
+      <arg value="${action}"/>
+    </exec>
   </target>
   <target name="stop-webserver">
     <exec executable="zmmailboxdctl">
@@ -193,30 +194,30 @@
     <delete>
       <fileset dir="${common.jars.dir}" includes="zm-store*.jar,zimbrastore*.jar"/>
     </delete>
-	<if>
+	<antcontrib:if>
       <available file="${zimbra.webapp.dir}" type="dir" property="zimbra.webapp.installed"/>
       <then>
         <delete verbose="true">
           <fileset dir="${zimbra.webapp.dir}/WEB-INF/lib/" includes="zm-store*.jar,zimbrastore*.jar"/>
         </delete>
       </then>
-    </if>
-	<if>
+    </antcontrib:if>
+	<antcontrib:if>
 	  <available file="${jetty.webapps.dir}/zimbraAdmin/" type="dir" property="zimbraadmin.webapp.installed"/>
 	  <then>
 	    <delete verbose="true">
 	      <fileset dir="${zimbra-admin.webapp.dir}/WEB-INF/lib/" includes="zm-store*.jar,zimbrastore*.jar"/>
 	    </delete>
 	  </then>
-	</if>
-    <if>
+	</antcontrib:if>
+    <antcontrib:if>
       <available file="${service.webapp.dir}" type="dir" property="service.webapp.installed"/>
       <then>
         <delete verbose="true">
           <fileset dir="${service.webapp.dir}/WEB-INF/lib/" includes="zm-store*.jar,zimbrastore*.jar"/>
         </delete>
       </then>
-    </if>
+    </antcontrib:if>
   </target>
   <target name="undeploy" depends="stop-webserver">
     <antcall target="undeploy-no-stop"/>
@@ -224,24 +225,24 @@
   <target name="deploy" depends="jar,set-dev-version,undeploy">
     <copy file="${build.dir}/${jar.file}" tofile="${common.jars.dir}/zimbrastore.jar"/>
     <!-- have to use zimbrastore.jar until https://bugzilla.zimbra.com/show_bug.cgi?id=106076 is fixed -->
-    <if>
+    <antcontrib:if>
       <available file="${jetty.webapps.dir}/zimbra/" type="dir" property="zimbra.webapp.installed"/>
       <then>
         <copy file="${build.dir}/${jar.file}" todir="${zimbra.webapp.dir}/WEB-INF/lib/"/>
       </then>
-    </if>
-	<if>
+    </antcontrib:if>
+	<antcontrib:if>
 	  <available file="${jetty.webapps.dir}/zimbraAdmin/" type="dir" property="zimbraadmin.webapp.installed"/>
 	  <then>
         <copy file="${build.dir}/${jar.file}" todir="${zimbra-admin.webapp.dir}/WEB-INF/lib/"/>
 	  </then>
-	</if>
-    <if>
+	</antcontrib:if>
+    <antcontrib:if>
       <available file="${jetty.webapps.dir}/service/" type="dir" property="service.webapp.installed"/>
       <then>
         <copy file="${build.dir}/${jar.file}" todir="${service.webapp.dir}/WEB-INF/lib/"/>
       </then>
-    </if>
+    </antcontrib:if>
     <antcall target="start-webserver"/>
   </target>
   <target name="deploy-war" depends="war">
@@ -260,7 +261,7 @@
     <unzip dest="${jetty.home.dir}/webapps/service" src="${jetty.home.dir}/webapps/${warfilename}"/>
     <delete file="${jetty.home.dir}/webapps/${warfilename}"/>
   </target>
- 
+
   <target name="war" depends="jar,set-dev-version">
     <delete dir="${build.tmp.dir}"/>
     <!-- delete anything that may have been left over, e.g.: older versions of same libs -->

--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -95,11 +95,12 @@
   <dependency org="cglib" name="cglib" rev="2.2.2" />
   <dependency org="cglib" name="cglib-nodep" rev="2.2"/>
   <dependency org="org.objenesis" name="objenesis" rev="1.2"/>
-  <dependency org="asm" name="asm" rev="3.3.1" /> 
+  <dependency org="asm" name="asm" rev="3.3.1" />
   <dependency org="zimbra" name="zm-common" rev="latest.integration" />
   <dependency org="zimbra" name="zm-soap" rev="latest.integration" />
   <dependency org="zimbra" name="zm-client" rev="latest.integration" />
   <dependency org="zimbra" name="zm-native" rev="latest.integration"/>
   <dependency org="org.xmlunit" name="xmlunit-core" rev="2.3.0"/>
+  <dependency org="ant-contrib" name="ant-contrib" rev="1.0b3" />
  </dependencies>
 </ivy-module>


### PR DESCRIPTION
The intention of this PR is to remove reliance on `ant-contrib` being externally installed on the system. 

The following was done:
- rewrite the ivy2 download section to not rely upon `antcontrib:if`
- add `antcontrib` to the `ivy.xml` files for each of the sub-projects
- add new target `taskdefs` which makes the `antcontrib` namespace available (although not without the namespacing)
- update all targets that use `if` to depend on `taskdefs` and to prefix use of `if` with `antcontrib:`
- move propertyregex statements inside the target that requires them so as to utilize the `taskdefs` dependency along with adding the `antcontrib:` prefix.

**Verification:**
`zm-build/build.pl` verification was done along with an install of the resulting installer.

Also ran all of the various targets that are used in normal development to ensure all ran without errors.
- clean
- compile
- publish-local
- deploy-foss
- test
- test-all
