### PR TITLE
ZCS-1850:case-insensitive SieveImmutableHeaders

### DIFF
--- a/store/src/java-test/com/zimbra/cs/filter/AddHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/AddHeaderTest.java
@@ -630,7 +630,7 @@ public class AddHeaderTest {
                 + "  addheader \"Content-Type\" \"text/plain\";\n"
                 + "  addheader \"MIME-Version\" \"1.0\";\n"
                 + "  addheader \"Content-Transfer-Encoding\" \"7bit\";\n"
-                + "  addheader \"Content-Disposition\" \"inline\";\n"
+                + "  addheader \"content-disposition\" \"inline\";\n"
                 + "}\n"
                 + "tag \"tag-example2\";\n";
 
@@ -652,21 +652,10 @@ public class AddHeaderTest {
                             Mailbox.ID_FOLDER_INBOX, true);
             Integer itemId = mbox1.getItemIds(null, Mailbox.ID_FOLDER_INBOX).getIds(MailItem.Type.MESSAGE).get(0);
             Message message = mbox1.getMessageById(null, itemId);
-            for (Enumeration<Header> enumeration = message.getMimeMessage().getAllHeaders(); enumeration.hasMoreElements();) {
-                Header header = enumeration.nextElement();
-                if ("Content-Type".equals(header.getName())) {
-                    Assert.fail();
-                }
-                if ("MIME-Version".equals(header.getName())) {
-                    Assert.fail();
-                }
-                if ("Content-Transfer-Encoding".equals(header.getName())) {
-                    Assert.fail();
-                }
-                if ("Content-Disposition".equals(header.getName())) {
-                    Assert.fail();
-                }
-            }
+            Assert.assertNull(message.getMimeMessage().getHeader("Content-Type"));
+            Assert.assertNull(message.getMimeMessage().getHeader("Content-Disposition"));
+            Assert.assertNull(message.getMimeMessage().getHeader("Content-Transfer-Encoding"));
+            Assert.assertNull(message.getMimeMessage().getHeader("MIME-Version"));
             String[] tags = message.getTags();
             Assert.assertEquals(2, tags.length);
             Assert.assertEquals("tag-example1", tags[0]);
@@ -690,7 +679,7 @@ public class AddHeaderTest {
                 + "  addheader \"Content-Type\" \"text/plain\";\n"
                 + "  addheader \"MIME-Version\" \"1.0\";\n"
                 + "  addheader \"Content-Transfer-Encoding\" \"7bit\";\n"
-                + "  addheader \"Content-Disposition\" \"inline\";\n"
+                + "  addheader \"CONTENT-DISPOSITION\" \"inline\";\n"
                 + "}\n"
                 + "tag \"tag-example2\";\n";
         try {
@@ -712,21 +701,11 @@ public class AddHeaderTest {
                             Mailbox.ID_FOLDER_INBOX, true);
             Integer itemId = mbox1.getItemIds(null, Mailbox.ID_FOLDER_INBOX).getIds(MailItem.Type.MESSAGE).get(0);
             Message message = mbox1.getMessageById(null, itemId);
-            for (Enumeration<Header> enumeration = message.getMimeMessage().getAllHeaders(); enumeration.hasMoreElements();) {
-                Header header = enumeration.nextElement();
-                if ("Content-Type".equals(header.getName())) {
-                    Assert.fail();
-                }
-                if ("MIME-Version".equals(header.getName())) {
-                    Assert.fail();
-                }
-                if ("Content-Transfer-Encoding".equals(header.getName())) {
-                    Assert.fail();
-                }
-                if ("Content-Disposition".equals(header.getName())) {
-                    Assert.fail();
-                }
-            }
+            Assert.assertNull(message.getMimeMessage().getHeader("Content-Type"));
+            Assert.assertNull(message.getMimeMessage().getHeader("Content-Disposition"));
+            Assert.assertNull(message.getMimeMessage().getHeader("Content-Transfer-Encoding"));
+            Assert.assertNull(message.getMimeMessage().getHeader("MIME-Version"));
+
             String[] tags = message.getTags();
             Assert.assertEquals(2, tags.length);
             Assert.assertEquals("tag-example1", tags[0]);

--- a/store/src/java-test/com/zimbra/cs/filter/DeleteHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/DeleteHeaderTest.java
@@ -1130,7 +1130,7 @@ public class DeleteHeaderTest {
                 + "  deleteheader \"MIME-Version\" \"1.0\";\n"
                 + "  deleteheader \"Content-Transfer-Encoding\" \"7bit\";\n"
                 + "  deleteheader \"Content-Disposition\" \"inline\";\n"
-                + "  deleteheader \"Auto-Submitted\" \"auto-generated\";\n"
+                + "  deleteheader \"auto-submitted\" \"auto-generated\";\n"
                 + "}\n"
                 + "tag \"tag-example2\";\n";
         try {
@@ -1149,34 +1149,11 @@ public class DeleteHeaderTest {
                             Mailbox.ID_FOLDER_INBOX, true);
             Integer itemId = mbox1.getItemIds(null, Mailbox.ID_FOLDER_INBOX).getIds(MailItem.Type.MESSAGE).get(0);
             Message message = mbox1.getMessageById(null, itemId);
-            boolean contentTypeMatchFound = false;
-            boolean mimeVersionMatchFound = false;
-            boolean contentTransferEncodingMatchFound = false;
-            boolean contentDispositionMatchFound = false;
-            boolean autoSubmittedMatchFound = false;
-            for (Enumeration<Header> enumeration = message.getMimeMessage().getAllHeaders(); enumeration.hasMoreElements();) {
-                Header header = enumeration.nextElement();
-                if ("Content-Type".equals(header.getName())) {
-                    contentTypeMatchFound = true;
-                }
-                if ("MIME-Version".equals(header.getName())) {
-                    mimeVersionMatchFound = true;
-                }
-                if ("Content-Transfer-Encoding".equals(header.getName())) {
-                    contentTransferEncodingMatchFound = true;
-                }
-                if ("Content-Disposition".equals(header.getName())) {
-                    contentDispositionMatchFound = true;
-                }
-                if ("Auto-Submitted".equals(header.getName())) {
-                    autoSubmittedMatchFound = true;
-                }
-            }
-            Assert.assertTrue(contentTypeMatchFound);
-            Assert.assertTrue(mimeVersionMatchFound);
-            Assert.assertTrue(contentTransferEncodingMatchFound);
-            Assert.assertTrue(contentDispositionMatchFound);
-            Assert.assertTrue(autoSubmittedMatchFound);
+            Assert.assertNotNull(message.getMimeMessage().getHeader("Content-Type"));
+            Assert.assertNotNull(message.getMimeMessage().getHeader("Content-Disposition"));
+            Assert.assertNotNull(message.getMimeMessage().getHeader("Content-Transfer-Encoding"));
+            Assert.assertNotNull(message.getMimeMessage().getHeader("MIME-Version"));
+            Assert.assertNotNull(message.getMimeMessage().getHeader("Auto-Submitted"));
             String[] tags = message.getTags();
             Assert.assertEquals(2, tags.length);
             Assert.assertEquals("tag-example1", tags[0]);

--- a/store/src/java-test/com/zimbra/cs/filter/ReplaceHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/ReplaceHeaderTest.java
@@ -1420,7 +1420,7 @@ public class ReplaceHeaderTest {
                 + "  replaceheader :newvalue \"2.0\" :matches \"MIME-Version\" \"*\";\n"
                 + "  replaceheader :newvalue \"8bit\" :matches \"Content-Transfer-Encoding\" \"*\";\n"
                 + "  replaceheader :newvalue \"attachment\" :matches \"Content-Disposition\" \"*\";\n"
-                + "  replaceheader :newvalue \"auto-replied\" :matches \"Auto-Submitted\" \"*\";\n"
+                + "  replaceheader :newvalue \"Auto-replied\" :matches \"AUTO-SUBMITTED\" \"*\";\n"
                 + "}\n";
 
         try {
@@ -1438,24 +1438,11 @@ public class ReplaceHeaderTest {
                             Mailbox.ID_FOLDER_INBOX, true);
             Integer itemId = mbox1.getItemIds(null, Mailbox.ID_FOLDER_INBOX).getIds(MailItem.Type.MESSAGE).get(0);
             Message message = mbox1.getMessageById(null, itemId);
-            for (Enumeration<Header> enumeration = message.getMimeMessage().getAllHeaders(); enumeration.hasMoreElements();) {
-                Header header = enumeration.nextElement();
-                if ("Content-Type".equals(header.getName())) {
-                    Assert.assertEquals("text/plain; charset=\"ISO-2022-JP\"", header.getValue());
-                }
-                if ("MIME-Version".equals(header.getName())) {
-                    Assert.assertEquals("1.0", header.getValue());
-                }
-                if ("Content-Transfer-Encoding".equals(header.getName())) {
-                    Assert.assertEquals("7bit", header.getValue());
-                }
-                if ("Content-Disposition".equals(header.getName())) {
-                    Assert.assertEquals("inline", header.getValue());
-                }
-                if ("Auto-Submitted".equals(header.getName())) {
-                    Assert.assertEquals("auto-generated", header.getValue());
-                }
-            }
+            Assert.assertEquals("text/plain; charset=\"ISO-2022-JP\"", message.getMimeMessage().getHeader("Content-Type")[0]);
+            Assert.assertEquals("inline", message.getMimeMessage().getHeader("Content-Disposition")[0]);
+            Assert.assertEquals("7bit", message.getMimeMessage().getHeader("Content-Transfer-Encoding")[0]);
+            Assert.assertEquals("1.0", message.getMimeMessage().getHeader("MIME-Version")[0]);
+            Assert.assertEquals("auto-generated", message.getMimeMessage().getHeader("Auto-Submitted")[0]);
         } catch (Exception e) {
             fail("No exception should be thrown: " + e.getMessage());
         }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/EditHeaderExtension.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/EditHeaderExtension.java
@@ -548,8 +548,7 @@ public class EditHeaderExtension {
      */
     static public boolean isImmutableHeaderKey(String key, ZimbraMailAdapter mailAdapter) {
         List<String> immutableHeaders = Arrays.asList(mailAdapter.getAccount().getSieveImmutableHeaders().split(","));
-        immutableHeaders.replaceAll(String::trim);
-        return immutableHeaders.contains(key) ? true : false;
+        return immutableHeaders.stream().map(String::trim).anyMatch(x -> x.equalsIgnoreCase(key));
     }
 
     /**


### PR DESCRIPTION
[bug]
Each element of the 'SieveImmutableHeaders' attribute was compared case-sensitively with the header name specified in the editheader actions' parameter.  As a result, sometimes headers were not immutable, and mistakenly added, deleted, and replaced.

[fix]
* Compared the header name case-insensitively. Any header name listed in the 'SieveImmutableHeaders' will not be editable no matter what letter the header name is specified in.
* Refactored the unit case code for improving the visibility.

[manual test]
* Unit test case: PASS
  - AddHeaderTest
  - DeleteHeaderTest
  - ReplaceHeaderTest