### PR TITLE
ZCS-3132 Fixing NG attributes

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -11587,24 +11587,8 @@ public class ZAttrProvisioning {
      *
      * @since ZCS 8.8.5
      */
-    @ZAttr(id=2132)
-    public static final String A_zimbraNetworkAdminNGEnabled = "zimbraNetworkAdminNGEnabled";
-
-    /**
-     * Whether to enable zimbra network new generation backup module.
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2131)
-    public static final String A_zimbraNetworkBackupNGEnabled = "zimbraNetworkBackupNGEnabled";
-
-    /**
-     * Whether to enable zimbra network new generation HSM module.
-     *
-     * @since ZCS 8.8.5
-     */
     @ZAttr(id=2130)
-    public static final String A_zimbraNetworkHSMNGEnabled = "zimbraNetworkHSMNGEnabled";
+    public static final String A_zimbraNetworkAdminNGEnabled = "zimbraNetworkAdminNGEnabled";
 
     /**
      * Contents of a signed Zimbra license key - an XML string.
@@ -11621,9 +11605,7 @@ public class ZAttrProvisioning {
     public static final String A_zimbraNetworkMobileNGEnabled = "zimbraNetworkMobileNGEnabled";
 
     /**
-     * Deprecated since: 8.8.5. This attribute has been replaced with
-     * individual attributes. Orig desc: Whether to enable zimbra network new
-     * generation modules.
+     * Whether to enable zimbra network new generation modules.
      *
      * @since ZCS 8.8.0
      */

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9372,10 +9372,9 @@ TODO: delete them permanently from here
 <desc>outgoing sieve script defined by admin (not able to edit and view from the end user) applied after the end user filter rule</desc>
 </attr>
 
-<attr id="2117" name="zimbraNetworkModulesNGEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mailbox" since="8.8.0" deprecatedSince="8.8.5">
+<attr id="2117" name="zimbraNetworkModulesNGEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mailbox" since="8.8.0">
   <globalConfigValue>TRUE</globalConfigValue>
   <desc>Whether to enable zimbra network new generation modules.</desc>
-  <deprecateDesc>This attribute has been replaced with individual attributes</deprecateDesc>
 </attr>
 
 <attr id="2118" name="zimbraNetworkMobileNGEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mailbox" since="8.8.0" >
@@ -9442,17 +9441,7 @@ TODO: delete them permanently from here
   <desc>End-user email address verification status</desc>
 </attr>
 
-<attr id="2130" name="zimbraNetworkHSMNGEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mailbox" since="8.8.5">
-  <globalConfigValue>FALSE</globalConfigValue>
-  <desc>Whether to enable zimbra network new generation HSM module.</desc>
-</attr>
-
-<attr id="2131" name="zimbraNetworkBackupNGEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mailbox" since="8.8.5">
-  <globalConfigValue>FALSE</globalConfigValue>
-  <desc>Whether to enable zimbra network new generation backup module.</desc>
-</attr>
-
-<attr id="2132" name="zimbraNetworkAdminNGEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mailbox" since="8.8.5" >
+<attr id="2130" name="zimbraNetworkAdminNGEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mailbox" since="8.8.5" >
   <globalConfigValue>FALSE</globalConfigValue>
   <desc>Whether to enable zimbra network new generation admin module.</desc>
 </attr>

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -47521,7 +47521,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @since ZCS 8.8.5
      */
-    @ZAttr(id=2132)
+    @ZAttr(id=2130)
     public boolean isNetworkAdminNGEnabled() {
         return getBooleanAttr(Provisioning.A_zimbraNetworkAdminNGEnabled, false, true);
     }
@@ -47534,7 +47534,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @since ZCS 8.8.5
      */
-    @ZAttr(id=2132)
+    @ZAttr(id=2130)
     public void setNetworkAdminNGEnabled(boolean zimbraNetworkAdminNGEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraNetworkAdminNGEnabled, zimbraNetworkAdminNGEnabled ? Provisioning.TRUE : Provisioning.FALSE);
@@ -47550,7 +47550,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @since ZCS 8.8.5
      */
-    @ZAttr(id=2132)
+    @ZAttr(id=2130)
     public Map<String,Object> setNetworkAdminNGEnabled(boolean zimbraNetworkAdminNGEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraNetworkAdminNGEnabled, zimbraNetworkAdminNGEnabled ? Provisioning.TRUE : Provisioning.FALSE);
@@ -47564,7 +47564,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @since ZCS 8.8.5
      */
-    @ZAttr(id=2132)
+    @ZAttr(id=2130)
     public void unsetNetworkAdminNGEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraNetworkAdminNGEnabled, "");
