### PR TITLE
zcs-2520:replaceheader may break the message structure

### DIFF
--- a/store/src/java-test/com/zimbra/cs/filter/ReplaceHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/ReplaceHeaderTest.java
@@ -1666,15 +1666,10 @@ public class ReplaceHeaderTest {
                             Mailbox.ID_FOLDER_INBOX, true);
             Integer itemId = mbox1.getItemIds(null, Mailbox.ID_FOLDER_INBOX).getIds(MailItem.Type.MESSAGE).get(0);
             Message message = mbox1.getMessageById(null, itemId);
-            String newSubject = "";
-            for (Enumeration<Header> enumeration = message.getMimeMessage().getAllHeaders(); enumeration.hasMoreElements();) {
-                Header temp = enumeration.nextElement();
-                if ("X-Header-With-Control-Chars2".equals(temp.getName())) {
-                    newSubject = temp.getValue();
-                    break;
-                }
-            }
-            Assert.assertEquals("[Test]line 1 CRLF\r\n line 2", newSubject);
+            String[] headers = message.getMimeMessage().getHeader("X-Header-With-Control-Chars2");
+            Assert.assertNotNull(headers);
+            Assert.assertNotSame(0, headers.length);
+            Assert.assertEquals("=?UTF-8?B?W1Rlc3RdbGluZSAxIENSTEYNCiBsaW5lIDINCg==?=", headers[0]);
         } catch (Exception e) {
             fail("No exception should be thrown: " + e.getMessage());
         }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/AddHeader.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/AddHeader.java
@@ -48,6 +48,7 @@ import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.filter.FilterUtil;
 import com.zimbra.cs.filter.ZimbraMailAdapter;
 import com.zimbra.cs.filter.ZimbraMailAdapter.PARSESTATUS;
