### PR TITLE
Bugfix/zcs 2638

### DIFF
--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -281,6 +281,7 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
     private Element mVoiceStorePrincipal;
     private long mSize;
     private boolean mNoTagCache;
+    private boolean alwaysRefreshFolders;
     private ZContactByPhoneCache mContactByPhoneCache;
     private final ZMailboxLock lock;
     private int lastChangeId = 0;
@@ -394,6 +395,7 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
         private String mDeviceId;
         private boolean mGenerateDeviceId;
         private SoapTransport.NotificationFormat notificationFormat = SoapTransport.NotificationFormat.DEFAULT;
+        private boolean alwaysRefreshFolders;
 
         public Options() {
         }
@@ -449,6 +451,9 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
 
         public ZAuthToken getAuthToken() { return mAuthToken; }
         public Options setAuthToken(ZAuthToken authToken) { mAuthToken = authToken;  return this; }
+
+        public boolean getAlwaysRefreshFolders() { return alwaysRefreshFolders; }
+        public Options setAlwaysRefreshFolders(boolean alwaysRefresh) { alwaysRefreshFolders = alwaysRefresh; return this; }
 
         public SoapTransport.NotificationFormat getNotificationFormat() {
             return notificationFormat;
@@ -664,6 +669,7 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
         }
         mNotificationFormat = options.getNotificationFormat();
         mNotifyPreference = SessionPreference.fromOptions(options);
+        alwaysRefreshFolders = options.getAlwaysRefreshFolders();
 
         mClientIp = options.getClientIp();
 
