### PR TITLE
ZMS-708: Fix for error logged when clearing imapd cache

### DIFF
--- a/store/src/java/com/zimbra/cs/account/callback/EphemeralBackendCheck.java
+++ b/store/src/java/com/zimbra/cs/account/callback/EphemeralBackendCheck.java
@@ -117,7 +117,7 @@ public class EphemeralBackendCheck extends AttributeCallback {
         } catch (ServiceException e) {
             ZimbraLog.ephemeral.error("unable to reset attribute migration info", e);
         }
-        AttributeMigration.clearConfigCacheOnAllServers(false);
+        AttributeMigration.clearConfigCacheOnAllServers(false, true);
     }
 
 

--- a/store/src/java/com/zimbra/cs/ephemeral/migrate/AttributeMigration.java
+++ b/store/src/java/com/zimbra/cs/ephemeral/migrate/AttributeMigration.java
@@ -546,7 +546,7 @@ public class AttributeMigration {
 
         @Override
         public void flushCache() {
-            clearConfigCacheOnAllServers(true);
+            clearConfigCacheOnAllServers(true, false);
         }
     }
 
@@ -758,7 +758,7 @@ public class AttributeMigration {
         }
     }
 
-    public static void clearConfigCacheOnAllServers(boolean includeLocal) {
+    public static void clearConfigCacheOnAllServers(boolean includeLocal, boolean registerTokenInPrevStore) {
         ExecutorService executor = newCachedThreadPool(newDaemonThreadFactory("ClearEphemeralConfigCache"));
         List<Server> servers = null;
         List<Server> imapServers = null;
@@ -810,36 +810,42 @@ public class AttributeMigration {
 
         }
 
-        /* To flush the cache on imapd servers via the X-ZIMBRA-FLUSHCACHE command, the auth token needs to be registered
-         * with the previous ephemeral backend, if one exists. This is because the imapd server may still be using
-         * the previous backend.
+        /* To flush the cache on imapd servers via the X-ZIMBRA-FLUSHCACHE command, in some cases, the auth token needs to be registered
+         * with the previous ephemeral backend. This is because the imapd server may still be using the previous backend.
          */
         EphemeralStore.Factory previousEphemeralFactory = null;
         if (imapServers != null && imapServers.size() > 0) {
-            try {
-                previousEphemeralFactory = EphemeralStore.getNewFactory(BackendType.previous);
-            } catch (ServiceException e) {
-                ZimbraLog.ephemeral.error("could not instantiate previous EphemeralStore; cannot flush cache on imapd servers", e);
-            }
-            if (previousEphemeralFactory != null) {
-                EphemeralStore previousEphemeralStore = previousEphemeralFactory.getStore();
-                for (Server server: imapServers) {
-                    executor.submit(new Runnable() {
-
-                        @Override
-                        public void run() {
-                            try {
-                                ZimbraAuthToken token = (ZimbraAuthToken) AuthProvider.getAdminAuthToken();
-                                token.registerWithEphemeralStore(previousEphemeralStore);
-                                FlushCache.flushCacheOnImapDaemon(server, "config", null, LC.zimbra_ldap_user.value(), token);
-                                ZimbraLog.ephemeral.debug("sent X-ZIMBRA-FLUSHCACHE IMAP request to imapd server %s", server.getServiceHostname());
-                            } catch (ServiceException e) {
-                                ZimbraLog.ephemeral.error("cannot send X-ZIMBRA-FLUSHCACHE IMAP request to imapd server %s", server.getServiceHostname(), e);
-                            }
-                        }
-
-                    });
+            if (registerTokenInPrevStore) {
+                try {
+                    previousEphemeralFactory = EphemeralStore.getNewFactory(BackendType.previous);
+                } catch (ServiceException e) {
+                    ZimbraLog.ephemeral.warn("could not instantiate previous EphemeralStore; imapd servers may not recognize auth token", e);
                 }
+            }
+            final EphemeralStore previousEphemeralStore;
+            if (previousEphemeralFactory != null) {
+                previousEphemeralStore = registerTokenInPrevStore ? previousEphemeralFactory.getStore() : null;
+            } else {
+                previousEphemeralStore = null;
+            }
+            for (Server server: imapServers) {
+                executor.submit(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        try {
+                            ZimbraAuthToken token = (ZimbraAuthToken) AuthProvider.getAdminAuthToken();
+                            if (registerTokenInPrevStore && previousEphemeralStore != null) {
+                                token.registerWithEphemeralStore(previousEphemeralStore);
+                            }
+                            FlushCache.flushCacheOnImapDaemon(server, "config", null, LC.zimbra_ldap_user.value(), token);
+                            ZimbraLog.ephemeral.debug("sent X-ZIMBRA-FLUSHCACHE IMAP request to imapd server %s", server.getServiceHostname());
+                        } catch (ServiceException e) {
+                            ZimbraLog.ephemeral.error("cannot send X-ZIMBRA-FLUSHCACHE IMAP request to imapd server %s", server.getServiceHostname(), e);
+                        }
+                    }
+
+                });
             }
         }
         executor.shutdown();

--- a/store/src/java/com/zimbra/cs/ephemeral/migrate/ZimbraMigrationInfo.java
+++ b/store/src/java/com/zimbra/cs/ephemeral/migrate/ZimbraMigrationInfo.java
@@ -53,7 +53,7 @@ public class ZimbraMigrationInfo extends MigrationInfo {
     @Override
     protected void clearSavedData() throws ServiceException {
         config.unsetAttributeMigrationInfo();
-        AttributeMigration.clearConfigCacheOnAllServers(true);
+        AttributeMigration.clearConfigCacheOnAllServers(true, false);
     }
 
     @Override


### PR DESCRIPTION
The _AttributeMigration::clearConfigCacheOnAllServers_ method is used for two distinct use cases: when updating attribute migration status, and when changing _zimbraEphemeralBackendURL_. Currently, the method tries to register the admin auth token used to issue `X-ZIMBRA-FLUSHCACHE` in the previous ephemeral store; however, this is only necessary when changing the ephemeral backend. If _zimbraPreviousEphemeralBackendURL_ is unset, which can happen when this method is called during migration, the method is unable to instantiate the ephemeral store, logs an error, and doesn't flush imapd caches. This should not happen if we are calling this method during the migration process, since registering the auth token in the previous store is unnecessary.

This fix updates this method with a new boolean argument _registerTokenInPrevStore_, which is set to _true_ only when this is called from the _EphemeralBackendCheck_ attribute callback. If _false_, the logic to register the auth token in the previous ephemeral store is bypassed.