### PR TITLE
ZCS-2730:API to restore a selected contact backup file

### DIFF
--- a/common/src/java/com/zimbra/common/soap/MailConstants.java
+++ b/common/src/java/com/zimbra/common/soap/MailConstants.java
@@ -1339,4 +1339,12 @@ public final class MailConstants {
     public static final String OP_INHERIT = "inherit";
     public static final String OP_MUTE = "mute";
     public static final String OP_RESET_IMAP_UID = "resetimapuid";
+
+    // Contacts API
+    public static final String E_RESTORE_CONTACTS_REQUEST = "RestoreContactsRequest";
+    public static final String E_RESTORE_CONTACTS_RESPONSE = "RestoreContactsResponse";
+    public static final QName RESTORE_CONTACTS_REQUEST = QName.get(E_RESTORE_CONTACTS_REQUEST, NAMESPACE);
+    public static final QName RESTORE_CONTACTS_RESPONSE = QName.get(E_RESTORE_CONTACTS_RESPONSE, NAMESPACE);
+    public static final String A_CONTACTS_BACKUP_FILE_NAME = "contactsBackupFileName";
+    public static final String A_CONTACTS_BACKUP_FOLDER_NAME = "ContactsBackup";
 }

--- a/soap/src/java/com/zimbra/soap/JaxbUtil.java
+++ b/soap/src/java/com/zimbra/soap/JaxbUtil.java
@@ -1114,7 +1114,11 @@ public final class JaxbUtil {
             com.zimbra.soap.mail.message.GetLastItemIdInMailboxRequest.class,
             com.zimbra.soap.mail.message.GetLastItemIdInMailboxResponse.class,
             com.zimbra.soap.mail.message.BeginTrackingIMAPRequest.class,
-            com.zimbra.soap.mail.message.BeginTrackingIMAPResponse.class
+            com.zimbra.soap.mail.message.BeginTrackingIMAPResponse.class,
+
+            //Contacts API
+            com.zimbra.soap.mail.message.RestoreContactsRequest.class,
+            com.zimbra.soap.mail.message.RestoreContactsResponse.class
         };
 
         try {

--- a/soap/src/java/com/zimbra/soap/mail/message/RestoreContactsRequest.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/RestoreContactsRequest.java
@@ -1,0 +1,54 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2017 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.soap.mail.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.google.common.base.Objects;
+import com.zimbra.common.soap.MailConstants;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name = MailConstants.E_RESTORE_CONTACTS_REQUEST)
+public class RestoreContactsRequest {
+
+    /**
+     * @zm-api-field-tag contact-backup
+     * @zm-api-field-description Filename of contact backup file
+     */
+    @XmlAttribute(name = MailConstants.A_CONTACTS_BACKUP_FILE_NAME, required = true)
+    private String contactsBackupFileName;
+
+    public String getContactsBackupFileName() {
+        return contactsBackupFileName;
+    }
+
+    public void setContactsBackupFileName(String contactsBackupFileName) {
+        this.contactsBackupFileName = contactsBackupFileName;
+    }
+
+    public Objects.ToStringHelper addToStringInfo(Objects.ToStringHelper helper) {
+        return helper.add("contactsBackupFileName", contactsBackupFileName);
+    }
+
+    @Override
+    public String toString() {
+        return addToStringInfo(Objects.toStringHelper(this)).toString();
+    }
+}

--- a/soap/src/java/com/zimbra/soap/mail/message/RestoreContactsResponse.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/RestoreContactsResponse.java
@@ -1,0 +1,44 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2017 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.soap.mail.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.MailConstants;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name = MailConstants.E_RESTORE_CONTACTS_RESPONSE)
+public class RestoreContactsResponse {
+
+    /**
+     * @zm-api-field-tag status
+     * @zm-api-field-description Restore request status
+     */
+    @XmlAttribute(name = MailConstants.A_STATUS, required = true)
+    private String status;
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+}

--- a/store/docs/rest.txt
+++ b/store/docs/rest.txt
@@ -52,7 +52,7 @@ URL
 ------------------------------------------------------------
 
    http://server/home/[~][{username}]/[{folder}]?[{query-params}]
-          fmt={ics, csv, etc}
+          fmt={ics, csv, ldif etc}
           id={item-id}
           list={item-id}*[,{item-id}]
           imap_id={item-imap-id}  (must also specify folder)

