### PR TITLE
ZCS-2670:API to verify ownership of forwarding email address

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -6492,6 +6492,34 @@ public class ZAttrProvisioning {
     public static final String A_zimbraFeatureMailForwardingInFiltersEnabled = "zimbraFeatureMailForwardingInFiltersEnabled";
 
     /**
+     * RFC822 forwarding address under verification for an account
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2128)
+    public static final String A_zimbraFeatureMailForwardingVerificationAddress = "zimbraFeatureMailForwardingVerificationAddress";
+
+    /**
+     * Enable end-user mail forwarding verification
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2126)
+    public static final String A_zimbraFeatureMailForwardingVerificationEnabled = "zimbraFeatureMailForwardingVerificationEnabled";
+
+    /**
+     * Expiry time for end-user mail forwarding verification. Must be in
+     * valid duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2127)
+    public static final String A_zimbraFeatureMailForwardingVerificationExpiry = "zimbraFeatureMailForwardingVerificationExpiry";
+
+    /**
      * Deprecated since: 5.0. done via skin template overrides. Orig desc:
      * whether user is allowed to set mail polling interval
      */

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -440,6 +440,26 @@ public class ZAttrProvisioning {
         public boolean isAlias() { return this == alias;}
     }
 
+    public static enum FeatureAddressVerificationStatus {
+        verified("verified"),
+        pending("pending"),
+        failed("failed"),
+        expired("expired");
+        private String mValue;
+        private FeatureAddressVerificationStatus(String value) { mValue = value; }
+        public String toString() { return mValue; }
+        public static FeatureAddressVerificationStatus fromString(String s) throws ServiceException {
+            for (FeatureAddressVerificationStatus value : values()) {
+                if (value.mValue.equals(s)) return value;
+             }
+             throw ServiceException.INVALID_REQUEST("invalid value: "+s+", valid values: "+ Arrays.asList(values()), null);
+        }
+        public boolean isVerified() { return this == verified;}
+        public boolean isPending() { return this == pending;}
+        public boolean isFailed() { return this == failed;}
+        public boolean isExpired() { return this == expired;}
+    }
+
     public static enum FeatureSocialFiltersEnabled {
         SocialCast("SocialCast"),
         LinkedIn("LinkedIn"),
@@ -6093,6 +6113,42 @@ public class ZAttrProvisioning {
     public static final String A_zimbraExternalUserMailAddress = "zimbraExternalUserMailAddress";
 
     /**
+     * RFC822 email address under verification for an account
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2128)
+    public static final String A_zimbraFeatureAddressUnderVerification = "zimbraFeatureAddressUnderVerification";
+
+    /**
+     * Enable end-user email address verification
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2126)
+    public static final String A_zimbraFeatureAddressVerificationEnabled = "zimbraFeatureAddressVerificationEnabled";
+
+    /**
+     * Expiry time for end-user email address verification. Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2127)
+    public static final String A_zimbraFeatureAddressVerificationExpiry = "zimbraFeatureAddressVerificationExpiry";
+
+    /**
+     * End-user email address verification status
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2129)
+    public static final String A_zimbraFeatureAddressVerificationStatus = "zimbraFeatureAddressVerificationStatus";
+
+    /**
      * whether email features and tabs are enabled in the web client if
      * accessed from the admin console
      *
@@ -6490,34 +6546,6 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=704)
     public static final String A_zimbraFeatureMailForwardingInFiltersEnabled = "zimbraFeatureMailForwardingInFiltersEnabled";
-
-    /**
-     * RFC822 forwarding address under verification for an account
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2128)
-    public static final String A_zimbraFeatureMailForwardingVerificationAddress = "zimbraFeatureMailForwardingVerificationAddress";
-
-    /**
-     * Enable end-user mail forwarding verification
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2126)
-    public static final String A_zimbraFeatureMailForwardingVerificationEnabled = "zimbraFeatureMailForwardingVerificationEnabled";
-
-    /**
-     * Expiry time for end-user mail forwarding verification. Must be in
-     * valid duration format: {digits}{time-unit}. digits: 0-9, time-unit:
-     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
-     * milliseconds. If time unit is not specified, the default is
-     * s(seconds).
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2127)
-    public static final String A_zimbraFeatureMailForwardingVerificationExpiry = "zimbraFeatureMailForwardingVerificationExpiry";
 
     /**
      * Deprecated since: 5.0. done via skin template overrides. Orig desc:

--- a/common/src/java/com/zimbra/common/soap/AccountConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AccountConstants.java
@@ -558,4 +558,11 @@ public class AccountConstants {
     public static final String A_CONSUMER_APP_NAME = "appName";
     public static final String A_APPROVED_ON = "approvedOn";
     public static final String A_CONSUMER_DEVICE = "device";
+    
+    //ext user prov URL metadata constants
+    public static final String P_ACCOUNT_ID = "aid";
+    public static final String P_FOLDER_ID = "fid";
+    public static final String P_LINK_EXPIRY = "exp";
+    public static final String P_EMAIL = "email";
+    public static final String P_ADDRESS_VERIFICATION = "address-verification";
 }

--- a/common/src/java/com/zimbra/common/util/L10nUtil.java
+++ b/common/src/java/com/zimbra/common/util/L10nUtil.java
@@ -274,8 +274,12 @@ public class L10nUtil {
         
         //sieve
         seiveRejectMDNSubject,
-        seiveRejectMDNErrorMsg
+        seiveRejectMDNErrorMsg,
 
+        //forwarding email address verification
+        verifyEmailSubject,
+        verifyEmailBodyText,
+        verifyEmailBodyHtml
         // add other messages in the future...
     }
 

--- a/store-conf/conf/msgs/ZsMsg.properties
+++ b/store-conf/conf/msgs/ZsMsg.properties
@@ -907,7 +907,7 @@ zipFile = Zip File
 seiveRejectMDNSubject = Disposition notification
 seiveRejectMDNErrorMsg = The message was refused by the recipient's mail filtering program. The reason given was as follows:
 
-# forwarding email address verification
+# email address verification
 verifyEmailSubject = Request for email address verification by {0}
 verifyEmailBodyText =\
   {0} has requested verification of your email address\n\

--- a/store-conf/conf/msgs/ZsMsg.properties
+++ b/store-conf/conf/msgs/ZsMsg.properties
@@ -906,3 +906,19 @@ zipFile = Zip File
 
 seiveRejectMDNSubject = Disposition notification
 seiveRejectMDNErrorMsg = The message was refused by the recipient's mail filtering program. The reason given was as follows:
+
+# forwarding email address verification
+verifyEmailSubject = Request for email address verification by {0}
+verifyEmailBodyText =\
+  {0} has requested verification of your email address\n\
+  \n\
+  Click on the link below to verify your email address: {1}\n\
+  The link expires by: {2}\n\
+  *~*~*~*~*~*~*~*~*~*\n
+verifyEmailBodyHtml =\
+  <div style="font-family:sans-serif;">\
+  <h1 style="font-size:1.3em;">{0} has requested verification of your email address</h1>\
+  <hr>\
+  Click on this <a href="{1}">link</a> to verify your email address</br>\
+  The link expires by {2}\
+  </div>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9584,4 +9584,18 @@ TODO: delete them permanently from here
   </desc>
 </attr>
 
+<attr id="2126" name="zimbraFeatureMailForwardingVerificationEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited" since="8.8.5">
+  <defaultCOSValue>FALSE</defaultCOSValue>
+  <desc>Enable end-user mail forwarding verification</desc>
+</attr>
+
+<attr id="2127" name="zimbraFeatureMailForwardingVerificationExpiry" type="duration" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited" since="8.8.5">
+  <defaultCOSValue>1d</defaultCOSValue>
+  <desc>Expiry time for end-user mail forwarding verification</desc>
+</attr>
+
+<attr id="2128" name="zimbraFeatureMailForwardingVerificationAddress" type="cs_emailp" cardinality="single" optionalIn="account" callback="PrefMailForwardingAddress" since="8.8.5">
+  <desc>RFC822 forwarding address under verification for an account</desc>
+</attr>
+
 </attrs>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9584,18 +9584,21 @@ TODO: delete them permanently from here
   </desc>
 </attr>
 
-<attr id="2126" name="zimbraFeatureMailForwardingVerificationEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited" since="8.8.5">
+<attr id="2126" name="zimbraFeatureAddressVerificationEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited" since="8.8.5">
   <defaultCOSValue>FALSE</defaultCOSValue>
-  <desc>Enable end-user mail forwarding verification</desc>
+  <desc>Enable end-user email address verification</desc>
 </attr>
 
-<attr id="2127" name="zimbraFeatureMailForwardingVerificationExpiry" type="duration" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited" since="8.8.5">
+<attr id="2127" name="zimbraFeatureAddressVerificationExpiry" type="duration" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited" since="8.8.5">
   <defaultCOSValue>1d</defaultCOSValue>
-  <desc>Expiry time for end-user mail forwarding verification</desc>
+  <desc>Expiry time for end-user email address verification</desc>
 </attr>
 
-<attr id="2128" name="zimbraFeatureMailForwardingVerificationAddress" type="cs_emailp" cardinality="single" optionalIn="account" callback="PrefMailForwardingAddress" since="8.8.5">
-  <desc>RFC822 forwarding address under verification for an account</desc>
+<attr id="2128" name="zimbraFeatureAddressUnderVerification" type="cs_emailp" cardinality="single" optionalIn="account" callback="PrefMailForwardingAddress" since="8.8.5">
+  <desc>RFC822 email address under verification for an account</desc>
 </attr>
 
+<attr id="2129" name="zimbraFeatureAddressVerificationStatus" type="enum" value="verified,pending,failed,expired" cardinality="single" optionalIn="account" since="8.8.5">
+  <desc>End-user email address verification status</desc>
+</attr>
 </attrs>

--- a/store/src/java-test/com/zimbra/cs/account/ExtShareInfoTest.java
+++ b/store/src/java-test/com/zimbra/cs/account/ExtShareInfoTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 
 import com.google.common.collect.Maps;
 import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.L10nUtil;
 import com.zimbra.cs.mailbox.ACL;
 import com.zimbra.cs.mailbox.MailItem;
 import com.zimbra.cs.mailbox.MailboxManager;
@@ -66,6 +67,7 @@ public class ExtShareInfoTest {
 
          // this MailboxManager does everything except use SMTP to deliver mail
          MailboxManager.setInstance(new DirectInsertionMailboxManager());
+         L10nUtil.setMsgClassLoader("../store-conf/conf/msgs");
     }
 
     @Test

--- a/store/src/java-test/com/zimbra/cs/account/ExtShareInfoTest.java
+++ b/store/src/java-test/com/zimbra/cs/account/ExtShareInfoTest.java
@@ -92,7 +92,6 @@ public class ExtShareInfoTest {
         sid.setOwnerAcctDisplayName("Demo User Two");
 
         try {
-
             sid.setRights(ACL.stringToRights("rwidxap"));
             MimeMultipart mmp = ShareInfo.NotificationSender.genNotifBody(sid,
                     notes, locale, null, null);

--- a/store/src/java-test/com/zimbra/cs/service/ModifyPrefsTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/ModifyPrefsTest.java
@@ -105,9 +105,9 @@ public class ModifyPrefsTest {
         Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
         Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct1);
         acct1.setFeatureMailForwardingEnabled(true);
-        acct1.setFeatureMailForwardingVerificationEnabled(true);
+        acct1.setFeatureAddressVerificationEnabled(true);
         Assert.assertNull(acct1.getPrefMailForwardingAddress());
-        Assert.assertNull(acct1.getFeatureMailForwardingVerificationAddress());
+        Assert.assertNull(acct1.getFeatureAddressUnderVerification());
         ModifyPrefsRequest request = new ModifyPrefsRequest();
         Pref pref = new Pref(Provisioning.A_zimbraPrefMailForwardingAddress,
             "test1@somedomain.com");
@@ -117,29 +117,21 @@ public class ModifyPrefsTest {
         /*
          * Verify that the forwarding address is not directly stored into
          * 'zimbraPrefMailForwardingAddress' Instead, it is stored in
-         * 'zimbraFeatureMailForwardingVerificationAddress' till the time it
+         * 'zimbraFeatureAddressUnderVerification' till the time it
          * gets verification
          */
         Assert.assertNull(acct1.getPrefMailForwardingAddress());
         Assert.assertEquals("test1@somedomain.com",
-            acct1.getFeatureMailForwardingVerificationAddress());
-        // Verify that the verification link is sent to forwarding address
-        Integer itemId = mbox.getItemIds(null, Mailbox.ID_FOLDER_SENT).getIds(MailItem.Type.MESSAGE)
-            .get(0);
-        Message message = mbox.getMessageById(null, itemId);
-        Assert.assertEquals("test1@somedomain.com",
-            message.getMimeMessage().getAllRecipients()[0].toString());
-        Assert.assertEquals("Request for email address verification by test@zimbra.com",
-            message.getSubject());
+            acct1.getFeatureAddressUnderVerification());
         /*
          * disable the verification feature and check that the forwarding
          * address is directly stored into 'zimbraPrefMailForwardingAddress'
          */
         acct1.setPrefMailForwardingAddress(null);
-        acct1.setFeatureMailForwardingVerificationAddress(null);
-        acct1.setFeatureMailForwardingVerificationEnabled(false);
+        acct1.setFeatureAddressUnderVerification(null);
+        acct1.setFeatureAddressVerificationEnabled(false);
         new ModifyPrefs().handle(req, ServiceTestUtil.getRequestContext(mbox.getAccount()));
-        Assert.assertNull(acct1.getFeatureMailForwardingVerificationAddress());
+        Assert.assertNull(acct1.getFeatureAddressUnderVerification());
         Assert.assertEquals("test1@somedomain.com", acct1.getPrefMailForwardingAddress());
     }
 }

