### PR TITLE
Bug 98011: Enable UseGCLogFileRotation per default

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -605,15 +605,15 @@ public final class LC {
             " -Dorg.apache.jasper.compiler.disablejsr199=true" +
             " -XX:+UseConcMarkSweepGC" +
             " -XX:SoftRefLRUPolicyMSPerMB=1" +
+            " -XX:-OmitStackTraceInFastThrow" +
             " -verbose:gc" +
             " -XX:+PrintGCDetails" +
             " -XX:+PrintGCDateStamps" +
             " -XX:+PrintGCApplicationStoppedTime" +
-            " -XX:-OmitStackTraceInFastThrow" +
             " -Xloggc:/opt/zimbra/log/gc.log" +
-            " -XX:-UseGCLogFileRotation" +
+            " -XX:+UseGCLogFileRotation" +
             " -XX:NumberOfGCLogFiles=20" +
-            " -XX:GCLogFileSize=4096K");
+            " -XX:GCLogFileSize=10M");
     @Supported
     public static final KnownKey mailboxd_pidfile = KnownKey.newKey("${zimbra_log_directory}/mailboxd.pid");
 


### PR DESCRIPTION
Right now the file `/opt/zimbra/log/gc.log` grows slowly but steadily
and without bounds until the mailbox process is restarted.

This was added in [bug 85857](https://bugzilla.zimbra.com/show_bug.cgi?id=85857) but it looks like the option was accidently
kept to off.

This patch also increases the rotation limit from 4M to 10M to keep the
file from being rotated too often.

Since the file `/opt/zimbra/log/gc.log.0.current` is created as root, the
permissions have to be fixed up as they are done for `/opt/zimbra/log/gc.log`
without rotation. The required change can be found in zimbra/zm-launcher#2