### PR TITLE
ZCS-3424: change default value of zimbraFeatureContactBackupFrequency to 0

### DIFF
--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9409,7 +9409,7 @@ TODO: delete them permanently from here
 </attr>
 
 <attr id="2124" name="zimbraFeatureContactBackupFrequency" type="duration" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" callback="ContactBackupFeature" since="8.8.5">
-  <globalConfigValue>1d</globalConfigValue>
+  <globalConfigValue>0</globalConfigValue>
   <desc>
     Sleep time between subsequent contact backups. 0 means that contact
     backup is disabled.
@@ -9447,7 +9447,7 @@ TODO: delete them permanently from here
 </attr>
 
 <attr id="2131" name="zimbraFeatureContactBackupEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited" since="8.8.5">
-  <defaultCOSValue>TRUE</defaultCOSValue>
+  <defaultCOSValue>FALSE</defaultCOSValue>
   <desc>Enable contact backup feature</desc>
 </attr>
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -13725,13 +13725,13 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * Enable contact backup feature
      *
-     * @return zimbraFeatureContactBackupEnabled, or true if unset
+     * @return zimbraFeatureContactBackupEnabled, or false if unset
      *
      * @since ZCS 8.8.5
      */
     @ZAttr(id=2131)
     public boolean isFeatureContactBackupEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraFeatureContactBackupEnabled, true, true);
+        return getBooleanAttr(Provisioning.A_zimbraFeatureContactBackupEnabled, false, true);
     }
 
     /**
@@ -22362,7 +22362,6 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @return zimbraId, or null if unset
      */
-    @Override
     @ZAttr(id=1)
     public String getId() {
         return getAttr(Provisioning.A_zimbraId, null, true);

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -15800,13 +15800,13 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @see #getFeatureContactBackupFrequencyAsString()
      *
-     * @return zimbraFeatureContactBackupFrequency in millseconds, or 86400000 (1d)  if unset
+     * @return zimbraFeatureContactBackupFrequency in millseconds, or 0 (0)  if unset
      *
      * @since ZCS 8.8.5
      */
     @ZAttr(id=2124)
     public long getFeatureContactBackupFrequency() {
-        return getTimeInterval(Provisioning.A_zimbraFeatureContactBackupFrequency, 86400000L, true);
+        return getTimeInterval(Provisioning.A_zimbraFeatureContactBackupFrequency, 0L, true);
     }
 
     /**
@@ -15816,13 +15816,13 @@ public abstract class ZAttrConfig extends Entry {
      * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
      * specified, the default is s(seconds).
      *
-     * @return zimbraFeatureContactBackupFrequency, or "1d" if unset
+     * @return zimbraFeatureContactBackupFrequency, or "0" if unset
      *
      * @since ZCS 8.8.5
      */
     @ZAttr(id=2124)
     public String getFeatureContactBackupFrequencyAsString() {
-        return getAttr(Provisioning.A_zimbraFeatureContactBackupFrequency, "1d", true);
+        return getAttr(Provisioning.A_zimbraFeatureContactBackupFrequency, "0", true);
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -8470,13 +8470,13 @@ public abstract class ZAttrCos extends NamedEntry {
     /**
      * Enable contact backup feature
      *
-     * @return zimbraFeatureContactBackupEnabled, or true if unset
+     * @return zimbraFeatureContactBackupEnabled, or false if unset
      *
      * @since ZCS 8.8.5
      */
     @ZAttr(id=2131)
     public boolean isFeatureContactBackupEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraFeatureContactBackupEnabled, true, true);
+        return getBooleanAttr(Provisioning.A_zimbraFeatureContactBackupEnabled, false, true);
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -8782,13 +8782,13 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @see #getFeatureContactBackupFrequencyAsString()
      *
-     * @return zimbraFeatureContactBackupFrequency in millseconds, or 86400000 (1d)  if unset
+     * @return zimbraFeatureContactBackupFrequency in millseconds, or 0 (0)  if unset
      *
      * @since ZCS 8.8.5
      */
     @ZAttr(id=2124)
     public long getFeatureContactBackupFrequency() {
-        return getTimeInterval(Provisioning.A_zimbraFeatureContactBackupFrequency, 86400000L, true);
+        return getTimeInterval(Provisioning.A_zimbraFeatureContactBackupFrequency, 0L, true);
     }
 
     /**
@@ -8798,13 +8798,13 @@ public abstract class ZAttrServer extends NamedEntry {
      * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
      * specified, the default is s(seconds).
      *
-     * @return zimbraFeatureContactBackupFrequency, or "1d" if unset
+     * @return zimbraFeatureContactBackupFrequency, or "0" if unset
      *
      * @since ZCS 8.8.5
      */
     @ZAttr(id=2124)
     public String getFeatureContactBackupFrequencyAsString() {
-        return getAttr(Provisioning.A_zimbraFeatureContactBackupFrequency, "1d", true);
+        return getAttr(Provisioning.A_zimbraFeatureContactBackupFrequency, "0", true);
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/callback/ContactBackupFeature.java
+++ b/store/src/java/com/zimbra/cs/account/callback/ContactBackupFeature.java
@@ -42,7 +42,7 @@ public class ContactBackupFeature extends AttributeCallback  {
             return;
         }
         long interval = localServer.getTimeInterval(Provisioning.A_zimbraFeatureContactBackupFrequency, 0);
-        ZimbraLog.backup.info("Contact backup interval set to %d.", interval);
+        ZimbraLog.contactbackup.info("Contact backup interval set to %d.", interval);
         if (interval > 0) {
             if (ContactBackupThread.isRunning()) {
                 ContactBackupThread.shutdown();

--- a/store/src/java/com/zimbra/cs/mailbox/ContactBackupThread.java
+++ b/store/src/java/com/zimbra/cs/mailbox/ContactBackupThread.java
@@ -136,8 +136,6 @@ public class ContactBackupThread extends Thread {
                 ZimbraLog.contactbackup.debug("thread was interrupted.");
                 shutdownRequested = true;
             }
-        } else {
-            shutdownRequested = true;
         }
     }
 


### PR DESCRIPTION
change default value of zimbraFeatureContactBackupFrequency to 0, to disable contact backup feature by default.
Also, changed the logger in ContactBackupFeature class to be in sync with logger used everywhere for this feature.