### PR TITLE
ZCS-3614:ActiveSync:Add X-Originating-IP header

### DIFF
--- a/store/src/java-test/com/zimbra/cs/account/MockProvisioning.java
+++ b/store/src/java-test/com/zimbra/cs/account/MockProvisioning.java
@@ -686,7 +686,12 @@ public final class MockProvisioning extends Provisioning {
 
     @Override
     public List<Identity> getAllIdentities(Account account) {
-        throw new UnsupportedOperationException();
+        List<Identity> result = new ArrayList<Identity>();
+        Map<String, Object> attrs = new HashMap<String, Object>();
+        attrs.put(A_zimbraPrefIdentityName, ProvisioningConstants.DEFAULT_IDENTITY_NAME);
+        attrs.put(A_zimbraPrefIdentityId, account.getId());
+        result.add(new Identity(account, ProvisioningConstants.DEFAULT_IDENTITY_NAME, account.getId(), attrs, this));
+        return result;
     }
 
     @Override


### PR DESCRIPTION
X-Originating-IP header not added for messages sent by activesync mobile device client

[fix]
Implemented the getAllIdentities() method for MockProvisioning class
so that an ActiveSync related unit case can send a message without any exception.