### PR TITLE
Not able to delete a member from a contact group after the upgrade to ZCS 8.7.1

### DIFF
--- a/store/src/java-test/com/zimbra/cs/mailbox/ContactTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/ContactTest.java
@@ -259,7 +259,7 @@ public final class ContactTest {
         Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
         Contact contact = mbox.createContact(null, new ParsedContact(attrs, Lists.newArrayList(textAttachment)), Mailbox.ID_FOLDER_CONTACTS, null);
 
-        ParsedContact pc = new ParsedContact(contact).modify(new ParsedContact.FieldDeltaList(), new ArrayList<Attachment>());
+        ParsedContact pc = new ParsedContact(contact).modify(new ParsedContact.FieldDeltaList(), new ArrayList<Attachment>(), "ownerId");
         MimeMessage mm = new Mime.FixedMimeMessage(JMSession.getSession(), pc.getContentStream());
         MimePart mp = Mime.getMimePart(mm, "1");
         Assert.assertEquals("text/plain", mp.getContentType());
@@ -301,7 +301,7 @@ public final class ContactTest {
         Contact contact = mbox.createContact(null, new ParsedContact(attrs, Lists.newArrayList(attachment1)), Mailbox.ID_FOLDER_CONTACTS, null);
         Attachment attachment2 = new Attachment(attachData, "image/png", "image", "image2.png");
         try {
-            ParsedContact pc = new ParsedContact(contact).modify(new ParsedContact.FieldDeltaList(), Lists.newArrayList(attachment2));
+            ParsedContact pc = new ParsedContact(contact).modify(new ParsedContact.FieldDeltaList(), Lists.newArrayList(attachment2), "ownerId");
         } catch (ServiceException se) {
             Assert.assertEquals("check the INVALID_IMAGE exception", "mail.INVALID_IMAGE", se.getCode());
         }

--- a/store/src/java/com/zimbra/cs/dav/resource/AddressObject.java
+++ b/store/src/java/com/zimbra/cs/dav/resource/AddressObject.java
@@ -163,7 +163,7 @@ public class AddressObject extends MailItemResource {
         }
         ContactGroup contactGroup = null;
         try {
-            contactGroup = ContactGroup.init(contact.get(ContactConstants.A_groupMember));
+            contactGroup = ContactGroup.init(contact.get(ContactConstants.A_groupMember), contact.getMailbox().getAccountId());
         } catch (ServiceException e) {
             ZimbraLog.dav.warn("can't get group members for Contact %d", contact.getId(), e);
         }

--- a/store/src/java/com/zimbra/cs/mailbox/Contact.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Contact.java
@@ -587,11 +587,11 @@ public class Contact extends MailItem {
      * Returns a list of all email address fields for this contact.
      */
     public List<String> getEmailAddresses() {
-        return getEmailAddresses(emailFields, fields, DerefGroupMembersOption.INLINE_ONLY);
+        return getEmailAddresses(emailFields, fields, DerefGroupMembersOption.INLINE_ONLY, getMailbox().getAccountId() );
     }
 
     public List<String> getEmailAddresses(DerefGroupMembersOption derefGroupMemberOpt) {
-        return getEmailAddresses(emailFields, fields, derefGroupMemberOpt);
+        return getEmailAddresses(emailFields, fields, derefGroupMemberOpt, getMailbox().getAccountId() );
     }
 
     public static final boolean isEmailField(String[] emailFields, String fieldName) {
@@ -608,7 +608,7 @@ public class Contact extends MailItem {
     }
 
     public static final List<String> getEmailAddresses(String[] fieldNames,
-            Map<String, String> fields, DerefGroupMembersOption derefGroupMemberOpt) {
+            Map<String, String> fields, DerefGroupMembersOption derefGroupMemberOpt, String ownerAcctId) {
         List<String> result = new ArrayList<String>();
         for (String name : fieldNames) {
             String addr = fields.get(name);
@@ -621,7 +621,7 @@ public class Contact extends MailItem {
             String encodedGroupMembers = fields.get(ContactConstants.A_groupMember);
             if (encodedGroupMembers != null) {
                 try {
-                    ContactGroup contactGroup = ContactGroup.init(encodedGroupMembers);
+                    ContactGroup contactGroup = ContactGroup.init(encodedGroupMembers, ownerAcctId);
                     List<String> emailAddrs = contactGroup.getInlineEmailAddresses();
                     for (String addr : emailAddrs) {
                         result.add(addr);

--- a/store/src/java/com/zimbra/cs/mailbox/ContactMemberOfMap.java
+++ b/store/src/java/com/zimbra/cs/mailbox/ContactMemberOfMap.java
@@ -62,7 +62,7 @@ public class ContactMemberOfMap {
                     Contact contact = ((ContactHit)hit).getContact();
                     ContactGroup contactGroup = null;
                     try {
-                        contactGroup = ContactGroup.init(contact.get(ContactConstants.A_groupMember));
+                        contactGroup = ContactGroup.init(contact.get(ContactConstants.A_groupMember), mbox.getAccountId());
                         List<Member> members = contactGroup.getMembers();
                         if (members == null) {
                             continue;

--- a/store/src/java/com/zimbra/cs/mime/ParsedContact.java
+++ b/store/src/java/com/zimbra/cs/mime/ParsedContact.java
@@ -414,7 +414,7 @@ public final class ParsedContact {
     }
 
     // convert legacy API to the new API
-    public ParsedContact modify(Map<String, String> fieldDelta, List<Attachment> attachDelta)
+    public ParsedContact modify(Map<String, String> fieldDelta, List<Attachment> attachDelta, String ownerAcctId)
     throws ServiceException {
         FieldDeltaList fieldDeltaList = new FieldDeltaList();
 
@@ -422,15 +422,15 @@ public final class ParsedContact {
             fieldDeltaList.addAttrDelta(entry.getKey(), entry.getValue(), null);
         }
 
-        return modify(fieldDeltaList, attachDelta);
+        return modify(fieldDeltaList, attachDelta, ownerAcctId);
     }
 
-    public ParsedContact modify(FieldDeltaList fieldDeltaList, List<Attachment> attachDelta)
+    public ParsedContact modify(FieldDeltaList fieldDeltaList, List<Attachment> attachDelta, String ownerAcctId)
     throws ServiceException {
-        return modify(fieldDeltaList, attachDelta, false);
+        return modify(fieldDeltaList, attachDelta, false, ownerAcctId );
     }
     public ParsedContact modify(FieldDeltaList fieldDeltaList, List<Attachment> attachDelta,
-            boolean discardExistingMembers)
+                                boolean discardExistingMembers, String ownerAcctId)
     throws ServiceException {
         if (attachDelta != null && !attachDelta.isEmpty()) {
             try {
@@ -454,7 +454,7 @@ public final class ParsedContact {
         ContactGroup contactGroup = null;
         String encodedContactGroup = contactFields.get(ContactConstants.A_groupMember);
         contactGroup = encodedContactGroup == null?
-                ContactGroup.init() : ContactGroup.init(encodedContactGroup);
+                ContactGroup.init() : ContactGroup.init(encodedContactGroup, ownerAcctId);
 
         boolean contactGroupMemberChanged = false;
         if (discardExistingMembers && contactGroup.hasMembers()) {
@@ -742,7 +742,7 @@ public final class ParsedContact {
         // fetch all the 'email' addresses for this contact into a single concatenated string
         // We don't index members in a contact group because it's only confusing when searching.
         StringBuilder emails  = new StringBuilder();
-        for (String email : Contact.getEmailAddresses(emailFields, getFields(), DerefGroupMembersOption.NONE)) {
+        for (String email : Contact.getEmailAddresses(emailFields, getFields(), DerefGroupMembersOption.NONE, acct.getId() )) {
             emails.append(email).append(',');
         }
 

--- a/store/src/java/com/zimbra/cs/service/formatter/ContactFolderFormatter.java
+++ b/store/src/java/com/zimbra/cs/service/formatter/ContactFolderFormatter.java
@@ -124,7 +124,7 @@ public class ContactFolderFormatter extends Formatter {
         Map<String,String> fields = ((Contact) item).getFields();
         for (String k : fields.keySet()) {
             if (ContactConstants.A_groupMember.equals(k)) {
-                printContactGroup(fields.get(k), out);
+                printContactGroup(fields.get(k), out, item.getMailbox().getAccountId());
             } else {
                 out.write(FIELD_DELIMITER);
                 out.write(k.getBytes("UTF-8"));
@@ -155,11 +155,11 @@ public class ContactFolderFormatter extends Formatter {
         }
     }
 
-    private void printContactGroup(String encodedContactGroup, OutputStream out) throws IOException {
+    private void printContactGroup(String encodedContactGroup, OutputStream out, String ownerAcctId) throws IOException {
         ContactGroup contactGroup = null;
 
         try {
-            contactGroup = ContactGroup.init(encodedContactGroup);
+            contactGroup = ContactGroup.init(encodedContactGroup, ownerAcctId);
         } catch (ServiceException e) {
             ZimbraLog.contact.warn("unable to init contact group", e);
         }

--- a/store/src/java/com/zimbra/cs/service/mail/CreateContact.java
+++ b/store/src/java/com/zimbra/cs/service/mail/CreateContact.java
@@ -315,7 +315,7 @@ public class CreateContact extends MailDocumentHandler  {
             }
         }
 
-        return new ParsedContact(existing).modify(deltaList, attachments, discardExistingMembers);
+        return new ParsedContact(existing).modify(deltaList, attachments, discardExistingMembers, mbox.getAccountId());
     }
 
     private static String parseCertificate(Element elt, String name, ZimbraSoapContext zsc, OperationContext octxt,

--- a/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
@@ -712,7 +712,7 @@ public class ItemActionHelper {
                 for (String key : fields.keySet()) {
                     if (ContactConstants.A_groupMember.equals(key)) {
                         String memberEncoded = fields.get(key);
-                        ContactGroup group = ContactGroup.init(memberEncoded);
+                        ContactGroup group = ContactGroup.init(memberEncoded, ct.getMailbox().getAccountId());
                         for (Member m : group.getMembers()) {
                             members.put(m.getValue(), m.getType().getSoapEncoded());
                         }

--- a/store/src/java/com/zimbra/qa/unittest/TestContactGroup.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestContactGroup.java
@@ -33,10 +33,6 @@ import static org.junit.Assert.*;
 import com.zimbra.common.account.Key.AccountBy;
 import com.zimbra.common.mailbox.ContactConstants;
 import com.zimbra.common.service.ServiceException;
-import com.zimbra.common.soap.AccountConstants;
-import com.zimbra.common.soap.Element;
-import com.zimbra.common.soap.MailConstants;
-import com.zimbra.common.soap.SoapHttpTransport;
 import com.zimbra.common.util.ByteUtil;
 import com.zimbra.common.util.CliUtil;
 import com.zimbra.common.util.Log;
@@ -83,7 +79,7 @@ public class TestContactGroup {
     // encode, then return decoded, so encode/decode get tested
     private ContactGroup reEncode(ContactGroup contactGroup) throws Exception {
         String encoded = contactGroup.encode();
-        return ContactGroup.init(encoded);
+        return ContactGroup.init(encoded, "ownerAcctId" );
     }
     
     @BeforeClass


### PR DESCRIPTION
ZCS-613
Bugzilla: https://bugzilla.zimbra.com/show_bug.cgi?id=107777

Migrate legacy group metadata by stripping accountId for local contacts references.
Most of changes are to pass along the account owner Id.