### PR TITLE
ZCS-1824 imap append max msg size

### DIFF
--- a/common/src/java/com/zimbra/common/zclient/ZClientException.java
+++ b/common/src/java/com/zimbra/common/zclient/ZClientException.java
@@ -54,7 +54,7 @@ public class ZClientException extends ServiceException {
     }
 
     public static ZClientException UPLOAD_SIZE_LIMIT_EXCEEDED(String msg, Throwable cause) {
-        return new ZClientException(msg, UPLOAD_SIZE_LIMIT_EXCEEDED, SENDERS_FAULT, cause);
+        return new ZClientUploadSizeLimitExceededException(msg, cause);
     }
 
     public static ZClientException UPLOAD_FAILED(String msg, Throwable cause) {
@@ -78,6 +78,13 @@ public class ZClientException extends ServiceException {
 
         public ZClientNoSuchItemException(int id) {
             this(id, null);
+        }
+    }
+
+    public static class ZClientUploadSizeLimitExceededException extends ZClientException {
+        private static final long serialVersionUID = 1728995252512138761L;
+        public ZClientUploadSizeLimitExceededException(String msg, Throwable cause) {
+            super(msg, UPLOAD_SIZE_LIMIT_EXCEEDED, SENDERS_FAULT, cause);
         }
     }
 

--- a/store/src/java/com/zimbra/cs/imap/AppendMessage.java
+++ b/store/src/java/com/zimbra/cs/imap/AppendMessage.java
@@ -41,6 +41,7 @@ import com.zimbra.common.mime.shim.JavaMailInternetHeaders;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ByteUtil;
 import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.imap.ImapParseException.ImapMaximumSizeExceededException;
 import com.zimbra.cs.mailbox.DeliveryOptions;
 import com.zimbra.cs.mailbox.Flag;
 import com.zimbra.cs.mailbox.Message;
@@ -244,12 +245,12 @@ final class AppendMessage {
         if ((maxMsgSize != 0 /* 0 means unlimited */) && (size > handler.getConfig().getMaxMessageSize())) {
             cleanup();
             if (catenate) {
-                throw new ImapParseException(tag, "TOOBIG", "maximum message size exceeded", false);
+                throw new ImapParseException.ImapMaximumSizeExceededException(tag, "TOOBIG", "message");
             } else {
-                throw new ImapParseException(tag, "maximum message size exceeded", true);
+                throw new ImapMaximumSizeExceededException(tag, "message");
             }
         } else if (size <= 0) {
-            throw new ImapParseException(tag, "zero-length message", false);
+            throw new ImapParseException(tag, "zero-length message", false, false);
         }
     }
 

--- a/store/src/java/com/zimbra/cs/imap/ImapHandler.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapHandler.java
@@ -46,7 +46,6 @@ import java.util.regex.Pattern;
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
-import com.zimbra.cs.service.admin.AddAccountLogger;
 import org.dom4j.DocumentException;
 
 import com.google.common.base.Charsets;
@@ -81,7 +80,6 @@ import com.zimbra.common.util.AccessBoundedRegex;
 import com.zimbra.common.util.Constants;
 import com.zimbra.common.util.DateUtil;
 import com.zimbra.common.util.Log;
-import com.zimbra.common.util.LogFactory;
 import com.zimbra.common.util.Pair;
 import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
@@ -115,6 +113,7 @@ import com.zimbra.cs.security.sasl.AuthenticatorUser;
 import com.zimbra.cs.security.sasl.PlainAuthenticator;
 import com.zimbra.cs.security.sasl.ZimbraAuthenticator;
 import com.zimbra.cs.server.ServerThrottle;
+import com.zimbra.cs.service.admin.AddAccountLogger;
 import com.zimbra.cs.service.admin.AdminAccessControl;
 import com.zimbra.cs.service.admin.FlushCache;
 import com.zimbra.cs.service.mail.FolderAction;
@@ -333,10 +332,10 @@ public abstract class ImapHandler {
     }
 
     protected void handleParseException(ImapParseException e) throws IOException {
-        String message = (e.mCode == null ? "" : '[' + e.mCode + "] ") + e.getMessage();
+        String message = (e.responseCode == null ? "" : '[' + e.responseCode + "] ") + e.getMessage();
         if (e.mTag == null) {
             sendBAD(message);
-        } else if (e.mNO) {
+        } else if (e.userServerResponseNO) {
             sendNO(e.mTag, message);
         } else {
             sendBAD(e.mTag, message);

--- a/store/src/java/com/zimbra/cs/imap/ImapHandler.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapHandler.java
@@ -83,6 +83,7 @@ import com.zimbra.common.util.Log;
 import com.zimbra.common.util.Pair;
 import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.common.zclient.ZClientException.ZClientUploadSizeLimitExceededException;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.AccountServiceException;
 import com.zimbra.cs.account.AuthToken;
@@ -95,6 +96,7 @@ import com.zimbra.cs.account.auth.AuthContext;
 import com.zimbra.cs.imap.ImapCredentials.EnabledHack;
 import com.zimbra.cs.imap.ImapFlagCache.ImapFlag;
 import com.zimbra.cs.imap.ImapMessage.ImapMessageSet;
+import com.zimbra.cs.imap.ImapParseException.ImapMaximumSizeExceededException;
 import com.zimbra.cs.imap.ImapSessionManager.FolderDetails;
 import com.zimbra.cs.imap.ImapSessionManager.InitialFolderValues;
 import com.zimbra.cs.index.SearchParams;
@@ -2785,6 +2787,9 @@ public abstract class ImapHandler {
                 appendHint.append("[APPENDUID ").append(uvv).append(' ')
                     .append(ImapFolder.encodeSubsequence(createdIds)).append("] ");
             }
+        } catch (ZClientUploadSizeLimitExceededException zcusle) {
+            ZimbraLog.imap.debug("upload limit hit", zcusle);
+            throw new ImapMaximumSizeExceededException(tag, "message");
         } catch (ServiceException e) {
             for (AppendMessage append : appends) {
                 append.cleanup();

--- a/store/src/java/com/zimbra/cs/imap/ImapParseException.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapParseException.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2013, 2014, 2016, 2017 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -17,30 +17,46 @@
 
 package com.zimbra.cs.imap;
 
-class ImapParseException extends ImapException {
+public class ImapParseException extends ImapException {
     private static final long serialVersionUID = 4675342317380797673L;
 
-    String mTag, mCode;
-    boolean mNO;
+    protected String mTag;
+    protected String responseCode;
+    protected boolean userServerResponseNO;  /* if true use "NO" as server response, else use "BAD" */
 
-    ImapParseException() {
+    protected ImapParseException() {
     }
 
-    ImapParseException(String tag, String message) {
+    protected ImapParseException(String tag, String message) {
         super("parse error: " + message);
         mTag = tag;
     }
 
-    ImapParseException(String tag, String message, boolean no) {
-        super((no ? "" : "parse error: ") + message);
-        mTag = tag;
-        mNO = no;
-    }
-
-    ImapParseException(String tag, String code, String message, boolean parseError) {
+    protected ImapParseException(String tag, String message, boolean no, boolean parseError) {
         super((parseError ? "parse error: " : "") + message);
         mTag = tag;
-        mCode = code;
-        mNO = code != null;
+        userServerResponseNO = no;
+    }
+
+    protected ImapParseException(String tag, String code, String message, boolean parseError) {
+        super((parseError ? "parse error: " : "") + message);
+        mTag = tag;
+        responseCode = code;
+        userServerResponseNO = code != null;
+    }
+
+    protected static class ImapMaximumSizeExceededException extends ImapParseException {
+        private static final long serialVersionUID = -8080429172062016010L;
+        public static final String sizeExceededFmt = "maximum %s size exceeded";
+        protected ImapMaximumSizeExceededException(String tag, String code, String exceededType) {
+            super(tag, code,
+                    String.format(sizeExceededFmt, exceededType),
+                    false /* don't prefix parse error: */);
+        }
+        protected ImapMaximumSizeExceededException(String tag, String exceededType) {
+            super(tag,
+                    String.format(sizeExceededFmt, exceededType),
+                    false /* use BAD not NO */, false /* don't prefix parse error: */);
+        }
     }
 }

--- a/store/src/java/com/zimbra/cs/imap/ImapRequest.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapRequest.java
@@ -59,7 +59,7 @@ import com.zimbra.soap.admin.type.CacheEntryType;
 /**
  * @since Apr 30, 2005
  */
-abstract class ImapRequest {
+public abstract class ImapRequest {
     private static final boolean[] TAG_CHARS      = new boolean[128];
     private static final boolean[] ATOM_CHARS     = new boolean[128];
     private static final boolean[] ASTRING_CHARS  = new boolean[128];
@@ -285,7 +285,7 @@ abstract class ImapRequest {
         return isLogin;
     }
 
-    protected String getCommand(String requestLine) {
+    public static String getCommand(String requestLine) {
         int i = requestLine.indexOf(' ') + 1;
         if (i > 0) {
             int j = requestLine.indexOf(' ', i);
@@ -546,7 +546,7 @@ abstract class ImapRequest {
         return tag = readContent(TAG_CHARS);
     }
 
-    static String parseTag(String src) throws ImapParseException {
+    public static String parseTag(String src) throws ImapParseException {
         int i;
         for (i = 0; i < src.length(); i++) {
             char c = src.charAt(i);

--- a/store/src/java/com/zimbra/cs/imap/ImapRequest.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapRequest.java
@@ -125,43 +125,43 @@ public abstract class ImapRequest {
         }
         MONTH_NUMBER = builder.build();
     }
-    static final boolean NONZERO = false;
-    static final boolean ZERO_OK = true;
+    protected static final boolean NONZERO = false;
+    protected static final boolean ZERO_OK = true;
 
-    final ImapHandler mHandler;
-    String tag;
-    List<Part> parts = new ArrayList<Part>();
-    int index;
-    int offset;
+    protected final ImapHandler mHandler;
+    protected String tag;
+    protected final List<Part> parts = new ArrayList<Part>();
+    protected int index;
+    protected int offset;
     private boolean isAppend;
     private boolean isLogin;
     private final int maxNestingInSearchRequest;
 
-    ImapRequest(ImapHandler handler) {
+    protected ImapRequest(ImapHandler handler) {
         mHandler = handler;
         maxNestingInSearchRequest = LC.imap_max_nesting_in_search_request.intValue();
     }
 
-    ImapRequest rewind() {
+    protected ImapRequest rewind() {
         index = offset = 0;
         return this;
     }
 
     protected abstract class Part {
-        abstract int size();
-        abstract byte[] getBytes() throws IOException;
-        abstract String getString() throws ImapParseException;
-        abstract Literal getLiteral() throws ImapParseException;
+        protected abstract int size();
+        protected abstract byte[] getBytes() throws IOException;
+        protected abstract String getString() throws ImapParseException;
+        protected abstract Literal getLiteral() throws ImapParseException;
 
-        boolean isString() {
+        protected boolean isString() {
             return false;
         }
 
-        boolean isLiteral() {
+        protected boolean isLiteral() {
             return false;
         }
 
-        void cleanup() {
+        protected void cleanup() {
         }
     }
 
@@ -173,22 +173,22 @@ public abstract class ImapRequest {
         }
 
         @Override
-        int size() {
+        protected int size() {
             return str.length();
         }
 
         @Override
-        byte[] getBytes() {
+        protected byte[] getBytes() {
             return str.getBytes();
         }
 
         @Override
-        boolean isString() {
+        protected boolean isString() {
             return true;
         }
 
         @Override
-        String getString() {
+        protected String getString() {
             return str;
         }
 
@@ -198,7 +198,7 @@ public abstract class ImapRequest {
         }
 
         @Override
-        Literal getLiteral() throws ImapParseException {
+        protected Literal getLiteral() throws ImapParseException {
             throw new ImapParseException(tag, "not inside literal");
         }
     }
@@ -211,27 +211,27 @@ public abstract class ImapRequest {
         }
 
         @Override
-        int size() {
+        protected int size() {
             return lit.size();
         }
 
         @Override
-        byte[] getBytes() throws IOException {
+        protected byte[] getBytes() throws IOException {
             return lit.getBytes();
         }
 
         @Override
-        boolean isLiteral() {
+        protected boolean isLiteral() {
             return true;
         }
 
         @Override
-        Literal getLiteral() {
+        protected Literal getLiteral() {
             return lit;
         }
 
         @Override
-        void cleanup() {
+        protected void cleanup() {
             lit.cleanup();
         }
 
@@ -250,11 +250,11 @@ public abstract class ImapRequest {
         }
     }
 
-    void addPart(Literal literal) {
+    protected void addPart(Literal literal) {
         addPart(new LiteralPart(literal));
     }
 
-    void addPart(String line) {
+    protected void addPart(String line) {
         if (parts.isEmpty()) {
             String cmd = getCommand(line);
             if ("APPEND".equalsIgnoreCase(cmd)) {
@@ -266,11 +266,11 @@ public abstract class ImapRequest {
         addPart(new StringPart(line));
     }
 
-    void addPart(Part part) {
+    protected void addPart(Part part) {
         parts.add(part);
     }
 
-    void cleanup() {
+    protected void cleanup() {
         for (Part part : parts) {
             part.cleanup();
         }
@@ -296,11 +296,11 @@ public abstract class ImapRequest {
         return null;
     }
 
-    String getCurrentLine() throws ImapParseException {
+    protected String getCurrentLine() throws ImapParseException {
         return parts.get(index).getString();
     }
 
-    byte[] toByteArray() throws IOException {
+    protected byte[] toByteArray() throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         for (Part part : parts) {
             byte[] content = part.getBytes();
@@ -313,7 +313,7 @@ public abstract class ImapRequest {
     }
 
 
-    String getTag() {
+    protected String getTag() {
         if (tag == null && index == 0 && offset == 0 && parts.size() > 0) {
             try {
                 readTag();
@@ -330,7 +330,7 @@ public abstract class ImapRequest {
      *
      * @see ImapHandler#extensionEnabled(String)
      */
-    boolean extensionEnabled(String extension) {
+    protected boolean extensionEnabled(String extension) {
         return mHandler == null || mHandler.extensionEnabled(extension);
     }
 
@@ -338,16 +338,15 @@ public abstract class ImapRequest {
      * Records the "tag" for the request. This tag will later be used to indicate that the server has finished
      * processing the request. It may also be used when generating a parse exception.
      */
-    void setTag(String value) {
+    protected void setTag(String value) {
         tag = value;
     }
 
-
-    String readContent(boolean[] acceptable) throws ImapParseException {
+    protected String readContent(boolean[] acceptable) throws ImapParseException {
         return readContent(acceptable, false);
     }
 
-    String readContent(boolean[] acceptable, boolean emptyOK) throws ImapParseException {
+    protected String readContent(boolean[] acceptable, boolean emptyOK) throws ImapParseException {
         String content = getCurrentLine();
         int i;
         for (i = offset; i < content.length(); i++) {
@@ -368,14 +367,14 @@ public abstract class ImapRequest {
     /**
      * Returns whether the read position is at the very end of the request.
      */
-    boolean eof() {
+    protected boolean eof() {
         return index >= parts.size() || offset >= parts.get(index).size();
     }
 
     /**
      * Returns the character at the read position, or -1 if we're at the end of a literal or of a line.
      */
-    int peekChar() throws ImapParseException {
+    protected int peekChar() throws ImapParseException {
         if (index >= parts.size()) {
             return -1;
         }
@@ -383,7 +382,7 @@ public abstract class ImapRequest {
         return offset < str.length() ? str.charAt(offset) : -1;
     }
 
-    String peekATOM() {
+    protected String peekATOM() {
         int i = index;
         int o = offset;
         try {
@@ -396,11 +395,11 @@ public abstract class ImapRequest {
         }
     }
 
-    void skipSpace() throws ImapParseException {
+    protected void skipSpace() throws ImapParseException {
         skipChar(' ');
     }
 
-    void skipChar(char c) throws ImapParseException {
+    protected void skipChar(char c) throws ImapParseException {
         if (index >= parts.size()) {
             throw new ImapParseException(tag, "unexpected end of line; expected '" + c + "'");
         }
@@ -416,25 +415,25 @@ public abstract class ImapRequest {
         }
     }
 
-    void skipNIL() throws ImapParseException {
+    protected void skipNIL() throws ImapParseException {
         skipAtom("NIL");
     }
 
-    void skipAtom(String atom) throws ImapParseException {
+    protected void skipAtom(String atom) throws ImapParseException {
         if (!readATOM().equals(atom)) {
             throw new ImapParseException(tag, "did not find expected " + atom);
         }
     }
 
-    String readAtom() throws ImapParseException {
+    protected String readAtom() throws ImapParseException {
         return readContent(ATOM_CHARS);
     }
 
-    String readATOM() throws ImapParseException {
+    protected String readATOM() throws ImapParseException {
         return readContent(ATOM_CHARS).toUpperCase();
     }
 
-    String readQuoted(Charset charset) throws ImapParseException {
+    protected String readQuoted(Charset charset) throws ImapParseException {
         String result = readQuoted();
         if (charset == null || Charsets.ISO_8859_1.equals(charset) || Charsets.US_ASCII.equals(charset)) {
             return result;
@@ -443,7 +442,7 @@ public abstract class ImapRequest {
         }
     }
 
-    String readQuoted() throws ImapParseException {
+    protected String readQuoted() throws ImapParseException {
         String content = getCurrentLine();
         StringBuilder result = null;
 
@@ -472,24 +471,24 @@ public abstract class ImapRequest {
         throw new ImapParseException(tag, "unexpected end of line in quoted string");
     }
 
-    abstract Literal readLiteral() throws IOException, ImapParseException;
+    protected abstract Literal readLiteral() throws IOException, ImapParseException;
 
     private String readLiteral(Charset charset) throws IOException, ImapParseException {
         return new String(readLiteral().getBytes(), charset);
     }
 
-    Literal readLiteral8() throws IOException, ImapParseException {
+    protected Literal readLiteral8() throws IOException, ImapParseException {
         if (peekChar() == '~' && extensionEnabled("BINARY")) {
             skipChar('~');
         }
         return readLiteral();
     }
 
-    String readAstring() throws IOException, ImapParseException {
+    protected String readAstring() throws IOException, ImapParseException {
         return readAstring(null);
     }
 
-    String readAstring(Charset charset) throws IOException, ImapParseException {
+    protected String readAstring(Charset charset) throws IOException, ImapParseException {
         return readAstring(charset, ASTRING_CHARS);
     }
 
@@ -542,7 +541,7 @@ public abstract class ImapRequest {
         }
     }
 
-    String readTag() throws ImapParseException {
+    protected String readTag() throws ImapParseException {
         return tag = readContent(TAG_CHARS);
     }
 
@@ -561,11 +560,11 @@ public abstract class ImapRequest {
         }
     }
 
-    String readNumber() throws ImapParseException {
+    protected String readNumber() throws ImapParseException {
         return readNumber(ZERO_OK);
     }
 
-    String readNumber(boolean zeroOK) throws ImapParseException {
+    protected String readNumber(boolean zeroOK) throws ImapParseException {
         String number = readContent(NUMBER_CHARS);
         if (number.startsWith("0") && (!zeroOK || number.length() > 1)) {
             throw new ImapParseException(tag, "invalid number: " + number);
@@ -573,7 +572,7 @@ public abstract class ImapRequest {
         return number;
     }
 
-    int parseInteger(String number) throws ImapParseException {
+    protected int parseInteger(String number) throws ImapParseException {
         try {
             return Integer.parseInt(number);
         } catch (NumberFormatException nfe) {
@@ -581,7 +580,7 @@ public abstract class ImapRequest {
         }
     }
 
-    long parseLong(String number) throws ImapParseException {
+    protected long parseLong(String number) throws ImapParseException {
         try {
             return Long.parseLong(number);
         } catch (NumberFormatException nfe) {
@@ -589,7 +588,7 @@ public abstract class ImapRequest {
         }
     }
 
-    byte[] readBase64(boolean skipEquals) throws ImapParseException {
+    protected byte[] readBase64(boolean skipEquals) throws ImapParseException {
         // in some cases, "=" means to just return null and be done with it
         if (skipEquals && peekChar() == '=') {
             skipChar('=');
@@ -608,11 +607,11 @@ public abstract class ImapRequest {
         return new Base64().decode(encoded.getBytes(Charsets.US_ASCII));
     }
 
-    String readSequence(boolean specialsOK) throws ImapParseException {
+    protected String readSequence(boolean specialsOK) throws ImapParseException {
         return validateSequence(readContent(SEQUENCE_CHARS), specialsOK);
     }
 
-    String readSequence() throws ImapParseException {
+    protected String readSequence() throws ImapParseException {
         return validateSequence(readContent(SEQUENCE_CHARS), true);
     }
 
@@ -631,7 +630,7 @@ public abstract class ImapRequest {
         }
     }
 
-    List<CacheEntryType> readCacheEntryTypes() throws IOException, ImapParseException {
+    protected List<CacheEntryType> readCacheEntryTypes() throws IOException, ImapParseException {
         if (peekChar() != '(') {
             CacheEntryType type = readCacheEntryType();
             if (type != null) {
@@ -660,7 +659,7 @@ public abstract class ImapRequest {
         }
     }
 
-    List<CacheEntrySelector> readCacheEntries() throws IOException, ImapParseException {
+    protected List<CacheEntrySelector> readCacheEntries() throws IOException, ImapParseException {
         if (eof()) {
             return null;
         }
@@ -692,10 +691,11 @@ public abstract class ImapRequest {
 
     private String validateSequence(String value, boolean specialsOK) throws ImapParseException {
         // "$" is OK per RFC 5182 [SEARCHRES]
-        if (value.equals("$") && specialsOK && extensionEnabled("SEARCHRES")) {
+        if ("$".equals(value) && specialsOK && extensionEnabled("SEARCHRES")) {
             return value;
         }
-        int i, last = LAST_PUNCT;
+        int i;
+        int last = LAST_PUNCT;
         boolean colon = false;
         for (i = 0; i < value.length(); i++) {
             char c = value.charAt(i);
@@ -732,11 +732,11 @@ public abstract class ImapRequest {
     }
 
 
-    String readFolder() throws IOException, ImapParseException {
+    protected String readFolder() throws IOException, ImapParseException {
         return readFolder(false);
     }
 
-    String readFolderPattern() throws IOException, ImapParseException {
+    protected String readFolderPattern() throws IOException, ImapParseException {
         return readFolder(true);
     }
 
@@ -752,7 +752,7 @@ public abstract class ImapRequest {
         }
     }
 
-    List<String> readFlags() throws ImapParseException {
+    protected List<String> readFlags() throws ImapParseException {
         List<String> tags = new ArrayList<String>();
         String content = getCurrentLine();
         boolean parens = (peekChar() == '(');
@@ -793,7 +793,7 @@ public abstract class ImapRequest {
         return readDate(false, false);
     }
 
-    Date readDate(boolean datetime, boolean checkRange) throws ImapParseException {
+    protected Date readDate(boolean datetime, boolean checkRange) throws ImapParseException {
         String dateStr = (peekChar() == '"' ? readQuoted() : readAtom());
         if (dateStr.length() < (datetime ? 26 : 10)) {
             throw new ImapParseException(tag, "invalid date format");
@@ -801,7 +801,8 @@ public abstract class ImapRequest {
         Calendar cal = new GregorianCalendar();
         cal.clear();
 
-        int pos = 0, count;
+        int pos = 0;
+        int count;
         if (datetime && dateStr.charAt(0) == ' ') {
             pos++;
         }
@@ -890,7 +891,7 @@ public abstract class ImapRequest {
     }
 
 
-    Map<String, String> readParameters(boolean nil) throws IOException, ImapParseException {
+    protected Map<String, String> readParameters(boolean nil) throws IOException, ImapParseException {
         if (peekChar() != '(') {
             if (!nil) {
                 throw new ImapParseException(tag, "did not find expected '('");
@@ -915,8 +916,7 @@ public abstract class ImapRequest {
         return params;
     }
 
-
-    int readFetch(List<ImapPartSpecifier> parts) throws IOException, ImapParseException {
+    protected int readFetch(List<ImapPartSpecifier> parts) throws IOException, ImapParseException {
         boolean list = peekChar() == '(';
         int attributes = 0;
         if (list)  skipChar('(');
@@ -1002,8 +1002,10 @@ public abstract class ImapRequest {
         return attributes;
     }
 
-    ImapPartSpecifier readPartSpecifier(boolean binary, boolean literals) throws ImapParseException, IOException {
-        String sectionPart = "", sectionText = "";
+    protected ImapPartSpecifier readPartSpecifier(boolean binary, boolean literals)
+            throws ImapParseException, IOException {
+        String sectionPart = "";
+        String sectionText = "";
         List<String> headers = null;
         boolean done = false;
 
@@ -1199,11 +1201,11 @@ public abstract class ImapRequest {
         return parent;
     }
 
-    ImapSearch readSearch(Charset charset) throws IOException, ImapParseException {
+    protected ImapSearch readSearch(Charset charset) throws IOException, ImapParseException {
         return readSearchClause(charset, MULTIPLE_CLAUSES, new AndOperation(), 0);
     }
 
-    Charset readCharset() throws IOException, ImapParseException {
+    protected Charset readCharset() throws IOException, ImapParseException {
         String charset = readAstring();
         try {
             return Charset.forName(charset);

--- a/store/src/java/com/zimbra/cs/imap/ImapURL.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapURL.java
@@ -29,7 +29,6 @@ import com.zimbra.common.mailbox.ItemIdentifier;
 import com.zimbra.common.mailbox.MailboxStore;
 import com.zimbra.common.mailbox.ZimbraMailItem;
 import com.zimbra.common.service.ServiceException;
-import com.zimbra.common.util.ByteUtil;
 import com.zimbra.common.util.InputStreamWithSize;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
@@ -44,14 +43,6 @@ import com.zimbra.cs.util.JMSession;
  * See https://tools.ietf.org/html/rfc5092 - IMAP URL Scheme
  */
 final class ImapURL {
-    private static class ImapUrlException extends ImapParseException {
-        private static final long serialVersionUID = 174398702563521440L;
-
-        ImapUrlException(String tag, String url, String message) {
-            super(tag, "BADURL \"" + url.replace("\\", "\\\\").replace("\"", "\\\"") + '"', "APPEND failed: " + message, false);
-        }
-    }
-
     private final String mURL;
 
     private String mUsername;
@@ -62,6 +53,14 @@ final class ImapURL {
     // private long mUidValidity;
     private int mUid;
     private ImapPartSpecifier mPart;
+
+    private static class ImapUrlException extends ImapParseException {
+        private static final long serialVersionUID = 174398702563521440L;
+
+        ImapUrlException(String tag, String url, String message) {
+            super(tag, "BADURL \"" + url.replace("\\", "\\\\").replace("\"", "\\\"") + '"', "APPEND failed: " + message, false);
+        }
+    }
 
     ImapURL(String tag, ImapHandler handler, String url) throws ImapParseException {
         if (url == null || url.length() == 0)
@@ -198,7 +197,7 @@ final class ImapURL {
         }
 
         @Override
-        Literal readLiteral() throws ImapParseException {
+        protected Literal readLiteral() throws ImapParseException {
             return getNextBuffer();
         }
     }
@@ -227,16 +226,18 @@ final class ImapURL {
             InputStreamWithSize content = null;
             // special-case the situation where the relevant folder is already SELECTed
             ImapFolder i4folder = handler.getSelectedFolder();
-            if (state == ImapHandler.State.SELECTED && i4session != null && i4folder != null) {
-                if (acct.getId().equals(i4session.getTargetAccountId()) && mPath.isEquivalent(i4folder.getPath())) {
-                    ImapMessage i4msg = i4folder.getByImapId(mUid);
-                    if (i4msg == null || i4msg.isExpunged()) {
-                        throw new ImapUrlException(tag, mURL, "no such message");
-                    }
-                    MailboxStore i4Mailbox = i4folder.getMailbox();
-                    ZimbraMailItem item = i4Mailbox.getItemById(octxt, ItemIdentifier.fromAccountIdAndItemId(i4Mailbox.getAccountId(), i4msg.msgId), i4msg.getMailItemType());
-                    content = ImapMessage.getContent(item);
+            if (state == ImapHandler.State.SELECTED && (i4session != null) && (i4folder != null) &&
+                    acct.getId().equals(i4session.getTargetAccountId())
+                    && mPath.isEquivalent(i4folder.getPath())) {
+                ImapMessage i4msg = i4folder.getByImapId(mUid);
+                if (i4msg == null || i4msg.isExpunged()) {
+                    throw new ImapUrlException(tag, mURL, "no such message");
                 }
+                MailboxStore i4Mailbox = i4folder.getMailbox();
+                ZimbraMailItem item = i4Mailbox.getItemById(octxt,
+                        ItemIdentifier.fromAccountIdAndItemId(i4Mailbox.getAccountId(), i4msg.msgId),
+                        i4msg.getMailItemType());
+                content = ImapMessage.getContent(item);
             }
             // if not, have to fetch by IMAP UID if we're local or handle off-server URLs
             if (content == null) {
@@ -266,14 +267,10 @@ final class ImapURL {
 
         } catch (NoSuchItemException e) {
             ZimbraLog.imap.info("no such message", e);
-        } catch (ServiceException e) {
-            ZimbraLog.imap.info("can't fetch content from IMAP URL", e);
-        } catch (MessagingException e) {
+        } catch (ServiceException | MessagingException | BinaryDecodingException e) {
             ZimbraLog.imap.info("can't fetch content from IMAP URL", e);
         } catch (IOException e) {
             ZimbraLog.imap.info("error reading content from IMAP URL", e);
-        } catch (BinaryDecodingException e) {
-            ZimbraLog.imap.info("can't fetch content from IMAP URL", e);
         }
         throw new ImapUrlException(tag, mURL, "error fetching IMAP URL content");
     }

--- a/store/src/java/com/zimbra/cs/imap/ImapURL.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapURL.java
@@ -373,6 +373,6 @@ final class ImapURL {
         System.out.println(new ImapURL("tag", handler, "imap://bester;auth=gssapi@psicorp.org/~peter/%E6%97%A5%E6%9C%AC%E8%AA%9E/%E5%8F%B0%E5%8C%97/;UID=11916"));
         System.out.println(new ImapURL("tag", handler, "imap://;AUTH=*@minbari.org/gray-council/;uid=20/;section="));
 
-        System.out.println(new ImapUrlException("tag", "\"\\\"", "msg").mCode);
+        System.out.println(new ImapUrlException("tag", "\"\\\"", "msg").responseCode);
     }
 }

--- a/store/src/java/com/zimbra/cs/imap/NioImapDecoder.java
+++ b/store/src/java/com/zimbra/cs/imap/NioImapDecoder.java
@@ -172,9 +172,9 @@ final class NioImapDecoder extends CumulativeProtocolDecoder {
     }
 
     private static final class Context {
-        boolean overflow = false;
-        int literal = -1;
-        String request;
+        private boolean overflow = false;
+        private int literal = -1;
+        private String request;
     }
 
     static final class TooLongLineException extends RecoverableProtocolDecoderException {
@@ -186,22 +186,54 @@ final class NioImapDecoder extends CumulativeProtocolDecoder {
         }
     }
 
-    static final class TooBigLiteralException extends RecoverableProtocolDecoderException {
+    protected static final class TooBigLiteralException extends RecoverableProtocolDecoderException {
         private static final long serialVersionUID = 4272855594291614583L;
+        private static final String maxLiteralSizeExceeded = "maximum literal size exceeded";
+        private static final String maxMessageSizeExceeded = "maximum message size exceeded";
 
-        private String request;
+        /* The request string - e.g. "A02 LOGIN fred test123" */
+        private final String request;
+        private String requestTag = null;
+        private String imapCmd = null;
 
-        TooBigLiteralException(String req) {
+        protected TooBigLiteralException(String req) {
             request = req;
         }
 
+        /** @return the buffer containing the IMAP command processed so far*/
         public String getRequest() {
             return request;
         }
 
+        /** @return tag for IMAP command */
+        public String getRequestTag() {
+            if (requestTag != null) {
+                return requestTag;
+            }
+            try {
+                requestTag = ImapRequest.parseTag(request);
+            } catch (ImapParseException e1) {
+                requestTag = "*";
+            }
+            return requestTag;
+        }
+
+        /** @return tag for IMAP command */
+        public String getCommand() {
+            if (imapCmd != null) {
+                return imapCmd;
+            }
+            imapCmd = ImapRequest.getCommand(request);
+            return imapCmd;
+        }
+
         @Override
         public String getMessage() {
-            return "maximum literal size exceeded";
+            if ("APPEND".equalsIgnoreCase(getCommand())) {
+                /* Only one literal in APPEND cmd & this is a friendlier msg */
+                return maxMessageSizeExceeded;
+            }
+            return maxLiteralSizeExceeded;
         }
     }
 

--- a/store/src/java/com/zimbra/cs/imap/NioImapHandler.java
+++ b/store/src/java/com/zimbra/cs/imap/NioImapHandler.java
@@ -83,16 +83,12 @@ final class NioImapHandler extends ImapHandler implements NioHandler {
                 ZimbraLog.imap.error("Error detected by SSL subsystem, dropping connection:" + e);
                 dropConnection(false);  // Bug 79904 prevent using SSL port in plain text
             } else if (e instanceof NioImapDecoder.TooBigLiteralException) {
-                String tag;
-                if (request != null) {
-                    tag = request.getTag();
-                } else {
-                    try {
-                        tag = ImapRequest.parseTag(((NioImapDecoder.TooBigLiteralException) e).getRequest());
-                    } catch (ImapParseException e1) {
-                        tag = "*";
-                    }
-                }
+                NioImapDecoder.TooBigLiteralException tble = (NioImapDecoder.TooBigLiteralException) e;
+                /* 'tble' has access to the buffer of the IMAP command read so far, which may
+                 * be useful if better, context sensitive error reporting is desired.  See its getMessage()
+                 * method for an example of special handling for APPEND
+                 */
+                String tag = (request != null) ? tag = request.getTag() : tble.getRequestTag();
                 sendBAD(tag, e.getMessage());
             } else if (e instanceof RecoverableProtocolDecoderException) {
                 sendBAD("*", e.getMessage());

--- a/store/src/java/com/zimbra/cs/imap/NioImapServer.java
+++ b/store/src/java/com/zimbra/cs/imap/NioImapServer.java
@@ -40,10 +40,7 @@ public final class NioImapServer extends NioServer implements ImapServer, Realti
 
     public NioImapServer(ImapConfig config) throws ServiceException {
         super(config);
-        decoder = new NioImapDecoder();
-        decoder.setMaxChunkSize(config.getWriteChunkSize());
-        decoder.setMaxLineLength(config.getMaxRequestSize());
-        decoder.setMaxLiteralSize(config.getMaxMessageSize());
+        decoder = new NioImapDecoder(config);
         registerMBean(getName());
         ZimbraPerf.addStatsCallback(this);
         ServerThrottle.configureThrottle(config.getProtocol(), LC.imap_throttle_ip_limit.intValue(), LC.imap_throttle_acct_limit.intValue(), getThrottleSafeHosts(), getThrottleWhitelist());

--- a/store/src/java/com/zimbra/cs/imap/TcpImapRequest.java
+++ b/store/src/java/com/zimbra/cs/imap/TcpImapRequest.java
@@ -16,11 +16,12 @@
  */
 package com.zimbra.cs.imap;
 
+import java.io.IOException;
+
 import com.zimbra.common.io.TcpServerInputStream;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
-
-import java.io.IOException;
+import com.zimbra.cs.imap.ImapParseException.ImapMaximumSizeExceededException;
 
 final class TcpImapRequest extends ImapRequest {
     final class ImapTerminatedException extends ImapParseException {
@@ -33,7 +34,7 @@ final class TcpImapRequest extends ImapRequest {
         ImapContinuationException(boolean send)  { super(); sendContinuation = send; }
     }
 
-    private TcpServerInputStream input;
+    private final TcpServerInputStream input;
     private long literalCounter = -1;
     private boolean unlogged;
     private long requestSize = 0;
@@ -52,12 +53,12 @@ final class TcpImapRequest extends ImapRequest {
                 if ((msgLimit != 0 /* 0 means unlimited */) && (msgLimit < maxLiteralSize)) {
                     if (size > msgLimit) {
                         throwSizeExceeded("message");
-                    } 
-                } 
+                    }
+                }
             } catch (ServiceException se) {
                 ZimbraLog.imap.warn("unable to check zimbraMtaMaxMessageSize", se);
             }
-        } 
+        }
         if (isMaxRequestSizeExceeded() || size > maxLiteralSize) {
             throwSizeExceeded("request");
         }
@@ -67,7 +68,7 @@ final class TcpImapRequest extends ImapRequest {
         if (tag == null && index == 0 && offset == 0) {
             tag = readTag(); rewind();
         }
-        throw new ImapParseException(tag, "maximum " + exceededType + " size exceeded", true);
+        throw new ImapMaximumSizeExceededException(tag, exceededType);
     }
 
     void continuation() throws IOException, ImapParseException {


### PR DESCRIPTION
Should see a consistent error message now between the IMAP server implementations.
Also, the NIO decoder should now pick up config changes dynamically instead of requiring a server restart.