### PR TITLE
add getDataSourceByName to ZMailbox

### DIFF
--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -4733,6 +4733,20 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
         return null;
     }
 
+    /**
+     * Gets a data source by name.
+     * @return the data source, or <tt>null</tt> if no data source with the
+     * given name exists
+     */
+    public ZDataSource getDataSourceByName(String name) throws ServiceException {
+        for (ZDataSource ds : getAllDataSources()) {
+            if (ds.getName() != null && ds.getName().equals(name)) {
+                return ds;
+            }
+        }
+        return null;
+    }
+
     public void modifyDataSource(ZDataSource source) throws ServiceException {
         ModifyDataSourceRequest req = new ModifyDataSourceRequest();
         req.setDataSource(source.toJaxb());

--- a/store/src/java/com/zimbra/qa/unittest/server/TestDataSourceServer.java
+++ b/store/src/java/com/zimbra/qa/unittest/server/TestDataSourceServer.java
@@ -69,7 +69,7 @@ public class TestDataSourceServer {
         String dsId = zmbox.createDataSource(zds);
         assertNotNull("DataSource should have an ID", dsId);
         assertFalse("DataSource id should not be empty", dsId.isEmpty());
-        ZDataSource ds = TestUtil.getDataSource(zmbox, DSName);
+        ZDataSource ds = zmbox.getDataSourceByName(DSName);
         assertNotNull("should retrieve a non-null DataSource", ds);
         assertTrue("expecting ZOAuthDataSource", ds instanceof ZOAuthDataSource);
         ZOAuthDataSource oads = (ZOAuthDataSource)ds;


### PR DESCRIPTION
Added getDataSourceByName, so that oauth service can check if a datasource for specific target already exists and update it if needed.