### PR TITLE
zcs-2915:Few mimes are discarded on LMTP inject

### DIFF
--- a/store/src/java/com/zimbra/cs/filter/RuleManager.java
+++ b/store/src/java/com/zimbra/cs/filter/RuleManager.java
@@ -406,10 +406,10 @@ public final class RuleManager {
         };
 
         try {
+            boolean applyRules = true;
             Account account = mailbox.getAccount();
             for (String filter : filters) {
                 // Determine whether to apply rules
-                boolean applyRules = true;
                 Node node = getRulesNode(account, filter);
 
                 if (null == node) {
@@ -419,6 +419,7 @@ public final class RuleManager {
                         !account.getBooleanAttr(Provisioning.A_zimbraSpamApplyUserFilters, false)) {
                     // Don't apply user filters to spam by default
                     applyRules = false;
+                    break;
                 }
                 if (applyRules) {
                     if (filter.equals(FILTER_RULES_CACHE_KEY)) {
@@ -435,8 +436,10 @@ public final class RuleManager {
                     mailAdapter.resetCapabilities();
                 }
             }
-            mailAdapter.executeAllActions();
-            addedMessageIds = mailAdapter.getAddedMessageIds();
+            if (applyRules) {
+                mailAdapter.executeAllActions();
+                addedMessageIds = mailAdapter.getAddedMessageIds();
+            }
         } catch (ErejectException ex) {
             throw DeliveryServiceException.DELIVERY_REJECTED(ex.getMessage(), ex);
         } catch (Exception e) {


### PR DESCRIPTION


[Bug]
Five test scripts are failed because of a bug introduced by the fix of zcs-168.  Any spammy message delivered to the user with empty filter rules was discarded.

[Root cause]
Originally when the triggering message was spammy, the Sieve filter is neither evaluated nor executed.  After the fix of zcs-168, the Sieve filter was indeed not evaluated and an empty action list was generated.  ZCS, however, mistakenly executed such empty action list; the empty action list meant that the message should be discarded.

[Fix]
When the message is spammy and the attribute 'zimbraSpamApplyUserFilters' is FALSE (default), ZCS will not evaluate and execute the filter rule.

--------
Unit test:
ant test-all --> PASS

(1) Automation test : 105 scripts listed in the automation_list.txt --> PASS
([automation_list.txt](https://github.com/Zimbra/zm-mailbox/files/1328871/automation_list.txt))
This list includes:
* scripts listed up in zcs-2915  --> PASS
/opt/qa/soapvalidator/data/soapvalidator/MailClient/Mail/Bugs/bug_28727.xml
/opt/qa/soapvalidator/data/soapvalidator/MailClient/Mail/SMTP/MailSpamLifetime.xml
/opt/qa/soapvalidator/data/soapvalidator/MailClient/Search/Junk/search_junk.xml
/opt/qa/soapvalidator/data/soapvalidator/MailClient/Spam/message_action_spam.xml
/opt/qa/soapvalidator/data/soapvalidator/MailClient/Spam/spamBasic.xml
* scripts under the data/soapvalidator/MailClient/Filters/Sieve/  --> PASS
* scripts of SPAM related --> PASS
data/soapvalidator/MailClient/Folders/searchfolder_modify.xml
data/soapvalidator/MailClient/Prefs/ForwardedMail/zimbraPrefMailForwardingAddress.xml
data/soapvalidator/MailClient/Search/Bugs/bug62687.xml
data/soapvalidator/MailClient/Spam/dspamBasic.xml

(2) Automation test: data/soapvalidator/MailClient/DataSource/Bugs/DataSource_FromAddress.xml  SendMsgRequest --> PASS (No message will be discarded any more)
  (Accessing the external account (Yahoo.com) was still failed due to the bad credential)

[Note] Some of the scripts were failed at the part where the bug was not related to the affected area of the zcs-168. 