@@ -47579,154 +47579,10 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @since ZCS 8.8.5
      */
-    @ZAttr(id=2132)
+    @ZAttr(id=2130)
     public Map<String,Object> unsetNetworkAdminNGEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraNetworkAdminNGEnabled, "");
-        return attrs;
-    }
-
-    /**
-     * Whether to enable zimbra network new generation backup module.
-     *
-     * @return zimbraNetworkBackupNGEnabled, or false if unset
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2131)
-    public boolean isNetworkBackupNGEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraNetworkBackupNGEnabled, false, true);
-    }
-
-    /**
-     * Whether to enable zimbra network new generation backup module.
-     *
-     * @param zimbraNetworkBackupNGEnabled new value
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2131)
-    public void setNetworkBackupNGEnabled(boolean zimbraNetworkBackupNGEnabled) throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraNetworkBackupNGEnabled, zimbraNetworkBackupNGEnabled ? Provisioning.TRUE : Provisioning.FALSE);
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Whether to enable zimbra network new generation backup module.
-     *
-     * @param zimbraNetworkBackupNGEnabled new value
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2131)
-    public Map<String,Object> setNetworkBackupNGEnabled(boolean zimbraNetworkBackupNGEnabled, Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraNetworkBackupNGEnabled, zimbraNetworkBackupNGEnabled ? Provisioning.TRUE : Provisioning.FALSE);
-        return attrs;
-    }
-
-    /**
-     * Whether to enable zimbra network new generation backup module.
-     *
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2131)
-    public void unsetNetworkBackupNGEnabled() throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraNetworkBackupNGEnabled, "");
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Whether to enable zimbra network new generation backup module.
-     *
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2131)
-    public Map<String,Object> unsetNetworkBackupNGEnabled(Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraNetworkBackupNGEnabled, "");
-        return attrs;
-    }
-
-    /**
-     * Whether to enable zimbra network new generation HSM module.
-     *
-     * @return zimbraNetworkHSMNGEnabled, or false if unset
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2130)
-    public boolean isNetworkHSMNGEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraNetworkHSMNGEnabled, false, true);
-    }
-
-    /**
-     * Whether to enable zimbra network new generation HSM module.
-     *
-     * @param zimbraNetworkHSMNGEnabled new value
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2130)
-    public void setNetworkHSMNGEnabled(boolean zimbraNetworkHSMNGEnabled) throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraNetworkHSMNGEnabled, zimbraNetworkHSMNGEnabled ? Provisioning.TRUE : Provisioning.FALSE);
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Whether to enable zimbra network new generation HSM module.
-     *
-     * @param zimbraNetworkHSMNGEnabled new value
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2130)
-    public Map<String,Object> setNetworkHSMNGEnabled(boolean zimbraNetworkHSMNGEnabled, Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraNetworkHSMNGEnabled, zimbraNetworkHSMNGEnabled ? Provisioning.TRUE : Provisioning.FALSE);
-        return attrs;
-    }
-
-    /**
-     * Whether to enable zimbra network new generation HSM module.
-     *
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2130)
-    public void unsetNetworkHSMNGEnabled() throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraNetworkHSMNGEnabled, "");
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Whether to enable zimbra network new generation HSM module.
-     *
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2130)
-    public Map<String,Object> unsetNetworkHSMNGEnabled(Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraNetworkHSMNGEnabled, "");
         return attrs;
     }
 
@@ -47865,9 +47721,7 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Deprecated since: 8.8.5. This attribute has been replaced with
-     * individual attributes. Orig desc: Whether to enable zimbra network new
-     * generation modules.
+     * Whether to enable zimbra network new generation modules.
      *
      * @return zimbraNetworkModulesNGEnabled, or true if unset
      *
@@ -47879,9 +47733,7 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Deprecated since: 8.8.5. This attribute has been replaced with
-     * individual attributes. Orig desc: Whether to enable zimbra network new
-     * generation modules.
+     * Whether to enable zimbra network new generation modules.
      *
      * @param zimbraNetworkModulesNGEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -47896,9 +47748,7 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Deprecated since: 8.8.5. This attribute has been replaced with
-     * individual attributes. Orig desc: Whether to enable zimbra network new
-     * generation modules.
+     * Whether to enable zimbra network new generation modules.
      *
      * @param zimbraNetworkModulesNGEnabled new value
      * @param attrs existing map to populate, or null to create a new map
@@ -47914,9 +47764,7 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Deprecated since: 8.8.5. This attribute has been replaced with
-     * individual attributes. Orig desc: Whether to enable zimbra network new
-     * generation modules.
+     * Whether to enable zimbra network new generation modules.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -47930,9 +47778,7 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Deprecated since: 8.8.5. This attribute has been replaced with
-     * individual attributes. Orig desc: Whether to enable zimbra network new
-     * generation modules.
+     * Whether to enable zimbra network new generation modules.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -35550,7 +35550,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @since ZCS 8.8.5
      */
