### PR TITLE
ZCS-2443 junits are unable to find store/conf/attrs directory

### DIFF
--- a/common/src/java-test/com/zimbra/common/mime/MimeHeaderTest.java
+++ b/common/src/java-test/com/zimbra/common/mime/MimeHeaderTest.java
@@ -21,13 +21,22 @@ import java.util.List;
 
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.google.common.base.Strings;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.localconfig.LocalConfigTestUtil;
 import com.zimbra.common.util.CharsetUtil;
 
 public class MimeHeaderTest {
+
+    @BeforeClass
+    public static void init() throws Exception {
+        if (Strings.isNullOrEmpty(System.getProperty("zimbra.config"))) {
+            System.setProperty("zimbra.config", "../store/src/java-test/localconfig-test.xml");
+        }
+    }
 
     @After
     public void reset() {

--- a/store/src/java-test/com/zimbra/cs/db/DbMailboxTest.java
+++ b/store/src/java-test/com/zimbra/cs/db/DbMailboxTest.java
@@ -30,6 +30,7 @@ import com.zimbra.cs.account.MockProvisioning;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.db.DbPool.DbConnection;
 import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
 
 /**
  * Unit test for {@link DbMailbox}.
@@ -42,6 +43,7 @@ public class DbMailboxTest {
 
     @BeforeClass
     public static void init() throws Exception {
+        MailboxTestUtil.initServer();
         Provisioning.setInstance(new MockProvisioning());
         LC.zimbra_class_database.setDefault(HSQLDB.class.getName());
         DbPool.startup();

--- a/store/src/java-test/com/zimbra/cs/filter/SpamTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/SpamTest.java
@@ -28,6 +28,7 @@ import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.Config;
 import com.zimbra.cs.account.MockProvisioning;
 import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
 import com.zimbra.cs.mime.Mime;
 import com.zimbra.cs.service.util.SpamHandler;
 import com.zimbra.cs.util.JMSession;
@@ -38,7 +39,8 @@ import com.zimbra.cs.util.JMSession;
 public class SpamTest {
 
     @BeforeClass
-    public static void init() throws ServiceException {
+    public static void init() throws Exception {
+        MailboxTestUtil.initServer();
         MockProvisioning prov = new MockProvisioning();
         Provisioning.setInstance(prov);
         Config config = prov.getConfig();

--- a/store/src/java-test/com/zimbra/cs/imap/ImapLoadBalancingMechanismTest.java
+++ b/store/src/java-test/com/zimbra/cs/imap/ImapLoadBalancingMechanismTest.java
@@ -24,12 +24,14 @@ import javax.servlet.http.HttpServletRequest;
 
 import junit.framework.Assert;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.MockServer;
 import com.zimbra.cs.account.Server;
 import com.zimbra.cs.imap.ImapLoadBalancingMechanism.CustomLBMech;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
 import com.zimbra.cs.service.MockHttpServletRequest;
 
 /**
@@ -37,6 +39,11 @@ import com.zimbra.cs.service.MockHttpServletRequest;
  *
  */
 public final class ImapLoadBalancingMechanismTest {
+
+    @BeforeClass
+    public static void init() throws Exception {
+        MailboxTestUtil.initServer();
+    }
 
     @Test
     public void ClientIpHashMechanismEmptyServerList()

--- a/store/src/java-test/com/zimbra/cs/index/query/DateQueryTest.java
+++ b/store/src/java-test/com/zimbra/cs/index/query/DateQueryTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 
 import com.zimbra.cs.account.MockProvisioning;
 import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
 
 /**
  * Unit test for {@link DateQuery}.
@@ -39,6 +40,7 @@ public final class DateQueryTest {
 
     @BeforeClass
     public static void init() throws Exception {
+        MailboxTestUtil.initServer();
         MockProvisioning prov = new MockProvisioning();
         prov.createAccount("zero@zimbra.com", "secret", new HashMap<String, Object>());
         Provisioning.setInstance(prov);

--- a/store/src/java-test/com/zimbra/cs/index/query/SizeQueryTest.java
+++ b/store/src/java-test/com/zimbra/cs/index/query/SizeQueryTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 
 import com.zimbra.cs.account.MockProvisioning;
 import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
 
 /**
  * Unit test for {@link SizeQuery}.
@@ -35,6 +36,7 @@ public final class SizeQueryTest {
 
     @BeforeClass
     public static void init() throws Exception {
+        MailboxTestUtil.initServer();
         MockProvisioning prov = new MockProvisioning();
         prov.createAccount("zero@zimbra.com", "secret", new HashMap<String, Object>());
         Provisioning.setInstance(prov);

--- a/store/src/java-test/com/zimbra/cs/mime/MimeHandlerManagerTest.java
+++ b/store/src/java-test/com/zimbra/cs/mime/MimeHandlerManagerTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 
 import com.zimbra.cs.account.MockProvisioning;
 import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
 import com.zimbra.cs.mime.handler.TextEnrichedHandler;
 import com.zimbra.cs.mime.handler.TextHtmlHandler;
 import com.zimbra.cs.mime.handler.UnknownTypeHandler;
@@ -34,7 +35,8 @@ import com.zimbra.cs.mime.handler.UnknownTypeHandler;
 public class MimeHandlerManagerTest {
 
     @BeforeClass
-    public static void init() {
+    public static void init() throws Exception {
+        MailboxTestUtil.initServer();
         MockProvisioning prov = new MockProvisioning();
         prov.clearMimeHandlers();
 


### PR DESCRIPTION
[Issue]:
ServiceException.FAILURE("attrs directory does not exists:") was thrown in some unit tests

[Fix]:
Added Mailbox.initServer() in the @BeforeClass method of these unit tests. After fixing these tests, the MimeHeaderTest started failing.
Applied the fix for locating the localconfig-test.xml file to MimeHeaderTest

[Testing]:
Travis-CI build is passing
https://travis-ci.org/rohan-ambasta/zm-mailbox/