### PR TITLE
zcs-2473:Sieve filter's error handling about :matches

### DIFF
--- a/store/src/java-test/com/zimbra/cs/filter/HeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/HeaderTest.java
@@ -173,6 +173,9 @@ public class HeaderTest {
             RuleManager.clearCachedRules(account);
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
+            account.unsetAdminSieveScriptBefore();
+            account.unsetMailSieveScript();
+            account.unsetAdminSieveScriptAfter();
             account.setMailSieveScript(filterScript);
             List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox), mbox,
@@ -417,18 +420,15 @@ public class HeaderTest {
     }
 
     @Test
-    public void ttt() throws Exception {
-        String script = "require [\"tag\"];\n"
-                + "if anyof (header :contains [\"X_Header\"] \"123\") { "
-                + "    tag \"321321\";"
-                + "    stop;"
-                + "}"
-                ;
-        String sourceMsg =
-            "X_Header: sample\\\\pattern\n";
-            try {
+    public void testMalencodedHeader() throws Exception {
+        String script = "if header :matches [\"Subject\"] \"*\" { tag \"321321\"; }";
+        String sourceMsg = "Subject: =?ABC?A?GyRCJFskMhsoQg==?=";
+        try {
             Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
             RuleManager.clearCachedRules(account);
+            account.unsetAdminSieveScriptBefore();
+            account.unsetMailSieveScript();
+            account.unsetAdminSieveScriptAfter();
             account.setAdminSieveScriptBefore(script);
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
@@ -438,10 +438,9 @@ public class HeaderTest {
             Assert.assertEquals(1, ids.size());
 
             Message msg = mbox.getMessageById(null, ids.get(0).getId());
-            Assert.assertEquals(0, msg.getTags().length);
+            Assert.assertEquals(1, msg.getTags().length);
         } catch (Exception e) {
-            e.printStackTrace();
-            fail("No exception should be thrown");
+            fail("No exception should be thrown" + e);
         }
     }
 }

--- a/store/src/java-test/com/zimbra/cs/filter/ReplaceHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/ReplaceHeaderTest.java
@@ -1700,7 +1700,6 @@ public class ReplaceHeaderTest {
             Assert.assertNotSame(0, headers.length);
             Assert.assertEquals("[test]=?ABC?A?GyRCJFskMhsoQg==?=", headers[0]);
         } catch (Exception e) {
-            e.printStackTrace();
             fail("No exception should be thrown" + e);
         }
     }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/EditHeaderExtension.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/EditHeaderExtension.java
@@ -406,14 +406,12 @@ public class EditHeaderExtension {
      */
     public boolean matchCondition(ZimbraMailAdapter mailAdapter, Header header, List<String> headerList, String value, SieveContext context) throws LookupException, SieveException, MessagingException {
         boolean matchFound = false;
-        String unfoldedAndDecodedHeaderValue = "";
+        String unfoldedAndDecodedHeaderValue = MimeUtility.unfold(header.getValue());
         try {
-            unfoldedAndDecodedHeaderValue =  MimeUtility.decodeText(MimeUtility.unfold(header.getValue()));
-            ZimbraLog.filter.debug("Header value before unfolding and decoding: %s", header.getValue());
+            unfoldedAndDecodedHeaderValue =  MimeUtility.decodeText(unfoldedAndDecodedHeaderValue);
             ZimbraLog.filter.debug("Header value after unfolding and decoding: %s", unfoldedAndDecodedHeaderValue);
         } catch (UnsupportedEncodingException uee) {
-            ZimbraLog.filter.debug("Failed to decode \"%s\"", MimeUtility.unfold(header.getValue()));
-            throw new MessagingException("Exception occured while decoding header value.", uee);
+         // value would contain any un-decodable value, fine
         }
 
         if (this.valueTag) {

--- a/store/src/java/com/zimbra/cs/filter/jsieve/HeaderTest.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/HeaderTest.java
@@ -348,11 +348,13 @@ public class HeaderTest extends Header {
                 }
                 List<String> decodedValues = new ArrayList<>();
                 for (String value : values) {
+                    value = MimeUtility.unfold(value);
                     try {
-                        decodedValues.add(MimeUtility.decodeText(MimeUtility.unfold(value)));
+                        value = MimeUtility.decodeText(value);
                     } catch (UnsupportedEncodingException e) {
-                        throw new SieveMailException("Exception occured while decoding header value", e);
+                        // "value" would contain the undecoded value, fine
                     }
+                    decodedValues.add(value);
                 }
                 values = decodedValues;
                 break;


### PR DESCRIPTION
[bug]
The way of handling the error case regarding the ":matches"
operation has been altered, any mal-encoded value cancels
the filter execution with UnsupportedEncodingException,
and the message is delivered to the Inbox.

Previously, when the header value was mal-encoded, the
:matches compared the "key" to the header value "as is"
(the encoded value).

[root cause]
Each header value is decoded and unfolded before the match
operation is attempted.  When MimeUtility.decodeText() tries
to decode the header value, and if it finds that the given
value is mal-encoded, it throws the UnsupportedEncodingException.
In reality, as the header would contain the un-decodable
value, it is totally fine to ignore such exception.

This issue affects:
 * header test
 * address test
 * addheader action
 * deleteheader action
 * replaceheader action

[fix]
When the ":matches" operation needs to handle a mal-encoded
header value, it will no longer throw the UnsupportedEncodingException
and it will not abort the filter execution any more.
The mal-encoded header value will be compared with the
keys "as is" (as a not-encoded-just-a-plain-ascii string).

* unit test
  - removed an old test cases (HeaderTest.ttt())
  - Fix to add an initialization of the filter rule (HeaderTest.doTest())