### PR TITLE
ZCS-1870:Multi-byte text in a long line gets garbled

### DIFF
--- a/common/src/java-test/com/zimbra/common/zmime/ZMimeBodyPartTest.java
+++ b/common/src/java-test/com/zimbra/common/zmime/ZMimeBodyPartTest.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2011, 2012, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2011, 2012, 2013, 2014, 2016, 2017 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -16,6 +16,7 @@
  */
 package com.zimbra.common.zmime;
 
+import org.apache.commons.lang.StringUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -84,10 +85,9 @@ public class ZMimeBodyPartTest {
         testEncodingSelection("single NUL", "cyb\u0000le illus.", ZTransferEncoding.QUOTED_PRINTABLE);
         testEncodingSelection("single control char", "ESCAPE ME \u001B", ZTransferEncoding.SEVEN_BIT);
 
-        StringBuilder sb = new StringBuilder(1000);
-        for (int i = 0; i < 1000; i++) {
-            sb.append("X");
-        }
-        testEncodingSelection("line too long", sb.toString(), ZTransferEncoding.QUOTED_PRINTABLE);
+        testEncodingSelection("line too long (ascii)", StringUtils.leftPad("", 1000, "X"), ZTransferEncoding.QUOTED_PRINTABLE);
+        testEncodingSelection("line too long (JIS)", new String(StringUtils.leftPad("", 1000, "あ").getBytes("ISO-2022-JP")), ZTransferEncoding.QUOTED_PRINTABLE);
+        testEncodingSelection("line too long (utf-8)", new String(StringUtils.leftPad("", 1000, "あ").getBytes("UTF-8")), ZTransferEncoding.BASE64);
+        testEncodingSelection("line too long (shift-jis)", new String(StringUtils.leftPad("", 1000, "あ").getBytes("Shift-JIS")), ZTransferEncoding.BASE64);
     }
 }

--- a/common/src/java/com/zimbra/common/zmime/ZMimeBodyPart.java
+++ b/common/src/java/com/zimbra/common/zmime/ZMimeBodyPart.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2011, 2012, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2011, 2012, 2013, 2014, 2016, 2017 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -412,7 +412,7 @@ public class ZMimeBodyPart extends MimeBodyPart implements ZMimePart {
             } else if (toolong == 0) {
                 return "8bit"; //section 6.2 of RFC2045
             } else {
-                return "binary";
+                return "base64";
             }
         }
     }

--- a/store/src/java/com/zimbra/cs/mime/Mime.java
+++ b/store/src/java/com/zimbra/cs/mime/Mime.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2016, 2017 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -668,6 +668,13 @@ public class Mime {
 
     public static void recursiveRepairTransferEncoding(MimeMessage mm) throws MessagingException, IOException {
         for (MPartInfo mpi : listParts(mm, null)) {
+            String cte = mpi.mPart.getHeader("Content-Transfer-Encoding", null);
+            String ct = getContentType(mpi.mPart);
+            if (StringUtil.isNullOrEmpty(cte) &&
+                !ct.equals(MimeConstants.CT_MESSAGE_RFC822) &&
+                !ct.startsWith(MimeConstants.CT_MULTIPART_PREFIX)) {
+                mpi.mPart.addHeader("Content-Transfer-Encoding", "8bit");
+            }
             repairTransferEncoding(mpi.mPart);
         }
     }


### PR DESCRIPTION
[Problem]
Currently when the mail server receives the SendMsg request
whose message's mime parts have following characteristics,
the mail server transfers the outgoing message to the SMTP
server with the header "Content-Transfer-Encoding: binary".
 - If that mime part is not an attachment or its Content-Type's primary type is "text".
 - If that mime part contains non-ASCII characters more than 25% of the part size.
 - If that mime part has a line which is longer than MAX_LINE_OCTETS (900).
Because the MTA (Postfix) does not support the "Content-
Transfer-Encoding: binary", Postfix treats such mime part as
"7bit", and folds a long line into 998 characters without
consideration of multi-byte characters.  As a result, the
multi-byte character which CRLF is inserted in the middle of
the byte-string gets garbled.

[History]
This bug was introduced by the Bug 86352 (a redirected message
was garbled when the original message consisted of the multi-byte
characters but didn't have a Content-Transfer-Encoding header).
During the fix of Bug 86352, when a mime-part did not have CTE
header, and the mime contents matched the above conditions, the
"Content-Transfer-Encoding: binary" was inserted. Correctly, it
should have 7bit or 8bit, because the content is still formatted
in the line-oriented mime-part.

[Fix]
(1) If the mime-part is matched with the condition above, and if
it is sent via SnedMail, ZCS will put "Content-Transfer-Encoding:
base64".
(2) When ZCS redirects such a message, and if the original message
does not have any Content-Transfer-Encoding header, then ZCS will
add "Content-Transfer-Encoding: 8bit" before redirecting.

Although 7bit is a default value of the CTE defined in the RFC,
8bit is chosen for the pattern (2), because:
 - Most of the MTA servers, including Postfix, support 8BITMIME extension.
 - 8bit is a super-set of the 7bit.

----
Manual test
* Compose a long line multi-byte text message on the ZWC, and send to userA --> Verify that message is encoded in base64 and not garbled on the userA's ZWC.
* Send a raw Shift-JIS text message via LMTP to userB; the message is single mime part without Content-Transfer-Encoding header.  UserB has a Sieve filter which redirects messages to userC --> Verify that userC received a redirected message which is not garbled on the userC's ZWC.
- Ran automation script zm-qa/data/soapvalidator/MailClient/Mail/Bugs/bug50507.xml  (similar issues to this bug and Bug 86352)