### PR TITLE
ZCS-1864:LmtpServer returns 451 error for wrong encoded subject message

### DIFF
--- a/common/src/java-test/com/zimbra/common/mime/MimeHeaderTest.java
+++ b/common/src/java-test/com/zimbra/common/mime/MimeHeaderTest.java
@@ -28,6 +28,7 @@ import com.google.common.base.Strings;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.localconfig.LocalConfigTestUtil;
 import com.zimbra.common.util.CharsetUtil;
+import com.zimbra.common.zmime.ZInternetHeader;
 
 public class MimeHeaderTest {
 
@@ -251,5 +252,16 @@ public class MimeHeaderTest {
         List<InternetAddress> iaddrs = hdr.expandAddresses();
         Assert.assertEquals(1, iaddrs.size());
         Assert.assertEquals(src, iaddrs.get(0).getAddress());
+    }
+
+    @Test
+    public void testMalformedEndcodedHeader() {
+        String subjectHeaderInvalid = "=?euc-jp?B?=1B?=";
+        String subjectHeaderValid = "=?utf-8?B?SGVsbG8gV29ybGQh?=";
+        // if encoded header has malformed value, return the value as it is
+        // without throwing exception
+        Assert.assertEquals(subjectHeaderInvalid, ZInternetHeader.decode(subjectHeaderInvalid));
+        // if encoded header has valid value, return the decoded string
+        Assert.assertEquals("Hello World!", ZInternetHeader.decode(subjectHeaderValid));
     }
 }

--- a/common/src/java/com/zimbra/common/zmime/ZMimeUtility.java
+++ b/common/src/java/com/zimbra/common/zmime/ZMimeUtility.java
@@ -72,6 +72,9 @@ public class ZMimeUtility {
         try {
             byte[] dbuffer = new byte[word.length];
             int dsize = decoder.read(dbuffer);
+            if(dsize == -1) {
+                return null;
+            }
             return new ZByteString(dbuffer, 0, dsize, CharsetUtil.normalizeCharset(charset));
         } catch (OutOfMemoryError oome) {
             throw oome;


### PR DESCRIPTION
Issue:
When the Subject consists of a malformed encoding string, LmtpServer returns 451 error. As a result, because of the error code of 4xx, the remote MTA re-tries to send the same message repeatedly.

Fix:
If decoder.read() returns -1, return null. This results into returning the String as it is.

Added junit test