### PR TITLE
WIP: ZCS:2486 - Separated jetty.base and jetty.home, removed jetty-<version>

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -37,10 +37,7 @@
    </target>
 
    <target name="pkg" depends="clean-pkg,all">
-      <exec dir="." executable="./pkg-builder.pl" failonerror="true">
-         <arg value="--define"/>
-         <arg value="jetty.distro=jetty-distribution-9.3.5.v20151012"/>
-      </exec>
+      <exec dir="." executable="./pkg-builder.pl" failonerror="true"/>
    </target>
 
    <target name="pkg-after-plough-through-tests" depends="test-all-plough-through,pkg"/>

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -19,9 +19,6 @@ sub parse_defines()
 {
    Die("wrong commandline options")
      if ( !GetOptions( "defines=s" => \%DEFINES ) );
-
-   Die("jetty.distro not specified (--define jetty.distro=<xxxx>)")
-     if ( !exists $DEFINES{'jetty.distro'} );
 }
 
 sub cpy_file($$)
@@ -198,9 +195,9 @@ sub stage_zimbra_mbox_war($)
 {
    my $stage_base_dir = shift;
 
-   make_path("$stage_base_dir/opt/zimbra/$DEFINES{'jetty.distro'}/webapps/service");
-   System("cd $stage_base_dir/opt/zimbra/$DEFINES{'jetty.distro'}/webapps/service && jar -xf @{[getcwd()]}/store/build/service.war");
-   cpy_file( "store/conf/web.xml.production", "$stage_base_dir/opt/zimbra/$DEFINES{'jetty.distro'}/etc/service.web.xml.in" );
+   make_path("$stage_base_dir/opt/zimbra/jetty_base/webapps/service");
+   System("cd $stage_base_dir/opt/zimbra/jetty_base/webapps/service && jar -xf @{[getcwd()]}/store/build/service.war");
+   cpy_file( "store/conf/web.xml.production", "$stage_base_dir/opt/zimbra/jetty_base/etc/service.web.xml.in" );
 
    return ["."];
 }


### PR DESCRIPTION
- Zimbra's Jetty Distribution (9.3.5.v20151012) is installed in /opt/zimbra/common/jetty_home/ via a separate package.
- Zimbra specific webapps and other custom jetty configuration files will be installed in /opt/zimbra/jetty_base/.
- Now /opt/zimbra/mailboxd and /opt/zimbra/jetty are symbolic links that point to /opt/zimbra/jetty_base/.