-    @ZAttr(id=2132)
+    @ZAttr(id=2130)
     public boolean isNetworkAdminNGEnabled() {
         return getBooleanAttr(Provisioning.A_zimbraNetworkAdminNGEnabled, false, true);
     }
@@ -35563,7 +35563,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @since ZCS 8.8.5
      */
-    @ZAttr(id=2132)
+    @ZAttr(id=2130)
     public void setNetworkAdminNGEnabled(boolean zimbraNetworkAdminNGEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraNetworkAdminNGEnabled, zimbraNetworkAdminNGEnabled ? Provisioning.TRUE : Provisioning.FALSE);
@@ -35579,7 +35579,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @since ZCS 8.8.5
      */
-    @ZAttr(id=2132)
+    @ZAttr(id=2130)
     public Map<String,Object> setNetworkAdminNGEnabled(boolean zimbraNetworkAdminNGEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraNetworkAdminNGEnabled, zimbraNetworkAdminNGEnabled ? Provisioning.TRUE : Provisioning.FALSE);
@@ -35593,7 +35593,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @since ZCS 8.8.5
      */
-    @ZAttr(id=2132)
+    @ZAttr(id=2130)
     public void unsetNetworkAdminNGEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraNetworkAdminNGEnabled, "");
@@ -35608,154 +35608,10 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @since ZCS 8.8.5
      */
-    @ZAttr(id=2132)
+    @ZAttr(id=2130)
     public Map<String,Object> unsetNetworkAdminNGEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraNetworkAdminNGEnabled, "");
