### PR TITLE
ZCS-2746 Marking forwarded message as read

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -6532,6 +6532,14 @@ public class ZAttrProvisioning {
     public static final String A_zimbraFeatureMAPIConnectorEnabled = "zimbraFeatureMAPIConnectorEnabled";
 
     /**
+     * Mark messages sent to a forwarding address as read
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2123)
+    public static final String A_zimbraFeatureMarkMailForwardedAsRead = "zimbraFeatureMarkMailForwardedAsRead";
+
+    /**
      * Whether to enable Zimbra Mobile Gateway feature
      *
      * @since ZCS 8.7.0,9.0.0

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9563,4 +9563,11 @@ TODO: delete them permanently from here
   <defaultCOSValue>Received,DKIM-Signature,Authentication-Results,Received-SPF,Message-ID,Content-Type,Content-Disposition,Content-Transfer-Encoding,MIME-Version,Auto-Submitted</defaultCOSValue>
   <desc>Comma separated list of sieve immutable headers</desc>
 </attr>
+
+<attr id="2123" name="zimbraFeatureMarkMailForwardedAsRead" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="8.8.5">
+  <defaultCOSValue>FALSE</defaultCOSValue>
+  <desc>Mark messages sent to a forwarding address as read</desc>
+</attr>
+
+
 </attrs>

--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -5,13 +5,15 @@
  <info organisation="zimbra" module="zm-store" status="integration">
  </info>
  <dependencies>
-  <dependency org="org.powermock" name="powermock-module-junit4" rev="1.5.5" />
-  <dependency org="org.powermock" name="powermock-module-junit4-common" rev="1.5.5" />
-  <dependency org="org.powermock" name="powermock-api-mockito" rev="1.5.5" />
-  <dependency org="org.powermock" name="powermock-core" rev="1.5.5" />
-  <dependency org="org.powermock" name="powermock-api-support" rev="1.5.5" />
-  <dependency org="org.powermock" name="powermock-reflect" rev="1.5.5" />
-  <dependency org="org.mockito" name="mockito-all" rev="1.9.5" />
+  <dependency org="org.powermock" name="powermock-module-junit4" rev="1.6.5"/>
+  <dependency org="org.powermock" name="powermock-module-junit4-common" rev="1.6.5" />
+  <dependency org="org.powermock" name="powermock-api-easymock" rev="1.6.5"/>
+  <dependency org="org.powermock" name="powermock-api-mockito" rev="1.6.5" />
+  <dependency org="org.powermock" name="powermock-core" rev="1.6.5" />
+  <dependency org="org.powermock" name="powermock-api-support" rev="1.6.5" />
+  <dependency org="org.powermock" name="powermock-reflect" rev="1.6.5" />
+  <dependency org="org.powermock" name="powermock-api-mockito-common" rev="1.6.5"/>
+  <dependency org="org.mockito" name="mockito-all" rev="1.10.19" />
   <dependency org="org.javassist" name="javassist" rev="3.18.2-GA" />
   <dependency org="org.slf4j" name="slf4j-api" rev="1.6.4"/>
   <dependency org="org.slf4j" name="slf4j-log4j12" rev="1.6.4"/>

--- a/store/src/java-test/com/zimbra/cs/filter/IncomingMessageHandlerTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/IncomingMessageHandlerTest.java
@@ -1,0 +1,242 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite, Network Edition.
+ * Copyright (C) 2013, 2014 Zimbra, Inc.  All Rights Reserved.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.filter;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.ldap.LdapProvisioning;
+import com.zimbra.cs.filter.jsieve.ActionFlag;
+import com.zimbra.cs.mailbox.DeliveryContext;
+import com.zimbra.cs.mailbox.DeliveryOptions;
+import com.zimbra.cs.mailbox.Flag;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.Message;
+import com.zimbra.cs.mailbox.OperationContext;
+import com.zimbra.cs.mime.ParsedMessage;
+
+/**
+ * @author zimbra
+ *
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ Provisioning.class })
+@PowerMockIgnore({"javax.xml.parsers.*", "org.apache.log4j.*", "org.xml.sax.*", "org.w3c.dom.*"})
+public class IncomingMessageHandlerTest {
+
+    @Mock
+    private Provisioning prov = PowerMockito.mock(LdapProvisioning.class);
+
+    @Before
+    public void setUp() {
+        PowerMockito.mockStatic(Provisioning.class);
+        PowerMockito.when(Provisioning.getInstance()).thenReturn(prov);
+    }
+
+
+    @Test
+    public void testImplicitKeepWhenForwardFeatureEnabledAndReadFlagSet() {
+        try {
+            OperationContext octxt = EasyMock.createMock(OperationContext.class);
+            DeliveryContext dctxt = EasyMock.createMock(DeliveryContext.class);
+            String recipientsAddress = "user1@email.com";
+            int size = 100;
+            int defaultFolderId = 2;
+            boolean noICal = false;
+            Mailbox mailbox = new MockMailbox();
+            IncomingMessageHandler messageHandler = new IncomingMessageHandler(octxt, dctxt,
+                mailbox, recipientsAddress, null, size, defaultFolderId, noICal);
+            Account acct = mailbox.getAccount();
+            acct.setPrefMailForwardingAddress("forwar@zimbra.com");
+            acct.setFeatureMarkMailForwardedAsRead(true);
+            acct.setFeatureMailForwardingEnabled(true);
+            List<ActionFlag> actions = new ArrayList<ActionFlag>();
+            String[] tags = { "yellow" };
+
+            Message msg = messageHandler.implicitKeep(actions, tags);
+            assertEquals(0, msg.getFlagBitmask());
+        } catch (ServiceException e) {
+            Assert.fail("No Exception should be thrown.");
+        }
+
+    }
+
+    @Test
+    public void testImplicitKeepWhenForwardFeatureEnabledButReadFlagNotSet() {
+        try {
+            OperationContext octxt = EasyMock.createMock(OperationContext.class);
+            DeliveryContext dctxt = EasyMock.createMock(DeliveryContext.class);
+            String recipientsAddress = "user1@email.com";
+            int size = 100;
+            int defaultFolderId = 2;
+            boolean noICal = false;
+            Mailbox mailbox = new MockMailbox();
+
+            IncomingMessageHandler messageHandler = new IncomingMessageHandler(octxt, dctxt,
+                mailbox, recipientsAddress, null, size, defaultFolderId, noICal);
+
+            Account acct = mailbox.getAccount();
+            acct.setPrefMailForwardingAddress("forwar@zimbra.com");
+            acct.setFeatureMarkMailForwardedAsRead(false);
+            acct.setFeatureMailForwardingEnabled(true);
+            List<ActionFlag> actions = new ArrayList<ActionFlag>();
+            String[] tags = { "yellow" };
+
+            Message msg = messageHandler.implicitKeep(actions, tags);
+            assertEquals(Flag.BITMASK_UNREAD, msg.getFlagBitmask());
+        } catch (ServiceException e) {
+            Assert.fail("No Exception should be thrown.");
+        }
+
+    }
+
+    @Test
+    public void testImplicitKeepWhenForwardFeatureDisabled() {
+        try {
+            OperationContext octxt = EasyMock.createMock(OperationContext.class);
+            DeliveryContext dctxt = EasyMock.createMock(DeliveryContext.class);
+            String recipientsAddress = "user1@email.com";
+            int size = 100;
+            int defaultFolderId = 2;
+            boolean noICal = false;
+            Mailbox mailbox = new MockMailbox();
+
+            IncomingMessageHandler messageHandler = new IncomingMessageHandler(octxt, dctxt,
+                mailbox, recipientsAddress, null, size, defaultFolderId, noICal);
+
+            Account acct = mailbox.getAccount();
+            acct.setFeatureMarkMailForwardedAsRead(false);
+            acct.setFeatureMailForwardingEnabled(false);
+            List<ActionFlag> actions = new ArrayList<ActionFlag>();
+            String[] tags = { "yellow" };
+
+            Message msg = messageHandler.implicitKeep(actions, tags);
+            assertEquals(Flag.BITMASK_UNREAD, msg.getFlagBitmask());
+        } catch (ServiceException e) {
+            Assert.fail("No Exception should be thrown.");
+        }
+
+    }
+    
+    public Account getAccount() throws ServiceException {
+
+        HashMap<String, Object> attrs;
+        attrs = new HashMap<String, Object>();
+        attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        Account acctLocal = new MockAccount("test@zimbra.com", null, attrs, attrs, prov);
+
+        return acctLocal;
+    }
+
+    public class MockAccount extends Account {
+
+        private boolean zimbraFeatureMarkMailForwardedAsRead;
+        private String prefMailForwardingAddress;
+        private boolean zimbraFeatureMailForwardingEnabled;
+
+        /**
+         * @param name
+         * @param id
+         * @param attrs
+         * @param defaults
+         * @param prov
+         */
+        public MockAccount(String name, String id, Map<String, Object> attrs,
+                           Map<String, Object> defaults, Provisioning prov) {
+            super(name, id, attrs, defaults, prov);
+        }
+
+        public boolean isFeatureAntispamEnabled() {
+            return false;
+        }
+
+        public String getPrefMailForwardingAddress() {
+            return this.prefMailForwardingAddress;
+        }
+
+        public boolean isFeatureMailForwardingEnabled() {
+            return this.zimbraFeatureMailForwardingEnabled;
+        }
+
+        public boolean isFeatureMarkMailForwardedAsRead() {
+            return zimbraFeatureMarkMailForwardedAsRead;
+        }
+
+        @Override
+        public void setFeatureMarkMailForwardedAsRead(boolean zimbraFeatureMarkMailForwardedAsRead)
+            throws ServiceException {
+            this.zimbraFeatureMarkMailForwardedAsRead = zimbraFeatureMarkMailForwardedAsRead;
+        }
+
+        @Override
+        public void setPrefMailForwardingAddress(String zimbraPrefMailForwardingAddress)
+            throws ServiceException {
+            this.prefMailForwardingAddress = zimbraPrefMailForwardingAddress;
+        }
+
+        @Override
+        public void setFeatureMailForwardingEnabled(boolean zimbraFeatureMailForwardingEnabled)
+            throws ServiceException {
+            this.zimbraFeatureMailForwardingEnabled = zimbraFeatureMailForwardingEnabled;
+        }
+    }
+
+    public class MockMailbox extends Mailbox {
+
+        private Account account;
+        /**
+         * @param data
+         */
+        protected MockMailbox() {
+            
+            HashMap<String, Object> attrs;
+            attrs = new HashMap<String, Object>();
+            attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+            account = new MockAccount("test@zimbra.com", null, attrs, attrs, prov);
+        }
+
+        @Override
+        public Account getAccount() throws ServiceException {
+            return account;
+        }
+
+        @Override
+        public String getAccountId() {
+            return "test";
+        }
+
+        @Override
+        public Message addMessage(OperationContext octxt, ParsedMessage pm, DeliveryOptions dopt,
+            DeliveryContext dctxt) throws IOException, ServiceException {
+
+            Message msg = PowerMockito.mock(Message.class);
+            PowerMockito.when(msg.getFlagBitmask()).thenReturn(dopt.getFlags());
+            return msg;
+        }
+    }
+
+}

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -16108,6 +16108,78 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * Mark messages sent to a forwarding address as read
+     *
+     * @return zimbraFeatureMarkMailForwardedAsRead, or false if unset
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2123)
+    public boolean isFeatureMarkMailForwardedAsRead() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureMarkMailForwardedAsRead, false, true);
+    }
+
+    /**
+     * Mark messages sent to a forwarding address as read
+     *
+     * @param zimbraFeatureMarkMailForwardedAsRead new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2123)
+    public void setFeatureMarkMailForwardedAsRead(boolean zimbraFeatureMarkMailForwardedAsRead) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMarkMailForwardedAsRead, zimbraFeatureMarkMailForwardedAsRead ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Mark messages sent to a forwarding address as read
+     *
+     * @param zimbraFeatureMarkMailForwardedAsRead new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2123)
+    public Map<String,Object> setFeatureMarkMailForwardedAsRead(boolean zimbraFeatureMarkMailForwardedAsRead, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMarkMailForwardedAsRead, zimbraFeatureMarkMailForwardedAsRead ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Mark messages sent to a forwarding address as read
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2123)
+    public void unsetFeatureMarkMailForwardedAsRead() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMarkMailForwardedAsRead, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Mark messages sent to a forwarding address as read
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2123)
+    public Map<String,Object> unsetFeatureMarkMailForwardedAsRead(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMarkMailForwardedAsRead, "");
+        return attrs;
+    }
+
+    /**
      * Whether to enable Zimbra Mobile Gateway feature
      *
      * @return zimbraFeatureMobileGatewayEnabled, or false if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -11056,6 +11056,78 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * Mark messages sent to a forwarding address as read
+     *
+     * @return zimbraFeatureMarkMailForwardedAsRead, or false if unset
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2123)
+    public boolean isFeatureMarkMailForwardedAsRead() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureMarkMailForwardedAsRead, false, true);
+    }
+
+    /**
+     * Mark messages sent to a forwarding address as read
+     *
+     * @param zimbraFeatureMarkMailForwardedAsRead new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2123)
+    public void setFeatureMarkMailForwardedAsRead(boolean zimbraFeatureMarkMailForwardedAsRead) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMarkMailForwardedAsRead, zimbraFeatureMarkMailForwardedAsRead ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Mark messages sent to a forwarding address as read
+     *
+     * @param zimbraFeatureMarkMailForwardedAsRead new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2123)
+    public Map<String,Object> setFeatureMarkMailForwardedAsRead(boolean zimbraFeatureMarkMailForwardedAsRead, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMarkMailForwardedAsRead, zimbraFeatureMarkMailForwardedAsRead ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Mark messages sent to a forwarding address as read
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2123)
+    public void unsetFeatureMarkMailForwardedAsRead() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMarkMailForwardedAsRead, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Mark messages sent to a forwarding address as read
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2123)
+    public Map<String,Object> unsetFeatureMarkMailForwardedAsRead(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMarkMailForwardedAsRead, "");
+        return attrs;
+    }
+
+    /**
      * Whether to enable Zimbra Mobile Gateway feature
      *
      * @return zimbraFeatureMobileGatewayEnabled, or false if unset

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -762,7 +762,14 @@ public class Mailbox implements MailboxStore {
         // index init done in open()
         lock = new MailboxLock(data.accountId, this);
     }
-
+    
+    /** Introduced only for unit testing */
+    protected Mailbox() {
+        mId = -1;
+        index = null;
+        lock = null;     
+    }
+    
     public void setGalSyncMailbox(boolean galSyncMailbox) {
         this.galSyncMailbox = galSyncMailbox;
     }


### PR DESCRIPTION
ZCS-2746 Mark messages sent to a forwarding address as read

Added attribute 'zimbraFeatureMarkMailForwardedAsRead' to set message as read when forwarded to another address
Added code to mark message as read when 'zimbraFeatureMarkMailForwardedAsRead' true.
Added unit test
Verified that when 'zimbraFeatureMarkMailForwardedAsRead' true the message in Inbox is read and when false message in Inbox is false