--- a/store/src/java-test/com/zimbra/cs/service/ModifyPrefsTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/ModifyPrefsTest.java
@@ -1,0 +1,145 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2017 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.service;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import javax.mail.Address;
+import javax.mail.internet.MimeMessage;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.common.collect.Maps;
+import com.zimbra.common.account.Key;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.util.L10nUtil;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.MailItem;
+import com.zimbra.cs.mailbox.MailSender;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.mailbox.Message;
+import com.zimbra.cs.mailbox.Mailbox.MailboxData;
+import com.zimbra.cs.service.account.ModifyPrefs;
+import com.zimbra.cs.service.mail.ServiceTestUtil;
+import com.zimbra.soap.JaxbUtil;
+import com.zimbra.soap.account.message.ModifyPrefsRequest;
+import com.zimbra.soap.account.type.Pref;
+
+import junit.framework.Assert;
+
+public class ModifyPrefsTest {
+
+    public static String zimbraServerDir = "";
+
+    @BeforeClass
+    public static void init() throws Exception {
+        MailboxTestUtil.initServer();
+        Provisioning prov = Provisioning.getInstance();
+
+        Map<String, Object> attrs = Maps.newHashMap();
+        prov.createDomain("zimbra.com", attrs);
+
+        attrs = Maps.newHashMap();
+        prov.createAccount("test@zimbra.com", "secret", attrs);
+
+        MailboxManager.setInstance(new MailboxManager() {
+
+            @Override
+            protected Mailbox instantiateMailbox(MailboxData data) {
+                return new Mailbox(data) {
+
+                    @Override
+                    public MailSender getMailSender() {
+                        return new MailSender() {
+
+                            @Override
+                            protected Collection<Address> sendMessage(Mailbox mbox, MimeMessage mm,
+                                Collection<RollbackData> rollbacks)
+                                throws SafeMessagingException, IOException {
+                                try {
+                                    return Arrays.asList(getRecipients(mm));
+                                } catch (Exception e) {
+                                    return Collections.emptyList();
+                                }
+                            }
+                        };
+                    }
+                };
+            }
+        });
+
+        L10nUtil.setMsgClassLoader("../store-conf/conf/msgs");
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        MailboxTestUtil.clearData();
+    }
+
+    @Test
+    public void testMsgMaxAttr() throws Exception {
+        Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct1);
+        acct1.setFeatureMailForwardingEnabled(true);
+        acct1.setFeatureMailForwardingVerificationEnabled(true);
+        Assert.assertNull(acct1.getPrefMailForwardingAddress());
+        Assert.assertNull(acct1.getFeatureMailForwardingVerificationAddress());
+        ModifyPrefsRequest request = new ModifyPrefsRequest();
+        Pref pref = new Pref(Provisioning.A_zimbraPrefMailForwardingAddress,
+            "test1@somedomain.com");
+        request.addPref(pref);
+        Element req = JaxbUtil.jaxbToElement(request);
+        new ModifyPrefs().handle(req, ServiceTestUtil.getRequestContext(mbox.getAccount()));
+        /*
+         * Verify that the forwarding address is not directly stored into
+         * 'zimbraPrefMailForwardingAddress' Instead, it is stored in
+         * 'zimbraFeatureMailForwardingVerificationAddress' till the time it
+         * gets verification
+         */
+        Assert.assertNull(acct1.getPrefMailForwardingAddress());
+        Assert.assertEquals("test1@somedomain.com",
+            acct1.getFeatureMailForwardingVerificationAddress());
+        // Verify that the verification link is sent to forwarding address
+        Integer itemId = mbox.getItemIds(null, Mailbox.ID_FOLDER_SENT).getIds(MailItem.Type.MESSAGE)
+            .get(0);
+        Message message = mbox.getMessageById(null, itemId);
+        Assert.assertEquals("test1@somedomain.com",
+            message.getMimeMessage().getAllRecipients()[0].toString());
+        Assert.assertEquals("Request for email address verification by test@zimbra.com",
+            message.getSubject());
+        /*
+         * disable the verification feature and check that the forwarding
+         * address is directly stored into 'zimbraPrefMailForwardingAddress'
+         */
+        acct1.setPrefMailForwardingAddress(null);
+        acct1.setFeatureMailForwardingVerificationAddress(null);
+        acct1.setFeatureMailForwardingVerificationEnabled(false);
+        new ModifyPrefs().handle(req, ServiceTestUtil.getRequestContext(mbox.getAccount()));
+        Assert.assertNull(acct1.getFeatureMailForwardingVerificationAddress());
+        Assert.assertEquals("test1@somedomain.com", acct1.getPrefMailForwardingAddress());
+    }
+}

