### PR TITLE
ZMS-713: add failing SOAP test for the underlying problem

### DIFF
--- a/store/src/java/com/zimbra/cs/imap/ImapHandler.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapHandler.java
@@ -1648,7 +1648,6 @@ public abstract class ImapHandler {
         if (initial.firstUnread > 0) {
             sendUntagged("OK [UNSEEN " + initial.firstUnread + "] mailbox contains unseen messages");
         }
-
         sendUntagged("OK [UIDVALIDITY " + i4folder.getUIDValidity() + "] UIDs are valid for this mailbox");
         /** note: not sending back a "* OK [UIDNEXT ....]" response for search folders
          * Also, if uidnext is negative (mountpoints currently?) then best to leave it out,

--- a/store/src/java/com/zimbra/cs/imap/ImapHandler.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapHandler.java
@@ -1648,6 +1648,7 @@ public abstract class ImapHandler {
         if (initial.firstUnread > 0) {
             sendUntagged("OK [UNSEEN " + initial.firstUnread + "] mailbox contains unseen messages");
         }
+
         sendUntagged("OK [UIDVALIDITY " + i4folder.getUIDValidity() + "] UIDs are valid for this mailbox");
         /** note: not sending back a "* OK [UIDNEXT ....]" response for search folders
          * Also, if uidnext is negative (mountpoints currently?) then best to leave it out,


### PR DESCRIPTION
This is the result of a research spike ZMS-713. The goal of the research was to figure out why some IMAP compliance tests are failing only when being executed in a sequence. The Compliance test suite is complaining about wrong UIDVALIDITY value that is being sent by one of the 3 connections used by the test. The reason why Remote IMAP is sending the wrong value is that ImapListener does not pick up folder deletion when IMAP session is not in a selected state and a folder with the same name is created by another connection.