### PR TITLE
ZCS-1858(4):declare extension in "require" command, Part 2

### DIFF
--- a/store/src/java-test/com/zimbra/cs/filter/AddressTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/AddressTest.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2014, 2016, 2017 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -520,6 +520,43 @@ public class AddressTest {
             Assert.assertTrue(msg.isTagged(FlagInfo.PRIORITY));
         } catch (Exception e) {
             fail("No exception should be thrown" + e);
+        }
+    }
+
+    /*
+     * The ascii-numeric comparator should be looked up in the list of the "require".
+     */
+    @Test
+    public void testMissingComparatorNumericDeclaration() throws Exception {
+        // Default match type :is is used.
+        // No "comparator-i;ascii-numeric" capability text in the require command
+        String filterScript = "require [\"tag\"];"
+                + "if address :comparator \"i;ascii-numeric\" \"To\" \"test1@zimbra.com\" {\n"
+                + "  tag \"is\";\n"
+                + "} else {\n"
+                + "  tag \"not is\";\n"
+                + "}";
+        try {
+            Account account = Provisioning.getInstance().getAccount(
+                    MockProvisioning.DEFAULT_ACCOUNT_ID);
+            RuleManager.clearCachedRules(account);
+            Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
+
+            account.unsetAdminSieveScriptBefore();
+            account.unsetMailSieveScript();
+            account.unsetAdminSieveScriptAfter();
+            account.setMailSieveScript(filterScript);
+            List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(
+                    new OperationContext(mbox), mbox,
+                    new ParsedMessage("To: test1@zimbra.com\nSubject: example\n".getBytes(), false), 0,
+                    account.getName(),
+                    new DeliveryContext(),
+                    Mailbox.ID_FOLDER_INBOX, true);
+            Assert.assertEquals(1, ids.size());
+            Message msg = mbox.getMessageById(null, ids.get(0).getId());
+            Assert.assertEquals(null, ArrayUtil.getFirstElement(msg.getTags()));
+        } catch (Exception e) {
+            fail("No exception should be thrown " + e);
         }
     }
 }

--- a/store/src/java-test/com/zimbra/cs/filter/DeleteHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/DeleteHeaderTest.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2016 Synacor, Inc.
+ * Copyright (C) 2016, 2017 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -1317,6 +1317,32 @@ public class DeleteHeaderTest {
                     account.getName(), new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
             Message message = mbox.getMessageById(null, ids.get(0).getId());
             Assert.assertNull(message.getMimeMessage().getHeader("X-Mal-Encoded-Header"));
+        } catch (Exception e) {
+            fail("No exception should be thrown" + e);
+        }
+    }
+
+    /*
+     * The ascii-numeric comparator should be looked up in the list of the "require".
+     */
+    @Test
+    public void testMissingComparatorNumericDeclaration() throws Exception {
+        // Default match type :is is used.
+        // No "comparator-i;ascii-numeric" capability text in the require command
+        String script = "require [\"editheader\"];\n"
+                    + "deleteheader :comparator \"i;ascii-numeric\" \"X-Header\" \"example\";";
+        try {
+            Account account = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+            Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
+            RuleManager.clearCachedRules(account);
+            account.setSieveEditHeaderEnabled(true);
+            account.setAdminSieveScriptBefore(script);
+            account.setMailSieveScript(script);
+            List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox),
+                    mbox, new ParsedMessage("X-Header: example".getBytes(), false), 0,
+                    account.getName(), new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
+            Message message = mbox.getMessageById(null, ids.get(0).getId());
+            Assert.assertNotNull(message.getMimeMessage().getHeader("X-Header"));
         } catch (Exception e) {
             fail("No exception should be thrown" + e);
         }

