### PR TITLE
zcs-3263:sieve:undeleted blob by editheader action

### DIFF
--- a/store/src/java-test/com/zimbra/cs/filter/ZimbraMailAdapterTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/ZimbraMailAdapterTest.java
@@ -15,6 +15,7 @@ import com.zimbra.cs.mailbox.DeliveryContext;
 import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.MailboxTestUtil;
 import com.zimbra.cs.mime.ParsedMessage;
+import com.zimbra.cs.store.Blob;
 
 import junit.framework.Assert;
 
@@ -55,5 +56,21 @@ public class ZimbraMailAdapterTest {
 
         Assert.assertNull(nonSharedDeliveryCtxt.getMailBoxSpecificBlob(mboxId));
         Assert.assertNotNull(nonSharedDeliveryCtxt.getIncomingBlob());
+
+        Mockito.when(handler.getDeliveryContext()).thenReturn(sharedDeliveryCtxt);
+        Blob blobFile = sharedDeliveryCtxt.getMailBoxSpecificBlob(mboxId);
+        mailAdapter.cloneParsedMessage();
+        mailAdapter.updateIncomingBlob();
+        Assert.assertNotNull(sharedDeliveryCtxt.getMailBoxSpecificBlob(mboxId));
+        Assert.assertNull(sharedDeliveryCtxt.getIncomingBlob());
+        Assert.assertNotSame(blobFile, sharedDeliveryCtxt.getMailBoxSpecificBlob(mboxId));
+
+        Mockito.when(handler.getDeliveryContext()).thenReturn(nonSharedDeliveryCtxt);
+        blobFile = nonSharedDeliveryCtxt.getMailBoxSpecificBlob(mboxId);
+        mailAdapter.cloneParsedMessage();
+        mailAdapter.updateIncomingBlob();
+        Assert.assertNull(nonSharedDeliveryCtxt.getMailBoxSpecificBlob(mboxId));
+        Assert.assertNotNull(nonSharedDeliveryCtxt.getIncomingBlob());
+        Assert.assertEquals(blobFile, nonSharedDeliveryCtxt.getMailBoxSpecificBlob(mboxId));
     }
 }

--- a/store/src/java-test/com/zimbra/cs/store/MockStoreManager.java
+++ b/store/src/java-test/com/zimbra/cs/store/MockStoreManager.java
@@ -214,6 +214,11 @@ public final class MockStoreManager extends StoreManager {
         public long getRawSize() {
             return content.length;
         }
+
+        @Override
+        public boolean isCompressed() throws IOException {
+            return false;
+        }
     }
 
     private static final class MockLocalBlob extends Blob {

--- a/store/src/java/com/zimbra/cs/filter/ZimbraMailAdapter.java
+++ b/store/src/java/com/zimbra/cs/filter/ZimbraMailAdapter.java
@@ -933,18 +933,30 @@ public class ZimbraMailAdapter implements MailAdapter, EnvelopeAccessors {
                 ByteUtil.closeStream(in);
             }
 
-            Blob prevBlob = ctxt.getMailBoxSpecificBlob(mailbox.getId());
-            if (prevBlob != null) {
-                sm.quietDelete(prevBlob);
-                ctxt.clearMailBoxSpecificBlob(mailbox.getId());
+            if (!parsedMessageCloned) {
+                Blob prevBlob = ctxt.getIncomingBlob();
+                if (prevBlob != null) {
+                    sm.quietDelete(prevBlob);
+                }
+            } else {
+                Blob prevBlob = ctxt.getMailBoxSpecificBlob(mailbox.getId());
+                if (prevBlob != null) {
+                    sm.quietDelete(prevBlob);
+                    ctxt.clearMailBoxSpecificBlob(mailbox.getId());
+                }
             }
 
             if (ctxt.getShared()) {
                 ctxt.setMailBoxSpecificBlob(mailbox.getId(), blob);
                 ZimbraLog.filter.debug("setting mailbox specific blob for mailbox %d", mailbox.getId());
             } else {
-                ctxt.setIncomingBlob(blob);
-                ZimbraLog.filter.debug("Updated incoming blob");
+                try {
+                    ctxt.deepsetIncomingBlob(blob);
+                    ZimbraLog.filter.debug("Updated incoming blob");
+                } catch (IOException e) {
+                    ZimbraLog.filter.error("Unable to update incomimg blob.", e);
+                    return;
+                }
             }
         }
     }

