### PR TITLE
ZCS-3597 Fixing ExternalUserProvServletTest

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -140,6 +140,7 @@
       <pathelement location="${build.classes.dir}" />
       <pathelement location="${test.classes.dir}" />
       <pathelement location="${msgs.dir}" />
+      <pathelement location="${test.src.dir}" />
     </path>
 
     <!-- Platform -->
@@ -315,11 +316,6 @@
                     <include name="${test.pattern}"/>
                     <exclude name="**/Abstract*Test.java"/>
                     <exclude name="**/cs/mailbox/ContactTest.java"/>
-                    <exclude name="**/cs/imap/ImapHandlerTest.java"/>
-                    <exclude name="**/cs/filter/FileIntoCopyTest.java"/>
-                    <exclude name="**/cs/filter/HeaderTest.java"/>
-                    <exclude name="**/cs/filter/EnvelopeTest.java"/>
-                    <exclude name="**/cs/mailbox/ContactAutoCompleteTest.java"/>
                 </fileset>
             </batchtest>
           </junit>

--- a/store/src/java-test/com/zimbra/cs/filter/EnvelopeTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/EnvelopeTest.java
@@ -23,11 +23,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 
 import com.google.common.collect.Maps;
 import com.zimbra.common.util.ArrayUtil;
@@ -51,6 +54,7 @@ public class EnvelopeTest {
             + "to: test@zimbra.com\n"
             + "Subject: Example\n";
 
+    @Rule public TestName testName = new TestName();
     @BeforeClass
     public static void init() throws Exception {
         MailboxTestUtil.initServer();
@@ -61,7 +65,7 @@ public class EnvelopeTest {
 
     @Before
     public void setUp() throws Exception {
-        MailboxTestUtil.clearData();
+       System.out.println(testName.getMethodName());
     }
 
     @Test
@@ -1048,6 +1052,15 @@ public class EnvelopeTest {
             Assert.assertEquals(null, ArrayUtil.getFirstElement(msg.getTags()));
         } catch (Exception e) {
             fail("No exception should be thrown" + e);
+        }
+    }
+    
+    @After
+    public void tearDown() {
+        try {
+            MailboxTestUtil.clearData();
+        } catch (Exception e) {
+            e.printStackTrace();
         }
     }
 }

--- a/store/src/java-test/com/zimbra/cs/filter/FileIntoCopyTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/FileIntoCopyTest.java
@@ -19,10 +19,15 @@ package com.zimbra.cs.filter;
 import static org.junit.Assert.*;
 import java.util.HashMap;
 import java.util.List;
+
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
+
 import com.zimbra.common.account.Key;
 import com.zimbra.common.util.ArrayUtil;
 import com.zimbra.cs.account.Account;
@@ -45,6 +50,7 @@ import com.zimbra.qa.unittest.TestUtil;
 
 public class FileIntoCopyTest {
 
+    @Rule public TestName testName = new TestName();
     @BeforeClass
     public static void init() throws Exception {
         MailboxTestUtil.initServer();
@@ -56,7 +62,7 @@ public class FileIntoCopyTest {
 
     @Before
     public void setUp() throws Exception {
-        MailboxTestUtil.clearData();
+       System.out.println(testName.getMethodName());
     }
 
     @Test
@@ -570,6 +576,15 @@ public class FileIntoCopyTest {
         } catch (Exception e) {
             e.printStackTrace();
             fail("No exception should be thrown");
+        }
+    }
+    
+    @After
+    public void tearDown() {
+        try {
+            MailboxTestUtil.clearData();
+        } catch (Exception e) {
+            e.printStackTrace();
         }
     }
 }

--- a/store/src/java-test/com/zimbra/cs/filter/FlagTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/FlagTest.java
@@ -19,10 +19,13 @@ package com.zimbra.cs.filter;
 import java.util.HashMap;
 import java.util.List;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 
 import com.zimbra.common.filter.Sieve.Flag;
 import com.zimbra.cs.account.Account;
@@ -45,6 +48,7 @@ import com.zimbra.cs.service.util.ItemId;
  */
 public final class FlagTest {
 
+    @Rule public TestName testName = new TestName();
     @BeforeClass
     public static void init() throws Exception {
         MailboxTestUtil.initServer();
@@ -54,7 +58,7 @@ public final class FlagTest {
 
     @Before
     public void setUp() throws Exception {
-        MailboxTestUtil.clearData();
+       System.out.println(testName.getMethodName());
     }
 
     @Test
@@ -71,6 +75,15 @@ public final class FlagTest {
         Assert.assertEquals(1, ids.size());
         Message msg = mbox.getMessageById(null, ids.get(0).getId());
         Assert.assertTrue(msg.isTagged(FlagInfo.PRIORITY));
+    }
+    
+    @After
+    public void tearDown() {
+        try {
+            MailboxTestUtil.clearData();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
 }

--- a/store/src/java-test/com/zimbra/cs/filter/HeaderTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/HeaderTest.java
@@ -25,10 +25,13 @@ import java.util.List;
 
 import javax.mail.internet.MimeMessage;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 
 import com.zimbra.common.util.ArrayUtil;
 import com.zimbra.common.util.ByteUtil;
@@ -51,6 +54,7 @@ import com.zimbra.cs.service.util.ItemId;
 import com.zimbra.cs.util.JMSession;
 
 public class HeaderTest {
+    @Rule public TestName testName = new TestName();
     private static String sampleMsg = "Received: from edge01e.zimbra.com ([127.0.0.1])\n"
             + "\tby localhost (edge01e.zimbra.com [127.0.0.1]) (amavisd-new, port 10032)\n"
             + "\twith ESMTP id DN6rfD1RkHD7; Fri, 24 Jun 2016 01:45:31 -0400 (EDT)\n"
@@ -74,7 +78,7 @@ public class HeaderTest {
 
     @Before
     public void setUp() throws Exception {
-        MailboxTestUtil.clearData();
+       System.out.println(testName.getMethodName());
     }
 
     @Test
@@ -479,6 +483,15 @@ public class HeaderTest {
             Assert.assertEquals(null, ArrayUtil.getFirstElement(msg.getTags()));
         } catch (Exception e) {
             fail("No exception should be thrown" + e);
+        }
+    }
+    
+    @After
+    public void tearDown() {
+        try {
+            MailboxTestUtil.clearData();
+        } catch (Exception e) {
+            e.printStackTrace();
         }
     }
 }

--- a/store/src/java-test/com/zimbra/cs/filter/RejectTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/RejectTest.java
@@ -22,11 +22,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 
 import com.google.common.collect.Maps;
 import com.zimbra.common.account.Key;
@@ -47,6 +50,7 @@ import com.zimbra.cs.service.util.ItemId;
 
 public class RejectTest {
 
+    @Rule public TestName testName = new TestName();
     private static String sampleBaseMsg = "Received: from edge01e.zimbra.com ([127.0.0.1])\n"
             + "\tby localhost (edge01e.zimbra.com [127.0.0.1]) (amavisd-new, port 10032)\n"
             + "\twith ESMTP id DN6rfD1RkHD7; Fri, 24 Jun 2016 01:45:31 -0400 (EDT)\n"
@@ -93,7 +97,7 @@ public class RejectTest {
 
     @Before
     public void setUp() throws Exception {
-        MailboxTestUtil.clearData();
+        System.out.println(testName.getMethodName());
     }
 
     /*
@@ -307,6 +311,15 @@ public class RejectTest {
             Assert.assertEquals("example", msg.getSubject());
         } catch (Exception e) {
             fail("No exception should be thrown: " + e.getMessage());
+        }
+    }
+    
+    @After
+    public void tearDown() {
+        try {
+            MailboxTestUtil.clearData();
+        } catch (Exception e) {
+            e.printStackTrace();
         }
     }
 }

--- a/store/src/java-test/com/zimbra/cs/mailbox/ContactAutoCompleteTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/ContactAutoCompleteTest.java
@@ -30,9 +30,13 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.MethodRule;
 import org.junit.rules.TestName;
+import org.junit.rules.TestWatchman;
+import org.junit.runners.model.FrameworkMethod;
 
 import com.google.common.collect.ImmutableMap;
+import com.zimbra.common.account.Key;
 import com.zimbra.common.mailbox.ContactConstants;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.MockProvisioning;
@@ -49,12 +53,21 @@ import com.zimbra.cs.mime.ParsedContact;
 public final class ContactAutoCompleteTest {
 
     @Rule public TestName testName = new TestName();
+    @Rule
+    public MethodRule watchman = new TestWatchman() {
+        @Override
+        public void failed(Throwable e, FrameworkMethod method) {
+            System.out.println(method.getName() + " " + e.getClass().getSimpleName());
+        }
+    };
+
     @BeforeClass
     public static void init() throws Exception {
         System.setProperty("zimbra.config", "../store/src/java-test/localconfig-test.xml");
         MailboxTestUtil.initServer();
         Provisioning prov = Provisioning.getInstance();
         prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
+        prov.createAccount("test2@zimbra.com", "secret", new HashMap<String, Object>());
         Provisioning.setInstance(prov);
     }
 
@@ -152,7 +165,9 @@ public final class ContactAutoCompleteTest {
     @Test
     public void hitGroup() throws Exception {
         ContactAutoComplete.AutoCompleteResult result = new ContactAutoComplete.AutoCompleteResult(10);
-        result.rankings = new ContactRankings(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test2@zimbra.com");
+//        result.rankings = new ContactRankings(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        result.rankings = new ContactRankings(acct1.getId());
         ContactAutoComplete.ContactEntry group = new ContactAutoComplete.ContactEntry();
         group.mDisplayName = "G1";
         group.mIsContactGroup = true;

--- a/store/src/java-test/com/zimbra/cs/mailbox/ContactAutoCompleteTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/ContactAutoCompleteTest.java
@@ -23,11 +23,14 @@ import java.util.Map;
 
 import javax.mail.internet.InternetAddress;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 
 import com.google.common.collect.ImmutableMap;
 import com.zimbra.common.mailbox.ContactConstants;
@@ -45,6 +48,7 @@ import com.zimbra.cs.mime.ParsedContact;
  */
 public final class ContactAutoCompleteTest {
 
+    @Rule public TestName testName = new TestName();
     @BeforeClass
     public static void init() throws Exception {
         System.setProperty("zimbra.config", "../store/src/java-test/localconfig-test.xml");
@@ -56,7 +60,7 @@ public final class ContactAutoCompleteTest {
 
     @Before
     public void setUp() throws Exception {
-        MailboxTestUtil.clearData();
+       System.out.println(testName.getMethodName());
     }
 
     @Test
@@ -74,6 +78,15 @@ public final class ContactAutoCompleteTest {
         contact.mEmail = "c2@zimbra.com";
         result.addEntry(contact);
         Assert.assertEquals(result.entries.size(), 2);
+    }
+    
+    @After
+    public void tearDown() {
+        try {
+            MailboxTestUtil.clearData();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     @Test

--- a/store/src/java-test/com/zimbra/cs/mailbox/ContactTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/ContactTest.java
@@ -31,10 +31,13 @@ import java.util.zip.GZIPInputStream;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimePart;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -73,6 +76,7 @@ import com.zimbra.cs.util.JMSession;
  */
 public final class ContactTest {
 
+    @Rule public TestName testName = new TestName();
     @BeforeClass
     public static void init() throws Exception {
         MailboxTestUtil.initServer();
@@ -82,7 +86,7 @@ public final class ContactTest {
 
     @Before
     public void setUp() throws Exception {
-        MailboxTestUtil.clearData();
+       System.out.println(testName.getMethodName());
     }
 
     @Test
@@ -305,7 +309,8 @@ public final class ContactTest {
 
     @Test
     public void testTruncatedContactsTgzImport() throws IOException {
-        File file = new File("src/java-test/Truncated.tgz");
+        File file = new File(MailboxTestUtil.getZimbraServerDir("") + "store/src/java-test/Truncated.tgz");
+        System.out.println(file.getAbsolutePath());
         InputStream is = new FileInputStream(file);
         ArchiveInputStream ais = new TarArchiveInputStream(new GZIPInputStream(is), "UTF-8");
         ArchiveInputEntry aie;
@@ -314,10 +319,20 @@ public final class ContactTest {
             try {
                 ArchiveFormatter.readArchiveEntry(ais, aie);
             } catch (IOException e) {
+                e.printStackTrace();
                 errorCaught = true;
                 break;
             }
         }
         Assert.assertTrue(errorCaught);
+    }
+    
+    @After
+    public void tearDown() {
+        try {
+            MailboxTestUtil.clearData();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/store/src/java-test/com/zimbra/cs/service/ExternalUserProvServletTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/ExternalUserProvServletTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -79,6 +80,7 @@ public class ExternalUserProvServletTest {
         Assert.assertEquals(FeatureAddressVerificationStatus.verified, acct1.getFeatureAddressVerificationStatus());
     }
     
+    @After
     public void tearDown() {
         try {
             MailboxTestUtil.clearData();

--- a/store/src/java-test/com/zimbra/cs/service/ExternalUserProvServletTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/ExternalUserProvServletTest.java
@@ -23,7 +23,9 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 
 import com.google.common.collect.Maps;
 import com.zimbra.common.account.Key;
@@ -35,6 +37,7 @@ import com.zimbra.cs.mailbox.MailboxTestUtil;
 import junit.framework.Assert;
 
 public class ExternalUserProvServletTest {
+    @Rule public TestName testName = new TestName();
 
     @BeforeClass
     public static void init() throws Exception {
@@ -45,11 +48,12 @@ public class ExternalUserProvServletTest {
         attrs = Maps.newHashMap();
         prov.createAccount("test@zimbra.com", "secret", attrs);
     }
-
+    
     @Before
-    public void setUp() throws Exception {
-        MailboxTestUtil.clearData();
+    public void before() {
+        System.out.println(testName.getMethodName());
     }
+
 
     @Test
     public void testHandleAddressVerificationExpired() throws Exception {
@@ -73,5 +77,13 @@ public class ExternalUserProvServletTest {
         servlet.handleAddressVerification(req, resp, acct1.getId(), "test2@zimbra.com", false);
         Assert.assertEquals("test2@zimbra.com", acct1.getPrefMailForwardingAddress());
         Assert.assertEquals(FeatureAddressVerificationStatus.verified, acct1.getFeatureAddressVerificationStatus());
+    }
+    
+    public void tearDown() {
+        try {
+            MailboxTestUtil.clearData();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/store/src/java-test/com/zimbra/cs/store/MockStoreManager.java
+++ b/store/src/java-test/com/zimbra/cs/store/MockStoreManager.java
@@ -196,6 +196,16 @@ public final class MockStoreManager extends StoreManager {
             content = new byte[0];
         }
 
+        @Override
+        public void copy(Blob blob) throws IOException {
+            super.copy(blob);
+            if (blob instanceof MockBlob) {
+                setContent(((MockBlob)blob).getContent());
+            } else {
+                setContent(null);
+            }
+        }
+
         void setContent(byte[] content) {
             this.content = content;
         }
@@ -218,6 +228,10 @@ public final class MockStoreManager extends StoreManager {
         @Override
         public boolean isCompressed() throws IOException {
             return false;
+        }
+
+        public byte[] getContent() {
+            return content;
         }
     }
 

--- a/store/src/java/com/zimbra/cs/mailbox/DeliveryContext.java
+++ b/store/src/java/com/zimbra/cs/mailbox/DeliveryContext.java
@@ -87,11 +87,7 @@ public class DeliveryContext {
     
     public DeliveryContext deepsetIncomingBlob(Blob blob) throws IOException {
         if (null != blob && null != mIncomingBlob) {
-            mIncomingBlob.setFile(blob.getFile());
-            mIncomingBlob.setPath(blob.getPath());
-            mIncomingBlob.setCompressed(blob.isCompressed());
-            mIncomingBlob.setDigest(blob.getDigest());
-            mIncomingBlob.setRawSize(blob.getRawSize());
+            mIncomingBlob.copy(blob);
         } else if (null == mIncomingBlob) {
             setIncomingBlob(blob);
         }

--- a/store/src/java/com/zimbra/cs/store/Blob.java
+++ b/store/src/java/com/zimbra/cs/store/Blob.java
@@ -63,6 +63,14 @@ public class Blob {
         this.digest = digest;
     }
 
+    public void copy(Blob blob) throws IOException {
+        setFile(blob.getFile());
+        setPath(blob.getPath());
+        setCompressed(blob.isCompressed());
+        setDigest(blob.getDigest());
+        setRawSize(blob.getRawSize());
+    }
+
     public File getFile() {
         return file;
     }


### PR DESCRIPTION
ZCS-3597 Fixing ExternalUserProvServletTest

Added "MailboxTestUtil.clearData();" in tearDown method.