### PR TITLE
ZCS-3365:more help on URL in usage

### DIFF
--- a/store/src/java/com/zimbra/cs/ephemeral/migrate/AttributeMigrationUtil.java
+++ b/store/src/java/com/zimbra/cs/ephemeral/migrate/AttributeMigrationUtil.java
@@ -60,7 +60,7 @@ public class AttributeMigrationUtil {
         boolean clear = cl.hasOption('c');
         List<String> clArgs = cl.getArgList();
         if (clArgs.isEmpty() && !help && !clear && !showStatus) {
-            ZimbraLog.ephemeral.error("must specify URL of destionation ephemeral store");
+            ZimbraLog.ephemeral.error("must specify URL of destination ephemeral store");
             return;
         }
         if (help || (clear && showStatus)) {
@@ -187,7 +187,8 @@ public class AttributeMigrationUtil {
     private static void usage() {
         HelpFormatter format = new HelpFormatter();
         format.printHelp(new PrintWriter(System.err, true), 80,
-            "zmmigrateattrs [options] [URL] [attr1 attr2 attr3 ...]", null, OPTIONS, 2, 2, null);
+            "zmmigrateattrs [options] [URL] [attr1 attr2 attr3 ...]", null, OPTIONS, 2, 2,
+            "\n'URL' MUST be provided for all options except for:\n '--clear' (-c) and '--status' (-s)");
             System.exit(0);
     }
 }


### PR DESCRIPTION
* Make it clear that for most things, URL is required by
  adding a footer to the usage message
* Fix minor typo in log message

New usage message:

# zmmigrateattrs -h
usage: zmmigrateattrs [options] [URL] [attr1 attr2 attr3 ...]
  -a,--account <arg>      Comma-separated list of accounts to migrate. If not
                          specified, all accounts will be migrated
  -c,--clear              Clear the migration info
  -d,--debug              Enable debug logging
  -h,--help               Display this help message
  -n,--num-threads <arg>  Number of threads to use in the migration. If not set,
                          defaults to 1
  -r,--dry-run            Dry run: display info on what the migration would
                          accomplish
  -s,--status             Show migration status

'URL' MUST be provided for all options except for:
'--clear' (-c) and '--status' (-s)