### PR TITLE
ZIMBRA-121: File event logger

### DIFF
--- a/common/src/java/com/zimbra/common/util/ZimbraLog.java
+++ b/common/src/java/com/zimbra/common/util/ZimbraLog.java
@@ -471,6 +471,13 @@ public final class ZimbraLog {
     public static final Log event = LogFactory.getLog("zimbra.event");
 
     /**
+     * the "zimbra.eventlog" logger. This is used for logging actual event data,
+     * as opposed to the "zimbra.event" logger, which is used for general messages
+     * about the event system.
+     */
+    public static final Log eventlog = LogFactory.getLog("zimbra.eventlog");
+
+    /**
      * Maps the log category name to its description.
      */
     public static final Map<String, String> CATEGORY_DESCRIPTIONS;
@@ -560,6 +567,7 @@ public final class ZimbraLog {
         descriptions.put(ews.getCategory(), "EWS operations");
         descriptions.put(contactbackup.getCategory(), "Contact Backup and restore");
         descriptions.put(event.getCategory(), "Event log operations");
+        descriptions.put(eventlog.getCategory(), "Serialized events");
         CATEGORY_DESCRIPTIONS = Collections.unmodifiableMap(descriptions);
     }
 

--- a/store-conf/conf/log4j.properties.production
+++ b/store-conf/conf/log4j.properties.production
@@ -103,6 +103,16 @@ log4j.appender.EWS.File=/opt/zimbra/log/ews.log
 log4j.appender.EWS.layout=com.zimbra.common.util.ZimbraPatternLayout
 log4j.appender.EWS.layout.ConversionPattern=%d %-5p [%t] [%z] %c{1} - %m%n
 
+#Appender EVENTS writes to the file "event.log".
+log4j.appender.EVENTS=org.apache.log4j.rolling.RollingFileAppender
+log4j.appender.EVENTS.RollingPolicy=org.apache.log4j.rolling.TimeBasedRollingPolicy
+log4j.appender.EVENTS.RollingPolicy.FileNamePattern=/opt/zimbra/log/event.log.%d{yyyy-MM-dd}
+log4j.appender.EVENTS.File=/opt/zimbra/log/event.log
+log4j.appender.EVENTS.layout=com.zimbra.common.util.ZimbraPatternLayout
+#The conversion pattern is simpler because event log entries are already serialized in a
+#meaningful way, and can be deserialized back into Event objects.
+log4j.appender.EVENTS.layout.ConversionPattern=%m%n
+
 # HttpMethodBase spews out too many WARN on the badly formatted cookies.
 log4j.logger.org.apache.commons.httpclient.HttpMethodBase=ERROR
 
@@ -122,6 +132,8 @@ log4j.logger.zimbra.activity=INFO,ACTIVITY
 log4j.logger.zimbra.searchstat=INFO,SEARCHSTAT
 log4j.additivity.zimbra.ews=false
 log4j.logger.zimbra.ews=INFO,EWS
+log4j.additivity.zimbra.eventlog=false
+log4j.logger.zimbra.eventlog=INFO,EVENTS
 
 log4j.logger.zimbra=INFO
 log4j.logger.zimbra.op=WARN

--- a/store/src/java-test/com/zimbra/cs/event/logger/FileEventLoggerTest.java
+++ b/store/src/java-test/com/zimbra/cs/event/logger/FileEventLoggerTest.java
@@ -1,0 +1,28 @@
+package com.zimbra.cs.event.logger;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.event.Event;
+import com.zimbra.cs.event.Event.EventContextField;
+import com.zimbra.cs.event.Event.EventType;
+import com.zimbra.cs.event.logger.FileEventLogHandler.EventFormatter;
+
+public class FileEventLoggerTest {
+
+    @Test
+    public void testEventFormatter() throws Exception {
+        EventFormatter fmt = new FileEventLogHandler.ZimbraEventFormatter();
+        long timestamp = System.currentTimeMillis();
+        Event event = new Event("testid", EventType.SENT, timestamp);
+        event.setContextField(EventContextField.SENDER, "sender");
+        event.setContextField(EventContextField.RECEIVER, "receiver");
+        String formatted = fmt.toLogString(event);
+        ZimbraLog.test.info("FORMATTED: %s", formatted);
+        Event deserialized = fmt.fromLogString(formatted);
+        ZimbraLog.test.info("DESERIALIZED: %s", deserialized);
+        assertEquals("events are different", event, deserialized);
+    }
+}

--- a/store/src/java/com/zimbra/cs/event/Event.java
+++ b/store/src/java/com/zimbra/cs/event/Event.java
@@ -2,6 +2,8 @@ package com.zimbra.cs.event;
 
 import javax.mail.Address;
 
+import com.google.common.base.Objects;
+import com.google.common.base.Objects.ToStringHelper;
 import com.zimbra.cs.mime.ParsedAddress;
 
 import java.util.ArrayList;
@@ -124,5 +126,30 @@ public class Event {
      */
     public static Event generateReceivedEvent(String accountId, int messageId, String sender, String recipient) {
         return generateEvent(accountId, messageId, sender, recipient, EventType.RECEIVED);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other instanceof Event) {
+            Event otherEvent = (Event) other;
+            return accountId.equals(otherEvent.accountId) &&
+                    eventType == otherEvent.eventType &&
+                    timestamp == otherEvent.timestamp &&
+                    context.equals(otherEvent.context);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public String toString() {
+        ToStringHelper helper = Objects.toStringHelper(this)
+                .add("acctId", accountId)
+                .add("type", eventType)
+                .add("timestamp", timestamp);
+        for (Map.Entry<EventContextField, Object> entry: context.entrySet()) {
+            helper.add(entry.getKey().toString(), entry.getValue().toString());
+        }
+        return helper.toString();
     }
 }

--- a/store/src/java/com/zimbra/cs/event/logger/FileEventLogHandler.java
+++ b/store/src/java/com/zimbra/cs/event/logger/FileEventLogHandler.java
@@ -1,0 +1,140 @@
+package com.zimbra.cs.event.logger;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.type.TypeReference;
+
+import com.zimbra.common.util.Log;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.event.Event;
+import com.zimbra.cs.event.Event.EventContextField;
+import com.zimbra.cs.event.Event.EventType;
+
+/**
+ * Event log handler that logs events to a log file in a structured manner.
+ * This lets us re-index events or migrate them to a different backend.
+ */
+public class FileEventLogHandler implements EventLogHandler {
+
+    private EventFormatter formatter;
+    private static final Log log = ZimbraLog.eventlog;
+
+    public FileEventLogHandler(EventFormatter formatter) {
+        this.formatter = formatter;
+    }
+
+    @Override
+    public void log(Event event) {
+        String logString = formatter.toLogString(event);
+        if (logString != null) {
+            log.info(logString);
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        //nothing to do here
+    }
+
+    static interface EventFormatter {
+        String toLogString(Event event);
+        Event fromLogString(String string);
+    }
+
+    static class ZimbraEventFormatter implements EventFormatter {
+
+        private static final String KEY_TYPE = "type";
+        private static final String KEY_TIMESTAMP = "timestamp";
+        private static final String KEY_ACCT_ID = "id";
+
+        @Override
+        public String toLogString(Event event) {
+            String accountId = event.getAccountId();
+            String type = event.getEventType().toString();
+            String timestamp = String.valueOf(event.getTimestamp());
+            ObjectMapper mapper = new ObjectMapper();
+            Map<String, Object> eventMap = new HashMap<>();
+
+            eventMap.put(KEY_ACCT_ID, accountId);
+            eventMap.put(KEY_TIMESTAMP, timestamp);
+            eventMap.put(KEY_TYPE, type);
+            for (Map.Entry<EventContextField, Object> entry: event.getContext().entrySet()) {
+                eventMap.put(entry.getKey().toString(), entry.getValue());
+            }
+            try {
+                return mapper.writeValueAsString(eventMap);
+            } catch (IOException e) {
+                ZimbraLog.event.error("unable to serialize %s event for account %s", type, accountId, e);
+                return null;
+            }
+        }
+
+        @Override
+        public Event fromLogString(String string) {
+            ObjectMapper mapper = new ObjectMapper();
+            try {
+                String acctId = null;
+                EventType type = null;
+                Long timestamp = null;
+                Map<EventContextField, Object> contextMap = new HashMap<>();
+                Map<String, String> eventDataMap = mapper.readValue(string, new TypeReference<Map<String, String>>() {});
+                for(Map.Entry<String, String> entry: eventDataMap.entrySet()) {
+                    String key = entry.getKey();
+                    String value = entry.getValue();
+                    switch(key) {
+                    case KEY_TYPE:
+                        type = EventType.valueOf(value);
+                        break;
+                    case KEY_ACCT_ID:
+                        acctId = value;
+                        break;
+                    case KEY_TIMESTAMP:
+                        timestamp = Long.valueOf(value);
+                        break;
+                    default:
+                        try {
+                            EventContextField ctxtField = EventContextField.valueOf(key);
+                            contextMap.put(ctxtField, value);
+                        } catch (IllegalArgumentException e) {
+                            ZimbraLog.event.warn("unknown event field: %s", key);
+                        }
+                    }
+                }
+                if (acctId == null) {
+                    ZimbraLog.event.error("unable to deserialize event [%s], no account ID found", string);
+                    return null;
+                } else if (type == null) {
+                    ZimbraLog.event.error("unable to deserialize event [%s], no  event type found", string);
+                    return null;
+                } else if (timestamp == null) {
+                    ZimbraLog.event.error("unable to deserialize event [%s], no  event type found", string);
+                    return null;
+                }
+                Event event = new Event(acctId, type, timestamp);
+                event.setContext(contextMap);
+                return event;
+            } catch (IOException e) {
+                ZimbraLog.event.error("unable to deserialize event [%s]", string, e);
+                return null;
+            }
+        }
+    }
+
+    public static class Factory implements EventLogHandler.Factory {
+
+        private FileEventLogHandler instance;
+
+        @Override
+        public EventLogHandler createHandler(String config) {
+            synchronized (Factory.class) {
+                if (instance == null) {
+                    instance = new FileEventLogHandler(new ZimbraEventFormatter());
+                }
+                return instance;
+            }
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/util/Zimbra.java
+++ b/store/src/java/com/zimbra/cs/util/Zimbra.java
@@ -50,6 +50,7 @@ import com.zimbra.cs.db.Versions;
 import com.zimbra.cs.ephemeral.EphemeralStore;
 import com.zimbra.cs.ephemeral.LdapEphemeralStore;
 import com.zimbra.cs.event.logger.EventLogger;
+import com.zimbra.cs.event.logger.FileEventLogHandler;
 import com.zimbra.cs.extension.ExtensionUtil;
 import com.zimbra.cs.index.IndexStore;
 import com.zimbra.cs.index.queue.IndexingService;
@@ -303,8 +304,8 @@ public final class Zimbra {
             redoLog.initRedoLogManager();
         }
 
-        EventLogger eventLogger = EventLogger.getEventLogger();
-        eventLogger.startupEventNotifierExecutor();
+        EventLogger.registerHandlerFactory("file", new FileEventLogHandler.Factory());
+        EventLogger.getEventLogger().startupEventNotifierExecutor();
 
         System.setProperty("ical4j.unfolding.relaxed", "true");
 


### PR DESCRIPTION
This is the default event logger that serializes events into a logfile. Events are logged to `opt/zimbra/log/event.log` with the same rollover configuration as the other logs.

This is done using a new `eventlog` logger category. This is distinct from the existing `event` category, which is used for general logging of the event system. 

The _EventFormatter_ class is used for serializing/deserializing an event object. The deserialization functionality will be used in the future for re-indexing events in solr.