### PR TITLE
ZIMBRA-863 Updated war packaging

### DIFF
--- a/store/build.xml
+++ b/store/build.xml
@@ -268,9 +268,8 @@
     <ivy:install organisation="org.slf4j" module="slf4j-api" revision="1.6.4" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.slf4j" module="slf4j-log4j12" revision="1.6.4" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.apache.james" module="apache-jsieve-core" revision="0.5" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
-    <ivy:install organisation="org.apache.lucene" module="lucene-core" revision="3.5.0" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
-    <ivy:install organisation="org.apache.lucene" module="lucene-analyzers" revision="3.5.0" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
-  	<ivy:install organisation="org.apache.lucene" module="lucene-smartcn" revision="3.5.0" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
+    <ivy:install organisation="org.apache.lucene" module="lucene-core" revision="6.6.0" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
+    <ivy:install organisation="org.apache.lucene" module="lucene-analyzers-common" revision="6.6.0" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="ant-tar-patched" module="ant-tar-patched" revision="1.0" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.apache.mina" module="mina-core" revision="2.0.4" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="zimbra" module="zm-ews-stub" revision="2.0" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>


### PR DESCRIPTION
Realized that the packaging for `zimbra-mbox-war` was still dropping in some obsoleted JAR files.  About the `lucene-smartcn` dependency. Not sure this is still needed.  Ilya and I talked about this earlier.  

Everything builds fine without it.  Will continue to test and can re-add this if necessary.  There is the following comment at the top of this section of the file:

    delete anything that may have been left over, e.g.: older versions of same libs

So this may be something that is no longer needed.  With the older JAR files still in place it breaks certain functions, such as autocomplete.