+import com.zimbra.cs.mime.MimeUtil;
 
 
 public class AddHeader extends AbstractCommand {
@@ -90,7 +91,7 @@ public class AddHeader extends AbstractCommand {
 
         headerValue = FilterUtil.replaceVariables(mailAdapter, headerValue);
         try {
-            headerValue = MimeUtility.fold(headerName.length() + 2, MimeUtility.encodeText(headerValue));
+            headerValue = MimeUtility.fold(headerName.length() + 2, MimeUtil.encodeWord(headerValue, null, null, true));
         } catch (UnsupportedEncodingException uee) {
             throw new OperationException("addheader: Error occured while encoding header value.", uee);
         }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/ReplaceHeader.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/ReplaceHeader.java
@@ -42,6 +42,7 @@ import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.filter.FilterUtil;
 import com.zimbra.cs.filter.ZimbraMailAdapter;
 import com.zimbra.cs.filter.ZimbraMailAdapter.PARSESTATUS;
+import com.zimbra.cs.mime.MimeUtil;
 
 public class ReplaceHeader extends AbstractCommand {
     private EditHeaderExtension ehe = new EditHeaderExtension();
@@ -130,7 +131,7 @@ public class ReplaceHeader extends AbstractCommand {
                                 }
                                 if (ehe.getNewValue() != null) {
                                     newHeaderValue = FilterUtil.replaceVariables(mailAdapter, ehe.getNewValue());
-                                    newHeaderValue = MimeUtility.fold(newHeaderName.length() + 2, MimeUtility.encodeText(newHeaderValue));
+                                    newHeaderValue = MimeUtility.fold(newHeaderName.length() + 2, MimeUtil.encodeWord(newHeaderValue, null, null, true));
                                 } else {
                                     newHeaderValue = header.getValue();
                                 }

--- a/store/src/java/com/zimbra/cs/mime/MimeUtil.java
+++ b/store/src/java/com/zimbra/cs/mime/MimeUtil.java
@@ -1,0 +1,179 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2017 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.mime;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+
+import javax.mail.internet.MimeUtility;
+
+import com.sun.mail.util.BEncoderStream;
+import com.sun.mail.util.PropUtil;
+import com.sun.mail.util.QEncoderStream;
+
+public class MimeUtil {
+    /** (non-Javadoc)
+     * Encode <tt>string</tt> no matter what characters are contained in it.
+     * @param string text to be encoded
+     * @param charset if it's set to <tt>null</tt>, UTF-8 is chosen as default
+     * @param encoding if it's set to <tt>null</tt>, base64 encoding is chosen as default
+     * @param encodingWord available when encoding is "quoted-printable". If it's set to <tt>false</tt>,
+     * only "=_?" characters are encoded, otherwise "=_?\"#$%&'(),.:;<>@[\\]^`{|}~" will be encoded.
+     * @return encoded text
+     * @throws UnsupportedEncodingException
+     *
+     * @see  javax.mail.internet.MimeUtility.encodeWord(String string, String charset, String encoding, boolean encodingWord)
+     */
+    public static String encodeWord(String string, String charset,
+            String encoding, boolean encodingWord) throws UnsupportedEncodingException {
+        if (!string.contains("\r") && !string.contains("\n")){
+            String result = string;
+            try {
+                result = MimeUtility.encodeText(string);
+            } catch (UnsupportedEncodingException e) {
+                // ignore the exception and return the source string as is.
+            }
+            return result;
+        }
+
+        // Else, apply the specified charset conversion.
+        String jcharset;
+        if (charset == null) { // use default charset
+            jcharset = MimeUtility.getDefaultJavaCharset(); // the java charset
+            charset = getDefaultMIMECharset(); // the MIME equivalent
+        } else // MIME charset -> java charset
+            jcharset = MimeUtility.javaCharset(charset);
+
+        // If no transfer-encoding is specified, figure one out.
+        if (encoding == null) {
+            encoding = "B";
+        }
+
+        boolean b64;
+        if (encoding.equalsIgnoreCase("B")) {
+            b64 = true;
+        } else if (encoding.equalsIgnoreCase("Q")) {
+            b64 = false;
+        } else {
+            throw new UnsupportedEncodingException(
+                    "Unknown transfer encoding: " + encoding);
+        }
+
+        StringBuffer outb = new StringBuffer(); // the output buffer
+        doEncode(string, b64, jcharset,
+                // As per RFC 2047, size of an encoded string should not
+                // exceed 75 bytes.
+                // 7 = size of "=?", '?', 'B'/'Q', '?', "?="
+                75 - 7 - charset.length(), // the available space
+                "=?" + charset + "?" + encoding + "?", // prefix
+                true, encodingWord, outb);
+
+        return outb.toString();
+    }
+
+    /*
+     * The following two properties allow disabling the fold()
+     * and unfold() methods and reverting to the previous behavior.
+     * They should never need to be changed and are here only because
+     * of my paranoid concern with compatibility.
+     */
+    private static final boolean foldEncodedWords =
+            PropUtil.getBooleanSystemProperty("mail.mime.foldencodedwords", false);
+
+    /** (non-Javadoc)
+     * @see javax.mail.internet.MimeUtility.doEncode(String string, boolean b64, String jcharset, int avail, String prefix, boolean first, boolean encodingWord, StringBuffer buf)
+     */
+    private static void doEncode(String string, boolean b64,
+            String jcharset, int avail, String prefix,
+            boolean first, boolean encodingWord, StringBuffer buf)
+                    throws UnsupportedEncodingException {
+
+        // First find out what the length of the encoded version of
+        // 'string' would be.
+        byte[] bytes = string.getBytes(jcharset);
+        int len;
+        if (b64) {
+            // "B" encoding
+            len = BEncoderStream.encodedLength(bytes);
+        } else {
+            // "Q"
+            len = QEncoderStream.encodedLength(bytes, encodingWord);
+        }
+
+        int size;
+        if ((len > avail) && ((size = string.length()) > 1)) {
+            // If the length is greater than 'avail', split 'string'
+            // into two and recurse.
+            doEncode(string.substring(0, size/2), b64, jcharset,
+                    avail, prefix, first, encodingWord, buf);
+            doEncode(string.substring(size/2, size), b64, jcharset,
+                    avail, prefix, false, encodingWord, buf);
+        } else {
+            // length <= than 'avail'. Encode the given string
+            ByteArrayOutputStream os = new ByteArrayOutputStream();
+            OutputStream eos; // the encoder
+            if (b64) {
+                // "B" encoding
+                eos = new BEncoderStream(os);
+            } else {
+                // "Q" encoding
+                eos = new QEncoderStream(os, encodingWord);
+            }
+
+            try { // do the encoding
+                eos.write(bytes);
+                eos.close();
+            } catch (IOException ioex) { }
+
+            byte[] encodedBytes = os.toByteArray(); // the encoded stuff
+            // Now write out the encoded (all ASCII) bytes into our
+            // StringBuffer
+            if (!first) {
+                // not the first line of this sequence
+                if (foldEncodedWords) {
+                    buf.append("\r\n "); // start a continuation line
+                } else {
+                    buf.append(" "); // line will be folded later
+                }
+            }
+
+            buf.append(prefix);
+            for (int i = 0; i < encodedBytes.length; i++) {
+                buf.append((char)encodedBytes[i]);
+            }
+            buf.append("?="); // terminate the current sequence
+        }
+    }
+
+    /*
+     * Get the default MIME charset for this locale.
+     */
+    private static String defaultMIMECharset;
+    static String getDefaultMIMECharset() {
+        if (defaultMIMECharset == null) {
+            try {
+                defaultMIMECharset = System.getProperty("mail.mime.charset");
+            } catch (SecurityException ex) { }  // ignore it
+        }
+        if (defaultMIMECharset == null) {
+            defaultMIMECharset = MimeUtility.mimeCharset(MimeUtility.getDefaultJavaCharset());
+        }
+        return defaultMIMECharset;
+    }
+}

--- a/store/src/java/com/zimbra/cs/mime/MimeUtil.java
+++ b/store/src/java/com/zimbra/cs/mime/MimeUtil.java
@@ -57,8 +57,9 @@ public class MimeUtil {
         if (charset == null) { // use default charset
             jcharset = MimeUtility.getDefaultJavaCharset(); // the java charset
             charset = getDefaultMIMECharset(); // the MIME equivalent
-        } else // MIME charset -> java charset
+        } else { // MIME charset -> java charset
             jcharset = MimeUtility.javaCharset(charset);
+        }
 
         // If no transfer-encoding is specified, figure one out.
         if (encoding == null) {


### PR DESCRIPTION
[Bug]
Performing replaceheader to the header with encoded line-breaks may break the message structure.  When the replaceheader generates the following style of the header, any undesired headers may be added or the MIME structure of the resulting message may be broken.
The resulting header value after replaceheader...
 - contains one or more than one line break characters (0x0A or 0x0D)
 - consists of only printable US-ASCII characters (0x21 - 0x7E), space (0x20), or tab (0x09)
 - the first character of the second line or later starts at the beginning of the line.

[Fix]
If the modified header value meets the following condition, that modified header value will be Base64 encoded:
 - the text consists of only 0x21 - 0x7E, 0x20, 0x09, 0x0A, and 0x0D
 - the 0x0A and/or 0x0D is in the middle of the text.

[Affected area]
  replaceheader
  addheader