### PR TITLE
zcs-282:SIEVE:notify:Capitalize the header name

### DIFF
--- a/store/src/java/com/zimbra/cs/filter/FilterUtil.java
+++ b/store/src/java/com/zimbra/cs/filter/FilterUtil.java
@@ -709,7 +709,7 @@ public final class FilterUtil {
                   "body".equalsIgnoreCase(headerName))) {
                 List<String> values = mailtoParams.get(headerName);
                 for (String value : values) {
-                    notification.addHeader(headerName, value);
+                    notification.addHeaderLine(headerName + ": " + value);
                 }
             }
         }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/NotifyMailto.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/NotifyMailto.java
@@ -44,6 +44,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.TreeMap;
 
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.AddressException;
@@ -251,7 +252,7 @@ public class NotifyMailto extends Notify {
             method = FilterUtil.replaceVariables(mailAdapter, method);
         }
         
-        mailtoParams = new HashMap<String, List<String>>();
+        mailtoParams = new TreeMap<String, List<String>>(String.CASE_INSENSITIVE_ORDER);
         try {
             URL url = new URL(method);
             mailto = FilterUtil.replaceVariables(mailAdapter, url.getPath());
@@ -275,12 +276,13 @@ public class NotifyMailto extends Notify {
                     String headerName = null;
                     String headerValue = null;
                     try {
-                        headerName = URLDecoder.decode(token[0].toLowerCase(), "UTF-8");
+                        headerName = URLDecoder.decode(token[0], "UTF-8");
                     } catch (UnsupportedEncodingException e)  {
                         // No exception should be thrown because the charset is always "UTF-8"
                     } catch (IllegalArgumentException e) {
-                        headerName = token[0].toLowerCase();
+                        headerName = token[0];
                     }
+                    headerName = Character.toUpperCase(headerName.charAt(0)) + headerName.substring(1);
                     if (token.length == 1) {
                         // The value must be empty
                         headerValue = "";


### PR DESCRIPTION
Headers specified by mailto: URI should capitalize the first letter

[Problem]
The name of the URL headers specified in the "mailto:" parameter was
always lower-cased; RFC says the the first letter of the added header
name should be capitalized though.

[Fix]
* The name of the URL headers will be capitalized. Although the MIME
  header name is defined as only ASCII character's string, if the
  header name should consisted of non-ascii characters, the first
  letter of the header name will not changed.

* Fixed an unit test case "testNotifyMethodCapability_OnlineYes":
  It was failed because the filter string was not grammatically correct,
  and it threw an exception.

----
[Unit test] ant test-all (note) --> PASS
[Automation script] The scripts under data/soapvalidator/MailClient/Filters/Sieve/ (97 scripts) --> PASS

(note) Except for the src/java-test/com/zimbra/cs/index/LuceneIndexTest.java; it was failed before this fix.