### PR TITLE
ZCS-2730:Adding resolve request parameter

### DIFF
--- a/common/src/java/com/zimbra/common/soap/MailConstants.java
+++ b/common/src/java/com/zimbra/common/soap/MailConstants.java
@@ -1346,5 +1346,6 @@ public final class MailConstants {
     public static final QName RESTORE_CONTACTS_REQUEST = QName.get(E_RESTORE_CONTACTS_REQUEST, NAMESPACE);
     public static final QName RESTORE_CONTACTS_RESPONSE = QName.get(E_RESTORE_CONTACTS_RESPONSE, NAMESPACE);
     public static final String A_CONTACTS_BACKUP_FILE_NAME = "contactsBackupFileName";
+    public static final String A_CONTACTS_RESTORE_RESOLVE = "resolve";
     public static final String A_CONTACTS_BACKUP_FOLDER_NAME = "ContactsBackup";
 }

--- a/soap/src/java/com/zimbra/soap/mail/message/RestoreContactsRequest.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/RestoreContactsRequest.java
@@ -16,12 +16,16 @@
  */
 package com.zimbra.soap.mail.message;
 
+import java.util.Arrays;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import com.google.common.base.Objects;
+import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.MailConstants;
 
 @XmlAccessorType(XmlAccessType.NONE)
@@ -35,6 +39,38 @@ public class RestoreContactsRequest {
     @XmlAttribute(name = MailConstants.A_CONTACTS_BACKUP_FILE_NAME, required = true)
     private String contactsBackupFileName;
 
+    /**
+     * @zm-api-field-tag resolve
+     * @zm-api-field-description restore resolve action
+     */
+    @XmlAttribute(name=MailConstants.A_CONTACTS_RESTORE_RESOLVE /* resolve */, required=false)
+    private Resolve resolve;
+
+    public Resolve getResolve() {
+        return resolve;
+    }
+
+    public void setResolve(Resolve resolve) {
+        this.resolve = resolve;
+    }
+
+    @XmlEnum
+    public static enum Resolve {
+        ignore, modify, replace, reset;
+
+        public static Resolve fromString(String value) throws ServiceException {
+            if (value == null) {
+                return null;
+            }
+            try {
+                return Resolve.valueOf(value);
+            } catch (IllegalArgumentException e) {
+                throw ServiceException.INVALID_REQUEST(
+                        "Invalid value: " + value + ", valid values: " + Arrays.asList(Resolve.values()), null);
+            }
+        }
+    }
+
     public String getContactsBackupFileName() {
         return contactsBackupFileName;
     }
@@ -44,7 +80,7 @@ public class RestoreContactsRequest {
     }
 
     public Objects.ToStringHelper addToStringInfo(Objects.ToStringHelper helper) {
-        return helper.add("contactsBackupFileName", contactsBackupFileName);
+        return helper.add("contactsBackupFileName", contactsBackupFileName).add("resolve", resolve);
     }
 
     @Override

--- a/store/docs/soap.txt
+++ b/store/docs/soap.txt
@@ -4697,18 +4697,20 @@ If IMAP tracking is already enabled, does nothing.
 
 -----------------------------
 API to restore contact backup file from the contact backup list
-<RestoreContactsRequest contactsBackupFileName="{backup_file_name}">
+<RestoreContactsRequest contactsBackupFileName="{backup_file_name}" resolve="{restore_resolve}">
 </RestoreContactsRequest>
+
+{restore_resolve} = ignore | modify | reset | replace
 
 Note: First, retrieve the contact backup file name with GetContactBackupList Soap API,
 then send that file name in 'contactsBackupFileName' parameter of RestoreContactsRequest.
 RestoreContactsRequest will search for file inside 'ContactsBackup' briefcase folder
 and if found, will restore it.
+The 'resolve' parameter is optional. It supports ignore, modify, reset, replace options in
+import Rest API. By default, the resolve action is 'reset'.
 
-<RestoreContactsResponse status="{status}">
+<RestoreContactsResponse>
 </RestoreContactsResponse>
-
-{status} = SUCCESS | FAILURE;
 
 -----------------------------
 Api to get list of available contact backup files


### PR DESCRIPTION
Adding one more parameter in RestoreContactRequest called 'resolve' to support all 4 options (replace, ignore, reset and modify) in import API