### PR TITLE
ZCS-2388 : Editheader actions should not be supported in zimbraMail namespace

### DIFF
--- a/store/src/java-test/com/zimbra/cs/service/mail/GetFilterRulesTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/mail/GetFilterRulesTest.java
@@ -18,6 +18,7 @@ package com.zimbra.cs.service.mail;
 
 import com.google.common.collect.Maps;
 import com.zimbra.common.account.Key;
+import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.MailConstants;
 import com.zimbra.cs.account.Account;
@@ -693,6 +694,66 @@ public class GetFilterRulesTest {
             XMLDiffChecker.assertXMLEquals(expectedSoap, response.prettyPrint());
         } catch (Exception e) {
             fail("No exception should be thrown" + e);
+        }
+    }
+
+    @Test
+    public void testNegativeCaseAddheaderAction() {
+        try {
+            Account acct = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+            RuleManager.clearCachedRules(acct);
+
+            String filterScript = "require [\"editheader\"];\n" +
+                "\n" +
+                "# t60\n" +
+                "addheader \"X-Test-Header\" \"test value\";\n";
+            acct.setMailSieveScript(filterScript);
+
+            Element request = new Element.XMLElement(MailConstants.GET_FILTER_RULES_REQUEST);
+            new GetFilterRules().handle(request, ServiceTestUtil.getRequestContext(acct));
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ServiceException);
+            Assert.assertEquals("parse error: Invalid addheader action: addheader action is not allowed in user scripts", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testNegativeCaseDeleteheaderAction() {
+        try {
+            Account acct = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+            RuleManager.clearCachedRules(acct);
+
+            String filterScript = "require [\"editheader\"];\n" +
+                "\n" +
+                "# t60\n" +
+                "deleteheader \"X-Test-Header\";\n";
+            acct.setMailSieveScript(filterScript);
+
+            Element request = new Element.XMLElement(MailConstants.GET_FILTER_RULES_REQUEST);
+            new GetFilterRules().handle(request, ServiceTestUtil.getRequestContext(acct));
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ServiceException);
+            Assert.assertEquals("parse error: Invalid deleteheader action: deleteheader action is not allowed in user scripts", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testNegativeCaseReplaceheaderAction() {
+        try {
+            Account acct = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+            RuleManager.clearCachedRules(acct);
+
+            String filterScript = "require [\"editheader\"];\n" +
+                "\n" +
+                "# t60\n" +
+                "replaceheader :newvalue \"[test]\" :is \"X-Test-Header\" \"test value\";\n";
+            acct.setMailSieveScript(filterScript);
+
+            Element request = new Element.XMLElement(MailConstants.GET_FILTER_RULES_REQUEST);
+            new GetFilterRules().handle(request, ServiceTestUtil.getRequestContext(acct));
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ServiceException);
+            Assert.assertEquals("parse error: Invalid replaceheader action: replaceheader action is not allowed in user scripts", e.getMessage());
         }
     }
 }

--- a/store/src/java-test/com/zimbra/cs/service/mail/ModifyFilterRulesTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/mail/ModifyFilterRulesTest.java
@@ -707,4 +707,99 @@ public class ModifyFilterRulesTest {
 
         assertEquals(expectedScript, acct.getMailSieveScript());
     }
+
+    @Test
+    public void testNegativeAddheaderAction() {
+        try {
+            Account account = Provisioning.getInstance().getAccount(
+                    MockProvisioning.DEFAULT_ACCOUNT_ID);
+            RuleManager.clearCachedRules(account);
+
+            String xml = "<ModifyFilterRulesRequest xmlns=\"urn:zimbraMail\">\n" +
+                "      <filterRules>\n" +
+                "        <filterRule name=\"t60\" active=\"1\">\n" +
+                "          <filterTests condition=\"anyof\" index=\"1\">\n" +
+                "            <headerTest stringComparison=\"matches\" header=\"subject\" value=\"*\"/>\n" +
+                "          </filterTests>\n" +
+                "          <filterActions index=\"2\">\n" +
+                "            <actionAddheader>\n" +
+                "              <headerName>sub2</headerName>\n" +
+                "              <headerValue>${1}</headerValue>\n" +
+                "            </actionAddheader>\n" +
+                "          </filterActions>\n" +
+                "        </filterRule>\n" +
+                "      </filterRules>\n" +
+                "</ModifyFilterRulesRequest>";
+
+            Element request = Element.parseXML(xml);
+            new ModifyFilterRules().handle(request, ServiceTestUtil.getRequestContext(account));
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ServiceException);
+            Assert.assertEquals("parse error: Invalid addheader action: addheader action is not allowed in user scripts", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testNegativeDeleteheaderAction() {
+        try {
+            Account account = Provisioning.getInstance().getAccount(
+                    MockProvisioning.DEFAULT_ACCOUNT_ID);
+            RuleManager.clearCachedRules(account);
+
+            String xml = "<ModifyFilterRulesRequest xmlns=\"urn:zimbraMail\">\n" +
+                "      <filterRules>\n" +
+                "        <filterRule name=\"t60\" active=\"1\">\n" +
+                "          <filterTests condition=\"anyof\" index=\"1\">\n" +
+                "            <headerTest stringComparison=\"matches\" header=\"subject\" value=\"*\"/>\n" +
+                "          </filterTests>\n" +
+                "          <filterActions index=\"2\">\n" +
+                "            <actionDeleteheader>\n" +
+                "              <headerName>sub2</headerName>\n" +
+                "            </actionDeleteheader>\n" +
+                "          </filterActions>\n" +
+                "        </filterRule>\n" +
+                "      </filterRules>\n" +
+                "</ModifyFilterRulesRequest>";
+
+            Element request = Element.parseXML(xml);
+            new ModifyFilterRules().handle(request, ServiceTestUtil.getRequestContext(account));
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ServiceException);
+            Assert.assertEquals("parse error: Invalid deleteheader action: deleteheader action is not allowed in user scripts", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testNegativeReplaceheaderAction() {
+        try {
+            Account account = Provisioning.getInstance().getAccount(
+                    MockProvisioning.DEFAULT_ACCOUNT_ID);
+            RuleManager.clearCachedRules(account);
+
+            String xml = "<ModifyFilterRulesRequest xmlns=\"urn:zimbraMail\">\n" +
+                "      <filterRules>\n" +
+                "        <filterRule name=\"t60\" active=\"1\">\n" +
+                "          <filterTests condition=\"anyof\" index=\"1\">\n" +
+                "            <headerTest stringComparison=\"matches\" header=\"subject\" value=\"*\"/>\n" +
+                "          </filterTests>\n" +
+                "          <filterActions index=\"2\">\n" +
+                "            <actionReplaceheader>\n" +
+                "              <newValue>new_header_value</newValue>\n" +
+                "              <test>\n" +
+                "                <headerName>sub2</headerName>\n" +
+                "                <headerValue>test testing</headerValue>\n" +
+                "              </test>\n" +
+                "            </actionReplaceheader>\n" +
+                "          </filterActions>\n" +
+                "        </filterRule>\n" +
+                "      </filterRules>\n" +
+                "</ModifyFilterRulesRequest>";
+
+            Element request = Element.parseXML(xml);
+            new ModifyFilterRules().handle(request, ServiceTestUtil.getRequestContext(account));
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ServiceException);
+            Assert.assertEquals("parse error: Invalid replaceheader action: replaceheader action is not allowed in user scripts", e.getMessage());
+        }
+    }
 }

--- a/store/src/java/com/zimbra/cs/filter/RuleManager.java
+++ b/store/src/java/com/zimbra/cs/filter/RuleManager.java
@@ -816,7 +816,7 @@ public final class RuleManager {
         }
         String sieveScriptAttrName = getAdminScriptAttributeName(filterType, afType);
         SieveToSoap sieveToSoap = new SieveToSoap(getRuleNames(entry.getAttr(sieveScriptAttrName)));
-        sieveToSoap.accept(node);
+        sieveToSoap.accept(node, true);
         return sieveToSoap.toFilterRules();
     }
 

--- a/store/src/java/com/zimbra/cs/filter/SieveVisitor.java
+++ b/store/src/java/com/zimbra/cs/filter/SieveVisitor.java
@@ -403,7 +403,15 @@ public abstract class SieveVisitor {
         accept(node, null);
     }
 
+    public void accept(Node node, boolean isAdminScript) throws ServiceException {
+        accept(node, null, isAdminScript);
+    }
+
     private void accept(Node parent, RuleProperties props) throws ServiceException {
+        accept(parent, props, false);
+    }
+
+    private void accept(Node parent, RuleProperties props, boolean isAdminScript) throws ServiceException {
         visitNode(parent, VisitPhase.begin, props);
 
         int numChildren = parent.jjtGetNumChildren();
@@ -422,7 +430,7 @@ public abstract class SieveVisitor {
             } else if (node instanceof ASTtest) {
                 acceptTest(node, props);
             } else if (node instanceof ASTcommand) {
-                acceptAction(node, props);
+                acceptAction(node, props, isAdminScript);
             } else {
                 accept(node, props);
             }
@@ -759,7 +767,7 @@ public abstract class SieveVisitor {
         visitTest(node, VisitPhase.end, props);
     }
 
-    private void acceptAction(Node node, RuleProperties props) throws ServiceException {
+    private void acceptAction(Node node, RuleProperties props, boolean isAdminScript) throws ServiceException {
         visitAction(node, VisitPhase.begin, props);
         String nodeName = getNodeName(node);
 
@@ -955,11 +963,23 @@ public abstract class SieveVisitor {
                 throw ServiceException.PARSE_ERROR("Invalid log action: Missing log message", null);
             }
         } else if ("addheader".equalsIgnoreCase(nodeName)) {
-            parseAddheader(node, props);
+            if (isAdminScript) {
+                parseAddheader(node, props);
+            } else {
+                throw ServiceException.PARSE_ERROR("Invalid addheader action: addheader action is not allowed in user scripts", null);
+            }
         } else if ("deleteheader".equalsIgnoreCase(nodeName)) {
-            parseDeleteheader(node, props);
+            if (isAdminScript) {
+                parseDeleteheader(node, props);
+            } else {
+                throw ServiceException.PARSE_ERROR("Invalid deleteheader action: deleteheader action is not allowed in user scripts", null);
+            }
         } else if ("replaceheader".equalsIgnoreCase(nodeName)) {
-            parseReplaceheader(node, props);
+            if (isAdminScript) {
+                parseReplaceheader(node, props);
+            } else {
+                throw ServiceException.PARSE_ERROR("Invalid replaceheader action: replaceheader action is not allowed in user scripts", null);
+            }
         } else {
             accept(node, props);
         }


### PR DESCRIPTION
Problem : editheader actions should not be supported in user script using api

Fix : Allowed editheader actions only in admin scripts using api

Testing done :
1) api tested manually
2) added unit tests to verify the same