### PR TITLE
Bugfix/zcs 1825

### DIFF
--- a/store/src/java/com/zimbra/cs/imap/ImapListener.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapListener.java
@@ -465,13 +465,16 @@ public abstract class ImapListener extends Session {
         } else if (id == mFolderId && mFolder instanceof ImapFolder) {
             // Once the folder's gone, there's no point in keeping an IMAP Session listening on it around.
             detach();
+            removeFromSessionCache();
+            //set MailStore to NULL before closing connection to avoid serializing this session
+            mailbox = null;
+
             // notify client that mailbox is deselected due to delete?
             // RFC 2180 3.3: "The server MAY allow the DELETE/RENAME of a multi-accessed
             //                mailbox, but disconnect all other clients who have the
             //                mailbox accessed by sending a untagged BYE response."
-            if (handler != null) {
-                handler.close();
-            }
+            handler.close();
+            handler = null;
         } else if (ImapMessage.SUPPORTED_TYPES.contains(type)) {
             mFolder.handleItemDelete(changeId, id, chg);
         }

--- a/store/src/java/com/zimbra/cs/imap/ImapRemoteSession.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapRemoteSession.java
@@ -19,29 +19,15 @@ package com.zimbra.cs.imap;
 import java.util.TreeMap;
 
 import com.zimbra.client.ZMailbox;
-import com.zimbra.client.event.ZEventHandler;
 import com.zimbra.common.mailbox.BaseItemInfo;
 import com.zimbra.common.mailbox.MailItemType;
-import com.zimbra.common.mailbox.MailboxStore;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.session.PendingModifications;
 import com.zimbra.cs.session.PendingModifications.Change;
 import com.zimbra.cs.session.PendingRemoteModifications;
-import com.zimbra.soap.type.AccountWithModifications;
 
 public class ImapRemoteSession extends ImapListener {
-    private final ZEventHandler zMailboxEventHandler = new ZEventHandler() {
-        @Override
-        public void handlePendingModification(int changeId, AccountWithModifications info) throws ServiceException {
-            ZimbraLog.imap.debug("Handling modification from ZMailbox");
-            MailboxStore store = getMailbox();
-            if(store != null && store instanceof ZMailbox) {
-                ImapServerListenerPool.getInstance().get((ZMailbox)store).notifyAccountChange(info);
-            }
-        }
-    };
-
     protected class PagedRemoteFolderData extends ImapListener.PagedFolderData {
 
         PagedRemoteFolderData(String cachekey, ImapFolder i4folder) {
@@ -92,9 +78,6 @@ public class ImapRemoteSession extends ImapListener {
     protected ImapRemoteSession(ImapMailboxStore imapStore, ImapFolder i4folder, ImapHandler handler) throws ServiceException {
         super(imapStore, i4folder, handler);
         mailbox = imapStore.getMailboxStore();
-        if(mailbox instanceof ZMailbox) {
-            ((ZMailbox)mailbox).addEventHandler(zMailboxEventHandler);
-        }
     }
 
     @Override

--- a/store/src/java/com/zimbra/cs/service/mail/WaitSetRequest.java
+++ b/store/src/java/com/zimbra/cs/service/mail/WaitSetRequest.java
@@ -292,7 +292,7 @@ public class WaitSetRequest extends MailDocumentHandler {
                 AccountWithModifications info = new AccountWithModifications(signalledAccount, lastChangeId);
                 @SuppressWarnings("rawtypes")
                 PendingModifications accountMods = cb.pendingModifications.get(signalledAccount);
-                Map<Integer, PendingFolderModifications> folderMap = PendingModifications.encodeFolderModifications(accountMods, folderInterests);
+                Map<Integer, PendingFolderModifications> folderMap = PendingModifications.encodeIMAPFolderModifications(accountMods, folderInterests);
                 if(folderInterests!= null && !folderInterests.isEmpty() && !folderMap.isEmpty()) {
                     //interested only in specific folders
                     if(expand) {

--- a/store/src/java/com/zimbra/cs/session/PendingModifications.java
+++ b/store/src/java/com/zimbra/cs/session/PendingModifications.java
@@ -434,12 +434,12 @@ public abstract class PendingModifications<T extends ZimbraMailItem> {
     }
 
     @SuppressWarnings("rawtypes")
-    public static Map<Integer, PendingFolderModifications> encodeFolderModifications(PendingModifications accountMods) throws ServiceException {
-        return encodeFolderModifications(accountMods, null);
+    public static Map<Integer, PendingFolderModifications> encodeIMAPFolderModifications(PendingModifications accountMods) throws ServiceException {
+        return encodeIMAPFolderModifications(accountMods, null);
     }
 
     @SuppressWarnings("rawtypes")
-    public static Map<Integer, PendingFolderModifications> encodeFolderModifications(PendingModifications accountMods, Set<Integer> folderInterests) throws ServiceException {
+    public static Map<Integer, PendingFolderModifications> encodeIMAPFolderModifications(PendingModifications accountMods, Set<Integer> folderInterests) throws ServiceException {
         HashMap<Integer, PendingFolderModifications> folderMap = Maps.newHashMap();
         if(accountMods!= null && accountMods.created != null) {
             for(Object mod : accountMods.created.values()) {
@@ -479,7 +479,12 @@ public abstract class PendingModifications<T extends ZimbraMailItem> {
                                 //aggregate tag deletions so they are sent to each folder we are interested in
                                 tagDeletes.add(JaxbUtil.getDeletedItemSOAP(key.getItemId(), what.toString()));
                             } else {
-                                Integer folderId = mod.getFolderId();
+                                Integer folderId;
+                                if(what == MailItem.Type.FOLDER) {
+                                    folderId = key.getItemId();
+                                } else {
+                                    folderId = mod.getFolderId();
+                                }
                                 if(folderInterests != null && !folderInterests.contains(folderId)) {
                                     continue;
                                 }

--- a/store/src/java/com/zimbra/cs/session/SoapSession.java
+++ b/store/src/java/com/zimbra/cs/session/SoapSession.java
@@ -1469,7 +1469,7 @@ public class SoapSession extends Session {
         if(SoapTransport.NotificationFormat.valueOf(zsc.getNotificationFormat()) == SoapTransport.NotificationFormat.IMAP) {
             try {
                 AccountWithModifications info = new AccountWithModifications(zsc.getAuthtokenAccountId(), mbox.getLastChangeID());
-                Map<Integer, PendingFolderModifications> folderMods = PendingModifications.encodeFolderModifications(pms);
+                Map<Integer, PendingFolderModifications> folderMods = PendingModifications.encodeIMAPFolderModifications(pms);
                 info.setPendingFolderModifications(folderMods.values());
                 eNotify.addUniqueElement(JaxbUtil.jaxbToElement(info, eNotify.getFactory()));
             } catch (ContainerException | ServiceException e) {


### PR DESCRIPTION
There are 2 reasons why when a folder is deleted outside of IMAP connection, the connection is not being dropped. Bot are addressed in this PR. 

1. Notifications that are sent via WaitSets and SOAP headers when a folder is deleted are sent within context of the parent of the deleted folder. At the same time, ImapListener is registered to listen for modifications only on the selected folder and does not get notified of changes in the parents of the selected folder.

2. Remote IMAP does not register to listen for modification notifications until IMAP client selects a folder. If IMAP client issues DELETE command in non-selected state, remote IMAP ignores modification notifications sent by mailbox server via SOAP headers.

