### PR TITLE
Bugfix/zcs 1858

### DIFF
--- a/store/src/java-test/com/zimbra/cs/filter/AddressTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/AddressTest.java
@@ -340,7 +340,8 @@ public class AddressTest {
             RuleManager.clearCachedRules(acct);
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
 
-            String filterScript = "if address :is :comparator \"i;ascii-numeric\" \"To\" \"\" {"
+            String filterScript = "require [\"comparator-i;ascii-numeric\"];"
+                                + "if address :is :comparator \"i;ascii-numeric\" \"To\" \"\" {"
                                 + "  tag \"compareEmptyStringWithAsciiNumeric\";"
                                 + "}";
 

--- a/store/src/java-test/com/zimbra/cs/filter/DeleteHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/DeleteHeaderTest.java
@@ -431,7 +431,7 @@ public class DeleteHeaderTest {
     @Test
     public void testDeleteHeaderWithNumericComparisionUsingValue() {
         try {
-            String filterScript = "require [\"editheader\"];\n"
+            String filterScript = "require [\"editheader\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                     + " deleteheader :value \"lt\" :comparator \"i;ascii-numeric\" \"X-Numeric-Header\" \"3\" \r\n"
                     + "  ;\n";
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
@@ -468,7 +468,7 @@ public class DeleteHeaderTest {
     @Test
     public void testDeleteHeaderWithNumericComparisionUsingCount() {
         try {
-            String filterScript = "require [\"editheader\"];\n"
+            String filterScript = "require [\"editheader\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                     + " deleteheader :count \"ge\" :comparator \"i;ascii-numeric\" \"X-Numeric-Header\" \"3\" \r\n"
                     + "  ;\n";
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
@@ -845,7 +845,7 @@ public class DeleteHeaderTest {
     @Test
     public void testDeleteHeaderWithValueComparisionForCasemapComparator() {
         try {
-            String filterScript = "require [\"editheader\"];\n"
+            String filterScript = "require [\"editheader\", \"relational\"];\n"
                     + " deleteheader :value \"lt\" :comparator \"i;ascii-casemap\" \"X-Numeric-Header\" \"3\" \r\n"
                     + "  ;\n";
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");

--- a/store/src/java-test/com/zimbra/cs/filter/EnvelopeTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/EnvelopeTest.java
@@ -611,7 +611,7 @@ public class EnvelopeTest {
 
     @Test
     public void testCompareEmptyStringWithAsciiNumeric() {
-        String filterScript = "require \"envelope\";\n"
+        String filterScript = "require [\"envelope\", \"comparator-i;ascii-numeric\"];\n"
                 + "if envelope :comparator \"i;ascii-numeric\" :all :is \"from\" \"\" {\n"
                 + "  tag \"testCompareEmptyStringWithAsciiNumeric envelope\";"
                 + "}"
@@ -652,7 +652,7 @@ public class EnvelopeTest {
 
     @Test
     public void testTo_Alias() {
-        String filterScript = "require [\"variables\", \"envelope\"];\n"
+        String filterScript = "require [\"variables\", \"envelope\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                 + "set \"rcptto\" \"unknown\";\n"
                 + "if envelope :all :matches \"to\" \"*\" {\n"
                 + "  set \"rcptto\" \"${1}\";\n"
@@ -707,7 +707,7 @@ public class EnvelopeTest {
 
     @Test
     public void testCountForEmptyFromHeader() {
-        String filterScript = "require \"envelope\";\n"
+        String filterScript = "require [\"envelope\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                 + "if envelope :count \"eq\" :comparator \"i;ascii-numeric\" :all \"FROM\" \"0\" {\n"
                 + "tag \"0\";\n"
                 + "}\n"

--- a/store/src/java-test/com/zimbra/cs/filter/ErejectTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/ErejectTest.java
@@ -106,7 +106,7 @@ public class ErejectTest {
     public void test() {
         Account acct1 = null;
         Mailbox mbox1 = null;
-
+        boolean isPassed = false;
         try {
             acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
             mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
@@ -130,6 +130,7 @@ public class ErejectTest {
                     List<Integer> items = mbox1.getItemIds(null, Mailbox.ID_FOLDER_INBOX)
                             .getIds(MailItem.Type.MESSAGE);
                     Assert.assertEquals(null, items);
+                    isPassed = true;
                 } catch (Exception ex) {
                     fail("No exception should be thrown: " + ex.getMessage());
                 }
@@ -138,6 +139,9 @@ public class ErejectTest {
             }
         } catch (Exception e) {
              fail("No exception should be thrown: " + e.getMessage());
+        }
+        if (!isPassed) {
+            fail("DeliveryServiceException/ErejectException should have been thrown, but no exception is thrown");
         }
     }
     

--- a/store/src/java-test/com/zimbra/cs/filter/HeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/HeaderTest.java
@@ -148,7 +148,7 @@ public class HeaderTest {
     // The "X-Minus: -abc" is not a negative value, but positive infinity as it is just a string.
     @Test
     public void testNumericMinusCharacterValueIs() {
-        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\"];\n"
+        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                 + "if header :is :comparator \"i;ascii-numeric\" "
                 + "[\"X-Minus\"] [\"\"] { tag \"Xminus\";}";
         doTest(filterScript, "Xminus");
@@ -159,7 +159,7 @@ public class HeaderTest {
     // Hence the Subject text is treated as positive infinity, and so is an empty string
     @Test
     public void testNumericEmptyIs() {
-        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\"];\n"
+        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                 + "if header :is :comparator \"i;ascii-numeric\" "
                 + "[\"Subject\"] [\"\"] { tag \"subject\";}";
         doTest(filterScript, "subject");

--- a/store/src/java-test/com/zimbra/cs/filter/NotifyMailtoTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/NotifyMailtoTest.java
@@ -977,7 +977,7 @@ public class NotifyMailtoTest {
     @Test
     public void testNotifyMethodCapability_Relational() {
         String filterScript =
-                "require [\"enotify\", \"tag\", \"relational\"];\n"
+                "require [\"enotify\", \"tag\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
               + "if notify_method_capability :count \"eq\"\n"
               + "     \"mailto:test2@zimbra.com\"\n"
               + "     \"Online\"\n"
@@ -1013,7 +1013,7 @@ public class NotifyMailtoTest {
     @Test
     public void testNotify_variable() {
         String filterScript =
-                "require [\"enotify\", \"tag\", \"variables\"];\n"
+                "require [\"enotify\", \"tag\", \"variables\", \"envelope\"];\n"
               + "if envelope :matches [\"To\"]     \"*\" {set \"rcptto\"        \"${1}\";}\n"
               + "if envelope :matches [\"From\"]   \"*\" {set \"mailfrom\"      \"${1}\";}\n"
               + "if header   :matches  \"Date\"    \"*\" {set \"dateheader\"    \"${1}\";}\n"
@@ -1241,7 +1241,7 @@ public class NotifyMailtoTest {
     @Test
     public void testNotify_mimeVariables() {
         String filterScript =
-                "require [\"enotify\", \"tag\", \"variables\"];\n"
+                "require [\"enotify\", \"tag\", \"variables\", \"envelope\"];\n"
               + "if envelope :matches [\"To\"]     \"*\" {set \"rcptto\"        \"${1}\";}\n"
               + "if envelope :matches [\"From\"]   \"*\" {set \"mailfrom\"      \"${1}\";}\n"
               + "if anyof(not envelope :is [\"From\"] \"\") {\n"

--- a/store/src/java-test/com/zimbra/cs/filter/RelationalExtensionTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/RelationalExtensionTest.java
@@ -72,47 +72,49 @@ public class RelationalExtensionTest {
     @Test
     public void testCountAddressNumericGE1() {
         // RFC 5231 6. Example first example would evaluate to true
-        String filterScript = "if address :count \"ge\" :comparator \"i;ascii-numeric\" "
-                + "[\"to\", \"cc\"] [\"3\"] {" + "tag \"Priority\";}";
+        String filterScript = "require [\"relational\", \"comparator-i;ascii-numeric\"];"
+                + "if address :count \"ge\" :comparator \"i;ascii-numeric\" "
+                + "[\"to\", \"cc\"] [\"3\"] { tag \"Priority\";}";
         doTest(filterScript, "Priority");
     }
 
     @Test
     public void testCountAddressNumericGE2() {
         // RFC 5231 6. Example second example would evaluate to false
-        String filterScript = "if anyof (address :count \"ge\" :comparator \"i;ascii-numeric\"\n"
+        String filterScript = "require [\"relational\", \"tag\", \"comparator-i;ascii-numeric\"];\n"
+                + "if anyof (address :count \"ge\" :comparator \"i;ascii-numeric\"\n"
                 + "[\"to\"] [\"3\"],\n"
                 + "address :count \"ge\" :comparator \"i;ascii-numeric\"\n"
                 + "[\"cc\"] [\"3\"] )\n"
-                + "{" + "tag \"Priority\";}";
-        doTest(filterScript, null);
+                + "{ tag \"Priority\";} else { tag \"No Priority\";}";
+        doTest(filterScript, "No Priority");
     }
 
     @Test
     public void testCountHeaderNumericGE1() {
         // RFC 5231 6. Example third example would evaluate to false
-        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\"];\n"
+        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                 + "if header :count \"ge\" :comparator \"i;ascii-numeric\" "
-                + "[\"received\"] [\"3\"] {" + "tag \"Priority\";}";
-        doTest(filterScript, null);
+                + "[\"received\"] [\"3\"] { tag \"Priority\";} else { tag \"No Priority\";}";
+        doTest(filterScript, "No Priority");
     }
 
     @Test
     public void testCountHeaderNumericGE2() {
         // RFC 5231 6. Example fourth example would evaluate to true
-        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\"];\n"
+        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                 + "if header :count \"ge\" :comparator \"i;ascii-numeric\" "
-                + "[\"received\", \"subject\"] [\"3\"] {" + "tag \"Priority\";}";
+                + "[\"received\", \"subject\"] [\"3\"] { tag \"Priority\";}";
         doTest(filterScript, "Priority");
     }
 
     @Test
     public void testCountHeaderNumericGE3() {
         // RFC 5231 6. Example fifth example would evaluate to false
-        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\"];\n"
+        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                 + "if header :count \"ge\" :comparator \"i;ascii-numeric\" "
-                + "[\"to\", \"cc\"] [\"3\"] {" + "tag \"Priority\";}";
-        doTest(filterScript, null);
+                + "[\"to\", \"cc\"] [\"3\"] { tag \"Priority\";} else { tag \"No Priority\";}";
+        doTest(filterScript, "No Priority");
     }
 
     @Test
@@ -126,7 +128,7 @@ public class RelationalExtensionTest {
         // So the email address string of the To address (foo@example.com, baz@example.com)
         // will be treated as an empty string "", and it represents positive infinity.
         // Positive infinity is definitely grater than 1, so this test should return TRUE.
-        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\"];\n"
+        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                 + "if address :value \"gt\" :comparator \"i;ascii-numeric\" "
                 + "[\"to\"] [\"0\"] {" + "tag \"Priority\";}";
         doTest(filterScript, "Priority");
@@ -135,7 +137,8 @@ public class RelationalExtensionTest {
     @Test
     public void testValueAddressCasemapGT() {
         // "from" address starts with 'N'-'Z'
-        String filterScript = "if address :value \"gt\" :comparator \"i;ascii-casemap\" "
+        String filterScript = "require [\"relational\", \"tag\", \"comparator-i;ascii-numeric\"];\n"
+                + "if address :value \"gt\" :comparator \"i;ascii-casemap\" "
                 + "[\"from\"] [\"M\"] {" + "tag \"Priority\";}";
         doTest(filterScript, "Priority");
     }
@@ -143,16 +146,16 @@ public class RelationalExtensionTest {
     @Test
     public void testValueHeaderNumericGT() {
         // RFC 5231 7. Extended Example (modified)
-        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\"];\n"
+        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                 + "if header :value \"gt\" :comparator \"i;ascii-numeric\" "
-                + "[\"x-priority\"] [\"3\"] {" + "tag \"Priority\";}";
-        doTest(filterScript, null);
+                + "[\"x-priority\"] [\"3\"] { tag \"Priority\";} else { tag \"No Priority\";}";
+        doTest(filterScript, "No Priority");
     }
 
     @Test
     public void testValueHeadeNumericrLT() {
         // RFC 5231 7. Extended Example
-        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\"];\n"
+        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                 + "if header :value \"lt\" :comparator \"i;ascii-numeric\" "
                 + "[\"x-priority\"] [\"3\"] {" + "tag \"Priority\";}";
         doTest(filterScript, "Priority");
@@ -161,7 +164,7 @@ public class RelationalExtensionTest {
     @Test
     public void testValueHeaderNumericLE() {
         // RFC 5231 7. Extended Example (modified)
-        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\"];\n"
+        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                 + "if header :value \"le\" :comparator \"i;ascii-numeric\" "
                 + "[\"x-priority\"] [\"3\"] {" + "tag \"Priority\";}";
         doTest(filterScript, "Priority");
@@ -170,7 +173,7 @@ public class RelationalExtensionTest {
     @Test
     public void testValueHeaderNumericEQ() {
         // RFC 5231 7. Extended Example (modified)
-        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\"];\n"
+        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                 + "if header :value \"eq\" :comparator \"i;ascii-numeric\" "
                 + "[\"x-priority\"] [\"1\"] {" + "tag \"Priority\";}";
         doTest(filterScript, "Priority");
@@ -179,10 +182,10 @@ public class RelationalExtensionTest {
     @Test
     public void testValueHeaderNumericNE() {
         // RFC 5231 7. Extended Example (modified)
-        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\"];\n"
+        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                 + "if header :value \"ne\" :comparator \"i;ascii-numeric\" "
-                + "[\"x-priority\"] [\"1\"] {" + "tag \"Priority\";}";
-        doTest(filterScript, null);
+                + "[\"x-priority\"] [\"1\"] { tag \"Priority\";} else { tag \"No Priority\";}";
+        doTest(filterScript, "No Priority");
     }
 
     @Test
@@ -207,7 +210,7 @@ public class RelationalExtensionTest {
     public void testBadFormat_nokeys() {
         String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\"];\n"
                 + "if header :value \"gt\" :comparator \"i;ascii-casemap\" "
-                + "[\"subject\"] :foo {" + "tag \"Priority\";}";
+                + "[\"subject\"] :foo { tag \"Priority\";} else { tag \"No Priority\";}";
         /*
          * The following error will occur:
          * org.apache.jsieve.exception.SyntaxException: Expecting a StringList of keys Line 2 column 1.
@@ -219,7 +222,7 @@ public class RelationalExtensionTest {
     public void testBadFormat_noTestName() {
         String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\"];\n"
                 + "if relational :value \"gt\" :comparator \"i;ascii-casemap\" "
-                + "[\"subject\"] [\"test\"] {" + "tag \"Priority\";}";
+                + "[\"subject\"] [\"test\"] { tag \"Priority\";} else { tag \"No Priority\";}";
         /*
          * The following error will occur:
          * org.apache.jsieve.exception.SyntaxException: Found unexpected arguments. Line 2 column 1.
@@ -232,7 +235,8 @@ public class RelationalExtensionTest {
         // RFC 5231 10. Security Considerations
         // An implementation MUST ensure that the test for envelope "to" only
         // reflects the delivery to the current user.
-        String filterScript = "if envelope :count \"eq\" :comparator \"i;ascii-numeric\" "
+        String filterScript = "require [\"envelope\", \"relational\", \"comparator-i;ascii-numeric\"];"
+                + "if envelope :count \"eq\" :comparator \"i;ascii-numeric\" "
                 + "[\"TO\"] [\"1\"] {" + "tag \"Priority\";}";
         doTest(filterScript, "Priority");
     }
@@ -246,16 +250,18 @@ public class RelationalExtensionTest {
         // to someone else.
         // The number of sample LMTP RCPT TO addresses is 2, but the number of
         // address to be evaluated for the "envelope" test should be 1.
-        String filterScript = "if envelope :count \"gt\" :comparator \"i;ascii-numeric\" "
-                + "[\"to\"] [\"1\"] {" + "tag \"Priority\";}";
-        doTest(filterScript, null);
+        String filterScript = "require [\"envelope\", \"relational\", \"comparator-i;ascii-numeric\"];"
+                + "if envelope :count \"gt\" :comparator \"i;ascii-numeric\" "
+                + "[\"to\"] [\"1\"] { tag \"Priority\";} else { tag \"No Priority\";}";
+        doTest(filterScript, "No Priority");
     }
 
     @Test
     public void testValueEnvelopeFromNumericGT() {
         // invalid comparison
         // See the comment on testValueAddressNumericGT.
-        String filterScript = "if envelope :value \"gt\" :comparator \"i;ascii-numeric\" "
+        String filterScript = "require [\"envelope\", \"relational\", \"comparator-i;ascii-numeric\"];"
+                + "if envelope :value \"gt\" :comparator \"i;ascii-numeric\" "
                 + "[\"from\"] [\"1\"] {" + "tag \"Priority\";}";
         doTest(filterScript, "Priority");
     }
@@ -263,9 +269,10 @@ public class RelationalExtensionTest {
     @Test
     public void testValueEnvelopeCasemapGT() {
         // LMTP MAIL FROM envelope (<abc@zimbra.com>) does not start 'N'-'Z'
-        String filterScript = "if envelope :value \"gt\" :comparator \"i;ascii-casemap\" "
-                + "[\"from\"] [\"M\"] {" + "tag \"Priority\";}";
-        doTest(filterScript, null);
+        String filterScript = "require [\"envelope\", \"relational\"];"
+                + "if envelope :value \"gt\" :comparator \"i;ascii-casemap\" "
+                + "[\"from\"] [\"M\"] { tag \"Priority\";} else { tag \"No Priority\";}";
+        doTest(filterScript, "No Priority");
     }
 
     @Test
@@ -273,7 +280,7 @@ public class RelationalExtensionTest {
         // LMTP MAIL FROM envelope (<abc@zimbra.com>) matchs the all upper case string
         // RFC 5228 Section 2.7.3. "i;ascii-casemap" comparator which treats uppercase and lowercase
         //   characters in the US-ASCII subset of UTF-8 as the same
-        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\"];\n"
+        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\", \"envelope\"];\n"
                 + "if envelope :value \"eq\" :comparator \"i;ascii-casemap\" "
                 + "[\"from\"] \"ABC@ZIMBRA.COM\" {" + "tag \"Priority\";}";
         doTest(filterScript, "Priority");
@@ -283,16 +290,17 @@ public class RelationalExtensionTest {
     public void testValueEnvelopeOctet() {
         // LMTP MAIL FROM envelope (<abc@zimbra.com>) does not match the all upper case string
         // RFC 5228 Section 2.7.3. i;octet comparator simply compares octets
-        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\"];\n"
+        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\", \"envelope\"];\n"
                 + "if envelope :value \"eq\" :comparator \"i;octet\" "
-                + "[\"from\"] \"ABC@ZIMBRA.COM\" {" + "tag \"Priority\";}";
-        doTest(filterScript, null);
+                + "[\"from\"] \"ABC@ZIMBRA.COM\" { tag \"Priority\";} else { tag \"No Priority\";}";
+        doTest(filterScript, "No Priority");
     }
 
     @Test
     public void testBadFormat_invalidEnvHeaderName() {
-        String filterScript = "if envelope :value \"gt\" :comparator \"i;ascii-casemap\" "
-                + "[\"AUTH\"] [\"M\"] {" + "tag \"Priority\";}";
+        String filterScript = "require [\"envelope\", \"relational\"];"
+                + "if envelope :value \"gt\" :comparator \"i;ascii-casemap\" "
+                + "[\"AUTH\"] [\"M\"] {" + "tag \"Priority\";} else { tag \"No Priority\";}";
          // The following error will occur:
          // org.apache.jsieve.exception.SyntaxException: Unexpected header name as a value for <envelope-part>: 'AUTH'
         doTest(filterScript, null);
@@ -300,7 +308,8 @@ public class RelationalExtensionTest {
 
     @Test
     public void testValueEnvelopeFromNumeric_AllUpperCase() {
-        String filterScript = "IF ENVELOPE :COUNT \"EQ\" :COMPARATOR \"I;ASCII-NUMERIC\" "
+        String filterScript = "REQUIRE [\"envelope\", \"relational\", \"tag\", \"comparator-i;ascii-numeric\"];\n"
+                + "IF ENVELOPE :COUNT \"EQ\" :COMPARATOR \"I;ASCII-NUMERIC\" "
                 + "[\"TO\"] [\"1\"] {" + "TAG \"Priority\";}";
         doTest(filterScript, "Priority");
     }
@@ -309,10 +318,10 @@ public class RelationalExtensionTest {
     // and none of tag commands should be executed.
     @Test
     public void testValueHeaderNumericNegativeValue() {
-        String filterScript = "require [\"tag\", \"relational\"];\n"
+        String filterScript = "require [\"tag\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                 + "if header :value \"lt\" :comparator \"i;ascii-numeric\" "
-                + "[\"x-priority\"] [\"-1\"] { tag \"Priority\"; }"
-                + "tag \"Negative\"";
+                + "[\"x-priority\"] [\"-1\"] { tag \"Priority\"; } else { tag \"No Priority\";}"
+                + "tag \"Negative\";";
         doTest(filterScript, null);
     }
 
@@ -320,9 +329,9 @@ public class RelationalExtensionTest {
     // and none of tag commands should be executed.
     @Test
     public void testValueAddressNumericNegativeValue() {
-        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\"];\n"
+        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                 + "if address :value \"lt\" :comparator \"i;ascii-numeric\" "
-                + "[\"to\"] [\"-1\"] { tag \"to\"; }"
+                + "[\"to\"] [\"-1\"] { tag \"to\"; } else { tag \"No To\";}"
                 + "tag \"Negative\";";
         doTest(filterScript, null);
     }
@@ -331,9 +340,9 @@ public class RelationalExtensionTest {
     // and none of tag commands should be executed.
     @Test
     public void testValueEnvelopeFromNumericNegativeValue() {
-        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\"];\n"
+        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                 + "if envelope :value \"lt\" :comparator \"i;ascii-numeric\" "
-                + "[\"from\"] [\"-1\"] { tag \"from\"; }"
+                + "[\"from\"] [\"-1\"] { tag \"from\"; } else { tag \"No From\";}"
                 + "tag \"Negative\";";
         doTest(filterScript, null);
     }
@@ -342,9 +351,9 @@ public class RelationalExtensionTest {
     // and none of tag commands should be executed.
     @Test
     public void testCountHeaderNumericNegativeValue() {
-        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\"];\n"
+        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                 + "if header :count \"le\" :comparator \"i;ascii-numeric\" "
-                + "[\"received\"] [\"-3\"] { tag \"received\";}"
+                + "[\"received\"] [\"-3\"] { tag \"received\";} else { tag \"No Received\";}"
                 + "tag \"Negative\";";
         doTest(filterScript, null);
     }
@@ -353,7 +362,7 @@ public class RelationalExtensionTest {
     // and the tag command should not be executed.
     @Test
     public void testCountAddressNumericNegativeValue() {
-        String filterScript = "require [\"tag\", \"relational\"];\n"
+        String filterScript = "require [\"tag\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                 + "if address :count \"le\" :comparator \"i;ascii-numeric\" "
                 + "[\"to\", \"cc\"] [\"-1\"] { tag \"Priority\"; }";
         doTest(filterScript, null);
@@ -363,7 +372,7 @@ public class RelationalExtensionTest {
     // and the tag command should not be executed.
     @Test
     public void testCountEnvelopeToNumericNegativeValue() {
-        String filterScript = "require [\"tag\", \"relational\"];\n"
+        String filterScript = "require [\"tag\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                 + "if envelope :count \"gt\" :comparator \"i;ascii-numeric\" "
                 + "[\"to\"] [\"-1\"] { }"
                 + "tag \"Priority\";";

--- a/store/src/java-test/com/zimbra/cs/filter/ReplaceHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/ReplaceHeaderTest.java
@@ -554,7 +554,7 @@ public class ReplaceHeaderTest {
     @Test
     public void testReplaceHeaderWithNumericComparisionUsingCount() {
         try {
-            String filterScript = "require [\"editheader\"];\n"
+            String filterScript = "require [\"editheader\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                     + " replaceheader :newname \"X-Numeric2-Header\" :count \"ge\" :comparator \"i;ascii-numeric\" \"X-Numeric-Header\" \"3\" \r\n"
                     + "  ;\n";
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
@@ -590,7 +590,7 @@ public class ReplaceHeaderTest {
     @Test
     public void testReplaceHeaderWithXSpamScore() {
         try {
-            String filterScript = "require [\"editheader\", \"variables\"];\n"
+            String filterScript = "require [\"editheader\", \"variables\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                     + "if anyof(header :value \"ge\" :comparator \"i;ascii-numeric\" [\"X-Spam-Score\"] [\"80\"]) {"
                     +"      if exists \"Subject\" {"
                     +"        replaceheader :newvalue \"[SPAM]${1}\" :matches \"Subject\" \"*\";"
@@ -1021,7 +1021,7 @@ public class ReplaceHeaderTest {
     @Test
     public void testReplaceHeaderWithCaseMapComparatorUsingValue() {
         try {
-            String filterScript = "require [\"editheader\"];\n"
+            String filterScript = "require [\"editheader\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                     + " replaceheader :newname \"X-Test2-Header\" :newvalue \"0\" :value \"lt\" :comparator \"i;ascii-casemap\" \"X-Test-Header\" \"test2\" \r\n"
                     + "  ;\n";
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");

--- a/store/src/java-test/com/zimbra/cs/filter/SetVariableTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/SetVariableTest.java
@@ -644,7 +644,7 @@ public class SetVariableTest {
                        + "\n"
                        + "Hello World.";
             RuleManager.clearCachedRules(account);
-            filterScript = "require [\"variables\"];\n"
+            filterScript = "require [\"variables\", \"comparator-i;ascii-numeric\"];\n"
                          + "set :lower :upperfirst \"name\" \"Joe\";\n"
                          + "if string :is :comparator \"i;ascii-numeric\" \"${name}\" [ \"Joe\", \"Hello\", \"User\" ]{\n"
                          + "  tag \"sales-1\";\n"
@@ -1564,7 +1564,7 @@ public class SetVariableTest {
             Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
             RuleManager.clearCachedRules(account);
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
-            filterScript = "require [\"variables\"];\n"
+            filterScript = "require [\"variables\", \"envelope\"];\n"
                          + "set \"dollar\" \"$\";\n"
                          + "set \"val\" \"xyz\";\n"
                          + "if header :matches :comparator \"i;ascii-casemap\" \"Subject\" \"${dollar}${val}\" {\n"

--- a/store/src/java/com/zimbra/cs/filter/JsieveConfigMapHandler.java
+++ b/store/src/java/com/zimbra/cs/filter/JsieveConfigMapHandler.java
@@ -40,6 +40,7 @@ public class JsieveConfigMapHandler {
     public static final String CAPABILITY_REJECT     = "reject";
     public static final String CAPABILITY_ENOTIFY    = "enotify";
     public static final String CAPABILITY_EDITHEADER = "editheader";
+    public static final String CAPABILITY_COMPARATOR_NUMERIC = "comparator-i;ascii-numeric";
 
     /*
      * jSieve's command map
@@ -115,6 +116,7 @@ public class JsieveConfigMapHandler {
         mTestMap.put("community_requests", com.zimbra.cs.filter.jsieve.CommunityRequestsTest.class.getName());
         mTestMap.put("community_content", com.zimbra.cs.filter.jsieve.CommunityContentTest.class.getName());
         mTestMap.put(CAPABILITY_RELATIONAL, com.zimbra.cs.filter.jsieve.RelationalTest.class.getName());
+        mTestMap.put(CAPABILITY_COMPARATOR_NUMERIC, com.zimbra.cs.filter.jsieve.ComparatorNumericTest.class.getName());
         mTestMap.put("string", com.zimbra.cs.filter.jsieve.StringTest.class.getName());
 
         // The capability string associated with the 'notify' action is

--- a/store/src/java/com/zimbra/cs/filter/SieveVisitor.java
+++ b/store/src/java/com/zimbra/cs/filter/SieveVisitor.java
@@ -541,8 +541,8 @@ public abstract class SieveVisitor {
                 firstTagArgNode = (SieveNode) getNode(node, 0, 0);
                 if (firstTagArgNode.getValue() instanceof TagArgument) {
                      String firstArgStr = firstTagArgNode.getValue().toString();
-                     if (":count".equals(firstArgStr) || ":value".equals(firstArgStr)) {
-                        if (":count".equals(firstArgStr)) {
+                     if (HeaderConstants.COUNT.equalsIgnoreCase(firstArgStr) || HeaderConstants.VALUE.equalsIgnoreCase(firstArgStr)) {
+                        if (HeaderConstants.COUNT.equalsIgnoreCase(firstArgStr)) {
                              isCount = true;
                         }
                         valueComparison = Sieve.ValueComparison.valueOf(getValue(node, 0, 1, 0, 0));

--- a/store/src/java/com/zimbra/cs/filter/SoapToSieve.java
+++ b/store/src/java/com/zimbra/cs/filter/SoapToSieve.java
@@ -31,6 +31,7 @@ import com.google.common.base.Objects;
 import com.google.common.base.Strings;
 import com.zimbra.common.filter.Sieve;
 import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.HeaderConstants;
 import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.soap.mail.type.EditheaderTest;
@@ -49,6 +50,9 @@ public final class SoapToSieve {
 
     // end of line in sieve script
     public static final String END_OF_LINE = ";\n";
+    public static final String requireCommon = "\"fileinto\", \"copy\", \"reject\", \"tag\", \"flag\", "
+            + "\"variables\", \"log\", \"enotify\", \"envelope\", \"body\", "
+            + "\"ereject\", \"reject\", \"relational\", \"comparator-i;ascii-numeric\"";
 
     public SoapToSieve(List<FilterRule> rules) {
         this.rules = rules;
@@ -57,7 +61,7 @@ public final class SoapToSieve {
     public String getSieveScript() throws ServiceException {
         if (buffer == null) {
             buffer = new StringBuilder();
-            buffer.append("require [\"fileinto\", \"copy\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\", \"enotify\"]" + END_OF_LINE);
+            buffer.append("require [" + requireCommon + "]" + END_OF_LINE);
             for (FilterRule rule : rules) {
                 buffer.append('\n');
                 handleRule(rule);
@@ -69,7 +73,7 @@ public final class SoapToSieve {
     public String getAdminSieveScript() throws ServiceException {
         if (buffer == null) {
             buffer = new StringBuilder();
-            buffer.append("require [\"fileinto\", \"copy\", \"reject\", \"tag\", \"flag\", \"variables\", \"log\", \"enotify\", \"editheader\"]" + END_OF_LINE);
+            buffer.append("require [" + requireCommon + ", \"editheader\"]" + END_OF_LINE);
             for (FilterRule rule : rules) {
                 buffer.append('\n');
                 handleRule(rule, true);
@@ -414,7 +418,7 @@ public final class SoapToSieve {
     }
 
     private static String toSieve(String name, String header, Sieve.ValueComparison comp, Sieve.Comparator valueComparator, boolean caseSensitive, String value, boolean isCount, Sieve.AddressPart part) throws ServiceException {
-        String countOrVal = isCount ? ":count" : ":value";
+        String countOrVal = isCount ? HeaderConstants.COUNT : HeaderConstants.VALUE;
         Sieve.Comparator comparator;
         if (valueComparator == null) {
             boolean numeric = true;

--- a/store/src/java/com/zimbra/cs/filter/jsieve/AddressTest.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/AddressTest.java
@@ -121,7 +121,7 @@ public class AddressTest extends Address {
 
         if (HeaderConstants.COUNT.equals(matchType)) {
             for (final String key: keys) {
-                isMatched = ZimbraComparatorUtils.counts(comparator,
+                isMatched = ZimbraComparatorUtils.counts(mail, comparator,
                     operator, headerValues, ZimbraComparatorUtils.getMatchKey(addressPart, key), context);
                 if (isMatched) {
                     break;
@@ -130,26 +130,16 @@ public class AddressTest extends Address {
         } else {
             Iterator headerValuesIter = headerValues.iterator();
             while (!isMatched && headerValuesIter.hasNext()) {
-                isMatched = match(comparator, matchType,
-                    operator, (String)headerValuesIter.next(), keys, context);
-            }
-        }
-        return isMatched;
-    }
+                // Iterate over the keys looking for a match
+                String headerValue = (String)headerValuesIter.next();
+                for (final String key: keys) {
+                    isMatched = ZimbraComparatorUtils.match(mail, comparator, matchType, operator,
+                            headerValue, key, context);
+                    if (isMatched) {
+                        break;
+                    }
+                }
 
-    /**
-     * Compares the value of the specified address field with the operator
-     */
-    private boolean match(String comparator, String matchType, String operator,
-            String headerValue, List<String> keys, SieveContext context)
-        throws SieveException {
-        // Iterate over the keys looking for a match
-        boolean isMatched = false;
-        for (final String key: keys) {
-            isMatched = ZimbraComparatorUtils.match(comparator, matchType, operator,
-                                                    headerValue, key, context);
-            if (isMatched) {
-                break;
             }
         }
         return isMatched;

--- a/store/src/java/com/zimbra/cs/filter/jsieve/ComparatorNumericTest.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/ComparatorNumericTest.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2016 Synacor, Inc.
+ * Copyright (C) 2017 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -16,32 +16,19 @@
  */
 package com.zimbra.cs.filter.jsieve;
 
-import static com.zimbra.cs.filter.JsieveConfigMapHandler.CAPABILITY_EREJECT;
-
 import org.apache.jsieve.Arguments;
-import org.apache.jsieve.Block;
 import org.apache.jsieve.SieveContext;
-import org.apache.jsieve.StringListArgument;
-import org.apache.jsieve.commands.optional.Reject;
 import org.apache.jsieve.exception.SieveException;
+import org.apache.jsieve.exception.SyntaxException;
 import org.apache.jsieve.mail.MailAdapter;
+import org.apache.jsieve.tests.AbstractTest;
 
-import com.zimbra.cs.filter.ZimbraMailAdapter;
+import static com.zimbra.cs.filter.JsieveConfigMapHandler.CAPABILITY_COMPARATOR_NUMERIC;
 
-public class Ereject extends Reject {
-
+public class ComparatorNumericTest extends AbstractTest {
     @Override
-    protected Object executeBasic(MailAdapter mail, Arguments arguments, Block block, SieveContext context)
-            throws SieveException {
-        if (!(mail instanceof ZimbraMailAdapter)) {
-            return null;
-        }
-        ZimbraMailAdapter mailAdapter  = (ZimbraMailAdapter) mail;
-        Require.checkCapability(mailAdapter, CAPABILITY_EREJECT);
-
-        mailAdapter.setDiscardActionPresent();
-        final String message = ((StringListArgument) arguments.getArgumentList().get(0)).getList().get(0);
-        mail.addAction(new ActionEreject(message));
-        return null;
+    protected boolean executeBasic(MailAdapter mail, Arguments arguments,
+            SieveContext context) throws SieveException {
+        throw new SyntaxException("Unexpected test " + CAPABILITY_COMPARATOR_NUMERIC);
     }
 }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/DateTest.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/DateTest.java
@@ -64,15 +64,17 @@ public class DateTest extends AbstractTest {
             if (argument instanceof TagArgument)
             {
                 String tag = ((TagArgument) argument).getTag();
-                if (tag.equals(BEFORE) || tag.equals(AFTER))
+                if (tag.equals(BEFORE) || tag.equals(AFTER)) {
                     comparator = tag;
-                else
+                } else {
                     throw new SyntaxException(
                         "Found unexpected: \"" + tag + "\"");
+                }
             }
         }
-        if (null == comparator)
+        if (null == comparator) {
             throw new SyntaxException("Expecting \"" + BEFORE + "\" or \"" + AFTER + "\"");
+        }
 
         // Second argument MUST be a date
         if (argumentsIter.hasNext())
@@ -88,13 +90,15 @@ public class DateTest extends AbstractTest {
                 }
             }
         }
-        if (null == date)
+        if (null == date) {
             throw new SyntaxException("Expecting a valid date (yyyyMMdd)");
+        }
 
         // There MUST NOT be any further arguments
-        if (argumentsIter.hasNext())
-            throw new SyntaxException("Found unexpected argument(s)");               
-        
+        if (argumentsIter.hasNext()) {
+            throw new SyntaxException("Found unexpected argument(s)");
+        }
+
         if (mail instanceof DummyMailAdapter) {
             return true;
         }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/EditHeaderExtension.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/EditHeaderExtension.java
@@ -415,9 +415,9 @@ public class EditHeaderExtension {
         }
 
         if (this.valueTag) {
-            matchFound = ZimbraComparatorUtils.values(comparator, relationalComparator, unfoldedAndDecodedHeaderValue, value, context);
+            matchFound = ZimbraComparatorUtils.values(mailAdapter, comparator, relationalComparator, unfoldedAndDecodedHeaderValue, value, context);
         } else if (this.countTag) {
-            matchFound = ZimbraComparatorUtils.counts(comparator, relationalComparator, headerList, value, context);
+            matchFound = ZimbraComparatorUtils.counts(mailAdapter, comparator, relationalComparator, headerList, value, context);
         } else if (this.is && ComparatorUtils.is(this.comparator, unfoldedAndDecodedHeaderValue, value, context)) {
             matchFound = true;
         } else if (this.contains && ComparatorUtils.contains(this.comparator, unfoldedAndDecodedHeaderValue, value, context)) {

--- a/store/src/java/com/zimbra/cs/filter/jsieve/EnvelopeTest.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/EnvelopeTest.java
@@ -17,6 +17,7 @@
 
 package com.zimbra.cs.filter.jsieve;
 
+import static com.zimbra.cs.filter.JsieveConfigMapHandler.CAPABILITY_ENVELOPE;
 import static com.zimbra.cs.filter.jsieve.ComparatorName.ASCII_NUMERIC_COMPARATOR;
 import static org.apache.jsieve.comparators.ComparatorNames.ASCII_CASEMAP_COMPARATOR;
 import static org.apache.jsieve.comparators.MatchTypeTags.IS_TAG;
@@ -66,6 +67,8 @@ public class EnvelopeTest extends Envelope {
         if (!(mail instanceof ZimbraMailAdapter)) {
             return false;
         }
+        ZimbraMailAdapter mailAdapter  = (ZimbraMailAdapter) mail;
+        Require.checkCapability(mailAdapter, CAPABILITY_ENVELOPE);
 
         ZimbraComparatorUtils.TestParameters params = ZimbraComparatorUtils.parseTestArguments(mail, arguments, context);
         params.setKeys(HeaderTest.replaceVariables(params.getKeys(), mail));
@@ -75,9 +78,8 @@ public class EnvelopeTest extends Envelope {
         }
 
         if (MatchTypeTags.MATCHES_TAG.equals(params.getMatchType())) {
-            ZimbraMailAdapter zma  = (ZimbraMailAdapter) mail;
             try {
-                HeaderTest.evaluateVarExp(zma, params.getHeaderNames(), HeaderTest.SourceType.ENVELOPE, params.getKeys());
+                HeaderTest.evaluateVarExp(mailAdapter, params.getHeaderNames(), HeaderTest.SourceType.ENVELOPE, params.getKeys());
             } catch (MessagingException e) {
                 throw new SieveException("Exception occured while evaluating variable expression.", e);
             }
@@ -152,7 +154,7 @@ public class EnvelopeTest extends Envelope {
 
         if (HeaderConstants.COUNT.equals(matchType)) {
             for (final String key: keys) {
-                isMatched = ZimbraComparatorUtils.counts(comparator,
+                isMatched = ZimbraComparatorUtils.counts(mail, comparator,
                         operator, headerValues, ZimbraComparatorUtils.getMatchKey(addressPart, key), context);
                 if (isMatched) {
                     break;
@@ -169,8 +171,15 @@ public class EnvelopeTest extends Envelope {
                 } else {
                     normalizedKeys = keys;
                 }
-                isMatched = match(comparator, matchType, operator, (String)headerValuesIter.next(), normalizedKeys,
-                        context);
+                String headerValue = (String)headerValuesIter.next();
+                // Iterate over the keys looking for a match
+                for (final String key: keys) {
+                    isMatched = ZimbraComparatorUtils.match(mail, comparator, matchType, operator,
+                            headerValue, key, context);
+                    if (isMatched) {
+                        break;
+                    }
+                }
             }
         }
         
@@ -214,20 +223,5 @@ public class EnvelopeTest extends Envelope {
             matchAddress = matchAddress.toLowerCase();
         }
         return matchAddress;
-    }
-
-    private boolean match(String comparator, String matchType, String operator,
-            String headerValue, List<String> keys, SieveContext context)
-                                throws SieveException {
-        // Iterate over the keys looking for a match
-        boolean isMatched = false;
-        for (final String key: keys) {
-            isMatched = ZimbraComparatorUtils.match(comparator, matchType, operator,
-                    headerValue, key, context);
-            if (isMatched) {
-                break;
-            }
-        }
-        return isMatched;
     }
 }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/HeaderTest.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/HeaderTest.java
@@ -228,7 +228,7 @@ public class HeaderTest extends Header {
                 headerValues.addAll(mail.getMatchingHeader((String) headerNamesIter.next()));
             }
             for (final String key: keys) {
-                isMatched = ZimbraComparatorUtils.counts(comparator,
+                isMatched = ZimbraComparatorUtils.counts(mail, comparator,
                     operator, headerValues, key, context);
                 if (isMatched) {
                     break;
@@ -236,52 +236,29 @@ public class HeaderTest extends Header {
             }
         } else {
             while (!isMatched && headerNamesIter.hasNext()) {
-                isMatched = match(comparator, matchType, operator,
-                    mail.getMatchingHeader((String) headerNamesIter.next()),
-                    keys, context);
+                List<String> headerValues = mail.getMatchingHeader((String) headerNamesIter.next());
+                if (headerValues.isEmpty()) {
+                    isMatched = false;
+                } else {
+                    // Compares each header value to each key.
+                    Iterator headerValuesIter = headerValues.iterator();
+                    while (!isMatched && headerValuesIter.hasNext()) {
+                        String headerValue = (String) headerValuesIter.next();
+                        // Iterate over the keys looking for a match
+                        for (final String key: keys) {
+                            isMatched = ZimbraComparatorUtils.match(mail, comparator, matchType, operator,
+                                    headerValue, key, context);
+                            if (isMatched) {
+                                break;
+                            }
+                        }
+                    }
+                }
             }
         }
         return isMatched;
     }
 
-    /**
-     * Traverses the values set of the specific header field(s) to check the filter key
-     */
-    protected boolean match(String comparator, String matchType, String operator,
-        List<String> headerValues, List<String> keys, SieveContext context)
-            throws SieveException {
-        if (headerValues.isEmpty()) {
-            return false;
-        }
-
-        // Iterate over the header values looking for a match
-        boolean isMatched = false;
-        Iterator headerValuesIter = headerValues.iterator();
-        while (!isMatched && headerValuesIter.hasNext()) {
-            isMatched = match(comparator, matchType, operator,
-                              (String) headerValuesIter.next(), keys, context);
-        }
-        return isMatched;
-    }
-
-    /**
-     * Compares each header value to each key.
-     */
-    protected boolean match(String comparator, String matchType,
-        String operator, String headerValue, List<String> keys, SieveContext context)
-            throws SieveException {
-        // Iterate over the keys looking for a match
-        boolean isMatched = false;
-        for (final String key: keys) {
-            isMatched = ZimbraComparatorUtils.match(comparator, matchType, operator,
-                headerValue, key, context);
-            if (isMatched) {
-                break;
-            }
-        }
-        return isMatched;
-    }
-    
     protected boolean match(MailAdapter mail, String comparator, String matchType, List<String> headerNames, List<String> keys, 
             SieveContext context) throws SieveException {
         if (mail instanceof DummyMailAdapter) {

--- a/store/src/java/com/zimbra/cs/filter/jsieve/NotifyMethodCapabilityTest.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/NotifyMethodCapabilityTest.java
@@ -192,7 +192,7 @@ public class NotifyMethodCapabilityTest extends AbstractTest {
             throw context.getCoordinate().syntaxException(
                     "Found unexpected arguments");
         }
-        return test(comparator, matchType, operator, uri, capability, keys, context);
+        return test(mail, comparator, matchType, operator, uri, capability, keys, context);
     }
 
     @Override
@@ -200,7 +200,7 @@ public class NotifyMethodCapabilityTest extends AbstractTest {
         // override validation -- it's already done in executeBasic above
     }
 
-    private boolean test(String comparator, String matchType, String operator,
+    private boolean test(MailAdapter mail, String comparator, String matchType, String operator,
             String uri, String capability, List<String> keys, SieveContext context) throws SieveException {
         if (null == uri || null == capability) {
             return false;
@@ -216,7 +216,7 @@ public class NotifyMethodCapabilityTest extends AbstractTest {
         }
 
         if (HeaderConstants.COUNT.equalsIgnoreCase(matchType)) {
-            return testCount(keys, comparator, operator, context);
+            return testCount(mail, keys, comparator, operator, context);
         }
         // There is no way to detect the online/offline status of the recipient.
         // The test always returns "maybe" for the "mailto" notification method
@@ -230,11 +230,11 @@ public class NotifyMethodCapabilityTest extends AbstractTest {
         return false;
     }
 
-    private boolean testCount(List<String> keys, String comparator, String operator, SieveContext context) throws SieveException {
+    private boolean testCount(MailAdapter mail, List<String> keys, String comparator, String operator, SieveContext context) throws SieveException {
         List<String> values = Arrays.asList(CAPABILITY_MAYBE);
         boolean isMatched = false;
         for (String key : keys) {
-            isMatched = ZimbraComparatorUtils.counts(comparator,
+            isMatched = ZimbraComparatorUtils.counts(mail, comparator,
                 operator, values, key, context);
             if (isMatched) {
                 break;

--- a/store/src/java/com/zimbra/cs/filter/jsieve/Reject.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/Reject.java
@@ -20,6 +20,8 @@ import com.zimbra.cs.account.Account;
 import com.zimbra.cs.filter.FilterUtil;
 import com.zimbra.cs.filter.ZimbraMailAdapter;
 
+import static com.zimbra.cs.filter.JsieveConfigMapHandler.CAPABILITY_REJECT;
+
 import org.apache.jsieve.Arguments;
 import org.apache.jsieve.Block;
 import org.apache.jsieve.SieveContext;
@@ -42,6 +44,8 @@ public class Reject extends org.apache.jsieve.commands.optional.Reject {
             return null;
         }
         ZimbraMailAdapter mailAdapter = (ZimbraMailAdapter) mail;
+        Require.checkCapability(mailAdapter, CAPABILITY_REJECT);
+
         Account account = null;
         account = mailAdapter.getAccount();
         if (account.isSieveRejectMailEnabled()) {

--- a/store/src/java/com/zimbra/cs/filter/jsieve/StringTest.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/StringTest.java
@@ -226,7 +226,7 @@ public class StringTest extends Header {
             sourceValues.removeAll(Arrays.asList("", null));
             keyIter = keyValues.iterator();
             while (!isMatched && keyIter.hasNext()) {
-                isMatched = ZimbraComparatorUtils.counts(comparator,
+                isMatched = ZimbraComparatorUtils.counts(mail, comparator,
                     operator, sourceValues, keyIter.next(), context);
             }
         } else {
@@ -235,7 +235,7 @@ public class StringTest extends Header {
                 String source = sourceIter.next();
                 keyIter = keyValues.iterator();
                 while(!isMatched && keyIter.hasNext()) {
-                    isMatched = ZimbraComparatorUtils.match(comparator, matchType, operator,
+                    isMatched = ZimbraComparatorUtils.match(mail, comparator, matchType, operator,
                             source, keyIter.next(), context);
                 }
             }


### PR DESCRIPTION
ZCS-1858:declare extension in "require" command, Part 2
    
Support "require" command with the following capability strings for the Sieve extensions:
     capability   | Extension
     -------------+------------------
     "envelope"   | RFC 5228 Test envelope
     "comparator-"| RFC 5228 "comparator-i;ascii-numeric"
     "relational" | RFC 5231 :count/:value match-type, and six relational-match operators
     "ereject"    | RFC 5429
     "reject"     | RFC 5429
    
This fix makes it mandatory for the Sieve test/command above to declare the capability in "require" command.
If the Sieve extension is used without declaration in the "require" command, the entire filter execution will be canceled and the message is delivered to the Inbox without any modification.