### PR TITLE
ZCS-2410 : Support JWT in AuthRequest for authentication

### DIFF
--- a/common/src/java/com/zimbra/common/service/ServiceException.java
+++ b/common/src/java/com/zimbra/common/service/ServiceException.java
@@ -347,7 +347,11 @@ public class ServiceException extends Exception {
     }
 
     public static ServiceException AUTH_REQUIRED() {
-        return new ServiceException("no valid authtoken present", AUTH_REQUIRED, SENDERS_FAULT);
+        return AUTH_REQUIRED("no valid authtoken present", null);
+    }
+
+    public static ServiceException AUTH_REQUIRED(String message, Throwable cause) {
+        return new ServiceException(message, AUTH_REQUIRED, SENDERS_FAULT, cause);
     }
 
     public static ServiceException CANNOT_DISABLE_TWO_FACTOR_AUTH() {

--- a/common/src/java/com/zimbra/common/service/ServiceException.java
+++ b/common/src/java/com/zimbra/common/service/ServiceException.java
@@ -347,11 +347,7 @@ public class ServiceException extends Exception {
     }
 
     public static ServiceException AUTH_REQUIRED() {
-        return AUTH_REQUIRED("no valid authtoken present", null);
-    }
-
-    public static ServiceException AUTH_REQUIRED(String message, Throwable cause) {
-        return new ServiceException(message, AUTH_REQUIRED, SENDERS_FAULT, cause);
+        return new ServiceException("no valid authtoken present", AUTH_REQUIRED, SENDERS_FAULT);
     }
 
     public static ServiceException CANNOT_DISABLE_TWO_FACTOR_AUTH() {

--- a/common/src/java/com/zimbra/common/soap/AccountConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AccountConstants.java
@@ -444,7 +444,7 @@ public class AccountConstants {
     public static final String A_VERIFY_ACCOUNT = "verifyAccount";
     public static final String A_CSRF_SUPPORT = "csrfTokenSecured";
     public static final String A_TOKEN_TYPE = "tokenType";
-    public static final String E_JWT_AUTH_TOKEN = "jwtAuthToken";
+    public static final String E_JWT_TOKEN = "jwtToken";
 
     // account ACLs
     public static final String A_ACCESSKEY = "key";

--- a/common/src/java/com/zimbra/common/soap/AccountConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AccountConstants.java
@@ -444,7 +444,7 @@ public class AccountConstants {
     public static final String A_VERIFY_ACCOUNT = "verifyAccount";
     public static final String A_CSRF_SUPPORT = "csrfTokenSecured";
     public static final String A_TOKEN_TYPE = "tokenType";
-
+    public static final String E_JWT_AUTH_TOKEN = "jwtAuthToken";
 
     // account ACLs
     public static final String A_ACCESSKEY = "key";

--- a/soap/src/java/com/zimbra/soap/account/message/AuthRequest.java
+++ b/soap/src/java/com/zimbra/soap/account/message/AuthRequest.java
@@ -114,6 +114,12 @@ public class AuthRequest {
     private AuthToken authToken;
 
     /**
+     * @zm-api-field-description JWT auth token
+     */
+    @XmlElement(name=AccountConstants.E_JWT_AUTH_TOKEN /* jwtAuthToken */, required=false)
+    private String jwtAuthToken;
+
+    /**
      * @zm-api-field-tag virtual-host
      * @zm-api-field-description if specified (in conjunction with by="name"), virtual-host is used to determine
      * the domain of the account name, if it does not include a domain component. For example, if the domain
@@ -219,6 +225,9 @@ public class AuthRequest {
 
     public AuthToken getAuthToken() { return authToken; }
     public AuthRequest setAuthToken(AuthToken authToken) { this.authToken = authToken; return this; }
+
+    public String getJwtAuthToken() { return jwtAuthToken; }
+    public AuthRequest setJwtAuthToken(String jwtAuthToken) { this.jwtAuthToken = jwtAuthToken; return this; }
 
     public String getVirtualHost() { return virtualHost; }
     public AuthRequest setVirtualHost(String host) { this.virtualHost = host; return this; }

--- a/soap/src/java/com/zimbra/soap/account/message/AuthRequest.java
+++ b/soap/src/java/com/zimbra/soap/account/message/AuthRequest.java
@@ -116,8 +116,8 @@ public class AuthRequest {
     /**
      * @zm-api-field-description JWT auth token
      */
-    @XmlElement(name=AccountConstants.E_JWT_AUTH_TOKEN /* jwtAuthToken */, required=false)
-    private String jwtAuthToken;
+    @XmlElement(name=AccountConstants.E_JWT_TOKEN /* jwtToken */, required=false)
+    private String jwtToken;
 
     /**
      * @zm-api-field-tag virtual-host
@@ -226,8 +226,8 @@ public class AuthRequest {
     public AuthToken getAuthToken() { return authToken; }
     public AuthRequest setAuthToken(AuthToken authToken) { this.authToken = authToken; return this; }
 
-    public String getJwtAuthToken() { return jwtAuthToken; }
-    public AuthRequest setJwtAuthToken(String jwtAuthToken) { this.jwtAuthToken = jwtAuthToken; return this; }
+    public String getJwtToken() { return jwtToken; }
+    public AuthRequest setJwtToken(String jwtToken) { this.jwtToken = jwtToken; return this; }
 
     public String getVirtualHost() { return virtualHost; }
     public AuthRequest setVirtualHost(String host) { this.virtualHost = host; return this; }

--- a/store/src/java-test/com/zimbra/cs/util/JWTBasedAuthTest.java
+++ b/store/src/java-test/com/zimbra/cs/util/JWTBasedAuthTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import com.zimbra.common.account.Key;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.AccountServiceException.AuthFailedServiceException;
 import com.zimbra.cs.account.AuthToken;
 import com.zimbra.cs.account.AuthToken.TokenType;
 import com.zimbra.cs.account.AuthToken.Usage;
@@ -21,6 +22,7 @@ import com.zimbra.cs.mailbox.MailboxTestUtil;
 import com.zimbra.cs.service.AuthProvider;
 import com.zimbra.cs.service.account.Auth;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import junit.framework.Assert;
@@ -56,13 +58,6 @@ public class JWTBasedAuthTest {
         validateJWT(at, acct.getId());
     }
 
-    private void validateJWT(AuthToken at, String acctId) throws ServiceException, AuthTokenException {
-        String jwt = at.getEncoded();
-        AuthTokenKey tokenKey = AuthTokenKey.getCurrentKey();
-        java.security.Key key = new SecretKeySpec(tokenKey.getKey(), SignatureAlgorithm.HS512.getJcaName());
-        assert Jwts.parser().setSigningKey(key).parseClaimsJws(jwt).getBody().getSubject().equals(acctId);
-    }
-
     // positive case
     @Test
     public void testValdiateAndCreateNewJwtAuthToken() throws ServiceException, AuthTokenException {
@@ -70,24 +65,30 @@ public class JWTBasedAuthTest {
         Account acct = prov.get(Key.AccountBy.name, "test@zimbra.com");
         AuthToken at = AuthProvider.getAuthToken(acct, 0, TokenType.JWT);
         String token = at.getEncoded();
-        AuthToken newAt = Auth.validateAndCreateNewJwtToken(token, acct, prov);
+        Claims claims = Auth.validateJwtToken(token);
+        Account authTokenAcct = prov.getAccountById(claims.getSubject());
+        AuthToken newAt = AuthProvider.getAuthToken(authTokenAcct, TokenType.JWT);
         Assert.assertNotNull(newAt);
         Assert.assertNotSame(at, newAt);
-        String jwt = newAt.getEncoded();
-        java.security.Key key = new SecretKeySpec("pass".getBytes(StandardCharsets.UTF_8), SignatureAlgorithm.HS512.getJcaName());
-        assert Jwts.parser().setSigningKey(key).parseClaimsJws(jwt).getBody().getSubject().equals(acct.getId());
+        Assert.assertSame(acct, authTokenAcct);
+        validateJWT(newAt, authTokenAcct.getId());
     }
 
     // negative case
     @Test
     public void testNegativeValdiateAndCreateNewJwtAuthToken() throws ServiceException, AuthTokenException {
-        Provisioning prov = Provisioning.getInstance();
-        Account acct = prov.get(Key.AccountBy.name, "test@zimbra.com");
         String token = "abc.dev.xyz";
         try {
-            Auth.validateAndCreateNewJwtToken(token, acct, prov);
-        } catch(Exception e) {
-            Assert.assertTrue(e.getMessage().contains("Malformed JWT received"));
+            Auth.validateJwtToken(token);
+        } catch(AuthFailedServiceException afse) {
+            Assert.assertTrue(afse.getReason().equals("Malformed JWT received"));
         }
+    }
+
+    private void validateJWT(AuthToken at, String acctId) throws ServiceException, AuthTokenException {
+        String jwt = at.getEncoded();
+        AuthTokenKey tokenKey = AuthTokenKey.getCurrentKey();
+        java.security.Key key = new SecretKeySpec(tokenKey.getKey(), SignatureAlgorithm.HS512.getJcaName());
+        assert Jwts.parser().setSigningKey(key).parseClaimsJws(jwt).getBody().getSubject().equals(acctId);
     }
 }

--- a/store/src/java/com/zimbra/cs/service/account/Auth.java
+++ b/store/src/java/com/zimbra/cs/service/account/Auth.java
@@ -150,12 +150,6 @@ public class Auth extends AccountDocumentHandler {
             acct = prov.getAccountById(claims.getSubject());
             acctAutoProvisioned = true;
         }
-        // generate and return jwt only if tokenType is JWT
-        if (TokenType.JWT.equals(tokenType) && claims != null) {
-            AuthToken at = AuthProvider.getAuthToken(acct, TokenType.JWT);
-            ZimbraLog.account.debug("auth: generated JWT based on authToken Element");
-            return doResponse(request, at, zsc, context, acct, csrfSupport, trustedToken, newDeviceId);
-        }
 
         if (authTokenEl != null) {
             boolean verifyAccount = authTokenEl.getAttributeBool(AccountConstants.A_VERIFY_ACCOUNT, false);


### PR DESCRIPTION
Change : 
1)  support jwt in AuthRequest
2) validate jwt received in AuthRequest
3) create new jwt if requested jwt is valid
4) send created jwt in response

Testing :
Added positive and negative test cases in unit tests

Testing to be done by QA :
1) Automate positive and negative test cases for jwt in AuthRequest
2) Test all scenarios related to jwt in AuthRequest