### PR TITLE
zcs-2212:Inconsistent handling of "\" in editheader

### DIFF
--- a/store/src/java-test/com/zimbra/cs/filter/DeleteHeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/DeleteHeaderTest.java
@@ -1347,4 +1347,89 @@ public class DeleteHeaderTest {
             fail("No exception should be thrown" + e);
         }
     }
+
+    @Test
+    public void testBackslashAsciiCasemap4bs() throws Exception {
+        // Matches four backslashes
+        String script = "require [\"editheader\"];\n"
+                + "deleteheader :comparator \"i;ascii-casemap\" \"X-Header\"  \"Sample\\\\\\\\\\\\\\\\Pattern\";"
+                + "deleteheader :comparator \"i;ascii-casemap\" \"X-HeaderA\" \"Sample\\\\\\\\Pattern\";"
+                + "deleteheader :comparator \"i;ascii-casemap\" \"X-HeaderB\" \"Sample\\\\Pattern\";"
+                + "deleteheader :comparator \"i;ascii-casemap\" \"X-HeaderC\" \"Sample\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\Pattern\";";
+        String pattern = "Sample\\\\\\\\Pattern";
+        String msg = "X-Header: " + pattern + "\n"
+                   + "X-HeaderA: " + pattern + "\n"
+                   + "X-HeaderB: " + pattern + "\n"
+                   + "X-HeaderC: " + pattern + "\n";
+        boolean result = testBackslash(script, pattern, msg);
+        Assert.assertTrue(result);
+    }
+
+    @Test
+    public void testBackslashAsciiCasemap5bs() throws Exception {
+        // Matches five backslashes
+        String script = "require [\"editheader\"];\n"
+                + "deleteheader :comparator \"i;ascii-casemap\" \"X-Header\"  \"Sample\\\\\\\\\\\\\\\\\\\\Pattern\";"
+                + "deleteheader :comparator \"i;ascii-casemap\" \"X-HeaderA\" \"Sample\\\\\\\\\\Pattern\";"
+                + "deleteheader :comparator \"i;ascii-casemap\" \"X-HeaderB\" \"Sample\\\\\\Pattern\";"
+                + "deleteheader :comparator \"i;ascii-casemap\" \"X-HeaderC\" \"Sample\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\Pattern\";";
+        String pattern = "Sample\\\\\\\\\\Pattern";
+        String msg = "X-Header: " + pattern + "\n"
+                   + "X-HeaderA: " + pattern + "\n"
+                   + "X-HeaderB: " + pattern + "\n"
+                   + "X-HeaderC: " + pattern + "\n";
+        boolean result = testBackslash(script, pattern, msg);
+        Assert.assertTrue(result);
+    }
+
+    @Test
+    public void testBackslashOctet() throws Exception {
+        String script = "require [\"editheader\"];\n"
+                + "deleteheader :comparator \"i;octet\" \"X-Header\"  \"Sample\\\\\\\\\\\\\\\\Pattern\";"
+                + "deleteheader :comparator \"i;octet\" \"X-HeaderA\" \"Sample\\\\\\\\Pattern\";"
+                + "deleteheader :comparator \"i;octet\" \"X-HeaderB\" \"Sample\\\\Pattern\";"
+                + "deleteheader :comparator \"i;octet\" \"X-HeaderC\" \"Sample\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\Pattern\";";
+        String pattern = "Sample\\\\\\\\Pattern";
+        String msg = "X-Header: " + pattern + "\n"
+                   + "X-HeaderA: " + pattern + "\n"
+                   + "X-HeaderB: " + pattern + "\n"
+                   + "X-HeaderC: " + pattern + "\n";
+        boolean result = testBackslash(script, pattern, msg);
+        Assert.assertTrue(result);
+    }
+
+    private boolean testBackslash(String script, String pattern, String msg) {
+        try {
+            Account account = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+            Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
+            RuleManager.clearCachedRules(account);
+            account.unsetAdminSieveScriptBefore();
+            account.unsetMailSieveScript();
+            account.unsetAdminSieveScriptAfter();
+            account.setSieveEditHeaderEnabled(true);
+            account.setAdminSieveScriptBefore(script);
+            List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox),
+                    mbox, new ParsedMessage(msg.getBytes(), false), 0,
+                    account.getName(), new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
+            Message message = mbox.getMessageById(null, ids.get(0).getId());
+            String[] headers = message.getMimeMessage().getHeader("X-Header");
+            Assert.assertNull(headers);
+            headers = message.getMimeMessage().getHeader("X-HeaderA");
+            Assert.assertNotNull(headers);
+            Assert.assertNotSame(0, headers.length);
+            Assert.assertEquals(pattern, headers[0]);
+            headers = message.getMimeMessage().getHeader("X-HeaderB");
+            Assert.assertNotNull(headers);
+            Assert.assertNotSame(0, headers.length);
+            Assert.assertEquals(pattern, headers[0]);
+            headers = message.getMimeMessage().getHeader("X-HeaderC");
+            Assert.assertNotNull(headers);
+            Assert.assertNotSame(0, headers.length);
+            Assert.assertEquals(pattern, headers[0]);
+            return true;
+        } catch (Exception e) {
+            fail("No exception should be thrown" + e);
+            return false;
+        }
+    }
 }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/EditHeaderExtension.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/EditHeaderExtension.java
