### PR TITLE
ZCS-3227:zmmetadump NPE

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/util/MetadataDump.java
+++ b/store/src/java/com/zimbra/cs/mailbox/util/MetadataDump.java
@@ -58,6 +58,9 @@ public final class MetadataDump {
     private static final String OPT_FILE = "file";
     private static final String OPT_HELP = "h";
     private static final String OPT_STR = "String";
+    public static final String DB_COLS_HDR = "[Database Columns]";
+    public static final String METADATA_HDR = "[Metadata]";
+    public static final String BLOBPATH_HDR = "[Blob Path]";
 
     private static Options sOptions = new Options();
 
@@ -94,7 +97,7 @@ public final class MetadataDump {
     private static final String METADATA_COLUMN = "metadata";
 
     private static class Row implements Iterable<Entry<String, String>> {
-        private Map<String, String> mMap = new LinkedHashMap<String, String>();
+        private final Map<String, String> mMap = new LinkedHashMap<String, String>();
 
         Row()  { }
 
@@ -113,7 +116,7 @@ public final class MetadataDump {
         }
 
         void print(PrintStream ps) throws ServiceException {
-            ps.println("[Database Columns]");
+            ps.println(DB_COLS_HDR);
             for (Entry<String, String> entry : this) {
                 String col = entry.getKey();
                 if (!col.equalsIgnoreCase(METADATA_COLUMN)) {
@@ -145,12 +148,12 @@ public final class MetadataDump {
                     String dir = vol.getBlobDir(mboxId, itemId);
                     String modContent = mMap.get("mod_content");
                     String blobPath = dir + File.separator + itemIdStr + "-" + modContent + ".msg";
-                    ps.println("[Blob Path]");
+                    ps.println(BLOBPATH_HDR);
                     ps.println(blobPath);
                     ps.println();
                 }
             }
-            ps.println("[Metadata]");
+            ps.println(METADATA_HDR);
             Metadata md = new Metadata(mMap.get(METADATA_COLUMN));
             ps.println(md.prettyPrint());
         }

--- a/store/src/java/com/zimbra/cs/stats/ZimbraPerf.java
+++ b/store/src/java/com/zimbra/cs/stats/ZimbraPerf.java
@@ -432,6 +432,14 @@ public class ZimbraPerf {
      * during realtime stats collection.
      */
     public static void addStatsCallback(RealtimeStatsCallback callback) {
+        if (realtimeStats == null) {
+            ZimbraLog.perf.debug("Call to addStatsCallback when realtimeStats has not been initialized\n%s",
+                    ZimbraLog.getStackTrace(15));
+            /* This probably happens inside a commandline tool like zmmetadump where it doesn't
+             * make sense to mix in stats with those of the main Zimbra process.
+             */
+            return;
+        }
         realtimeStats.addCallback(callback);
     }
 

--- a/store/src/java/com/zimbra/qa/unittest/TestMetadataDump.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestMetadataDump.java
@@ -1,0 +1,114 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2017 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.qa.unittest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.Lists;
+import com.zimbra.common.util.ByteUtil;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.Message;
+import com.zimbra.cs.mailbox.util.MetadataDump;
+
+public class TestMetadataDump {
+
+    @Rule
+    public TestName testInfo = new TestName();
+    public final static String ZMMETADUMP ="/opt/zimbra/bin/zmmetadump";
+
+    private String USER_NAME = null;
+    private String prefix = null;
+
+    @Before
+    public void setUp() throws Exception {
+        prefix = testInfo.getMethodName() + "-";
+        USER_NAME = prefix + "user1";
+        tearDown();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        TestUtil.deleteAccountIfExists(USER_NAME);
+    }
+
+    @Test
+    public void zmmetadumpHelp() throws Exception
+    {
+        List<String> cmdArgs = Lists.newArrayList();
+        cmdArgs.add(ZMMETADUMP);
+        cmdArgs.add("-h");
+        String cmd = Joiner.on(' ').join(cmdArgs);
+        int exitValue;
+        ProcessBuilder pb = new ProcessBuilder(cmdArgs);
+        Process process = pb.start();
+        exitValue = process.waitFor();
+        String error = new String(ByteUtil.getContent(process.getErrorStream(), -1));
+        String lookFor = "Usage: zmmetadump -m";
+        assertTrue(String.format("STDERR from '%s' should contain '%s' was:\n%s", cmd, lookFor, error),
+                error.contains(lookFor));
+        assertEquals(String.format("Exit code for '%s'", cmd), 0, exitValue);
+    }
+
+    /* ZCS-3227 zmmetadump non-functional due to NPE being thrown.
+     * Not the first time commandline tools like this have been broken, so good to have a test
+     * that will pick up on it.
+     */
+    @Test
+    public void zmmetadumpItem() throws Exception
+    {
+        Account acct = TestUtil.createAccount(USER_NAME);
+        Mailbox mbox = TestUtil.getMailbox(USER_NAME);
+        String subject = prefix + "Test Message";
+        Message msg = TestUtil.addMessage(mbox, subject);
+        List<String> cmdArgs = Lists.newArrayList();
+        cmdArgs.add(ZMMETADUMP);
+        cmdArgs.add("-m");
+        cmdArgs.add(acct.getName());
+        cmdArgs.add("-i");
+        cmdArgs.add(Integer.toString(msg.getId()));
+        String cmd = Joiner.on(' ').join(cmdArgs);
+        int exitValue;
+        ProcessBuilder pb = new ProcessBuilder(cmdArgs);
+        Process process = pb.start();
+        exitValue = process.waitFor();
+        String error = new String(ByteUtil.getContent(process.getErrorStream(), -1));
+        String stdout = new String(ByteUtil.getContent(process.getInputStream(), -1));
+        if ((exitValue != 0) && (!error.isEmpty())) {
+            ZimbraLog.test.info("STDERR:%s", error);
+        }
+        String[] patts = { " subject: " + subject,
+                MetadataDump.DB_COLS_HDR, MetadataDump.METADATA_HDR, MetadataDump.BLOBPATH_HDR };
+        for (String patt : patts) {
+            assertTrue(String.format("STDOUT from '%s' should contain '%s' was:\n%s", cmd, patt, stdout),
+                    stdout.contains(patt));
+        }
+        assertEquals(String.format("Exit code for '%s'", cmd), 0, exitValue);
+    }
+}

--- a/store/src/java/com/zimbra/qa/unittest/ZimbraSuite.java
+++ b/store/src/java/com/zimbra/qa/unittest/ZimbraSuite.java
@@ -159,6 +159,7 @@ public class ZimbraSuite  {
         sClasses.add(TestImapOneWayImport.class);
         sClasses.add(TestGetContactsRequest.class);
         sClasses.add(TestRemoteImapSoapSessions.class);
+        sClasses.add(TestMetadataDump.class);
     }
 
     /**


### PR DESCRIPTION
* ZimbraPerf - ignore attempt to add a callback if initialization not
               done.
* MetadataDump - declare some stings in variables for re-use.
* TestMetadataDump - new tests which execute zmmetadump - hopefully will
  help catch any breakage in the tool early in future.
* ZimbraSuite - add `TestMetadataDump`