### PR TITLE
zcs-1591:Sieve:normalize folder name for "fileinto"

### DIFF
--- a/store/src/java-test/com/zimbra/cs/filter/FileIntoCopyTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/FileIntoCopyTest.java
@@ -543,4 +543,33 @@ public class FileIntoCopyTest {
             fail("No exception should be thrown");
         }
     }
+
+    @Test
+    public void testPlainFileIntoWithSpaces() {
+        String filterScript = "require [\"fileinto\"];\n"
+            + "fileinto \" abc\";"   // final destination folder = " abc"
+            + "fileinto \"abc \";"   // final destination folder = "abc"
+            + "fileinto \" abc \";"; // final destination folder = " abc"
+        try {
+            Account account = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+            RuleManager.clearCachedRules(account);
+            Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
+            account.setMailSieveScript(filterScript);
+            String raw = "From: sender@zimbra.com\n" + "To: test1@zimbra.com\n" + "Subject: Test\n"
+                + "\n" + "Hello World.";
+            List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox),
+                mbox, new ParsedMessage(raw.getBytes(), false), 0, account.getName(),
+                new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
+            Assert.assertEquals(2, ids.size());
+            Message msg = mbox.getMessageById(null, ids.get(0).getId());
+            Folder folder  = mbox.getFolderById(null, msg.getFolderId());
+            Assert.assertEquals(" abc", folder.getName());
+            msg = mbox.getMessageById(null, ids.get(1).getId());
+            folder = mbox.getFolderById(null, msg.getFolderId());
+            Assert.assertEquals("abc", folder.getName());
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("No exception should be thrown");
+        }
+    }
 }

--- a/store/src/java-test/com/zimbra/cs/filter/FileIntoCopyTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/FileIntoCopyTest.java
@@ -560,13 +560,13 @@ public class FileIntoCopyTest {
             List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox),
                 mbox, new ParsedMessage(raw.getBytes(), false), 0, account.getName(),
                 new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
-            Assert.assertEquals(2, ids.size());
+            assertEquals(2, ids.size());
             Message msg = mbox.getMessageById(null, ids.get(0).getId());
             Folder folder  = mbox.getFolderById(null, msg.getFolderId());
-            Assert.assertEquals(" abc", folder.getName());
+            assertEquals(" abc", folder.getName());
             msg = mbox.getMessageById(null, ids.get(1).getId());
             folder = mbox.getFolderById(null, msg.getFolderId());
-            Assert.assertEquals("abc", folder.getName());
+            assertEquals("abc", folder.getName());
         } catch (Exception e) {
             e.printStackTrace();
             fail("No exception should be thrown");

--- a/store/src/java/com/zimbra/cs/filter/ZimbraMailAdapter.java
+++ b/store/src/java/com/zimbra/cs/filter/ZimbraMailAdapter.java
@@ -57,6 +57,7 @@ import com.zimbra.common.mime.shim.JavaMailInternetAddress;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ByteUtil;
 import com.zimbra.common.util.Pair;
+import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.IDNUtil;
@@ -546,6 +547,8 @@ public class ZimbraMailAdapter implements MailAdapter, EnvelopeAccessors {
     }
 
     private boolean isPathContainedInFiledIntoPaths(String folderPath) {
+        folderPath = StringUtil.trimTrailingSpaces(folderPath);
+
         // 1. Check folder name case-sensitively if it has already been registered in folderIntoPaths list
         if (filedIntoPaths.contains(folderPath)) {
             return true;


### PR DESCRIPTION
Problem:
Duplicated mails get delivered to the same folder when the fileinto actions
within nested "if" contain matched variables.

Root cause:
In general, the Sieve processor has a logic to prevent delivering same message
into the same folder multiple time. But in this case, the filter rule is actually
instructed to store the message into two different folders:
 folder name of "var test 5" – by the value of the variables ${var5}
 folder name of "var test 5 " (extra one space to the end of the folder name)
   – by the ${1} which is matched to the subject of "[var test 5 ]var test 6"
On the other hand, as a nature of ZCS, any trailing space(s) in the folder
name is trimmed automatically; therefore the second attempt goes to the same
folder as the first one, and ends up to deliver the two identical messages into
the same folder.
This case can be seen not only in this case, but also in the fileinto's folder
name with trailing spaces, like:
```
fileinto "abc def";
fileinto "abc def ";
```

Fix:
Trim the trailing space(s) before executing the fileinto action.
(Note) Any spaces at the beginning of the folder name are valid. Those spaces
will not be trimmed.