@@ -418,11 +418,11 @@ public class EditHeaderExtension {
             matchFound = ZimbraComparatorUtils.values(mailAdapter, comparator, relationalComparator, unfoldedAndDecodedHeaderValue, value, context);
         } else if (this.countTag) {
             matchFound = ZimbraComparatorUtils.counts(mailAdapter, comparator, relationalComparator, headerList, value, context);
-        } else if (this.is && ComparatorUtils.is(this.comparator, unfoldedAndDecodedHeaderValue, value, context)) {
+        } else if (this.is && ComparatorUtils.is(comparator, unfoldedAndDecodedHeaderValue, value, context)) {
             matchFound = true;
-        } else if (this.contains && ComparatorUtils.contains(this.comparator, unfoldedAndDecodedHeaderValue, value, context)) {
+        } else if (this.contains && ComparatorUtils.contains(comparator, unfoldedAndDecodedHeaderValue, value, context)) {
             matchFound = true;
-        } else if (this.matches && matchValue(value, unfoldedAndDecodedHeaderValue)) {
+        } else if (this.matches && ComparatorUtils.matches(comparator, unfoldedAndDecodedHeaderValue, value, context)) {
             matchFound = true;
         } else {
             ZimbraLog.filter.debug("Key: %s and Value: %s pair not matching requested criteria.", this.key, value);
@@ -547,18 +547,6 @@ public class EditHeaderExtension {
     static public boolean isImmutableHeaderKey(String key, ZimbraMailAdapter mailAdapter) {
         List<String> immutableHeaders = Arrays.asList(mailAdapter.getAccount().getSieveImmutableHeaders().split(","));
         return immutableHeaders.stream().map(String::trim).anyMatch(x -> x.equalsIgnoreCase(key));
-    }
-
-    /**
-     * @param regex
-     * @param value
-     * @return
-     */
-    private boolean matchValue(String regex, String value) {
-        regex = ComparatorUtils.sieveToJavaRegex(regex);
-        Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
-        Matcher matcher = pattern.matcher(value);
-        return matcher.matches();
     }
 
     static public boolean saveChanges(ZimbraMailAdapter zma, String actionName, MimeMessage mm) {


### PR DESCRIPTION
Sieve:ReplaceHeader:Match pattern containing more than four backslashes leads to incorrect behaviour

[Problem]
When the match pattern contains four or more than four
backslashes in a row, replaceheader matches does not match correctly.

[Root cause]
The replaceheader and deleteheader call the com.zimbra.cs.filter.jsieve.EditHeaderExtension.matchValue() which makes a matching pattern using jsieve's org.apache.jsieve.comparators.ComparatorUtils.sieveToJavaRegex() method, but this method had a bug.  Other tests, such as header or address, have already used the fixed version of com.zimbra.cs.filter.FilterUtil.sieveToJavaRegex(), but replaceheader and deleteheader did not yet.

[Fix]
Call the fixed version of sieveToJavaRegex() method from replaceheader and deleteheader.