@@ -4025,8 +4031,12 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
 
     private void populateFolderCache() throws ServiceException {
         if (mUserRoot != null) {
+            if(alwaysRefreshFolders) {
+                noOp();
+            }
             return;
         }
+
         if (mNotifyPreference == null || mNotifyPreference == SessionPreference.full) {
             noOp();
             if (mUserRoot != null) {

--- a/store/src/java/com/zimbra/cs/imap/ImapCredentials.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapCredentials.java
@@ -143,6 +143,7 @@ public class ImapCredentials implements java.io.Serializable {
             options.setNoSession(false);
             options.setUserAgent("zclient-imap", SystemUtil.getProductVersion());
             options.setNotificationFormat(NotificationFormat.IMAP);
+            options.setAlwaysRefreshFolders(true);
             MailboxStore store =  ZMailbox.getMailbox(options);
             mStore = ImapMailboxStore.get(store, mAccountId);
             ZimbraLog.imap.debug("Registering listener with ZMailbox");

--- a/store/src/java/com/zimbra/cs/imap/ImapListener.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapListener.java
@@ -460,7 +460,6 @@ public abstract class ImapListener extends Session {
         } else if (id == folderId.id && mFolder instanceof ImapFolder) {
             // Once the folder's gone, there's no point in keeping an IMAP Session listening on it around.
             detach();
-            removeFromSessionCache();
             //set MailStore to NULL before closing connection to avoid serializing this session
             mailbox = null;
 

--- a/store/src/java/com/zimbra/cs/imap/ImapPath.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapPath.java
@@ -30,7 +30,6 @@ import com.zimbra.common.mailbox.ItemIdentifier;
 import com.zimbra.common.mailbox.MailboxStore;
 import com.zimbra.common.mailbox.MountpointStore;
 import com.zimbra.common.service.ServiceException;
-import com.zimbra.common.soap.SoapTransport.NotificationFormat;
 import com.zimbra.common.util.Pair;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;

--- a/store/src/java/com/zimbra/cs/imap/ImapPath.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapPath.java
@@ -30,6 +30,7 @@ import com.zimbra.common.mailbox.ItemIdentifier;
 import com.zimbra.common.mailbox.MailboxStore;
 import com.zimbra.common.mailbox.MountpointStore;
 import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.SoapTransport.NotificationFormat;
 import com.zimbra.common.util.Pair;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
@@ -308,6 +309,7 @@ public class ImapPath implements Comparable<ImapPath> {
                     AccountUtil.getSoapUri(target));
             options.setTargetAccount(target.getName());
             options.setNoSession(true);
+            options.setAlwaysRefreshFolders(true);
             ZMailbox zmbx = ZMailbox.getMailbox(options);
             zmbx.setAccountId(target.getId()); /* need this when logging in using another user's auth */
             zmbx.setName(target.getName()); /* need this when logging in using another user's auth */

--- a/store/src/java/com/zimbra/cs/imap/ImapRemoteSession.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapRemoteSession.java
@@ -90,6 +90,20 @@ public class ImapRemoteSession extends ImapListener {
         return true;
     }
 
+    private void unregisterFromRemoteServer() {
+        try {
+            ImapServerListenerPool.getInstance().getForAccountId(mailbox.getAccountId()).removeListener(this);
+        } catch (ServiceException e) {
+            ZimbraLog.imap.error(e);
+        }
+    }
+
+    @Override
+    public ImapListener detach() {
+        unregisterFromRemoteServer();
+        return super.detach();
+    }
+
     @Override
     protected void notifyPendingCreates(@SuppressWarnings("rawtypes") PendingModifications pnsIn,
             int changeId, AddedItems added) {

--- a/store/src/java/com/zimbra/qa/unittest/SharedImapTests.java
+++ b/store/src/java/com/zimbra/qa/unittest/SharedImapTests.java
@@ -885,6 +885,23 @@ public abstract class SharedImapTests extends ImapTestBase {
     }
 
     @Test(timeout=100000)
+    public void testListSubfolders() throws Exception {
+        String testFolder = "imaptest1";
+        String testSubFolder = "test";
+        connection = connectAndLogin(USER);
+        otherConnection = connectAndLogin(USER);
+        List<ListData> listData = connection.list("", "");
+        assertEquals("expecting list response length to be 1", 1, listData.size());
+        char delimiter = listData.get(0).getDelimiter();
+        connection.create(testFolder + delimiter);
+        String testSubFolderPath = String.format("%s%s%s", testFolder, delimiter, testSubFolder);
+        listData = otherConnection.list("", String.format("%s%s%%",testFolder, delimiter));
+        assertEquals("expecting to find one subfolder", 1, listData.size());
+        String foundFolder = listData.get(0).getMailbox();
+        assertEquals(String.format("Expecting to find %s folder in list response", testSubFolderPath), testSubFolderPath, foundFolder);
+    }
+
+    @Test(timeout=100000)
     public void testFolderDeletedByOtherConnectionSelected() throws Exception {
         String newFolder = "imaptest1";
         connection = connectAndLogin(USER);

--- a/store/src/java/com/zimbra/qa/unittest/SharedImapTests.java
+++ b/store/src/java/com/zimbra/qa/unittest/SharedImapTests.java
@@ -895,6 +895,7 @@ public abstract class SharedImapTests extends ImapTestBase {
         char delimiter = listData.get(0).getDelimiter();
         connection.create(testFolder + delimiter);
         String testSubFolderPath = String.format("%s%s%s", testFolder, delimiter, testSubFolder);
+        connection.create(testSubFolderPath);
         listData = otherConnection.list("", String.format("%s%s%%",testFolder, delimiter));
         assertEquals("expecting to find one subfolder", 1, listData.size());
         String foundFolder = listData.get(0).getMailbox();


### PR DESCRIPTION
This PR addresses the scenarios where remote IMAP server uses outdated list of folders when processing IMAP requests. The two scenarios that I found so far are 
1) a remote IMAP session in a non-selected state does not pick up folder changes from SOAP notifications
2) a remote IMAP session finds cached folder in IMAP session cache after that folder has been deleted and re-created with the same path

These changes bring the number of IMAP compliance test failures on remote IMAP down to 13 (the same as local IMAP and older ZCS versions)