### PR TITLE
ZCS-2454 Sorting client keys before iterating

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -36,6 +36,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -1872,18 +1874,23 @@ public class Mailbox implements MailboxStore {
             return null;
         } else {
 
-            for (String key : mData.configKeys) {
+            SortedSet<String> clientIds= new TreeSet<String>(mData.configKeys);
+            for (String key : clientIds) {
                 if (pattern.matcher(key).matches()) {
+                   
                     previousDeviceId = key;
                     if (previousDeviceId.indexOf(":") != -1) {
                         int index = previousDeviceId.indexOf(":");
                         previousDeviceId = previousDeviceId.substring(0, index);
                     }
-                    break;
+                    String tmp = previousDeviceId.toLowerCase();
+                    if (!tmp.contains("build")) {
+                        break;
+                    }
+                    
                 }
             }
         }
-
         return previousDeviceId;
     }
 


### PR DESCRIPTION
ZCS-2454 Fix to continue delta sync on client upgrade

Currently when MacOutlook 16 version is upgraded it results in a different user agent(UA) string. The UA string is used to create the SyncKey. The change in UA results in SyncKey exception and delta sync stops.
Added code to continue even when the UA string has changed by referring to the previous sync key.

Added unit test.

Verified that delta sync happened even when deviceId changed to a different one than stored in database.
