### PR TITLE
ZCS-3362 unstable RunUnitTestsRequests

### DIFF
--- a/store/src/java/com/zimbra/qa/unittest/TestEmbeddedRemoteImapNotificationsViaMailbox.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestEmbeddedRemoteImapNotificationsViaMailbox.java
@@ -15,7 +15,6 @@ public class TestEmbeddedRemoteImapNotificationsViaMailbox extends TestImapNotif
 
     @Before
     public void setUp() throws ServiceException, IOException, DocumentException, ConfigException  {
-        saveImapConfigSettings();
         TestUtil.setLCValue(LC.imap_always_use_remote_store, String.valueOf(true));
         imapServer.setReverseProxyUpstreamImapServers(new String[] {});
         super.sharedSetUp();
@@ -25,7 +24,6 @@ public class TestEmbeddedRemoteImapNotificationsViaMailbox extends TestImapNotif
     @After
     public void tearDown() throws ServiceException, DocumentException, ConfigException, IOException  {
         super.sharedTearDown();
-        restoreImapConfigSettings();
     }
 
     @Override

--- a/store/src/java/com/zimbra/qa/unittest/TestEmbeddedRemoteImapNotificationsViaWaitsets.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestEmbeddedRemoteImapNotificationsViaWaitsets.java
@@ -14,7 +14,6 @@ public class TestEmbeddedRemoteImapNotificationsViaWaitsets extends TestImapNoti
 
     @Before
     public void setUp() throws ServiceException, IOException, DocumentException, ConfigException  {
-        saveImapConfigSettings();
         TestUtil.setLCValue(LC.imap_always_use_remote_store, String.valueOf(true));
         imapServer.setReverseProxyUpstreamImapServers(new String[] {});
         super.sharedSetUp();
@@ -24,7 +23,6 @@ public class TestEmbeddedRemoteImapNotificationsViaWaitsets extends TestImapNoti
     @After
     public void tearDown() throws ServiceException, DocumentException, ConfigException, IOException  {
         super.sharedTearDown();
-        restoreImapConfigSettings();
     }
 
     @Override

--- a/store/src/java/com/zimbra/qa/unittest/TestImapDaemonNotifications.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestImapDaemonNotifications.java
@@ -1,8 +1,9 @@
 package com.zimbra.qa.unittest;
 
+import static org.junit.Assert.fail;
+
 import org.junit.After;
 import org.junit.Before;
-import static org.junit.Assert.fail;
 
 import com.zimbra.client.ZFolder;
 import com.zimbra.client.ZMailbox;
@@ -14,7 +15,6 @@ public class TestImapDaemonNotifications extends SharedImapNotificationTests {
     public void setUp() throws Exception  {
         getLocalServer();
         TestUtil.assumeTrue("remoteImapServerEnabled false for this server", imapServer.isRemoteImapServerEnabled());
-        saveImapConfigSettings();
         TestUtil.setLCValue(LC.imap_always_use_remote_store, String.valueOf(false));
         imapServer.setReverseProxyUpstreamImapServers(new String[] {imapServer.getServiceHostname()});
         super.sharedSetUp();
@@ -24,7 +24,6 @@ public class TestImapDaemonNotifications extends SharedImapNotificationTests {
     @After
     public void tearDown() throws Exception  {
         super.sharedTearDown();
-        restoreImapConfigSettings();
         TestUtil.flushImapDaemonCache(imapServer);
         getAdminConnection().reloadLocalConfig();
     }

--- a/store/src/java/com/zimbra/qa/unittest/TestImapViaEmbeddedLocal.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestImapViaEmbeddedLocal.java
@@ -27,7 +27,6 @@ public class TestImapViaEmbeddedLocal extends SharedImapTests {
 
     @Before
     public void setUp() throws ServiceException, IOException, DocumentException, ConfigException  {
-        saveImapConfigSettings();
         TestUtil.setLCValue(LC.imap_always_use_remote_store, String.valueOf(false));
         imapServer.setReverseProxyUpstreamImapServers(new String[] {});
         super.sharedSetUp();
@@ -37,7 +36,6 @@ public class TestImapViaEmbeddedLocal extends SharedImapTests {
     @After
     public void tearDown() throws ServiceException, DocumentException, ConfigException, IOException  {
         super.sharedTearDown();
-        restoreImapConfigSettings();
     }
 
     @Override

--- a/store/src/java/com/zimbra/qa/unittest/TestImapViaEmbeddedRemote.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestImapViaEmbeddedRemote.java
@@ -25,7 +25,6 @@ public class TestImapViaEmbeddedRemote extends SharedImapTests {
 
     @Before
     public void setUp() throws ServiceException, IOException, DocumentException, ConfigException  {
-        saveImapConfigSettings();
         TestUtil.setLCValue(LC.imap_always_use_remote_store, String.valueOf(true));
         imapServer.setReverseProxyUpstreamImapServers(new String[] {});
         super.sharedSetUp();
@@ -35,7 +34,6 @@ public class TestImapViaEmbeddedRemote extends SharedImapTests {
     @After
     public void tearDown() throws ServiceException, DocumentException, ConfigException, IOException  {
         super.sharedTearDown();
-        restoreImapConfigSettings();
     }
 
     @Override

--- a/store/src/java/com/zimbra/qa/unittest/TestImapViaImapDaemon.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestImapViaImapDaemon.java
@@ -53,8 +53,13 @@ import com.zimbra.soap.admin.type.CacheEntryType;
           TestUtil.assumeTrue("remoteImapServerEnabled false for this server", imapServer.isRemoteImapServerEnabled());
           TestUtil.setLCValue(LC.imap_always_use_remote_store, String.valueOf(false));
           imapServer.setReverseProxyUpstreamImapServers(new String[] {imapServer.getServiceHostname()});
-          imapServer.setImapServerEnabled(false);
-          imapServer.setImapSSLServerEnabled(false);
+          // As we're connecting to the IMAP daemon's port directly, there is no harm
+          // in having the other IMAP daemon running.  Also, currently, changing the value of these
+          // settings may result in zmconfigd restarting mailboxd (due to attrs having
+          // requiresRestart="mailbox" in zimbra-attrs.xml).  Obviously, that results in RunUnitTestsRequest
+          // failing because the process it was talking to has disappeared!
+          // imapServer.setImapServerEnabled(false);
+          // imapServer.setImapSSLServerEnabled(false);
           super.sharedSetUp();
           TestUtil.flushImapDaemonCache(imapServer);
       }

--- a/store/src/java/com/zimbra/qa/unittest/TestImapViaImapDaemon.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestImapViaImapDaemon.java
@@ -51,7 +51,6 @@ import com.zimbra.soap.admin.type.CacheEntryType;
       public void setUp() throws Exception  {
           getLocalServer();
           TestUtil.assumeTrue("remoteImapServerEnabled false for this server", imapServer.isRemoteImapServerEnabled());
-          saveImapConfigSettings();
           TestUtil.setLCValue(LC.imap_always_use_remote_store, String.valueOf(false));
           imapServer.setReverseProxyUpstreamImapServers(new String[] {imapServer.getServiceHostname()});
           imapServer.setImapServerEnabled(false);
@@ -63,7 +62,6 @@ import com.zimbra.soap.admin.type.CacheEntryType;
       @After
       public void tearDown() throws Exception {
           super.sharedTearDown();
-          restoreImapConfigSettings();
           if (imapHostname != null) {
               TestUtil.flushImapDaemonCache(imapServer);
               getAdminConnection().reloadLocalConfig();

--- a/store/src/java/com/zimbra/qa/unittest/TestLocalImapNotifications.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestLocalImapNotifications.java
@@ -1,5 +1,7 @@
 package com.zimbra.qa.unittest;
 
+import static org.junit.Assert.assertNull;
+
 import java.io.IOException;
 
 import org.dom4j.DocumentException;
@@ -11,12 +13,10 @@ import com.zimbra.client.ZMailbox;
 import com.zimbra.common.localconfig.ConfigException;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
-import static org.junit.Assert.assertNull;
 public class TestLocalImapNotifications extends SharedImapNotificationTests {
 
     @Before
     public void setUp() throws ServiceException, IOException, DocumentException, ConfigException  {
-        saveImapConfigSettings();
         TestUtil.setLCValue(LC.imap_always_use_remote_store, String.valueOf(false));
         imapServer.setReverseProxyUpstreamImapServers(new String[] {});
         super.sharedSetUp();
@@ -26,7 +26,6 @@ public class TestLocalImapNotifications extends SharedImapNotificationTests {
     @After
     public void tearDown() throws ServiceException, DocumentException, ConfigException, IOException  {
         super.sharedTearDown();
-        restoreImapConfigSettings();
     }
 
     @Override

--- a/store/src/java/com/zimbra/qa/unittest/TestRemoteImapSoapSessions.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestRemoteImapSoapSessions.java
@@ -22,13 +22,12 @@ public class TestRemoteImapSoapSessions extends ImapTestBase {
     @Before
     public void setUp() throws ServiceException, IOException, DocumentException, ConfigException  {
         sharedSetUp();
-        saveImapConfigSettings();
         boolean canUseRemoteImap = false;
         boolean canUseLocalImap = imapServer.isImapServerEnabled() && imapServer.isImapCleartextLoginEnabled();
         if(canUseLocalImap) {
             TestUtil.setLCValue(LC.imap_always_use_remote_store, String.valueOf(true));
         } else {
-            canUseRemoteImap = imapServer.isRemoteImapServerEnabled() && imapServer.isImapCleartextLoginEnabled() && 
+            canUseRemoteImap = imapServer.isRemoteImapServerEnabled() && imapServer.isImapCleartextLoginEnabled() &&
                     Arrays.asList(imapServer.getReverseProxyUpstreamImapServers()).contains(imapServer.getServiceHostname());
         }
         TestUtil.assumeTrue("neither embeded remote, nor standalone imapd are available", canUseRemoteImap || canUseLocalImap);
@@ -37,7 +36,6 @@ public class TestRemoteImapSoapSessions extends ImapTestBase {
     @After
     public void tearDown() throws ServiceException, DocumentException, ConfigException, IOException  {
         sharedTearDown();
-        restoreImapConfigSettings();
     }
 
     @Test


### PR DESCRIPTION
Don't set 2 LDAP attributes that trigger zmconfigd to restart mailboxd - we don't actually need to set them!

Verified that with these changes, imap logging went to the appropriate log file (imapd.log or mailbox.log) depending on the test being executed.