### PR TITLE
add external client instance to ZimbraHttpClientManager

### DIFF
--- a/common/src/java/com/zimbra/common/httpclient/ZimbraHttpClientManager.java
+++ b/common/src/java/com/zimbra/common/httpclient/ZimbraHttpClientManager.java
@@ -30,13 +30,13 @@ import com.zimbra.common.util.ZimbraLog;
 
 public class ZimbraHttpClientManager {
     protected static ZimbraHttpClientManager instance;
-    final CloseableHttpAsyncClient internalAsyncClient;
-    final CloseableHttpClient internalClient;
-    final CloseableHttpClient externalClient;
-    final PoolingHttpClientConnectionManager internalConnectionMgr;
-    final PoolingHttpClientConnectionManager externallConnectionMgr;
-    final RequestConfig internalRequestConfig;
-    final RequestConfig externalRequestConfig;
+    private final CloseableHttpAsyncClient internalAsyncClient;
+    private final CloseableHttpClient internalClient;
+    private final CloseableHttpClient externalClient;
+    private final PoolingHttpClientConnectionManager internalConnectionMgr;
+    private final PoolingHttpClientConnectionManager externallConnectionMgr;
+    private final RequestConfig internalRequestConfig;
+    private final RequestConfig externalRequestConfig;
 
     public ZimbraHttpClientManager() {
         SSLContext sslcontext = null;

--- a/common/src/java/com/zimbra/common/httpclient/ZimbraHttpClientManager.java
+++ b/common/src/java/com/zimbra/common/httpclient/ZimbraHttpClientManager.java
@@ -33,12 +33,11 @@ public class ZimbraHttpClientManager {
     private final CloseableHttpAsyncClient internalAsyncClient;
     private final CloseableHttpClient internalClient;
     private final CloseableHttpClient externalClient;
-    private final PoolingHttpClientConnectionManager internalConnectionMgr;
-    private final PoolingHttpClientConnectionManager externallConnectionMgr;
-    private final RequestConfig internalRequestConfig;
-    private final RequestConfig externalRequestConfig;
-
     public ZimbraHttpClientManager() {
+        PoolingHttpClientConnectionManager internalConnectionMgr;
+        PoolingHttpClientConnectionManager externallConnectionMgr;
+        RequestConfig internalRequestConfig;
+        RequestConfig externalRequestConfig;
         SSLContext sslcontext = null;
         try {
             sslcontext = SSLContexts.custom().loadTrustMaterial(CustomTrustManager.loadKeyStore(), new TrustSelfSignedStrategy()).build();


### PR DESCRIPTION
LocalConfig parameters for external HTTP connections (connections from Zimbra to other services) are different from those for internal connections (connections between Zimbra components), so need a separate instance of HttpClient and a separate connection manager for external connections. This is similar to com.zimbra.common.util.ZimbraHttpConnectionManager, which uses Apache Commons.