-        return attrs;
-    }
-
-    /**
-     * Whether to enable zimbra network new generation backup module.
-     *
-     * @return zimbraNetworkBackupNGEnabled, or false if unset
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2131)
-    public boolean isNetworkBackupNGEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraNetworkBackupNGEnabled, false, true);
-    }
-
-    /**
-     * Whether to enable zimbra network new generation backup module.
-     *
-     * @param zimbraNetworkBackupNGEnabled new value
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2131)
-    public void setNetworkBackupNGEnabled(boolean zimbraNetworkBackupNGEnabled) throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraNetworkBackupNGEnabled, zimbraNetworkBackupNGEnabled ? Provisioning.TRUE : Provisioning.FALSE);
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Whether to enable zimbra network new generation backup module.
-     *
-     * @param zimbraNetworkBackupNGEnabled new value
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2131)
-    public Map<String,Object> setNetworkBackupNGEnabled(boolean zimbraNetworkBackupNGEnabled, Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraNetworkBackupNGEnabled, zimbraNetworkBackupNGEnabled ? Provisioning.TRUE : Provisioning.FALSE);
-        return attrs;
-    }
-
-    /**
-     * Whether to enable zimbra network new generation backup module.
-     *
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2131)
-    public void unsetNetworkBackupNGEnabled() throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraNetworkBackupNGEnabled, "");
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Whether to enable zimbra network new generation backup module.
-     *
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2131)
-    public Map<String,Object> unsetNetworkBackupNGEnabled(Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraNetworkBackupNGEnabled, "");
-        return attrs;
-    }
-
-    /**
-     * Whether to enable zimbra network new generation HSM module.
-     *
-     * @return zimbraNetworkHSMNGEnabled, or false if unset
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2130)
-    public boolean isNetworkHSMNGEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraNetworkHSMNGEnabled, false, true);
-    }
-
-    /**
-     * Whether to enable zimbra network new generation HSM module.
-     *
-     * @param zimbraNetworkHSMNGEnabled new value
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2130)
-    public void setNetworkHSMNGEnabled(boolean zimbraNetworkHSMNGEnabled) throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraNetworkHSMNGEnabled, zimbraNetworkHSMNGEnabled ? Provisioning.TRUE : Provisioning.FALSE);
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Whether to enable zimbra network new generation HSM module.
-     *
-     * @param zimbraNetworkHSMNGEnabled new value
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2130)
-    public Map<String,Object> setNetworkHSMNGEnabled(boolean zimbraNetworkHSMNGEnabled, Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraNetworkHSMNGEnabled, zimbraNetworkHSMNGEnabled ? Provisioning.TRUE : Provisioning.FALSE);
-        return attrs;
-    }
-
-    /**
-     * Whether to enable zimbra network new generation HSM module.
-     *
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2130)
-    public void unsetNetworkHSMNGEnabled() throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraNetworkHSMNGEnabled, "");
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Whether to enable zimbra network new generation HSM module.
-     *
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 8.8.5
-     */
-    @ZAttr(id=2130)
-    public Map<String,Object> unsetNetworkHSMNGEnabled(Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraNetworkHSMNGEnabled, "");
         return attrs;
     }
 
@@ -35832,9 +35688,7 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Deprecated since: 8.8.5. This attribute has been replaced with
-     * individual attributes. Orig desc: Whether to enable zimbra network new
-     * generation modules.
+     * Whether to enable zimbra network new generation modules.
      *
      * @return zimbraNetworkModulesNGEnabled, or true if unset
      *
@@ -35846,9 +35700,7 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Deprecated since: 8.8.5. This attribute has been replaced with
-     * individual attributes. Orig desc: Whether to enable zimbra network new
-     * generation modules.
+     * Whether to enable zimbra network new generation modules.
      *
      * @param zimbraNetworkModulesNGEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -35863,9 +35715,7 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Deprecated since: 8.8.5. This attribute has been replaced with
-     * individual attributes. Orig desc: Whether to enable zimbra network new
-     * generation modules.
+     * Whether to enable zimbra network new generation modules.
      *
      * @param zimbraNetworkModulesNGEnabled new value
      * @param attrs existing map to populate, or null to create a new map