--- a/store/docs/soap.txt
+++ b/store/docs/soap.txt
@@ -4696,6 +4696,21 @@ If IMAP tracking is already enabled, does nothing.
 <BeginTrackingIMAPResponse/>
 
 -----------------------------
+API to restore contact backup file from the contact backup list
+<RestoreContactsRequest contactsBackupFileName="{backup_file_name}">
+</RestoreContactsRequest>
+
+Note: First, retrieve the contact backup file name with GetContactBackupList Soap API,
+then send that file name in 'contactsBackupFileName' parameter of RestoreContactsRequest.
+RestoreContactsRequest will search for file inside 'ContactsBackup' briefcase folder
+and if found, will restore it.
+
+<RestoreContactsResponse status="{status}">
+</RestoreContactsResponse>
+
+{status} = SUCCESS | FAILURE;
+
+-----------------------------
 Api to get list of available contact backup files
 <GetContactBackupListRequest xmlns="urn:zimbraMail" />
 

--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -70,6 +70,7 @@
   <dependency org="org.apache.httpcomponents" name="httpasyncclient" rev="4.1.2"/>
   <dependency org="org.apache.httpcomponents" name="httpcore" rev="4.4.5"/>
   <dependency org="org.apache.httpcomponents" name="httpcore-nio" rev="4.4.5"/>
+  <dependency org="org.apache.httpcomponents" name="httpmime" rev="4.3.1"/>
   <dependency org="org.apache.commons" name="commons-compress" rev="1.10" />
   <dependency org="org.apache.mina" name="mina-core" rev="2.0.4"/>
   <dependency org="org.apache.curator" name="curator-recipes" rev="2.0.1-incubating" />

