### PR TITLE
zcs-3585,3558,3559:Unit test DeleteHeaderTest failed

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -320,7 +320,6 @@
                     <exclude name="**/cs/filter/HeaderTest.java"/>
                     <exclude name="**/cs/filter/EnvelopeTest.java"/>
                     <exclude name="**/cs/mailbox/ContactAutoCompleteTest.java"/>
-                    <exclude name="**/cs/service/ExternalUserProvServletTest.java"/>
                 </fileset>
             </batchtest>
           </junit>

--- a/build-common.xml
+++ b/build-common.xml
@@ -320,6 +320,7 @@
                     <exclude name="**/cs/filter/HeaderTest.java"/>
                     <exclude name="**/cs/filter/EnvelopeTest.java"/>
                     <exclude name="**/cs/mailbox/ContactAutoCompleteTest.java"/>
+                    <exclude name="**/cs/service/ExternalUserProvServletTest.java"/>
                 </fileset>
             </batchtest>
           </junit>

--- a/store/src/java-test/com/zimbra/cs/store/MockStoreManager.java
+++ b/store/src/java-test/com/zimbra/cs/store/MockStoreManager.java
@@ -196,6 +196,16 @@ public final class MockStoreManager extends StoreManager {
             content = new byte[0];
         }
 
+        @Override
+        public void copy(Blob blob) throws IOException {
+            super.copy(blob);
+            if (blob instanceof MockBlob) {
+                setContent(((MockBlob)blob).getContent());
+            } else {
+                setContent(null);
+            }
+        }
+
         void setContent(byte[] content) {
             this.content = content;
         }
@@ -218,6 +228,10 @@ public final class MockStoreManager extends StoreManager {
         @Override
         public boolean isCompressed() throws IOException {
             return false;
+        }
+
+        public byte[] getContent() {
+            return content;
         }
     }
 

--- a/store/src/java/com/zimbra/cs/mailbox/DeliveryContext.java
+++ b/store/src/java/com/zimbra/cs/mailbox/DeliveryContext.java
@@ -87,11 +87,7 @@ public class DeliveryContext {
     
     public DeliveryContext deepsetIncomingBlob(Blob blob) throws IOException {
         if (null != blob && null != mIncomingBlob) {
-            mIncomingBlob.setFile(blob.getFile());
-            mIncomingBlob.setPath(blob.getPath());
-            mIncomingBlob.setCompressed(blob.isCompressed());
-            mIncomingBlob.setDigest(blob.getDigest());
-            mIncomingBlob.setRawSize(blob.getRawSize());
+            mIncomingBlob.copy(blob);
         } else if (null == mIncomingBlob) {
             setIncomingBlob(blob);
         }

--- a/store/src/java/com/zimbra/cs/store/Blob.java
+++ b/store/src/java/com/zimbra/cs/store/Blob.java
@@ -63,6 +63,14 @@ public class Blob {
         this.digest = digest;
     }
 
+    public void copy(Blob blob) throws IOException {
+        setFile(blob.getFile());
+        setPath(blob.getPath());
+        setCompressed(blob.isCompressed());
+        setDigest(blob.getDigest());
+        setRawSize(blob.getRawSize());
+    }
+
     public File getFile() {
         return file;
     }


### PR DESCRIPTION
[Problem]
Unit test com.zimbra.cs.filter.DeleteHeaderTest failed.

[Root cause]
The unit test uses the MockBlob object to keep not only
the blob data, like other real-world Blob object, but also
its message data itself (the member parameter "content").
The MockBlob didn't copy the "content", so the old contents
remained.

[Fix]
Added the Blob.copy() method to perform a deep copy.
The child class of the MockBlob.copy() will copy the data
of the "content" as well.

[Unit test]
ant test-all --> PASS