### PR TITLE
ZCS-3016 zmailbox perm denied

### DIFF
--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -242,11 +242,10 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
 
     private static final int CALENDAR_FOLDER_ALL = -1;
     /* Generally set "accountId" explicitly when using another user's auth token, as don't have GetAccountInfo
-     * capability which is what is normally used to get the account ID.  Choosing not to populate accountId
-     * for other use cases to avoid increasing memory footprint.
+     * capability which is what is normally used to get the account ID.  Note that not always set.
      */
     private String accountId = null;
-    /* As above, generally set "name" explicitly only when using another user's auth token */
+    /* As above, generally set "name" explicitly when using another user's auth token */
     private String name = null;
     private String authName = null;
     private static final Pattern sAttachmentId = Pattern.compile("\\d+,'.*','(.*)'");
@@ -750,8 +749,10 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
     private void initTargetAccount(String key, AccountBy by) {
         if (AccountBy.id.equals(by)) {
             mTransport.setTargetAcctId(key);
+            accountId = key;
         } else if (AccountBy.name.equals(by)) {
             mTransport.setTargetAcctName(key);
+            name = key;
         }
     }
 

--- a/store/src/java/com/zimbra/cs/dav/DavContext.java
+++ b/store/src/java/com/zimbra/cs/dav/DavContext.java
@@ -677,7 +677,11 @@ public class DavContext {
         zoptions.setNoSession(true);
         zoptions.setTargetAccount(acct.getId());
         zoptions.setTargetAccountBy(Key.AccountBy.id);
-        return ZMailbox.getMailbox(zoptions);
+        ZMailbox zmbx = ZMailbox.getMailbox(zoptions);
+        if (zmbx != null) {
+            zmbx.setName(acct.getName()); /* need this when logging in using another user's auth */
+        }
+        return zmbx;
     }
 
     public String getNewName() throws DavException {

--- a/store/src/java/com/zimbra/cs/dav/resource/MailItemResource.java
+++ b/store/src/java/com/zimbra/cs/dav/resource/MailItemResource.java
@@ -254,7 +254,11 @@ public abstract class MailItemResource extends DavResource {
         zoptions.setNoSession(true);
         zoptions.setTargetAccount(acct.getId());
         zoptions.setTargetAccountBy(Key.AccountBy.id);
-        return ZMailbox.getMailbox(zoptions);
+        ZMailbox zmbx = ZMailbox.getMailbox(zoptions);
+        if (zmbx != null) {
+            zmbx.setName(acct.getName()); /* need this when logging in using another user's auth */
+        }
+        return zmbx;
     }
     private void deleteDestinationItem(DavContext ctxt, Collection dest, int id) throws ServiceException, DavException {
         Mailbox mbox = getMailbox(ctxt);

--- a/store/src/java/com/zimbra/cs/dav/resource/RemoteCollection.java
+++ b/store/src/java/com/zimbra/cs/dav/resource/RemoteCollection.java
@@ -21,6 +21,8 @@ import java.util.Collections;
 
 import javax.servlet.http.HttpServletResponse;
 
+import com.zimbra.client.ZFolder;
+import com.zimbra.client.ZMailbox;
 import com.zimbra.common.account.Key;
 import com.zimbra.common.auth.ZAuthToken;
 import com.zimbra.common.service.ServiceException;
@@ -40,8 +42,6 @@ import com.zimbra.cs.mailbox.calendar.cache.CtagInfo;
 import com.zimbra.cs.service.AuthProvider;
 import com.zimbra.cs.service.util.ItemId;
 import com.zimbra.cs.util.AccountUtil;
-import com.zimbra.client.ZFolder;
-import com.zimbra.client.ZMailbox;
 
 public class RemoteCollection extends Collection {
 
@@ -78,7 +78,7 @@ public class RemoteCollection extends Collection {
         if (zview != null)
             view = MailItem.Type.of(zview.name());
     }
-    
+
     @Override
     public void delete(DavContext ctxt) throws DavException {
         throw new DavException("cannot delete this resource", HttpServletResponse.SC_FORBIDDEN, null);
@@ -101,7 +101,11 @@ public class RemoteCollection extends Collection {
         zoptions.setNoSession(true);
         zoptions.setTargetAccount(ownerId);
         zoptions.setTargetAccountBy(Key.AccountBy.id);
-        return ZMailbox.getMailbox(zoptions);
+        ZMailbox zmbx = ZMailbox.getMailbox(zoptions);
+        if (zmbx != null) {
+            zmbx.setName(target.getName()); /* need this when logging in using another user's auth */
+        }
+        return zmbx;
     }
     protected void getMountpointTarget(DavContext ctxt) throws ServiceException {
         ZAuthToken zat = AuthProvider.getAuthToken(ctxt.getAuthAccount()).toZAuthToken();

--- a/store/src/java/com/zimbra/cs/filter/FilterUtil.java
+++ b/store/src/java/com/zimbra/cs/filter/FilterUtil.java
@@ -31,7 +31,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.commons.lang.StringEscapeUtils;
+
 import javax.mail.Address;
 import javax.mail.Header;
 import javax.mail.MessagingException;
@@ -40,6 +40,7 @@ import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
 
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.jsieve.exception.SyntaxException;
 
@@ -257,7 +258,11 @@ public final class FilterUtil {
         zoptions.setNoSession(true);
         zoptions.setTargetAccount(account.getId());
         zoptions.setTargetAccountBy(AccountBy.id);
-        return ZMailbox.getMailbox(zoptions);
+        ZMailbox zmbx = ZMailbox.getMailbox(zoptions);
+        if (zmbx != null) {
+            zmbx.setName(account.getName()); /* need this when logging in using another user's auth */
+        }
+        return zmbx;
     }
 
     public static final String HEADER_FORWARDED = "X-Zimbra-Forwarded";
@@ -850,7 +855,7 @@ public final class FilterUtil {
      * @param matchedVariables a list of Matched Variables
      * @param sourceStr text string that may contain "variable-ref" (RFC 5229 Section 3.)
      * @return Replaced text string
-     * @throws SyntaxException 
+     * @throws SyntaxException
      */
     public static String replaceVariables(ZimbraMailAdapter mailAdapter, String sourceStr) throws SyntaxException {
         if (null == mailAdapter) {
@@ -860,7 +865,7 @@ public final class FilterUtil {
             return sourceStr;
         }
         validateVariableIndex(sourceStr);
-        
+
         try {
             Require.checkCapability(mailAdapter, CAPABILITY_VARIABLES);
         } catch (SyntaxException e) {
@@ -989,7 +994,7 @@ public final class FilterUtil {
 			}
 		}
 		processedStr = sb.toString();
-		
+
 		return processedStr;
 	}
 
@@ -1035,7 +1040,7 @@ public final class FilterUtil {
         }
         return buffer.toString();
     }
-    
+
     /**
      * Returns true if the char is a special char for regex
      */

--- a/store/src/java/com/zimbra/cs/mailbox/MailSender.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailSender.java
@@ -805,7 +805,11 @@ public class MailSender {
                     options.setTargetAccount(targetUser.getId());
                     options.setTargetAccountBy(AccountBy.id);
                 }
-                return ZMailbox.getMailbox(options);
+                ZMailbox zmbx = ZMailbox.getMailbox(options);
+                if (zmbx != null) {
+                    zmbx.setName(targetUser.getName());
+                }
+                return zmbx;
             }
         } catch (Exception e) {
             ZimbraLog.smtp.info("could not fetch home mailbox for delegated send", e);

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -763,7 +763,7 @@ public class Mailbox implements MailboxStore {
         // index init done in open()
         lock = new MailboxLock(data.accountId, this);
     }
-    
+
     public void setGalSyncMailbox(boolean galSyncMailbox) {
         this.galSyncMailbox = galSyncMailbox;
     }
@@ -1878,7 +1878,7 @@ public class Mailbox implements MailboxStore {
             SortedSet<String> clientIds= new TreeSet<String>(mData.configKeys);
             for (String key : clientIds) {
                 if (pattern.matcher(key).matches()) {
-                   
+
                     previousDeviceId = key;
                     if (previousDeviceId.indexOf(":") != -1) {
                         int index = previousDeviceId.indexOf(":");
@@ -1888,7 +1888,7 @@ public class Mailbox implements MailboxStore {
                     if (!tmp.contains("build")) {
                         break;
                     }
-                    
+
                 }
             }
         }
@@ -5899,6 +5899,7 @@ public class Mailbox implements MailboxStore {
                         options.setUri(uri);
                         options.setNoSession(true);
                         ZMailbox zmbox = ZMailbox.getMailbox(options);
+                        zmbox.setAccountId(orgAccount.getId());
                         zmbox.iCalReply(ical, sender);
                     } catch (IOException e) {
                         throw ServiceException.FAILURE("Error while posting REPLY to organizer mailbox host", e);
@@ -6055,16 +6056,16 @@ public class Mailbox implements MailboxStore {
         }
 
         StagedBlob staged = sm.stage(blob, this);
-        
+
         Account account = this.getAccount();
         boolean localMsgMarkedRead = false;
-        if (account.getPrefMailForwardingAddress() != null && account.isFeatureMailForwardingEnabled() 
+        if (account.getPrefMailForwardingAddress() != null && account.isFeatureMailForwardingEnabled()
             && account.isFeatureMarkMailForwardedAsRead()) {
             ZimbraLog.mailbox.debug("Marking forwarded message as read.");
             flags = flags & ~Flag.BITMASK_UNREAD;
             localMsgMarkedRead = true;
-        } 
-       
+        }
+
 
         lock.lock();
         try {
@@ -6073,7 +6074,7 @@ public class Mailbox implements MailboxStore {
                         rcptEmail, dinfo, customData, dctxt, staged);
                 if (localMsgMarkedRead && account.getPrefMailSendReadReceipts().isAlways()) {
                     SendDeliveryReport.sendReport(account, message, true, null, null);
-                } 
+                }
                 return message;
             } finally {
                 if (deleteIncoming) {
@@ -8760,6 +8761,7 @@ public class Mailbox implements MailboxStore {
         zoptions.setTargetAccount(shareOwner.getId());
         zoptions.setTargetAccountBy(Key.AccountBy.id);
         ZMailbox zmbx = ZMailbox.getMailbox(zoptions);
+        zmbx.setName(shareOwner.getName()); /* need this when logging in using another user's auth */
         ZFolder zfolder = zmbx.getFolderByUuid(shloc.getUuid());
 
         if (zfolder != null) {

--- a/store/src/java/com/zimbra/cs/mailbox/calendar/cache/CtagInfoCache.java
+++ b/store/src/java/com/zimbra/cs/mailbox/calendar/cache/CtagInfoCache.java
@@ -56,7 +56,7 @@ import com.zimbra.cs.util.AccountUtil;
 
 public class CtagInfoCache {
 
-    private MemcachedMap<CalendarKey, CtagInfo> mMemcachedLookup;
+    private final MemcachedMap<CalendarKey, CtagInfo> mMemcachedLookup;
 
     CtagInfoCache() {
         ZimbraMemcachedClient memcachedClient = MemcachedConnector.getClient();

--- a/store/src/java/com/zimbra/cs/service/mail/GetMiniCal.java
+++ b/store/src/java/com/zimbra/cs/service/mail/GetMiniCal.java
@@ -27,6 +27,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
+import com.zimbra.client.ZMailbox;
+import com.zimbra.client.ZMailbox.ZGetMiniCalResult;
+import com.zimbra.client.ZMailbox.ZMiniCalError;
+import com.zimbra.common.account.Key;
+import com.zimbra.common.account.Key.AccountBy;
 import com.zimbra.common.calendar.ICalTimeZone;
 import com.zimbra.common.calendar.WellKnownTimeZones;
 import com.zimbra.common.localconfig.LC;
@@ -39,8 +44,6 @@ import com.zimbra.cs.account.AccountServiceException;
 import com.zimbra.cs.account.AuthToken;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.Server;
-import com.zimbra.common.account.Key;
-import com.zimbra.common.account.Key.AccountBy;
 import com.zimbra.cs.mailbox.Folder;
 import com.zimbra.cs.mailbox.MailItem;
 import com.zimbra.cs.mailbox.MailServiceException;
@@ -51,17 +54,14 @@ import com.zimbra.cs.mailbox.OperationContext;
 import com.zimbra.cs.mailbox.calendar.IcalXmlStrMap;
 import com.zimbra.cs.mailbox.calendar.Util;
 import com.zimbra.cs.mailbox.calendar.cache.CalSummaryCache;
+import com.zimbra.cs.mailbox.calendar.cache.CalSummaryCache.CalendarDataResult;
 import com.zimbra.cs.mailbox.calendar.cache.CalendarCacheManager;
 import com.zimbra.cs.mailbox.calendar.cache.CalendarData;
 import com.zimbra.cs.mailbox.calendar.cache.CalendarItemData;
 import com.zimbra.cs.mailbox.calendar.cache.InstanceData;
-import com.zimbra.cs.mailbox.calendar.cache.CalSummaryCache.CalendarDataResult;
 import com.zimbra.cs.service.util.ItemId;
 import com.zimbra.cs.service.util.ItemIdFormatter;
 import com.zimbra.cs.util.AccountUtil;
-import com.zimbra.client.ZMailbox;
-import com.zimbra.client.ZMailbox.ZGetMiniCalResult;
-import com.zimbra.client.ZMailbox.ZMiniCalError;
 import com.zimbra.soap.ZimbraSoapContext;
 
 /*
@@ -233,7 +233,7 @@ public class GetMiniCal extends CalendarRequest {
                 if (partStat == null)
                     partStat = item.getDefaultData().getPartStat();
                 if (IcalXmlStrMap.PARTSTAT_DECLINED.equals(partStat))
-                    continue;   
+                    continue;
                 Long start = inst.getDtStart();
                 if (start != null) {
                     String datestampStart = getDatestamp(cal, start);
@@ -272,6 +272,7 @@ public class GetMiniCal extends CalendarRequest {
             zoptions.setTargetAccountBy(AccountBy.id);
             zoptions.setNoSession(true);
             ZMailbox zmbx = ZMailbox.getMailbox(zoptions);
+            zmbx.setName(target.getName()); /* need this when logging in using another user's auth */
             String remoteIds[] = new String[remoteFolders.size()];
             for (int i=0; i < remoteIds.length; i++) remoteIds[i] = remoteFolders.get(i).toString();
             ZGetMiniCalResult result = zmbx.getMiniCal(rangeStart, rangeEnd, remoteIds);

--- a/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
@@ -503,6 +503,7 @@ public class ItemAction extends MailDocumentHandler {
                 zoptions.setTargetAccount(owner.getId());
                 zoptions.setTargetAccountBy(Key.AccountBy.id);
                 ZMailbox zmbx = ZMailbox.getMailbox(zoptions);
+                zmbx.setName(owner.getName()); /* need this when logging in using another user's auth */
                 ZFolder zfolder = zmbx.getFolderById(iidFolder.toString(zsc.getAuthtokenAccountId()));
                 if (!(zfolder instanceof ZMountpoint))
                     break;

--- a/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
@@ -616,6 +616,7 @@ public class ItemActionHelper {
         zoptions.setTargetAccount(target.getId());
         zoptions.setTargetAccountBy(Key.AccountBy.id);
         ZMailbox zmbx = ZMailbox.getMailbox(zoptions);
+        zmbx.setName(target.getName()); /* need this when logging in using another user's auth */
 
         // check for mountpoints before going any further...
         ZFolder zfolder = zmbx.getFolderById(mIidFolder.toString(mAuthenticatedAccount));

--- a/store/src/java/com/zimbra/cs/service/mail/Search.java
+++ b/store/src/java/com/zimbra/cs/service/mail/Search.java
@@ -451,6 +451,7 @@ public class Search extends MailDocumentHandler  {
         zoptions.setTargetAccountBy(AccountBy.id);
         zoptions.setNoSession(true);
         ZMailbox zmbx = ZMailbox.getMailbox(zoptions);
+        zmbx.setName(target.getName()); /* need this when logging in using another user's auth */
 
         Element resp = zmbx.invoke(req);
         for (Element hit : resp.listElements()) {

--- a/store/src/java/com/zimbra/cs/service/mail/SendInviteReply.java
+++ b/store/src/java/com/zimbra/cs/service/mail/SendInviteReply.java
@@ -476,7 +476,11 @@ public class SendInviteReply extends CalendarRequest {
         zoptions.setNoSession(true);
         zoptions.setTargetAccount(targetAcct.getId());
         zoptions.setTargetAccountBy(Key.AccountBy.id);
-        return ZMailbox.getMailbox(zoptions);
+        ZMailbox zmbx = ZMailbox.getMailbox(zoptions);
+        if (zmbx != null) {
+            zmbx.setName(targetAcct.getName()); /* need this when logging in using another user's auth */
+        }
+        return zmbx;
     }
 
     private static AddInviteResult sendAddInvite(ZMailbox zmbx, OperationContext octxt, Message msg)


### PR DESCRIPTION
PERM_DENIED spam in mailbox.log as a result of ZMailbox calling GetInfoRequest when it doesn't have the capabilities for that API to get the account ID when authenticating as another user.

Essentially, store the account ID / account name (used for logging) when constructing ZMailbox if know them and know might not have perms to GetInfo