### PR TITLE
ZIMBRA-112: SEEN/READ/REPLIED Events

### DIFF
--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -6528,7 +6528,10 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
         return resp.getSearches();
     }
 
-
+    @Override
+    public void markMsgSeen(OpContext octxt, ItemIdentifier iid) throws ServiceException {
+        doAction(messageAction("seen", iid.toString()));
+    }
 
     public static class OpenIMAPFolderParams {
 

--- a/common/src/java/com/zimbra/common/mailbox/MailboxStore.java
+++ b/common/src/java/com/zimbra/common/mailbox/MailboxStore.java
@@ -88,4 +88,5 @@ public interface MailboxStore {
     public int getLastChangeID();
     public List<Integer> resetImapUid(OpContext octxt, List<Integer> itemIds) throws ServiceException;
     public void noOp() throws ServiceException;
+    public void markMsgSeen(OpContext octxt, ItemIdentifier msgId) throws ServiceException;
 }

--- a/common/src/java/com/zimbra/common/soap/MailConstants.java
+++ b/common/src/java/com/zimbra/common/soap/MailConstants.java
@@ -1366,6 +1366,7 @@ public final class MailConstants {
     public static final String OP_INHERIT = "inherit";
     public static final String OP_MUTE = "mute";
     public static final String OP_RESET_IMAP_UID = "resetimapuid";
+    public static final String OP_SEEN = "seen";
 
     // Contacts API
     public static final String E_RESTORE_CONTACTS_REQUEST = "RestoreContactsRequest";

--- a/store/src/java-test/com/zimbra/cs/event/logger/SolrEventLoggerTest.java
+++ b/store/src/java-test/com/zimbra/cs/event/logger/SolrEventLoggerTest.java
@@ -59,7 +59,7 @@ public class SolrEventLoggerTest {
 
     private void checkTimestamp(SolrInputDocument doc, long timestamp) throws Exception {
         String fieldValue = (String) doc.getFieldValue("ev_timestamp");
-        String formatted = DateTimeFormatter.ISO_INSTANT.format(Instant.ofEpochSecond(timestamp));
+        String formatted = DateTimeFormatter.ISO_INSTANT.format(Instant.ofEpochMilli(timestamp));
         assertEquals("incorrect timestamp", formatted, fieldValue);
     }
 
@@ -67,23 +67,16 @@ public class SolrEventLoggerTest {
         assertEquals(String.format("incorrect %s value", field), value, doc.getFieldValue(field));
     }
 
-    private void checkNumFields(SolrInputDocument doc, int numFields) throws Exception {
-        assertEquals("incorrect number of fields", numFields, doc.getFieldNames().size());
-    }
-
     @Test
     public void testSolrEventDocuments() throws Exception {
         long timestamp = System.currentTimeMillis();
 
         SolrInputDocument sent = new SolrEventDocument(generateSentEvent(ACCOUNT_ID_1, timestamp, RECIPIENT)).getDocument();
-        ZimbraLog.test.info(sent);
-        checkNumFields(sent, 3);
         checkEventType(sent, EventType.SENT);
         checkTimestamp(sent, timestamp);
         checkDynamicFieldValue(sent, "receiver_s", RECIPIENT);
 
         SolrInputDocument received = new SolrEventDocument(generateReceivedEvent(ACCOUNT_ID_1, timestamp, SENDER)).getDocument();
-        checkNumFields(received, 3);
         checkEventType(received, EventType.RECEIVED);
         checkTimestamp(received, timestamp);
         checkDynamicFieldValue(received, "sender_s", SENDER);

--- a/store/src/java/com/zimbra/cs/datasource/MailItemImport.java
+++ b/store/src/java/com/zimbra/cs/datasource/MailItemImport.java
@@ -119,6 +119,7 @@ public abstract class MailItemImport implements DataSource.DataImport {
         }
         if (msg == null) {
             DeliveryOptions dopts = new DeliveryOptions().setFolderId(folderId).setFlags(flags);
+            dopts.setDataSourceId(dataSource.getId());
             Folder folder = mbox.getFolderById(octxt, folderId);
             String folderName = folder.getName();
             if (folderName.startsWith("/")) {
@@ -133,7 +134,6 @@ public abstract class MailItemImport implements DataSource.DataImport {
             }
             if (ctxt != null) {
                 ctxt.setTimestamp(pm.getReceivedDate());
-                ctxt.setDataSourceId(dataSource.getId());
                 dopts.setCallbackContext(ctxt);
             }
             msg = mbox.addMessage(octxt, pm, dopts, null);

--- a/store/src/java/com/zimbra/cs/event/Event.java
+++ b/store/src/java/com/zimbra/cs/event/Event.java
@@ -1,13 +1,20 @@
 package com.zimbra.cs.event;
 
 import javax.mail.Address;
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Objects.ToStringHelper;
 import com.google.common.base.Strings;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.mailbox.Message;
 import com.zimbra.cs.mime.ParsedAddress;
+import com.zimbra.cs.mime.ParsedMessage;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +37,7 @@ public class Event {
         RECEIVED(UniqueOn.MSG_AND_SENDER),
         READ(UniqueOn.MESSAGE),
         SEEN(UniqueOn.MESSAGE),
+        REPLIED(UniqueOn.MESSAGE),
         DELETE_DATASOURCE(UniqueOn.DATASOURCE, true),
         DELETE_ACCOUNT(UniqueOn.ACCOUNT, true);
 
@@ -157,19 +165,41 @@ public class Event {
     /**
      * Convenience method to generate a SENT event for every recipient of the email
      */
-    public static List<Event> generateSentEvents(String accountId, int messageId, Address sender, Address[] allRecipients, String dsId, Long timestamp) {
-        List<Event> sentEvents = new ArrayList<>(allRecipients.length);
-        for (Address address : allRecipients) {
-            sentEvents.add(generateSentEvent(accountId, messageId, sender.toString(), address.toString(), dsId, timestamp));
+    public static List<Event> generateSentEvents(Message msg, Long timestamp) {
+        try {
+            String acctId = msg.getAccountId();
+            int msgId = msg.getId();
+            String dsId = msg.getDataSourceId();
+            ParsedMessage pm = msg.getParsedMessage();
+            MimeMessage mm = pm.getMimeMessage();
+            Address[] recipients = mm.getAllRecipients();
+            String sender = pm.getSender();
+            if (sender == null || recipients == null) {
+                return Collections.emptyList();
+            }
+            List<Event> sentEvents = new ArrayList<>(recipients.length);
+            for (Address address : recipients) {
+                sentEvents.add(generateSentEvent(acctId, msgId, sender, address.toString(), dsId, timestamp));
+            }
+            return sentEvents;
+        } catch (MessagingException | ServiceException e) {
+            ZimbraLog.event.warn("unable to generate SENT events for message %d", msg.getId());
+            return Collections.emptyList();
         }
-        return sentEvents;
     }
 
     /**
      * Convenience method to generate a single RECEIVED event
      */
-    public static Event generateReceivedEvent(String accountId, int messageId, String sender, String recipient, String dsId, Long timestamp) {
-        return generateEvent(accountId, messageId, sender, recipient, EventType.RECEIVED, dsId, timestamp);
+    public static Event generateReceivedEvent(Message msg, String recipient, Long timestamp) {
+        ParsedMessage pm;
+        try {
+            pm = msg.getParsedMessage();
+            return generateEvent(msg.getAccountId(), msg.getId(), pm.getSender(), recipient, EventType.RECEIVED, msg.getDataSourceId(), timestamp);
+        } catch (ServiceException e) {
+            ZimbraLog.event.warn("unable to generate RECEIVED events for message %d", msg.getId());
+            return null;
+        }
     }
 
     /**
@@ -185,9 +215,22 @@ public class Event {
      * Generate an internal event representing the deletion of an account
      */
     public static Event generateDeleteAccountEvent(String accountId) {
-        return new Event(accountId, EventType.DELETE_ACCOUNT, System.currentTimeMillis());
+       return new Event(accountId, EventType.DELETE_ACCOUNT, System.currentTimeMillis());
     }
 
+    public static Event generateMsgEvent(Message msg, EventType eventType) {
+        Event event = new Event(msg.getAccountId(), eventType, System.currentTimeMillis());
+        event.setContextField(EventContextField.MSG_ID, msg.getId());
+        String sender = msg.getSender();
+        if (sender != null) {
+            event.setContextField(EventContextField.SENDER, new ParsedAddress(sender.toString()).emailPart);
+        }
+        String dsId = msg.getDataSourceId();
+        if (dsId != null) {
+            event.setDataSourceId(dsId);
+        }
+        return event;
+    }
 
     @Override
     public boolean equals(Object other) {

--- a/store/src/java/com/zimbra/cs/event/SolrCloudEventStore.java
+++ b/store/src/java/com/zimbra/cs/event/SolrCloudEventStore.java
@@ -17,7 +17,6 @@ public class SolrCloudEventStore extends SolrEventStore {
     public static class Factory extends SolrEventStore.Factory {
 
         private CloudSolrClient client;
-        SolrCloudHelper solrHelper;
 
         public Factory() throws ServiceException {
             super();
@@ -25,7 +24,7 @@ public class SolrCloudEventStore extends SolrEventStore {
 
         @Override
         public EventStore getEventStore(String accountId) {
-            return new SolrCloudEventStore(accountId, solrHelper);
+            return new SolrCloudEventStore(accountId, (SolrCloudHelper) solrHelper);
         }
 
         @Override

--- a/store/src/java/com/zimbra/cs/event/logger/EventLogger.java
+++ b/store/src/java/com/zimbra/cs/event/logger/EventLogger.java
@@ -108,7 +108,7 @@ public class EventLogger {
     }
 
     public boolean log(Event event) {
-        if (!enabled) {
+        if (!enabled || event == null) {
             return false;
         }
         try {

--- a/store/src/java/com/zimbra/cs/imap/ImapHandler.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapHandler.java
@@ -3976,13 +3976,17 @@ public abstract class ImapHandler {
                         }
                     }
 
+                    String folderOwner = i4folder.getFolder().getFolderItemIdentifier().accountId;
+                    ItemIdentifier iid = ItemIdentifier.fromAccountIdAndItemId(
+                            (folderOwner != null) ? folderOwner : mbox.getAccountId(), i4msg.msgId);
+                    // trigger a SEEN event for each message, since this may be
+                    // the first time that the message has been served to a client
+                    mbox.markMsgSeen(getContext(), iid);
+
                     // 6.4.5: "The \Seen flag is implicitly set; if this causes the flags to
                     //         change, they SHOULD be included as part of the FETCH responses."
-                    // FIXME: optimize by doing a single mark-read op on multiple messages
+                    // FIXME: optimize by doing a single mark-read and mark-seen op on multiple messages
                     if (markMessage) {
-                        String folderOwner = i4folder.getFolder().getFolderItemIdentifier().accountId;
-                        ItemIdentifier iid = ItemIdentifier.fromAccountIdAndItemId(
-                                (folderOwner != null) ? folderOwner : mbox.getAccountId(), i4msg.msgId);
                         mbox.flagItemAsRead(getContext(), iid, i4msg.getMailItemType());
                     }
                     ImapFolder.DirtyMessage unsolicited = i4folder.undirtyMessage(i4msg);

--- a/store/src/java/com/zimbra/cs/mailbox/Chat.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Chat.java
@@ -69,7 +69,7 @@ public class Chat extends Message {
 
     static Chat create(int id, Folder folder, ParsedMessage pm, StagedBlob staged, boolean unread, int flags, Tag.NormalizedTags ntags)
     throws ServiceException {
-        return (Chat) Message.createInternal(id, folder, null, pm, staged, unread, flags, ntags, null, true, null, null, new ChatCreateFactory());
+        return (Chat) Message.createInternal(id, folder, null, pm, staged, unread, flags, ntags, null, true, null, null, null, new ChatCreateFactory());
     }
 
     @Override boolean isMutable() { return true; }

--- a/store/src/java/com/zimbra/cs/mailbox/DeliveryOptions.java
+++ b/store/src/java/com/zimbra/cs/mailbox/DeliveryOptions.java
@@ -35,6 +35,7 @@ public class DeliveryOptions {
     private Message.DraftInfo mDraftInfo = null;
     private CustomMetadata mCustomMetadata = null;
     private MessageCallbackContext mCallbackContext = null;
+    private String dsId;
 
     public int getFolderId() { return mFolderId; }
     public boolean getNoICal() { return mNoICal; }
@@ -45,6 +46,7 @@ public class DeliveryOptions {
     public Message.DraftInfo getDraftInfo() { return mDraftInfo; }
     public CustomMetadata getCustomMetadata() { return mCustomMetadata; }
     public MessageCallbackContext getCallbackContext() { return mCallbackContext; }
+    public String geDataSourceId() { return dsId; }
 
     public DeliveryOptions setFolderId(int folderId) {
         mFolderId = folderId;
@@ -98,6 +100,11 @@ public class DeliveryOptions {
 
     public DeliveryOptions setCallbackContext(MessageCallbackContext callbackContext) {
         mCallbackContext = callbackContext;
+        return this;
+    }
+
+    public DeliveryOptions setDataSourceId(String dsId) {
+        this.dsId = dsId;
         return this;
     }
 }

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -147,9 +147,11 @@ import com.zimbra.cs.mailbox.FoldersTagsCache.FoldersTags;
 import com.zimbra.cs.mailbox.MailItem.CustomMetadata;
 import com.zimbra.cs.mailbox.MailItem.PendingDelete;
 import com.zimbra.cs.mailbox.MailItem.TargetConstraint;
+import com.zimbra.cs.mailbox.MailItem.Type;
 import com.zimbra.cs.mailbox.MailItem.UnderlyingData;
 import com.zimbra.cs.mailbox.MailServiceException.NoSuchItemException;
 import com.zimbra.cs.mailbox.MailboxListener.ChangeNotification;
+import com.zimbra.cs.mailbox.Message.EventFlag;
 import com.zimbra.cs.mailbox.Note.Rectangle;
 import com.zimbra.cs.mailbox.Tag.NormalizedTags;
 import com.zimbra.cs.mailbox.calendar.CalendarMailSender;
@@ -6088,12 +6090,12 @@ public class Mailbox implements MailboxStore {
     public Message addMessage(OperationContext octxt, ParsedMessage pm, DeliveryOptions dopt, DeliveryContext dctxt, Message.DraftInfo dinfo)
     throws IOException, ServiceException {
         return addMessage(octxt, pm, dopt.getFolderId(), dopt.getNoICal(), dopt.getFlags(), dopt.getTags(),
-                          dopt.getConversationId(), dopt.getRecipientEmail(), dinfo, dopt.getCustomMetadata(), dopt.getCallbackContext(), dctxt);
+                          dopt.getConversationId(), dopt.getRecipientEmail(), dinfo, dopt.getCustomMetadata(), dopt.getCallbackContext(), dctxt, dopt.geDataSourceId());
     }
 
     private Message addMessage(OperationContext octxt, ParsedMessage pm, int folderId, boolean noICal, int flags,
             String[] tags, int conversationId, String rcptEmail, Message.DraftInfo dinfo, CustomMetadata customData,
-            MessageCallbackContext callbackContext, DeliveryContext dctxt)
+            MessageCallbackContext callbackContext, DeliveryContext dctxt, String dataSourceId)
     throws IOException, ServiceException {
         // and then actually add the message
         long start = ZimbraPerf.STOPWATCH_MBOX_ADD_MSG.start();
@@ -6171,7 +6173,7 @@ public class Mailbox implements MailboxStore {
         try {
             try {
                 Message message =  addMessageInternal(octxt, pm, folderId, noICal, flags, tags, conversationId,
-                        rcptEmail, dinfo, customData, dctxt, staged, callbackContext);
+                        rcptEmail, dinfo, customData, dctxt, staged, callbackContext, dataSourceId);
                 if (localMsgMarkedRead && account.getPrefMailSendReadReceipts().isAlways()) {
                     SendDeliveryReport.sendReport(account, message, true, null, null);
                 }
@@ -6200,7 +6202,7 @@ public class Mailbox implements MailboxStore {
 
     private Message addMessageInternal(OperationContext octxt, ParsedMessage pm, int folderId, boolean noICal,
             int flags, String[] tags, int conversationId, String rcptEmail, Message.DraftInfo dinfo,
-            CustomMetadata customData, DeliveryContext dctxt, StagedBlob staged, MessageCallbackContext callbackContext)
+            CustomMetadata customData, DeliveryContext dctxt, StagedBlob staged, MessageCallbackContext callbackContext, String dsId)
     throws IOException, ServiceException {
         assert lock.isWriteLockedByCurrentThread();
         if (pm == null) {
@@ -6376,7 +6378,7 @@ public class Mailbox implements MailboxStore {
             if (cpi != null && CalendarItem.isAcceptableInvite(getAccount(), cpi)) {
                 iCal = cpi.cal;
             }
-            msg = Message.create(messageId, folder, convTarget, pm, staged, unread, flags, ntags, dinfo, noICal, iCal, extended);
+            msg = Message.create(messageId, folder, convTarget, pm, staged, unread, flags, ntags, dinfo, noICal, iCal, extended, dsId);
 
             redoRecorder.setMessageId(msg.getId());
 
@@ -6529,7 +6531,7 @@ public class Mailbox implements MailboxStore {
         if (callbackContext != null) {
             MessageCallback callback = callbacks.get(callbackContext.getCallbackType());
             if (callback != null) {
-                callback.execute(msg.getId(), pm, callbackContext);
+                callback.execute(msg, callbackContext);
             }
         }
         return msg;
@@ -6606,7 +6608,7 @@ public class Mailbox implements MailboxStore {
         if (id == ID_AUTO_INCREMENT) {
             // special-case saving a new draft
             return addMessage(octxt, pm, ID_FOLDER_DRAFTS, true, Flag.BITMASK_DRAFT | Flag.BITMASK_FROM_ME,
-                              null, ID_AUTO_INCREMENT, ":API:", dinfo, null, null, null);
+                              null, ID_AUTO_INCREMENT, ":API:", dinfo, null, null, null, null);
         }
 
         // write the draft content directly to the mailbox's blob staging area
@@ -10652,43 +10654,56 @@ public class Mailbox implements MailboxStore {
         }
     }
 
+    public void setMessageEventFlag(Message msg, Message.EventFlag eventFlag) throws ServiceException {
+        boolean success = false;
+        try {
+            beginTransaction("setMessageEventFlag", null);
+            msg.setEventFlag(eventFlag);
+            success = true;
+        } finally {
+            endTransaction(success);
+        }
+    }
+
+    public void markMsgSeen(OperationContext octxt, int id) throws ServiceException {
+        Message msg = getMessageById(octxt, id);
+        msg.advanceEventFlag(EventFlag.seen);
+    }
+
+    @Override
+    public void markMsgSeen(OpContext octxt, ItemIdentifier itemId) throws ServiceException {
+        markMsgSeen(OperationContext.asOperationContext(octxt), itemId.id);
+    }
+
     public interface MessageCallback {
 
         public static enum Type {
             sent, received
         }
 
-        public void execute(int msgId, ParsedMessage pm, MessageCallbackContext ctxt);
+        public void execute(Message msg, MessageCallbackContext ctxt);
     }
 
     public class SentMessageCallback implements MessageCallback {
 
         @Override
-        public void execute(int msgId, ParsedMessage pm, MessageCallbackContext ctxt) {
-            MimeMessage mm = pm.getMimeMessage();
-            try {
-                long timestamp = ctxt.getTimestamp() == null ? System.currentTimeMillis() : ctxt.getTimestamp();
-                String dsId = ctxt.getDataSourceId();
-                List<Event> sentEvents = Event.generateSentEvents(getAccountId(), msgId, mm.getFrom()[0], mm.getAllRecipients(), dsId, timestamp);
-                EventLogger.getEventLogger().log(sentEvents);
-            } catch (MessagingException e) {
-                ZimbraLog.soap.warn(String.format("Couldn't log SENT event for message %s", msgId), e);
-            }
+        public void execute(Message msg, MessageCallbackContext ctxt) {
+            long timestamp = ctxt.getTimestamp() == null ? System.currentTimeMillis() : ctxt.getTimestamp();
+            List<Event> events = Event.generateSentEvents(msg, timestamp);
+            EventLogger.getEventLogger().log(events);
         }
     }
 
     public class ReceivedMessageCallback implements MessageCallback {
 
         @Override
-        public void execute(int msgId, ParsedMessage pm, MessageCallbackContext ctxt) {
-            String sender = pm.getSender();
+        public void execute(Message msg, MessageCallbackContext ctxt) {
             String recipient = ctxt.getRecipient();
             if (Strings.isNullOrEmpty(recipient)) {
-                ZimbraLog.event.warn("no recipient specified for message %d", msgId);
+                ZimbraLog.event.warn("no recipient specified for message %d", msg.getId());
             } else {
                 long timestamp = ctxt.getTimestamp() == null ? System.currentTimeMillis() : ctxt.getTimestamp();
-                String dsId = ctxt.getDataSourceId();
-                EventLogger.getEventLogger().log(Event.generateReceivedEvent(getAccountId(), msgId, sender, recipient, dsId, timestamp));
+                EventLogger.getEventLogger().log(Event.generateReceivedEvent(msg, recipient, timestamp));
             }
         }
     }

--- a/store/src/java/com/zimbra/cs/mailbox/Message.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Message.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.mail.MessagingException;
@@ -29,6 +30,7 @@ import javax.mail.internet.MimeMessage;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 import com.zimbra.common.account.Key.AccountBy;
 import com.zimbra.common.account.ZAttrProvisioning.PrefCalendarApptVisibility;
 import com.zimbra.common.calendar.ICalTimeZone;
@@ -51,8 +53,13 @@ import com.zimbra.cs.account.CalendarResource;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.accesscontrol.Rights.User;
 import com.zimbra.cs.db.DbMailItem;
+import com.zimbra.cs.event.Event;
+import com.zimbra.cs.event.Event.EventType;
+import com.zimbra.cs.event.logger.EventLogger;
 import com.zimbra.cs.index.IndexDocument;
 import com.zimbra.cs.index.SortBy;
+import com.zimbra.cs.index.history.SavedSearchPromptLog.SavedSearchStatus;
+import com.zimbra.cs.mailbox.Flag.FlagInfo;
 import com.zimbra.cs.mailbox.MailItem.TemporaryIndexingException;
 import com.zimbra.cs.mailbox.MailItem.Type;
 import com.zimbra.cs.mailbox.MailItem.UnderlyingData;
@@ -211,6 +218,9 @@ public class Message extends MailItem {
     private String recipients;
     private String fragment;
     private String rawSubject;
+    private String dsId;
+    private boolean sentByMe;
+    private EventFlag eventFlag;
 
     private DraftInfo draftInfo;
     private ArrayList<CalendarItemInfo> calendarItemInfos;
@@ -538,15 +548,15 @@ public class Message extends MailItem {
 
     static Message create(int id, Folder folder, Conversation conv, ParsedMessage pm, StagedBlob staged,
                           boolean unread, int flags, Tag.NormalizedTags ntags, DraftInfo dinfo,
-                          boolean noICal, ZVCalendar cal, CustomMetadataList extended)
+                          boolean noICal, ZVCalendar cal, CustomMetadataList extended, String dsId)
     throws ServiceException {
         return createInternal(id, folder, conv, pm, staged, unread, flags, ntags,
-                              dinfo, noICal, cal, extended, new MessageCreateFactory());
+                              dinfo, noICal, cal, extended, dsId, new MessageCreateFactory());
     }
 
     static Message createInternal(int id, Folder folder, Conversation conv, ParsedMessage pm, StagedBlob staged,
             boolean unread, int flags, Tag.NormalizedTags ntags, DraftInfo dinfo, boolean noICal, ZVCalendar cal,
-            CustomMetadataList extended, MessageCreateFactory fact)
+            CustomMetadataList extended, String dsId, MessageCreateFactory fact)
     throws ServiceException {
         if (folder == null || !folder.canContain(Type.MESSAGE)) {
             throw MailServiceException.CANNOT_CONTAIN(folder, Type.MESSAGE);
@@ -561,14 +571,14 @@ public class Message extends MailItem {
 
         List<Invite> components = null;
         String methodStr = null;
+        boolean sentByMe = false;
+        if (!Strings.isNullOrEmpty(sender)) {
+            sentByMe = AccountUtil.addressMatchesAccountOrSendAs(acct, sender);
+        }
         // Skip calendar processing if message is being filed as spam or trash.
         if (cal != null && folder.getId() != Mailbox.ID_FOLDER_SPAM && folder.getId() != Mailbox.ID_FOLDER_TRASH) {
             // XXX: shouldn't we just be checking flags for Flag.FLAG_FROM_ME?
             //   boolean sentByMe = (flags & Flag.FLAG_FROM_ME) != 0;
-            boolean sentByMe = false;
-            if (!Strings.isNullOrEmpty(sender)) {
-                sentByMe = AccountUtil.addressMatchesAccountOrSendAs(acct, sender);
-            }
             try {
                 components = Invite.createFromCalendar(acct, pm.getFragment(acct.getLocale()), cal, sentByMe, mbox, id);
                 methodStr = cal.getPropVal(ICalTok.METHOD, ICalTok.PUBLISH.toString()).toUpperCase();
@@ -608,7 +618,8 @@ public class Message extends MailItem {
         data.setFlags(flags & (Flag.FLAGS_MESSAGE | Flag.FLAGS_GENERIC));
         data.setTags(ntags);
         data.setSubject(pm.getNormalizedSubject());
-        data.metadata = encodeMetadata(DEFAULT_COLOR_RGB, 1, 1, extended, pm, pm.getFragment(acct.getLocale()), dinfo, null, null).toString();
+        data.metadata = encodeMetadata(DEFAULT_COLOR_RGB, 1, 1, extended, pm, pm.getFragment(acct.getLocale()),
+                dinfo, null, null, dsId, sentByMe, EventFlag.not_seen).toString();
         data.unreadCount = unread ? 1 : 0;
         data.contentChanged(mbox);
 
@@ -1290,6 +1301,47 @@ public class Message extends MailItem {
         }
     }
 
+    public boolean hasDataSourceId() {
+        return !Strings.isNullOrEmpty(dsId);
+    }
+
+    public String getDataSourceId() {
+        return dsId;
+    }
+
+    public boolean isSentByMe() {
+        return sentByMe;
+    }
+
+    public EventFlag getEventFlag() {
+        return eventFlag;
+    }
+
+    void setEventFlag(EventFlag eventFlag) {
+        this.eventFlag = eventFlag;
+        try {
+            saveMetadata();
+        } catch (ServiceException e) {
+            ZimbraLog.event.warn("unable to save metadata with event flag %s; duplicate events may be generated", eventFlag.name(), e);
+        }
+    }
+
+    /**
+     * Try to advance the event flag on the message. If the provided flag is the next
+     * step in the progression, log the appropriate event and update to the current flag
+     */
+    public void advanceEventFlag(EventFlag nextEventFlag) {
+        if (!isSentByMe() && eventFlag.canAdvanceTo(nextEventFlag) && nextEventFlag != EventFlag.not_seen) {
+            Event event = Event.generateMsgEvent(this, nextEventFlag.getEventType());
+            EventLogger.getEventLogger().log(event);
+            try {
+                getMailbox().setMessageEventFlag(this, nextEventFlag);
+            } catch (ServiceException e) {
+                ZimbraLog.event.error("error advancing event flag of msg %d to %s", getId(), nextEventFlag.name(), e);
+            }
+        }
+    }
+
     void updateBlobData(MailboxBlob mblob) throws IOException, ServiceException {
         long size = mblob.getSize();
         if (getSize() == size && StringUtil.equal(getDigest(), mblob.getDigest()) && StringUtil.equal(getLocator(), mblob.getLocator()))
@@ -1343,6 +1395,11 @@ public class Message extends MailItem {
 
         // tell the tags about the new read/unread item
         updateTagUnread(delta, deletedDelta);
+
+        if (delta < 0) {
+            // log a READ event if this is the first time the message is being marked as unread
+            advanceEventFlag(EventFlag.read);
+        }
     }
 
     /** @perms {@link ACL#RIGHT_INSERT} on the target folder,
@@ -1496,7 +1553,7 @@ public class Message extends MailItem {
 
         // rewrite the DB row to reflect our new view
         saveData(new DbMailItem(mMailbox), encodeMetadata(mRGBColor, mMetaVersion, mVersion, mExtendedData, pm, fragment,
-                draftInfo, calendarItemInfos, calendarIntendedFor));
+                draftInfo, calendarItemInfos, calendarIntendedFor, dsId, sentByMe, eventFlag));
 
         if (parent instanceof VirtualConversation) {
             ((VirtualConversation) parent).recalculateMetadata(Collections.singletonList(this));
@@ -1566,24 +1623,28 @@ public class Message extends MailItem {
         if (rawSubj != null) {
             rawSubject = rawSubj;
         }
+        dsId = meta.get(Metadata.FN_DS_ID, null);
+        sentByMe = meta.getBool(Metadata.FN_SENT_BY_ME, false);
+        eventFlag = EventFlag.of(meta.getInt(Metadata.FN_EVENT_FLAG, 0));
     }
 
     @Override
     Metadata encodeMetadata(Metadata meta) {
         return encodeMetadata(meta, mRGBColor, mMetaVersion, mVersion, mExtendedData, sender, recipients, fragment,
-                mData.getSubject(), rawSubject, draftInfo, calendarItemInfos, calendarIntendedFor);
+                mData.getSubject(), rawSubject, draftInfo, calendarItemInfos, calendarIntendedFor, dsId, sentByMe, eventFlag);
     }
 
     private static Metadata encodeMetadata(Color color, int metaVersion, int version, CustomMetadataList extended, ParsedMessage pm,
-            String fragment, DraftInfo dinfo, List<CalendarItemInfo> calItemInfos, String calIntendedFor) {
+            String fragment, DraftInfo dinfo, List<CalendarItemInfo> calItemInfos, String calIntendedFor,
+            String dsId, boolean sentByMe, EventFlag eventFlag) {
         return encodeMetadata(new Metadata(), color, metaVersion, version, extended, pm.getSender(), pm.getRecipients(),
                 fragment, pm.getNormalizedSubject(), pm.getSubject(), dinfo,
-                calItemInfos, calIntendedFor);
+                calItemInfos, calIntendedFor, dsId, sentByMe, eventFlag);
     }
 
     static Metadata encodeMetadata(Metadata meta, Color color, int metaVersion, int version, CustomMetadataList extended, String sender,
             String recipients, String fragment, String subject, String rawSubj, DraftInfo dinfo,
-            List<CalendarItemInfo> calItemInfos, String calIntendedFor) {
+            List<CalendarItemInfo> calItemInfos, String calIntendedFor, String dsId, boolean sentByMe, EventFlag eventFlag) {
         // try to figure out a simple way to make the raw subject from the normalized one
         String prefix = null;
         if (rawSubj == null || rawSubj.equals(subject)) {
@@ -1598,6 +1659,9 @@ public class Message extends MailItem {
         meta.put(Metadata.FN_FRAGMENT, fragment);
         meta.put(Metadata.FN_PREFIX, prefix);
         meta.put(Metadata.FN_RAW_SUBJ, rawSubj);
+        meta.put(Metadata.FN_DS_ID, dsId);
+        meta.put(Metadata.FN_SENT_BY_ME, sentByMe);
+        meta.put(Metadata.FN_EVENT_FLAG, eventFlag.getId());
 
         if (calItemInfos != null) {
             MetadataList mdList = new MetadataList();
@@ -1642,5 +1706,65 @@ public class Message extends MailItem {
         }
         helper.add("fragment", fragment);
         return helper.toString();
+    }
+
+    @Override
+    void alterTag(Tag tag, boolean add) throws ServiceException {
+        if (add && (tag instanceof Flag)
+                && ((Flag) tag).toBitmask() == FlagInfo.REPLIED.toBitmask()) {
+            advanceEventFlag(EventFlag.replied);
+        }
+        super.alterTag(tag, add);
+    }
+
+
+    public static enum EventFlag {
+        not_seen(0),
+        seen(1, EventType.SEEN),
+        read(2, EventType.READ),
+        replied(3, EventType.REPLIED);
+
+        private int id;
+        private EventType eventType;
+
+        private static final Map<Integer, EventFlag> MAP;
+        static {
+            ImmutableMap.Builder<Integer, EventFlag> builder = ImmutableMap.builder();
+            for (EventFlag flag: EventFlag.values()) {
+                builder.put(flag.id, flag);
+            }
+            MAP = builder.build();
+        }
+        private EventFlag(int id) {
+            this.id = id;
+        }
+
+        private EventFlag(int id, EventType eventType) {
+            this.id = id;
+            this.eventType = eventType;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public EventType getEventType() {
+            return eventType;
+        }
+
+        public boolean canAdvanceTo(EventFlag other) {
+            return id == other.id - 1;
+        }
+
+        static EventFlag of(int id) {
+            EventFlag flag = MAP.get(id);
+            if (flag == null) {
+                ZimbraLog.event.warn("encountered invalid event flag id %s, defaulting to not_seen", id);
+                return not_seen;
+            } else {
+                return flag;
+            }
+        }
+
     }
 }

--- a/store/src/java/com/zimbra/cs/mailbox/MessageCallbackContext.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MessageCallbackContext.java
@@ -3,7 +3,6 @@ package com.zimbra.cs.mailbox;
 import com.zimbra.cs.mailbox.Mailbox.MessageCallback;
 
 public class MessageCallbackContext {
-    private String dsId;
     private String recipient;
     private Long timestamp;
     private MessageCallback.Type type;
@@ -16,20 +15,12 @@ public class MessageCallbackContext {
         return type;
     }
 
-    public String getDataSourceId() {
-        return dsId;
-    }
-
     public String getRecipient() {
         return recipient;
     }
 
     public Long getTimestamp() {
         return timestamp;
-    }
-
-    public void setDataSourceId(String dsId) {
-        this.dsId = dsId;
     }
 
     public void setRecipient(String recipient) {

--- a/store/src/java/com/zimbra/cs/mailbox/Metadata.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Metadata.java
@@ -122,6 +122,9 @@ public final class Metadata {
     public static final String FN_WIKI_WORD        = "ww";
     public static final String FN_ELIDED           = "X";
     public static final String FN_EXTRA_DATA       = "xd";
+    public static final String FN_DS_ID            = "dsid";
+    public static final String FN_SENT_BY_ME       = "sbm";
+    public static final String FN_EVENT_FLAG       = "ev";
 
     private final Integer associatedItemId;
 

--- a/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
@@ -92,6 +92,7 @@ public class ItemAction extends MailDocumentHandler {
     public static final String OP_INHERIT = MailConstants.OP_INHERIT;
     public static final String OP_MUTE = MailConstants.OP_MUTE;
     public static final String OP_IMAP_RESET = MailConstants.OP_RESET_IMAP_UID;
+    public static final String OP_SEEN = MailConstants.OP_SEEN;
 
     @Override
     public Element handle(Element request, Map<String, Object> context) throws ServiceException {
@@ -247,6 +248,8 @@ public class ItemAction extends MailDocumentHandler {
                 mbox.resetImapUid(octxt, local);
 
                 localResults = new ItemActionResult(local);
+            } else if (opStr.equals(MailConstants.OP_SEEN)) {
+                localResults = ItemActionHelper.SEEN(octxt, mbox, responseProto, local).getResult();
             } else {
                 throw ServiceException.INVALID_REQUEST("unknown operation: " + opStr, null);
             }

--- a/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
@@ -68,6 +68,7 @@ import com.zimbra.cs.mailbox.Flag;
 import com.zimbra.cs.mailbox.Folder;
 import com.zimbra.cs.mailbox.MailItem;
 import com.zimbra.cs.mailbox.MailItem.TargetConstraint;
+import com.zimbra.cs.mailbox.Message.EventFlag;
 import com.zimbra.cs.mailbox.MailServiceException;
 import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.Message;
@@ -185,6 +186,13 @@ public class ItemActionHelper {
             List<Integer> ids, MailItem.Type type, TargetConstraint tcon, ItemId iidFolder) throws ServiceException {
         ItemActionHelper ia = new ItemActionHelper(octxt, mbox, responseProto, ids, Op.MOVE, type, true, tcon);
         ia.setIidFolder(iidFolder);
+        ia.schedule();
+        return ia;
+    }
+
+    public static ItemActionHelper SEEN(OperationContext octxt, Mailbox mbox, SoapProtocol responseProto,
+            List<Integer> ids) throws ServiceException {
+        ItemActionHelper ia = new ItemActionHelper(octxt, mbox, responseProto, ids, Op.SEEN, MailItem.Type.MESSAGE, true, null);
         ia.schedule();
         return ia;
     }
@@ -315,7 +323,8 @@ public class ItemActionHelper {
         RENAME("rename"),
         UPDATE("update"),
         LOCK("lock"),
-        UNLOCK("unlock");
+        UNLOCK("unlock"),
+        SEEN("seen");
 
         private final String name;
 
@@ -546,6 +555,11 @@ public class ItemActionHelper {
             case UNLOCK:
                 for (int id : ids) {
                     getMailbox().unlock(getOpCtxt(), id, type, mAuthenticatedAccount.getId());
+                }
+                break;
+            case SEEN:
+                for (int id: ids) {
+                    getMailbox().markMsgSeen(getOpCtxt(), id);
                 }
                 break;
             default:

--- a/store/src/java/com/zimbra/cs/service/mail/Search.java
+++ b/store/src/java/com/zimbra/cs/service/mail/Search.java
@@ -41,6 +41,9 @@ import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.AuthToken;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.Server;
+import com.zimbra.cs.event.Event;
+import com.zimbra.cs.event.logger.EventLogger;
+import com.zimbra.cs.index.ConversationHit;
 import com.zimbra.cs.index.MessageHit;
 import com.zimbra.cs.index.QueryInfo;
 import com.zimbra.cs.index.ResultsPager;
@@ -49,15 +52,15 @@ import com.zimbra.cs.index.SearchParams.ExpandResults;
 import com.zimbra.cs.index.SortBy;
 import com.zimbra.cs.index.ZimbraHit;
 import com.zimbra.cs.index.ZimbraQueryResults;
-import com.zimbra.cs.index.history.SavedSearchPromptLog;
 import com.zimbra.cs.index.history.SearchHistory;
-import com.zimbra.cs.index.history.ZimbraSearchHistory;
-import com.zimbra.cs.index.history.SavedSearchPromptLog.SavedSearchStatus;
 import com.zimbra.cs.mailbox.ContactMemberOfMap;
+import com.zimbra.cs.mailbox.Conversation;
 import com.zimbra.cs.mailbox.MailItem;
 import com.zimbra.cs.mailbox.MailServiceException;
 import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailbox.Message;
+import com.zimbra.cs.mailbox.Message.EventFlag;
 import com.zimbra.cs.mailbox.OperationContext;
 import com.zimbra.cs.mailbox.calendar.cache.CacheToXML;
 import com.zimbra.cs.mailbox.calendar.cache.CalSummaryCache;
@@ -121,7 +124,7 @@ public class Search extends MailDocumentHandler  {
             // must use results.getSortBy() because the results might have ignored our sortBy
             // request and used something else...
             response.addAttribute(MailConstants.A_SORTBY, results.getSortBy().toString());
-            putHits(zsc, octxt, response, results, params, memberOfMap);
+            putHits(zsc, octxt, response, results, params, memberOfMap, mbox);
 
             if(addToSearchHistory(octxt, account, mbox, addToHistory, params, defaultSearch)) {
                 response.addAttribute(MailConstants.A_SAVE_SEARCH_PROMPT, true);
@@ -160,7 +163,7 @@ public class Search extends MailDocumentHandler  {
     }
 
     private void putHits(ZimbraSoapContext zsc, OperationContext octxt, Element el, ZimbraQueryResults results,
-            SearchParams params, Map<String,Set<String>> memberOfMap) throws ServiceException {
+            SearchParams params, Map<String,Set<String>> memberOfMap, Mailbox mbox) throws ServiceException {
 
         if (params.getInlineRule() == ExpandResults.HITS ||
             params.getInlineRule() == ExpandResults.FIRST_MSG ||
@@ -211,7 +214,17 @@ public class Search extends MailDocumentHandler  {
                 } else {
                     expand = expandValue.matches(hit.getParsedItemID());
                 }
+                MessageHit msgHit = (MessageHit) hit;
+                Message msg = msgHit.getMessage();
+                msg.advanceEventFlag(EventFlag.seen);
                 resp.add(hit, expand);
+            } else if (hit instanceof ConversationHit) {
+                ConversationHit convHit = (ConversationHit) hit;
+                Conversation conv = convHit.getConversation();
+                for (Message msg: mbox.getMessagesByConversation(octxt, conv.getId())) {
+                    msg.advanceEventFlag(EventFlag.seen);
+                }
+                resp.add(hit);
             } else {
                 resp.add(hit);
             }
@@ -219,6 +232,7 @@ public class Search extends MailDocumentHandler  {
         resp.addHasMore(pager.hasNext());
         resp.add(results.getResultInfo());
     }
+
     // Calendar summary cache stuff
 
     /**

--- a/store/src/java/com/zimbra/cs/session/SoapSession.java
+++ b/store/src/java/com/zimbra/cs/session/SoapSession.java
@@ -61,6 +61,7 @@ import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.Mailbox.FolderNode;
 import com.zimbra.cs.mailbox.MailboxManager;
 import com.zimbra.cs.mailbox.Message;
+import com.zimbra.cs.mailbox.Message.EventFlag;
 import com.zimbra.cs.mailbox.Mountpoint;
 import com.zimbra.cs.mailbox.OperationContext;
 import com.zimbra.cs.mailbox.OperationContextData;
@@ -1493,6 +1494,11 @@ public class SoapSession extends Session {
                                 expandLocalMountpoint(octxt, (Mountpoint) mi, eCreated.getFactory(), mountpoints);
                                 expandRemoteMountpoints(octxt, zsc, mountpoints);
                                 transferMountpointContents(elem, octxt, mountpoints);
+                            }
+                            if (item instanceof Message) {
+                                Message msg = (Message) item;
+                                //change the flag on the cached item; this is just a snapshot
+                                mbox.getMessageById(octxt, msg.getId()).advanceEventFlag(EventFlag.seen);
                             }
                         } catch (ServiceException e) {
                             ZimbraLog.session.warn("error encoding item " + mi.getId(), e);


### PR DESCRIPTION
This PR introduces three new message event types: `SEEN`, `READ` and `REPLIED`. The purpose of these events is to enable calculation of useful contact-level metrics such as the email open rate and average reply time.

#### EventFlag mechanism
The event state is stored in message metadata using the new `EventFlag` enum. A new message is instantiated as `not_seen`; the new method `Message:advanceEventFlag` is used to advance the event flag through the other states. The events must be triggered in order: a `SEEN` event can only be triggered for a message that has an internal event flag of `not_seen`; a `READ` event can only be triggered for a `seen` event, etc. This event flag metadata field also insures that only one event of each category is logged per message.

#### Other New Metadata Fields
In addition to the EventFlag metadata field, several others have been added:
 - The boolean `sentByMe` is `true` for outgoing messages and false otherwise. This is used to ensure that these three events are only triggered for incoming messages.
 - If the message is created from a datasource, the datasource ID is now stored in metadata so that it can be added to the logged event.

#### Event triggers
The `SEEN` event is triggered in one of two ways:
 - In the `SearchRequest` SOAP handler, with the event being potentially triggered for each message returned to the client. This covers the case where the user loads the UI or selects a folder to view.
 - In `SoapSession`, when a created item is returned to the client as part of notification headers. While it is not guaranteed that this will result in the user actually _seeing_ the item at that time, it is the best approximation we have for the time being.

The `READ` and `REPLIED` events are easier. `READ` is triggered the first time that the `UNREAD` message flag is unset; `REPLIED` is triggered the first time that the `REPLIED` message flag is set.

#### UPDATE 11/20
In order to trigger SEEN events from the IMAP FETCH command, I added a new `MailboxStore::markMsgSeen` interface method. The `Mailbox` implementation simply calls `advanceEventFlag` on the specified message. The `ZMailbox` implementation invokes `MsgActionRequest` with the new "seen" action. `ItemActionHelper` has been updated to handle the new operation.
`ImapHandler::fetch` calls this new method after fetching the message from the MailboxStore.

It should be noted that if FETCH_MARK_READ is true, this will result in `SEEN` and `READ` events being logged back-to-back, which may skew event-driven data. To compensate, queries that calculate differences between `SEEN` and `READ` events may need to be made to ignore time deltas below a certain threshold.