--- a/store/src/java-test/com/zimbra/cs/filter/EnvelopeTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/EnvelopeTest.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2016 Synacor, Inc.
+ * Copyright (C) 2016, 2017 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -1005,6 +1005,49 @@ public class EnvelopeTest {
             Assert.assertEquals("is-all", tags[2]);
         } catch (Exception e) {
             fail("No exception should be thrown: " + e);
+        }
+    }
+
+    /*
+     * The ascii-numeric comparator should be looked up in the list of the "require".
+     */
+    @Test
+    public void testMissingComparatorNumericDeclaration() throws Exception {
+        // Default match type :is is used.
+        // No "comparator-i;ascii-numeric" capability text in the require command
+        String filterScript = "require [\"envelope\"];"
+                + "if envelope :comparator \"i;ascii-numeric\" \"To\" \"xyz@zimbra.com\" {\n"
+                + "  tag \"is\";\n"
+                + "} else {\n"
+                + "  tag \"not is\";\n"
+                + "}";
+        LmtpEnvelope env = new LmtpEnvelope();
+        LmtpAddress sender = new LmtpAddress("<t1@zimbra.com>", new String[] { "BODY", "SIZE" }, null);
+        LmtpAddress recipient = new LmtpAddress("<xyz@zimbra.com>", null, null);
+        env.setSender(sender);
+        env.addLocalRecipient(recipient);
+
+        try {
+            Account account = Provisioning.getInstance().getAccount(
+                    MockProvisioning.DEFAULT_ACCOUNT_ID);
+            RuleManager.clearCachedRules(account);
+            Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
+
+            account.unsetAdminSieveScriptBefore();
+            account.unsetMailSieveScript();
+            account.unsetAdminSieveScriptAfter();
+            account.setMailSieveScript(filterScript);
+            List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(
+                    new OperationContext(mbox), mbox,
+                    new ParsedMessage(sampleMsg.getBytes(), false), 0,
+                    account.getName(), env,
+                    new DeliveryContext(),
+                    Mailbox.ID_FOLDER_INBOX, true);
+            Assert.assertEquals(1, ids.size());
+            Message msg = mbox.getMessageById(null, ids.get(0).getId());
+            Assert.assertEquals(null, ArrayUtil.getFirstElement(msg.getTags()));
+        } catch (Exception e) {
+            fail("No exception should be thrown" + e);
         }
     }
 }

--- a/store/src/java-test/com/zimbra/cs/filter/HeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/HeaderTest.java
@@ -443,4 +443,42 @@ public class HeaderTest {
             fail("No exception should be thrown" + e);
         }
     }
+
+    /*
+     * The ascii-numeric comparator should be looked up in the list of the "require".
+     */
+    @Test
+    public void testMissingComparatorNumericDeclaration() throws Exception {
+        // Default match type :is is used.
+        // No "comparator-i;ascii-numeric" capability text in the require command
+        String filterScript = "require [\"tag\"];"
+                + "if header :comparator \"i;ascii-numeric\" \"Subject\" \"こんにちは\" {\n"
+                + "  tag \"is\";\n"
+                + "} else {\n"
+                + "  tag \"not is\";\n"
+                + "}";
+        try {
+            LmtpEnvelope env = setEnvelopeInfo();
+            Account account = Provisioning.getInstance().getAccount(
+                    MockProvisioning.DEFAULT_ACCOUNT_ID);
+            RuleManager.clearCachedRules(account);
+            Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
+
+            account.unsetAdminSieveScriptBefore();
+            account.unsetMailSieveScript();
+            account.unsetAdminSieveScriptAfter();
+            account.setMailSieveScript(filterScript);
+            List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(
+                    new OperationContext(mbox), mbox,
+                    new ParsedMessage(sampleMsg.getBytes(), false), 0,
+                    account.getName(), env,
+                    new DeliveryContext(),
+                    Mailbox.ID_FOLDER_INBOX, true);
+            Assert.assertEquals(1, ids.size());
+            Message msg = mbox.getMessageById(null, ids.get(0).getId());
+            Assert.assertEquals(null, ArrayUtil.getFirstElement(msg.getTags()));
+        } catch (Exception e) {
+            fail("No exception should be thrown" + e);
+        }
+    }
 }

--- a/store/src/java-test/com/zimbra/cs/filter/MimeHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/MimeHeaderTest.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2016, 2017 Synacor, Inc.
+ * Copyright (C) 2017 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -36,11 +36,49 @@ import com.zimbra.cs.mailbox.MailboxManager;
 import com.zimbra.cs.mailbox.MailboxTestUtil;
 import com.zimbra.cs.mailbox.Message;
 import com.zimbra.cs.mailbox.OperationContext;
-import com.zimbra.cs.mailbox.Flag.FlagInfo;
 import com.zimbra.cs.mime.ParsedMessage;
 import com.zimbra.cs.service.util.ItemId;
 
