### PR TITLE
ZCS-3545:nullify the preference value

### DIFF
--- a/store/src/java/com/zimbra/cs/service/account/ModifyPrefs.java
+++ b/store/src/java/com/zimbra/cs/service/account/ModifyPrefs.java
@@ -35,6 +35,7 @@ import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
 
 import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.lang.StringUtils;
 
 import com.google.common.base.Strings;
 import com.zimbra.common.account.ZAttrProvisioning.FeatureAddressVerificationStatus;
@@ -86,7 +87,7 @@ public class ModifyPrefs extends AccountDocumentHandler {
                 throw ServiceException.INVALID_REQUEST("pref name must start with " + PREF_PREFIX,
                     null);
 
-            if (Provisioning.A_zimbraPrefAccountProfileImage.equals(name)) {
+            if (Provisioning.A_zimbraPrefAccountProfileImage.equals(name) && !StringUtils.isBlank(value)) {
                 value = FileUploadServletUtil.getImageBase64(zsc, value);
             }
 

--- a/store/src/java/com/zimbra/cs/service/util/FileUploadServletUtil.java
+++ b/store/src/java/com/zimbra/cs/service/util/FileUploadServletUtil.java
@@ -31,7 +31,7 @@ public class FileUploadServletUtil {
             throw MailServiceException.INVALID_IMAGE("Uploaded image is not a valid image file");
         }
         if (up.getSize() > 3145728l) {
-            throw ServiceException.OPERATION_DENIED("Uploaded image is larger than 3MB");
+            throw ServiceException.FORBIDDEN("Uploaded image is larger than 3 MB");
         }
         InputStream in = null;
         String result = null;


### PR DESCRIPTION
The account profile image value should get nullified if empty value is sent in ModifyPrefs request.

