### PR TITLE
ZCS-2349 - Ensure Remote IMAP sees fresh view of account

### DIFF
--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -1122,7 +1122,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
         emailAddress = fixupAccountName(emailAddress);
 
         Account account = accountCache.getByName(emailAddress);
-        if (account == null) {
+        if (loadFromMaster || account == null) {
             account = getAccountByQuery(
                     mDIT.mailBranchBaseDN(),
                     filterFactory.accountByName(emailAddress),

--- a/store/src/java/com/zimbra/cs/security/sasl/PlainAuthenticator.java
+++ b/store/src/java/com/zimbra/cs/security/sasl/PlainAuthenticator.java
@@ -34,7 +34,7 @@ import java.util.Map;
 
 public class PlainAuthenticator extends Authenticator {
     public static final String MECHANISM = "PLAIN";
-    
+
     public PlainAuthenticator(AuthenticatorUser user) {
         super(MECHANISM, user);
     }
@@ -90,7 +90,7 @@ public class PlainAuthenticator extends Authenticator {
             ZimbraLog.account.info("authentication failed for " + authenticateId + " (no such account)");
             return null;
         }
-        
+
         // make sure the protocol is enabled for the user
         if (!isProtocolEnabled(authAccount, protocol)) {
             ZimbraLog.account.info("Authentication failed - %s not enabled for %s", protocol, authAccount.getName());

--- a/store/src/java/com/zimbra/cs/security/sasl/PlainAuthenticator.java
+++ b/store/src/java/com/zimbra/cs/security/sasl/PlainAuthenticator.java
@@ -25,6 +25,7 @@ import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.auth.AuthContext;
+import com.zimbra.cs.imap.ImapDaemon;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -85,7 +86,11 @@ public class PlainAuthenticator extends Authenticator {
                                           AuthContext.Protocol protocol, String origRemoteIp, String remoteIp, String userAgent)
     throws ServiceException {
         Provisioning prov = Provisioning.getInstance();
-        Account authAccount = prov.get(Key.AccountBy.name, authenticateId);
+        boolean loadFromMaster = false;
+        if (!ImapDaemon.isRunningImapInsideMailboxd()) {
+            loadFromMaster = true;
+        }
+        Account authAccount = prov.get(Key.AccountBy.name, authenticateId, loadFromMaster);
         if (authAccount == null) {
             ZimbraLog.account.info("authentication failed for " + authenticateId + " (no such account)");
             return null;


### PR DESCRIPTION
When the IMAP code is executed as a separate process the shared `LdapProvisioning` object is no longer available.

This causes an issue since the in-memory cached view of the Account is not updated automatically when the mailbox processes the `ChangePassword` request.
This update forces an account reload if and only if we are operating inside the remote imapd process.
In the case of the embedded imap server there is no reason to do the update since LdapProvisioning contains a `write-through` cache of account objects.
