### PR TITLE
ZCS-2390: support JWT in soap requests for authentication

### DIFF
--- a/common/src/java/com/zimbra/common/soap/HeaderConstants.java
+++ b/common/src/java/com/zimbra/common/soap/HeaderConstants.java
@@ -25,6 +25,7 @@ public final class HeaderConstants {
     public static final String A_TYPE       = "type";
     public static final String E_ACCOUNT    = "account";
     public static final String E_AUTH_TOKEN = "authToken";
+    public static final String E_JWT_TOKEN = "jwtToken";
     public static final String E_AUTH_TOKEN_CONTROL = "authTokenControl";
     public static final String A_VOID_ON_EXPIRED = "voidOnExpired";
     public static final String A_BY         = "by";

--- a/common/src/java/com/zimbra/common/util/Constants.java
+++ b/common/src/java/com/zimbra/common/util/Constants.java
@@ -46,5 +46,7 @@ public class Constants {
 
     //JWT constants
     public static final String AUTH_DATA_CLAIM = "authData";
+    public static final String AUTH_HEADER = "Authorization";
+    public static final String BEARER= "Bearer";
 
 }

--- a/store/src/java/com/zimbra/cs/account/ZimbraAuthToken.java
+++ b/store/src/java/com/zimbra/cs/account/ZimbraAuthToken.java
@@ -83,6 +83,7 @@ public class ZimbraAuthToken extends AuthToken implements Cloneable {
     private static final String C_VALIDITY_VALUE  = "vv";
     private static final String C_AUTH_MECH = "am";
     private static final String C_USAGE = "u";
+    private static final String C_TOKEN_TYPE = "tt";
     //cookie ID for keeping track of account's cookies
     private static final String C_TOKEN_ID = "tid";
     //mailbox server version where this account resides
@@ -215,12 +216,18 @@ public class ZimbraAuthToken extends AuthToken implements Cloneable {
             } else {
                 usage = Usage.AUTH;
             }
+            String tokenTypeCode = (String)map.get(C_TOKEN_TYPE);
+            if (tokenTypeCode != null) {
+                tokenType = TokenType.fromCode(tokenTypeCode);
+            } else {
+                tokenType = TokenType.AUTH;
+            }
             externalUserEmail = (String)map.get(C_EXTERNAL_USER_EMAIL);
             digest = (String)map.get(C_DIGEST);
-            String vv = (String)map.get(C_VALIDITY_VALUE);
-            if (vv != null) {
+            String validityValueCode = (String)map.get(C_VALIDITY_VALUE);
+            if (validityValueCode != null) {
                 try {
-                    validityValue = Integer.parseInt(vv);
+                    validityValue = Integer.parseInt(validityValueCode);
                 } catch (NumberFormatException e) {
                     validityValue = -1;
                 }
@@ -542,6 +549,9 @@ public class ZimbraAuthToken extends AuthToken implements Cloneable {
 
         if (usage != null) {
             BlobMetaData.encodeMetaData(C_USAGE, usage.getCode(), encodedBuff);
+        }
+        if (tokenType != null) {
+            BlobMetaData.encodeMetaData(C_TOKEN_TYPE, tokenType.getCode(), encodedBuff);
         }
         BlobMetaData.encodeMetaData(C_TOKEN_ID, tokenID, encodedBuff);
         BlobMetaData.encodeMetaData(C_EXTERNAL_USER_EMAIL, externalUserEmail, encodedBuff);

--- a/store/src/java/com/zimbra/cs/service/account/Auth.java
+++ b/store/src/java/com/zimbra/cs/service/account/Auth.java
@@ -146,7 +146,7 @@ public class Auth extends AccountDocumentHandler {
         // if authToken is present in request then use it
         if (jwtTokenElement != null && authTokenEl == null) {
             String jwt = jwtTokenElement.getText();
-            claims = validateJwtToken(jwt);
+            claims = validateJWT(jwt);
             acct = prov.getAccountById(claims.getSubject());
             acctAutoProvisioned = true;
         }
@@ -530,15 +530,15 @@ public class Auth extends AccountDocumentHandler {
             AccountUtil.addAccountToLogContext(prov, aid, ZimbraLog.C_ANAME, ZimbraLog.C_AID, null);
     }
 
-    public static Claims validateJwtToken(String jwt) throws ServiceException {
+    public static Claims validateJWT(String jwt) throws ServiceException {
         if (StringUtil.isNullOrEmpty(jwt)) {
-            throw ServiceException.AUTH_REQUIRED();
+            throw AuthFailedServiceException.AUTH_FAILED("Invalid JWT received");
         }
         AuthTokenKey authTokenKey = null;
         try {
             authTokenKey = AuthTokenKey.getCurrentKey();
         } catch (ServiceException e) {
-            ZimbraLog.account.fatal("unable to get latest AuthTokenKey", e);
+            ZimbraLog.account.warn("unable to get latest AuthTokenKey", e);
             throw e;
         }
         java.security.Key key = new SecretKeySpec(authTokenKey.getKey(), SignatureAlgorithm.HS512.getJcaName());

--- a/store/src/java/com/zimbra/soap/ZimbraSoapContext.java
+++ b/store/src/java/com/zimbra/soap/ZimbraSoapContext.java
@@ -39,6 +39,7 @@ import com.zimbra.cs.account.AccessManager;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.AccountServiceException;
 import com.zimbra.cs.account.AuthToken;
+import com.zimbra.cs.account.AuthToken.TokenType;
 import com.zimbra.cs.account.AuthTokenException;
 import com.zimbra.cs.account.GuestAccount;
 import com.zimbra.cs.account.Provisioning;
@@ -278,10 +279,13 @@ public final class ZimbraSoapContext {
 
         try {
             mAuthToken = AuthProvider.getAuthToken(ctxt, context);
+            if (mAuthToken == null) {
+                mAuthToken = AuthProvider.getAuthToken(ctxt, context, TokenType.JWT);
+            }
             if (mAuthToken != null) {
                 boolean isRegistered = mAuthToken.isRegistered();
                 boolean isExpired = mAuthToken.isExpired();
-                if (isExpired || !isRegistered) {
+                if (!mAuthToken.isJWT() && (isExpired || !isRegistered)) {
                     boolean voidOnExpired = false;
 
                     if (ctxt != null) {


### PR DESCRIPTION
Added logic to look for jwtToken in soap context and if not found, look in http request in Authorization header. Once jwtToken is found, validate it and pass the auth token created from encoded string stored inside jwt to dispatch the request.
Added junit test.