### PR TITLE
Bug 105959: Change default value of cbpolicyd_cache_file

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -574,7 +574,7 @@ public final class LC {
     public static final KnownKey cbpolicyd_pid_file = KnownKey.newKey("${zimbra_log_directory}/cbpolicyd.pid");
     public static final KnownKey cbpolicyd_log_file = KnownKey.newKey("${zimbra_log_directory}/cbpolicyd.log");
     public static final KnownKey cbpolicyd_db_file = KnownKey.newKey("${zimbra_home}/data/cbpolicyd/db/cbpolicyd.sqlitedb");
-    public static final KnownKey cbpolicyd_cache_file = KnownKey.newKey("${zimbra_home}/data/cache");
+    public static final KnownKey cbpolicyd_cache_file = KnownKey.newKey("${zimbra_home}/data/cbpolicyd/cbpolicyd.cache");
     public static final KnownKey cbpolicyd_log_mail = KnownKey.newKey("main");
     public static final KnownKey cbpolicyd_log_detail = KnownKey.newKey("modules");
 


### PR DESCRIPTION
The Zimbra `cbpolicyd` creates the rather generically named cache file `/opt/zimbra/data/cache`.  It took me a while to find out where that file came from when I wanted to create a directory with the same name there (which we use for our scripts).

This patch changes the default filename to `/opt/zimbra/data/cbpolicyd/cbpolicyd.cache`.

The file is deleted and recreated on each restart of `cbpolicyd` so no further cleanup is required.