--- a/store/src/java-test/com/zimbra/cs/service/mail/SendShareNotificationTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/mail/SendShareNotificationTest.java
@@ -128,7 +128,7 @@ public class SendShareNotificationTest extends SendShareNotification {
             }
         });
 
-        L10nUtil.setMsgClassLoader("conf/msgs");
+        L10nUtil.setMsgClassLoader("../store-conf/conf/msgs");
     }
 
     @Before

--- a/store/src/java/com/zimbra/cs/account/ShareInfo.java
+++ b/store/src/java/com/zimbra/cs/account/ShareInfo.java
@@ -1095,12 +1095,12 @@ public class ShareInfo {
             }
         }
 
-        private static class HtmlPartDataSource extends MimePartDataSource {
+        public static class HtmlPartDataSource extends MimePartDataSource {
             private static final String CONTENT_TYPE =
                 MimeConstants.CT_TEXT_HTML + "; " + MimeConstants.P_CHARSET + "=" + MimeConstants.P_CHARSET_UTF8;
             private static final String NAME = "HtmlDataSource";
 
-            HtmlPartDataSource(String text) {
+            public HtmlPartDataSource(String text) {
                 super(text);
             }
 

--- a/store/src/java/com/zimbra/cs/account/ShareInfo.java
+++ b/store/src/java/com/zimbra/cs/account/ShareInfo.java
@@ -16,12 +16,6 @@
  */
 package com.zimbra.cs.account;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -33,7 +27,6 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.activation.DataHandler;
-import javax.activation.DataSource;
 import javax.mail.Address;
 import javax.mail.MessagingException;
 import javax.mail.Transport;
@@ -42,7 +35,6 @@ import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMultipart;
 
-import org.apache.commons.codec.binary.Hex;
 
 import com.google.common.base.Strings;
 import com.sun.mail.smtp.SMTPMessage;
@@ -55,7 +47,6 @@ import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.MailConstants.ShareConstants;
 import com.zimbra.common.soap.SoapProtocol;
-import com.zimbra.common.util.BlobMetaData;
 import com.zimbra.common.util.L10nUtil;
 import com.zimbra.common.util.L10nUtil.MsgKey;
 import com.zimbra.common.util.Pair;
@@ -76,10 +67,11 @@ import com.zimbra.cs.mailbox.MetadataList;
 import com.zimbra.cs.mailbox.Mountpoint;
 import com.zimbra.cs.mailbox.OperationContext;
 import com.zimbra.cs.mailbox.acl.AclPushSerializer;
-import com.zimbra.cs.servlet.ZimbraServlet;
 import com.zimbra.cs.util.AccountUtil;
 import com.zimbra.cs.util.JMSession;
 import com.zimbra.soap.mail.message.SendShareNotificationRequest.Action;
+import com.zimbra.cs.util.AccountUtil.HtmlPartDataSource;
+import com.zimbra.cs.util.AccountUtil.XmlPartDataSource;
 
 
 public class ShareInfo {
@@ -555,10 +547,9 @@ public class ShareInfo {
 
         private static final String HTML_LINE_BREAK = "<br>";
         private static final String NEWLINE = "\n";
-
-
+        
         public static MimeMultipart genNotifBody(ShareInfoData sid, String notes,
-                Locale locale, Action action, String externalGroupMember)
+            Locale locale, Action action, String externalGroupMember)
         throws MessagingException, ServiceException {
 
             // Body
@@ -576,8 +567,8 @@ public class ShareInfo {
             boolean goesToExternalAddr = (externalGranteeName != null);
             if (action == null && goesToExternalAddr) {
                 Account owner = Provisioning.getInstance().getAccountById(sid.getOwnerAcctId());
-                extUserShareAcceptUrl = getShareAcceptURL(owner, sid.getItemId(), externalGranteeName);
-                extUserLoginUrl = getExtUserLoginURL(owner);
+                extUserShareAcceptUrl = AccountUtil.getShareAcceptURL(owner, sid.getItemId(), externalGranteeName);
+                extUserLoginUrl = AccountUtil.getExtUserLoginURL(owner);
             }
 
             // TEXT part (add me first!)
@@ -618,35 +609,37 @@ public class ShareInfo {
             return mmp;
         }
 
-        private static String getExtUserLoginURL(Account owner) throws ServiceException {
-            return ZimbraServlet.getServiceUrl(
-                    owner.getServer(),
-                    Provisioning.getInstance().getDomain(owner),
-                    "?virtualacctdomain=" + owner.getDomainName());
-        }
+        public static String getMimePartHtml(ShareInfoData sid, String notes, Locale locale,
+            Action action, String extUserShareAcceptUrl, String extUserLoginUrl) throws MessagingException, ServiceException {
 
-        private static String getShareAcceptURL(Account account, int folderId, String externalUserEmail)
-                throws ServiceException {
-            StringBuilder encodedBuff = new StringBuilder();
-            BlobMetaData.encodeMetaData("aid", account.getId(), encodedBuff);
-            BlobMetaData.encodeMetaData("fid", folderId, encodedBuff);
-            BlobMetaData.encodeMetaData("email", externalUserEmail, encodedBuff);
-            Domain domain = Provisioning.getInstance().getDomain(account);
-            if (domain != null) {
-                long urlExpiration = domain.getExternalShareInvitationUrlExpiration();
-                if (urlExpiration != 0) {
-                    BlobMetaData.encodeMetaData("exp", System.currentTimeMillis() + urlExpiration, encodedBuff);
-                }
+            String mimePartHtml;
+            if (action == Action.revoke) {
+                mimePartHtml = genRevokePart(sid, locale, true);
+            } else if (action == Action.expire) {
+                mimePartHtml = genExpirePart(sid, locale, true);
+            } else {
+                mimePartHtml = genPart(sid, action == Action.edit, notes, extUserShareAcceptUrl,
+                    extUserLoginUrl, locale, null, true);
             }
-            String data = new String(Hex.encodeHex(encodedBuff.toString().getBytes()));
-            ExtAuthTokenKey key = ExtAuthTokenKey.getCurrentKey();
-            String hmac = TokenUtil.getHmac(data, key.getKey());
-            String encoded = key.getVersion() + "_" + hmac + "_" + data;
-            String path = "/service/extuserprov/?p=" + encoded;
-            return ZimbraServlet.getServiceUrl(
-                    account.getServer(), Provisioning.getInstance().getDomain(account), path);
-        }
 
+            return mimePartHtml;
+        }
+        
+        
+        
+        public static String getMimePartText(ShareInfoData sid, String notes, Locale locale,
+            Action action, String extUserShareAcceptUrl, String extUserLoginUrl) throws MessagingException, ServiceException {
+            String mimePartText;
+            if (action == Action.revoke) {
+                mimePartText = genRevokePart(sid, locale, false);
+            } else if (action == Action.expire) {
+                mimePartText = genExpirePart(sid, locale, false);
+            } else {
+                mimePartText = genPart(sid, action == Action.edit, notes, extUserShareAcceptUrl,
+                    extUserLoginUrl, locale, null, false);
+            }
+            return mimePartText;
+        }
 
         private static String genPart(ShareInfoData sid, boolean shareModified, String senderNotes,
                 String extUserShareAcceptUrl, String extUserLoginUrl, Locale locale, StringBuilder sb, boolean html) {
@@ -703,7 +696,7 @@ public class ShareInfo {
                     sid.getOwnerNotifName());
         }
 
-        private static String genXmlPart(ShareInfoData sid, String senderNotes, StringBuilder sb, Action action)
+        public static String genXmlPart(ShareInfoData sid, String senderNotes, StringBuilder sb, Action action)
                 throws ServiceException {
             if (sb == null) {
                 sb = new StringBuilder();
@@ -1063,78 +1056,6 @@ public class ShareInfo {
                 buildContentAndSend(out, dl, visitor, locale, null);
             }
         }
-
-        private static abstract class MimePartDataSource implements DataSource {
-
-            private final String mText;
-            private byte[] mBuf = null;
-
-            public MimePartDataSource(String text) {
-                mText = text;
-            }
-
-            @Override
-            public InputStream getInputStream() throws IOException {
-                synchronized(this) {
-                    if (mBuf == null) {
-                        ByteArrayOutputStream buf = new ByteArrayOutputStream();
-                        OutputStreamWriter wout =
-                            new OutputStreamWriter(buf, MimeConstants.P_CHARSET_UTF8);
-                        String text = mText;
-                        wout.write(text);
-                        wout.flush();
-                        mBuf = buf.toByteArray();
-                    }
-                }
-                return new ByteArrayInputStream(mBuf);
-            }
-
-            @Override
-            public OutputStream getOutputStream() {
-                throw new UnsupportedOperationException();
-            }
-        }
-
-        public static class HtmlPartDataSource extends MimePartDataSource {
-            private static final String CONTENT_TYPE =
-                MimeConstants.CT_TEXT_HTML + "; " + MimeConstants.P_CHARSET + "=" + MimeConstants.P_CHARSET_UTF8;
-            private static final String NAME = "HtmlDataSource";
-
-            public HtmlPartDataSource(String text) {
-                super(text);
-            }
-
-            @Override
-            public String getContentType() {
-                return CONTENT_TYPE;
-            }
-
-            @Override
-            public String getName() {
-                return NAME;
-            }
-        }
-
-        private static class XmlPartDataSource extends MimePartDataSource {
-            private static final String CONTENT_TYPE =
-                MimeConstants.CT_XML_ZIMBRA_SHARE + "; " + MimeConstants.P_CHARSET + "=" + MimeConstants.P_CHARSET_UTF8;
-            private static final String NAME = "XmlDataSource";
-
-            XmlPartDataSource(String text) {
-                super(text);
-            }
-
-            @Override
-            public String getContentType() {
-                return CONTENT_TYPE;
-            }
-
-            @Override
-            public String getName() {
-                return NAME;
-            }
-        }
-
     }
 }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -15604,6 +15604,262 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * RFC822 forwarding address under verification for an account
+     *
+     * @return zimbraFeatureMailForwardingVerificationAddress, or null if unset
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2128)
+    public String getFeatureMailForwardingVerificationAddress() {
+        return getAttr(Provisioning.A_zimbraFeatureMailForwardingVerificationAddress, null, true);
+    }
+
+    /**
+     * RFC822 forwarding address under verification for an account
+     *
+     * @param zimbraFeatureMailForwardingVerificationAddress new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2128)
+    public void setFeatureMailForwardingVerificationAddress(String zimbraFeatureMailForwardingVerificationAddress) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationAddress, zimbraFeatureMailForwardingVerificationAddress);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * RFC822 forwarding address under verification for an account
+     *
+     * @param zimbraFeatureMailForwardingVerificationAddress new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2128)
+    public Map<String,Object> setFeatureMailForwardingVerificationAddress(String zimbraFeatureMailForwardingVerificationAddress, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationAddress, zimbraFeatureMailForwardingVerificationAddress);
+        return attrs;
+    }
+
+    /**
+     * RFC822 forwarding address under verification for an account
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2128)
+    public void unsetFeatureMailForwardingVerificationAddress() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationAddress, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * RFC822 forwarding address under verification for an account
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2128)
+    public Map<String,Object> unsetFeatureMailForwardingVerificationAddress(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationAddress, "");
+        return attrs;
+    }
+
+    /**
+     * Enable end-user mail forwarding verification
+     *
+     * @return zimbraFeatureMailForwardingVerificationEnabled, or false if unset
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2126)
+    public boolean isFeatureMailForwardingVerificationEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureMailForwardingVerificationEnabled, false, true);
+    }
+
+    /**
+     * Enable end-user mail forwarding verification
+     *
+     * @param zimbraFeatureMailForwardingVerificationEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2126)
+    public void setFeatureMailForwardingVerificationEnabled(boolean zimbraFeatureMailForwardingVerificationEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationEnabled, zimbraFeatureMailForwardingVerificationEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Enable end-user mail forwarding verification
+     *
+     * @param zimbraFeatureMailForwardingVerificationEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2126)
+    public Map<String,Object> setFeatureMailForwardingVerificationEnabled(boolean zimbraFeatureMailForwardingVerificationEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationEnabled, zimbraFeatureMailForwardingVerificationEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Enable end-user mail forwarding verification
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2126)
+    public void unsetFeatureMailForwardingVerificationEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Enable end-user mail forwarding verification
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2126)
+    public Map<String,Object> unsetFeatureMailForwardingVerificationEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * Expiry time for end-user mail forwarding verification. Must be in
+     * valid duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * <p>Use getFeatureMailForwardingVerificationExpiryAsString to access value as a string.
+     *
+     * @see #getFeatureMailForwardingVerificationExpiryAsString()
+     *
+     * @return zimbraFeatureMailForwardingVerificationExpiry in millseconds, or 86400000 (1d)  if unset
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2127)
+    public long getFeatureMailForwardingVerificationExpiry() {
+        return getTimeInterval(Provisioning.A_zimbraFeatureMailForwardingVerificationExpiry, 86400000L, true);
+    }
+
+    /**
+     * Expiry time for end-user mail forwarding verification. Must be in
+     * valid duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @return zimbraFeatureMailForwardingVerificationExpiry, or "1d" if unset
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2127)
+    public String getFeatureMailForwardingVerificationExpiryAsString() {
+        return getAttr(Provisioning.A_zimbraFeatureMailForwardingVerificationExpiry, "1d", true);
+    }
+
+    /**
+     * Expiry time for end-user mail forwarding verification. Must be in
+     * valid duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @param zimbraFeatureMailForwardingVerificationExpiry new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2127)
+    public void setFeatureMailForwardingVerificationExpiry(String zimbraFeatureMailForwardingVerificationExpiry) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationExpiry, zimbraFeatureMailForwardingVerificationExpiry);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Expiry time for end-user mail forwarding verification. Must be in
+     * valid duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @param zimbraFeatureMailForwardingVerificationExpiry new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2127)
+    public Map<String,Object> setFeatureMailForwardingVerificationExpiry(String zimbraFeatureMailForwardingVerificationExpiry, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationExpiry, zimbraFeatureMailForwardingVerificationExpiry);
+        return attrs;
+    }
+
+    /**
+     * Expiry time for end-user mail forwarding verification. Must be in
+     * valid duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2127)
+    public void unsetFeatureMailForwardingVerificationExpiry() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationExpiry, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Expiry time for end-user mail forwarding verification. Must be in
+     * valid duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2127)
+    public Map<String,Object> unsetFeatureMailForwardingVerificationExpiry(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationExpiry, "");
+        return attrs;
+    }
+
+    /**
      * Deprecated since: 5.0. done via skin template overrides. Orig desc:
      * whether user is allowed to set mail polling interval
      *

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -12089,6 +12089,393 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * RFC822 email address under verification for an account
+     *
+     * @return zimbraFeatureAddressUnderVerification, or null if unset
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2128)
+    public String getFeatureAddressUnderVerification() {
+        return getAttr(Provisioning.A_zimbraFeatureAddressUnderVerification, null, true);
+    }
+
+    /**
+     * RFC822 email address under verification for an account
+     *
+     * @param zimbraFeatureAddressUnderVerification new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2128)
+    public void setFeatureAddressUnderVerification(String zimbraFeatureAddressUnderVerification) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAddressUnderVerification, zimbraFeatureAddressUnderVerification);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * RFC822 email address under verification for an account
+     *
+     * @param zimbraFeatureAddressUnderVerification new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2128)
+    public Map<String,Object> setFeatureAddressUnderVerification(String zimbraFeatureAddressUnderVerification, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAddressUnderVerification, zimbraFeatureAddressUnderVerification);
+        return attrs;
+    }
+
+    /**
+     * RFC822 email address under verification for an account
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2128)
+    public void unsetFeatureAddressUnderVerification() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAddressUnderVerification, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * RFC822 email address under verification for an account
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2128)
+    public Map<String,Object> unsetFeatureAddressUnderVerification(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAddressUnderVerification, "");
+        return attrs;
+    }
+
+    /**
+     * Enable end-user email address verification
+     *
+     * @return zimbraFeatureAddressVerificationEnabled, or false if unset
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2126)
+    public boolean isFeatureAddressVerificationEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureAddressVerificationEnabled, false, true);
+    }
+
+    /**
+     * Enable end-user email address verification
+     *
+     * @param zimbraFeatureAddressVerificationEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2126)
+    public void setFeatureAddressVerificationEnabled(boolean zimbraFeatureAddressVerificationEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAddressVerificationEnabled, zimbraFeatureAddressVerificationEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Enable end-user email address verification
+     *
+     * @param zimbraFeatureAddressVerificationEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2126)
+    public Map<String,Object> setFeatureAddressVerificationEnabled(boolean zimbraFeatureAddressVerificationEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAddressVerificationEnabled, zimbraFeatureAddressVerificationEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Enable end-user email address verification
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2126)
+    public void unsetFeatureAddressVerificationEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAddressVerificationEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Enable end-user email address verification
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2126)
+    public Map<String,Object> unsetFeatureAddressVerificationEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAddressVerificationEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * Expiry time for end-user email address verification. Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * <p>Use getFeatureAddressVerificationExpiryAsString to access value as a string.
+     *
+     * @see #getFeatureAddressVerificationExpiryAsString()
+     *
+     * @return zimbraFeatureAddressVerificationExpiry in millseconds, or 86400000 (1d)  if unset
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2127)
+    public long getFeatureAddressVerificationExpiry() {
+        return getTimeInterval(Provisioning.A_zimbraFeatureAddressVerificationExpiry, 86400000L, true);
+    }
+
+    /**
+     * Expiry time for end-user email address verification. Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @return zimbraFeatureAddressVerificationExpiry, or "1d" if unset
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2127)
+    public String getFeatureAddressVerificationExpiryAsString() {
+        return getAttr(Provisioning.A_zimbraFeatureAddressVerificationExpiry, "1d", true);
+    }
+
+    /**
+     * Expiry time for end-user email address verification. Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @param zimbraFeatureAddressVerificationExpiry new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2127)
+    public void setFeatureAddressVerificationExpiry(String zimbraFeatureAddressVerificationExpiry) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAddressVerificationExpiry, zimbraFeatureAddressVerificationExpiry);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Expiry time for end-user email address verification. Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @param zimbraFeatureAddressVerificationExpiry new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2127)
+    public Map<String,Object> setFeatureAddressVerificationExpiry(String zimbraFeatureAddressVerificationExpiry, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAddressVerificationExpiry, zimbraFeatureAddressVerificationExpiry);
+        return attrs;
+    }
+
+    /**
+     * Expiry time for end-user email address verification. Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2127)
+    public void unsetFeatureAddressVerificationExpiry() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAddressVerificationExpiry, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Expiry time for end-user email address verification. Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2127)
+    public Map<String,Object> unsetFeatureAddressVerificationExpiry(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAddressVerificationExpiry, "");
+        return attrs;
+    }
+
+    /**
+     * End-user email address verification status
+     *
+     * <p>Valid values: [verified, pending, failed, expired]
+     *
+     * @return zimbraFeatureAddressVerificationStatus, or null if unset and/or has invalid value
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2129)
+    public ZAttrProvisioning.FeatureAddressVerificationStatus getFeatureAddressVerificationStatus() {
+        try { String v = getAttr(Provisioning.A_zimbraFeatureAddressVerificationStatus, true, true); return v == null ? null : ZAttrProvisioning.FeatureAddressVerificationStatus.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return null; }
+    }
+
+    /**
+     * End-user email address verification status
+     *
+     * <p>Valid values: [verified, pending, failed, expired]
+     *
+     * @return zimbraFeatureAddressVerificationStatus, or null if unset
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2129)
+    public String getFeatureAddressVerificationStatusAsString() {
+        return getAttr(Provisioning.A_zimbraFeatureAddressVerificationStatus, null, true);
+    }
+
+    /**
+     * End-user email address verification status
+     *
+     * <p>Valid values: [verified, pending, failed, expired]
+     *
+     * @param zimbraFeatureAddressVerificationStatus new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2129)
+    public void setFeatureAddressVerificationStatus(ZAttrProvisioning.FeatureAddressVerificationStatus zimbraFeatureAddressVerificationStatus) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAddressVerificationStatus, zimbraFeatureAddressVerificationStatus.toString());
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * End-user email address verification status
+     *
+     * <p>Valid values: [verified, pending, failed, expired]
+     *
+     * @param zimbraFeatureAddressVerificationStatus new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2129)
+    public Map<String,Object> setFeatureAddressVerificationStatus(ZAttrProvisioning.FeatureAddressVerificationStatus zimbraFeatureAddressVerificationStatus, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAddressVerificationStatus, zimbraFeatureAddressVerificationStatus.toString());
+        return attrs;
+    }
+
+    /**
+     * End-user email address verification status
+     *
+     * <p>Valid values: [verified, pending, failed, expired]
+     *
+     * @param zimbraFeatureAddressVerificationStatus new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2129)
+    public void setFeatureAddressVerificationStatusAsString(String zimbraFeatureAddressVerificationStatus) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAddressVerificationStatus, zimbraFeatureAddressVerificationStatus);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * End-user email address verification status
+     *
+     * <p>Valid values: [verified, pending, failed, expired]
+     *
+     * @param zimbraFeatureAddressVerificationStatus new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2129)
+    public Map<String,Object> setFeatureAddressVerificationStatusAsString(String zimbraFeatureAddressVerificationStatus, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAddressVerificationStatus, zimbraFeatureAddressVerificationStatus);
+        return attrs;
+    }
+
+    /**
+     * End-user email address verification status
+     *
+     * <p>Valid values: [verified, pending, failed, expired]
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2129)
+    public void unsetFeatureAddressVerificationStatus() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAddressVerificationStatus, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * End-user email address verification status
+     *
+     * <p>Valid values: [verified, pending, failed, expired]
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2129)
+    public Map<String,Object> unsetFeatureAddressVerificationStatus(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAddressVerificationStatus, "");
+        return attrs;
+    }
+
+    /**
      * whether email features and tabs are enabled in the web client if
      * accessed from the admin console
      *
@@ -15600,262 +15987,6 @@ public abstract class ZAttrAccount  extends MailTarget {
     public Map<String,Object> unsetFeatureMailForwardingInFiltersEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureMailForwardingInFiltersEnabled, "");
-        return attrs;
-    }
-
-    /**
-     * RFC822 forwarding address under verification for an account
-     *
-     * @return zimbraFeatureMailForwardingVerificationAddress, or null if unset
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2128)
-    public String getFeatureMailForwardingVerificationAddress() {
-        return getAttr(Provisioning.A_zimbraFeatureMailForwardingVerificationAddress, null, true);
-    }
-
-    /**
-     * RFC822 forwarding address under verification for an account
-     *
-     * @param zimbraFeatureMailForwardingVerificationAddress new value
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2128)
-    public void setFeatureMailForwardingVerificationAddress(String zimbraFeatureMailForwardingVerificationAddress) throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationAddress, zimbraFeatureMailForwardingVerificationAddress);
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * RFC822 forwarding address under verification for an account
-     *
-     * @param zimbraFeatureMailForwardingVerificationAddress new value
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2128)
-    public Map<String,Object> setFeatureMailForwardingVerificationAddress(String zimbraFeatureMailForwardingVerificationAddress, Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationAddress, zimbraFeatureMailForwardingVerificationAddress);
-        return attrs;
-    }
-
-    /**
-     * RFC822 forwarding address under verification for an account
-     *
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2128)
-    public void unsetFeatureMailForwardingVerificationAddress() throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationAddress, "");
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * RFC822 forwarding address under verification for an account
-     *
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2128)
-    public Map<String,Object> unsetFeatureMailForwardingVerificationAddress(Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationAddress, "");
-        return attrs;
-    }
-
-    /**
-     * Enable end-user mail forwarding verification
-     *
-     * @return zimbraFeatureMailForwardingVerificationEnabled, or false if unset
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2126)
-    public boolean isFeatureMailForwardingVerificationEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraFeatureMailForwardingVerificationEnabled, false, true);
-    }
-
-    /**
-     * Enable end-user mail forwarding verification
-     *
-     * @param zimbraFeatureMailForwardingVerificationEnabled new value
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2126)
-    public void setFeatureMailForwardingVerificationEnabled(boolean zimbraFeatureMailForwardingVerificationEnabled) throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationEnabled, zimbraFeatureMailForwardingVerificationEnabled ? Provisioning.TRUE : Provisioning.FALSE);
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Enable end-user mail forwarding verification
-     *
-     * @param zimbraFeatureMailForwardingVerificationEnabled new value
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2126)
-    public Map<String,Object> setFeatureMailForwardingVerificationEnabled(boolean zimbraFeatureMailForwardingVerificationEnabled, Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationEnabled, zimbraFeatureMailForwardingVerificationEnabled ? Provisioning.TRUE : Provisioning.FALSE);
-        return attrs;
-    }
-
-    /**
-     * Enable end-user mail forwarding verification
-     *
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2126)
-    public void unsetFeatureMailForwardingVerificationEnabled() throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationEnabled, "");
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Enable end-user mail forwarding verification
-     *
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2126)
-    public Map<String,Object> unsetFeatureMailForwardingVerificationEnabled(Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationEnabled, "");
-        return attrs;
-    }
-
-    /**
-     * Expiry time for end-user mail forwarding verification. Must be in
-     * valid duration format: {digits}{time-unit}. digits: 0-9, time-unit:
-     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
-     * milliseconds. If time unit is not specified, the default is
-     * s(seconds).
-     *
-     * <p>Use getFeatureMailForwardingVerificationExpiryAsString to access value as a string.
-     *
-     * @see #getFeatureMailForwardingVerificationExpiryAsString()
-     *
-     * @return zimbraFeatureMailForwardingVerificationExpiry in millseconds, or 86400000 (1d)  if unset
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2127)
-    public long getFeatureMailForwardingVerificationExpiry() {
-        return getTimeInterval(Provisioning.A_zimbraFeatureMailForwardingVerificationExpiry, 86400000L, true);
-    }
-
-    /**
-     * Expiry time for end-user mail forwarding verification. Must be in
-     * valid duration format: {digits}{time-unit}. digits: 0-9, time-unit:
-     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
-     * milliseconds. If time unit is not specified, the default is
-     * s(seconds).
-     *
-     * @return zimbraFeatureMailForwardingVerificationExpiry, or "1d" if unset
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2127)
-    public String getFeatureMailForwardingVerificationExpiryAsString() {
-        return getAttr(Provisioning.A_zimbraFeatureMailForwardingVerificationExpiry, "1d", true);
-    }
-
-    /**
-     * Expiry time for end-user mail forwarding verification. Must be in
-     * valid duration format: {digits}{time-unit}. digits: 0-9, time-unit:
-     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
-     * milliseconds. If time unit is not specified, the default is
-     * s(seconds).
-     *
-     * @param zimbraFeatureMailForwardingVerificationExpiry new value
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2127)
-    public void setFeatureMailForwardingVerificationExpiry(String zimbraFeatureMailForwardingVerificationExpiry) throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationExpiry, zimbraFeatureMailForwardingVerificationExpiry);
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Expiry time for end-user mail forwarding verification. Must be in
-     * valid duration format: {digits}{time-unit}. digits: 0-9, time-unit:
-     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
-     * milliseconds. If time unit is not specified, the default is
-     * s(seconds).
-     *
-     * @param zimbraFeatureMailForwardingVerificationExpiry new value
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2127)
-    public Map<String,Object> setFeatureMailForwardingVerificationExpiry(String zimbraFeatureMailForwardingVerificationExpiry, Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationExpiry, zimbraFeatureMailForwardingVerificationExpiry);
-        return attrs;
-    }
-
-    /**
-     * Expiry time for end-user mail forwarding verification. Must be in
-     * valid duration format: {digits}{time-unit}. digits: 0-9, time-unit:
-     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
-     * milliseconds. If time unit is not specified, the default is
-     * s(seconds).
-     *
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2127)
-    public void unsetFeatureMailForwardingVerificationExpiry() throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationExpiry, "");
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Expiry time for end-user mail forwarding verification. Must be in
-     * valid duration format: {digits}{time-unit}. digits: 0-9, time-unit:
-     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
-     * milliseconds. If time unit is not specified, the default is
-     * s(seconds).
-     *
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2127)
-    public Map<String,Object> unsetFeatureMailForwardingVerificationExpiry(Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationExpiry, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -10552,6 +10552,190 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * Enable end-user mail forwarding verification
+     *
+     * @return zimbraFeatureMailForwardingVerificationEnabled, or false if unset
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2126)
+    public boolean isFeatureMailForwardingVerificationEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureMailForwardingVerificationEnabled, false, true);
+    }
+
+    /**
+     * Enable end-user mail forwarding verification
+     *
+     * @param zimbraFeatureMailForwardingVerificationEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2126)
+    public void setFeatureMailForwardingVerificationEnabled(boolean zimbraFeatureMailForwardingVerificationEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationEnabled, zimbraFeatureMailForwardingVerificationEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Enable end-user mail forwarding verification
+     *
+     * @param zimbraFeatureMailForwardingVerificationEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2126)
+    public Map<String,Object> setFeatureMailForwardingVerificationEnabled(boolean zimbraFeatureMailForwardingVerificationEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationEnabled, zimbraFeatureMailForwardingVerificationEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Enable end-user mail forwarding verification
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2126)
+    public void unsetFeatureMailForwardingVerificationEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Enable end-user mail forwarding verification
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2126)
+    public Map<String,Object> unsetFeatureMailForwardingVerificationEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * Expiry time for end-user mail forwarding verification. Must be in
+     * valid duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * <p>Use getFeatureMailForwardingVerificationExpiryAsString to access value as a string.
+     *
+     * @see #getFeatureMailForwardingVerificationExpiryAsString()
+     *
+     * @return zimbraFeatureMailForwardingVerificationExpiry in millseconds, or 86400000 (1d)  if unset
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2127)
+    public long getFeatureMailForwardingVerificationExpiry() {
+        return getTimeInterval(Provisioning.A_zimbraFeatureMailForwardingVerificationExpiry, 86400000L, true);
+    }
+
+    /**
+     * Expiry time for end-user mail forwarding verification. Must be in
+     * valid duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @return zimbraFeatureMailForwardingVerificationExpiry, or "1d" if unset
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2127)
+    public String getFeatureMailForwardingVerificationExpiryAsString() {
+        return getAttr(Provisioning.A_zimbraFeatureMailForwardingVerificationExpiry, "1d", true);
+    }
+
+    /**
+     * Expiry time for end-user mail forwarding verification. Must be in
+     * valid duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @param zimbraFeatureMailForwardingVerificationExpiry new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2127)
+    public void setFeatureMailForwardingVerificationExpiry(String zimbraFeatureMailForwardingVerificationExpiry) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationExpiry, zimbraFeatureMailForwardingVerificationExpiry);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Expiry time for end-user mail forwarding verification. Must be in
+     * valid duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @param zimbraFeatureMailForwardingVerificationExpiry new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2127)
+    public Map<String,Object> setFeatureMailForwardingVerificationExpiry(String zimbraFeatureMailForwardingVerificationExpiry, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationExpiry, zimbraFeatureMailForwardingVerificationExpiry);
+        return attrs;
+    }
+
+    /**
+     * Expiry time for end-user mail forwarding verification. Must be in
+     * valid duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2127)
+    public void unsetFeatureMailForwardingVerificationExpiry() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationExpiry, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Expiry time for end-user mail forwarding verification. Must be in
+     * valid duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2127)
+    public Map<String,Object> unsetFeatureMailForwardingVerificationExpiry(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationExpiry, "");
+        return attrs;
+    }
+
+    /**
      * Deprecated since: 5.0. done via skin template overrides. Orig desc:
      * whether user is allowed to set mail polling interval
      *

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -7037,6 +7037,190 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * Enable end-user email address verification
+     *
+     * @return zimbraFeatureAddressVerificationEnabled, or false if unset
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2126)
+    public boolean isFeatureAddressVerificationEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureAddressVerificationEnabled, false, true);
+    }
+
+    /**
+     * Enable end-user email address verification
+     *
+     * @param zimbraFeatureAddressVerificationEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2126)
+    public void setFeatureAddressVerificationEnabled(boolean zimbraFeatureAddressVerificationEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAddressVerificationEnabled, zimbraFeatureAddressVerificationEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Enable end-user email address verification
+     *
+     * @param zimbraFeatureAddressVerificationEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2126)
+    public Map<String,Object> setFeatureAddressVerificationEnabled(boolean zimbraFeatureAddressVerificationEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAddressVerificationEnabled, zimbraFeatureAddressVerificationEnabled ? Provisioning.TRUE : Provisioning.FALSE);
+        return attrs;
+    }
+
+    /**
+     * Enable end-user email address verification
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2126)
+    public void unsetFeatureAddressVerificationEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAddressVerificationEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Enable end-user email address verification
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2126)
+    public Map<String,Object> unsetFeatureAddressVerificationEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAddressVerificationEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * Expiry time for end-user email address verification. Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * <p>Use getFeatureAddressVerificationExpiryAsString to access value as a string.
+     *
+     * @see #getFeatureAddressVerificationExpiryAsString()
+     *
+     * @return zimbraFeatureAddressVerificationExpiry in millseconds, or 86400000 (1d)  if unset
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2127)
+    public long getFeatureAddressVerificationExpiry() {
+        return getTimeInterval(Provisioning.A_zimbraFeatureAddressVerificationExpiry, 86400000L, true);
+    }
+
+    /**
+     * Expiry time for end-user email address verification. Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @return zimbraFeatureAddressVerificationExpiry, or "1d" if unset
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2127)
+    public String getFeatureAddressVerificationExpiryAsString() {
+        return getAttr(Provisioning.A_zimbraFeatureAddressVerificationExpiry, "1d", true);
+    }
+
+    /**
+     * Expiry time for end-user email address verification. Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @param zimbraFeatureAddressVerificationExpiry new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2127)
+    public void setFeatureAddressVerificationExpiry(String zimbraFeatureAddressVerificationExpiry) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAddressVerificationExpiry, zimbraFeatureAddressVerificationExpiry);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Expiry time for end-user email address verification. Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @param zimbraFeatureAddressVerificationExpiry new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2127)
+    public Map<String,Object> setFeatureAddressVerificationExpiry(String zimbraFeatureAddressVerificationExpiry, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAddressVerificationExpiry, zimbraFeatureAddressVerificationExpiry);
+        return attrs;
+    }
+
+    /**
+     * Expiry time for end-user email address verification. Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2127)
+    public void unsetFeatureAddressVerificationExpiry() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAddressVerificationExpiry, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Expiry time for end-user email address verification. Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2127)
+    public Map<String,Object> unsetFeatureAddressVerificationExpiry(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAddressVerificationExpiry, "");
+        return attrs;
+    }
+
+    /**
      * whether email features and tabs are enabled in the web client if
      * accessed from the admin console
      *
@@ -10548,190 +10732,6 @@ public abstract class ZAttrCos extends NamedEntry {
     public Map<String,Object> unsetFeatureMailForwardingInFiltersEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureMailForwardingInFiltersEnabled, "");
-        return attrs;
-    }
-
-    /**
-     * Enable end-user mail forwarding verification
-     *
-     * @return zimbraFeatureMailForwardingVerificationEnabled, or false if unset
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2126)
-    public boolean isFeatureMailForwardingVerificationEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraFeatureMailForwardingVerificationEnabled, false, true);
-    }
-
-    /**
-     * Enable end-user mail forwarding verification
-     *
-     * @param zimbraFeatureMailForwardingVerificationEnabled new value
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2126)
-    public void setFeatureMailForwardingVerificationEnabled(boolean zimbraFeatureMailForwardingVerificationEnabled) throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationEnabled, zimbraFeatureMailForwardingVerificationEnabled ? Provisioning.TRUE : Provisioning.FALSE);
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Enable end-user mail forwarding verification
-     *
-     * @param zimbraFeatureMailForwardingVerificationEnabled new value
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2126)
-    public Map<String,Object> setFeatureMailForwardingVerificationEnabled(boolean zimbraFeatureMailForwardingVerificationEnabled, Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationEnabled, zimbraFeatureMailForwardingVerificationEnabled ? Provisioning.TRUE : Provisioning.FALSE);
-        return attrs;
-    }
-
-    /**
-     * Enable end-user mail forwarding verification
-     *
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2126)
-    public void unsetFeatureMailForwardingVerificationEnabled() throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationEnabled, "");
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Enable end-user mail forwarding verification
-     *
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2126)
-    public Map<String,Object> unsetFeatureMailForwardingVerificationEnabled(Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationEnabled, "");
-        return attrs;
-    }
-
-    /**
-     * Expiry time for end-user mail forwarding verification. Must be in
-     * valid duration format: {digits}{time-unit}. digits: 0-9, time-unit:
-     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
-     * milliseconds. If time unit is not specified, the default is
-     * s(seconds).
-     *
-     * <p>Use getFeatureMailForwardingVerificationExpiryAsString to access value as a string.
-     *
-     * @see #getFeatureMailForwardingVerificationExpiryAsString()
-     *
-     * @return zimbraFeatureMailForwardingVerificationExpiry in millseconds, or 86400000 (1d)  if unset
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2127)
-    public long getFeatureMailForwardingVerificationExpiry() {
-        return getTimeInterval(Provisioning.A_zimbraFeatureMailForwardingVerificationExpiry, 86400000L, true);
-    }
-
-    /**
-     * Expiry time for end-user mail forwarding verification. Must be in
-     * valid duration format: {digits}{time-unit}. digits: 0-9, time-unit:
-     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
-     * milliseconds. If time unit is not specified, the default is
-     * s(seconds).
-     *
-     * @return zimbraFeatureMailForwardingVerificationExpiry, or "1d" if unset
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2127)
-    public String getFeatureMailForwardingVerificationExpiryAsString() {
-        return getAttr(Provisioning.A_zimbraFeatureMailForwardingVerificationExpiry, "1d", true);
-    }
-
-    /**
-     * Expiry time for end-user mail forwarding verification. Must be in
-     * valid duration format: {digits}{time-unit}. digits: 0-9, time-unit:
-     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
-     * milliseconds. If time unit is not specified, the default is
-     * s(seconds).
-     *
-     * @param zimbraFeatureMailForwardingVerificationExpiry new value
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2127)
-    public void setFeatureMailForwardingVerificationExpiry(String zimbraFeatureMailForwardingVerificationExpiry) throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationExpiry, zimbraFeatureMailForwardingVerificationExpiry);
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Expiry time for end-user mail forwarding verification. Must be in
-     * valid duration format: {digits}{time-unit}. digits: 0-9, time-unit:
-     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
-     * milliseconds. If time unit is not specified, the default is
-     * s(seconds).
-     *
-     * @param zimbraFeatureMailForwardingVerificationExpiry new value
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2127)
-    public Map<String,Object> setFeatureMailForwardingVerificationExpiry(String zimbraFeatureMailForwardingVerificationExpiry, Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationExpiry, zimbraFeatureMailForwardingVerificationExpiry);
-        return attrs;
-    }
-
-    /**
-     * Expiry time for end-user mail forwarding verification. Must be in
-     * valid duration format: {digits}{time-unit}. digits: 0-9, time-unit:
-     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
-     * milliseconds. If time unit is not specified, the default is
-     * s(seconds).
-     *
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2127)
-    public void unsetFeatureMailForwardingVerificationExpiry() throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationExpiry, "");
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Expiry time for end-user mail forwarding verification. Must be in
-     * valid duration format: {digits}{time-unit}. digits: 0-9, time-unit:
-     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
-     * milliseconds. If time unit is not specified, the default is
-     * s(seconds).
-     *
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2127)
-    public Map<String,Object> unsetFeatureMailForwardingVerificationExpiry(Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraFeatureMailForwardingVerificationExpiry, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/service/account/ModifyPrefs.java
+++ b/store/src/java/com/zimbra/cs/service/account/ModifyPrefs.java
@@ -20,22 +20,54 @@
  */
 package com.zimbra.cs.service.account;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.TimeZone;
+
+import javax.activation.DataHandler;
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeBodyPart;
+import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
+
+import org.apache.commons.codec.binary.Hex;
 
 import com.google.common.base.Strings;
+import com.zimbra.common.mime.MimeConstants;
+import com.zimbra.common.mime.shim.JavaMailInternetAddress;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AccountConstants;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.Element.KeyValuePair;
+import com.zimbra.common.util.BlobMetaData;
+import com.zimbra.common.util.CharsetUtil;
+import com.zimbra.common.util.L10nUtil;
 import com.zimbra.common.util.StringUtil;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.common.util.L10nUtil.MsgKey;
+import com.zimbra.common.zmime.ZMimeBodyPart;
+import com.zimbra.common.zmime.ZMimeMultipart;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.AttributeInfo;
 import com.zimbra.cs.account.AttributeManager;
+import com.zimbra.cs.account.ExtAuthTokenKey;
 import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.TokenUtil;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailbox.OperationContext;
+import com.zimbra.cs.mime.Mime;
+import com.zimbra.cs.servlet.ZimbraServlet;
+import com.zimbra.cs.util.AccountUtil;
+import com.zimbra.cs.util.JMSession;
 import com.zimbra.soap.ZimbraSoapContext;
+import com.zimbra.cs.account.ShareInfo.NotificationSender.HtmlPartDataSource;
 
 /**
  * @author schemers
@@ -48,6 +80,8 @@ public class ModifyPrefs extends AccountDocumentHandler {
         ZimbraSoapContext zsc = getZimbraSoapContext(context);
         Account account = getRequestedAccount(zsc);
 
+        OperationContext octxt = getOperationContext(zsc, context);
+        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account, false);
         if (!canModifyOptions(zsc, account))
             throw ServiceException.PERM_DENIED("can not modify options");
 
@@ -83,8 +117,26 @@ public class ModifyPrefs extends AccountDocumentHandler {
         }
 
         if (prefs.containsKey(Provisioning.A_zimbraPrefMailForwardingAddress)) {
-            if (!account.getBooleanAttr(Provisioning.A_zimbraFeatureMailForwardingEnabled, false))
+            if (!account.getBooleanAttr(Provisioning.A_zimbraFeatureMailForwardingEnabled, false)) {
                 throw ServiceException.PERM_DENIED("forwarding not enabled");
+            } else {
+                if (account.getBooleanAttr(
+                    Provisioning.A_zimbraFeatureMailForwardingVerificationEnabled, false)) {
+                    /*
+                     * forwarding address verification enabled, store the email
+                     * ID in 'zimbraFeatureMailForwardingVerificationAddress'
+                     * till the time it's verified
+                     */
+                    String emailIdToVerify = (String) prefs
+                        .get(Provisioning.A_zimbraPrefMailForwardingAddress);
+                    prefs.remove(Provisioning.A_zimbraPrefMailForwardingAddress);
+                    StringUtil.addToMultiMap(prefs,
+                        Provisioning.A_zimbraFeatureMailForwardingVerificationAddress,
+                        emailIdToVerify);
+                    Account authAccount = getAuthenticatedAccount(zsc);
+                    sendEmailVerificationLink(authAccount, account, emailIdToVerify, octxt, mbox);
+                }
+            }
         }
 
         // call modifyAttrs and pass true to checkImmutable
@@ -92,5 +144,74 @@ public class ModifyPrefs extends AccountDocumentHandler {
 
         Element response = zsc.createElement(AccountConstants.MODIFY_PREFS_RESPONSE);
         return response;
+    }
+
+    private static void sendEmailVerificationLink(Account authAccount, Account account,
+        String emailIdToVerify, OperationContext octxt, Mailbox mbox) throws ServiceException {
+        Locale locale = authAccount.getLocale();
+        String ownerAcctDisplayName = account.getDisplayName();
+        if (ownerAcctDisplayName == null) {
+            ownerAcctDisplayName = account.getName();
+        }
+        String subject = L10nUtil.getMessage(MsgKey.verifyEmailSubject, locale,
+            ownerAcctDisplayName);
+        String charset = authAccount.getAttr(Provisioning.A_zimbraPrefMailDefaultCharset,
+            MimeConstants.P_CHARSET_UTF8);
+        try {
+            MimeMessage mm = new Mime.FixedMimeMessage(JMSession.getSmtpSession(authAccount));
+            mm.setSubject(subject, CharsetUtil.checkCharset(subject, charset));
+            mm.setSentDate(new Date());
+            mm.setFrom(AccountUtil.getFriendlyEmailAddress(account));
+            mm.setSender(AccountUtil.getFriendlyEmailAddress(authAccount));
+            mm.setRecipient(javax.mail.Message.RecipientType.TO,
+                new JavaMailInternetAddress(emailIdToVerify));
+            long expiry = account.getFeatureMailForwardingVerificationExpiry();
+            Date now = new Date();
+            long expiryTime = now.getTime() + expiry;
+            DateFormat format = new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss z");
+            format.setTimeZone(TimeZone.getTimeZone("GMT"));
+            String gmtDate = format.format(expiryTime);
+            String url = getEmailVerificationURL(account, expiryTime, emailIdToVerify);
+            if (ZimbraLog.account.isDebugEnabled()) {
+                ZimbraLog.account.debug(
+                    "Expiry of Forwarding address verification link sent to %s is %s",
+                    emailIdToVerify, gmtDate);
+                ZimbraLog.account.debug("Forwarding address verification URL sent to %s is %s",
+                    emailIdToVerify, url);
+            }
+            String mimePartText = L10nUtil.getMessage(MsgKey.verifyEmailBodyText, locale,
+                ownerAcctDisplayName, url, gmtDate);
+            MimeMultipart mmp = new ZMimeMultipart("alternative");
+            MimeBodyPart textPart = new ZMimeBodyPart();
+            textPart.setText(mimePartText, MimeConstants.P_CHARSET_UTF8);
+            mmp.addBodyPart(textPart);
+            String mimePartHtml = L10nUtil.getMessage(MsgKey.verifyEmailBodyHtml, locale,
+                ownerAcctDisplayName, url, gmtDate);
+            MimeBodyPart htmlPart = new ZMimeBodyPart();
+            htmlPart.setDataHandler(new DataHandler(new HtmlPartDataSource(mimePartHtml)));
+            mmp.addBodyPart(htmlPart);
+            mm.setContent(mmp);
+            mm.saveChanges();
+            mbox.getMailSender().sendMimeMessage(octxt, mbox, true, mm, null, null, null, null,
+                false);
+        } catch (MessagingException e) {
+            ZimbraLog.account.warn("Failed to send verification link to email ID: '" + emailIdToVerify +"'", e);
+            throw ServiceException.FAILURE("Failed to send verification link to email ID: "+emailIdToVerify, e);
+        }
+    }
+
+    private static String getEmailVerificationURL(Account account, long expiry,
+        String externalUserEmail) throws ServiceException {
+        StringBuilder encodedBuff = new StringBuilder();
+        BlobMetaData.encodeMetaData("accountId", account.getId(), encodedBuff);
+        BlobMetaData.encodeMetaData("expiry", expiry, encodedBuff);
+        BlobMetaData.encodeMetaData("emailAddressUnderVerification", externalUserEmail, encodedBuff);
+        String data = new String(Hex.encodeHex(encodedBuff.toString().getBytes()));
+        ExtAuthTokenKey key = ExtAuthTokenKey.getCurrentKey();
+        String hmac = TokenUtil.getHmac(data, key.getKey());
+        String encoded = key.getVersion() + "_" + hmac + "_" + data;
+        String path = "/service/extuserprov/?p=" + encoded;
+        return ZimbraServlet.getServiceUrl(account.getServer(),
+            Provisioning.getInstance().getDomain(account), path);
     }
 }


### PR DESCRIPTION
API to verify ownership of forwarding email address
Added following LDAP attributes:
1. zimbraFeatureAddressVerificationEnabled: account, cos
2. zimbraFeatureAddressVerificationExpiry: account, cos
3. zimbraFeatureAddressUnderVerification: account
3. zimbraFeatureAddressVerificationStatus: account


If the 'zimbraFeatureMailForwardingVerificationEnabled' is TRUE, the forwarding address will be stored into 'zimbraFeatureMailForwardingVerificationAddress' instead of 'zimbraPrefMailForwardingAddress' and a verification link will be sent to forwarding address.
The link is same as that of 'ExtUserShare', but that it will contain following parameters:
accountId, expiry, emailAddressUnderVerification.

Testing Done:
Manual testing. Added Junit test.
ant test-all passed.
