### PR TITLE
ZCS-2320:Undeclared extension error is seen when executing few automa…

### DIFF
--- a/store/src/java-test/com/zimbra/cs/filter/RuleManagerTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/RuleManagerTest.java
@@ -108,4 +108,17 @@ public final class RuleManagerTest {
         Assert.assertArrayEquals(new String[] { "priority", "zimbra" }, msg.getTags());
     }
 
+    @Test
+    public void testGetRuleRequire() throws Exception {
+        String rule1 = "require [\"fileinto\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\", \"enotify\"];\r\n"
+            + "# filter1\r\n" + "if anyof (header :contains [\"subject\"] \"test\") {\r\n"
+            + "fileinto \"test\";\r\n" + "stop;\r\n" + "}\r\n";
+        String rule2 = "# filter2\r\n" + "if anyof (header :contains [\"subject\"] \"test\") {\r\n"
+            + "    tag \"test\";\r\n" + "stop;\r\n" + "}\r\n";
+        String script = rule1 + rule2;
+        Assert.assertEquals(rule1, RuleManager.getRuleByName(script, "filter1"));
+        String rule2WithRequire = "require [\"fileinto\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\", \"enotify\"];\r\n"
+            + rule2;
+        Assert.assertEquals(rule2WithRequire, RuleManager.getRuleByName(script, "filter2"));
+    }
 }

--- a/store/src/java/com/zimbra/cs/filter/RuleManager.java
+++ b/store/src/java/com/zimbra/cs/filter/RuleManager.java
@@ -309,6 +309,10 @@ public final class RuleManager {
 
         try {
             while ((line = reader.readLine()) != null) {
+                if (line.startsWith("require")) {
+                    buf.append(line).append("\r\n");
+                    continue;
+                }
                 Matcher matcher = PAT_RULE_NAME.matcher(line);
                 if (matcher.matches()) {
                     String currentName = matcher.group(1);


### PR DESCRIPTION
Issue:
"Undeclared extension" error is seen when executing filters manually from web client preferences

Fix:
Add the require statement at the beginning when fetching the partial rule from script

Added junit test.