### PR TITLE
Bugfix/zcs 2862

### DIFF
--- a/store/src/java/com/zimbra/cs/imap/ImapServerListener.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapServerListener.java
@@ -347,8 +347,8 @@ public class ImapServerListener {
     }
 
     private void cancelPendingRequest() {
-        ZimbraLog.imap.debug("Canceling pending AdminWaitSetRequest for waitset %s. Sequence %s", wsID, lastSequence.toString());
         if(pendingRequest != null && !(pendingRequest.isCancelled() || pendingRequest.isDone())) {
+            ZimbraLog.imap.debug("Canceling pending AdminWaitSetRequest for waitset %s. Sequence %s", wsID, lastSequence.toString());
             pendingRequest.cancel(true);
             pendingRequest = null;
         }

--- a/store/src/java/com/zimbra/cs/imap/ImapServerListener.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapServerListener.java
@@ -346,10 +346,11 @@ public class ImapServerListener {
         return wsID;
     }
 
-    private synchronized void cancelPendingRequest() {
+    private void cancelPendingRequest() {
         ZimbraLog.imap.debug("Canceling pending AdminWaitSetRequest for waitset %s. Sequence %s", wsID, lastSequence.toString());
         if(pendingRequest != null && !(pendingRequest.isCancelled() || pendingRequest.isDone())) {
             pendingRequest.cancel(true);
+            pendingRequest = null;
         }
     }
 

--- a/store/src/java/com/zimbra/cs/imap/ImapServerListener.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapServerListener.java
@@ -347,7 +347,7 @@ public class ImapServerListener {
     }
 
     private void cancelPendingRequest() {
-        if(pendingRequest != null && !(pendingRequest.isCancelled() || pendingRequest.isDone())) {
+        if (pendingRequest != null && !(pendingRequest.isCancelled() || pendingRequest.isDone())) {
             ZimbraLog.imap.debug("Canceling pending AdminWaitSetRequest for waitset %s. Sequence %s", wsID, lastSequence.toString());
             pendingRequest.cancel(true);
             pendingRequest = null;

--- a/store/src/java/com/zimbra/cs/imap/ImapServerListener.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapServerListener.java
@@ -68,6 +68,7 @@ public class ImapServerListener {
     private final AtomicInteger lastSequence = new AtomicInteger(0);
     private final SoapProvisioning soapProv = new SoapProvisioning();
     private Future<HttpResponse> pendingRequest;
+    private final Integer pendingRequestGuard = 1;
 
     ImapServerListener(String svr) throws ServiceException {
         this.server = svr;
@@ -349,8 +350,10 @@ public class ImapServerListener {
     private void cancelPendingRequest() {
         if (pendingRequest != null && !(pendingRequest.isCancelled() || pendingRequest.isDone())) {
             ZimbraLog.imap.debug("Canceling pending AdminWaitSetRequest for waitset %s. Sequence %s", wsID, lastSequence.toString());
-            pendingRequest.cancel(true);
-            pendingRequest = null;
+            synchronized (pendingRequestGuard) {
+                pendingRequest.cancel(true);
+                pendingRequest = null;
+            }
         }
     }
 


### PR DESCRIPTION
I believe that this particular synchronized keyword is superfluous and is at least one cause of the thread-lock that was seen in this case.

Nowhere else in the code is 'pendingRequest' actually used except in this function.
The variable is used to hold the Future and is only assigned once per asynchronous request.
It depends on a callback firing when the asynchronous SOAP request is issued to handle the response when it happens.

There are two main objects being locked:
- ImapListener instance
- ImapServerListener instance

This function is forcing synchronization on the entire object when each of them call each other respectively which causes each thread to lock one lock and attempt to acquire the lock in the other class.  Sometimes the timing works out and the first lock is released before the second one in either class is hit, and sometimes it isn't.  

I can't get this lock contention to happen on demand so far.  I am going to keep banging on it and seeing if refinement to my IMAP stress utility will eventually trigger it in a reliable way.