@@ -35881,9 +35731,7 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Deprecated since: 8.8.5. This attribute has been replaced with
-     * individual attributes. Orig desc: Whether to enable zimbra network new
-     * generation modules.
+     * Whether to enable zimbra network new generation modules.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -35897,9 +35745,7 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Deprecated since: 8.8.5. This attribute has been replaced with
-     * individual attributes. Orig desc: Whether to enable zimbra network new
-     * generation modules.
+     * Whether to enable zimbra network new generation modules.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/service/admin/GetAdminExtensionZimlets.java
+++ b/store/src/java/com/zimbra/cs/service/admin/GetAdminExtensionZimlets.java
@@ -55,14 +55,12 @@ public class GetAdminExtensionZimlets extends AdminDocumentHandler  {
 
         boolean mobileNGEnabled = true;
         boolean networkAdminEnabled = true;
-        boolean hsmNGEnabled = true;
-        boolean backupRestoreNGEnabled = true;
+        boolean networkNGEnabled  = true;
         
         try {
+          networkNGEnabled = Provisioning.getInstance().getLocalServer().isNetworkModulesNGEnabled();
           mobileNGEnabled = Provisioning.getInstance().getLocalServer().isNetworkMobileNGEnabled();
           networkAdminEnabled = Provisioning.getInstance().getLocalServer().isNetworkAdminNGEnabled();
-          hsmNGEnabled = Provisioning.getInstance().getLocalServer().isNetworkHSMNGEnabled();
-          backupRestoreNGEnabled = Provisioning.getInstance().getLocalServer().isNetworkBackupNGEnabled();
               
         } catch (ServiceException e) {
           ZimbraLog.mailbox.warn("Exception while getting zimbraNetworkModulesNG related attributes.", e);
@@ -77,27 +75,27 @@ public class GetAdminExtensionZimlets extends AdminDocumentHandler  {
 			
 			if (z.isExtension()) {
 			    boolean include = true;
-                if ("com_zimbra_mobilesync".equals(z.getName()) && mobileNGEnabled) {
+                if ("com_zimbra_mobilesync".equals(z.getName()) && mobileNGEnabled && networkNGEnabled) {
                     include = !mobileNGEnabled;
                     if (!include) {
                         ZimbraLog.mailbox.info("Disabled '%s' as zimbraNetworkMobileNGEnabled is true.", z.getName());
                     }
                 }
                 
-                if ("com_zimbra_hsm".equals(z.getName()) && hsmNGEnabled) {
-                    include = !hsmNGEnabled;
+                if ("com_zimbra_hsm".equals(z.getName()) && networkNGEnabled) {
+                    include = !networkNGEnabled;
                     if (!include) {
-                        ZimbraLog.mailbox.info("Disabled '%s'  as zimbraNetworHSMNGEnabled is true.", z.getName());
+                        ZimbraLog.mailbox.info("Disabled '%s'  as zimbraNetworNGEnabled is true.", z.getName());
                     }
                 }
                 
-                if ("com_zimbra_backuprestore".equals(z.getName()) && backupRestoreNGEnabled) {
-                    include = !backupRestoreNGEnabled;
+                if ("com_zimbra_backuprestore".equals(z.getName()) && networkNGEnabled) {
+                    include = !networkNGEnabled;
                     if (!include) {
-                        ZimbraLog.mailbox.info("Disabled '%s' as zimbraNetworkBackupNGEnabled is true.", z.getName());
+                        ZimbraLog.mailbox.info("Disabled '%s' as zimbraNetworkNGEnabled is true.", z.getName());
                     }
                 }
-                if ("com_zimbra_delegatedadmin".equals(z.getName()) && networkAdminEnabled) {
+                if ("com_zimbra_delegatedadmin".equals(z.getName()) && networkAdminEnabled && networkNGEnabled) {
                     include = !networkAdminEnabled;
                     if (!include) {
                         ZimbraLog.mailbox.info("Disabled '%s' as zimbraNetworkAdminNGEnabled is true.", z.getName());


### PR DESCRIPTION
ZCS-3132 Fixed NG module related attributes.

Reintroduced zimbraNetworkModulesNGEnabled
Removed zimbraNetworkHSMNGEnabled and zimbraNetworkBackupNGEnabled.
Modified the code in GetAdminExtension as per the new set of attributes.