--- a/store/src/java/com/zimbra/cs/mailbox/DeliveryContext.java
+++ b/store/src/java/com/zimbra/cs/mailbox/DeliveryContext.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2013, 2014, 2016, 2017 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -20,7 +20,6 @@
  */
 package com.zimbra.cs.mailbox;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;

--- a/store/src/java/com/zimbra/cs/mailbox/DeliveryContext.java
+++ b/store/src/java/com/zimbra/cs/mailbox/DeliveryContext.java
@@ -20,6 +20,8 @@
  */
 package com.zimbra.cs.mailbox;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -84,6 +86,19 @@ public class DeliveryContext {
         return this;
     }
     
+    public DeliveryContext deepsetIncomingBlob(Blob blob) throws IOException {
+        if (null != blob && null != mIncomingBlob) {
+            mIncomingBlob.setFile(blob.getFile());
+            mIncomingBlob.setPath(blob.getPath());
+            mIncomingBlob.setCompressed(blob.isCompressed());
+            mIncomingBlob.setDigest(blob.getDigest());
+            mIncomingBlob.setRawSize(blob.getRawSize());
+        } else if (null == mIncomingBlob) {
+            setIncomingBlob(blob);
+        }
+        return this;
+    }
+
     public MailboxBlob getMailboxBlob() {
     	return mMailboxBlob;
     }

--- a/store/src/java/com/zimbra/cs/store/Blob.java
+++ b/store/src/java/com/zimbra/cs/store/Blob.java
@@ -152,6 +152,16 @@ public class Blob {
         return this;
     }
 
+    public Blob setFile(File file) {
+        this.file = file;
+        return this;
+    }
+
+    public Blob setPath(String path) {
+        this.path = path;
+        return this;
+    }
+
     public Blob copyCachedDataFrom(final Blob other) {
         if (compressed == null && other.compressed != null) {
             this.compressed = other.compressed;


### PR DESCRIPTION
Case 00633040: CNCI/IIJ - Blob file created by editheader
is remained undeleted under the incoming directory.

[Bug]
When the message is delivered to only one recipient who has a
sieve filter rule of edit header action(s), the intermediate
blob files are left undeleted under the incoming directory
/opt/zimbra/store/incoming for ever.

(If the message is delivered to two or more than two recipients,
and one of them has an editheader filter rule, no intermediate
blob files are remained)

If multiple recipients are specified in the triggering message,
and if at least one of them has a sieve filter of edit header
action, then the message will be cloned so that the edit header
action can manipulate the message without any side effect to
other recipients' message.  The first edit header action generates
an intermediate blob file of edited contents, and if multiple
edit header actions are performed, each edit header action
overwrites the previous intermediate blob file.  And finally,
the intermediate and cloned files are all cleaned up.

On the other hand, if there is only one recipient for the message,
the file is not shared (because it's not necessary to share with
other recipient).  The problem is whenever the edit header action
is executed, a new intermediate blob file is cloned, but at the end,
only the original message is deleted from the incoming directory,
but intermediate blob files are remained undeleted.

[Root cause]
When searching for a old intermediate blob, ZCS referred a wrong
meta data of the cloned intermediate blob file of the single recipient
message.

[Fix]
Check the correct blob file meta data (DeliveryContext.mIncomingBlob),
and if the blob is cloned, delete the previous blob file, and replace
the old blob meta data with a new one.

[Unit test]
Extended the existing unit case to test ZimbraMailAdapter.updateIncomingBlob()
so that the all combination of shared/non-shared message x no-cloned/ever-cloned
were covered.