### PR TITLE
ZCS-2320:handling multiple filter run scenario

### DIFF
--- a/store/src/java-test/com/zimbra/cs/filter/RuleManagerTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/RuleManagerTest.java
@@ -110,15 +110,15 @@ public final class RuleManagerTest {
 
     @Test
     public void testGetRuleRequire() throws Exception {
-        String rule1 = "require [\"fileinto\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\", \"enotify\"];\r\n"
-            + "# filter1\r\n" + "if anyof (header :contains [\"subject\"] \"test\") {\r\n"
+        String requireLine = "require [\"fileinto\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\", \"enotify\"];\r\n";
+        String rule1 = "# filter1\r\n" + "if anyof (header :contains [\"subject\"] \"test\") {\r\n"
             + "fileinto \"test\";\r\n" + "stop;\r\n" + "}\r\n";
         String rule2 = "# filter2\r\n" + "if anyof (header :contains [\"subject\"] \"test\") {\r\n"
-            + "    tag \"test\";\r\n" + "stop;\r\n" + "}\r\n";
-        String script = rule1 + rule2;
-        Assert.assertEquals(rule1, RuleManager.getRuleByName(script, "filter1"));
-        String rule2WithRequire = "require [\"fileinto\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\", \"enotify\"];\r\n"
-            + rule2;
-        Assert.assertEquals(rule2WithRequire, RuleManager.getRuleByName(script, "filter2"));
+            + "tag \"test\";\r\n" + "stop;\r\n" + "}\r\n";
+        String script = requireLine + rule1 + rule2;
+        Assert.assertEquals(requireLine, RuleManager.getRuleByName(script, "filter1").getFirst());
+        Assert.assertEquals(rule1, RuleManager.getRuleByName(script, "filter1").getSecond());
+        Assert.assertEquals(requireLine, RuleManager.getRuleByName(script, "filter2").getFirst());
+        Assert.assertEquals(rule2, RuleManager.getRuleByName(script, "filter2").getSecond());
     }
 }

--- a/store/src/java/com/zimbra/cs/service/mail/ApplyFilterRules.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ApplyFilterRules.java
@@ -21,6 +21,7 @@ import com.google.common.io.Closeables;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.MailConstants;
+import com.zimbra.common.util.Pair;
 import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
@@ -68,14 +69,19 @@ public class ApplyFilterRules extends MailDocumentHandler {
 
         // Concatenate script parts and create a new script to run on existing messages.
         StringBuilder buf = new StringBuilder();
+        boolean requireAppended = false;
         for (Element ruleEl : ruleElements) {
             String name = ruleEl.getAttribute(MailConstants.A_NAME);
-            String singleRule = RuleManager.getRuleByName(fullScript, name);
+            Pair<String, String> singleRule = RuleManager.getRuleByName(fullScript, name);
             if (singleRule == null) {
                 String msg = String.format("Could not find a rule named '%s'", name);
                 throw ServiceException.INVALID_REQUEST(msg, null);
             }
-            buf.append(singleRule).append("\n");
+            if(singleRule.getFirst() != null && requireAppended == false) {
+                buf.append(singleRule.getFirst());
+                requireAppended = true;
+            }
+            buf.append(singleRule.getSecond()).append("\n");
         }
         String partialScript = buf.toString();
         ZimbraLog.filter.debug("Applying partial script to existing messages: %s", partialScript);

--- a/store/src/java/com/zimbra/qa/unittest/TestFilterExisting.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestFilterExisting.java
@@ -111,8 +111,8 @@ public class TestFilterExisting {
         String rule1 = "# Rule 1\r\nabc\r\n";
         String rule2 = "# Rule 2\r\ndef\r\n";
         String script = rule1 + rule2;
-        Assert.assertEquals(rule1, RuleManager.getRuleByName(script, "Rule 1"));
-        Assert.assertEquals(rule2, RuleManager.getRuleByName(script, "Rule 2"));
+        Assert.assertEquals(rule1, RuleManager.getRuleByName(script, "Rule 1").getSecond());
+        Assert.assertEquals(rule2, RuleManager.getRuleByName(script, "Rule 2").getSecond());
     }
     @Test
     public void testKeep() throws Exception {


### PR DESCRIPTION
Handling multiple filter run test case. If user runs multiple filters at one time, the require line should be appended only once.

Updated the Junit test

 