### PR TITLE
ZCS-3546:API that allows me to set out of office response for specific domain

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -1783,7 +1783,8 @@ public class ZAttrProvisioning {
     public static enum PrefExternalSendersType {
         ALL("ALL"),
         ALLNOTINAB("ALLNOTINAB"),
-        INAB("INAB");
+        INAB("INAB"),
+        INSD("INSD");
         private String mValue;
         private PrefExternalSendersType(String value) { mValue = value; }
         public String toString() { return mValue; }
@@ -1796,6 +1797,7 @@ public class ZAttrProvisioning {
         public boolean isALL() { return this == ALL;}
         public boolean isALLNOTINAB() { return this == ALLNOTINAB;}
         public boolean isINAB() { return this == INAB;}
+        public boolean isINSD() { return this == INSD;}
     }
 
     public static enum PrefFileSharingApplication {
@@ -12796,7 +12798,8 @@ public class ZAttrProvisioning {
      * &quot;ALL&quot; minus users who are in the recipient&#039;s address
      * book. &quot;INAB&quot; Users/Addresses whose domain doesn&#039;t match
      * the recipient&#039;s domain or zimbraInternalSendersDomain and which
-     * are present in recipient&#039;s address book.
+     * are present in recipient&#039;s address book. &quot;INSD&quot; means
+     * users whose domain matches the specific domain
      *
      * @since ZCS 8.0.0
      */
@@ -13504,6 +13507,14 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=59)
     public static final String A_zimbraPrefOutOfOfficeReplyEnabled = "zimbraPrefOutOfOfficeReplyEnabled";
+
+    /**
+     * Specific domains to which custom out of office message is to be sent
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2132)
+    public static final String A_zimbraPrefOutOfOfficeSpecificDomains = "zimbraPrefOutOfOfficeSpecificDomains";
 
     /**
      * when user has OOO message enabled, when they login into web client,

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -6624,10 +6624,11 @@ TODO: delete them permanently from here
   <desc>additional domains considered as internal w.r.t. recipient</desc>
 </attr>
 
-<attr id="1320" name="zimbraPrefExternalSendersType" type="enum" value="ALL,ALLNOTINAB,INAB" cardinality="single" optionalIn="account,cos" flags="accountInherited" since="8.0.0">
+<attr id="1320" name="zimbraPrefExternalSendersType" type="enum" value="ALL,ALLNOTINAB,INAB,INSD" cardinality="single" optionalIn="account,cos" flags="accountInherited" since="8.0.0">
   <defaultCOSValue>ALL</defaultCOSValue>
   <desc>Specifies the meaning of an external sender.  "ALL" means users whose domain doesn't match the recipient's or zimbraInternalSendersDomain.  "ALLNOTINAB" means "ALL" minus users who are in the recipient's address book.
-  "INAB" Users/Addresses whose domain doesn't match the recipient's domain or zimbraInternalSendersDomain and which are present in recipient's address book.</desc>
+  "INAB" Users/Addresses whose domain doesn't match the recipient's domain or zimbraInternalSendersDomain and which are present in recipient's address book.
+  "INSD" means users whose domain matches the specific domain</desc>
 </attr>
 
 <attr id="1321" name="zimbraReverseProxyAdminEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="8.0.0">
@@ -9450,7 +9451,9 @@ TODO: delete them permanently from here
   <defaultCOSValue>FALSE</defaultCOSValue>
   <desc>Enable contact backup feature</desc>
 </attr>
-
+<attr id="2132" name="zimbraPrefOutOfOfficeSpecificDomains" type="string" cardinality="multi" optionalIn="account,cos" flags="accountInherited" since="8.8.5">
+  <desc>Specific domains to which custom out of office message is to be sent</desc>
+</attr>
 <attr id="2995" name="zimbraEphemeralBackendURL" type="string" cardinality="single" optionalIn="globalConfig" callback="EphemeralBackendCheck" since="8.7.6">
   <desc>URL of ephemeral storage backend</desc>
   <globalConfigValue>ldap://default</globalConfigValue>

--- a/store/src/java-test/com/zimbra/cs/mailbox/NotificationTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/NotificationTest.java
@@ -1,0 +1,104 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2017 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.mailbox;
+
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.common.collect.Maps;
+import com.zimbra.common.account.Key;
+import com.zimbra.common.account.ZAttrProvisioning.PrefExternalSendersType;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+
+import junit.framework.Assert;
+
+public class NotificationTest {
+
+    @BeforeClass
+    public static void init() throws Exception {
+        MailboxTestUtil.initServer();
+        Provisioning prov = Provisioning.getInstance();
+        Map<String, Object> attrs = Maps.newHashMap();
+
+        attrs = Maps.newHashMap();
+        attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        prov.createAccount("testZCS3546@zimbra.com", "secret", attrs);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        MailboxTestUtil.clearData();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        MailboxTestUtil.clearData();
+
+    }
+
+    @Test
+    public void testOOOWhenSpecificDomainSenderNotSet() throws Exception {
+        Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "testZCS3546@zimbra.com");
+        acct1.setPrefOutOfOfficeSuppressExternalReply(true);
+        Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
+        boolean skipOOO = Notification.skipOutOfOfficeMsg("test3@synacor.com", acct1, mbox1);
+        Assert.assertEquals(true, skipOOO);
+    }
+
+    @Test
+    public void testOOOWhenSpecificDomainSenderIsSet() throws Exception {
+        Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "testZCS3546@zimbra.com");
+        acct1.setPrefOutOfOfficeSuppressExternalReply(true);
+        acct1.setPrefExternalSendersType(PrefExternalSendersType.INSD);
+        String[] domains = {"synacor.com"};
+        acct1.setPrefOutOfOfficeSpecificDomains(domains);
+        Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
+        boolean skipOOO = Notification.skipOutOfOfficeMsg("test3@synacor.com", acct1, mbox1);
+        Assert.assertEquals(false, skipOOO);
+    }
+
+    @Test
+    public void testOOOMsgWhenSpecificDomainSenderIsSetWithSpecificDomainSender() throws Exception {
+        Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "testZCS3546@zimbra.com");
+        acct1.setPrefOutOfOfficeExternalReplyEnabled(true);
+        acct1.setPrefExternalSendersType(PrefExternalSendersType.INSD);
+        String[] domains = {"synacor.com"};
+        acct1.setPrefOutOfOfficeSpecificDomains(domains);
+        acct1.setInternalSendersDomain(domains);
+        Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
+        boolean customMsg = Notification.sendOutOfOfficeExternalReply("test3@synacor.com", acct1, mbox1);
+        Assert.assertEquals(true, customMsg);
+    }
+
+    @Test
+    public void testOOOMsgWhenSpecificDomainSenderIsSetWithInternalSender() throws Exception {
+        Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "testZCS3546@zimbra.com");
+        acct1.setPrefOutOfOfficeExternalReplyEnabled(true);
+        acct1.setPrefExternalSendersType(PrefExternalSendersType.INSD);
+        String[] domains = {"synacor.com"};
+        acct1.setPrefOutOfOfficeSpecificDomains(domains);
+        Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
+        boolean customMsg = Notification.sendOutOfOfficeExternalReply("test2@zimbra.com", acct1, mbox1);
+        Assert.assertEquals(false, customMsg);
+    }
+}

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -42507,9 +42507,10 @@ public abstract class ZAttrAccount  extends MailTarget {
      * &quot;ALL&quot; minus users who are in the recipient&#039;s address
      * book. &quot;INAB&quot; Users/Addresses whose domain doesn&#039;t match
      * the recipient&#039;s domain or zimbraInternalSendersDomain and which
-     * are present in recipient&#039;s address book.
+     * are present in recipient&#039;s address book. &quot;INSD&quot; means
+     * users whose domain matches the specific domain
      *
-     * <p>Valid values: [ALL, ALLNOTINAB, INAB]
+     * <p>Valid values: [ALL, ALLNOTINAB, INAB, INSD]
      *
      * @return zimbraPrefExternalSendersType, or ZAttrProvisioning.PrefExternalSendersType.ALL if unset and/or has invalid value
      *
@@ -42527,9 +42528,10 @@ public abstract class ZAttrAccount  extends MailTarget {
      * &quot;ALL&quot; minus users who are in the recipient&#039;s address
      * book. &quot;INAB&quot; Users/Addresses whose domain doesn&#039;t match
      * the recipient&#039;s domain or zimbraInternalSendersDomain and which
-     * are present in recipient&#039;s address book.
+     * are present in recipient&#039;s address book. &quot;INSD&quot; means
+     * users whose domain matches the specific domain
      *
-     * <p>Valid values: [ALL, ALLNOTINAB, INAB]
+     * <p>Valid values: [ALL, ALLNOTINAB, INAB, INSD]
      *
      * @return zimbraPrefExternalSendersType, or "ALL" if unset
      *
@@ -42547,9 +42549,10 @@ public abstract class ZAttrAccount  extends MailTarget {
      * &quot;ALL&quot; minus users who are in the recipient&#039;s address
      * book. &quot;INAB&quot; Users/Addresses whose domain doesn&#039;t match
      * the recipient&#039;s domain or zimbraInternalSendersDomain and which
-     * are present in recipient&#039;s address book.
+     * are present in recipient&#039;s address book. &quot;INSD&quot; means
+     * users whose domain matches the specific domain
      *
-     * <p>Valid values: [ALL, ALLNOTINAB, INAB]
+     * <p>Valid values: [ALL, ALLNOTINAB, INAB, INSD]
      *
      * @param zimbraPrefExternalSendersType new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -42570,9 +42573,10 @@ public abstract class ZAttrAccount  extends MailTarget {
      * &quot;ALL&quot; minus users who are in the recipient&#039;s address
      * book. &quot;INAB&quot; Users/Addresses whose domain doesn&#039;t match
      * the recipient&#039;s domain or zimbraInternalSendersDomain and which
-     * are present in recipient&#039;s address book.
+     * are present in recipient&#039;s address book. &quot;INSD&quot; means
+     * users whose domain matches the specific domain
      *
-     * <p>Valid values: [ALL, ALLNOTINAB, INAB]
+     * <p>Valid values: [ALL, ALLNOTINAB, INAB, INSD]
      *
      * @param zimbraPrefExternalSendersType new value
      * @param attrs existing map to populate, or null to create a new map
@@ -42594,9 +42598,10 @@ public abstract class ZAttrAccount  extends MailTarget {
      * &quot;ALL&quot; minus users who are in the recipient&#039;s address
      * book. &quot;INAB&quot; Users/Addresses whose domain doesn&#039;t match
      * the recipient&#039;s domain or zimbraInternalSendersDomain and which
-     * are present in recipient&#039;s address book.
+     * are present in recipient&#039;s address book. &quot;INSD&quot; means
+     * users whose domain matches the specific domain
      *
-     * <p>Valid values: [ALL, ALLNOTINAB, INAB]
+     * <p>Valid values: [ALL, ALLNOTINAB, INAB, INSD]
      *
      * @param zimbraPrefExternalSendersType new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -42617,9 +42622,10 @@ public abstract class ZAttrAccount  extends MailTarget {
      * &quot;ALL&quot; minus users who are in the recipient&#039;s address
      * book. &quot;INAB&quot; Users/Addresses whose domain doesn&#039;t match
      * the recipient&#039;s domain or zimbraInternalSendersDomain and which
-     * are present in recipient&#039;s address book.
+     * are present in recipient&#039;s address book. &quot;INSD&quot; means
+     * users whose domain matches the specific domain
      *
-     * <p>Valid values: [ALL, ALLNOTINAB, INAB]
+     * <p>Valid values: [ALL, ALLNOTINAB, INAB, INSD]
      *
      * @param zimbraPrefExternalSendersType new value
      * @param attrs existing map to populate, or null to create a new map
@@ -42641,9 +42647,10 @@ public abstract class ZAttrAccount  extends MailTarget {
      * &quot;ALL&quot; minus users who are in the recipient&#039;s address
      * book. &quot;INAB&quot; Users/Addresses whose domain doesn&#039;t match
      * the recipient&#039;s domain or zimbraInternalSendersDomain and which
-     * are present in recipient&#039;s address book.
+     * are present in recipient&#039;s address book. &quot;INSD&quot; means
+     * users whose domain matches the specific domain
      *
-     * <p>Valid values: [ALL, ALLNOTINAB, INAB]
+     * <p>Valid values: [ALL, ALLNOTINAB, INAB, INSD]
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -42663,9 +42670,10 @@ public abstract class ZAttrAccount  extends MailTarget {
      * &quot;ALL&quot; minus users who are in the recipient&#039;s address
      * book. &quot;INAB&quot; Users/Addresses whose domain doesn&#039;t match
      * the recipient&#039;s domain or zimbraInternalSendersDomain and which
-     * are present in recipient&#039;s address book.
+     * are present in recipient&#039;s address book. &quot;INSD&quot; means
+     * users whose domain matches the specific domain
      *
-     * <p>Valid values: [ALL, ALLNOTINAB, INAB]
+     * <p>Valid values: [ALL, ALLNOTINAB, INAB, INSD]
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
@@ -49908,6 +49916,140 @@ public abstract class ZAttrAccount  extends MailTarget {
     public Map<String,Object> unsetPrefOutOfOfficeReplyEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraPrefOutOfOfficeReplyEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * Specific domains to which custom out of office message is to be sent
+     *
+     * @return zimbraPrefOutOfOfficeSpecificDomains, or empty array if unset
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2132)
+    public String[] getPrefOutOfOfficeSpecificDomains() {
+        return getMultiAttr(Provisioning.A_zimbraPrefOutOfOfficeSpecificDomains, true, true);
+    }
+
+    /**
+     * Specific domains to which custom out of office message is to be sent
+     *
+     * @param zimbraPrefOutOfOfficeSpecificDomains new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2132)
+    public void setPrefOutOfOfficeSpecificDomains(String[] zimbraPrefOutOfOfficeSpecificDomains) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefOutOfOfficeSpecificDomains, zimbraPrefOutOfOfficeSpecificDomains);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Specific domains to which custom out of office message is to be sent
+     *
+     * @param zimbraPrefOutOfOfficeSpecificDomains new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2132)
+    public Map<String,Object> setPrefOutOfOfficeSpecificDomains(String[] zimbraPrefOutOfOfficeSpecificDomains, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefOutOfOfficeSpecificDomains, zimbraPrefOutOfOfficeSpecificDomains);
+        return attrs;
+    }
+
+    /**
+     * Specific domains to which custom out of office message is to be sent
+     *
+     * @param zimbraPrefOutOfOfficeSpecificDomains new to add to existing values
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2132)
+    public void addPrefOutOfOfficeSpecificDomains(String zimbraPrefOutOfOfficeSpecificDomains) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraPrefOutOfOfficeSpecificDomains, zimbraPrefOutOfOfficeSpecificDomains);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Specific domains to which custom out of office message is to be sent
+     *
+     * @param zimbraPrefOutOfOfficeSpecificDomains new to add to existing values
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2132)
+    public Map<String,Object> addPrefOutOfOfficeSpecificDomains(String zimbraPrefOutOfOfficeSpecificDomains, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraPrefOutOfOfficeSpecificDomains, zimbraPrefOutOfOfficeSpecificDomains);
+        return attrs;
+    }
+
+    /**
+     * Specific domains to which custom out of office message is to be sent
+     *
+     * @param zimbraPrefOutOfOfficeSpecificDomains existing value to remove
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2132)
+    public void removePrefOutOfOfficeSpecificDomains(String zimbraPrefOutOfOfficeSpecificDomains) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraPrefOutOfOfficeSpecificDomains, zimbraPrefOutOfOfficeSpecificDomains);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Specific domains to which custom out of office message is to be sent
+     *
+     * @param zimbraPrefOutOfOfficeSpecificDomains existing value to remove
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2132)
+    public Map<String,Object> removePrefOutOfOfficeSpecificDomains(String zimbraPrefOutOfOfficeSpecificDomains, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraPrefOutOfOfficeSpecificDomains, zimbraPrefOutOfOfficeSpecificDomains);
+        return attrs;
+    }
+
+    /**
+     * Specific domains to which custom out of office message is to be sent
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2132)
+    public void unsetPrefOutOfOfficeSpecificDomains() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefOutOfOfficeSpecificDomains, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Specific domains to which custom out of office message is to be sent
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2132)
+    public Map<String,Object> unsetPrefOutOfOfficeSpecificDomains(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefOutOfOfficeSpecificDomains, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -33210,9 +33210,10 @@ public abstract class ZAttrCos extends NamedEntry {
      * &quot;ALL&quot; minus users who are in the recipient&#039;s address
      * book. &quot;INAB&quot; Users/Addresses whose domain doesn&#039;t match
      * the recipient&#039;s domain or zimbraInternalSendersDomain and which
-     * are present in recipient&#039;s address book.
+     * are present in recipient&#039;s address book. &quot;INSD&quot; means
+     * users whose domain matches the specific domain
      *
-     * <p>Valid values: [ALL, ALLNOTINAB, INAB]
+     * <p>Valid values: [ALL, ALLNOTINAB, INAB, INSD]
      *
      * @return zimbraPrefExternalSendersType, or ZAttrProvisioning.PrefExternalSendersType.ALL if unset and/or has invalid value
      *
@@ -33230,9 +33231,10 @@ public abstract class ZAttrCos extends NamedEntry {
      * &quot;ALL&quot; minus users who are in the recipient&#039;s address
      * book. &quot;INAB&quot; Users/Addresses whose domain doesn&#039;t match
      * the recipient&#039;s domain or zimbraInternalSendersDomain and which
-     * are present in recipient&#039;s address book.
+     * are present in recipient&#039;s address book. &quot;INSD&quot; means
+     * users whose domain matches the specific domain
      *
-     * <p>Valid values: [ALL, ALLNOTINAB, INAB]
+     * <p>Valid values: [ALL, ALLNOTINAB, INAB, INSD]
      *
      * @return zimbraPrefExternalSendersType, or "ALL" if unset
      *
@@ -33250,9 +33252,10 @@ public abstract class ZAttrCos extends NamedEntry {
      * &quot;ALL&quot; minus users who are in the recipient&#039;s address
      * book. &quot;INAB&quot; Users/Addresses whose domain doesn&#039;t match
      * the recipient&#039;s domain or zimbraInternalSendersDomain and which
-     * are present in recipient&#039;s address book.
+     * are present in recipient&#039;s address book. &quot;INSD&quot; means
+     * users whose domain matches the specific domain
      *
-     * <p>Valid values: [ALL, ALLNOTINAB, INAB]
+     * <p>Valid values: [ALL, ALLNOTINAB, INAB, INSD]
      *
      * @param zimbraPrefExternalSendersType new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -33273,9 +33276,10 @@ public abstract class ZAttrCos extends NamedEntry {
      * &quot;ALL&quot; minus users who are in the recipient&#039;s address
      * book. &quot;INAB&quot; Users/Addresses whose domain doesn&#039;t match
      * the recipient&#039;s domain or zimbraInternalSendersDomain and which
-     * are present in recipient&#039;s address book.
+     * are present in recipient&#039;s address book. &quot;INSD&quot; means
+     * users whose domain matches the specific domain
      *
-     * <p>Valid values: [ALL, ALLNOTINAB, INAB]
+     * <p>Valid values: [ALL, ALLNOTINAB, INAB, INSD]
      *
      * @param zimbraPrefExternalSendersType new value
      * @param attrs existing map to populate, or null to create a new map
@@ -33297,9 +33301,10 @@ public abstract class ZAttrCos extends NamedEntry {
      * &quot;ALL&quot; minus users who are in the recipient&#039;s address
      * book. &quot;INAB&quot; Users/Addresses whose domain doesn&#039;t match
      * the recipient&#039;s domain or zimbraInternalSendersDomain and which
-     * are present in recipient&#039;s address book.
+     * are present in recipient&#039;s address book. &quot;INSD&quot; means
+     * users whose domain matches the specific domain
      *
-     * <p>Valid values: [ALL, ALLNOTINAB, INAB]
+     * <p>Valid values: [ALL, ALLNOTINAB, INAB, INSD]
      *
      * @param zimbraPrefExternalSendersType new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -33320,9 +33325,10 @@ public abstract class ZAttrCos extends NamedEntry {
      * &quot;ALL&quot; minus users who are in the recipient&#039;s address
      * book. &quot;INAB&quot; Users/Addresses whose domain doesn&#039;t match
      * the recipient&#039;s domain or zimbraInternalSendersDomain and which
-     * are present in recipient&#039;s address book.
+     * are present in recipient&#039;s address book. &quot;INSD&quot; means
+     * users whose domain matches the specific domain
      *
-     * <p>Valid values: [ALL, ALLNOTINAB, INAB]
+     * <p>Valid values: [ALL, ALLNOTINAB, INAB, INSD]
      *
      * @param zimbraPrefExternalSendersType new value
      * @param attrs existing map to populate, or null to create a new map
@@ -33344,9 +33350,10 @@ public abstract class ZAttrCos extends NamedEntry {
      * &quot;ALL&quot; minus users who are in the recipient&#039;s address
      * book. &quot;INAB&quot; Users/Addresses whose domain doesn&#039;t match
      * the recipient&#039;s domain or zimbraInternalSendersDomain and which
-     * are present in recipient&#039;s address book.
+     * are present in recipient&#039;s address book. &quot;INSD&quot; means
+     * users whose domain matches the specific domain
      *
-     * <p>Valid values: [ALL, ALLNOTINAB, INAB]
+     * <p>Valid values: [ALL, ALLNOTINAB, INAB, INSD]
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -33366,9 +33373,10 @@ public abstract class ZAttrCos extends NamedEntry {
      * &quot;ALL&quot; minus users who are in the recipient&#039;s address
      * book. &quot;INAB&quot; Users/Addresses whose domain doesn&#039;t match
      * the recipient&#039;s domain or zimbraInternalSendersDomain and which
-     * are present in recipient&#039;s address book.
+     * are present in recipient&#039;s address book. &quot;INSD&quot; means
+     * users whose domain matches the specific domain
      *
-     * <p>Valid values: [ALL, ALLNOTINAB, INAB]
+     * <p>Valid values: [ALL, ALLNOTINAB, INAB, INSD]
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
@@ -38633,6 +38641,140 @@ public abstract class ZAttrCos extends NamedEntry {
     public Map<String,Object> unsetPrefOutOfOfficeCacheDuration(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraPrefOutOfOfficeCacheDuration, "");
+        return attrs;
+    }
+
+    /**
+     * Specific domains to which custom out of office message is to be sent
+     *
+     * @return zimbraPrefOutOfOfficeSpecificDomains, or empty array if unset
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2132)
+    public String[] getPrefOutOfOfficeSpecificDomains() {
+        return getMultiAttr(Provisioning.A_zimbraPrefOutOfOfficeSpecificDomains, true, true);
+    }
+
+    /**
+     * Specific domains to which custom out of office message is to be sent
+     *
+     * @param zimbraPrefOutOfOfficeSpecificDomains new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2132)
+    public void setPrefOutOfOfficeSpecificDomains(String[] zimbraPrefOutOfOfficeSpecificDomains) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefOutOfOfficeSpecificDomains, zimbraPrefOutOfOfficeSpecificDomains);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Specific domains to which custom out of office message is to be sent
+     *
+     * @param zimbraPrefOutOfOfficeSpecificDomains new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2132)
+    public Map<String,Object> setPrefOutOfOfficeSpecificDomains(String[] zimbraPrefOutOfOfficeSpecificDomains, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefOutOfOfficeSpecificDomains, zimbraPrefOutOfOfficeSpecificDomains);
+        return attrs;
+    }
+
+    /**
+     * Specific domains to which custom out of office message is to be sent
+     *
+     * @param zimbraPrefOutOfOfficeSpecificDomains new to add to existing values
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2132)
+    public void addPrefOutOfOfficeSpecificDomains(String zimbraPrefOutOfOfficeSpecificDomains) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraPrefOutOfOfficeSpecificDomains, zimbraPrefOutOfOfficeSpecificDomains);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Specific domains to which custom out of office message is to be sent
+     *
+     * @param zimbraPrefOutOfOfficeSpecificDomains new to add to existing values
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2132)
+    public Map<String,Object> addPrefOutOfOfficeSpecificDomains(String zimbraPrefOutOfOfficeSpecificDomains, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraPrefOutOfOfficeSpecificDomains, zimbraPrefOutOfOfficeSpecificDomains);
+        return attrs;
+    }
+
+    /**
+     * Specific domains to which custom out of office message is to be sent
+     *
+     * @param zimbraPrefOutOfOfficeSpecificDomains existing value to remove
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2132)
+    public void removePrefOutOfOfficeSpecificDomains(String zimbraPrefOutOfOfficeSpecificDomains) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraPrefOutOfOfficeSpecificDomains, zimbraPrefOutOfOfficeSpecificDomains);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Specific domains to which custom out of office message is to be sent
+     *
+     * @param zimbraPrefOutOfOfficeSpecificDomains existing value to remove
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2132)
+    public Map<String,Object> removePrefOutOfOfficeSpecificDomains(String zimbraPrefOutOfOfficeSpecificDomains, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraPrefOutOfOfficeSpecificDomains, zimbraPrefOutOfOfficeSpecificDomains);
+        return attrs;
+    }
+
+    /**
+     * Specific domains to which custom out of office message is to be sent
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2132)
+    public void unsetPrefOutOfOfficeSpecificDomains() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefOutOfOfficeSpecificDomains, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Specific domains to which custom out of office message is to be sent
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.5
+     */
+    @ZAttr(id=2132)
+    public Map<String,Object> unsetPrefOutOfOfficeSpecificDomains(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefOutOfOfficeSpecificDomains, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/mailbox/Notification.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Notification.java
@@ -325,14 +325,11 @@ public class Notification implements LmtpCallback {
 
             // Body
             // check whether to send "external" OOO reply
-            if (account.isPrefOutOfOfficeSuppressExternalReply() && isOfExternalSenderType(destination, account, mbox)
-            		&&  !isInternalSender(destination, account)) {
-            	ZimbraLog.mailbox.info(destination
-        				+ " is external user and no external reply option is set, so no OOO will be sent. ");
-        		return;
+            if (skipOutOfOfficeMsg(destination, account, mbox)) {
+                ZimbraLog.mailbox.info("%s is external user and no external reply option is set, so no OOO will be sent.", destination);
+                return;
             }
-            boolean sendExternalReply = account.isPrefOutOfOfficeExternalReplyEnabled()
-                   && !isInternalSender(destination, account) && isOfExternalSenderType(destination, account, mbox);
+            boolean sendExternalReply = sendOutOfOfficeExternalReply(destination, account, mbox);
             String body = account.getAttr(sendExternalReply ?
                     Provisioning.A_zimbraPrefOutOfOfficeExternalReply : Provisioning.A_zimbraPrefOutOfOfficeReply, "");
             charset = getCharset(account, body);
@@ -361,6 +358,28 @@ public class Notification implements LmtpCallback {
         } catch (MessagingException me) {
             ofailed("send failed", destination, rcpt, msgId, me);
         }
+    }
+
+    /**
+     * whether OutOfOffice message has to be sent to external sender or not
+     * @return   true  - message should  not be sent
+     *           false - message should be sent
+     */
+    public static boolean skipOutOfOfficeMsg(String senderAddr, Account account, Mailbox mbox) {
+        return account.isPrefOutOfOfficeSuppressExternalReply() && isOfExternalSenderType(senderAddr, account, mbox)
+                &&  !isInternalSender(senderAddr, account) && !isOfSpecificDomainSenderType(senderAddr, account);
+    }
+
+    /**
+     * standard Out of Office standard message should be sent or custom message
+     * @return    true - custom message should be sent
+     *            false - standard message should be sent
+     */
+    public static boolean sendOutOfOfficeExternalReply(String senderAddr, Account account, Mailbox mbox) {
+        boolean sendExternalReply = account.isPrefOutOfOfficeExternalReplyEnabled()
+                && !isInternalSender(senderAddr, account) && isOfExternalSenderType(senderAddr, account, mbox);
+         sendExternalReply = sendExternalReply || isOfSpecificDomainSenderType(senderAddr, account);
+         return sendExternalReply;
     }
 
     private static boolean isInternalSender(String senderAddr, Account account) {
@@ -400,6 +419,19 @@ public class Notification implements LmtpCallback {
             default:
                 return true;
         }
+    }
+
+    private static boolean isOfSpecificDomainSenderType(String senderAddr, Account account) {
+        if (account.getPrefExternalSendersType().isINSD()) {
+            String[] senderAddrParts = EmailUtil.getLocalPartAndDomain(senderAddr);
+            String senderDomain = senderAddrParts[1];
+            for (String specificDom : account.getPrefOutOfOfficeSpecificDomains()) {
+                if (specificDom.equalsIgnoreCase(senderDomain)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     private String getCharset(Account account, String data) {


### PR DESCRIPTION
enhance the ModifyPrefs request to allow user to set custom out of office message to be sent to senders which belong to specific domains.
added ldap attribute  to store the list of domains: zimbraPrefOutOfOfficeSpecificDomains
added new value "INSD" in the existing "zimbraPrefExternalSendersType" ldap attribute.
Added Junit tests. ant test-all passed.

Tests | Failures | Errors | Skipped | Success rate | Time
-- | -- | -- | -- | -- | --
1198 | 0 | 0 | 10 | 100.00% | 250.882

