### PR TITLE
ZCS-1010:Add an attribute for comparator in case of valueComparison

### DIFF
--- a/common/src/java/com/zimbra/common/soap/MailConstants.java
+++ b/common/src/java/com/zimbra/common/soap/MailConstants.java
@@ -679,6 +679,7 @@ public final class MailConstants {
     public static final String A_STRING_COMPARISON = "stringComparison";
     public static final String A_VALUE_COMPARISON = "valueComparison";
     public static final String A_COUNT_COMPARISON = "countComparison";
+    public static final String A_VALUE_COMPARISON_COMPARATOR = "valueComparisonComparator";
     public static final String A_CASE_SENSITIVE = "caseSensitive";
     public static final String A_NUMBER_COMPARISON = "numberComparison";
     public static final String A_DATE_COMPARISON = "dateComparison";

--- a/soap/src/java/com/zimbra/soap/mail/type/FilterTest.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/FilterTest.java
@@ -138,6 +138,12 @@ public class FilterTest {
         @XmlAttribute(name=MailConstants.A_COUNT_COMPARISON /* countComparison */, required=false)
         private String countComparison;
 
+        /**
+         * @zm-api-field-tag value-comparison-comparator
+         * @zm-api-field-description value comparison comparator - <b>i;ascii-numeric|i;ascii-casemap|i;octet</b>
+         */
+        @XmlAttribute(name=MailConstants.A_VALUE_COMPARISON_COMPARATOR /* valueComparisonComparator */, required=false)
+        private String valueComparisonComparator;
 
         public String getHeader() {
             return header;
@@ -198,6 +204,14 @@ public class FilterTest {
             this.countComparison = countComparison;
         }
 
+        public String getValueComparisonComparator() {
+            return valueComparisonComparator;
+        }
+
+        public void setValueComparisonComparator(String valueComparisonComparator) {
+            this.valueComparisonComparator = valueComparisonComparator;
+        }
+
         @Override
         public String toString() {
             return Objects.toStringHelper(this)
@@ -205,6 +219,7 @@ public class FilterTest {
                 .add("part", part)
                 .add("comparison", comparison)
                 .add("valueComparison", valueComparison)
+                .add("valueComparisonComparator", valueComparisonComparator)
                 .add("countComparison", countComparison)
                 .add("caseSensitive", caseSensitive)
                 .add("value", value)
@@ -516,7 +531,7 @@ public class FilterTest {
     }
 
     @XmlAccessorType(XmlAccessType.NONE)
-    @JsonPropertyOrder({ "index", "negative", "header", "caseSensitive", "stringComparison", "valueComparison", "countComparison", "value" })
+    @JsonPropertyOrder({ "index", "negative", "header", "caseSensitive", "stringComparison", "valueComparison","valueComparisonComparator", "countComparison", "value" })
     public static final class HeaderTest extends FilterTest {
 
         // Comma separated list
@@ -547,6 +562,13 @@ public class FilterTest {
          */
         @XmlAttribute(name=MailConstants.A_COUNT_COMPARISON /* countComparison */, required=false)
         private String countComparison;
+
+        /**
+         * @zm-api-field-tag value-comparison-comparator
+         * @zm-api-field-description value comparison comparator - <b>i;ascii-numeric|i;ascii-casemap|i;octet</b>
+         */
+        @XmlAttribute(name=MailConstants.A_VALUE_COMPARISON_COMPARATOR /* valueComparisonComparator */, required=false)
+        private String valueComparisonComparator;
 
         /**
          * @zm-api-field-tag value
@@ -625,12 +647,21 @@ public class FilterTest {
             this.value = value;
         }
 
+        public String getValueComparisonComparator() {
+            return valueComparisonComparator;
+        }
+
+        public void setValueComparisonComparator(String valueComparisonComparator) {
+            this.valueComparisonComparator = valueComparisonComparator;
+        }
+
         @Override
         public String toString() {
             return Objects.toStringHelper(this)
                 .add("headers", headers)
                 .add("stringComparison", stringComparison)
                 .add("valueComparison", valueComparison)
+                .add("valueComparisonComparator", valueComparisonComparator)
                 .add("countComparison", countComparison)
                 .add("value", value)
                 .add("caseSensitive", caseSensitive)

--- a/store/docs/soap-admin.txt
+++ b/store/docs/soap-admin.txt
@@ -2997,6 +2997,16 @@ Tests:
   <addressBookTest header="{header-name}"/>
   <addressTest [part="{all|localpart|domain}"] stringComparison="{type}" [caseSensitive="{0|1}"]
       header="{comma-separated-header-names}" value="{value}"/>
+  <addressTest [part="{all|localpart|domain}"] valueComparison="{gt|ge|lt|le|eq|ne}" [valueComparisonComparator="{i;ascii-numeric|i;ascii-casemap|i;octet}"] [caseSensitive="{0|1}"]
+      header="{comma-separated-header-names}" value="{value}"/>
+  <addressTest [part="{all|localpart|domain}"] countComparison="{gt|ge|lt|le|eq|ne}"
+      header="{comma-separated-header-names}" value="{value}"/>
+  <envelopeTest [part="{all|localpart|domain}"] stringComparison="{type}" [caseSensitive="{0|1}"]
+      header="{comma-separated-header-names}" value="{value}"/>
+  <envelopeTest [part="{all|localpart|domain}"] valueComparison="{gt|ge|lt|le|eq|ne}" [valueComparisonComparator="{i;ascii-numeric|i;ascii-casemap|i;octet}"] [caseSensitive="{0|1}"]
+      header="{comma-separated-header-names}" value="{value}"/>
+  <envelopeTest [part="{all|localpart|domain}"] countComparison="{gt|ge|lt|le|eq|ne}"
+      header="{comma-separated-header-names}" value="{value}"/>
   <attachmentTest/>
   <bulkTest/>
   <contactRankingTest header="{header-name}"/>
@@ -3009,6 +3019,8 @@ Tests:
   <flaggedTest flagName="{flagged|read|priority}"/>
   <headerExistsTest header="{header-name}"/>
   <headerTest header="{comma-separated-header-names}" stringComparison="{type}" [caseSensitive="{0|1}"] value="{value}"/>
+  <headerTest header="{comma-separated-header-names}" valueComparison="{gt|ge|lt|le|eq|ne}" [valueComparisonComparator="{i;ascii-numeric|i;ascii-casemap|i;octet}"] [caseSensitive="{0|1}"] value="{value}"/>
+  <headerTest header="{comma-separated-header-names}" countComparison="{gt|ge|lt|le|eq|ne}" value="{value}"/>
   <importanceTest imp="{high|normal|low}"/>
   <inviteTest>
     <method>{method}</method>+

--- a/store/docs/soap.txt
+++ b/store/docs/soap.txt
@@ -3259,6 +3259,16 @@ Tests:
   <addressBookTest header="{header-name}"/>
   <addressTest [part="{all|localpart|domain}"] stringComparison="{type}" [caseSensitive="{0|1}"]
       header="{comma-separated-header-names}" value="{value}"/>
+  <addressTest [part="{all|localpart|domain}"] valueComparison="{gt|ge|lt|le|eq|ne}" [valueComparisonComparator="{i;ascii-numeric|i;ascii-casemap|i;octet}"] [caseSensitive="{0|1}"]
+      header="{comma-separated-header-names}" value="{value}"/>
+  <addressTest [part="{all|localpart|domain}"] countComparison="{gt|ge|lt|le|eq|ne}"
+      header="{comma-separated-header-names}" value="{value}"/>
+  <envelopeTest [part="{all|localpart|domain}"] stringComparison="{type}" [caseSensitive="{0|1}"]
+      header="{comma-separated-header-names}" value="{value}"/>
+  <envelopeTest [part="{all|localpart|domain}"] valueComparison="{gt|ge|lt|le|eq|ne}" [valueComparisonComparator="{i;ascii-numeric|i;ascii-casemap|i;octet}"] [caseSensitive="{0|1}"]
+      header="{comma-separated-header-names}" value="{value}"/>
+  <envelopeTest [part="{all|localpart|domain}"] countComparison="{gt|ge|lt|le|eq|ne}"
+      header="{comma-separated-header-names}" value="{value}"/>
   <attachmentTest/>
   <bulkTest/>
   <contactRankingTest header="{header-name}"/>
@@ -3271,6 +3281,8 @@ Tests:
   <flaggedTest flagName="{flagged|read|priority}"/>
   <headerExistsTest header="{header-name}"/>
   <headerTest header="{comma-separated-header-names}" stringComparison="{type}" [caseSensitive="{0|1}"] value="{value}"/>
+  <headerTest header="{comma-separated-header-names}" valueComparison="{gt|ge|lt|le|eq|ne}" [valueComparisonComparator="{i;ascii-numeric|i;ascii-casemap|i;octet}"] [caseSensitive="{0|1}"] value="{value}"/>
+  <headerTest header="{comma-separated-header-names}" countComparison="{gt|ge|lt|le|eq|ne}" value="{value}"/>
   <importanceTest imp="{high|normal|low}"/>
   <inviteTest>
     <method>{method}</method>+

--- a/store/src/java-test/com/zimbra/cs/filter/ValueComparisonTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/ValueComparisonTest.java
@@ -1,0 +1,586 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2017 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.filter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.HashMap;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.zimbra.common.account.Key;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.MailConstants;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.MockProvisioning;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.service.mail.GetFilterRules;
+import com.zimbra.cs.service.mail.ModifyFilterRules;
+import com.zimbra.cs.service.mail.ServiceTestUtil;
+import com.zimbra.cs.util.XMLDiffChecker;
+
+public class ValueComparisonTest {
+
+    @BeforeClass
+    public static void init() throws Exception {
+        MailboxTestUtil.initServer();
+        Provisioning prov = Provisioning.getInstance();
+        prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        MailboxTestUtil.clearData();
+    }
+
+    /**
+     * Tests rule creation through ModifyFilterRulesRequest for header test having caseSensitive attribute with
+     * string comparison
+     * @throws Exception
+     */
+    @Test
+    public void testHeaderTestStringComparisonCaseSensitivity() throws Exception {
+        Account acct = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+        Element request = new Element.XMLElement(MailConstants.MODIFY_FILTER_RULES_REQUEST);
+
+        Element rules = request.addNonUniqueElement(MailConstants.E_FILTER_RULES);
+        Element rule = rules.addNonUniqueElement(MailConstants.E_FILTER_RULE);
+        rule.addAttribute(MailConstants.A_ACTIVE, true);
+        rule.addAttribute(MailConstants.A_NAME, "Test1");
+        Element filteraction = rule.addNonUniqueElement(MailConstants.E_FILTER_ACTIONS);
+        Element actionInto = filteraction.addNonUniqueElement(MailConstants.E_ACTION_FILE_INTO);
+        actionInto.addAttribute(MailConstants.A_FOLDER_PATH, "Junk");
+        filteraction.addNonUniqueElement(MailConstants.E_ACTION_STOP);
+        Element filterTests = rule.addNonUniqueElement(MailConstants.E_FILTER_TESTS);
+        filterTests.addAttribute(MailConstants.A_CONDITION, "anyof");
+        Element headerTest = filterTests.addNonUniqueElement(MailConstants.E_HEADER_TEST);
+        headerTest.addAttribute(MailConstants.A_HEADER, "subject");
+        headerTest.addAttribute(MailConstants.A_STRING_COMPARISON, "contains");
+        headerTest.addAttribute(MailConstants.A_CASE_SENSITIVE, "true");
+        headerTest.addAttribute(MailConstants.A_VALUE, "Important");
+
+        try {
+            new ModifyFilterRules().handle(request, ServiceTestUtil.getRequestContext(acct));
+        } catch (ServiceException e) {
+            fail("This test is expected not to throw exception. ");
+        }
+
+        String expectedScript = "require [\"fileinto\", \"copy\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\", \"enotify\"];\n\n";
+        expectedScript += "# Test1\n";
+        expectedScript += "if anyof (header :contains :comparator \"i;octet\" [\"subject\"] \"Important\") {\n";
+        expectedScript += "    fileinto \"Junk\";\n";
+        expectedScript += "    stop;\n";
+        expectedScript += "}\n";
+
+        ZimbraLog.filter.info(acct.getMailSieveScript());
+        ZimbraLog.filter.info(expectedScript);
+        assertEquals(expectedScript, acct.getMailSieveScript());
+    }
+
+    /**
+     * Tests rule creation through ModifyFilterRulesRequest for address test having caseSensitive attribute with
+     * string comparison
+     * @throws Exception
+     */
+    @Test
+    public void testAddressTestStringComparisonCaseSensitivity() throws Exception {
+        Account acct = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+        Element request = new Element.XMLElement(MailConstants.MODIFY_FILTER_RULES_REQUEST);
+
+        Element rules = request.addNonUniqueElement(MailConstants.E_FILTER_RULES);
+        Element rule = rules.addNonUniqueElement(MailConstants.E_FILTER_RULE);
+        rule.addAttribute(MailConstants.A_ACTIVE, true);
+        rule.addAttribute(MailConstants.A_NAME, "Test1");
+        Element filteraction = rule.addNonUniqueElement(MailConstants.E_FILTER_ACTIONS);
+        Element actionInto = filteraction.addNonUniqueElement(MailConstants.E_ACTION_FILE_INTO);
+        actionInto.addAttribute(MailConstants.A_FOLDER_PATH, "Junk");
+        filteraction.addNonUniqueElement(MailConstants.E_ACTION_STOP);
+        Element filterTests = rule.addNonUniqueElement(MailConstants.E_FILTER_TESTS);
+        filterTests.addAttribute(MailConstants.A_CONDITION, "anyof");
+        Element addressTest = filterTests.addNonUniqueElement(MailConstants.E_ADDRESS_TEST);
+        addressTest.addAttribute(MailConstants.A_HEADER, "from");
+        addressTest.addAttribute(MailConstants.A_STRING_COMPARISON, "contains");
+        addressTest.addAttribute(MailConstants.A_CASE_SENSITIVE, "true");
+        addressTest.addAttribute(MailConstants.A_VALUE, "abCD");
+
+        try {
+            new ModifyFilterRules().handle(request, ServiceTestUtil.getRequestContext(acct));
+        } catch (ServiceException e) {
+            fail("This test is expected not to throw exception. ");
+        }
+
+        String expectedScript = "require [\"fileinto\", \"copy\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\", \"enotify\"];\n\n";
+        expectedScript += "# Test1\n";
+        expectedScript += "if anyof (address :all :contains :comparator \"i;octet\" [\"from\"] \"abCD\") {\n";
+        expectedScript += "    fileinto \"Junk\";\n";
+        expectedScript += "    stop;\n";
+        expectedScript += "}\n";
+
+        ZimbraLog.filter.info(acct.getMailSieveScript());
+        ZimbraLog.filter.info(expectedScript);
+        assertEquals(expectedScript, acct.getMailSieveScript());
+    }
+
+    /**
+     * Tests rule creation through ModifyFilterRulesRequest for envelope test having caseSensitive attribute with
+     * string comparison
+     * @throws Exception
+     */
+    @Test
+    public void testEnvelopeTestStringComparisonCaseSensitivity() throws Exception {
+        Account acct = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+        Element request = new Element.XMLElement(MailConstants.MODIFY_FILTER_RULES_REQUEST);
+
+        Element rules = request.addNonUniqueElement(MailConstants.E_FILTER_RULES);
+        Element rule = rules.addNonUniqueElement(MailConstants.E_FILTER_RULE);
+        rule.addAttribute(MailConstants.A_ACTIVE, true);
+        rule.addAttribute(MailConstants.A_NAME, "Test1");
+        Element filteraction = rule.addNonUniqueElement(MailConstants.E_FILTER_ACTIONS);
+        Element actionInto = filteraction.addNonUniqueElement(MailConstants.E_ACTION_FILE_INTO);
+        actionInto.addAttribute(MailConstants.A_FOLDER_PATH, "Junk");
+        filteraction.addNonUniqueElement(MailConstants.E_ACTION_STOP);
+        Element filterTests = rule.addNonUniqueElement(MailConstants.E_FILTER_TESTS);
+        filterTests.addAttribute(MailConstants.A_CONDITION, "anyof");
+        Element envelopeTest = filterTests.addNonUniqueElement(MailConstants.E_ENVELOPE_TEST);
+        envelopeTest.addAttribute(MailConstants.A_HEADER, "from");
+        envelopeTest.addAttribute(MailConstants.A_STRING_COMPARISON, "contains");
+        envelopeTest.addAttribute(MailConstants.A_CASE_SENSITIVE, "true");
+        envelopeTest.addAttribute(MailConstants.A_VALUE, "abCD");
+
+        try {
+            new ModifyFilterRules().handle(request, ServiceTestUtil.getRequestContext(acct));
+        } catch (ServiceException e) {
+            fail("This test is expected not to throw exception. ");
+        }
+
+        String expectedScript = "require [\"fileinto\", \"copy\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\", \"enotify\"];\n\n";
+        expectedScript += "# Test1\n";
+        expectedScript += "if anyof (envelope :all :contains :comparator \"i;octet\" [\"from\"] \"abCD\") {\n";
+        expectedScript += "    fileinto \"Junk\";\n";
+        expectedScript += "    stop;\n";
+        expectedScript += "}\n";
+
+        ZimbraLog.filter.info(acct.getMailSieveScript());
+        ZimbraLog.filter.info(expectedScript);
+        assertEquals(expectedScript, acct.getMailSieveScript());
+    }
+
+    /**
+     * Tests rule creation through ModifyFilterRulesRequest for header test having caseSensitive attribute with
+     * value comparison
+     * @throws Exception
+     */
+    @Test
+    public void testHeaderTestValueComparisonCaseSensitivity() throws Exception {
+        Account acct = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+        Element request = new Element.XMLElement(MailConstants.MODIFY_FILTER_RULES_REQUEST);
+
+        Element rules = request.addNonUniqueElement(MailConstants.E_FILTER_RULES);
+        Element rule = rules.addNonUniqueElement(MailConstants.E_FILTER_RULE);
+        rule.addAttribute(MailConstants.A_ACTIVE, true);
+        rule.addAttribute(MailConstants.A_NAME, "Test1");
+        Element filteraction = rule.addNonUniqueElement(MailConstants.E_FILTER_ACTIONS);
+        Element actionInto = filteraction.addNonUniqueElement(MailConstants.E_ACTION_FILE_INTO);
+        actionInto.addAttribute(MailConstants.A_FOLDER_PATH, "Junk");
+        filteraction.addNonUniqueElement(MailConstants.E_ACTION_STOP);
+        Element filterTests = rule.addNonUniqueElement(MailConstants.E_FILTER_TESTS);
+        filterTests.addAttribute(MailConstants.A_CONDITION, "anyof");
+        Element headerTest = filterTests.addNonUniqueElement(MailConstants.E_HEADER_TEST);
+        headerTest.addAttribute(MailConstants.A_HEADER, "subject");
+        headerTest.addAttribute(MailConstants.A_VALUE_COMPARISON, "eq");
+        headerTest.addAttribute(MailConstants.A_CASE_SENSITIVE, "true");
+        headerTest.addAttribute(MailConstants.A_VALUE, "Important");
+
+        try {
+            new ModifyFilterRules().handle(request, ServiceTestUtil.getRequestContext(acct));
+        } catch (ServiceException e) {
+            fail("This test is expected not to throw exception. ");
+        }
+
+        String expectedScript = "require [\"fileinto\", \"copy\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\", \"enotify\"];\n\n";
+        expectedScript += "# Test1\n";
+        expectedScript += "if anyof (header :value \"eq\" :comparator \"i;octet\" [\"subject\"] \"Important\") {\n";
+        expectedScript += "    fileinto \"Junk\";\n";
+        expectedScript += "    stop;\n";
+        expectedScript += "}\n";
+
+        ZimbraLog.filter.info(acct.getMailSieveScript());
+        ZimbraLog.filter.info(expectedScript);
+        assertEquals(expectedScript, acct.getMailSieveScript());
+    }
+
+    /**
+     * Tests rule creation through ModifyFilterRulesRequest for address test having caseSensitive attribute with
+     * value comparison
+     * @throws Exception
+     */
+    @Test
+    public void testAddressTestValueComparisonCaseSensitivity() throws Exception {
+        Account acct = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+        Element request = new Element.XMLElement(MailConstants.MODIFY_FILTER_RULES_REQUEST);
+
+        Element rules = request.addNonUniqueElement(MailConstants.E_FILTER_RULES);
+        Element rule = rules.addNonUniqueElement(MailConstants.E_FILTER_RULE);
+        rule.addAttribute(MailConstants.A_ACTIVE, true);
+        rule.addAttribute(MailConstants.A_NAME, "Test1");
+        Element filteraction = rule.addNonUniqueElement(MailConstants.E_FILTER_ACTIONS);
+        Element actionInto = filteraction.addNonUniqueElement(MailConstants.E_ACTION_FILE_INTO);
+        actionInto.addAttribute(MailConstants.A_FOLDER_PATH, "Junk");
+        filteraction.addNonUniqueElement(MailConstants.E_ACTION_STOP);
+        Element filterTests = rule.addNonUniqueElement(MailConstants.E_FILTER_TESTS);
+        filterTests.addAttribute(MailConstants.A_CONDITION, "anyof");
+        Element addressTest = filterTests.addNonUniqueElement(MailConstants.E_ADDRESS_TEST);
+        addressTest.addAttribute(MailConstants.A_HEADER, "from");
+        addressTest.addAttribute(MailConstants.A_VALUE_COMPARISON, "eq");
+        addressTest.addAttribute(MailConstants.A_CASE_SENSITIVE, "true");
+        addressTest.addAttribute(MailConstants.A_VALUE, "abCD");
+
+        try {
+            new ModifyFilterRules().handle(request, ServiceTestUtil.getRequestContext(acct));
+        } catch (ServiceException e) {
+            fail("This test is expected not to throw exception. ");
+        }
+
+        String expectedScript = "require [\"fileinto\", \"copy\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\", \"enotify\"];\n\n";
+        expectedScript += "# Test1\n";
+        expectedScript += "if anyof (address :value \"eq\" :all :comparator \"i;octet\" [\"from\"] \"abCD\") {\n";
+        expectedScript += "    fileinto \"Junk\";\n";
+        expectedScript += "    stop;\n";
+        expectedScript += "}\n";
+
+        ZimbraLog.filter.info(acct.getMailSieveScript());
+        ZimbraLog.filter.info(expectedScript);
+        assertEquals(expectedScript, acct.getMailSieveScript());
+    }
+
+    /**
+     * Tests rule creation through ModifyFilterRulesRequest for envelope test having caseSensitive attribute with
+     * value comparison
+     * @throws Exception
+     */
+    @Test
+    public void testEnvelopeTestValueComparisonCaseSensitivity() throws Exception {
+        Account acct = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+        Element request = new Element.XMLElement(MailConstants.MODIFY_FILTER_RULES_REQUEST);
+
+        Element rules = request.addNonUniqueElement(MailConstants.E_FILTER_RULES);
+        Element rule = rules.addNonUniqueElement(MailConstants.E_FILTER_RULE);
+        rule.addAttribute(MailConstants.A_ACTIVE, true);
+        rule.addAttribute(MailConstants.A_NAME, "Test1");
+        Element filteraction = rule.addNonUniqueElement(MailConstants.E_FILTER_ACTIONS);
+        Element actionInto = filteraction.addNonUniqueElement(MailConstants.E_ACTION_FILE_INTO);
+        actionInto.addAttribute(MailConstants.A_FOLDER_PATH, "Junk");
+        filteraction.addNonUniqueElement(MailConstants.E_ACTION_STOP);
+        Element filterTests = rule.addNonUniqueElement(MailConstants.E_FILTER_TESTS);
+        filterTests.addAttribute(MailConstants.A_CONDITION, "anyof");
+        Element envelopeTest = filterTests.addNonUniqueElement(MailConstants.E_ENVELOPE_TEST);
+        envelopeTest.addAttribute(MailConstants.A_HEADER, "from");
+        envelopeTest.addAttribute(MailConstants.A_VALUE_COMPARISON, "eq");
+        envelopeTest.addAttribute(MailConstants.A_CASE_SENSITIVE, "true");
+        envelopeTest.addAttribute(MailConstants.A_VALUE, "abCD");
+
+        try {
+            new ModifyFilterRules().handle(request, ServiceTestUtil.getRequestContext(acct));
+        } catch (ServiceException e) {
+            fail("This test is expected not to throw exception. ");
+        }
+
+        String expectedScript = "require [\"fileinto\", \"copy\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\", \"enotify\"];\n\n";
+        expectedScript += "# Test1\n";
+        expectedScript += "if anyof (envelope :value \"eq\" :all :comparator \"i;octet\" [\"from\"] \"abCD\") {\n";
+        expectedScript += "    fileinto \"Junk\";\n";
+        expectedScript += "    stop;\n";
+        expectedScript += "}\n";
+
+        ZimbraLog.filter.info(acct.getMailSieveScript());
+        ZimbraLog.filter.info(expectedScript);
+        assertEquals(expectedScript, acct.getMailSieveScript());
+    }
+
+    /**
+     * Tests rule creation through ModifyFilterRulesRequest for header test having value comparison with 
+     * valueComparisonComparator
+     * @throws Exception
+     */
+    @Test
+    public void testHeaderTestValueComparisonComparator() throws Exception {
+        Account acct = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+        Element request = new Element.XMLElement(MailConstants.MODIFY_FILTER_RULES_REQUEST);
+
+        Element rules = request.addNonUniqueElement(MailConstants.E_FILTER_RULES);
+        Element rule = rules.addNonUniqueElement(MailConstants.E_FILTER_RULE);
+        rule.addAttribute(MailConstants.A_ACTIVE, true);
+        rule.addAttribute(MailConstants.A_NAME, "Test1");
+        Element filteraction = rule.addNonUniqueElement(MailConstants.E_FILTER_ACTIONS);
+        Element actionInto = filteraction.addNonUniqueElement(MailConstants.E_ACTION_FILE_INTO);
+        actionInto.addAttribute(MailConstants.A_FOLDER_PATH, "Junk");
+        filteraction.addNonUniqueElement(MailConstants.E_ACTION_STOP);
+        Element filterTests = rule.addNonUniqueElement(MailConstants.E_FILTER_TESTS);
+        filterTests.addAttribute(MailConstants.A_CONDITION, "anyof");
+        Element headerTest = filterTests.addNonUniqueElement(MailConstants.E_HEADER_TEST);
+        headerTest.addAttribute(MailConstants.A_HEADER, "subject");
+        headerTest.addAttribute(MailConstants.A_VALUE_COMPARISON, "eq");
+        headerTest.addAttribute(MailConstants.A_VALUE_COMPARISON_COMPARATOR, "i;octet");
+        headerTest.addAttribute(MailConstants.A_VALUE, "Important");
+
+        try {
+            new ModifyFilterRules().handle(request, ServiceTestUtil.getRequestContext(acct));
+        } catch (ServiceException e) {
+            fail("This test is expected not to throw exception. ");
+        }
+
+        String expectedScript = "require [\"fileinto\", \"copy\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\", \"enotify\"];\n\n";
+        expectedScript += "# Test1\n";
+        expectedScript += "if anyof (header :value \"eq\" :comparator \"i;octet\" [\"subject\"] \"Important\") {\n";
+        expectedScript += "    fileinto \"Junk\";\n";
+        expectedScript += "    stop;\n";
+        expectedScript += "}\n";
+
+        ZimbraLog.filter.info(acct.getMailSieveScript());
+        ZimbraLog.filter.info(expectedScript);
+        assertEquals(expectedScript, acct.getMailSieveScript());
+    }
+
+    /**
+     * Tests rule creation through ModifyFilterRulesRequest for address test having value comparison with 
+     * valueComparisonComparator
+     * @throws Exception
+     */
+    @Test
+    public void testAddressTestValueComparisonComparator() throws Exception {
+        Account acct = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+        Element request = new Element.XMLElement(MailConstants.MODIFY_FILTER_RULES_REQUEST);
+
+        Element rules = request.addNonUniqueElement(MailConstants.E_FILTER_RULES);
+        Element rule = rules.addNonUniqueElement(MailConstants.E_FILTER_RULE);
+        rule.addAttribute(MailConstants.A_ACTIVE, true);
+        rule.addAttribute(MailConstants.A_NAME, "Test1");
+        Element filteraction = rule.addNonUniqueElement(MailConstants.E_FILTER_ACTIONS);
+        Element actionInto = filteraction.addNonUniqueElement(MailConstants.E_ACTION_FILE_INTO);
+        actionInto.addAttribute(MailConstants.A_FOLDER_PATH, "Junk");
+        filteraction.addNonUniqueElement(MailConstants.E_ACTION_STOP);
+        Element filterTests = rule.addNonUniqueElement(MailConstants.E_FILTER_TESTS);
+        filterTests.addAttribute(MailConstants.A_CONDITION, "anyof");
+        Element addressTest = filterTests.addNonUniqueElement(MailConstants.E_ADDRESS_TEST);
+        addressTest.addAttribute(MailConstants.A_HEADER, "from");
+        addressTest.addAttribute(MailConstants.A_VALUE_COMPARISON, "eq");
+        addressTest.addAttribute(MailConstants.A_VALUE_COMPARISON_COMPARATOR, "i;octet");
+        addressTest.addAttribute(MailConstants.A_VALUE, "abCD");
+
+        try {
+            new ModifyFilterRules().handle(request, ServiceTestUtil.getRequestContext(acct));
+        } catch (ServiceException e) {
+            fail("This test is expected not to throw exception. ");
+        }
+
+        String expectedScript = "require [\"fileinto\", \"copy\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\", \"enotify\"];\n\n";
+        expectedScript += "# Test1\n";
+        expectedScript += "if anyof (address :value \"eq\" :all :comparator \"i;octet\" [\"from\"] \"abCD\") {\n";
+        expectedScript += "    fileinto \"Junk\";\n";
+        expectedScript += "    stop;\n";
+        expectedScript += "}\n";
+
+        ZimbraLog.filter.info(acct.getMailSieveScript());
+        ZimbraLog.filter.info(expectedScript);
+        assertEquals(expectedScript, acct.getMailSieveScript());
+    }
+
+    /**
+     * Tests rule creation through ModifyFilterRulesRequest for envelope test having value comparison with 
+     * valueComparisonComparator
+     * @throws Exception
+     */
+    @Test
+    public void testEnvelopeTestValueComparisonComparator() throws Exception {
+        Account acct = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+        Element request = new Element.XMLElement(MailConstants.MODIFY_FILTER_RULES_REQUEST);
+
+        Element rules = request.addNonUniqueElement(MailConstants.E_FILTER_RULES);
+        Element rule = rules.addNonUniqueElement(MailConstants.E_FILTER_RULE);
+        rule.addAttribute(MailConstants.A_ACTIVE, true);
+        rule.addAttribute(MailConstants.A_NAME, "Test1");
+        Element filteraction = rule.addNonUniqueElement(MailConstants.E_FILTER_ACTIONS);
+        Element actionInto = filteraction.addNonUniqueElement(MailConstants.E_ACTION_FILE_INTO);
+        actionInto.addAttribute(MailConstants.A_FOLDER_PATH, "Junk");
+        filteraction.addNonUniqueElement(MailConstants.E_ACTION_STOP);
+        Element filterTests = rule.addNonUniqueElement(MailConstants.E_FILTER_TESTS);
+        filterTests.addAttribute(MailConstants.A_CONDITION, "anyof");
+        Element envelopeTest = filterTests.addNonUniqueElement(MailConstants.E_ENVELOPE_TEST);
+        envelopeTest.addAttribute(MailConstants.A_HEADER, "from");
+        envelopeTest.addAttribute(MailConstants.A_VALUE_COMPARISON, "eq");
+        envelopeTest.addAttribute(MailConstants.A_VALUE_COMPARISON_COMPARATOR, "i;octet");
+        envelopeTest.addAttribute(MailConstants.A_VALUE, "abCD");
+
+        try {
+            new ModifyFilterRules().handle(request, ServiceTestUtil.getRequestContext(acct));
+        } catch (ServiceException e) {
+            fail("This test is expected not to throw exception. ");
+        }
+
+        String expectedScript = "require [\"fileinto\", \"copy\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\", \"enotify\"];\n\n";
+        expectedScript += "# Test1\n";
+        expectedScript += "if anyof (envelope :value \"eq\" :all :comparator \"i;octet\" [\"from\"] \"abCD\") {\n";
+        expectedScript += "    fileinto \"Junk\";\n";
+        expectedScript += "    stop;\n";
+        expectedScript += "}\n";
+
+        ZimbraLog.filter.info(acct.getMailSieveScript());
+        ZimbraLog.filter.info(expectedScript);
+        assertEquals(expectedScript, acct.getMailSieveScript());
+    }
+
+    /**
+     * Tests GetFilterRulesRequest for rule containing header test and caseSensitive attribute with
+     * value comparison
+     * @throws Exception
+     */
+    @Test
+    public void testGetRuleHeaderTestValueComparisonCaseSensitivity() throws Exception {
+        try {
+            String filterScript = "require [\"fileinto\", \"copy\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\", \"enotify\"];\n\n";
+            filterScript += "if anyof (header :value \"eq\" :comparator \"i;octet\" [\"subject\"] \"Important\") {\n";
+            filterScript += "    fileinto \"Junk\";\n";
+            filterScript += "    stop;\n";
+            filterScript += "}\n";
+
+            ZimbraLog.filter.info(filterScript);
+
+            Account account = Provisioning.getInstance().getAccount(
+                    MockProvisioning.DEFAULT_ACCOUNT_ID);
+            RuleManager.clearCachedRules(account);
+            account.setMailSieveScript(filterScript);
+
+            Element request = new Element.XMLElement(MailConstants.GET_FILTER_RULES_REQUEST);
+            Element response = new GetFilterRules().handle(request, ServiceTestUtil.getRequestContext(account));
+
+            String expectedSoapResponse =
+                    "<GetFilterRulesResponse xmlns=\"urn:zimbraMail\"> \n"
+                    + "<filterRules> \n"
+                    +  "<filterRule active=\"1\"> \n"
+                    + "<filterTests condition=\"anyof\"> \n"
+                    + "<headerTest valueComparison=\"eq\" caseSensitive=\"1\" header=\"subject\" index=\"0\" valueComparisonComparator=\"i;octet\" value=\"Important\"/> \n"
+                    + "</filterTests> \n"
+                    + "<filterActions> \n"
+                    + " <actionFileInto folderPath=\"Junk\" index=\"0\" copy=\"0\"/> \n"
+                    + "  <actionStop index=\"1\"/> \n"
+                    + "</filterActions> \n"
+                    + "</filterRule> \n"
+                    + "</filterRules> \n"
+                    +"</GetFilterRulesResponse>";
+            ZimbraLog.filter.info(response.prettyPrint());
+            XMLDiffChecker.assertXMLEquals(expectedSoapResponse, response.prettyPrint());
+        } catch (Exception e) {
+            fail("No exception should be thrown" + e);
+        }
+    }
+
+    /**
+     * Tests GetFilterRulesRequest for rule containing address test and caseSensitive attribute with
+     * value comparison
+     * @throws Exception
+     */
+    @Test
+    public void testGetRuleAddressTestValueComparisonCaseSensitivity() throws Exception {
+        try {
+            String filterScript = "require [\"fileinto\", \"copy\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\", \"enotify\"];\n\n";
+            filterScript += "if anyof (address :value \"eq\" :all :comparator \"i;octet\" [\"from\"] \"abCD\") {\n";
+            filterScript += "    fileinto \"Junk\";\n";
+            filterScript += "    stop;\n";
+            filterScript += "}\n";
+
+            ZimbraLog.filter.info(filterScript);
+
+            Account account = Provisioning.getInstance().getAccount(
+                    MockProvisioning.DEFAULT_ACCOUNT_ID);
+            RuleManager.clearCachedRules(account);
+            account.setMailSieveScript(filterScript);
+
+            Element request = new Element.XMLElement(MailConstants.GET_FILTER_RULES_REQUEST);
+            Element response = new GetFilterRules().handle(request, ServiceTestUtil.getRequestContext(account));
+
+            String expectedSoapResponse =
+                    "<GetFilterRulesResponse xmlns=\"urn:zimbraMail\"> \n"
+                    + "<filterRules> \n"
+                    +  "<filterRule active=\"1\"> \n"
+                    + "<filterTests condition=\"anyof\"> \n"
+                    + "<addressTest valueComparison=\"eq\" caseSensitive=\"1\" part=\"all\" header=\"from\" index=\"0\" valueComparisonComparator=\"i;octet\" value=\"abCD\"/> \n"
+                    + "</filterTests> \n"
+                    + "<filterActions> \n"
+                    + " <actionFileInto folderPath=\"Junk\" index=\"0\" copy=\"0\"/> \n"
+                    + "  <actionStop index=\"1\"/> \n"
+                    + "</filterActions> \n"
+                    + "</filterRule> \n"
+                    + "</filterRules> \n"
+                    +"</GetFilterRulesResponse>";
+            ZimbraLog.filter.info(response.prettyPrint());
+            XMLDiffChecker.assertXMLEquals(expectedSoapResponse, response.prettyPrint());
+        } catch (Exception e) {
+            fail("No exception should be thrown" + e);
+        }
+    }
+
+    /**
+     * Tests GetFilterRulesRequest for rule containing envelope test and caseSensitive attribute with
+     * value comparison
+     * @throws Exception
+     */
+    @Test
+    public void testGetRuleEnvelopeTestValueComparisonCaseSensitivity() throws Exception {
+        try {
+            String filterScript = "require [\"fileinto\", \"copy\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\", \"enotify\"];\n\n";
+            filterScript += "if anyof (envelope :value \"eq\" :all :comparator \"i;octet\" [\"from\"] \"abCD\") {\n";
+            filterScript += "    fileinto \"Junk\";\n";
+            filterScript += "    stop;\n";
+            filterScript += "}\n";
+
+            ZimbraLog.filter.info(filterScript);
+
+            Account account = Provisioning.getInstance().getAccount(
+                    MockProvisioning.DEFAULT_ACCOUNT_ID);
+            RuleManager.clearCachedRules(account);
+            account.setMailSieveScript(filterScript);
+
+            Element request = new Element.XMLElement(MailConstants.GET_FILTER_RULES_REQUEST);
+            Element response = new GetFilterRules().handle(request, ServiceTestUtil.getRequestContext(account));
+
+            String expectedSoapResponse =
+                    "<GetFilterRulesResponse xmlns=\"urn:zimbraMail\"> \n"
+                    + "<filterRules> \n"
+                    +  "<filterRule active=\"1\"> \n"
+                    + "<filterTests condition=\"anyof\"> \n"
+                    + "<envelopeTest valueComparison=\"eq\" caseSensitive=\"1\" part=\"all\" header=\"from\" index=\"0\" valueComparisonComparator=\"i;octet\" value=\"abCD\"/> \n"
+                    + "</filterTests> \n"
+                    + "<filterActions> \n"
+                    + " <actionFileInto folderPath=\"Junk\" index=\"0\" copy=\"0\"/> \n"
+                    + "  <actionStop index=\"1\"/> \n"
+                    + "</filterActions> \n"
+                    + "</filterRule> \n"
+                    + "</filterRules> \n"
+                    +"</GetFilterRulesResponse>";
+            ZimbraLog.filter.info(response.prettyPrint());
+            XMLDiffChecker.assertXMLEquals(expectedSoapResponse, response.prettyPrint());
+        } catch (Exception e) {
+            fail("No exception should be thrown" + e);
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/filter/SieveToSoap.java
+++ b/store/src/java/com/zimbra/cs/filter/SieveToSoap.java
@@ -288,7 +288,7 @@ public final class SieveToSoap extends SieveVisitor {
 
     @Override
     protected void visitHeaderTest(Node node, VisitPhase phase, RuleProperties props,
-            List<String> headers, Sieve.ValueComparison comparison, boolean isCount, String value) {
+            List<String> headers, Sieve.ValueComparison comparison, Sieve.Comparator comparator, boolean isCount, String value) {
         if (phase == VisitPhase.begin) {
             FilterTest.HeaderTest test = addTest(new FilterTest.HeaderTest(), props);
             test.setHeaders(Joiner.on(',').join(headers));
@@ -296,6 +296,12 @@ public final class SieveToSoap extends SieveVisitor {
                test.setCountComparison(comparison.toString());
             } else {
                test.setValueComparison(comparison.toString());
+               if (comparator != null) {
+                   test.setValueComparisonComparator(comparator.toString());
+                   if (Sieve.Comparator.ioctet.equals(comparator)) {
+                       test.setCaseSensitive(true);
+                   }
+               }
             }
             test.setValue(value);
         }
@@ -317,9 +323,9 @@ public final class SieveToSoap extends SieveVisitor {
 
     @Override
     protected void visitAddressTest(Node node, VisitPhase phase, RuleProperties props, List<String> headers,
-            Sieve.AddressPart part, Sieve.ValueComparison comparison, boolean isCount, String value) {
+            Sieve.AddressPart part, Sieve.ValueComparison comparison, Sieve.Comparator comparator, boolean isCount, String value) {
         FilterTest.AddressTest test = new FilterTest.AddressTest();
-        visitAddress(test, phase, props, headers, part, comparison, isCount, value);
+        visitAddress(test, phase, props, headers, part, comparison, comparator, isCount, value);
     }
 
     @Override
@@ -338,13 +344,13 @@ public final class SieveToSoap extends SieveVisitor {
 
     @Override
     protected void visitEnvelopeTest(Node node, VisitPhase phase, RuleProperties props, List<String> headers,
-            Sieve.AddressPart part, Sieve.ValueComparison comparison, boolean isCount, String value) {
+            Sieve.AddressPart part, Sieve.ValueComparison comparison, Sieve.Comparator comparator, boolean isCount, String value) {
         FilterTest.EnvelopeTest test = new FilterTest.EnvelopeTest();
-        visitAddress(test, phase, props, headers, part, comparison, isCount, value);
+        visitAddress(test, phase, props, headers, part, comparison, comparator, isCount, value);
     }
 
     private void visitAddress(FilterTest.AddressTest test, VisitPhase phase, RuleProperties props, List<String> headers, Sieve.AddressPart part,
-        Sieve.ValueComparison comparison, boolean isCount, String value) {
+        Sieve.ValueComparison comparison, Sieve.Comparator comparator, boolean isCount, String value) {
         if (test != null && phase == VisitPhase.begin) {
             addTest(test, props);
             test.setHeader(Joiner.on(',').join(headers));
@@ -353,6 +359,12 @@ public final class SieveToSoap extends SieveVisitor {
                 test.setCountComparison(comparison.toString());
              } else {
                 test.setValueComparison(comparison.toString());
+                if (comparator != null) {
+                    test.setValueComparisonComparator(comparator.toString());
+                    if (Sieve.Comparator.ioctet.equals(comparator)) {
+                        test.setCaseSensitive(true);
+                    }
+                }
              }
             test.setValue(value);
         }

--- a/store/src/java/com/zimbra/cs/filter/SieveVisitor.java
+++ b/store/src/java/com/zimbra/cs/filter/SieveVisitor.java
@@ -88,7 +88,7 @@ public abstract class SieveVisitor {
 
     @SuppressWarnings("unused")
     protected void visitHeaderTest(Node node, VisitPhase phase, RuleProperties props, List<String> headers,
-            Sieve.ValueComparison comparison, boolean isCount, String value) throws ServiceException {
+            Sieve.ValueComparison comparison, Sieve.Comparator comparator, boolean isCount, String value) throws ServiceException {
         // empty method
     }
 
@@ -107,7 +107,7 @@ public abstract class SieveVisitor {
 
     @SuppressWarnings("unused")
     protected void visitAddressTest(Node node, VisitPhase phase, RuleProperties props, List<String> headers,
-        Sieve.AddressPart part, Sieve.ValueComparison comparison, boolean isCount, String value)
+        Sieve.AddressPart part, Sieve.ValueComparison comparison, Sieve.Comparator comparator, boolean isCount, String value)
         throws ServiceException {
         // empty method
     }
@@ -119,7 +119,7 @@ public abstract class SieveVisitor {
     }
 
     protected void visitEnvelopeTest(Node node, VisitPhase phase, RuleProperties props, List<String> headers,
-        Sieve.AddressPart part, Sieve.ValueComparison comparison, boolean isCount, String value)
+        Sieve.AddressPart part, Sieve.ValueComparison comparison, Sieve.Comparator comparator, boolean isCount, String value)
         throws ServiceException {
         // empty method
     }
@@ -513,9 +513,9 @@ public abstract class SieveVisitor {
 
                 if ("header".equalsIgnoreCase(nodeName)) {
                     if (valueComparison != null) {
-                        visitHeaderTest(node, VisitPhase.begin, props, headers, valueComparison, isCount, value);
+                        visitHeaderTest(node, VisitPhase.begin, props, headers, valueComparison, comparator, isCount, value);
                         accept(node, props);
-                        visitHeaderTest(node, VisitPhase.end, props, headers, valueComparison, isCount, value);
+                        visitHeaderTest(node, VisitPhase.end, props, headers, valueComparison, comparator, isCount, value);
                     } else {
                         visitHeaderTest(node, VisitPhase.begin, props, headers, comparison, caseSensitive, value);
                         accept(node, props);
@@ -577,10 +577,10 @@ public abstract class SieveVisitor {
 
                 if ("envelope".equalsIgnoreCase(nodeName)) {
                     if (valueComparison != null) {
-                        visitEnvelopeTest(node, VisitPhase.begin, props, headers, part, valueComparison, isCount,
+                        visitEnvelopeTest(node, VisitPhase.begin, props, headers, part, valueComparison, comparator, isCount,
                             value);
                         accept(node, props);
-                        visitEnvelopeTest(node, VisitPhase.end, props, headers, part, valueComparison, isCount, value);
+                        visitEnvelopeTest(node, VisitPhase.end, props, headers, part, valueComparison, comparator, isCount, value);
                     } else {
                         visitEnvelopeTest(node, VisitPhase.begin, props, headers, part, comparison, caseSensitive,
                             value);
@@ -589,9 +589,9 @@ public abstract class SieveVisitor {
                     }
                 } else {
                     if (valueComparison != null) {
-                        visitAddressTest(node, VisitPhase.begin, props, headers, part, valueComparison, isCount, value);
+                        visitAddressTest(node, VisitPhase.begin, props, headers, part, valueComparison, comparator, isCount, value);
                         accept(node, props);
-                        visitAddressTest(node, VisitPhase.end, props, headers, part, valueComparison, isCount, value);
+                        visitAddressTest(node, VisitPhase.end, props, headers, part, valueComparison, comparator, isCount, value);
                     } else {
                         visitAddressTest(node, VisitPhase.begin, props, headers, part, comparison, caseSensitive,
                             value);


### PR DESCRIPTION
1. added support for caseSensitivity attribute when valueComparison is used in header/address/envelope test.
2. added valueComparisonComparator attribute to explicitly specify the comparator to use for valueComparison

added junit tests.