### PR TITLE
ZCS-2728 : Add 2 LDAP attributes for Contacts backup functionality

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -6233,6 +6233,30 @@ public class ZAttrProvisioning {
     public static final String A_zimbraFeatureConfirmationPageEnabled = "zimbraFeatureConfirmationPageEnabled";
 
     /**
+     * Sleep time between subsequent contact backups. 0 means that contact
+     * backup is disabled. . Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2124)
+    public static final String A_zimbraFeatureContactBackupFrequency = "zimbraFeatureContactBackupFrequency";
+
+    /**
+     * Duration for which the backups should be preserved. . Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2125)
+    public static final String A_zimbraFeatureContactBackupLifeTime = "zimbraFeatureContactBackupLifeTime";
+
+    /**
      * whether detailed contact search UI is enabled
      *
      * @since ZCS 7.1.0

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9569,5 +9569,19 @@ TODO: delete them permanently from here
   <desc>Mark messages sent to a forwarding address as read</desc>
 </attr>
 
+<attr id="2124" name="zimbraFeatureContactBackupFrequency" type="duration" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited,domainAdminModifiable" callback="ContactBackupFeature" since="8.8.5">
+  <globalConfigValue>1d</globalConfigValue>
+  <desc>
+    Sleep time between subsequent contact backups. 0 means that contact
+    backup is disabled.
+  </desc>
+</attr>
+
+<attr id="2125" name="zimbraFeatureContactBackupLifeTime" type="duration" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited,domainAdminModifiable" since="8.8.5">
+  <globalConfigValue>15d</globalConfigValue>
+  <desc>
+    Duration for which the backups should be preserved.
+  </desc>
+</attr>
 
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -15787,6 +15787,230 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Sleep time between subsequent contact backups. 0 means that contact
+     * backup is disabled. . Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * <p>Use getFeatureContactBackupFrequencyAsString to access value as a string.
+     *
+     * @see #getFeatureContactBackupFrequencyAsString()
+     *
+     * @return zimbraFeatureContactBackupFrequency in millseconds, or 86400000 (1d)  if unset
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2124)
+    public long getFeatureContactBackupFrequency() {
+        return getTimeInterval(Provisioning.A_zimbraFeatureContactBackupFrequency, 86400000L, true);
+    }
+
+    /**
+     * Sleep time between subsequent contact backups. 0 means that contact
+     * backup is disabled. . Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @return zimbraFeatureContactBackupFrequency, or "1d" if unset
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2124)
+    public String getFeatureContactBackupFrequencyAsString() {
+        return getAttr(Provisioning.A_zimbraFeatureContactBackupFrequency, "1d", true);
+    }
+
+    /**
+     * Sleep time between subsequent contact backups. 0 means that contact
+     * backup is disabled. . Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @param zimbraFeatureContactBackupFrequency new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2124)
+    public void setFeatureContactBackupFrequency(String zimbraFeatureContactBackupFrequency) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureContactBackupFrequency, zimbraFeatureContactBackupFrequency);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Sleep time between subsequent contact backups. 0 means that contact
+     * backup is disabled. . Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @param zimbraFeatureContactBackupFrequency new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2124)
+    public Map<String,Object> setFeatureContactBackupFrequency(String zimbraFeatureContactBackupFrequency, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureContactBackupFrequency, zimbraFeatureContactBackupFrequency);
+        return attrs;
+    }
+
+    /**
+     * Sleep time between subsequent contact backups. 0 means that contact
+     * backup is disabled. . Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2124)
+    public void unsetFeatureContactBackupFrequency() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureContactBackupFrequency, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Sleep time between subsequent contact backups. 0 means that contact
+     * backup is disabled. . Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2124)
+    public Map<String,Object> unsetFeatureContactBackupFrequency(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureContactBackupFrequency, "");
+        return attrs;
+    }
+
+    /**
+     * Duration for which the backups should be preserved. . Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * <p>Use getFeatureContactBackupLifeTimeAsString to access value as a string.
+     *
+     * @see #getFeatureContactBackupLifeTimeAsString()
+     *
+     * @return zimbraFeatureContactBackupLifeTime in millseconds, or 1296000000 (15d)  if unset
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2125)
+    public long getFeatureContactBackupLifeTime() {
+        return getTimeInterval(Provisioning.A_zimbraFeatureContactBackupLifeTime, 1296000000L, true);
+    }
+
+    /**
+     * Duration for which the backups should be preserved. . Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @return zimbraFeatureContactBackupLifeTime, or "15d" if unset
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2125)
+    public String getFeatureContactBackupLifeTimeAsString() {
+        return getAttr(Provisioning.A_zimbraFeatureContactBackupLifeTime, "15d", true);
+    }
+
+    /**
+     * Duration for which the backups should be preserved. . Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @param zimbraFeatureContactBackupLifeTime new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2125)
+    public void setFeatureContactBackupLifeTime(String zimbraFeatureContactBackupLifeTime) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureContactBackupLifeTime, zimbraFeatureContactBackupLifeTime);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Duration for which the backups should be preserved. . Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @param zimbraFeatureContactBackupLifeTime new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2125)
+    public Map<String,Object> setFeatureContactBackupLifeTime(String zimbraFeatureContactBackupLifeTime, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureContactBackupLifeTime, zimbraFeatureContactBackupLifeTime);
+        return attrs;
+    }
+
+    /**
+     * Duration for which the backups should be preserved. . Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2125)
+    public void unsetFeatureContactBackupLifeTime() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureContactBackupLifeTime, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Duration for which the backups should be preserved. . Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2125)
+    public Map<String,Object> unsetFeatureContactBackupLifeTime(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureContactBackupLifeTime, "");
+        return attrs;
+    }
+
+    /**
      * Whether to display the distribution list folder in address book
      *
      * @return zimbraFeatureDistributionListFolderEnabled, or false if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -8770,6 +8770,230 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
+     * Sleep time between subsequent contact backups. 0 means that contact
+     * backup is disabled. . Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * <p>Use getFeatureContactBackupFrequencyAsString to access value as a string.
+     *
+     * @see #getFeatureContactBackupFrequencyAsString()
+     *
+     * @return zimbraFeatureContactBackupFrequency in millseconds, or 86400000 (1d)  if unset
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2124)
+    public long getFeatureContactBackupFrequency() {
+        return getTimeInterval(Provisioning.A_zimbraFeatureContactBackupFrequency, 86400000L, true);
+    }
+
+    /**
+     * Sleep time between subsequent contact backups. 0 means that contact
+     * backup is disabled. . Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @return zimbraFeatureContactBackupFrequency, or "1d" if unset
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2124)
+    public String getFeatureContactBackupFrequencyAsString() {
+        return getAttr(Provisioning.A_zimbraFeatureContactBackupFrequency, "1d", true);
+    }
+
+    /**
+     * Sleep time between subsequent contact backups. 0 means that contact
+     * backup is disabled. . Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @param zimbraFeatureContactBackupFrequency new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2124)
+    public void setFeatureContactBackupFrequency(String zimbraFeatureContactBackupFrequency) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureContactBackupFrequency, zimbraFeatureContactBackupFrequency);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Sleep time between subsequent contact backups. 0 means that contact
+     * backup is disabled. . Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @param zimbraFeatureContactBackupFrequency new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2124)
+    public Map<String,Object> setFeatureContactBackupFrequency(String zimbraFeatureContactBackupFrequency, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureContactBackupFrequency, zimbraFeatureContactBackupFrequency);
+        return attrs;
+    }
+
+    /**
+     * Sleep time between subsequent contact backups. 0 means that contact
+     * backup is disabled. . Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2124)
+    public void unsetFeatureContactBackupFrequency() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureContactBackupFrequency, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Sleep time between subsequent contact backups. 0 means that contact
+     * backup is disabled. . Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2124)
+    public Map<String,Object> unsetFeatureContactBackupFrequency(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureContactBackupFrequency, "");
+        return attrs;
+    }
+
+    /**
+     * Duration for which the backups should be preserved. . Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * <p>Use getFeatureContactBackupLifeTimeAsString to access value as a string.
+     *
+     * @see #getFeatureContactBackupLifeTimeAsString()
+     *
+     * @return zimbraFeatureContactBackupLifeTime in millseconds, or 1296000000 (15d)  if unset
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2125)
+    public long getFeatureContactBackupLifeTime() {
+        return getTimeInterval(Provisioning.A_zimbraFeatureContactBackupLifeTime, 1296000000L, true);
+    }
+
+    /**
+     * Duration for which the backups should be preserved. . Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @return zimbraFeatureContactBackupLifeTime, or "15d" if unset
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2125)
+    public String getFeatureContactBackupLifeTimeAsString() {
+        return getAttr(Provisioning.A_zimbraFeatureContactBackupLifeTime, "15d", true);
+    }
+
+    /**
+     * Duration for which the backups should be preserved. . Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @param zimbraFeatureContactBackupLifeTime new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2125)
+    public void setFeatureContactBackupLifeTime(String zimbraFeatureContactBackupLifeTime) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureContactBackupLifeTime, zimbraFeatureContactBackupLifeTime);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Duration for which the backups should be preserved. . Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @param zimbraFeatureContactBackupLifeTime new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2125)
+    public Map<String,Object> setFeatureContactBackupLifeTime(String zimbraFeatureContactBackupLifeTime, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureContactBackupLifeTime, zimbraFeatureContactBackupLifeTime);
+        return attrs;
+    }
+
+    /**
+     * Duration for which the backups should be preserved. . Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2125)
+    public void unsetFeatureContactBackupLifeTime() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureContactBackupLifeTime, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Duration for which the backups should be preserved. . Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2125)
+    public Map<String,Object> unsetFeatureContactBackupLifeTime(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureContactBackupLifeTime, "");
+        return attrs;
+    }
+
+    /**
      * Maximum size in bytes for file uploads
      *
      * @return zimbraFileUploadMaxSize, or 10485760 if unset

--- a/store/src/java/com/zimbra/cs/account/callback/ContactBackupFeature.java
+++ b/store/src/java/com/zimbra/cs/account/callback/ContactBackupFeature.java
@@ -1,0 +1,41 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2017 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.account.callback;
+
+import java.util.Map;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.AttributeCallback;
+import com.zimbra.cs.account.Entry;
+
+public class ContactBackupFeature extends AttributeCallback  {
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public void preModify(CallbackContext context, String attrName, Object attrValue, Map attrsToModify, Entry entry)
+            throws ServiceException {
+        // TODO Populate while implementing contact backup feature
+        
+    }
+
+    @Override
+    public void postModify(CallbackContext context, String attrName, Entry entry) {
+        // TODO Populate while implementing contact backup feature
+        
+    }
+
+}


### PR DESCRIPTION
Problem : Add 2 LDAP attributes for Contacts backup functionality

Fix : Added 2 LDAP attributes zimbraFeatureContactBackupFrequecy and zimbraFeatureContactBackupLifeTime with callback skeleton.

Testing done : Local dev environment build is successful.
(1)
zmprov desc -a zimbraFeatureContactBackupFrequecy
zimbraFeatureContactBackupFrequecy
    Sleep time between subsequent contact backups. 0 means that contact
    backup is disabled. . Must be in valid duration format:
    {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
    minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
    specified, the default is s(seconds).

               type : duration
              value : 
           callback : ContactBackupFeature
          immutable : false
        cardinality : single
         requiredIn : 
         optionalIn : server,globalConfig
              flags : domainAdminModifiable,serverInherited
           defaults : 1d
                min : 0
                max : 
                 id : 2124
    requiresRestart : 
              since : 8.8.5
    deprecatedSince : 
(2)
zmprov desc -a zimbraFeatureContactBackupLifeTime
zimbraFeatureContactBackupLifeTime
    Duration for which the backups should be preserved. . Must be in valid
    duration format: {digits}{time-unit}. digits: 0-9, time-unit:
    [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
    milliseconds. If time unit is not specified, the default is
    s(seconds).

               type : duration
              value : 
           callback : 
          immutable : false
        cardinality : single
         requiredIn : 
         optionalIn : server,globalConfig
              flags : domainAdminModifiable,serverInherited
           defaults : 15d
                min : 0
                max : 
                 id : 2125
    requiresRestart : 
              since : 8.8.5
    deprecatedSince : 

Testing to be done by QA : No testing required.