-public class BodyTest {
+public class MimeHeaderTest {
+    private static String sampleMsg = "from: xyz@example.com\n"
+            + "Subject: test message\n"
+            + "to: foo@example.com, baz@example.com\n"
+            + "cc: qux@example.com\n"
+            + "Subject: Bonjour\n"
+            + "MIME-Version: 1.0\n"
+            + "Content-Type: multipart/mixed; boundary=\"----=_Part_64_1822363563.1505482033554\"\n"
+            + "\n"
+            + "------=_Part_64_1822363563.1505482033554\n"
+            + "Content-Type: text/plain; charset=utf-8\n"
+            + "Content-Transfer-Encoding: 7bit\n"
+            + "\n"
+            + "Test message 2\n"
+            + "------=_Part_64_1822363563.1505482033554\n"
+            + "Content-Type: message/rfc822\n"
+            + "Content-Disposition: attachment\n"
+            + "\n"
+            + "Date: Fri, 15 Sep 2017 22:26:43 +0900 (JST)\n"
+            + "From: admin@synacorjapan.com\n"
+            + "To: user1 <user1@synacorjapan.com>\n"
+            + "Message-ID: <523389747.44.1505482003470.JavaMail.zimbra@synacorjapan.com>\n"
+            + "Subject: Hello\n"
+            + "MIME-Version: 1.0\n"
+            + "Content-Type: multipart/alternative; boundary=\"=_37c6ca38-873e-4a06-ad29-25a254075e83\"\n"
+            + "\n"
+            + "--=_37c6ca38-873e-4a06-ad29-25a254075e83\n"
+            + "Content-Type: text/plain; charset=utf-8\n"
+            + "Content-Transfer-Encoding: 7bit\n"
+            + "\n"
+            + "This is a sample email\n"
+            + "\n"
+            + "--=_37c6ca38-873e-4a06-ad29-25a254075e83\n"
+            + "Content-Type: text/html; charset=utf-8\n"
+            + "Content-Transfer-Encoding: 7bit\n"
+            + "\n"
+            + "<html><body><div style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt; color: #000000\"><div>Test message</div></div></body></html>\n"
+            + "--=_37c6ca38-873e-4a06-ad29-25a254075e83--\n"
+            + "\n"
+            + "------=_Part_64_1822363563.1505482033554--\n";
 
     @BeforeClass
     public static void init() throws Exception {
@@ -55,60 +93,15 @@ public class BodyTest {
     }
 
     @Test
-    public void testBug106637_InvalidCharset() throws Exception {
-        String script  = "if anyof (body :contains \"Bug 106637\") {\n"
-                       + "  flag \"flagged\";\n"
-                       + "}\n";
-
-        String message = "From: test@zimbra.com\n"
-                       + "Subject: test\n"
-                       + "Content-Type: text/plain; charset=\"undefined_charset\"\n"
-                       + "\n"
-                       + "Bug 106637\n";
-        test(script, message);
-    }
-
-    @Test
-    public void testValidCharset() throws Exception {
-        String script  = "if anyof (body :contains \"utf-8\") {\n"
-                + "  flag \"flagged\";\n"
-                + "}\n";
-
-        String message = "From: test@zimbra.com\n"
-                + "Subject: test\n"
-                + "Content-Type: text/plain; charset=\"UTF-8\"\n"
-                + "\n"
-                + "This message is written in utf-8 charset \n";
-        test(script, message);
-    }
-
-    @Test
-    public void testCharsetISO2022JP() throws Exception {
-        String script  = "if anyof (body :contains \"シフトJIS\") {\n"
-                + "  flag \"flagged\";\n"
-                + "}\n";
-
-        String message = "From: test@zimbra.com\n"
-                + "Subject: test\n"
-                + "Content-Type: text/plain; charset=\"ISO-2022-JP\"\n"
-                + "\n"
-                + "このメッセージはシフトJISで書かれています\n";
-
-        test(script, new String(message.getBytes("ISO2022JP")));
-    }
-
-    private void test(String script, String message) throws Exception {
-        Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
-        RuleManager.clearCachedRules(account);
-        account.setMailSieveScript(script);
-        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
-
-        List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox), mbox,
-                new ParsedMessage(message.getBytes(), false),
-                0, account.getName(), new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
-        Assert.assertEquals(1, ids.size());
-        Message msg = mbox.getMessageById(null, ids.get(0).getId());
-        Assert.assertTrue(msg.isTagged(FlagInfo.FLAGGED));
+    public void test() throws Exception {
+        // Default match type :is is used.
+        String filterScript = "require [\"tag\", \"comparator-i;ascii-numeric\"];"
+                + "if mime_header :comparator \"i;ascii-numeric\" \"Subject\" \"Hello\" {\n"
+                + "  tag \"is\";\n"
+                + "} else {\n"
+                + "  tag \"not is\";\n"
+                + "}";
+        doTest(filterScript, "is");
     }
 
     /*
@@ -119,11 +112,15 @@ public class BodyTest {
         // Default match type :is is used.
         // No "comparator-i;ascii-numeric" capability text in the require command
         String filterScript = "require [\"tag\"];"
-                + "if body :contains :comparator \"i;ascii-numeric\" \"Sample message\" {\n"
-                + "  tag \"contains\";\n"
+                + "if mime_header :comparator \"i;ascii-numeric\" \"Subject\" \"Hello\" {\n"
+                + "  tag \"is\";\n"
                 + "} else {\n"
-                + "  tag \"not contains\";\n"
+                + "  tag \"not is\";\n"
                 + "}";
+        doTest(filterScript, null);
+    }
+
+    private void doTest(String filterScript, String expected) throws Exception {
         try {
             Account account = Provisioning.getInstance().getAccount(
                     MockProvisioning.DEFAULT_ACCOUNT_ID);
@@ -136,15 +133,15 @@ public class BodyTest {
             account.setMailSieveScript(filterScript);
             List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox), mbox,
-                    new ParsedMessage("To: test1@zimbra.com\nSubject: test\n\nSample message".getBytes(), false), 0,
+                    new ParsedMessage(sampleMsg.getBytes(), false), 0,
                     account.getName(),
                     new DeliveryContext(),
                     Mailbox.ID_FOLDER_INBOX, true);
             Assert.assertEquals(1, ids.size());
             Message msg = mbox.getMessageById(null, ids.get(0).getId());
-            Assert.assertEquals(null, ArrayUtil.getFirstElement(msg.getTags()));
+            Assert.assertEquals(expected, ArrayUtil.getFirstElement(msg.getTags()));
         } catch (Exception e) {
-            fail("No exception should be thrown " + e);
+            fail("No exception should be thrown" + e);
         }
     }
 }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/AddressTest.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/AddressTest.java
@@ -16,6 +16,7 @@
  */
 package com.zimbra.cs.filter.jsieve;
 
+import static com.zimbra.cs.filter.jsieve.ComparatorName.ASCII_NUMERIC_COMPARATOR;
 import static org.apache.jsieve.comparators.MatchTypeTags.IS_TAG;
 import static org.apache.jsieve.tests.AddressPartTags.ALL_TAG;
 import static org.apache.jsieve.tests.AddressPartTags.LOCALPART_TAG;
@@ -78,6 +79,14 @@ public class AddressTest extends Address {
                 throw new SieveException("Exception occured while evaluating variable expression.", e);
             }
         }
+        if (params.getMatchType() == null) {
+            params.setMatchType(IS_TAG);
+        }
+        params.setComparator(ZimbraComparatorUtils.getComparator(params.getComparator(), params.getMatchType()));
+        if (ASCII_NUMERIC_COMPARATOR.equalsIgnoreCase(params.getComparator())) {
+            Require.checkCapability((ZimbraMailAdapter) mail, ASCII_NUMERIC_COMPARATOR);
+        }
+
         if (HeaderConstants.COUNT.equals(params.getMatchType()) || HeaderConstants.VALUE.equals(params.getMatchType()) || IS_TAG.equalsIgnoreCase(params.getMatchType())) {
             return match(mail,
                          (params.getAddressPart() == null ? ALL_TAG : params.getAddressPart()),
@@ -90,7 +99,7 @@ public class AddressTest extends Address {
             return match(mail,
                          (params.getAddressPart() == null ? ALL_TAG : params.getAddressPart()),
                          ZimbraComparatorUtils.getComparator(params.getComparator(), params.getMatchType()),
-                         (params.getMatchType() == null ? IS_TAG : params.getMatchType()),
+                         params.getMatchType(),
                          params.getHeaderNames(),
                          params.getKeys(), context);
         }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/BodyTest.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/BodyTest.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2013, 2014, 2016, 2017 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -44,6 +44,9 @@ import org.apache.jsieve.mail.MailAdapter;
 import org.apache.jsieve.tests.AbstractTest;
 
 import javax.mail.Part;
+
+import static com.zimbra.cs.filter.jsieve.ComparatorName.ASCII_NUMERIC_COMPARATOR;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -98,7 +101,11 @@ public class BodyTest extends AbstractTest {
                         if (argument instanceof StringListArgument) {
                             StringListArgument strList = (StringListArgument) argument;
                             try {
-                                caseSensitive = Sieve.Comparator.ioctet == Sieve.Comparator.fromString(strList.getList().get(0));
+                                String comparator = strList.getList().get(0);
+                                if (ASCII_NUMERIC_COMPARATOR.equalsIgnoreCase(comparator) && mail instanceof ZimbraMailAdapter) {
+                                    Require.checkCapability((ZimbraMailAdapter) mail, ASCII_NUMERIC_COMPARATOR);
+                                }
+                                caseSensitive = Sieve.Comparator.ioctet == Sieve.Comparator.fromString(comparator);
                             } catch (ServiceException e) {
                                 throw new SyntaxException(e.getMessage());
                             }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/DeleteHeader.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/DeleteHeader.java
@@ -17,6 +17,8 @@
 package com.zimbra.cs.filter.jsieve;
 
 import static com.zimbra.cs.filter.JsieveConfigMapHandler.CAPABILITY_EDITHEADER;
+import static com.zimbra.cs.filter.jsieve.ComparatorName.ASCII_NUMERIC_COMPARATOR;
+
 import java.util.List;
 import java.util.Enumeration;
 import java.util.HashSet;
@@ -55,6 +57,9 @@ public class DeleteHeader extends AbstractCommand {
             return null;
         }
         ZimbraMailAdapter mailAdapter = (ZimbraMailAdapter) mail;
+        if (ASCII_NUMERIC_COMPARATOR.equalsIgnoreCase(ehe.getComparator())) {
+            Require.checkCapability((ZimbraMailAdapter) mail, ASCII_NUMERIC_COMPARATOR);
+        }
         Require.checkCapability(mailAdapter, CAPABILITY_EDITHEADER);
         if (!mailAdapter.getAccount().isSieveEditHeaderEnabled()) {
             mailAdapter.setDeleteHeaderPresent(true);

--- a/store/src/java/com/zimbra/cs/filter/jsieve/EnvelopeTest.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/EnvelopeTest.java
@@ -84,6 +84,13 @@ public class EnvelopeTest extends Envelope {
                 throw new SieveException("Exception occured while evaluating variable expression.", e);
             }
         }
+        if (params.getMatchType() == null) {
+            params.setMatchType(IS_TAG);
+        }
+        params.setComparator(ZimbraComparatorUtils.getComparator(params.getComparator(), params.getMatchType()));
+        if (ASCII_NUMERIC_COMPARATOR.equalsIgnoreCase(params.getComparator())) {
+            Require.checkCapability(mailAdapter, ASCII_NUMERIC_COMPARATOR);
+        }
         
         if (HeaderConstants.COUNT.equals(params.getMatchType()) || HeaderConstants.VALUE.equals(params.getMatchType()) || IS_TAG.equals(params.getMatchType())) {
             return match(mail,
@@ -97,7 +104,7 @@ public class EnvelopeTest extends Envelope {
             return match(mail,
                     (params.getAddressPart() == null ? ALL_TAG : params.getAddressPart()),
                     ZimbraComparatorUtils.getComparator(params.getComparator(), params.getMatchType()),
-                    (params.getMatchType() == null ? IS_TAG : params.getMatchType()),
+                    params.getMatchType(),
                     params.getHeaderNames(),
                     params.getKeys(), context);
         }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/HeaderTest.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/HeaderTest.java
@@ -16,6 +16,7 @@
  */
 package com.zimbra.cs.filter.jsieve;
 
+import static com.zimbra.cs.filter.jsieve.ComparatorName.ASCII_NUMERIC_COMPARATOR;
 import static org.apache.jsieve.comparators.MatchTypeTags.CONTAINS_TAG;
 import static org.apache.jsieve.comparators.MatchTypeTags.IS_TAG;
 import static org.apache.jsieve.comparators.MatchTypeTags.MATCHES_TAG;
@@ -176,16 +177,18 @@ public class HeaderTest extends Header {
                     "Found unexpected arguments");
         }
 
+        if (null == matchType) {
+            matchType = IS_TAG;
+        }
+        comparator = ZimbraComparatorUtils.getComparator(comparator, matchType);
+        if (ASCII_NUMERIC_COMPARATOR.equalsIgnoreCase(comparator) && mail instanceof ZimbraMailAdapter) {
+            Require.checkCapability((ZimbraMailAdapter) mail, ASCII_NUMERIC_COMPARATOR);
+        }
         if (matchType != null
            && (HeaderConstants.COUNT.equalsIgnoreCase(matchType) || HeaderConstants.VALUE.equalsIgnoreCase(matchType) || IS_TAG.equalsIgnoreCase(matchType))) {
-            return match(mail,
-                    ZimbraComparatorUtils.getComparator(comparator, matchType),
-                         matchType, operator, headerNames, keys, context);
+            return match(mail, comparator, matchType, operator, headerNames, keys, context);
         } else {
-            return match(mail,
-                    ZimbraComparatorUtils.getComparator(comparator, matchType),
-                         (matchType == null ? IS_TAG : matchType),
-                         headerNames, keys, context);
+            return match(mail, comparator, matchType, headerNames, keys, context);
         }
     }
 

--- a/store/src/java/com/zimbra/cs/filter/jsieve/MimeHeaderTest.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/MimeHeaderTest.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2010, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2010, 2013, 2014, 2016, 2017 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -16,6 +16,8 @@
  */
 
 package com.zimbra.cs.filter.jsieve;
+
+import static com.zimbra.cs.filter.jsieve.ComparatorName.ASCII_NUMERIC_COMPARATOR;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -48,6 +50,9 @@ public class MimeHeaderTest extends Header {
             return false;
         }
         ZimbraMailAdapter zma = (ZimbraMailAdapter) mail;
+        if (ASCII_NUMERIC_COMPARATOR.equalsIgnoreCase(comparator)) {
+            Require.checkCapability(zma, ASCII_NUMERIC_COMPARATOR);
+        }
         // Iterate over the header names looking for a match
         boolean isMatched = false;
         Iterator<String> headerNamesIter = headerNames.iterator();

--- a/store/src/java/com/zimbra/cs/filter/jsieve/ReplaceHeader.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/ReplaceHeader.java
@@ -17,6 +17,8 @@
 package com.zimbra.cs.filter.jsieve;
 
 import static com.zimbra.cs.filter.JsieveConfigMapHandler.CAPABILITY_EDITHEADER;
+import static com.zimbra.cs.filter.jsieve.ComparatorName.ASCII_NUMERIC_COMPARATOR;
+
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -59,6 +61,9 @@ public class ReplaceHeader extends AbstractCommand {
             return null;
         }
         ZimbraMailAdapter mailAdapter = (ZimbraMailAdapter) mail;
+        if (ASCII_NUMERIC_COMPARATOR.equalsIgnoreCase(ehe.getComparator())) {
+            Require.checkCapability((ZimbraMailAdapter) mail, ASCII_NUMERIC_COMPARATOR);
+        }
         Require.checkCapability(mailAdapter, CAPABILITY_EDITHEADER);
         if (!mailAdapter.getAccount().isSieveEditHeaderEnabled()) {
             mailAdapter.setReplaceHeaderPresent(true);

--- a/store/src/java/com/zimbra/cs/filter/jsieve/StringTest.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/StringTest.java
@@ -16,6 +16,7 @@
  */
 package com.zimbra.cs.filter.jsieve;
 
+import static com.zimbra.cs.filter.JsieveConfigMapHandler.CAPABILITY_VARIABLES;
 import static com.zimbra.cs.filter.jsieve.ComparatorName.ASCII_NUMERIC_COMPARATOR;
 import static org.apache.jsieve.comparators.ComparatorNames.ASCII_CASEMAP_COMPARATOR;
 import static org.apache.jsieve.comparators.MatchTypeTags.CONTAINS_TAG;
@@ -72,6 +73,7 @@ public class StringTest extends Header {
         }
 
         ZimbraMailAdapter mailAdapter = (ZimbraMailAdapter) mail;
+        Require.checkCapability(mailAdapter, CAPABILITY_VARIABLES);
 
         String matchType = null;
         String comparator = null;


### PR DESCRIPTION
Additional fixes for the following Sieve commands without comparator-i;ascii-numeric.
 * header test with no match type (implicit :is)
 * address test with no match type (implicit :is)
 * envelope test with no match type (implicit :is)
 * deleteheader
 * replaceheader
 * mime_header (Zimbra special)
 * body (Zimbra special)

And "string" test needs to check the "variables" capability in the require list.