### PR TITLE
ZIMBRA-117: received event logging

### DIFF
--- a/store/src/java/com/zimbra/cs/datasource/MailItemImport.java
+++ b/store/src/java/com/zimbra/cs/datasource/MailItemImport.java
@@ -129,6 +129,7 @@ public abstract class MailItemImport implements DataSource.DataImport {
                 ctxt = new MessageCallbackContext(Type.sent);
             } else if (!folderName.equalsIgnoreCase("drafts") && !folderName.equalsIgnoreCase("trash")) {
                 ctxt = new MessageCallbackContext(Type.received);
+                ctxt.setRecipient(dataSource.getEmailAddress());
             }
             if (ctxt != null) {
                 ctxt.setDataSourceId(dataSource.getId());

--- a/store/src/java/com/zimbra/cs/event/Event.java
+++ b/store/src/java/com/zimbra/cs/event/Event.java
@@ -87,13 +87,21 @@ public class Event {
     }
 
     /**
-     * Convenience method to generate a single SENT event
+     * Base method that encapsulated the logic to create an event with commonly used fields
      */
-    public static Event generateSentEvent(String accountId, int messageId, String sender, String recipient, String dsId) {
-        Event event = new Event(accountId, EventType.SENT, System.currentTimeMillis());
+    private static Event generateEvent(String accountId, int messageId, String sender, String recipient, EventType eventType) {
+        Event event = new Event(accountId, eventType, System.currentTimeMillis());
         event.setContextField(EventContextField.MSG_ID, messageId);
         event.setContextField(EventContextField.SENDER, new ParsedAddress(sender.toString()).emailPart);
         event.setContextField(EventContextField.RECEIVER, new ParsedAddress(recipient.toString()).emailPart);
+        return event;
+    }
+
+    /**
+     * Convenience method to generate a single SENT event
+     */
+    public static Event generateSentEvent(String accountId, int messageId, String sender, String recipient, String dsId) {
+        Event event = generateEvent(accountId, messageId, sender, recipient, EventType.SENT);
         if (dsId != null) {
             event.setContextField(EventContextField.DATASOURCE_ID, dsId);
         }
@@ -109,5 +117,12 @@ public class Event {
             sentEvents.add(generateSentEvent(accountId, messageId, sender.toString(), address.toString(), dsId));
         }
         return sentEvents;
+    }
+
+    /**
+     * Convenience method to generate a single RECEIVED event
+     */
+    public static Event generateReceivedEvent(String accountId, int messageId, String sender, String recipient) {
+        return generateEvent(accountId, messageId, sender, recipient, EventType.RECEIVED);
     }
 }

--- a/store/src/java/com/zimbra/cs/filter/ExistingMessageHandler.java
+++ b/store/src/java/com/zimbra/cs/filter/ExistingMessageHandler.java
@@ -182,7 +182,7 @@ public final class ExistingMessageHandler implements FilterHandler {
         ItemId id = FilterUtil.addMessage(new DeliveryContext(), mailbox, getParsedMessage(),
                                           mailbox.getAccount().getName(), folderPath, false,
                                           FilterUtil.getFlagBitmask(flagActions, source.getFlagBitmask()),
-                                          tags, Mailbox.ID_AUTO_INCREMENT, octxt);
+                                          tags, Mailbox.ID_AUTO_INCREMENT, octxt, getMessageCallbackContext());
         if (id != null) {
             filtered = true;
             filed = true;

--- a/store/src/java/com/zimbra/cs/filter/FilterHandler.java
+++ b/store/src/java/com/zimbra/cs/filter/FilterHandler.java
@@ -29,6 +29,7 @@ import com.zimbra.cs.filter.jsieve.ErejectException;
 import com.zimbra.cs.lmtpserver.LmtpEnvelope;
 import com.zimbra.cs.mailbox.DeliveryContext;
 import com.zimbra.cs.mailbox.Message;
+import com.zimbra.cs.mailbox.Mailbox.MessageCallbackContext;
 import com.zimbra.cs.mime.ParsedMessage;
 import com.zimbra.cs.service.util.ItemId;
 
@@ -44,6 +45,10 @@ interface FilterHandler {
     MimeMessage getMimeMessage() throws ServiceException;
 
     default public DeliveryContext getDeliveryContext() {
+        return null;
+    }
+
+    default public MessageCallbackContext getMessageCallbackContext() {
         return null;
     }
 

--- a/store/src/java/com/zimbra/cs/filter/FilterUtil.java
+++ b/store/src/java/com/zimbra/cs/filter/FilterUtil.java
@@ -82,6 +82,8 @@ import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.Message;
 import com.zimbra.cs.mailbox.Mountpoint;
 import com.zimbra.cs.mailbox.OperationContext;
+import com.zimbra.cs.mailbox.Mailbox.MessageCallbackContext;
+import com.zimbra.cs.mailbox.Mailbox.MessageCallback.Type;
 import com.zimbra.cs.mime.MPartInfo;
 import com.zimbra.cs.mime.Mime;
 import com.zimbra.cs.mime.ParsedMessage;
@@ -170,7 +172,8 @@ public final class FilterUtil {
      * @return the id of the new message, or <tt>null</tt> if it was a duplicate
      */
     public static ItemId addMessage(DeliveryContext context, Mailbox mbox, ParsedMessage pm, String recipient,
-                                    String folderPath, boolean noICal, int flags, String[] tags, int convId, OperationContext octxt)
+                                    String folderPath, boolean noICal, int flags, String[] tags, int convId, OperationContext octxt,
+                                    MessageCallbackContext ctxt)
     throws ServiceException {
         // Do initial lookup.
         Pair<Folder, String> folderAndPath = mbox.getFolderByPathLongestMatch(
@@ -224,6 +227,9 @@ public final class FilterUtil {
             try {
                 DeliveryOptions dopt = new DeliveryOptions().setFolderId(folder).setNoICal(noICal);
                 dopt.setFlags(flags).setTags(tags).setConversationId(convId).setRecipientEmail(recipient);
+                if (ctxt != null) {
+                    dopt.setCallbackContext(ctxt);
+                }
                 Message msg = mbox.addMessage(octxt, pm, dopt, context);
                 if (msg == null) {
                     return null;

--- a/store/src/java/com/zimbra/cs/filter/IncomingMessageHandler.java
+++ b/store/src/java/com/zimbra/cs/filter/IncomingMessageHandler.java
@@ -36,6 +36,7 @@ import com.zimbra.cs.mailbox.Folder;
 import com.zimbra.cs.mailbox.MailItem;
 import com.zimbra.cs.mailbox.MailServiceException.NoSuchItemException;
 import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.Mailbox.MessageCallbackContext;
 import com.zimbra.cs.mailbox.Message;
 import com.zimbra.cs.mailbox.OperationContext;
 import com.zimbra.cs.mime.ParsedMessage;
@@ -102,7 +103,7 @@ public final class IncomingMessageHandler implements FilterHandler {
             throws ServiceException {
         ItemId id = FilterUtil.addMessage(dctxt, mailbox, parsedMessage, recipientAddress, folderPath,
                                           false, FilterUtil.getFlagBitmask(flagActions, Flag.BITMASK_UNREAD),
-                                          tags, Mailbox.ID_AUTO_INCREMENT, octxt);
+                                          tags, Mailbox.ID_AUTO_INCREMENT, octxt, getMessageCallbackContext());
 
         // Do spam training if the user explicitly filed the message into
         // the spam folder (bug 37164).
@@ -134,7 +135,7 @@ public final class IncomingMessageHandler implements FilterHandler {
         try {
             DeliveryOptions dopt = new DeliveryOptions().setFolderId(folderId).setNoICal(noICal).setRecipientEmail(recipientAddress);
             dopt.setFlags(FilterUtil.getFlagBitmask(flagActions, Flag.BITMASK_UNREAD)).setTags(tags);
-            dopt.setCallbackContext(new Mailbox.MessageCallbackContext(Mailbox.MessageCallback.Type.received));
+            dopt.setCallbackContext(getMessageCallbackContext());
             return mailbox.addMessage(octxt, parsedMessage, dopt, dctxt);
         } catch (IOException e) {
             throw ServiceException.FAILURE("Unable to add incoming message", e);
@@ -199,6 +200,13 @@ public final class IncomingMessageHandler implements FilterHandler {
     @Override
     public DeliveryContext getDeliveryContext() {
         return dctxt;
+    }
+
+    @Override
+    public MessageCallbackContext getMessageCallbackContext() {
+        MessageCallbackContext ctxt = new MessageCallbackContext(Mailbox.MessageCallback.Type.received);
+        ctxt.setRecipient(recipientAddress);
+        return ctxt;
     }
 
     public void setParsedMessage(ParsedMessage pm) {

--- a/store/src/java/com/zimbra/cs/filter/OutgoingMessageHandler.java
+++ b/store/src/java/com/zimbra/cs/filter/OutgoingMessageHandler.java
@@ -30,9 +30,9 @@ import com.zimbra.cs.filter.jsieve.ActionFlag;
 import com.zimbra.cs.lmtpserver.LmtpEnvelope;
 import com.zimbra.cs.mailbox.DeliveryOptions;
 import com.zimbra.cs.mailbox.Mailbox;
-import com.zimbra.cs.mailbox.Mailbox.MessageCallback.Type;
 import com.zimbra.cs.mailbox.Message;
 import com.zimbra.cs.mailbox.OperationContext;
+import com.zimbra.cs.mailbox.Mailbox.MessageCallbackContext;
 import com.zimbra.cs.mime.ParsedMessage;
 import com.zimbra.cs.service.util.ItemId;
 
@@ -100,7 +100,7 @@ public final class OutgoingMessageHandler implements FilterHandler {
             dopt.setFlags(FilterUtil.getFlagBitmask(flagActions, defaultFlags));
             dopt.setTags(FilterUtil.getTagsUnion(tags, defaultTags));
             dopt.setNoICal(noICal);
-            dopt.setCallbackContext(new Mailbox.MessageCallbackContext(Mailbox.MessageCallback.Type.sent));
+            dopt.setCallbackContext(getMessageCallbackContext());
             return mailbox.addMessage(octxt, parsedMessage, dopt, null);
         } catch (IOException e) {
             throw ServiceException.FAILURE("Unable to add sent message", e);
@@ -153,7 +153,7 @@ public final class OutgoingMessageHandler implements FilterHandler {
             throws ServiceException {
         return FilterUtil.addMessage(null, mailbox, parsedMessage, null, folderPath, noICal,
                                      FilterUtil.getFlagBitmask(flagActions, defaultFlags),
-                                     FilterUtil.getTagsUnion(tags, defaultTags), convId, octxt);
+                                     FilterUtil.getTagsUnion(tags, defaultTags), convId, octxt, getMessageCallbackContext());
     }
 
     @Override
@@ -166,5 +166,10 @@ public final class OutgoingMessageHandler implements FilterHandler {
 
     @Override
     public void afterFiltering() {
+    }
+
+    @Override
+    public MessageCallbackContext getMessageCallbackContext() {
+        return new Mailbox.MessageCallbackContext(Mailbox.MessageCallback.Type.sent);
     }
 }

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -793,6 +793,7 @@ public class Mailbox implements MailboxStore {
         lock = new MailboxLock(data.accountId, this);
         callbacks = new HashMap<>();
         callbacks.put(MessageCallback.Type.sent, new SentMessageCallback());
+        callbacks.put(MessageCallback.Type.received, new ReceivedMessageCallback());
     }
 
     public void setGalSyncMailbox(boolean galSyncMailbox) {
@@ -10634,6 +10635,7 @@ public class Mailbox implements MailboxStore {
 
     public static class MessageCallbackContext {
         private String dsId;
+        private String recipient;
         private MessageCallback.Type type;
 
         public MessageCallbackContext(MessageCallback.Type type) {
@@ -10648,8 +10650,16 @@ public class Mailbox implements MailboxStore {
             return dsId;
         }
 
+        public String getRecipient() {
+            return recipient;
+        }
+
         public void setDataSourceId(String dsId) {
             this.dsId = dsId;
+        }
+
+        public void setRecipient(String recipient) {
+            this.recipient = recipient;
         }
     }
 
@@ -10675,6 +10685,19 @@ public class Mailbox implements MailboxStore {
                 ZimbraLog.soap.warn(String.format("Couldn't log SENT event for message %s", msgId), e);
             }
         }
+    }
 
+    public class ReceivedMessageCallback implements MessageCallback {
+
+        @Override
+        public void execute(int msgId, ParsedMessage pm, MessageCallbackContext ctxt) {
+            String sender = pm.getSender();
+            String recipient = ctxt.getRecipient();
+            if (Strings.isNullOrEmpty(recipient)) {
+                ZimbraLog.event.warn("no recipient specified for message %d", msgId);
+            } else {
+                EventLogger.getEventLogger().log(Event.generateReceivedEvent(getAccountId(), msgId, sender, recipient));
+            }
+        }
     }
 }

--- a/store/src/java/com/zimbra/cs/service/formatter/ArchiveFormatter.java
+++ b/store/src/java/com/zimbra/cs/service/formatter/ArchiveFormatter.java
@@ -1401,8 +1401,16 @@ public abstract class ArchiveFormatter extends Formatter {
                         setFolderId(fldr.getId()).setNoICal(true).
                         setFlags(msg.getFlagBitmask()).
                         setTags(msg.getTags());
+                        MessageCallbackContext callbackCtxt = null;
                         if (fldr.getId() == Mailbox.ID_FOLDER_SENT) {
-                            MessageCallbackContext callbackCtxt = new MessageCallbackContext(Mailbox.MessageCallback.Type.sent);
+                             callbackCtxt = new MessageCallbackContext(Mailbox.MessageCallback.Type.sent);
+                            opt.setCallbackContext(callbackCtxt);
+                        } else if (fldr.getId() != Mailbox.ID_FOLDER_TRASH && fldr.getId() != Mailbox.ID_FOLDER_DRAFTS) {
+                            String recipient = mbox.getAccount().getName(); //assume the recipient is the name on the account
+                            callbackCtxt = new MessageCallbackContext(Mailbox.MessageCallback.Type.received);
+                            callbackCtxt.setRecipient(recipient);
+                        }
+                        if (callbackCtxt != null) {
                             opt.setCallbackContext(callbackCtxt);
                         }
                         newItem = mbox.addMessage(octxt, ais.getInputStream(), (int) aie.getSize(),


### PR DESCRIPTION
Logging a "received" event via _ReceivedMessageCallback_. This is triggered from _ArchiveFormatter_, _IncomingMessageHandler_, and _MailItemImport_.

As part of this change, I added a new _getMessageCallbackContext_ method to the _FilterHandler_ interface and ensured that the callback context is set for all FilterHandler call paths that add a message to the mailbox. _ExistingMessageHandler_ uses the default null value, so that no events are triggered when processing existing messages.