### PR TITLE
ZCS-2524: fixed off-by-one error when parsing CLI args

### DIFF
--- a/store/src/java/com/zimbra/cs/ephemeral/migrate/AttributeMigrationUtil.java
+++ b/store/src/java/com/zimbra/cs/ephemeral/migrate/AttributeMigrationUtil.java
@@ -107,7 +107,7 @@ public class AttributeMigrationUtil {
         List<String> attrsToMigrate;
         MigrationCallback callback;
         if (clArgs.size() > 1) {
-            attrsToMigrate = clArgs.subList(1, clArgs.size() - 1);
+            attrsToMigrate = clArgs.subList(1, clArgs.size());
         } else {
             attrsToMigrate = new ArrayList<String>(AttributeManager.getInstance().getEphemeralAttributeNames());
         }


### PR DESCRIPTION
When invoking `zmmigrateattrs` with an explicit list of attributes, the last attribute was being ignored due to an off-by-one error. If only a single attribute was specified, this would result in nothing being migrated.