### PR TITLE
Feature/zcs 2836

### DIFF
--- a/client/src/java/com/zimbra/client/ZCalDataSource.java
+++ b/client/src/java/com/zimbra/client/ZCalDataSource.java
@@ -20,7 +20,6 @@ import org.json.JSONException;
 
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.MailConstants;
-import com.zimbra.common.util.SystemUtil;
 import com.zimbra.soap.admin.type.DataSourceType;
 import com.zimbra.soap.mail.type.CalDataSourceNameOrId;
 import com.zimbra.soap.mail.type.DataSourceNameOrId;
@@ -31,8 +30,6 @@ import com.zimbra.soap.type.DataSources;
 
 public class ZCalDataSource extends ZDataSource implements ToZJSONObject {
 
-    private CalDataSource data;
-    
     public ZCalDataSource(String name, String folderId, boolean enabled) {
         data = DataSources.newCalDataSource();
         data.setName(name);
@@ -44,24 +41,13 @@ public class ZCalDataSource extends ZDataSource implements ToZJSONObject {
         this.data = DataSources.newCalDataSource(data);
     }
     
-    public String getId() {
-        return data.getId();
-    }
-
-    public String getName() {
-        return data.getName();
-    }
-
+    @Override
     public DataSourceType getType() {
         return DataSourceType.cal;
     }
     
     public String getFolderId() {
         return data.getFolderId();
-    }
-    
-    public boolean isEnabled() {
-        return SystemUtil.coalesce(data.isEnabled(), Boolean.FALSE);
     }
 
     @Deprecated

--- a/client/src/java/com/zimbra/client/ZDataSource.java
+++ b/client/src/java/com/zimbra/client/ZDataSource.java
@@ -121,11 +121,44 @@ public class ZDataSource  {
         return this;
     }
 
+    public ZDataSource setOAuthToken(String val) {
+        if(data != null) {
+            data.setOAuthToken(val);
+        }
+        return this;
+    }
+
+    public ZDataSource setClientId(String val) {
+        if(data != null) {
+            data.setClientId(val);
+        }
+        return this;
+    }
+
+    public ZDataSource setClientSecret(String val) {
+        if(data != null) {
+            data.setClientSecret(val);
+        }
+        return this;
+    }
+
     public String getRefreshToken() {
         return data == null ? null : data.getRefreshToken();
     }
 
     public String getRefreshTokenUrl() {
         return data == null ? null : data.getRefreshTokenUrl();
+    }
+
+    public String getOAuthToken() {
+        return data == null ? null : data.getOAuthToken();
+    }
+
+    public String getClientId() {
+        return data == null ? null : data.getClientId();
+    }
+
+    public String getClientSecret() {
+        return data == null ? null : data.getClientSecret();
     }
 }

--- a/client/src/java/com/zimbra/client/ZDataSource.java
+++ b/client/src/java/com/zimbra/client/ZDataSource.java
@@ -17,54 +17,59 @@
 
 package com.zimbra.client;
 
-import java.util.List;
-
-import com.zimbra.soap.account.type.AccountDataSource;
+import com.zimbra.common.util.SystemUtil;
 import com.zimbra.soap.admin.type.DataSourceType;
 import com.zimbra.soap.mail.type.DataSourceNameOrId;
+import com.zimbra.soap.mail.type.MailDataSource;
 import com.zimbra.soap.type.DataSource;
 import com.zimbra.soap.type.DataSources;
 
 public class ZDataSource  {
-    private AccountDataSource data;
+    protected DataSource data;
 
     public ZDataSource() {
         data = DataSources.newDataSource();
+        data.setEnabled(false);
     }
 
-    public ZDataSource(String name) {
+    public ZDataSource(String name, boolean enabled) {
         data = DataSources.newDataSource();
         data.setName(name);
+        data.setEnabled(enabled);
     }
 
-    public ZDataSource(String name, String importClass) {
+    public ZDataSource(String name, boolean enabled, Iterable<String> attributes) {
         data = DataSources.newDataSource();
-        data.setImportClass(importClass);
-        data.setName(name);
-    }
-
-    public ZDataSource(String name, String importClass, Iterable<String> attributes) {
-        data = DataSources.newDataSource();
-        data.setImportClass(importClass);
         data.setAttributes(attributes);
         data.setName(name);
+        data.setEnabled(enabled);
     }
 
     public ZDataSource(DataSource data) {
         this.data = DataSources.newDataSource(data);
     }
 
-    public DataSourceType getType() {
-        return DataSourceType.custom;
+    public DataSource toJaxb() {
+        MailDataSource jaxbObject = new MailDataSource();
+        jaxbObject.setId(data.getId());
+        jaxbObject.setName(data.getName());
+        jaxbObject.setEnabled(data.isEnabled());
+        return jaxbObject;
     }
+
+    public DataSourceNameOrId toJaxbNameOrId() {
+        DataSourceNameOrId jaxbObject = DataSourceNameOrId.createForId(data.getId());
+        return jaxbObject;
+    }
+
     public String getName() {
         return data.getName();
     }
     public void setName(String name) {
         data.setName(name);
     }
-    public void setFolderId(String name) {
-        data.setFolderId(name);
+    public DataSourceType getType() {
+        return DataSourceType.unknown;
     }
     public String getId() {
         return data.getId();
@@ -78,87 +83,8 @@ public class ZDataSource  {
     public void setImportClass(String importClass) {
         data.setImportClass(importClass);
     }
-    public List<String> getAttributes() {
-        return data.getAttributes();
-    }
-    public DataSource toJaxb() {
-        AccountDataSource jaxbObject = new AccountDataSource();
-        jaxbObject.setId(data.getId());
-        jaxbObject.setName(data.getName());
-        jaxbObject.setHost(data.getHost());
-        jaxbObject.setPort(data.getPort());
-        jaxbObject.setUsername(data.getUsername());
-        jaxbObject.setPassword(data.getPassword());
-        jaxbObject.setFolderId(data.getFolderId());
-        jaxbObject.setConnectionType(data.getConnectionType());
-        jaxbObject.setImportOnly(data.isImportOnly());
-        return jaxbObject;
-    }
-
-    public DataSourceNameOrId toJaxbNameOrId() {
-        DataSourceNameOrId jaxbObject = DataSourceNameOrId.createForId(data.getId());
-        return jaxbObject;
-    }
-
-    public ZDataSource setAttributes(Iterable<String> attrs) {
-        if(data != null) {
-            data.setAttributes(attrs);
-        }
-        return this;
-    }
-
-    public ZDataSource setRefreshToken(String val) {
-        if(data != null) {
-            data.setRefreshToken(val);
-        }
-        return this;
-    }
-
-    public ZDataSource setRefreshTokenURL(String val) {
-        if(data != null) {
-            data.setRefreshTokenUrl(val);
-        }
-        return this;
-    }
-
-    public ZDataSource setOAuthToken(String val) {
-        if(data != null) {
-            data.setOAuthToken(val);
-        }
-        return this;
-    }
-
-    public ZDataSource setClientId(String val) {
-        if(data != null) {
-            data.setClientId(val);
-        }
-        return this;
-    }
-
-    public ZDataSource setClientSecret(String val) {
-        if(data != null) {
-            data.setClientSecret(val);
-        }
-        return this;
-    }
-
-    public String getRefreshToken() {
-        return data == null ? null : data.getRefreshToken();
-    }
-
-    public String getRefreshTokenUrl() {
-        return data == null ? null : data.getRefreshTokenUrl();
-    }
-
-    public String getOAuthToken() {
-        return data == null ? null : data.getOAuthToken();
-    }
-
-    public String getClientId() {
-        return data == null ? null : data.getClientId();
-    }
-
-    public String getClientSecret() {
-        return data == null ? null : data.getClientSecret();
+    public void setEnabled(boolean enabled) { data.setEnabled(enabled); }
+    public boolean isEnabled() {
+        return SystemUtil.coalesce(data.isEnabled(), Boolean.FALSE);
     }
 }

--- a/client/src/java/com/zimbra/client/ZGetInfoResult.java
+++ b/client/src/java/com/zimbra/client/ZGetInfoResult.java
@@ -41,6 +41,7 @@ import com.zimbra.soap.account.type.Signature;
 import com.zimbra.soap.type.CalDataSource;
 import com.zimbra.soap.type.DataSource;
 import com.zimbra.soap.type.ImapDataSource;
+import com.zimbra.soap.type.OAuthDataSource;
 import com.zimbra.soap.type.Pop3DataSource;
 import com.zimbra.soap.type.RssDataSource;
 
@@ -106,6 +107,8 @@ public class ZGetInfoResult implements ToZJSONObject {
                 newList.add(new ZCalDataSource((CalDataSource) ds));
             } else if (ds instanceof RssDataSource) {
                 newList.add(new ZRssDataSource((RssDataSource) ds));
+            } else if (ds instanceof OAuthDataSource) {
+                newList.add(new ZOAuthDataSource((OAuthDataSource) ds));
             } else  {
                 newList.add(new ZDataSource(ds));
             }

--- a/client/src/java/com/zimbra/client/ZImapDataSource.java
+++ b/client/src/java/com/zimbra/client/ZImapDataSource.java
@@ -33,8 +33,6 @@ import com.zimbra.soap.type.ImapDataSource;
 
 public class ZImapDataSource extends ZDataSource implements ToZJSONObject {
 
-    private ImapDataSource data;
-
     public ZImapDataSource(ImapDataSource data) {
         this.data = DataSources.newImapDataSource(data);
     }
@@ -111,16 +109,8 @@ public class ZImapDataSource extends ZDataSource implements ToZJSONObject {
         return jaxbObject;
     }
 
+    @Override
     public DataSourceType getType() { return DataSourceType.imap; }
-
-    public String getId() { return data.getId(); }
-
-    public String getName() { return data.getName(); }
-    public void setName(String name) { data.setName(name); }
-
-    public boolean isEnabled() { return SystemUtil.coalesce(data.isEnabled(), Boolean.FALSE); }
-    
-    public void setEnabled(boolean enabled) { data.setEnabled(enabled); }
 
     public String getHost() { return data.getHost(); }
     public void setHost(String host) { data.setHost(host); }
@@ -130,7 +120,7 @@ public class ZImapDataSource extends ZDataSource implements ToZJSONObject {
 
     public String getUsername() { return data.getUsername(); }
     public void setUsername(String username) { data.setUsername(username); }
-
+    
     public String getFolderId() { return data.getFolderId(); }
     public void setFolderId(String folderid) { data.setFolderId(folderid); }
 

--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -222,6 +222,7 @@ import com.zimbra.soap.type.AccountWithModifications;
 import com.zimbra.soap.type.CalDataSource;
 import com.zimbra.soap.type.DataSource;
 import com.zimbra.soap.type.ImapDataSource;
+import com.zimbra.soap.type.OAuthDataSource;
 import com.zimbra.soap.type.Pop3DataSource;
 import com.zimbra.soap.type.RssDataSource;
 import com.zimbra.soap.type.SearchSortBy;
@@ -4709,6 +4710,8 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
                 result.add(new ZCalDataSource((CalDataSource) ds));
             } else if (ds instanceof RssDataSource) {
                 result.add(new ZRssDataSource((RssDataSource) ds));
+            } else if (ds instanceof OAuthDataSource) {
+                result.add(new ZOAuthDataSource((OAuthDataSource) ds));
             } else {
                 result.add(new ZDataSource(ds));
             }

--- a/client/src/java/com/zimbra/client/ZOAuthDataSource.java
+++ b/client/src/java/com/zimbra/client/ZOAuthDataSource.java
@@ -1,0 +1,104 @@
+package com.zimbra.client;
+
+import org.json.JSONException;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.soap.admin.type.DataSourceType;
+import com.zimbra.soap.mail.type.DataSourceNameOrId;
+import com.zimbra.soap.mail.type.MailOAuthDataSource;
+import com.zimbra.soap.mail.type.OAuthDataSourceNameOrId;
+import com.zimbra.soap.type.DataSource;
+import com.zimbra.soap.type.DataSources;
+import com.zimbra.soap.type.OAuthDataSource;
+
+public class ZOAuthDataSource extends ZDataSource implements ToZJSONObject {
+    public ZOAuthDataSource(OAuthDataSource data) {
+        this.data = DataSources.newOAuthDataSource(data);
+    }
+
+    public ZOAuthDataSource(String name, boolean enabled, String refreshToken, String refreshTokenURL, String folderId, String importClass, boolean isImportOnly)
+    throws ServiceException {
+        data = DataSources.newOAuthDataSource();
+        data.setName(name);
+        data.setEnabled(enabled);
+        ((OAuthDataSource)data).setRefreshToken(refreshToken);
+        ((OAuthDataSource)data).setRefreshTokenUrl(refreshTokenURL);
+        data.setImportClass(importClass);
+        try {
+            data.setFolderId(folderId);
+        } catch (NumberFormatException e) {
+            throw ServiceException.INVALID_REQUEST("Invalid folder id", e);
+        }
+        data.setImportOnly(isImportOnly);
+    }
+
+    private OAuthDataSource getData() {
+        return ((OAuthDataSource)data);
+    }
+
+    @Override
+    public DataSource toJaxb() {
+        MailOAuthDataSource jaxbObject = new MailOAuthDataSource();
+        jaxbObject.setId(data.getId());
+        jaxbObject.setName(data.getName());
+        jaxbObject.setRefreshToken(getData().getRefreshToken());
+        jaxbObject.setRefreshTokenUrl(getData().getRefreshTokenUrl());
+        jaxbObject.setFolderId(data.getFolderId());
+        jaxbObject.setImportOnly(data.isImportOnly());
+        jaxbObject.setImportClass(data.getImportClass());
+        jaxbObject.setEnabled(data.isEnabled());
+        return jaxbObject;
+    }
+
+    @Override
+    public DataSourceNameOrId toJaxbNameOrId() {
+        OAuthDataSourceNameOrId jaxbObject = OAuthDataSourceNameOrId.createForId(data.getId());
+        return jaxbObject;
+    }
+
+    @Override
+    public DataSourceType getType() { return DataSourceType.oauth; }
+
+    @Override
+    public ZJSONObject toZJSONObject() throws JSONException {
+        ZJSONObject zjo = new ZJSONObject();
+        zjo.put("id", data.getId());
+        zjo.put("name", data.getName());
+        zjo.put("enabled", data.isEnabled());
+        zjo.put("refreshToken", getData().getRefreshToken());
+        zjo.put("refreshTokenUrl", getData().getRefreshTokenUrl());
+        zjo.put("folderId", data.getFolderId());
+        zjo.put("importOnly", data.isImportOnly());
+        return zjo;
+    }
+    public String getFolderId() { return data.getFolderId(); }
+    public ZOAuthDataSource setFolderId(String folderid) {
+        data.setFolderId(folderid);
+        return this;
+    }
+    
+    public ZOAuthDataSource setRefreshToken(String val) {
+        getData().setRefreshToken(val);
+        return this;
+    }
+
+    public ZOAuthDataSource setRefreshTokenURL(String val) {
+        getData().setRefreshTokenUrl(val);
+        return this;
+    }
+
+    public String getRefreshToken() {
+        return getData().getRefreshToken();
+    }
+
+    public String getRefreshTokenUrl() {
+        return getData().getRefreshTokenUrl();
+    }
+
+    public String getImportClass() {
+        return data.getImportClass();
+    }
+    public void setImportClass(String importClass) {
+        data.setImportClass(importClass);
+    }
+}

--- a/client/src/java/com/zimbra/client/ZOAuthDataSource.java
+++ b/client/src/java/com/zimbra/client/ZOAuthDataSource.java
@@ -3,6 +3,7 @@ package com.zimbra.client;
 import org.json.JSONException;
 
 import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.soap.admin.type.DataSourceType;
 import com.zimbra.soap.mail.type.DataSourceNameOrId;
 import com.zimbra.soap.mail.type.MailOAuthDataSource;
@@ -27,6 +28,7 @@ public class ZOAuthDataSource extends ZDataSource implements ToZJSONObject {
         try {
             data.setFolderId(folderId);
         } catch (NumberFormatException e) {
+            ZimbraLog.datasource.error("Cannot create ZOAuthDataSource with name %s and import class %s, because folder ID is invalid: %s", name, importClass, folderId);
             throw ServiceException.INVALID_REQUEST("Invalid folder id", e);
         }
         data.setImportOnly(isImportOnly);

--- a/client/src/java/com/zimbra/client/ZOAuthDataSource.java
+++ b/client/src/java/com/zimbra/client/ZOAuthDataSource.java
@@ -67,6 +67,7 @@ public class ZOAuthDataSource extends ZDataSource implements ToZJSONObject {
         zjo.put("enabled", data.isEnabled());
         zjo.put("refreshToken", getData().getRefreshToken());
         zjo.put("refreshTokenUrl", getData().getRefreshTokenUrl());
+        zjo.put("importClass", getData().getImportClass());
         zjo.put("folderId", data.getFolderId());
         zjo.put("importOnly", data.isImportOnly());
         return zjo;

--- a/client/src/java/com/zimbra/client/ZPop3DataSource.java
+++ b/client/src/java/com/zimbra/client/ZPop3DataSource.java
@@ -66,7 +66,7 @@ public class ZPop3DataSource extends ZDataSource implements ToZJSONObject {
         src.addAttribute(MailConstants.A_DS_PASSWORD, data.getPassword());
         src.addAttribute(MailConstants.A_FOLDER, data.getFolderId());
         src.addAttribute(MailConstants.A_DS_CONNECTION_TYPE, data.getConnectionType().name());
-        src.addAttribute(MailConstants.A_DS_LEAVE_ON_SERVER, getData().isLeaveOnServer());
+        src.addAttribute(MailConstants.A_DS_LEAVE_ON_SERVER, leaveOnServer());
         ZimbraLog.test.info("XXX bburtin: " + src.prettyPrint());
         return src;
     }
@@ -89,7 +89,7 @@ public class ZPop3DataSource extends ZDataSource implements ToZJSONObject {
         jaxbObject.setPassword(data.getPassword());
         jaxbObject.setFolderId(data.getFolderId());
         jaxbObject.setConnectionType(data.getConnectionType());
-        jaxbObject.setLeaveOnServer(getData().isLeaveOnServer());
+        jaxbObject.setLeaveOnServer(leaveOnServer());
         jaxbObject.setEnabled(data.isEnabled());
         return jaxbObject;
     }

--- a/client/src/java/com/zimbra/client/ZPop3DataSource.java
+++ b/client/src/java/com/zimbra/client/ZPop3DataSource.java
@@ -143,7 +143,7 @@ public class ZPop3DataSource extends ZDataSource implements ToZJSONObject {
         zjo.put("username", data.getUsername());
         zjo.put("folderId", data.getFolderId());
         zjo.put("connectionType", data.getConnectionType().toString());
-        zjo.put("leaveOnServer", getData().isLeaveOnServer());
+        zjo.put("leaveOnServer", leaveOnServer());
         return zjo;
     }
 

--- a/client/src/java/com/zimbra/client/ZPop3DataSource.java
+++ b/client/src/java/com/zimbra/client/ZPop3DataSource.java
@@ -35,8 +35,6 @@ import com.zimbra.soap.type.Pop3DataSource;
 
 public class ZPop3DataSource extends ZDataSource implements ToZJSONObject {
 
-    private Pop3DataSource data;
-
     public ZPop3DataSource(Pop3DataSource data) {
         this.data = DataSources.newPop3DataSource(data);
     }
@@ -68,7 +66,7 @@ public class ZPop3DataSource extends ZDataSource implements ToZJSONObject {
         src.addAttribute(MailConstants.A_DS_PASSWORD, data.getPassword());
         src.addAttribute(MailConstants.A_FOLDER, data.getFolderId());
         src.addAttribute(MailConstants.A_DS_CONNECTION_TYPE, data.getConnectionType().name());
-        src.addAttribute(MailConstants.A_DS_LEAVE_ON_SERVER, data.isLeaveOnServer());
+        src.addAttribute(MailConstants.A_DS_LEAVE_ON_SERVER, getData().isLeaveOnServer());
         ZimbraLog.test.info("XXX bburtin: " + src.prettyPrint());
         return src;
     }
@@ -91,7 +89,7 @@ public class ZPop3DataSource extends ZDataSource implements ToZJSONObject {
         jaxbObject.setPassword(data.getPassword());
         jaxbObject.setFolderId(data.getFolderId());
         jaxbObject.setConnectionType(data.getConnectionType());
-        jaxbObject.setLeaveOnServer(data.isLeaveOnServer());
+        jaxbObject.setLeaveOnServer(getData().isLeaveOnServer());
         jaxbObject.setEnabled(data.isEnabled());
         return jaxbObject;
     }
@@ -101,16 +99,11 @@ public class ZPop3DataSource extends ZDataSource implements ToZJSONObject {
         Pop3DataSourceNameOrId jaxbObject = Pop3DataSourceNameOrId.createForId(data.getId());
         return jaxbObject;
     }
-
+    private Pop3DataSource getData() {
+        return ((Pop3DataSource)data);
+    }
+    @Override
     public DataSourceType getType() { return DataSourceType.pop3; }
-
-    public String getId() { return data.getId(); }
-
-    public String getName() { return data.getName(); }
-    public void setName(String name) { data.setName(name); }
-
-    public boolean isEnabled() { return SystemUtil.coalesce(data.isEnabled(), Boolean.FALSE); }
-    public void setEnabled(boolean enabled) { data.setEnabled(enabled); }
 
     public String getHost() { return data.getHost(); }
     public void setHost(String host) { data.setHost(host); }
@@ -134,11 +127,11 @@ public class ZPop3DataSource extends ZDataSource implements ToZJSONObject {
     }
     
     public boolean leaveOnServer() {
-        Boolean val = data.isLeaveOnServer();
+        Boolean val = getData().isLeaveOnServer();
         return (val == null ? true : val);
     }
     
-    public void setLeaveOnServer(boolean leaveOnServer) { data.setLeaveOnServer(leaveOnServer); }
+    public void setLeaveOnServer(boolean leaveOnServer) { getData().setLeaveOnServer(leaveOnServer); }
     
     public ZJSONObject toZJSONObject() throws JSONException {
         ZJSONObject zjo = new ZJSONObject();
@@ -150,7 +143,7 @@ public class ZPop3DataSource extends ZDataSource implements ToZJSONObject {
         zjo.put("username", data.getUsername());
         zjo.put("folderId", data.getFolderId());
         zjo.put("connectionType", data.getConnectionType().toString());
-        zjo.put("leaveOnServer", data.isLeaveOnServer());
+        zjo.put("leaveOnServer", getData().isLeaveOnServer());
         return zjo;
     }
 

--- a/client/src/java/com/zimbra/client/ZRssDataSource.java
+++ b/client/src/java/com/zimbra/client/ZRssDataSource.java
@@ -20,7 +20,6 @@ import org.json.JSONException;
 
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.MailConstants;
-import com.zimbra.common.util.SystemUtil;
 import com.zimbra.soap.admin.type.DataSourceType;
 import com.zimbra.soap.mail.type.DataSourceNameOrId;
 import com.zimbra.soap.mail.type.MailRssDataSource;
@@ -32,8 +31,6 @@ import com.zimbra.soap.type.RssDataSource;
 
 public class ZRssDataSource extends ZDataSource implements ToZJSONObject {
 
-    private RssDataSource data;
-    
     public ZRssDataSource(String name, String folderId, boolean enabled) {
         data = DataSources.newRssDataSource();
         data.setName(name);
@@ -46,16 +43,6 @@ public class ZRssDataSource extends ZDataSource implements ToZJSONObject {
     }
 
     @Override
-    public String getId() {
-        return data.getId();
-    }
-
-    @Override
-    public String getName() {
-        return data.getName();
-    }
-
-    @Override
     public DataSourceType getType() {
         return DataSourceType.rss;
     }
@@ -64,10 +51,6 @@ public class ZRssDataSource extends ZDataSource implements ToZJSONObject {
         return data.getFolderId();
     }
     
-    public boolean isEnabled() {
-        return SystemUtil.coalesce(data.isEnabled(), Boolean.FALSE);
-    }
-
     @Deprecated
     public Element toElement(Element parent) {
         Element src = parent.addElement(MailConstants.E_DS_RSS);

--- a/common/src/java/com/zimbra/common/soap/MailConstants.java
+++ b/common/src/java/com/zimbra/common/soap/MailConstants.java
@@ -1174,6 +1174,7 @@ public final class MailConstants {
     public static final String E_DS_RSS = "rss";
     public static final String E_DS_GAL = "gal";
     public static final String E_DS_CAL = "cal";
+    public static final String E_DS_OAUTH = "oauth";
     public static final String E_DS_UNKNOWN = "unknown";
     public static final String E_DS_LAST_ERROR = "lastError";
     public static final String A_DS_IS_ENABLED = "isEnabled";

--- a/soap/src/java/com/zimbra/soap/account/message/GetInfoResponse.java
+++ b/soap/src/java/com/zimbra/soap/account/message/GetInfoResponse.java
@@ -42,6 +42,7 @@ import com.zimbra.soap.account.type.AccountCaldavDataSource;
 import com.zimbra.soap.account.type.AccountDataSource;
 import com.zimbra.soap.account.type.AccountGalDataSource;
 import com.zimbra.soap.account.type.AccountImapDataSource;
+import com.zimbra.soap.account.type.AccountOAuthDataSource;
 import com.zimbra.soap.account.type.AccountPop3DataSource;
 import com.zimbra.soap.account.type.AccountRssDataSource;
 import com.zimbra.soap.account.type.AccountUnknownDataSource;
@@ -249,7 +250,7 @@ public final class GetInfoResponse {
         @XmlElement(name=MailConstants.E_DS_RSS /* rss */, type=AccountRssDataSource.class),
         @XmlElement(name=MailConstants.E_DS_GAL /* gal */, type=AccountGalDataSource.class),
         @XmlElement(name=MailConstants.E_DS_CAL /* cal */, type=AccountCalDataSource.class),
-        @XmlElement(name=MailConstants.E_DS /* dsrc */, type=AccountDataSource.class),
+        @XmlElement(name=MailConstants.E_DS_OAUTH /* oauth */, type=AccountOAuthDataSource.class),
         @XmlElement(name=MailConstants.E_DS_UNKNOWN /* unknown */, type=AccountUnknownDataSource.class)
     })
     private List<AccountDataSource> dataSources = Lists.newArrayList();

--- a/soap/src/java/com/zimbra/soap/account/type/AccountDataSource.java
+++ b/soap/src/java/com/zimbra/soap/account/type/AccountDataSource.java
@@ -38,8 +38,7 @@ import com.zimbra.soap.type.ZmBoolean;
 @XmlAccessorType(XmlAccessType.NONE)
 @XmlType(propOrder = {"lastError", "attributes"})
 @XmlRootElement
-public class AccountDataSource
-implements DataSource {
+public class AccountDataSource implements DataSource {
 
     /**
      * @zm-api-field-tag data-source-id
@@ -209,41 +208,6 @@ implements DataSource {
     @XmlElement(name=MailConstants.E_ATTRIBUTE /* a */, required=false)
     private List<String> attributes = Lists.newArrayList();
 
-    /**
-     * @zm-api-field-tag data-source-oauthToken
-     * @zm-api-field-description oauthToken for data source
-     */
-    @XmlAttribute(name=MailConstants.A_DS_OAUTH_TOKEN /* oauthToken */, required=false)
-    private String oauthToken;
-
-    /**
-     * @zm-api-field-tag data-source-refreshToken
-     * @zm-api-field-description refresh token for refreshing data source oauth token
-     */
-    @XmlAttribute(name = MailConstants.A_DS_REFRESH_TOKEN /* refreshToken */, required = false)
-    private String refreshToken;
-
-    /**
-     * @zm-api-field-tag data-source-refreshTokenUrl
-     * @zm-api-field-description refreshTokenUrl for refreshing data source oauth token
-     */
-    @XmlAttribute(name = MailConstants.A_DS_REFRESH_TOKEN_URL /* refreshTokenUrl */, required = false)
-    private String refreshTokenUrl;
-
-    /**
-     * @zm-api-field-tag data-source-clientId
-     * @zm-api-field-description client Id for refreshing data source oauth token
-     */
-    @XmlAttribute(name = MailConstants.A_DS_CLIENT_ID /* clientId */, required = false)
-    private String clientId;
-
-    /**
-     * @zm-api-field-tag data-source-clientSecret
-     * @zm-api-field-description client secret for refreshing data source oauth token
-     */
-    @XmlAttribute(name = MailConstants.A_DS_CLIENT_SECRET /* clientSecret */, required = false)
-    private String clientSecret;
-
     public AccountDataSource() {
     }
 
@@ -391,20 +355,6 @@ implements DataSource {
     public void setConnectionType(ConnectionType connectionType) {
         this.adsConnectionType = AdsConnectionType.CT_TO_ACT.apply(connectionType);
     }
-    public void setOAuthToken(String oauthToken) { this.oauthToken = oauthToken; }
-    public String getOAuthToken() { return oauthToken; }
-
-    public void setRefreshToken(String refreshToken) { this.refreshToken = refreshToken; }
-    public String getRefreshToken() { return refreshToken; }
-
-    public void setRefreshTokenUrl(String refreshTokenUrl) { this.refreshTokenUrl = refreshTokenUrl; }
-    public String getRefreshTokenUrl() { return refreshTokenUrl; }
-
-    public void setClientId(String clientId) { this.clientId = clientId; }
-    public String getClientId() { return clientId; }
-
-    public void setClientSecret(String clientSecret) { this.clientSecret = clientSecret; }
-    public String getClientSecret() { return clientSecret; }
 
     public Objects.ToStringHelper addToStringInfo(
                 Objects.ToStringHelper helper) {
@@ -430,11 +380,6 @@ implements DataSource {
             .add("importClass", importClass)
             .add("failingSince", failingSince)
             .add("lastError", lastError)
-            .add("oauthToken", oauthToken)
-            .add("clientId", clientId)
-            .add("clientSecret", clientSecret)
-            .add("refreshToken", refreshToken)
-            .add("refreshTokenUrl", refreshTokenUrl)
             .add("attributes", attributes);
     }
 

--- a/soap/src/java/com/zimbra/soap/account/type/AccountDataSource.java
+++ b/soap/src/java/com/zimbra/soap/account/type/AccountDataSource.java
@@ -210,6 +210,13 @@ implements DataSource {
     private List<String> attributes = Lists.newArrayList();
 
     /**
+     * @zm-api-field-tag data-source-oauthToken
+     * @zm-api-field-description oauthToken for data source
+     */
+    @XmlAttribute(name=MailConstants.A_DS_OAUTH_TOKEN /* oauthToken */, required=false)
+    private String oauthToken;
+
+    /**
      * @zm-api-field-tag data-source-refreshToken
      * @zm-api-field-description refresh token for refreshing data source oauth token
      */
@@ -222,6 +229,20 @@ implements DataSource {
      */
     @XmlAttribute(name = MailConstants.A_DS_REFRESH_TOKEN_URL /* refreshTokenUrl */, required = false)
     private String refreshTokenUrl;
+
+    /**
+     * @zm-api-field-tag data-source-clientId
+     * @zm-api-field-description client Id for refreshing data source oauth token
+     */
+    @XmlAttribute(name = MailConstants.A_DS_CLIENT_ID /* clientId */, required = false)
+    private String clientId;
+
+    /**
+     * @zm-api-field-tag data-source-clientSecret
+     * @zm-api-field-description client secret for refreshing data source oauth token
+     */
+    @XmlAttribute(name = MailConstants.A_DS_CLIENT_SECRET /* clientSecret */, required = false)
+    private String clientSecret;
 
     public AccountDataSource() {
     }
@@ -370,11 +391,20 @@ implements DataSource {
     public void setConnectionType(ConnectionType connectionType) {
         this.adsConnectionType = AdsConnectionType.CT_TO_ACT.apply(connectionType);
     }
+    public void setOAuthToken(String oauthToken) { this.oauthToken = oauthToken; }
+    public String getOAuthToken() { return oauthToken; }
+
     public void setRefreshToken(String refreshToken) { this.refreshToken = refreshToken; }
     public String getRefreshToken() { return refreshToken; }
 
     public void setRefreshTokenUrl(String refreshTokenUrl) { this.refreshTokenUrl = refreshTokenUrl; }
     public String getRefreshTokenUrl() { return refreshTokenUrl; }
+
+    public void setClientId(String clientId) { this.clientId = clientId; }
+    public String getClientId() { return clientId; }
+
+    public void setClientSecret(String clientSecret) { this.clientSecret = clientSecret; }
+    public String getClientSecret() { return clientSecret; }
 
     public Objects.ToStringHelper addToStringInfo(
                 Objects.ToStringHelper helper) {
@@ -400,6 +430,9 @@ implements DataSource {
             .add("importClass", importClass)
             .add("failingSince", failingSince)
             .add("lastError", lastError)
+            .add("oauthToken", oauthToken)
+            .add("clientId", clientId)
+            .add("clientSecret", clientSecret)
             .add("refreshToken", refreshToken)
             .add("refreshTokenUrl", refreshTokenUrl)
             .add("attributes", attributes);

--- a/soap/src/java/com/zimbra/soap/account/type/AccountOAuthDataSource.java
+++ b/soap/src/java/com/zimbra/soap/account/type/AccountOAuthDataSource.java
@@ -7,14 +7,6 @@ import com.zimbra.common.soap.MailConstants;
 import com.zimbra.soap.type.OAuthDataSource;
 @XmlType(propOrder = {})
 public class AccountOAuthDataSource extends AccountDataSource implements OAuthDataSource {
-    public AccountOAuthDataSource() {
-    }
-
-    public AccountOAuthDataSource(OAuthDataSource data) {
-        super(data);
-        refreshToken = data.getRefreshToken();
-        refreshTokenUrl = data.getRefreshTokenUrl();
-    }
     /**
      * @zm-api-field-tag data-source-refreshToken
      * @zm-api-field-description refresh token for refreshing data source oauth token
@@ -29,6 +21,14 @@ public class AccountOAuthDataSource extends AccountDataSource implements OAuthDa
     @XmlAttribute(name = MailConstants.A_DS_REFRESH_TOKEN_URL /* refreshTokenUrl */, required = false)
     private String refreshTokenUrl;
 
+    public AccountOAuthDataSource() {
+    }
+
+    public AccountOAuthDataSource(OAuthDataSource data) {
+        super(data);
+        refreshToken = data.getRefreshToken();
+        refreshTokenUrl = data.getRefreshTokenUrl();
+    }
 
     public void setRefreshToken(String refreshToken) { this.refreshToken = refreshToken; }
     public String getRefreshToken() { return refreshToken; }

--- a/soap/src/java/com/zimbra/soap/account/type/AccountOAuthDataSource.java
+++ b/soap/src/java/com/zimbra/soap/account/type/AccountOAuthDataSource.java
@@ -1,0 +1,40 @@
+package com.zimbra.soap.account.type;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
+
+import com.zimbra.common.soap.MailConstants;
+import com.zimbra.soap.type.OAuthDataSource;
+@XmlType(propOrder = {})
+public class AccountOAuthDataSource extends AccountDataSource implements OAuthDataSource {
+    public AccountOAuthDataSource() {
+    }
+
+    public AccountOAuthDataSource(OAuthDataSource data) {
+        super(data);
+        refreshToken = data.getRefreshToken();
+        refreshTokenUrl = data.getRefreshTokenUrl();
+    }
+    /**
+     * @zm-api-field-tag data-source-refreshToken
+     * @zm-api-field-description refresh token for refreshing data source oauth token
+     */
+    @XmlAttribute(name = MailConstants.A_DS_REFRESH_TOKEN /* refreshToken */, required = false)
+    private String refreshToken;
+
+    /**
+     * @zm-api-field-tag data-source-refreshTokenUrl
+     * @zm-api-field-description refreshTokenUrl for refreshing data source oauth token
+     */
+    @XmlAttribute(name = MailConstants.A_DS_REFRESH_TOKEN_URL /* refreshTokenUrl */, required = false)
+    private String refreshTokenUrl;
+
+
+    public void setRefreshToken(String refreshToken) { this.refreshToken = refreshToken; }
+    public String getRefreshToken() { return refreshToken; }
+
+    public void setRefreshTokenUrl(String refreshTokenUrl) { this.refreshTokenUrl = refreshTokenUrl; }
+    public String getRefreshTokenUrl() { return refreshTokenUrl; }
+
+
+}

--- a/soap/src/java/com/zimbra/soap/admin/type/DataSourceType.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/DataSourceType.java
@@ -26,7 +26,7 @@ import com.zimbra.common.service.ServiceException;
 @XmlEnum
 public enum DataSourceType {
     // case must match protocol
-    pop3, imap, caldav, contacts, yab, rss, cal, gal, xsync, tagmap, custom;
+    pop3, imap, caldav, contacts, yab, rss, cal, gal, xsync, tagmap, oauth, unknown;
 
     public static DataSourceType fromString(String s) throws ServiceException {
         try {

--- a/soap/src/java/com/zimbra/soap/mail/message/CreateDataSourceRequest.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/CreateDataSourceRequest.java
@@ -17,18 +17,19 @@
 
 package com.zimbra.soap.mail.message;
 
-import com.google.common.base.Objects;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElements;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import com.google.common.base.Objects;
 import com.zimbra.common.soap.MailConstants;
 import com.zimbra.soap.mail.type.MailCalDataSource;
 import com.zimbra.soap.mail.type.MailCaldavDataSource;
 import com.zimbra.soap.mail.type.MailGalDataSource;
 import com.zimbra.soap.mail.type.MailImapDataSource;
+import com.zimbra.soap.mail.type.MailOAuthDataSource;
 import com.zimbra.soap.mail.type.MailPop3DataSource;
 import com.zimbra.soap.mail.type.MailRssDataSource;
 import com.zimbra.soap.mail.type.MailUnknownDataSource;
@@ -56,6 +57,7 @@ public class CreateDataSourceRequest {
         @XmlElement(name=MailConstants.E_DS_RSS /* rss */, type=MailRssDataSource.class),
         @XmlElement(name=MailConstants.E_DS_GAL /* gal */, type=MailGalDataSource.class),
         @XmlElement(name=MailConstants.E_DS_CAL /* cal */, type=MailCalDataSource.class),
+        @XmlElement(name=MailConstants.E_DS_OAUTH /* oauth */, type=MailOAuthDataSource.class),
         @XmlElement(name=MailConstants.E_DS_UNKNOWN /* unknown */, type=MailUnknownDataSource.class)
     })
     private DataSource dataSource;

--- a/soap/src/java/com/zimbra/soap/mail/message/CreateDataSourceResponse.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/CreateDataSourceResponse.java
@@ -18,6 +18,7 @@
 package com.zimbra.soap.mail.message;
 
 import com.google.common.base.Objects;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -30,6 +31,7 @@ import com.zimbra.soap.mail.type.CalDataSourceId;
 import com.zimbra.soap.mail.type.CaldavDataSourceId;
 import com.zimbra.soap.mail.type.GalDataSourceId;
 import com.zimbra.soap.mail.type.ImapDataSourceId;
+import com.zimbra.soap.mail.type.OAuthDataSourceId;
 import com.zimbra.soap.mail.type.Pop3DataSourceId;
 import com.zimbra.soap.mail.type.RssDataSourceId;
 import com.zimbra.soap.mail.type.UnknownDataSourceId;
@@ -52,6 +54,7 @@ public class CreateDataSourceResponse {
         @XmlElement(name=MailConstants.E_DS_RSS /* rss */, type=RssDataSourceId.class),
         @XmlElement(name=MailConstants.E_DS_GAL /* gal */, type=GalDataSourceId.class),
         @XmlElement(name=MailConstants.E_DS_CAL /* cal */, type=CalDataSourceId.class),
+        @XmlElement(name=MailConstants.E_DS_OAUTH /* oauth */, type=OAuthDataSourceId.class),
         @XmlElement(name=MailConstants.E_DS_UNKNOWN /* unknown */, type=UnknownDataSourceId.class)
     })
     private Id dataSource;

--- a/soap/src/java/com/zimbra/soap/mail/message/GetDataSourcesResponse.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/GetDataSourcesResponse.java
@@ -35,6 +35,7 @@ import com.zimbra.soap.mail.type.MailCalDataSource;
 import com.zimbra.soap.mail.type.MailCaldavDataSource;
 import com.zimbra.soap.mail.type.MailGalDataSource;
 import com.zimbra.soap.mail.type.MailImapDataSource;
+import com.zimbra.soap.mail.type.MailOAuthDataSource;
 import com.zimbra.soap.mail.type.MailPop3DataSource;
 import com.zimbra.soap.mail.type.MailRssDataSource;
 import com.zimbra.soap.mail.type.MailUnknownDataSource;
@@ -56,6 +57,7 @@ public class GetDataSourcesResponse {
         @XmlElement(name=MailConstants.E_DS_RSS /* rss */, type=MailRssDataSource.class),
         @XmlElement(name=MailConstants.E_DS_GAL /* gal */, type=MailGalDataSource.class),
         @XmlElement(name=MailConstants.E_DS_CAL /* cal */, type=MailCalDataSource.class),
+        @XmlElement(name=MailConstants.E_DS_OAUTH /* custom */, type=MailOAuthDataSource.class),
         @XmlElement(name=MailConstants.E_DS_UNKNOWN /* unknown */, type=MailUnknownDataSource.class)
     })
     private List<DataSource> dataSources = Lists.newArrayList();

--- a/soap/src/java/com/zimbra/soap/mail/message/GetDataSourcesResponse.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/GetDataSourcesResponse.java
@@ -57,7 +57,7 @@ public class GetDataSourcesResponse {
         @XmlElement(name=MailConstants.E_DS_RSS /* rss */, type=MailRssDataSource.class),
         @XmlElement(name=MailConstants.E_DS_GAL /* gal */, type=MailGalDataSource.class),
         @XmlElement(name=MailConstants.E_DS_CAL /* cal */, type=MailCalDataSource.class),
-        @XmlElement(name=MailConstants.E_DS_OAUTH /* custom */, type=MailOAuthDataSource.class),
+        @XmlElement(name=MailConstants.E_DS_OAUTH /* oauth */, type=MailOAuthDataSource.class),
         @XmlElement(name=MailConstants.E_DS_UNKNOWN /* unknown */, type=MailUnknownDataSource.class)
     })
     private List<DataSource> dataSources = Lists.newArrayList();

--- a/soap/src/java/com/zimbra/soap/mail/type/CalDataSourceId.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/CalDataSourceId.java
@@ -20,7 +20,6 @@ package com.zimbra.soap.mail.type;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 
-import com.zimbra.common.soap.MailConstants;
 import com.zimbra.soap.type.Id;
 
 @XmlAccessorType(XmlAccessType.NONE)

--- a/soap/src/java/com/zimbra/soap/mail/type/GalDataSourceId.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/GalDataSourceId.java
@@ -20,7 +20,6 @@ package com.zimbra.soap.mail.type;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 
-import com.zimbra.common.soap.MailConstants;
 import com.zimbra.soap.type.Id;
 
 @XmlAccessorType(XmlAccessType.NONE)

--- a/soap/src/java/com/zimbra/soap/mail/type/ImapDataSourceId.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ImapDataSourceId.java
@@ -20,7 +20,6 @@ package com.zimbra.soap.mail.type;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 
-import com.zimbra.common.soap.MailConstants;
 import com.zimbra.soap.type.Id;
 
 @XmlAccessorType(XmlAccessType.NONE)

--- a/soap/src/java/com/zimbra/soap/mail/type/MailDataSource.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/MailDataSource.java
@@ -36,10 +36,7 @@ import com.zimbra.soap.type.ZmBoolean;
 
 @XmlAccessorType(XmlAccessType.NONE)
 @XmlType(propOrder = {"lastError", "attributes"})
-abstract public class MailDataSource
-implements DataSource {
-
-
+public class MailDataSource implements DataSource {
     /**
      * @zm-api-field-tag data-source-id
      * @zm-api-field-description Unique ID for data source

--- a/soap/src/java/com/zimbra/soap/mail/type/MailOAuthDataSource.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/MailOAuthDataSource.java
@@ -6,13 +6,6 @@ import com.zimbra.common.soap.MailConstants;
 import com.zimbra.soap.type.OAuthDataSource;
 
 public class MailOAuthDataSource extends MailDataSource implements OAuthDataSource {
-    public MailOAuthDataSource() {
-    }
-
-    public MailOAuthDataSource(OAuthDataSource data) {
-        super(data);
-    }
-
     /**
      * @zm-api-field-tag data-source-refreshToken
      * @zm-api-field-description refresh token for refreshing data source oauth token
@@ -26,6 +19,13 @@ public class MailOAuthDataSource extends MailDataSource implements OAuthDataSour
      */
     @XmlAttribute(name = MailConstants.A_DS_REFRESH_TOKEN_URL /* refreshTokenUrl */, required = false)
     private String refreshTokenUrl;
+
+    public MailOAuthDataSource() {
+    }
+
+    public MailOAuthDataSource(OAuthDataSource data) {
+        super(data);
+    }
 
     public void setRefreshToken(String refreshToken) { this.refreshToken = refreshToken; }
     public String getRefreshToken() { return refreshToken; }

--- a/soap/src/java/com/zimbra/soap/mail/type/MailOAuthDataSource.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/MailOAuthDataSource.java
@@ -1,0 +1,35 @@
+package com.zimbra.soap.mail.type;
+
+import javax.xml.bind.annotation.XmlAttribute;
+
+import com.zimbra.common.soap.MailConstants;
+import com.zimbra.soap.type.OAuthDataSource;
+
+public class MailOAuthDataSource extends MailDataSource implements OAuthDataSource {
+    public MailOAuthDataSource() {
+    }
+
+    public MailOAuthDataSource(OAuthDataSource data) {
+        super(data);
+    }
+
+    /**
+     * @zm-api-field-tag data-source-refreshToken
+     * @zm-api-field-description refresh token for refreshing data source oauth token
+     */
+    @XmlAttribute(name = MailConstants.A_DS_REFRESH_TOKEN /* refreshToken */, required = false)
+    private String refreshToken;
+
+    /**
+     * @zm-api-field-tag data-source-refreshTokenUrl
+     * @zm-api-field-description refreshTokenUrl for refreshing data source oauth token
+     */
+    @XmlAttribute(name = MailConstants.A_DS_REFRESH_TOKEN_URL /* refreshTokenUrl */, required = false)
+    private String refreshTokenUrl;
+
+    public void setRefreshToken(String refreshToken) { this.refreshToken = refreshToken; }
+    public String getRefreshToken() { return refreshToken; }
+
+    public void setRefreshTokenUrl(String refreshTokenUrl) { this.refreshTokenUrl = refreshTokenUrl; }
+    public String getRefreshTokenUrl() { return refreshTokenUrl; }
+}

--- a/soap/src/java/com/zimbra/soap/mail/type/OAuthDataSourceId.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/OAuthDataSourceId.java
@@ -1,0 +1,21 @@
+package com.zimbra.soap.mail.type;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+
+import com.zimbra.soap.type.Id;
+
+@XmlAccessorType(XmlAccessType.NONE)
+public class OAuthDataSourceId extends Id {
+    /**
+     * no-argument constructor wanted by JAXB
+     */
+    @SuppressWarnings("unused")
+    protected OAuthDataSourceId() {
+        this((String) null);
+    }
+
+    OAuthDataSourceId(String id) {
+        super(id);
+    }
+}

--- a/soap/src/java/com/zimbra/soap/mail/type/OAuthDataSourceNameOrId.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/OAuthDataSourceNameOrId.java
@@ -1,0 +1,20 @@
+package com.zimbra.soap.mail.type;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+
+@XmlAccessorType(XmlAccessType.NONE)
+public class OAuthDataSourceNameOrId extends DataSourceNameOrId {
+
+    public static OAuthDataSourceNameOrId createForName(String name) {
+        OAuthDataSourceNameOrId obj = new OAuthDataSourceNameOrId();
+        obj.setName(name);
+        return obj;
+    }
+
+    public static OAuthDataSourceNameOrId createForId(String id) {
+        OAuthDataSourceNameOrId obj = new OAuthDataSourceNameOrId();
+        obj.setId(id);
+        return obj;
+    }
+}

--- a/soap/src/java/com/zimbra/soap/type/AccountWithModifications.java
+++ b/soap/src/java/com/zimbra/soap/type/AccountWithModifications.java
@@ -18,7 +18,6 @@
 package com.zimbra.soap.type;
 
 import java.util.Collection;
-import java.util.List;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -26,7 +25,6 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
-import com.google.common.collect.Lists;
 import com.zimbra.common.soap.AdminConstants;
 import com.zimbra.common.soap.MailConstants;
 import com.zimbra.soap.mail.type.PendingFolderModifications;

--- a/soap/src/java/com/zimbra/soap/type/DataSources.java
+++ b/soap/src/java/com/zimbra/soap/type/DataSources.java
@@ -20,6 +20,7 @@ package com.zimbra.soap.type;
 import com.zimbra.soap.account.type.AccountCalDataSource;
 import com.zimbra.soap.account.type.AccountDataSource;
 import com.zimbra.soap.account.type.AccountImapDataSource;
+import com.zimbra.soap.account.type.AccountOAuthDataSource;
 import com.zimbra.soap.account.type.AccountPop3DataSource;
 import com.zimbra.soap.account.type.AccountRssDataSource;
 
@@ -47,6 +48,14 @@ public class DataSources {
 
     public static ImapDataSource newImapDataSource(ImapDataSource data) {
         return new AccountImapDataSource(data);
+    }
+
+    public static OAuthDataSource newOAuthDataSource() {
+        return new AccountOAuthDataSource();
+    }
+
+    public static OAuthDataSource newOAuthDataSource(OAuthDataSource data) {
+        return new AccountOAuthDataSource(data);
     }
 
     public static RssDataSource newRssDataSource() {

--- a/soap/src/java/com/zimbra/soap/type/OAuthDataSource.java
+++ b/soap/src/java/com/zimbra/soap/type/OAuthDataSource.java
@@ -1,0 +1,10 @@
+package com.zimbra.soap.type;
+
+public interface OAuthDataSource extends DataSource {
+    public void setRefreshToken(String refreshToken);
+    public String getRefreshToken();
+
+    public void setRefreshTokenUrl(String refreshTokenUrl);
+    public String getRefreshTokenUrl();
+
+}

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -8944,19 +8944,19 @@ TODO: delete them permanently from here
   <desc>Subject prefix for the spam training messages used to sent to the zimbraSpamIsSpamAccount/zimbraSpamIsNotSpamAccount account.</desc>
 </attr>
 
-<attr id="2021" name="zimbraDataSourceOAuthClientId" type="string" cardinality="single" optionalIn="imapDataSource" since="8.7.0,9.0.0">
+<attr id="2021" name="zimbraDataSourceOAuthClientId" type="string" cardinality="single" optionalIn="dataSource,imapDataSource" since="8.7.0,9.0.0">
   <desc>Client Id for OAuth token</desc>
 </attr>
 
-<attr id="2022" name="zimbraDataSourceOAuthClientSecret" type="string" cardinality="single" optionalIn="imapDataSource" since="8.7.0,9.0.0">
+<attr id="2022" name="zimbraDataSourceOAuthClientSecret" type="string" cardinality="single" optionalIn="dataSource,imapDataSource" since="8.7.0,9.0.0">
   <desc>Client Secret for OAuth token</desc>
 </attr>
 
-<attr id="2023" name="zimbraDataSourceOAuthRefreshToken" type="string" cardinality="single" optionalIn="imapDataSource" since="8.7.0,9.0.0">
+<attr id="2023" name="zimbraDataSourceOAuthRefreshToken" type="string" cardinality="single" optionalIn="dataSource,imapDataSource" since="8.7.0,9.0.0">
   <desc>Refresh token for authentication using OAuth</desc>
 </attr>
 
-<attr id="2024" name="zimbraDataSourceOAuthRefreshTokenUrl" type="string" cardinality="single" optionalIn="imapDataSource" since="8.7.0,9.0.0">
+<attr id="2024" name="zimbraDataSourceOAuthRefreshTokenUrl" type="string" cardinality="single" optionalIn="dataSource,imapDataSource" since="8.7.0,9.0.0">
   <desc>Url for refreshing OAuth Token</desc>
 </attr>
 

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -121,7 +121,8 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
               mailRecipient, account, alias, distributionList, cos,
               globalConfig, domain, securityGroup, server, mimeEntry,
               objectEntry, zimletEntry, calendarResource;
-              attribute, alwaysOnCluster
+              attribute, alwaysOnCluster, dataSource, pop3DataSource,
+              rssDataSource, imapDataSource, galDataSource
 
   flags:
     accountInfo............returned as part of the GetInfo call

--- a/store/src/java-test/com/zimbra/cs/datasource/DataSourceManagerTest.java
+++ b/store/src/java-test/com/zimbra/cs/datasource/DataSourceManagerTest.java
@@ -41,7 +41,7 @@ import com.zimbra.soap.admin.type.DataSourceType;
 
 public class DataSourceManagerTest {
     private Account testAccount = null;
-    private String CUSTOM_DS_ID = "testCustomDS";
+    private String OAUTH_DS_ID = "testOAuthDS";
     private String POP3_DS_ID = "testPop3DS";
     private String IMAP_DS_ID = "testImap3DS";
     private String CALDAV_DS_ID = "CalDavDS";
@@ -49,7 +49,7 @@ public class DataSourceManagerTest {
     private String CAL_DS_ID = "CalDataSource";
     private String GAL_DS_ID = "GALDataSource";
 
-    private String CUSTOM_DS_NAME = "TestCustomDataSource";
+    private String OAUTH_DS_NAME = "TestOAuthDataSource";
     private String POP3_DS_NAME = "TestPop3DataSource";
     private String IMAP_DS_NAME = "TestImapDataSource";
     private String CALDAV_DS_NAME = "TestCalDavDataSource";
@@ -115,20 +115,20 @@ public class DataSourceManagerTest {
     }
 
     @Test
-    public void testGetDataImportCustomClass() throws ServiceException {
+    public void testGetDataImportOAuthClass() throws ServiceException {
         Map<String, Object> testAttrs = new HashMap<String, Object>();
         testAttrs.put(Provisioning.A_zimbraDataSourceDomain, "zimbra.com");
         testAttrs.put(Provisioning.A_zimbraDataSourceImportClassName, "com.zimbra.cs.datasource.DataSourceManagerTest.TestDSImport");
-        DataSource ds = new DataSource(testAccount, DataSourceType.custom, CUSTOM_DS_NAME, CUSTOM_DS_ID, testAttrs, null);
+        DataSource ds = new DataSource(testAccount, DataSourceType.oauth, OAUTH_DS_NAME, OAUTH_DS_ID, testAttrs, null);
         assertNotNull("DataSource should not be NULL", ds);
         DataImport di = DataSourceManager.getInstance().getDataImport(ds);
         assertNull("should not be able to instantiate non existent DataImport class", di);
 
         testAttrs.put(Provisioning.A_zimbraDataSourceImportClassName, "com.zimbra.cs.gal.GalImport");
-        ds = new DataSource(testAccount, DataSourceType.custom, CUSTOM_DS_NAME, CUSTOM_DS_ID, testAttrs, null);
+        ds = new DataSource(testAccount, DataSourceType.oauth, OAUTH_DS_NAME, OAUTH_DS_ID, testAttrs, null);
         assertNotNull("DataSource should not be NULL", ds);
         di = DataSourceManager.getInstance().getDataImport(ds);
         assertNotNull("DataImport should not be NULL", di);
-        assertTrue("DataImport for 'custom' should be GalImport", di instanceof GalImport);
+        assertTrue("DataImport for 'oauth' should be GalImport", di instanceof GalImport);
     }
  }

--- a/store/src/java/com/zimbra/cs/account/ldap/entry/LdapDataSource.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/entry/LdapDataSource.java
@@ -63,6 +63,13 @@ public class LdapDataSource extends DataSource implements LdapEntry {
             case gal:
                 return AttributeClass.OC_zimbraGalDataSource;
             default: 
+                /*
+                 * All DataSource objects that are not pop3, imap, rss or gal are considered 'generic' 
+                 * and are represented by 'dataSource' objectClass in LDAP. 
+                 * WARNING: avoid adding more LDAP object classes for new implementations of data sources. Use dataSource object class
+                 * instead and keep all specifics of implementation in DataImport. 
+                 * Any configuration that is not covered by existing attributes can be stored in zimbraDataSourceAttribute or outside of LDAP.
+                 */
                 return AttributeClass.OC_zimbraDataSource;
         }
     }
@@ -77,17 +84,18 @@ public class LdapDataSource extends DataSource implements LdapEntry {
         }
         
         List<String> attr = attrs.getMultiAttrStringAsList(Provisioning.A_objectClass, CheckBinary.NOCHECK);
-        if (attr.contains(AttributeClass.OC_zimbraPop3DataSource)) 
+        if (attr.contains(AttributeClass.OC_zimbraPop3DataSource)) { 
             return DataSourceType.pop3;
-        else if (attr.contains(AttributeClass.OC_zimbraImapDataSource))
+        } else if (attr.contains(AttributeClass.OC_zimbraImapDataSource)) {
             return DataSourceType.imap;
-        else if (attr.contains(AttributeClass.OC_zimbraRssDataSource))
+        } else if (attr.contains(AttributeClass.OC_zimbraRssDataSource)) {
             return DataSourceType.rss;
-        else if (attr.contains(AttributeClass.OC_zimbraGalDataSource))
+        } else if (attr.contains(AttributeClass.OC_zimbraGalDataSource)) {
             return DataSourceType.gal;
-        else if (attr.contains(AttributeClass.OC_zimbraDataSource))
+        } else if (attr.contains(AttributeClass.OC_zimbraDataSource)) {
             return DataSourceType.unknown;
-        else
+        } else {
             throw ServiceException.FAILURE("unable to determine data source type from object class", null);
+        }
     }
 }

--- a/store/src/java/com/zimbra/cs/account/ldap/entry/LdapDataSource.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/entry/LdapDataSource.java
@@ -62,10 +62,8 @@ public class LdapDataSource extends DataSource implements LdapEntry {
                 return AttributeClass.OC_zimbraRssDataSource;
             case gal:
                 return AttributeClass.OC_zimbraGalDataSource;
-            case custom:
-                return AttributeClass.OC_zimbraDataSource;
             default: 
-                return null;
+                return AttributeClass.OC_zimbraDataSource;
         }
     }
 
@@ -88,7 +86,7 @@ public class LdapDataSource extends DataSource implements LdapEntry {
         else if (attr.contains(AttributeClass.OC_zimbraGalDataSource))
             return DataSourceType.gal;
         else if (attr.contains(AttributeClass.OC_zimbraDataSource))
-            return DataSourceType.custom;
+            return DataSourceType.unknown;
         else
             throw ServiceException.FAILURE("unable to determine data source type from object class", null);
     }

--- a/store/src/java/com/zimbra/cs/datasource/DataSourceManager.java
+++ b/store/src/java/com/zimbra/cs/datasource/DataSourceManager.java
@@ -214,16 +214,16 @@ public class DataSourceManager {
                         Constructor<?> constructor = cmdClass.getConstructor(new Class[] {DataSource.class});
                         return (DataImport) constructor.newInstance(ds);
                     }
-                    ZimbraLog.datasource.warn("Could not find custom DataImport class: %s. Check your classpath.", className);
+                    ZimbraLog.datasource.warn("Could not find DataImport class: %s for xsync dataSource %s Check your classpath.", className, ds.getName());
                     return null;
                 }
             } catch (Exception x) {
                 ZimbraLog.datasource.warn("Failed instantiating xsync class: %s", ds, x);
             }
-        case oauth:
-            try {
-                String className = ds.getDataSourceImportClassName();
-                if (className != null && className.length() > 0) {
+        default:
+            String className = ds.getDataSourceImportClassName();
+            if (className != null && className.length() > 0) {
+                try {
                     Class<?> cmdClass;
                     try {
                         cmdClass = Class.forName(className);
@@ -234,16 +234,15 @@ public class DataSourceManager {
                         Constructor<?> constructor = cmdClass.getConstructor(new Class[] {DataSource.class});
                         return (DataImport) constructor.newInstance(ds);
                     }
-                    ZimbraLog.datasource.warn("Could not find custom DataImport class: %s. Check your classpath.", className);
+                    ZimbraLog.datasource.warn("Could not find DataImport class: %s for dataSource %s Check your classpath.", className, ds.getName());
+                    return null;
+                } catch (Exception x) {
+                    ZimbraLog.datasource.warn("Caught an exception while instantiating DataImport class: %s", ds, x);
                     return null;
                 }
-            } catch (Exception x) {
-                ZimbraLog.datasource.warn("Caught an exception while instantiating custom class: %s", ds, x);
+            } else {
+                throw new IllegalArgumentException(String.format("Cannot create datasource %s with unknown data import type: %s and undefined zimbraDataSourceImportClassName", ds.getName(), ds.getType()));
             }
-            return null;
-        default:
-            // yab is handled by OfflineDataSourceManager
-            throw new IllegalArgumentException("Unknown data import type: " + ds.getType());
         }
     }
 

--- a/store/src/java/com/zimbra/cs/datasource/DataSourceManager.java
+++ b/store/src/java/com/zimbra/cs/datasource/DataSourceManager.java
@@ -220,7 +220,7 @@ public class DataSourceManager {
             } catch (Exception x) {
                 ZimbraLog.datasource.warn("Failed instantiating xsync class: %s", ds, x);
             }
-        case custom:
+        case oauth:
             try {
                 String className = ds.getDataSourceImportClassName();
                 if (className != null && className.length() > 0) {

--- a/store/src/java/com/zimbra/cs/service/mail/CreateDataSource.java
+++ b/store/src/java/com/zimbra/cs/service/mail/CreateDataSource.java
@@ -87,10 +87,10 @@ public class CreateDataSource extends MailDocumentHandler {
             LdapUtil.getLdapBooleanString(eDataSource.getAttributeBool(MailConstants.A_DS_IS_ENABLED)));
         dsAttrs.put(Provisioning.A_zimbraDataSourceImportOnly,
                 LdapUtil.getLdapBooleanString(eDataSource.getAttributeBool(MailConstants.A_DS_IS_IMPORTONLY, false)));
-        dsAttrs.put(Provisioning.A_zimbraDataSourceHost, eDataSource.getAttribute(MailConstants.A_DS_HOST));
-        dsAttrs.put(Provisioning.A_zimbraDataSourcePort, eDataSource.getAttribute(MailConstants.A_DS_PORT));
-        dsAttrs.put(Provisioning.A_zimbraDataSourceConnectionType, eDataSource.getAttribute(MailConstants.A_DS_CONNECTION_TYPE));
-        dsAttrs.put(Provisioning.A_zimbraDataSourceUsername, eDataSource.getAttribute(MailConstants.A_DS_USERNAME));
+        dsAttrs.put(Provisioning.A_zimbraDataSourceHost, eDataSource.getAttribute(MailConstants.A_DS_HOST, null));
+        dsAttrs.put(Provisioning.A_zimbraDataSourcePort, eDataSource.getAttribute(MailConstants.A_DS_PORT, null));
+        dsAttrs.put(Provisioning.A_zimbraDataSourceConnectionType, eDataSource.getAttribute(MailConstants.A_DS_CONNECTION_TYPE, prov.getConfig().getDataSourceConnectionTypeAsString()));
+        dsAttrs.put(Provisioning.A_zimbraDataSourceUsername, eDataSource.getAttribute(MailConstants.A_DS_USERNAME, null));
         String value = eDataSource.getAttribute(MailConstants.A_DS_PASSWORD, null);
         if (value != null) {
             dsAttrs.put(Provisioning.A_zimbraDataSourcePassword, value);

--- a/store/src/java/com/zimbra/cs/service/mail/ToXML.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ToXML.java
@@ -70,6 +70,7 @@ import com.zimbra.common.mime.MimeConstants;
 import com.zimbra.common.mime.MimeDetect;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.Element.ContainerException;
 import com.zimbra.common.soap.HeaderConstants;
 import com.zimbra.common.soap.MailConstants;
 import com.zimbra.common.util.ArrayUtil;
@@ -3126,7 +3127,15 @@ throws ServiceException {
         if (ds.getSmtpUsername() != null) {
             m.addAttribute(MailConstants.A_DS_SMTP_USERNAME, ds.getSmtpUsername());
         }
-
+        if(ds.getDataSourceImportClassName() != null) {
+            m.addAttribute(MailConstants.A_DS_IMPORT_CLASS, ds.getDataSourceImportClassName());
+        }
+        if(ds.getOauthRefreshToken() != null) {
+            m.addAttribute(MailConstants.A_DS_REFRESH_TOKEN, ds.getOauthRefreshToken());
+        }
+        if(ds.getOauthRefreshTokenUrl() != null) {
+            m.addAttribute(MailConstants.A_DS_REFRESH_TOKEN_URL, ds.getOauthRefreshTokenUrl());
+        }
         m.addAttribute(MailConstants.A_DS_EMAIL_ADDRESS, ds.getEmailAddress());
         m.addAttribute(MailConstants.A_DS_USE_ADDRESS_FOR_FORWARD_REPLY, ds.useAddressForForwardReply());
         m.addAttribute(MailConstants.A_DS_DEFAULT_SIGNATURE, ds.getDefaultSignature());
@@ -3163,6 +3172,8 @@ throws ServiceException {
                 return MailConstants.E_DS_GAL;
             case cal:
                 return MailConstants.E_DS_CAL;
+            case oauth:
+                return MailConstants.E_DS_OAUTH;
             default:
                 return MailConstants.E_DS_UNKNOWN;
         }

--- a/store/src/java/com/zimbra/qa/unittest/server/TestDataSourceServer.java
+++ b/store/src/java/com/zimbra/qa/unittest/server/TestDataSourceServer.java
@@ -65,10 +65,18 @@ public class TestDataSourceServer {
         attrs.add(stringAttr);
         attrs.add(jsonAttr);
         attrs.add(colonAttr);
+        String clientId = "someClientID";
+        String clientSecret = "someSecret";
+        String token = "oAuthToken";
         String refreshToken = "refresh-token";
         String refreshTokenUrl = "https://this.is.where.you/?refresh=the&token";
         ZMailbox zmbox = TestUtil.getZMailbox(USER_NAME);
-        ZDataSource zds = new ZDataSource(DSName, importClassName, attrs).setRefreshToken(refreshToken).setRefreshTokenURL(refreshTokenUrl);
+        ZDataSource zds = new ZDataSource(DSName, importClassName, attrs)
+        .setRefreshToken(refreshToken)
+        .setRefreshTokenURL(refreshTokenUrl)
+        .setClientId(clientId)
+        .setClientSecret(clientSecret)
+        .setOAuthToken(token);
         String dsId = zmbox.createDataSource(zds);
         assertNotNull("DataSource should have an ID", dsId);
         assertFalse("DataSource id should not be empty", dsId.isEmpty());
@@ -82,6 +90,12 @@ public class TestDataSourceServer {
         assertEquals("expecting refresh token: " + refreshToken, refreshToken, ds.getRefreshToken());
         assertNotNull("new DataSource should have a refresh token URL", ds.getRefreshTokenUrl());
         assertEquals("expecting refresh token URL: " + refreshTokenUrl, refreshTokenUrl, ds.getRefreshTokenUrl());
+        assertNotNull("new DataSource should have an OAuth token", ds.getOAuthToken());
+        assertEquals("expecting OAuth token : " + token, token, ds.getOAuthToken());
+        assertNotNull("new DataSource should have a client ID", ds.getClientId());
+        assertEquals("expecting OAuth client ID : " + clientId, clientId, ds.getClientId());
+        assertNotNull("new DataSource should have a client secretD", ds.getClientSecret());
+        assertEquals("expecting OAuth client secret : " + clientSecret, clientSecret, ds.getClientSecret());
         assertNotNull("new DataSource should have attributes", ds.getAttributes());
         assertFalse("new DataSource attributes should not be empty", ds.getAttributes().isEmpty());
         assertTrue("expecting to find attribute with value " + stringAttr, ds.getAttributes().contains(stringAttr));

--- a/store/src/java/com/zimbra/qa/unittest/server/TestDataSourceServer.java
+++ b/store/src/java/com/zimbra/qa/unittest/server/TestDataSourceServer.java
@@ -16,9 +16,11 @@
  */
 package com.zimbra.qa.unittest.server;
 
-import static org.junit.Assert.*;
-
-import java.util.ArrayList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.After;
 import org.junit.Before;
@@ -30,6 +32,7 @@ import com.zimbra.client.ZDataSource;
 import com.zimbra.client.ZFolder;
 import com.zimbra.client.ZImapDataSource;
 import com.zimbra.client.ZMailbox;
+import com.zimbra.client.ZOAuthDataSource;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.Server;
 import com.zimbra.cs.datasource.DataSourceManager;
@@ -55,52 +58,29 @@ public class TestDataSourceServer {
     }
 
     @Test
-    public void testCustomDS() throws Exception {
+    public void testOAuthDS() throws Exception {
         String DSName = "testCustomDS";
         String importClassName = "some.data.source.ClassName";
-        ArrayList<String> attrs = new ArrayList<String>();
-        String stringAttr = "somestringattr";
-        String jsonAttr = "{\"someVar\":\"someValue\"}";
-        String colonAttr = "someProp:someVal";
-        attrs.add(stringAttr);
-        attrs.add(jsonAttr);
-        attrs.add(colonAttr);
-        String clientId = "someClientID";
-        String clientSecret = "someSecret";
-        String token = "oAuthToken";
         String refreshToken = "refresh-token";
         String refreshTokenUrl = "https://this.is.where.you/?refresh=the&token";
         ZMailbox zmbox = TestUtil.getZMailbox(USER_NAME);
-        ZDataSource zds = new ZDataSource(DSName, importClassName, attrs)
-        .setRefreshToken(refreshToken)
-        .setRefreshTokenURL(refreshTokenUrl)
-        .setClientId(clientId)
-        .setClientSecret(clientSecret)
-        .setOAuthToken(token);
+        ZFolder folder = TestUtil.createFolder(zmbox, "/testCustomDS");
+        ZOAuthDataSource zds = new ZOAuthDataSource(DSName, true, refreshToken, refreshTokenUrl, folder.getId(), importClassName, true);
         String dsId = zmbox.createDataSource(zds);
         assertNotNull("DataSource should have an ID", dsId);
         assertFalse("DataSource id should not be empty", dsId.isEmpty());
         ZDataSource ds = TestUtil.getDataSource(zmbox, DSName);
         assertNotNull("should retrieve a non-null DataSource", ds);
-        assertNotNull("DataSource should have a name", ds.getName());
-        assertEquals("Data source name should be " + DSName, ds.getName(), DSName);
-        assertNotNull("new DataSource should have an import class", ds.getImportClass());
-        assertEquals("expecting import class: " + importClassName, importClassName, ds.getImportClass());
-        assertNotNull("new DataSource should have a refresh token", ds.getRefreshToken());
-        assertEquals("expecting refresh token: " + refreshToken, refreshToken, ds.getRefreshToken());
-        assertNotNull("new DataSource should have a refresh token URL", ds.getRefreshTokenUrl());
-        assertEquals("expecting refresh token URL: " + refreshTokenUrl, refreshTokenUrl, ds.getRefreshTokenUrl());
-        assertNotNull("new DataSource should have an OAuth token", ds.getOAuthToken());
-        assertEquals("expecting OAuth token : " + token, token, ds.getOAuthToken());
-        assertNotNull("new DataSource should have a client ID", ds.getClientId());
-        assertEquals("expecting OAuth client ID : " + clientId, clientId, ds.getClientId());
-        assertNotNull("new DataSource should have a client secretD", ds.getClientSecret());
-        assertEquals("expecting OAuth client secret : " + clientSecret, clientSecret, ds.getClientSecret());
-        assertNotNull("new DataSource should have attributes", ds.getAttributes());
-        assertFalse("new DataSource attributes should not be empty", ds.getAttributes().isEmpty());
-        assertTrue("expecting to find attribute with value " + stringAttr, ds.getAttributes().contains(stringAttr));
-        assertTrue("expecting to find attribute with value " + jsonAttr, ds.getAttributes().contains(jsonAttr));
-        assertTrue("expecting to find attribute with value " + colonAttr, ds.getAttributes().contains(colonAttr));
+        assertTrue("expecting ZOAuthDataSource", ds instanceof ZOAuthDataSource);
+        ZOAuthDataSource oads = (ZOAuthDataSource)ds;
+        assertNotNull("DataSource should have a name", oads.getName());
+        assertEquals("Data source name should be " + DSName, oads.getName(), DSName);
+        assertNotNull("new DataSource should have an import class", oads.getImportClass());
+        assertEquals("expecting import class: " + importClassName, importClassName, oads.getImportClass());
+        assertNotNull("new DataSource should have a refresh token", oads.getRefreshToken());
+        assertEquals("expecting refresh token: " + refreshToken, refreshToken, oads.getRefreshToken());
+        assertNotNull("new DataSource should have a refresh token URL", oads.getRefreshTokenUrl());
+        assertEquals("expecting refresh token URL: " + refreshTokenUrl, refreshTokenUrl, oads.getRefreshTokenUrl());
     }
 
     @Test


### PR DESCRIPTION
I had to abandon the idea of adding a completely generic 'custom' DataSource type, because it was turning out to be too convoluted and seemed like an premature optimization. Instead, I added 'oauth' type similar to 'imap', 'pop3' and others except that it allows a custom DataImport implementation. 

One optimization I added is to stop using special objectClass value for this new kind of datasource. 

Going forward, we may have to generalize SOAP handlers to handle all possible dataSource attributes so that new dataSource implementations don't have to add anything to zm-soap or zm-client libraries. For now, new zm-soap and zm-client classes cover oauth-based datasources.