### PR TITLE
ZCS-3010:IMAP APPEND CATENATE with URL broken

### DIFF
--- a/store/src/java/com/zimbra/cs/service/UserServlet.java
+++ b/store/src/java/com/zimbra/cs/service/UserServlet.java
@@ -505,6 +505,7 @@ public class UserServlet extends ZimbraServlet {
                     // if the target is a mountpoint, the request was already proxied to the resolved target
                     return;
                 }
+                context.target = item;  /* imap_id resolution needs this. */
             }
         }
 


### PR DESCRIPTION
* UserServlet - For remote IMAP, was using UserServlet GET specifying
  "imap_id".  The formatter requires `context.target` to have a value
  and this wasn't being setup under these circumstances.  Now set it up.
* New tests which exercise CATENATE with URLs which reference messages
  in shared folders.