### PR TITLE
ZCS-2388 : Editheader actions should not be supported in user mail sieve script

### DIFF
--- a/soap/src/java/com/zimbra/soap/mail/type/FilterAction.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/FilterAction.java
@@ -682,7 +682,7 @@ public class FilterAction {
          * @zm-api-field-tag filterTests
          * @zm-api-field-description tests
          */
-        @XmlElement(name=AdminConstants.E_TEST /* test */, required=false)
+        @XmlElement(name=AdminConstants.E_TEST /* test */, required=true)
         private EditheaderTest test;
 
         private DeleteheaderAction() {
@@ -748,9 +748,6 @@ public class FilterAction {
             }
             if (last != null && last && offset == null) {
                 throw ServiceException.PARSE_ERROR(":index <offset> must be provided with :last", null);
-            }
-            if (test == null) {
-                throw ServiceException.PARSE_ERROR("<test> is mandatory in action", null);
             }
             test.validateEditheaderTest();
         }

--- a/store/src/java-test/com/zimbra/cs/service/admin/ModifyFilterRulesAdminTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/admin/ModifyFilterRulesAdminTest.java
@@ -245,26 +245,6 @@ public class ModifyFilterRulesAdminTest {
         Assert.assertEquals(script, account.getAdminSieveScriptBefore());
     }
 
-    // negative test case
-    @Test
-    public void testNegativeSoapToSieveDeleteheaderAction() throws ServiceException, Exception {
-        List<String> values = new ArrayList<String>();
-        values.add("2");
-        DeleteheaderAction action = new DeleteheaderAction(null, null, null);
-        FilterRule filterRule = new FilterRule("rule1", true);
-        filterRule.addFilterAction(action);
-        List<FilterRule> filterRules = new ArrayList<FilterRule>();
-        filterRules.add(filterRule);
-
-        RuleManager.clearCachedRules(account);
-        try {
-            RuleManager.setAdminRulesFromXML(account, filterRules, FilterType.INCOMING, AdminFilterType.BEFORE);
-        } catch (ServiceException se) {
-            Assert.assertEquals("service.PARSE_ERROR", se.getCode());
-            Assert.assertTrue(se.getMessage().contains("<test> is mandatory in action"));
-        }
-    }
-
     /******************replaceheader*********************/
     @Test
     public void testSoapToSieveReplaceheaderActionBasic() throws ServiceException, Exception {


### PR DESCRIPTION
Removed null check and test added in https://github.com/Zimbra/zm-mailbox/pull/336. Made test filed required=true.