### PR TITLE
ZCS-2586:ImapProxy fails when using IMAP Daemon

### DIFF
--- a/store/src/java/com/zimbra/cs/imap/ImapProxy.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapProxy.java
@@ -82,6 +82,11 @@ public final class ImapProxy {
         } else if (server.isImapSSLServerEnabled()) {
             config.setPort(server.getIntAttr(Provisioning.A_zimbraImapSSLBindPort, ImapConfig.DEFAULT_SSL_PORT));
             config.setSecurity(MailConfig.Security.SSL);
+        } else if (server.isRemoteImapServerEnabled()) {
+            config.setPort(server.getIntAttr(Provisioning.A_zimbraRemoteImapBindPort, ImapConfig.DEFAULT_PORT));
+        } else if (server.isRemoteImapSSLServerEnabled()) {
+            config.setPort(server.getIntAttr(Provisioning.A_zimbraRemoteImapSSLBindPort, ImapConfig.DEFAULT_SSL_PORT));
+            config.setSecurity(MailConfig.Security.SSL);
         } else {
             throw ServiceException.PROXY_ERROR(new Exception("no open IMAP port for server " + host), path.asImapPath());
         }
@@ -94,6 +99,7 @@ public final class ImapProxy {
             connection.id(createIDInfo(handler));
             connection.authenticate(AuthProvider.getAuthToken(acct).getEncoded());
         } catch (Exception e) {
+            ZimbraLog.imap.warn("Problem opening proxy connection %s - %s", connection, e.getMessage());
             dropConnection();
             throw ServiceException.PROXY_ERROR(e, null);
         }
@@ -140,7 +146,7 @@ public final class ImapProxy {
             return;
 
         // FIXME: should close cleanly (i.e. with tagged LOGOUT)
-        ZimbraLog.imap.info("closing proxy connection");
+        ZimbraLog.imap.info("closing proxy connection %s", conn);
         conn.close();
     }
 

--- a/store/src/java/com/zimbra/qa/unittest/ImapTestBase.java
+++ b/store/src/java/com/zimbra/qa/unittest/ImapTestBase.java
@@ -64,6 +64,8 @@ public abstract class ImapTestBase {
     protected String testId;
 
     private static boolean saved_imap_always_use_remote_store;
+    private static boolean saved_imap_server_enabled;
+    private static boolean saved_imap_ssl_server_enabled;
     private static String[] saved_imap_servers = null;
 
     protected abstract int getImapPort();
@@ -125,6 +127,8 @@ public abstract class ImapTestBase {
         getLocalServer();
         saved_imap_always_use_remote_store = LC.imap_always_use_remote_store.booleanValue();
         saved_imap_servers = imapServer.getReverseProxyUpstreamImapServers();
+        saved_imap_server_enabled = imapServer.isImapServerEnabled();
+        saved_imap_ssl_server_enabled = imapServer.isImapSSLServerEnabled();
     }
 
     /** expect this to be called by subclass @After method */
@@ -133,6 +137,8 @@ public abstract class ImapTestBase {
         getLocalServer();
         if (imapServer != null) {
             imapServer.setReverseProxyUpstreamImapServers(saved_imap_servers);
+            imapServer.setImapServerEnabled(saved_imap_server_enabled);
+            imapServer.setImapSSLServerEnabled(saved_imap_ssl_server_enabled);
         }
         TestUtil.setLCValue(LC.imap_always_use_remote_store, String.valueOf(saved_imap_always_use_remote_store));
     }

--- a/store/src/java/com/zimbra/qa/unittest/TestImapViaImapDaemon.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestImapViaImapDaemon.java
@@ -46,6 +46,8 @@ import com.zimbra.soap.admin.type.CacheEntryType;
           saveImapConfigSettings();
           TestUtil.setLCValue(LC.imap_always_use_remote_store, String.valueOf(false));
           imapServer.setReverseProxyUpstreamImapServers(new String[] {imapServer.getServiceHostname()});
+          imapServer.setImapServerEnabled(false);
+          imapServer.setImapSSLServerEnabled(false);
           super.sharedSetUp();
           TestUtil.flushImapDaemonCache(imapServer);
       }


### PR DESCRIPTION
* `ImapProxy` now looks to see if remote IMAP server is enabled if IMAP
  server is disabled.
* `ImapTestBase` now saves and restores settings of
  `ZimbraImapServerEnabled` and `ZimbraImapSSLServerEnabled` on the
  local Server
* `TestImapViaImapDaemon` now disables `ZimbraImapServerEnabled`
  and `ZimbraImapSSLServerEnabled` on the local Server during its run to
  ensure that ImapProxy is exercised with remote IMAP.