### PR TITLE
ZCS-1858(3):declare extension in "require" command, Part 2

### DIFF
--- a/store/src/java-test/com/zimbra/cs/filter/AddressTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/AddressTest.java
@@ -364,7 +364,7 @@ public class AddressTest {
             RuleManager.clearCachedRules(acct);
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
 
-            String filterScript = "require \"tag\";\n"
+            String filterScript = "require [\"tag\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                     + "if address :count \"lt\" :comparator \"i;ascii-numeric\" \"To\" \"-1\" {"
                     + "  tag \"compareAsciiNumericNegativeValue\";"
                     + "}";
@@ -388,7 +388,7 @@ public class AddressTest {
             RuleManager.clearCachedRules(acct);
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
 
-            String filterScript = "require [\"tag\"];\n"
+            String filterScript = "require [\"tag\", \"comparator-i;ascii-numeric\"];\n"
                     + "if address :is :comparator \"i;ascii-numeric\" \" To\" \"test1@zimbra.com\" {"
                     + "  tag \"t1\";"
                     + "}"
@@ -413,7 +413,7 @@ public class AddressTest {
             RuleManager.clearCachedRules(acct);
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
 
-            String filterScript = "require [\"tag\"];\n"
+            String filterScript = "require [\"tag\", \"comparator-i;ascii-numeric\"];\n"
                     + "if address :is :comparator \"i;ascii-numeric\" \"To \" \"test1@zimbra.com\" {"
                     + "  tag \"t2\";"
                     + "}"
@@ -438,7 +438,7 @@ public class AddressTest {
             RuleManager.clearCachedRules(acct);
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
 
-            String filterScript = "require [\"tag\"];\n"
+            String filterScript = "require [\"tag\", \"comparator-i;ascii-numeric\"];\n"
                     + "if address :is :comparator \"i;ascii-numeric\" \" To \" \"test1@zimbra.com\" {"
                     + "  tag \"t3\";"
                     + "}"

--- a/store/src/java-test/com/zimbra/cs/filter/DeleteHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/DeleteHeaderTest.java
@@ -918,7 +918,7 @@ public class DeleteHeaderTest {
     @Test
     public void testDeleteNoValuePattern() {
         try {
-            String filterScript = "require [\"editheader\"];\n"
+            String filterScript = "require [\"editheader\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                     + " deleteheader :count \"gt\" :comparator \"i;ascii-numeric\" \"Subject\" \"\" \r\n"
                     + "  ;\n";
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
@@ -995,7 +995,7 @@ public class DeleteHeaderTest {
     @Test
     public void testDeleteHeaderCountNegative() {
         try {
-            String filterScript = "require [\"editheader\"];\n"
+            String filterScript = "require [\"editheader\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                     + "deleteheader :count \"le\" :comparator \"i;ascii-numeric\" \"X-Numeric-Header\" \"-1\";\n";
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
@@ -1086,7 +1086,7 @@ public class DeleteHeaderTest {
                 + "\tby edge01e.zimbra.com (Postfix) with ESMTP id 9245B13575C;\n"
                 + "\tFri, 24 Jun 2016 01:45:31 -0400 (EDT)\n" + "Subject: 1\n"
                 + "to: test@zimbra.com\n";
-            String filterScript = "require [\"editheader\"];\n"
+            String filterScript = "require [\"editheader\", \"comparator-i;ascii-numeric\"];\n"
                 + "deleteheader :is :comparator \"i;ascii-numeric\" \"Subject\" \"1\";\n";
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);

--- a/store/src/java-test/com/zimbra/cs/filter/EnvelopeTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/EnvelopeTest.java
@@ -750,7 +750,7 @@ public class EnvelopeTest {
 
     @Test
     public void testNumericNegativeValueCount() {
-        String filterScript = "require [\"envelope\", \"tag\", \"relational\"];\n"
+        String filterScript = "require [\"envelope\", \"tag\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                 + "if envelope :all :count \"lt\" :comparator \"i;ascii-numeric\" \"to\" \"-1\" {\n"
                 + "  tag \"To\";\n"
                 + "}";

--- a/store/src/java-test/com/zimbra/cs/filter/HeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/HeaderTest.java
@@ -116,7 +116,7 @@ public class HeaderTest {
     // and none of tag commands should be executed.
     @Test
     public void testNumericNegativeValueValue() {
-        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\"];\n"
+        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                 + "if header :value \"ge\" :comparator \"i;ascii-numeric\" "
                 + "[\"X-Spam-score\"] [\"500\"] { tag \"XSpamScore\";}"
                 + "tag \"Negative\";";
@@ -127,8 +127,8 @@ public class HeaderTest {
     // and none of tag commands should be executed.
     @Test
     public void testNumericNegativeValueCounts() {
-        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\"];\n"
-                + "if header :counts \"ge\" :comparator \"i;ascii-numeric\" "
+        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
+                + "if header :count \"ge\" :comparator \"i;ascii-numeric\" "
                 + "[\"Received\"] [\"-1\"] { tag \"Received\";}"
                 + "tag \"Negative\";";
         doTest(filterScript, null);
@@ -138,7 +138,7 @@ public class HeaderTest {
     // and none of tag commands should be executed.
     @Test
     public void testNumericNegativeValueIs() {
-        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\"];\n"
+        String filterScript = "require [\"fileinto\", \"tag\", \"flag\", \"log\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                 + "if header :is :comparator \"i;ascii-numeric\" "
                 + "[\"X-Spam-score\"] [\"-5\"] { tag \"XSpamScore\";}"
                 + "tag \"Negative\";";

--- a/store/src/java-test/com/zimbra/cs/filter/ReplaceHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/ReplaceHeaderTest.java
@@ -519,7 +519,7 @@ public class ReplaceHeaderTest {
     @Test
     public void testReplaceHeaderWithNumericComparisionUsingValue() {
         try {
-            String filterScript = "require [\"editheader\"];\n"
+            String filterScript = "require [\"editheader\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                     + " replaceheader :newname \"X-Numeric2-Header\" :newvalue \"0\" :value \"lt\" :comparator \"i;ascii-numeric\" \"X-Numeric-Header\" \"3\" \r\n"
                     + "  ;\n";
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
@@ -1095,7 +1095,7 @@ public class ReplaceHeaderTest {
     @Test
     public void testReplaceHeaderWithEmptyHeaderNewName() {
         try {
-            String filterScript = "require [\"editheader\"];\n"
+            String filterScript = "require [\"editheader\", \"relational\"];\n"
                     + " replaceheader :newname \"\" :newvalue \"0\" :value \"lt\" :comparator \"i;ascii-casemap\" \"X-Test-Header\" \"test2\" \r\n"
                     + "  ;\n";
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
@@ -1132,7 +1132,7 @@ public class ReplaceHeaderTest {
     @Test
     public void testReplaceHeaderWithSinlgeSpaceAsHeaderNewName() {
         try {
-            String filterScript = "require [\"editheader\"];\n"
+            String filterScript = "require [\"editheader\", \"relational\"];\n"
                     + " replaceheader :newname \" \" :newvalue \"0\" :value \"lt\" :comparator \"i;ascii-casemap\" \"X-Test-Header\" \"test2\" \r\n"
                     + "  ;\n";
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
@@ -1168,7 +1168,7 @@ public class ReplaceHeaderTest {
     @Test
     public void testReplaceHeaderWithMultipleSpacesAsHeaderNewName() {
         try {
-            String filterScript = "require [\"editheader\"];\n"
+            String filterScript = "require [\"editheader\", \"relational\"];\n"
                     + " replaceheader :newname \"    \" :newvalue \"0\" :value \"lt\" :comparator \"i;ascii-casemap\" \"X-Test-Header\" \"test2\" \r\n"
                     + "  ;\n";
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
@@ -1204,7 +1204,7 @@ public class ReplaceHeaderTest {
     @Test
     public void testReplaceHeaderStartingWithSpacesAsHeaderNewName() {
         try {
-            String filterScript = "require [\"editheader\"];\n"
+            String filterScript = "require [\"editheader\", \"relational\"];\n"
                     + " replaceheader :newname \" asdf\" :newvalue \"0\" :value \"lt\" :comparator \"i;ascii-casemap\" \"X-Test-Header\" \"test2\" \r\n"
                     + "  ;\n";
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
@@ -1276,7 +1276,7 @@ public class ReplaceHeaderTest {
     @Test
     public void testReplaceHeaderValueNegative() {
         try {
-            String filterScript = "require [\"editheader\"];\n"
+            String filterScript = "require [\"editheader\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
                     + "replaceheader :newname \"X-Numeric2-Header\" :newvalue \"0\" :value \"lt\" :comparator \"i;ascii-numeric\" \"X-Numeric-Header\" \"-3\";\n";
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
@@ -1460,7 +1460,7 @@ public class ReplaceHeaderTest {
                 + "\tby edge01e.zimbra.com (Postfix) with ESMTP id 9245B13575C;\n"
                 + "\tFri, 24 Jun 2016 01:45:31 -0400 (EDT)\n" + "Subject: 1\n"
                 + "to: test@zimbra.com\n";
-            String filterScript = "require [\"editheader\"];\n"
+            String filterScript = "require [\"editheader\", \"comparator-i;ascii-numeric\"];\n"
                 + "replaceheader :newvalue \"New Value\" :is :comparator \"i;ascii-numeric\" \"Subject\" \"1\";\n";
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
@@ -1552,7 +1552,7 @@ public class ReplaceHeaderTest {
     public void replaceHeaderSieveEditHeaderEnabledFalse() {
         try {
             String filterScript = "require [\"editheader\"];\n"
-                + "replaceheader :newvalue \"my subject\" :contains \"Subject\" \"example\"";
+                + "replaceheader :newvalue \"my subject\" :contains \"Subject\" \"example\";";
             Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
             RuleManager.clearCachedRules(acct1);
@@ -1591,6 +1591,9 @@ public class ReplaceHeaderTest {
             Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
             RuleManager.clearCachedRules(acct1);
             acct1.setSieveEditHeaderEnabled(true);
+            acct1.unsetAdminSieveScriptBefore();
+            acct1.unsetMailSieveScript();
+            acct1.unsetAdminSieveScriptAfter();
             acct1.setMailSieveScript(filterScript);
             RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox1), mbox1,
                 new ParsedMessage(sampleBaseMsg.getBytes(), false), 0, acct1.getName(), null,

--- a/store/src/java-test/com/zimbra/cs/filter/SetVariableTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/SetVariableTest.java
@@ -2059,7 +2059,8 @@ public class SetVariableTest {
             RuleManager.clearCachedRules(account);
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
-            filterScript = "if header :matches :comparator \"i;ascii-casemap\" \"Subject\" \"*C*a*c*ple*oo *ge*yo 123 *56*89 sie*e*t\" { "
+            filterScript = "require \"variables\";"
+                       + "if header :matches :comparator \"i;ascii-casemap\" \"Subject\" \"*C*a*c*ple*oo *ge*yo 123 *56*89 sie*e*t\" { "
                        + "tag \"${-1}\";}";
 
             account.setMailSieveScript(filterScript);
@@ -2091,7 +2092,8 @@ public class SetVariableTest {
             RuleManager.clearCachedRules(account);
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
-            filterScript = "if header :matches :comparator \"i;ascii-casemap\" \"Subject\" \"*C*a*c*ple*oo *ge*yo 123 *56*89 sie*e*t\" { "
+            filterScript = "require \"variables\";"
+                       + "if header :matches :comparator \"i;ascii-casemap\" \"Subject\" \"*C*a*c*ple*oo *ge*yo 123 *56*89 sie*e*t\" { "
                        + "tag \"${10}\";}";
 
             account.setMailSieveScript(filterScript);
@@ -2123,7 +2125,8 @@ public class SetVariableTest {
             RuleManager.clearCachedRules(account);
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
-            filterScript = "if header :matches :comparator \"i;ascii-casemap\" \"Subject\" \"*C*a*c*ple*oo *ge*yo 123 *56*89 sie*e*t\" { "
+            filterScript = "require \"variables\";"
+                       + "if header :matches :comparator \"i;ascii-casemap\" \"Subject\" \"*C*a*c*ple*oo *ge*yo 123 *56*89 sie*e*t\" { "
                        + "tag \"${0010}\";}";
 
             account.setMailSieveScript(filterScript);
@@ -2272,7 +2275,7 @@ public class SetVariableTest {
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
             
-            filterScript = "require [\"variables\", \"tag\"];\n"
+            filterScript = "require [\"variables\", \"tag\", \"comparator-i;ascii-numeric\"];\n"
                     + "set \"negative\" \"-123\";\n"
                     + "if string :is :comparator \"i;ascii-numeric\" \"${negative}\" \"-123\" {\n"
                     + "  tag \"negative\";\n"


### PR DESCRIPTION
Fixed unit tests
 - Added capability strings in "require".
 - Fixed mal-formatted script, and initialized the filter setting so that the filter can be tested successfully regardless of the executing order.