### PR TITLE
adjust Jaxb for TestDataSourceResponse, fix ZMailbox::testDataSource and add SOAP test

### DIFF
--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -217,6 +217,7 @@ import com.zimbra.soap.mail.type.ModifyContactSpec;
 import com.zimbra.soap.mail.type.NewContactAttr;
 import com.zimbra.soap.mail.type.NewContactGroupMember;
 import com.zimbra.soap.mail.type.NewSearchFolderSpec;
+import com.zimbra.soap.mail.type.TestDataSource;
 import com.zimbra.soap.type.AccountSelector;
 import com.zimbra.soap.type.AccountWithModifications;
 import com.zimbra.soap.type.CalDataSource;
@@ -4691,12 +4692,18 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
         DataSource jaxbObj = source.toJaxb();
         req.setDataSource(jaxbObj);
         TestDataSourceResponse resp = (TestDataSourceResponse)invokeJaxb(req);
-        boolean success = resp.getSuccess();
-        if(!success) {
-            return resp.getError();
-        } else {
-            return null;
+        List<TestDataSource> dataSources = resp.getDataSources();
+        int success = 0;
+        if(dataSources.size() > 0 && dataSources.get(0) != null) {
+            TestDataSource ds = dataSources.get(0);
+            success = ds.getSuccess();
+            if(success < 1) {
+                return ds.getError();
+            } else {
+                return null;
+            }
         }
+        return null;
     }
 
     public List<ZDataSource> getAllDataSources() throws ServiceException {

--- a/soap/src/java/com/zimbra/soap/mail/message/TestDataSourceResponse.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/TestDataSourceResponse.java
@@ -17,53 +17,62 @@
 
 package com.zimbra.soap.mail.message;
 
-import com.google.common.base.Objects;
+import java.util.Collections;
+import java.util.List;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElements;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import com.google.common.base.Objects;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.zimbra.common.soap.MailConstants;
-import com.zimbra.soap.type.ZmBoolean;
+import com.zimbra.soap.mail.type.TestDataSource;
 
 @XmlAccessorType(XmlAccessType.NONE)
 @XmlRootElement(name=MailConstants.E_TEST_DATA_SOURCE_RESPONSE)
 public class TestDataSourceResponse {
-
     /**
-     * @zm-api-field-tag success
-     * @zm-api-field-description Flags whether the test was successful
+     * @zm-api-field-description Data source information
      */
-    @XmlAttribute(name=MailConstants.A_DS_SUCCESS /* success */, required=true)
-    private final ZmBoolean success;
+    @XmlElements({
+        @XmlElement(name=MailConstants.E_DS_IMAP /* imap */, type=TestDataSource.class),
+        @XmlElement(name=MailConstants.E_DS_POP3 /* pop3 */, type=TestDataSource.class),
+        @XmlElement(name=MailConstants.E_DS_CALDAV /* caldav */, type=TestDataSource.class),
+        @XmlElement(name=MailConstants.E_DS_YAB /* yab */, type=TestDataSource.class),
+        @XmlElement(name=MailConstants.E_DS_RSS /* rss */, type=TestDataSource.class),
+        @XmlElement(name=MailConstants.E_DS_GAL /* gal */, type=TestDataSource.class),
+        @XmlElement(name=MailConstants.E_DS_CAL /* cal */, type=TestDataSource.class),
+        @XmlElement(name=MailConstants.E_DS_OAUTH /* oauth */, type=TestDataSource.class),
+        @XmlElement(name=MailConstants.E_DS_UNKNOWN /* unknown */, type=TestDataSource.class)
+    })
+    private List<TestDataSource> dataSources = Lists.newArrayList();
 
-    /**
-     * @zm-api-field-tag error-message
-     * @zm-api-field-description Error message
-     */
-    @XmlAttribute(name=MailConstants.A_DS_ERROR /* error */, required=false)
-    private String error;
+    public void setDataSources(Iterable <TestDataSource> dataSources) {
+        this.dataSources.clear();
+        if (dataSources != null) {
+            Iterables.addAll(this.dataSources,dataSources);
+        }
+    }
 
-    /**
-     * no-argument constructor wanted by JAXB
-     */
-    @SuppressWarnings("unused")
     private TestDataSourceResponse() {
-        this(false);
     }
 
-    public TestDataSourceResponse(boolean success) {
-        this.success = ZmBoolean.fromBool(success);
+    public TestDataSourceResponse addDataSource(TestDataSource dataSource) {
+        this.dataSources.add(dataSource);
+        return this;
     }
 
-    public void setError(String error) { this.error = error; }
-    public boolean getSuccess() { return ZmBoolean.toBool(success); }
-    public String getError() { return error; }
+    public List<TestDataSource> getDataSources() {
+        return Collections.unmodifiableList(dataSources);
+    }
 
     public Objects.ToStringHelper addToStringInfo(Objects.ToStringHelper helper) {
         return helper
-            .add("success", success)
-            .add("error", error);
+            .add("dataSources", dataSources);
     }
 
     @Override

--- a/soap/src/java/com/zimbra/soap/mail/type/TestDataSource.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/TestDataSource.java
@@ -1,0 +1,44 @@
+package com.zimbra.soap.mail.type;
+
+import javax.xml.bind.annotation.XmlAttribute;
+
+import com.zimbra.common.soap.MailConstants;
+
+public class TestDataSource {
+    /**
+     * @zm-api-field-tag data-source-success
+     * @zm-api-field-description 0 if data source test failed, 1 if test succeeded
+     */
+    @XmlAttribute(name = MailConstants.A_DS_SUCCESS /* success */, required = true)
+    private int success;
+
+    /**
+     * @zm-api-field-tag data-source-error
+     * @zm-api-field-description error message passed by DatImport::test method of the datasource being tested
+     */
+    @XmlAttribute(name = MailConstants.A_DS_ERROR /* error */, required = false)
+    private String error;
+
+    public TestDataSource() {
+        this.success = 1;
+        this.error = null;
+    }
+
+    public TestDataSource(String error) {
+        if(error != null && !error.isEmpty()) {
+            success = 0;
+        }
+        this.error = error;
+    }
+
+    public TestDataSource(int success, String error) {
+        this.success = success;
+        this.error = error;
+    }
+
+    public void setSuccess(int success) { this.success = success; }
+    public int getSuccess() { return success; }
+
+    public void setError(String error) { this.error = error; }
+    public String getError() { return this.error; }
+}

--- a/store/src/java/com/zimbra/qa/unittest/TestDataSource.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestDataSource.java
@@ -16,6 +16,13 @@
  */
 package com.zimbra.qa.unittest;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -26,13 +33,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 
 import com.google.common.collect.Lists;
 import com.zimbra.client.ZCalDataSource;
@@ -438,12 +438,33 @@ public class TestDataSource {
     }
 
     /**
+     * Tests {@link ZMailbox#testDataSource}.
+     */
+    @Test
+    public void testBadDataSource() throws Exception {
+        ZMailbox mbox = TestUtil.getZMailbox(USER_NAME);
+        // Create data source
+        Provisioning prov = Provisioning.getInstance();
+        Map<String, Object> attrs = new HashMap<String, Object>();
+        attrs.put(Provisioning.A_zimbraDataSourceEnabled, LdapConstants.LDAP_FALSE);
+        attrs.put(Provisioning.A_zimbraDataSourceHost, "testhost");
+        attrs.put(Provisioning.A_zimbraDataSourcePort, "0");
+        attrs.put(Provisioning.A_zimbraDataSourceUsername, "testuser");
+        attrs.put(Provisioning.A_zimbraDataSourcePassword, "testpass");
+        attrs.put(Provisioning.A_zimbraDataSourceFolderId, "1");
+        attrs.put(Provisioning.A_zimbraDataSourceConnectionType, ConnectionType.cleartext.toString());
+        prov.createDataSource(account, DataSourceType.pop3, NAME_PREFIX + DS_NAME, attrs);
+        ZDataSource zds = TestUtil.getDataSource(mbox, NAME_PREFIX + DS_NAME);
+        String testVal = mbox.testDataSource(zds);
+        assertNotNull("ZMailbox::testDataSource should return an error", testVal);
+    }
+
+    /**
      * Creates a folder that syncs to another folder via RSS, and verifies that an
      * RSS data source was implicitly created.
      */
     @Test
-    public void testRss()
-    throws Exception {
+    public void testRss() throws Exception {
         // Create source folder, make it publicly readable, and add a message to it.
         ZMailbox mbox = TestUtil.getZMailbox(USER_NAME);
         String parentId = Integer.toString(Mailbox.ID_FOLDER_USER_ROOT);


### PR DESCRIPTION
Jaxb classes for TestDataSourceResponse do not match what the response looks like and therefore ZMailbox::testDataSource does not properly report errors when DataImport::test method fails.
There was no test that validated ZMailbox::testDataSource for negative behavior - add this test.

This change is part of ZCS-2976, because this problem blocks me from creating fully tested Data Source implementation for ZCS-2976