--- a/store/src/java-test/com/zimbra/cs/service/mail/RestoreContactsTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/mail/RestoreContactsTest.java
@@ -1,0 +1,112 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2017 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.service.mail;
+
+import java.io.ByteArrayInputStream;
+import java.util.Map;
+
+import org.apache.http.StatusLine;
+import org.apache.http.HttpResponse;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.google.common.collect.Maps;
+import com.zimbra.common.account.Key;
+import com.zimbra.common.mime.MimeConstants;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.MailConstants;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.Folder;
+import com.zimbra.cs.mailbox.MailItem;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.mailbox.OperationContext;
+import com.zimbra.cs.store.file.FileBlobStore;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ RestoreContacts.class, HttpResponse.class, StatusLine.class,
+    FileBlobStore.class })
+@PowerMockIgnore({ "javax.crypto.*", "javax.xml.bind.annotation.*" })
+public class RestoreContactsTest {
+
+    private Account acct = null;
+
+    @BeforeClass
+    public static void init() throws Exception {
+        MailboxTestUtil.initServer();
+        Provisioning prov = Provisioning.getInstance();
+
+        Map<String, Object> attrs = Maps.newHashMap();
+        prov.createAccount("test@zimbra.com", "secret", attrs);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        MailboxTestUtil.clearData();
+        acct = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+    }
+
+    @Test
+    public void testRestore() throws Exception {
+        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+        Folder folder = mbox.createFolder(null, "Briefcase/ContactsBackup",
+            new Folder.FolderOptions().setDefaultView(MailItem.Type.DOCUMENT));
+        OperationContext octxt = new OperationContext(acct);
+        // Upload the contacts backup file to ContactsBackup folder in briefcase
+        mbox.createDocument(octxt, folder.getId(), "backup_dummy_test.tgz",
+            MimeConstants.CT_APPLICATION_ZIMBRA_DOC, "author", "description",
+            new ByteArrayInputStream("dummy data".getBytes()));
+        HttpResponse httpResponse = PowerMockito.mock(HttpResponse.class);
+        StatusLine httpStatusLine = PowerMockito.mock(StatusLine.class);
+        Mockito.when(httpStatusLine.getStatusCode()).thenReturn(200);
+        Mockito.when(httpResponse.getStatusLine()).thenReturn(httpStatusLine);
+        PowerMockito.stub(PowerMockito.method(RestoreContacts.class, "httpPostBackup"))
+            .toReturn(httpResponse);
+        PowerMockito.stub(PowerMockito.method(FileBlobStore.class, "getBlobPath", Mailbox.class,
+            int.class, int.class, short.class)).toReturn("/");
+        // RestoreContactRequest with valid backup file name
+        Element request = new Element.XMLElement(MailConstants.RESTORE_CONTACTS_REQUEST);
+        request.addAttribute("contactsBackupFileName", "backup_dummy_test.tgz");
+        Map<String, Object> context = ServiceTestUtil.getRequestContext(acct);
+        Element response = new RestoreContacts().handle(request, context);
+        String expectedResponse = "<RestoreContactsResponse status=\"SUCCESS\" xmlns=\"urn:zimbraMail\"/>";
+        Assert.assertEquals(expectedResponse, response.prettyPrint());
+        try {
+            // RestoreContactRequest with non-existing backup file name
+            Element request2 = new Element.XMLElement(MailConstants.RESTORE_CONTACTS_REQUEST);
+            request2.addAttribute("contactsBackupFileName", "backup_dummy_test_non_existing.tgz");
+            new RestoreContacts().handle(request2, context);
+            Assert.fail("ServiceException was expected");
+        } catch (ServiceException e) {
+            Assert.assertEquals("invalid request: No such file: backup_dummy_test_non_existing.tgz",
+                e.getMessage());
+            Assert.assertEquals("service.INVALID_REQUEST", e.getCode());
+
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/service/mail/MailService.java
+++ b/store/src/java/com/zimbra/cs/service/mail/MailService.java
@@ -229,5 +229,8 @@ public final class MailService implements DocumentService {
         dispatcher.registerHandler(MailConstants.GET_LAST_ITEM_ID_IN_MAILBOX_REQUEST, new GetLastItemIdInMailbox());
         dispatcher.registerHandler(MailConstants.GET_MODIFIED_ITEMS_IDS_REQUEST, new GetModifiedItemsIDs());
         dispatcher.registerHandler(MailConstants.RESET_RECENT_MESSAGE_COUNT_REQUEST, new ResetRecentMessageCount());
+
+        // Contacts API
+        dispatcher.registerHandler(MailConstants.RESTORE_CONTACTS_REQUEST, new RestoreContacts());
     }
 }

--- a/store/src/java/com/zimbra/cs/service/mail/RestoreContacts.java
+++ b/store/src/java/com/zimbra/cs/service/mail/RestoreContacts.java
@@ -1,0 +1,147 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2017 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.service.mail;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.CookieStore;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.mime.MultipartEntity;
+import org.apache.http.entity.mime.content.FileBody;
+import org.apache.http.impl.client.BasicCookieStore;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.cookie.BasicClientCookie;
+import org.eclipse.jetty.http.HttpStatus;
+
+import com.zimbra.common.mime.MimeConstants;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.MailConstants;
+import com.zimbra.common.util.ZimbraCookie;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.AuthToken;
+import com.zimbra.cs.account.AuthTokenException;
+import com.zimbra.cs.mailbox.Document;
+import com.zimbra.cs.mailbox.Folder;
+import com.zimbra.cs.mailbox.MailItem;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.OperationContext;
+import com.zimbra.cs.service.UserServlet;
+import com.zimbra.cs.store.file.FileBlobStore;
+import com.zimbra.soap.SoapServlet;
+import com.zimbra.soap.ZimbraSoapContext;
+import com.zimbra.soap.mail.message.RestoreContactsRequest;
+import com.zimbra.soap.mail.message.RestoreContactsResponse;
+
+public class RestoreContacts extends MailDocumentHandler {
+
+    public enum ContactRestoreStatus {
+        SUCCESS, FAILURE;
+    }
+
+    @Override
+    public Element handle(Element request, Map<String, Object> context) throws ServiceException {
+        ZimbraSoapContext zsc = getZimbraSoapContext(context);
+        Mailbox mbox = getRequestedMailbox(zsc);
+        OperationContext octxt = getOperationContext(zsc, context);
+        RestoreContactsRequest req = zsc.elementToJaxb(request);
+        String contactBackupFileName = req.getContactsBackupFileName();
+        // if folder does not exist, SoapFault is thrown by getFolderByName() itself.
+        Folder folder = mbox.getFolderByName(octxt, Mailbox.ID_FOLDER_BRIEFCASE,
+            MailConstants.A_CONTACTS_BACKUP_FOLDER_NAME);
+        ZimbraLog.contact.debug("Backup folder exists. Searching for %s.", contactBackupFileName);
+        List<MailItem> itemList = mbox.getItemList(octxt, MailItem.Type.DOCUMENT, folder.getId());
+        RestoreContactsResponse response = new RestoreContactsResponse();
+        boolean mailItemFound = false;
+        HttpResponse httpResponse = null;
+        for (MailItem item : itemList) {
+            if (item instanceof Document) {
+                Document doc = (Document) item;
+                if (doc.getName().equals(contactBackupFileName)) {
+                    mailItemFound = true;
+                    Object servReq = context.get(SoapServlet.SERVLET_REQUEST);
+                    String realm = "https://";
+                    HttpServletRequest httpRequest = null;
+                    if (servReq instanceof HttpServletRequest) {
+                        httpRequest = (HttpServletRequest) servReq;
+                        realm = httpRequest.isSecure() ? "https://" : "http://";
+                    }
+                    String url = realm + getLocalHost() + "/service/home/"
+                        + mbox.getAccount().getName() + "/?" + UserServlet.QP_FMT + "=tgz&"
+                        + UserServlet.QP_TYPES + "=contact&" + MimeConstants.P_CHARSET + "=UTF-8";
+                    CookieStore cookieStore = new BasicCookieStore();
+                    AuthToken authToken = octxt.getAuthToken();
+                    BasicClientCookie cookie = null;
+                    try {
+                        cookie = new BasicClientCookie(ZimbraCookie.COOKIE_ZM_AUTH_TOKEN, authToken.getEncoded());
+                        cookie.setPath("/");
+                        cookie.setDomain(mbox.getAccount().getDomainName());
+                        cookieStore.addCookie(cookie);
+                    } catch (AuthTokenException e) {
+                        throw ServiceException.FAILURE("Failed to get authentication token", e);
+                    }
+                    File file = new File(FileBlobStore.getBlobPath(mbox, doc.getId(),
+                        doc.getSavedSequence(), Short.valueOf(doc.getLocator())));
+                    if (!file.exists()) {
+                        throw ServiceException
+                            .INVALID_REQUEST("File does not exist: " + contactBackupFileName, null);
+                    }
+                    ZimbraLog.contact.debug("Backup file found. Restoring contacts in %s.",
+                        contactBackupFileName);
+                    httpResponse = httpPostBackup(file, url, cookieStore);
+                    break;
+                }
+            }
+        }
+        if (!mailItemFound) {
+            throw ServiceException.INVALID_REQUEST("No such file: " + contactBackupFileName, null);
+        }
+        ContactRestoreStatus status = httpResponse.getStatusLine().getStatusCode() == HttpStatus.OK_200 ? ContactRestoreStatus.SUCCESS : ContactRestoreStatus.FAILURE;
+        if ("SUCCESS".equals(status)) {
+            ZimbraLog.contact.debug("Restore operation for %s completed successfully",
+                contactBackupFileName);
+        } else {
+            ZimbraLog.contact.info("Restore operation for %s failed. Http respose status: %s",
+                contactBackupFileName, httpResponse.getStatusLine());
+        }
+        response.setStatus(status.name());
+        return zsc.jaxbToElement(response);
+    }
+
+    public static HttpResponse httpPostBackup(File file, String url, CookieStore cookieStore) throws ServiceException {
+        HttpResponse httpResponse = null;
+        HttpClient http = HttpClientBuilder.create().setDefaultCookieStore(cookieStore)
+            .build();
+        HttpPost post = new HttpPost(url);
+        MultipartEntity multipart = new MultipartEntity();
+        multipart.addPart("file", new FileBody(file));
+        post.setEntity(multipart);
+        try {
+            httpResponse = http.execute(post);
+        } catch (IOException e) {
+            throw ServiceException.FAILURE("Failed to execute contact restore request", null);
+        }
+        return httpResponse;
+    }
+}


### PR DESCRIPTION
API to restore particular contact backup file.
The API accepts filename as input parameter and restores that contact backup file (from existing hidden contact backup folder named 'ContactsBackup' in Briefcase folder).
Returns restore status as SUCCESS or FAILURE.

Updated API doc.

Testing Done:
Added Junit test.
Manual testing.

Automation testing to be done.