### PR TITLE
Bugfix/zcs 3025

### DIFF
--- a/store/src/java/com/zimbra/cs/imap/ImapPath.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapPath.java
@@ -256,8 +256,8 @@ public class ImapPath implements Comparable<ImapPath> {
     }
 
     protected MailboxStore getOwnerMailbox() throws ServiceException {
-        getOwnerImapMailboxStore(!onLocalServer());
-        return (null == imapMboxStore) ? null : imapMboxStore.getMailboxStore();
+        ImapMailboxStore store = getOwnerImapMailboxStore();
+        return (null == store) ? null : store.getMailboxStore();
     }
 
     protected ImapMailboxStore getOwnerImapMailboxStore() throws ServiceException {


### PR DESCRIPTION
 - add a SOAP test for copying an item to a mountpoint via IMAP
 - fix the code path that was supposed to returned correct owner's mailbox, but was returning the sharee's mailbox

Testing:
I ran dev SOAP test suite against develop branch and this branch and did not find any new failures in this branch. Also tested the behavior described in bugzilla manually with apple mail and Thunderbird