### PR TITLE
ZIMBRA-95: Related Contacts Functionality

### DIFF
--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -185,6 +185,8 @@ import com.zimbra.soap.mail.message.GetModifiedItemsIDsRequest;
 import com.zimbra.soap.mail.message.GetModifiedItemsIDsResponse;
 import com.zimbra.soap.mail.message.GetOutgoingFilterRulesRequest;
 import com.zimbra.soap.mail.message.GetOutgoingFilterRulesResponse;
+import com.zimbra.soap.mail.message.GetRelatedContactsRequest;
+import com.zimbra.soap.mail.message.GetRelatedContactsResponse;
 import com.zimbra.soap.mail.message.GetSearchHistoryRequest;
 import com.zimbra.soap.mail.message.GetSearchHistoryResponse;
 import com.zimbra.soap.mail.message.IMAPCopyRequest;
@@ -207,10 +209,10 @@ import com.zimbra.soap.mail.message.RecordIMAPSessionResponse;
 import com.zimbra.soap.mail.message.RejectSaveSearchPromptRequest;
 import com.zimbra.soap.mail.message.ResetRecentMessageCountRequest;
 import com.zimbra.soap.mail.message.SaveIMAPSubscriptionsRequest;
-import com.zimbra.soap.mail.message.TestDataSourceRequest;
-import com.zimbra.soap.mail.message.TestDataSourceResponse;
 import com.zimbra.soap.mail.message.SearchSuggestRequest;
 import com.zimbra.soap.mail.message.SearchSuggestResponse;
+import com.zimbra.soap.mail.message.TestDataSourceRequest;
+import com.zimbra.soap.mail.message.TestDataSourceResponse;
 import com.zimbra.soap.mail.type.ActionResult;
 import com.zimbra.soap.mail.type.ActionSelector;
 import com.zimbra.soap.mail.type.ContactSpec;
@@ -225,6 +227,7 @@ import com.zimbra.soap.mail.type.ModifyContactSpec;
 import com.zimbra.soap.mail.type.NewContactAttr;
 import com.zimbra.soap.mail.type.NewContactGroupMember;
 import com.zimbra.soap.mail.type.NewSearchFolderSpec;
+import com.zimbra.soap.mail.type.RelatedContactsTarget;
 import com.zimbra.soap.mail.type.TestDataSource;
 import com.zimbra.soap.type.AccountSelector;
 import com.zimbra.soap.type.AccountWithModifications;
@@ -6531,6 +6534,18 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
     @Override
     public void markMsgSeen(OpContext octxt, ItemIdentifier iid) throws ServiceException {
         doAction(messageAction("seen", iid.toString()));
+    }
+
+    public GetRelatedContactsResponse getRelatedContacts(List<RelatedContactsTarget> targets, String affinityType, Integer limit) throws ServiceException {
+        GetRelatedContactsRequest req = new GetRelatedContactsRequest();
+        req.setTargets(targets);
+        if (affinityType != null) {
+            req.setRequestedAffinity(affinityType);
+        }
+        if (limit != null) {
+            req.setLimit(limit);
+        }
+        return invokeJaxb(req);
     }
 
     public static class OpenIMAPFolderParams {

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -4736,6 +4736,16 @@ public class ZAttrProvisioning {
     public static final String A_zimbraConstraint = "zimbraConstraint";
 
     /**
+     * If TRUE, incoming emails will cause an AFFINITY event to be logged for
+     * each recipient. This allows for more accurate &quot;related
+     * contacts&quot; results, at the cost of higher index usage
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3046)
+    public static final String A_zimbraContactAffinityEventLoggingEnabled = "zimbraContactAffinityEventLoggingEnabled";
+
+    /**
      * Deprecated since: 6.0.7. deprecated in favor of
      * zimbraContactEmailFields, for bug 45475. Orig desc: Comma separates
      * list of attributes in contact object to search for email addresses
@@ -6814,6 +6824,14 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=821)
     public static final String A_zimbraFeatureReadReceiptsEnabled = "zimbraFeatureReadReceiptsEnabled";
+
+    /**
+     * Whether the Related Contacts feature is enabled on the account/COS
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3049)
+    public static final String A_zimbraFeatureRelatedContactsEnabled = "zimbraFeatureRelatedContactsEnabled";
 
     /**
      * saved search feature
@@ -14373,6 +14391,28 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=3036)
     public static final String A_zimbraReindexBatchSize = "zimbraReindexBatchSize";
+
+    /**
+     * The time window for which related contacts are calculated; emails
+     * older than this will not affect the contact affinity calculation. Must
+     * be in valid duration format: {digits}{time-unit}. digits: 0-9,
+     * time-unit: [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days,
+     * ms - milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3047)
+    public static final String A_zimbraRelatedContactsMaxAge = "zimbraRelatedContactsMaxAge";
+
+    /**
+     * The number of times two contacts have to co-occur on an email in order
+     * to be considered related
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3048)
+    public static final String A_zimbraRelatedContactsMinConcurrenceCount = "zimbraRelatedContactsMinConcurrenceCount";
 
     /**
      * port number on which the remote IMAP server should listen

--- a/common/src/java/com/zimbra/common/soap/MailConstants.java
+++ b/common/src/java/com/zimbra/common/soap/MailConstants.java
@@ -1383,4 +1383,17 @@ public final class MailConstants {
     public static final String E_BULK_ACTION = "BulkAction";
     public static final QName SEARCH_ACTION_REQUEST = QName.get(E_SEARCH_ACTION_REQUEST, NAMESPACE);
     public static final QName SEARCH_ACTION_RESPONSE = QName.get(E_SEARCH_ACTION_RESPONSE, NAMESPACE);
+
+    // Related Contacts
+    public static final String E_GET_RELATED_CONTACTS_REQUEST = "GetRelatedContactsRequest";
+    public static final String E_GET_RELATED_CONTACTS_RESPONSE = "GetRelatedContactsResponse";
+    public static final QName GET_RELATED_CONTACTS_REQUEST = QName.get(E_GET_RELATED_CONTACTS_REQUEST, NAMESPACE);
+    public static final QName GET_RELATED_CONTACTS_RESPONSE = QName.get(E_GET_RELATED_CONTACTS_RESPONSE, NAMESPACE);
+    public static final String E_AFFINITY_TARGET = "targetContact";
+    public static final String A_TARGET_EMAIL = "contact";
+    public static final String A_TARGET_AFFINITY_FIELD = "field";
+    public static final String A_REQUESTED_AFFINITY_FIELD = "requestedField";
+    public static final String E_RELATED_CONTACTS = "relatedContacts";
+    public static final String E_RELATED_CONTACT = "relatedContact";
+    public static final String A_AFFINITY_SCOPE = "scope";
 }

--- a/soap/src/java/com/zimbra/soap/JaxbUtil.java
+++ b/soap/src/java/com/zimbra/soap/JaxbUtil.java
@@ -898,6 +898,8 @@ public final class JaxbUtil {
             com.zimbra.soap.mail.message.GetPermissionResponse.class,
             com.zimbra.soap.mail.message.GetRecurRequest.class,
             com.zimbra.soap.mail.message.GetRecurResponse.class,
+            com.zimbra.soap.mail.message.GetRelatedContactsRequest.class,
+            com.zimbra.soap.mail.message.GetRelatedContactsResponse.class,
             com.zimbra.soap.mail.message.GetSearchFolderRequest.class,
             com.zimbra.soap.mail.message.GetSearchFolderResponse.class,
             com.zimbra.soap.mail.message.GetSearchHistoryRequest.class,

--- a/soap/src/java/com/zimbra/soap/mail/message/GetRelatedContactsRequest.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/GetRelatedContactsRequest.java
@@ -1,0 +1,44 @@
+package com.zimbra.soap.mail.message;
+
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElements;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.MailConstants;
+import com.zimbra.soap.mail.type.RelatedContactsTarget;
+
+@XmlRootElement(name=MailConstants.E_GET_RELATED_CONTACTS_REQUEST)
+public class GetRelatedContactsRequest {
+
+    /**
+     * @zm-api-field-description The maximum number of results to return. Defaults to 10 if not specified; capped at 500.
+     */
+    @XmlAttribute(name=MailConstants.A_QUERY_LIMIT, required=false)
+    private Integer limit;
+
+    /**
+     * @zm-api-field-description The type of contact affinity to use. If not specified,
+     * the combined affinity will be used.
+     */
+    @XmlAttribute(name=MailConstants.A_REQUESTED_AFFINITY_FIELD, required=false)
+    private String affinity;
+
+    @XmlElements({
+        @XmlElement(name=MailConstants.E_AFFINITY_TARGET, type=RelatedContactsTarget.class, required=true),
+    })
+    private List<RelatedContactsTarget> contacts;
+
+    public GetRelatedContactsRequest() {}
+
+    public List<RelatedContactsTarget> getTargets() { return contacts; }
+    public void setTargets(List<RelatedContactsTarget> contacts) { this.contacts = contacts; }
+
+    public String getRequestedAffinity() { return affinity; }
+    public void setRequestedAffinity(String affinity) { this.affinity = affinity; }
+
+    public Integer getLimit() { return limit; }
+    public void setLimit(int limit) { this.limit = limit; }
+}

--- a/soap/src/java/com/zimbra/soap/mail/message/GetRelatedContactsResponse.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/GetRelatedContactsResponse.java
@@ -1,0 +1,22 @@
+package com.zimbra.soap.mail.message;
+
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.google.common.collect.Lists;
+import com.zimbra.common.soap.MailConstants;
+import com.zimbra.soap.mail.type.RelatedContactResult;
+
+@XmlRootElement(name=MailConstants.E_GET_RELATED_CONTACTS_RESPONSE)
+public class GetRelatedContactsResponse {
+
+    @XmlElementWrapper(name=MailConstants.E_RELATED_CONTACTS)
+    @XmlElement(name=MailConstants.E_RELATED_CONTACT, type=RelatedContactResult.class)
+    private List<RelatedContactResult> relatedContacts = Lists.newArrayList();
+
+    public List<RelatedContactResult> getRelatedContacts() {return relatedContacts; }
+    public void addRelatedContact(RelatedContactResult result) { this.relatedContacts.add(result); }
+}

--- a/soap/src/java/com/zimbra/soap/mail/type/RelatedContactResult.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/RelatedContactResult.java
@@ -1,0 +1,46 @@
+package com.zimbra.soap.mail.type;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+
+import com.zimbra.common.soap.MailConstants;
+
+@XmlAccessorType(XmlAccessType.NONE)
+public class RelatedContactResult {
+
+    public RelatedContactResult() {}
+
+    public RelatedContactResult(String email, int scope) {
+        setEmail(email);
+        setScope(scope);
+    }
+
+    /**
+     * @zm-api-field-description The related contact's email address.
+     */
+    @XmlAttribute(name=MailConstants.A_EMAIL, required=true)
+    private String email;
+
+    /**
+     * @zm-api-field-description The related contact's name, if available.
+     */
+    @XmlAttribute(name=MailConstants.A_PERSONAL, required=false)
+    private String name;
+
+    /**
+     * @zm-api-field-description Flag specifying the scope of affinity
+     * for this contact. The higher the number, the wider the scope.
+     */
+    @XmlAttribute(name=MailConstants.A_AFFINITY_SCOPE, required=false)
+    private int scope;
+
+    public int getScope() { return scope; }
+    public void setScope(int scope) { this.scope = scope; }
+
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+}

--- a/soap/src/java/com/zimbra/soap/mail/type/RelatedContactsTarget.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/RelatedContactsTarget.java
@@ -1,0 +1,39 @@
+package com.zimbra.soap.mail.type;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+
+import com.zimbra.common.soap.MailConstants;
+
+@XmlAccessorType(XmlAccessType.NONE)
+public class RelatedContactsTarget {
+
+    public RelatedContactsTarget(String targetEmail, String affinity) {
+        setTargetEmail(targetEmail);
+        setAffinity(affinity);
+    }
+
+    public RelatedContactsTarget() {}
+
+    /**
+     * @zm-api-field-description The recipient field of the target.
+     * Options are "to", "cc", "bcc", or unset.
+     */
+    @XmlAttribute(name=MailConstants.A_TARGET_AFFINITY_FIELD, required=false)
+    private String affinity;
+
+    /**
+     * @zm-api-field-description The target email address.
+     */
+    @XmlElement(name=MailConstants.E_CONTACT, type=String.class)
+    private String targetEmail;
+
+
+    public void setAffinity(String affinity) { this.affinity = affinity; }
+    public String getAffinity() { return affinity; }
+
+    public void setTargetEmail(String email) { this.targetEmail = email; }
+    public String getTargetEmail() { return targetEmail; }
+}

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9713,7 +9713,7 @@ TODO: delete them permanently from here
     <desc>Time that mailstore will wait for space to free up in the shared indexing queue. Increase this value if you are reindexing several large mailboxes simultaneously.</desc>
 </attr>
 
-<attr id="3038" name="zimbraSolrMaxShardsPerNode" type="integer" cardinality="single" optionalIn="globalConfig,server,alwaysOnCluster" flags="serverInherited,serverPreferAlwaysOn" since="8.8.6">
+<attr id="3038" name="zimbraSolrMaxShardsPerNode" type="integer" min="1" cardinality="single" optionalIn="globalConfig,server,alwaysOnCluster" flags="serverInherited,serverPreferAlwaysOn" since="8.8.6">
   <globalConfigValue>1</globalConfigValue>
   <desc>Limit for how many replicas of the same SOLR Collection are allowed to be created on each node.</desc>
 </attr>
@@ -9729,12 +9729,12 @@ TODO: delete them permanently from here
      </desc>
 </attr>
 
-<attr id="3040" name="zimbraEventLoggingNumThreads" type="integer" cardinality="single" optionalIn="globalConfig,server,alwaysOnCluster" flags="serverInherited,serverPreferAlwaysOn" callback="EventLoggerCallback" since="8.8.6">
+<attr id="3040" name="zimbraEventLoggingNumThreads" type="integer" min="1" cardinality="single" optionalIn="globalConfig,server,alwaysOnCluster" flags="serverInherited,serverPreferAlwaysOn" callback="EventLoggerCallback" since="8.8.6"> 
   <globalConfigValue>10</globalConfigValue>
   <desc>Number of consumer threads used to process the event logging queue</desc>
 </attr>
 
-<attr id="3041" name="zimbraEventBatchMaxSize" type="integer" cardinality="single" optionalIn="globalConfig,server,alwaysOnCluster" flags="serverInherited,serverPreferAlwaysOn" callback="EventLoggerCallback" since="8.8.6">
+<attr id="3041" name="zimbraEventBatchMaxSize" type="integer" min="1" cardinality="single" optionalIn="globalConfig,server,alwaysOnCluster" flags="serverInherited,serverPreferAlwaysOn" callback="EventLoggerCallback" since="8.8.6">
   <globalConfigValue>100</globalConfigValue>
   <desc>Event batch size used by batching EventLogHandlers such as "solrcloud". When this limit is reached, the batch is flushed.</desc>
 </attr>
@@ -9758,4 +9758,23 @@ TODO: delete them permanently from here
   <desc>URL of the event storage backend to be queried for event analytics</desc>
 </attr>
 
+<attr id="3046" name="zimbraContactAffinityEventLoggingEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited" callback="EventLoggerCallback" since="8.8.6">
+  <desc>If TRUE, incoming emails will cause an AFFINITY event to be logged for each recipient. This allows for more accurate "related contacts" results, at the cost of higher index usage</desc>
+  <defaultCOSValue>TRUE</defaultCOSValue>
+</attr>
+
+<attr id="3047" name="zimbraRelatedContactsMaxAge" type="duration" cardinality="single" optionalIn="account,cos" flags="accountInherited" since="8.8.6">
+  <desc>The time window for which related contacts are calculated; emails older than this will not affect the contact affinity calculation</desc>
+  <defaultCOSValue>365d</defaultCOSValue>
+</attr>
+
+<attr id="3048" name="zimbraRelatedContactsMinConcurrenceCount" type="integer" min="1" cardinality="single" optionalIn="account,cos" flags="accountInherited" since="8.8.6">
+  <desc>The number of times two contacts have to co-occur on an email in order to be considered related</desc>
+  <defaultCOSValue>1</defaultCOSValue>
+</attr>
+
+<attr id="3049" name="zimbraFeatureRelatedContactsEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited" since="8.8.6">
+  <desc>Whether the Related Contacts feature is enabled on the account/COS</desc>
+  <defaultCOSValue>TRUE</defaultCOSValue>
+</attr>
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -6932,6 +6932,88 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * If TRUE, incoming emails will cause an AFFINITY event to be logged for
+     * each recipient. This allows for more accurate &quot;related
+     * contacts&quot; results, at the cost of higher index usage
+     *
+     * @return zimbraContactAffinityEventLoggingEnabled, or true if unset
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3046)
+    public boolean isContactAffinityEventLoggingEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraContactAffinityEventLoggingEnabled, true, true);
+    }
+
+    /**
+     * If TRUE, incoming emails will cause an AFFINITY event to be logged for
+     * each recipient. This allows for more accurate &quot;related
+     * contacts&quot; results, at the cost of higher index usage
+     *
+     * @param zimbraContactAffinityEventLoggingEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3046)
+    public void setContactAffinityEventLoggingEnabled(boolean zimbraContactAffinityEventLoggingEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraContactAffinityEventLoggingEnabled, zimbraContactAffinityEventLoggingEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * If TRUE, incoming emails will cause an AFFINITY event to be logged for
+     * each recipient. This allows for more accurate &quot;related
+     * contacts&quot; results, at the cost of higher index usage
+     *
+     * @param zimbraContactAffinityEventLoggingEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3046)
+    public Map<String,Object> setContactAffinityEventLoggingEnabled(boolean zimbraContactAffinityEventLoggingEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraContactAffinityEventLoggingEnabled, zimbraContactAffinityEventLoggingEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * If TRUE, incoming emails will cause an AFFINITY event to be logged for
+     * each recipient. This allows for more accurate &quot;related
+     * contacts&quot; results, at the cost of higher index usage
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3046)
+    public void unsetContactAffinityEventLoggingEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraContactAffinityEventLoggingEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * If TRUE, incoming emails will cause an AFFINITY event to be logged for
+     * each recipient. This allows for more accurate &quot;related
+     * contacts&quot; results, at the cost of higher index usage
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3046)
+    public Map<String,Object> unsetContactAffinityEventLoggingEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraContactAffinityEventLoggingEnabled, "");
+        return attrs;
+    }
+
+    /**
      * Deprecated since: 6.0.7. deprecated in favor of
      * zimbraContactEmailFields, for bug 45475. Orig desc: Comma separates
      * list of attributes in contact object to search for email addresses
@@ -17606,6 +17688,78 @@ public abstract class ZAttrAccount  extends MailTarget {
     public Map<String,Object> unsetFeatureReadReceiptsEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureReadReceiptsEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * Whether the Related Contacts feature is enabled on the account/COS
+     *
+     * @return zimbraFeatureRelatedContactsEnabled, or true if unset
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3049)
+    public boolean isFeatureRelatedContactsEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureRelatedContactsEnabled, true, true);
+    }
+
+    /**
+     * Whether the Related Contacts feature is enabled on the account/COS
+     *
+     * @param zimbraFeatureRelatedContactsEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3049)
+    public void setFeatureRelatedContactsEnabled(boolean zimbraFeatureRelatedContactsEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureRelatedContactsEnabled, zimbraFeatureRelatedContactsEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether the Related Contacts feature is enabled on the account/COS
+     *
+     * @param zimbraFeatureRelatedContactsEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3049)
+    public Map<String,Object> setFeatureRelatedContactsEnabled(boolean zimbraFeatureRelatedContactsEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureRelatedContactsEnabled, zimbraFeatureRelatedContactsEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether the Related Contacts feature is enabled on the account/COS
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3049)
+    public void unsetFeatureRelatedContactsEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureRelatedContactsEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether the Related Contacts feature is enabled on the account/COS
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3049)
+    public Map<String,Object> unsetFeatureRelatedContactsEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureRelatedContactsEnabled, "");
         return attrs;
     }
 
@@ -55586,6 +55740,201 @@ public abstract class ZAttrAccount  extends MailTarget {
     public Map<String,Object> unsetQuotaWarnPercent(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraQuotaWarnPercent, "");
+        return attrs;
+    }
+
+    /**
+     * The time window for which related contacts are calculated; emails
+     * older than this will not affect the contact affinity calculation. Must
+     * be in valid duration format: {digits}{time-unit}. digits: 0-9,
+     * time-unit: [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days,
+     * ms - milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * <p>Use getRelatedContactsMaxAgeAsString to access value as a string.
+     *
+     * @see #getRelatedContactsMaxAgeAsString()
+     *
+     * @return zimbraRelatedContactsMaxAge in millseconds, or 31536000000 (365d)  if unset
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3047)
+    public long getRelatedContactsMaxAge() {
+        return getTimeInterval(Provisioning.A_zimbraRelatedContactsMaxAge, 31536000000L, true);
+    }
+
+    /**
+     * The time window for which related contacts are calculated; emails
+     * older than this will not affect the contact affinity calculation. Must
+     * be in valid duration format: {digits}{time-unit}. digits: 0-9,
+     * time-unit: [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days,
+     * ms - milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @return zimbraRelatedContactsMaxAge, or "365d" if unset
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3047)
+    public String getRelatedContactsMaxAgeAsString() {
+        return getAttr(Provisioning.A_zimbraRelatedContactsMaxAge, "365d", true);
+    }
+
+    /**
+     * The time window for which related contacts are calculated; emails
+     * older than this will not affect the contact affinity calculation. Must
+     * be in valid duration format: {digits}{time-unit}. digits: 0-9,
+     * time-unit: [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days,
+     * ms - milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @param zimbraRelatedContactsMaxAge new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3047)
+    public void setRelatedContactsMaxAge(String zimbraRelatedContactsMaxAge) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRelatedContactsMaxAge, zimbraRelatedContactsMaxAge);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * The time window for which related contacts are calculated; emails
+     * older than this will not affect the contact affinity calculation. Must
+     * be in valid duration format: {digits}{time-unit}. digits: 0-9,
+     * time-unit: [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days,
+     * ms - milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @param zimbraRelatedContactsMaxAge new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3047)
+    public Map<String,Object> setRelatedContactsMaxAge(String zimbraRelatedContactsMaxAge, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRelatedContactsMaxAge, zimbraRelatedContactsMaxAge);
+        return attrs;
+    }
+
+    /**
+     * The time window for which related contacts are calculated; emails
+     * older than this will not affect the contact affinity calculation. Must
+     * be in valid duration format: {digits}{time-unit}. digits: 0-9,
+     * time-unit: [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days,
+     * ms - milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3047)
+    public void unsetRelatedContactsMaxAge() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRelatedContactsMaxAge, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * The time window for which related contacts are calculated; emails
+     * older than this will not affect the contact affinity calculation. Must
+     * be in valid duration format: {digits}{time-unit}. digits: 0-9,
+     * time-unit: [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days,
+     * ms - milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3047)
+    public Map<String,Object> unsetRelatedContactsMaxAge(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRelatedContactsMaxAge, "");
+        return attrs;
+    }
+
+    /**
+     * The number of times two contacts have to co-occur on an email in order
+     * to be considered related
+     *
+     * @return zimbraRelatedContactsMinConcurrenceCount, or 1 if unset
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3048)
+    public int getRelatedContactsMinConcurrenceCount() {
+        return getIntAttr(Provisioning.A_zimbraRelatedContactsMinConcurrenceCount, 1, true);
+    }
+
+    /**
+     * The number of times two contacts have to co-occur on an email in order
+     * to be considered related
+     *
+     * @param zimbraRelatedContactsMinConcurrenceCount new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3048)
+    public void setRelatedContactsMinConcurrenceCount(int zimbraRelatedContactsMinConcurrenceCount) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRelatedContactsMinConcurrenceCount, Integer.toString(zimbraRelatedContactsMinConcurrenceCount));
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * The number of times two contacts have to co-occur on an email in order
+     * to be considered related
+     *
+     * @param zimbraRelatedContactsMinConcurrenceCount new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3048)
+    public Map<String,Object> setRelatedContactsMinConcurrenceCount(int zimbraRelatedContactsMinConcurrenceCount, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRelatedContactsMinConcurrenceCount, Integer.toString(zimbraRelatedContactsMinConcurrenceCount));
+        return attrs;
+    }
+
+    /**
+     * The number of times two contacts have to co-occur on an email in order
+     * to be considered related
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3048)
+    public void unsetRelatedContactsMinConcurrenceCount() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRelatedContactsMinConcurrenceCount, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * The number of times two contacts have to co-occur on an email in order
+     * to be considered related
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3048)
+    public Map<String,Object> unsetRelatedContactsMinConcurrenceCount(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRelatedContactsMinConcurrenceCount, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -15707,13 +15707,13 @@ public abstract class ZAttrConfig extends Entry {
     /**
      * Whether event logging is enabled
      *
-     * @return zimbraEventLoggingEnabled, or false if unset
+     * @return zimbraEventLoggingEnabled, or true if unset
      *
      * @since ZCS 8.8.6
      */
     @ZAttr(id=3044)
     public boolean isEventLoggingEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraEventLoggingEnabled, false, true);
+        return getBooleanAttr(Provisioning.A_zimbraEventLoggingEnabled, true, true);
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -3190,6 +3190,88 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * If TRUE, incoming emails will cause an AFFINITY event to be logged for
+     * each recipient. This allows for more accurate &quot;related
+     * contacts&quot; results, at the cost of higher index usage
+     *
+     * @return zimbraContactAffinityEventLoggingEnabled, or true if unset
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3046)
+    public boolean isContactAffinityEventLoggingEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraContactAffinityEventLoggingEnabled, true, true);
+    }
+
+    /**
+     * If TRUE, incoming emails will cause an AFFINITY event to be logged for
+     * each recipient. This allows for more accurate &quot;related
+     * contacts&quot; results, at the cost of higher index usage
+     *
+     * @param zimbraContactAffinityEventLoggingEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3046)
+    public void setContactAffinityEventLoggingEnabled(boolean zimbraContactAffinityEventLoggingEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraContactAffinityEventLoggingEnabled, zimbraContactAffinityEventLoggingEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * If TRUE, incoming emails will cause an AFFINITY event to be logged for
+     * each recipient. This allows for more accurate &quot;related
+     * contacts&quot; results, at the cost of higher index usage
+     *
+     * @param zimbraContactAffinityEventLoggingEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3046)
+    public Map<String,Object> setContactAffinityEventLoggingEnabled(boolean zimbraContactAffinityEventLoggingEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraContactAffinityEventLoggingEnabled, zimbraContactAffinityEventLoggingEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * If TRUE, incoming emails will cause an AFFINITY event to be logged for
+     * each recipient. This allows for more accurate &quot;related
+     * contacts&quot; results, at the cost of higher index usage
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3046)
+    public void unsetContactAffinityEventLoggingEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraContactAffinityEventLoggingEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * If TRUE, incoming emails will cause an AFFINITY event to be logged for
+     * each recipient. This allows for more accurate &quot;related
+     * contacts&quot; results, at the cost of higher index usage
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3046)
+    public Map<String,Object> unsetContactAffinityEventLoggingEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraContactAffinityEventLoggingEnabled, "");
+        return attrs;
+    }
+
+    /**
      * Deprecated since: 6.0.7. deprecated in favor of
      * zimbraContactEmailFields, for bug 45475. Orig desc: Comma separates
      * list of attributes in contact object to search for email addresses
@@ -12351,6 +12433,78 @@ public abstract class ZAttrCos extends NamedEntry {
     public Map<String,Object> unsetFeatureReadReceiptsEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureReadReceiptsEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * Whether the Related Contacts feature is enabled on the account/COS
+     *
+     * @return zimbraFeatureRelatedContactsEnabled, or true if unset
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3049)
+    public boolean isFeatureRelatedContactsEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureRelatedContactsEnabled, true, true);
+    }
+
+    /**
+     * Whether the Related Contacts feature is enabled on the account/COS
+     *
+     * @param zimbraFeatureRelatedContactsEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3049)
+    public void setFeatureRelatedContactsEnabled(boolean zimbraFeatureRelatedContactsEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureRelatedContactsEnabled, zimbraFeatureRelatedContactsEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether the Related Contacts feature is enabled on the account/COS
+     *
+     * @param zimbraFeatureRelatedContactsEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3049)
+    public Map<String,Object> setFeatureRelatedContactsEnabled(boolean zimbraFeatureRelatedContactsEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureRelatedContactsEnabled, zimbraFeatureRelatedContactsEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether the Related Contacts feature is enabled on the account/COS
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3049)
+    public void unsetFeatureRelatedContactsEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureRelatedContactsEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether the Related Contacts feature is enabled on the account/COS
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3049)
+    public Map<String,Object> unsetFeatureRelatedContactsEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureRelatedContactsEnabled, "");
         return attrs;
     }
 
@@ -43139,6 +43293,201 @@ public abstract class ZAttrCos extends NamedEntry {
     public Map<String,Object> unsetQuotaWarnPercent(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraQuotaWarnPercent, "");
+        return attrs;
+    }
+
+    /**
+     * The time window for which related contacts are calculated; emails
+     * older than this will not affect the contact affinity calculation. Must
+     * be in valid duration format: {digits}{time-unit}. digits: 0-9,
+     * time-unit: [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days,
+     * ms - milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * <p>Use getRelatedContactsMaxAgeAsString to access value as a string.
+     *
+     * @see #getRelatedContactsMaxAgeAsString()
+     *
+     * @return zimbraRelatedContactsMaxAge in millseconds, or 31536000000 (365d)  if unset
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3047)
+    public long getRelatedContactsMaxAge() {
+        return getTimeInterval(Provisioning.A_zimbraRelatedContactsMaxAge, 31536000000L, true);
+    }
+
+    /**
+     * The time window for which related contacts are calculated; emails
+     * older than this will not affect the contact affinity calculation. Must
+     * be in valid duration format: {digits}{time-unit}. digits: 0-9,
+     * time-unit: [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days,
+     * ms - milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @return zimbraRelatedContactsMaxAge, or "365d" if unset
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3047)
+    public String getRelatedContactsMaxAgeAsString() {
+        return getAttr(Provisioning.A_zimbraRelatedContactsMaxAge, "365d", true);
+    }
+
+    /**
+     * The time window for which related contacts are calculated; emails
+     * older than this will not affect the contact affinity calculation. Must
+     * be in valid duration format: {digits}{time-unit}. digits: 0-9,
+     * time-unit: [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days,
+     * ms - milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @param zimbraRelatedContactsMaxAge new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3047)
+    public void setRelatedContactsMaxAge(String zimbraRelatedContactsMaxAge) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRelatedContactsMaxAge, zimbraRelatedContactsMaxAge);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * The time window for which related contacts are calculated; emails
+     * older than this will not affect the contact affinity calculation. Must
+     * be in valid duration format: {digits}{time-unit}. digits: 0-9,
+     * time-unit: [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days,
+     * ms - milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @param zimbraRelatedContactsMaxAge new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3047)
+    public Map<String,Object> setRelatedContactsMaxAge(String zimbraRelatedContactsMaxAge, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRelatedContactsMaxAge, zimbraRelatedContactsMaxAge);
+        return attrs;
+    }
+
+    /**
+     * The time window for which related contacts are calculated; emails
+     * older than this will not affect the contact affinity calculation. Must
+     * be in valid duration format: {digits}{time-unit}. digits: 0-9,
+     * time-unit: [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days,
+     * ms - milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3047)
+    public void unsetRelatedContactsMaxAge() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRelatedContactsMaxAge, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * The time window for which related contacts are calculated; emails
+     * older than this will not affect the contact affinity calculation. Must
+     * be in valid duration format: {digits}{time-unit}. digits: 0-9,
+     * time-unit: [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days,
+     * ms - milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3047)
+    public Map<String,Object> unsetRelatedContactsMaxAge(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRelatedContactsMaxAge, "");
+        return attrs;
+    }
+
+    /**
+     * The number of times two contacts have to co-occur on an email in order
+     * to be considered related
+     *
+     * @return zimbraRelatedContactsMinConcurrenceCount, or 1 if unset
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3048)
+    public int getRelatedContactsMinConcurrenceCount() {
+        return getIntAttr(Provisioning.A_zimbraRelatedContactsMinConcurrenceCount, 1, true);
+    }
+
+    /**
+     * The number of times two contacts have to co-occur on an email in order
+     * to be considered related
+     *
+     * @param zimbraRelatedContactsMinConcurrenceCount new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3048)
+    public void setRelatedContactsMinConcurrenceCount(int zimbraRelatedContactsMinConcurrenceCount) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRelatedContactsMinConcurrenceCount, Integer.toString(zimbraRelatedContactsMinConcurrenceCount));
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * The number of times two contacts have to co-occur on an email in order
+     * to be considered related
+     *
+     * @param zimbraRelatedContactsMinConcurrenceCount new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3048)
+    public Map<String,Object> setRelatedContactsMinConcurrenceCount(int zimbraRelatedContactsMinConcurrenceCount, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRelatedContactsMinConcurrenceCount, Integer.toString(zimbraRelatedContactsMinConcurrenceCount));
+        return attrs;
+    }
+
+    /**
+     * The number of times two contacts have to co-occur on an email in order
+     * to be considered related
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3048)
+    public void unsetRelatedContactsMinConcurrenceCount() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRelatedContactsMinConcurrenceCount, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * The number of times two contacts have to co-occur on an email in order
+     * to be considered related
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3048)
+    public Map<String,Object> unsetRelatedContactsMinConcurrenceCount(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRelatedContactsMinConcurrenceCount, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -8884,13 +8884,13 @@ public abstract class ZAttrServer extends NamedEntry {
     /**
      * Whether event logging is enabled
      *
-     * @return zimbraEventLoggingEnabled, or false if unset
+     * @return zimbraEventLoggingEnabled, or true if unset
      *
      * @since ZCS 8.8.6
      */
     @ZAttr(id=3044)
     public boolean isEventLoggingEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraEventLoggingEnabled, false, true);
+        return getBooleanAttr(Provisioning.A_zimbraEventLoggingEnabled, true, true);
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/callback/EventLoggerCallback.java
+++ b/store/src/java/com/zimbra/cs/account/callback/EventLoggerCallback.java
@@ -63,7 +63,8 @@ public class EventLoggerCallback extends AttributeCallback {
             } catch (ServiceException e) {
                 ZimbraLog.event.error("unable to determine zimbraEventLoggingEnabled value", e);
             }
-        } else if (attrName.equals(Provisioning.A_zimbraEventBackendURL)) {
+        } else if (attrName.equals(Provisioning.A_zimbraEventBackendURL) ||
+                attrName.equals(Provisioning.A_zimbraEventSolrIndexType)) {
             EventStore.clearFactory();
         } else {
             EventLogger.getEventLogger().restartEventNotifierExecutor();

--- a/store/src/java/com/zimbra/cs/contacts/AffinityScope.java
+++ b/store/src/java/com/zimbra/cs/contacts/AffinityScope.java
@@ -1,0 +1,126 @@
+package com.zimbra.cs.contacts;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.zimbra.common.service.ServiceException;
+
+/**
+ * AffinityScope defines the context within contacts are considered "related".
+ */
+public abstract class AffinityScope implements Comparable<AffinityScope> {
+
+    private static Map<Integer, AffinityScope> KNOWN_SCOPES = new HashMap<>();
+
+    public static AffinityScope OUTGOING_EXACT_MATCH            = new OutgoingAffinityScope(0, MatchType.ALL, false);
+    public static AffinityScope OUTGOING_EXACT_MATCH_ANY_FIELD  = new OutgoingAffinityScope(1, MatchType.ALL, true);
+    public static AffinityScope OUTGOING_BROAD_MATCH            = new OutgoingAffinityScope(2, MatchType.ANY, false);
+    public static AffinityScope OUTGOING_BROAD_MATCH_ANY_FIELD  = new OutgoingAffinityScope(3, MatchType.ANY, true);
+    public static AffinityScope INCOMING_FROM_TARGET            = new IncomingAffinityScope(4, true, true);
+    public static AffinityScope INCOMING_FROM_ANY_SENDER        = new IncomingAffinityScope(5, false, true);
+
+    static {
+        addScope(OUTGOING_EXACT_MATCH);
+        addScope(OUTGOING_EXACT_MATCH_ANY_FIELD);
+        addScope(OUTGOING_BROAD_MATCH);
+        addScope(OUTGOING_BROAD_MATCH_ANY_FIELD);
+        addScope(INCOMING_FROM_TARGET);
+        addScope(INCOMING_FROM_ANY_SENDER);
+    }
+
+    private RelatedVia relatedVia;
+    private boolean ignoreTargetAffinityField;
+    private int scopeLevel;
+    protected MatchType matchType;
+    protected boolean senderMustBeTarget;
+
+    private static void addScope(AffinityScope scope) {
+        KNOWN_SCOPES.put(scope.getLevel(), scope);
+    }
+
+    public static List<AffinityScope> getAffinityScopesForQuery(RelatedContactsParams params) {
+        int numTargets = params.getTargets().size();
+        List<AffinityScope> scopes = new ArrayList<>();
+        for (AffinityScope scope: KNOWN_SCOPES.values()) {
+            if (scope.getRelatedVia() == RelatedVia.INCOMING_MSGS) {
+                //don't include incoming msg scope if AFFINITY events are not logged
+                //or if there is only one target with senderMustBeTarget=true
+                if (!params.getIncludeIncomingMsgAffinity() || (scope.getSenderMustBeTarget() && numTargets == 1)) {
+                    continue;
+                }
+            }
+            scopes.add(scope);
+        }
+        Collections.sort(scopes);
+        return scopes;
+    }
+
+    private AffinityScope(int scopeLevel, RelatedVia relatedVia, boolean ignoreTargetAffinityField) {
+        this.scopeLevel = scopeLevel;
+        this.relatedVia = relatedVia;
+        this.ignoreTargetAffinityField = ignoreTargetAffinityField;
+    }
+
+    public static enum RelatedVia {
+        INCOMING_MSGS, OUTGOING_MSGS;
+    }
+
+    public static enum MatchType {
+        ALL, ANY;
+    }
+
+    public int getLevel() {
+        return scopeLevel;
+    }
+
+    public RelatedVia getRelatedVia() {
+        return relatedVia;
+    }
+
+    public boolean getIgnoreTargetAffinityField() {
+        return ignoreTargetAffinityField;
+    }
+
+    public MatchType getMatchType() {
+        return matchType;
+    }
+
+    public boolean getSenderMustBeTarget() {
+        return senderMustBeTarget;
+    }
+
+    @Override
+    public int compareTo(AffinityScope other) {
+        if (this == other) {
+            return 0;
+        }
+        return scopeLevel - other.getLevel();
+    }
+
+    public static class OutgoingAffinityScope extends AffinityScope {
+
+        public OutgoingAffinityScope(int id, MatchType matchType, boolean ignoreTargetAffinityField) {
+            super(id, RelatedVia.OUTGOING_MSGS, ignoreTargetAffinityField);
+            this.matchType = matchType;
+        }
+    }
+
+    public static class IncomingAffinityScope extends AffinityScope {
+
+        public IncomingAffinityScope(int id, boolean senderMustBeTarget, boolean ignoreTargetAffinityField) {
+            super(id, RelatedVia.INCOMING_MSGS, ignoreTargetAffinityField);
+            this.senderMustBeTarget = senderMustBeTarget;
+        }
+    }
+
+    public static AffinityScope of(int id) throws ServiceException {
+        AffinityScope scope = KNOWN_SCOPES.get(id);
+        if (scope == null) {
+            throw ServiceException.FAILURE(String.format("%d is not a known affinity scope ID",  id), null);
+        }
+        return scope;
+    }
+}

--- a/store/src/java/com/zimbra/cs/contacts/ComputationBackend.java
+++ b/store/src/java/com/zimbra/cs/contacts/ComputationBackend.java
@@ -1,0 +1,12 @@
+package com.zimbra.cs.contacts;
+
+import com.zimbra.common.service.ServiceException;
+
+/**
+ * Interface to calculate the contact affinity. This should not be called for each request, as it
+ * may involve intensive computation.
+ */
+public interface ComputationBackend {
+
+    public RelatedContactsResults calculateContactAffinity(RelatedContactsParams query) throws ServiceException;
+}

--- a/store/src/java/com/zimbra/cs/contacts/ContactAffinityQuery.java
+++ b/store/src/java/com/zimbra/cs/contacts/ContactAffinityQuery.java
@@ -1,0 +1,397 @@
+package com.zimbra.cs.contacts;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TermRangeQuery;
+import org.apache.lucene.util.BytesRef;
+import org.apache.solr.client.solrj.io.ModelCache;
+import org.apache.solr.client.solrj.io.SolrClientCache;
+import org.apache.solr.client.solrj.io.Tuple;
+import org.apache.solr.client.solrj.io.comp.ComparatorOrder;
+import org.apache.solr.client.solrj.io.comp.FieldComparator;
+import org.apache.solr.client.solrj.io.comp.StreamComparator;
+import org.apache.solr.client.solrj.io.eq.FieldEqualitor;
+import org.apache.solr.client.solrj.io.graph.GatherNodesStream;
+import org.apache.solr.client.solrj.io.graph.Traversal.Scatter;
+import org.apache.solr.client.solrj.io.stream.CloudSolrStream;
+import org.apache.solr.client.solrj.io.stream.IntersectStream;
+import org.apache.solr.client.solrj.io.stream.MergeStream;
+import org.apache.solr.client.solrj.io.stream.RankStream;
+import org.apache.solr.client.solrj.io.stream.StreamContext;
+import org.apache.solr.client.solrj.io.stream.TupleStream;
+import org.apache.solr.client.solrj.io.stream.metrics.CountMetric;
+import org.apache.solr.client.solrj.io.stream.metrics.Metric;
+import org.apache.solr.client.solrj.util.ClientUtils;
+import org.apache.solr.common.params.MapSolrParams;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+import com.google.common.collect.Sets;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.contacts.AffinityScope.MatchType;
+import com.zimbra.cs.contacts.RelatedContactsParams.AffinityTarget;
+import com.zimbra.cs.contacts.RelatedContactsParams.AffinityType;
+import com.zimbra.cs.contacts.RelatedContactsResults.RelatedContact;
+import com.zimbra.cs.event.Event.EventContextField;
+import com.zimbra.cs.event.Event.EventType;
+import com.zimbra.cs.event.SolrEventDocument;
+import com.zimbra.cs.index.LuceneFields;
+import com.zimbra.cs.index.solr.SolrCloudHelper;
+import com.zimbra.cs.mime.ParsedAddress;
+
+/**
+ * Class that builds a Solrcloud streaming query to calculate contact affinity.
+ */
+public class ContactAffinityQuery {
+
+    private static final String FLD_MSG_ID = LuceneFields.L_EVENT_MESSAGE_ID;
+    private static final String FLD_AFFINITY_TIMESTAMP = LuceneFields.L_EVENT_TIME;
+    private static final String FLD_COUNT = String.format("count(%s)", FLD_MSG_ID);
+    private static final String FLD_CONTACT_EMAIL = "node";
+    private static final String SEARCH_FIELDS = String.format("%s,%s", FLD_AFFINITY_TIMESTAMP, FLD_MSG_ID);
+    private static final int MODEL_CACHE_SIZE = 100;
+    private static final int MAX_MESSAGES_PER_SEARCH = 1000;
+    private static final int MAX_RESULTS = 200;
+
+    private String accountId;
+    private RelatedContactsParams params;
+    private SolrCloudHelper solrHelper;
+    private String coreName;
+    private List<RelatedContact> toExclude;
+
+    public ContactAffinityQuery(SolrCloudHelper solrHelper, RelatedContactsParams params) {
+        this.solrHelper = solrHelper;
+        this.params = params;
+        this.accountId = params.getAccountId();
+        this.coreName = solrHelper.getCoreName(accountId);
+        this.toExclude = new ArrayList<>();
+    }
+
+    private BooleanQuery.Builder newBooleanFilterQueryBuilder() {
+        BooleanQuery.Builder builder = new BooleanQuery.Builder();
+        if (solrHelper.needsAccountFilter()) {
+            builder.add(new TermQuery(new Term(LuceneFields.L_ACCOUNT_ID, accountId)), Occur.MUST);
+        }
+        return builder;
+    }
+
+    private void addRecipientClause(BooleanQuery.Builder builder, String recipientEmail, Occur occur) {
+        String field = SolrEventDocument.getSolrQueryField(EventContextField.RECEIVER);
+        String fieldValue = ClientUtils.escapeQueryChars(recipientEmail);
+        Query termQuery = new TermQuery(new Term(field, fieldValue));
+        builder.add(termQuery, occur);
+    }
+
+    private void addSenderClause(BooleanQuery.Builder builder, String senderEmail, Occur occur) {
+        String field = SolrEventDocument.getSolrQueryField(EventContextField.SENDER);
+        String fieldValue = ClientUtils.escapeQueryChars(senderEmail);
+        Query termQuery = new TermQuery(new Term(field, fieldValue));
+        builder.add(termQuery, occur);
+    }
+
+    private void addRecipientAndAffinityClause(BooleanQuery.Builder builder, AffinityTarget contact) {
+        BooleanQuery.Builder bq = new BooleanQuery.Builder();
+        addRecipientClause(bq, contact.getContactEmail(), Occur.MUST);
+        addAffinityTypeClause(bq, contact.getAffinityType());
+        builder.add(bq.build(), Occur.SHOULD);
+    }
+
+    private void addDateCutoffClause(BooleanQuery.Builder builder) {
+        if (params.hasDateCutoff()) {
+            String formatted = DateTimeFormatter.ISO_INSTANT.format(Instant.ofEpochMilli(params.getDateCutoff()));
+            Query rangeQuery = new TermRangeQuery(FLD_AFFINITY_TIMESTAMP, new BytesRef(formatted), new BytesRef("NOW"), true, true);
+            builder.add(rangeQuery, Occur.MUST);
+        }
+    }
+
+    private void addAffinityTypeClause(BooleanQuery.Builder builder, AffinityType affinityType) {
+        if (affinityType != AffinityType.all) {
+            String field = SolrEventDocument.getSolrQueryField(EventContextField.RECEIVER_TYPE);
+            Query termQuery = new TermQuery(new Term(field, affinityType.name()));
+            builder.add(termQuery, Occur.MUST);
+        }
+    }
+
+    private void addEventTypeClause(BooleanQuery.Builder builder, EventType eventType) {
+        String field = LuceneFields.L_EVENT_TYPE;
+        Query affinityClause = new TermQuery(new Term(field, eventType.toString()));
+        builder.add(affinityClause, Occur.MUST);
+    }
+
+    private TupleStream buildSearchStream(AffinityTarget target, EventType eventType, boolean ignoreAffinityType) throws IOException {
+        return buildSearchStream(Arrays.asList(target), eventType, ignoreAffinityType, null);
+    }
+
+    private TupleStream buildSearchStream(List<AffinityTarget> targets, EventType eventType, boolean ignoreAffinityType) throws IOException {
+        return buildSearchStream(targets, eventType, ignoreAffinityType, null);
+    }
+
+    private TupleStream buildSearchStream(List<AffinityTarget> targets, EventType eventType, boolean ignoreAffinityType, String sender) throws IOException {
+        BooleanQuery.Builder queryBuilder = new BooleanQuery.Builder();
+        BooleanQuery.Builder filterBuilder = newBooleanFilterQueryBuilder();
+
+        /*
+         *  Requested contact emails are query clauses
+         *  Affinity type is a filter clause only if one contact is provided, otherwise
+         *  it's a boolean clause
+         */
+        if (targets.size() == 1) {
+            AffinityTarget target = targets.get(0);
+            addRecipientClause(queryBuilder, target.getContactEmail(), Occur.MUST);
+            if (!ignoreAffinityType) {
+                addAffinityTypeClause(filterBuilder, target.getAffinityType());
+            }
+        } else {
+            //used to construct a union affinity query
+            for (AffinityTarget target: targets) {
+                if (ignoreAffinityType) {
+                    addRecipientClause(queryBuilder, target.getContactEmail(), Occur.SHOULD);
+                } else {
+                    addRecipientAndAffinityClause(queryBuilder, target);
+                }
+            }
+        }
+        addEventTypeClause(filterBuilder, eventType);
+        addDateCutoffClause(filterBuilder);
+
+        if (sender != null) {
+            addSenderClause(filterBuilder, sender, Occur.MUST);
+        }
+
+        String queryString = queryBuilder.build().toString();
+        String filterString = filterBuilder.build().toString();
+
+        Map<String, String> searchParams = new HashMap<>();
+        searchParams.put("q", queryString);
+        searchParams.put("fq", filterString);
+        searchParams.put("fl", SEARCH_FIELDS);
+        //limits results by both {MAX_MESSAGES_PER_SEARCH} hard cutoff and date,
+        //relies on the fact that message IDs are ascending in chronological order
+        searchParams.put("sort", FLD_MSG_ID + " desc");
+        searchParams.put("rows", String.valueOf(MAX_MESSAGES_PER_SEARCH));
+
+        return new CloudSolrStream(solrHelper.getZkHost(), coreName, new MapSolrParams(searchParams));
+    }
+
+    private TupleStream addNodesStream(TupleStream stream, EventType eventType) throws IOException {
+
+        BooleanQuery.Builder filterBuilder = newBooleanFilterQueryBuilder();
+        for (AffinityTarget target: params.getTargets()) {
+            addRecipientClause(filterBuilder, target.getContactEmail(), Occur.MUST_NOT);
+        }
+        addAffinityTypeClause(filterBuilder, params.getRequestedAffinityType());
+        addEventTypeClause(filterBuilder, eventType);
+
+        String filterQuery = filterBuilder.build().toString();
+
+        Map<String, String> params = new HashMap<>();
+        params.put("fq", filterQuery);
+
+        List<Metric> metrics = Arrays.asList(new CountMetric(FLD_MSG_ID));
+        String gatherField = SolrEventDocument.getSolrStoredField(EventContextField.RECEIVER);
+        Set<Scatter> scatter = Sets.newHashSet(Scatter.LEAVES);
+
+        return new GatherNodesStream(solrHelper.getZkHost(), coreName, stream,
+                FLD_MSG_ID, FLD_MSG_ID, gatherField, params, metrics, false, scatter, -1);
+    }
+
+    private TupleStream addRankStream(TupleStream stream) throws IOException {
+        //Get the top 200 results, sorted by count. The vast majority of queries will return less results than this.
+        //This way we can return the subset defined by params.getNumResults() and cache the rest for easy pagination.
+        StreamComparator comparator = new FieldComparator(FLD_COUNT, ComparatorOrder.DESCENDING);
+        return new RankStream(stream, MAX_RESULTS, comparator);
+    }
+
+    private TupleStream addIntersectStream(TupleStream stream1, TupleStream stream2) throws IOException {
+        return new IntersectStream(stream1, stream2, new FieldEqualitor(FLD_MSG_ID));
+    }
+
+    private TupleStream addDedupeStream(TupleStream stream) throws IOException {
+        List<String> filterValues = toExclude.stream().map(RelatedContact::getEmail).collect(Collectors.toList());
+        return new ContactDedupeTupleStream(stream, FLD_CONTACT_EMAIL, FLD_COUNT, filterValues);
+    }
+
+    private TupleStream mergeStreamsOnMessageId(TupleStream... streams) throws IOException {
+        return new MergeStream(new FieldComparator(FLD_MSG_ID, ComparatorOrder.DESCENDING), streams);
+    }
+
+    private TupleStream getOutgoingMessageIds(boolean matchAllTargets, boolean ignoreTargetAffinityType) throws IOException {
+        List<AffinityTarget> targets = params.getTargets();
+        TupleStream searchStream;
+        if (matchAllTargets) {
+            searchStream = buildSearchStream(targets.get(0), EventType.SENT, ignoreTargetAffinityType);
+            if (targets.size() > 1) {
+                //nest stream intersections
+                for (int i=1; i<targets.size(); i++) {
+                    searchStream = addIntersectStream(searchStream, buildSearchStream(targets.get(i), EventType.SENT, ignoreTargetAffinityType));
+                }
+            }
+        } else {
+            searchStream = buildSearchStream(targets, EventType.SENT, ignoreTargetAffinityType);
+        }
+        return searchStream;
+    }
+
+    private TupleStream getIncomingMessageIds(boolean senderMustBeTarget, boolean ignoreTargetAffinityField) throws IOException {
+        List<AffinityTarget> targets = params.getTargets();
+        TupleStream searchStream = null;
+        if (!senderMustBeTarget) {
+            searchStream = buildSearchStream(targets, EventType.AFFINITY, ignoreTargetAffinityField);
+        } else {
+            TupleStream[] toMerge = new TupleStream[targets.size()];
+            int idx = 0;
+            for (AffinityTarget sender: targets) {
+                //treat each target as a potential sender
+                String senderEmail = sender.getContactEmail();
+                List<AffinityTarget> others = targets.stream().filter(
+                        target -> !target.getContactEmail().equals(senderEmail)).collect(Collectors.toList());
+                TupleStream stream = buildSearchStream(others, EventType.AFFINITY, ignoreTargetAffinityField, senderEmail);
+                toMerge[idx] = stream;
+                idx++;
+            }
+            searchStream = mergeStreamsOnMessageId(toMerge);
+        }
+        return searchStream;
+    }
+
+    private TupleStream buildAffinityStream(AffinityScope scope) throws IOException {
+        EventType eventType;
+        TupleStream stream;
+
+        // 1. search for IDs of messages that satisfy the scope parameters
+        boolean ignoreTargetAffinityField = scope.getIgnoreTargetAffinityField();
+        switch (scope.getRelatedVia()) {
+        case OUTGOING_MSGS:
+            eventType = EventType.SENT;
+            boolean matchAllTargets = scope.getMatchType() == MatchType.ALL;
+            stream = getOutgoingMessageIds(matchAllTargets, ignoreTargetAffinityField);
+            break;
+        case INCOMING_MSGS:
+        default:
+            eventType = EventType.AFFINITY;
+            stream = getIncomingMessageIds(scope.getSenderMustBeTarget(), ignoreTargetAffinityField);
+            break;
+        }
+        // 2. walk to all other contacts referenced on these messages, counting the number of edges going to each contact
+        stream = addNodesStream(stream, eventType);
+
+        // 4. de-duplicate contacts
+        stream = addDedupeStream(stream);
+
+        // 5. sort by count
+        stream = addRankStream(stream);
+        return stream;
+    }
+
+    private void setStreamContext(TupleStream stream) {
+        StreamContext context = new StreamContext();
+        SolrClientCache clientCache = solrHelper.getClientCache();
+        context.setSolrClientCache(clientCache);
+        context.setModelCache(new ModelCache(MODEL_CACHE_SIZE, solrHelper.getZkHost(), clientCache));
+        stream.setStreamContext(context);
+
+    }
+
+    private void openStream(TupleStream stream) throws ServiceException {
+        try {
+            stream.open();
+        } catch (IOException e) {
+            throw ServiceException.FAILURE("error opening contact affinity TupleStream", e);
+        }
+    }
+
+    private Tuple readStream(TupleStream stream) throws ServiceException {
+        try {
+            return stream.read();
+        } catch (IOException e) {
+            throw ServiceException.FAILURE("error reading tuple from contact affinity TupleStream", e);
+        }
+    }
+
+    /**
+     * Compose and run a streaming expression to return related contacts for a given AffinityScope.
+     */
+    @VisibleForTesting
+    public RelatedContactsResults execute(AffinityScope scope) throws ServiceException {
+        try(TupleStream stream = buildAffinityStream(scope)) {
+            setStreamContext(stream);
+            openStream(stream);
+
+            RelatedContactsResults results = new RelatedContactsResults(params, System.currentTimeMillis());
+            while(true) {
+                Tuple tuple = readStream(stream);
+                if (tuple.EOF) {
+                    return results;
+                }
+                String contactEmail = tuple.getString(FLD_CONTACT_EMAIL);
+                double count = tuple.getDouble(FLD_COUNT);
+                if (count < params.getMinOccur()) {
+                    return results;
+                }
+                ParsedAddress parsed = new ParsedAddress(contactEmail);
+                String email = parsed.emailPart;
+                String name = parsed.personalPart;
+                RelatedContact contact = new RelatedContact(email, count, scope.getLevel());
+                if (!Strings.isNullOrEmpty(name)) {
+                    contact.setName(name);
+                }
+                results.addResult(contact);
+            }
+        } catch (IOException e) {
+            throw ServiceException.FAILURE("unable to build contact affinity streaming query", e);
+        }
+    }
+
+    /**
+     * Starting with the most narrow ÅffinityScope and expanding outward, run related contacts queries until
+     * the desired number of results is reached, or until the widest scope is searched.
+     * The number of results returned by this method may exceed the value of params.getLimit(); ContactAffinityStore will
+     * trim these results to the requested number. This allows us to cache more results that are returned,
+     * so that a subsequent request with a higher limit may still use the cache.
+     */
+    public RelatedContactsResults executeWithExpandingScope() throws ServiceException {
+
+        int minNumResults = params.getLimit();
+
+        //First we determine which affinity scopes are possible for this query
+         List<AffinityScope> scopes = AffinityScope.getAffinityScopesForQuery(params);
+
+        //We start at the most narrow scope and expand it until we reach the number of requested results.
+        //When expanding the scope, we pass in the results from the previous searches as a filter so we don't
+        //double-count results.
+
+        RelatedContactsResults results = new RelatedContactsResults(params, System.currentTimeMillis());
+        AffinityScope widestScope = scopes.get(scopes.size() - 1);
+        RelatedContactsResults scopeResults;
+        for (AffinityScope scope: scopes) {
+            if (scope == widestScope) {
+                results.setMaybeHasMore(false);
+            }
+            scopeResults = execute(scope);
+            results.addResults(scopeResults.getResults());
+            if (results.size() > minNumResults) {
+                //found enough results
+                return results;
+            } else {
+                //add the results from the previous scope to the filter
+                toExclude.addAll(scopeResults.getResults());
+            }
+        }
+        //if insufficient results are found, return what we have
+        return results;
+    }
+}

--- a/store/src/java/com/zimbra/cs/contacts/ContactAffinityStore.java
+++ b/store/src/java/com/zimbra/cs/contacts/ContactAffinityStore.java
@@ -1,0 +1,116 @@
+package com.zimbra.cs.contacts;
+
+import java.util.List;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.contacts.RelatedContactsResults.RelatedContact;
+
+/**
+ * Entry point into the contact affinity system. Delegates to ComputationBackend
+ * to calculate contact affinity and stores/retrieves results with ResultsCache.
+ */
+public class ContactAffinityStore {
+
+    private static Factory factory;
+    static {
+        try {
+            setFactory(ZimbraContactAffinityFactory.class);
+        } catch (ServiceException e) {
+            ZimbraLog.index.error("unable to set ContactAffinityStore Factory", e);
+        }
+    }
+
+    private String accountId;
+    private ComputationBackend compBackend;
+    private ResultsCache resultsCache;
+
+    public ContactAffinityStore(String accountId, ComputationBackend compBackend,
+            ResultsCache resultsCache) {
+        this.accountId = accountId;
+        this.compBackend = compBackend;
+        this.resultsCache = resultsCache;
+    }
+
+    public static final void setFactory(Class<? extends Factory> factoryClass) throws ServiceException {
+        String className = factoryClass.getName();
+        ZimbraLog.search.info("setting ContactAffinityStore.Factory class %s", className);
+        try {
+            factory = factoryClass.newInstance();
+        } catch (InstantiationException | IllegalAccessException e) {
+            throw ServiceException.FAILURE(String.format("unable to initialize ContactAffinityStore factory %s", className), e);
+        }
+    }
+
+    public static Factory getFactory() {
+        return factory;
+    }
+
+    private RelatedContactsResults applyLimit(RelatedContactsParams params, RelatedContactsResults results) {
+        int limit = params.getLimit();
+        List<RelatedContact> contactList = results.getResults();
+        if (limit >= contactList.size()) {
+            return results;
+        }
+        List<RelatedContact> requestedResultsRange = contactList.subList(0, limit);
+        RelatedContactsResults limitedResults = new RelatedContactsResults(params, results.getDate());
+        limitedResults.addResults(requestedResultsRange);
+        return limitedResults;
+    }
+
+    public RelatedContactsResults getRelatedContacts(RelatedContactsParams params) throws ServiceException {
+
+        RelatedContactsResults results = getFromCache(params);
+        if (results == null) {
+            //no cached results, so compute affinity. This may return more results than is
+            //requested, which is OK, since we will trim to the requested number.
+            results = calculateRelatedContacts(params);
+        } else if (params.getLimit() > results.size() && results.maybeHasMore()) {
+            //cached results don't satisfy the requested limit. If a wider scope is possible, compute again
+            results = calculateRelatedContacts(params);
+        }
+        return applyLimit(params, results);
+    }
+
+    private RelatedContactsResults calculateRelatedContacts(RelatedContactsParams params) throws ServiceException {
+        RelatedContactsResults results = compBackend.calculateContactAffinity(params);
+        storeInCache(results);
+        return results;
+    }
+
+    private RelatedContactsResults getFromCache(RelatedContactsParams params) throws ServiceException {
+        if (resultsCache != null) {
+            return resultsCache.getFromCache(params);
+        } else {
+            return null;
+        }
+    }
+
+    private void storeInCache(RelatedContactsResults relatedContacts) throws ServiceException {
+        if (resultsCache != null) {
+            resultsCache.storeInCache(relatedContacts);
+        }
+    }
+
+    public static abstract class Factory {
+
+        /**
+         * return an instance of ComputationBackend to be used for calculating contact affinity
+         */
+        protected abstract ComputationBackend getComputationBackend(String accountId) throws ServiceException;
+
+        /**
+         * return an instance of ResultsCache to be used for storing/querying known results
+         */
+        protected abstract ResultsCache getResultsCache(String accountId) throws ServiceException;
+
+        /**
+         * return an instance of ContactAffinityStore for the given account ID
+         */
+        public ContactAffinityStore getContactAffinityStore(String accountId) throws ServiceException{
+            ComputationBackend backend = getComputationBackend(accountId);
+            ResultsCache cache = getResultsCache(accountId);
+            return new ContactAffinityStore(accountId, backend, cache);
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/contacts/ContactDedupeTupleStream.java
+++ b/store/src/java/com/zimbra/cs/contacts/ContactDedupeTupleStream.java
@@ -1,0 +1,197 @@
+package com.zimbra.cs.contacts;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.solr.client.solrj.io.Tuple;
+import org.apache.solr.client.solrj.io.comp.StreamComparator;
+import org.apache.solr.client.solrj.io.stream.StreamContext;
+import org.apache.solr.client.solrj.io.stream.TupleStream;
+import org.apache.solr.client.solrj.io.stream.expr.Explanation;
+import org.apache.solr.client.solrj.io.stream.expr.Explanation.ExpressionType;
+import org.apache.solr.client.solrj.io.stream.expr.Expressible;
+import org.apache.solr.client.solrj.io.stream.expr.StreamExplanation;
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
+import org.apache.solr.client.solrj.io.stream.expr.StreamFactory;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.mime.ParsedAddress;
+
+/**
+ * Custom stream decorator used to deduplicate related contacts.
+ * In order to do this, we consume the entire stream and merge tuples representing
+ * the same contact, adding up their counts. The emitted tuple contains the longer of the
+ * address values.
+ *
+ * Optionally, a list of filter values can be provided; contacts that match
+ * will be skipped.
+ *
+ * For example, tuples for "bob smith <bsmith@zimbra.com>" and "bsmith@zimbra.com"
+ * would be merged into the longer of the two addresses.
+ *
+ * @author iraykin
+ *
+ */
+public class ContactDedupeTupleStream extends TupleStream implements Expressible {
+
+    private static final long serialVersionUID = 1;
+
+    private TupleStream stream;
+    private Multimap<String, Tuple> normalizedMap;
+    private LinkedList<Tuple> merged;
+    private Tuple EOF;
+    private String addrField;
+    private String countField;
+    private Set<String> filterValues;
+
+
+    public ContactDedupeTupleStream(TupleStream stream, String addrField, String countField, Collection<String> filterValues) {
+        this.stream = stream;
+        normalizedMap = ArrayListMultimap.create();
+        merged = Lists.newLinkedList();
+        this.addrField = addrField;
+        this.countField = countField;
+        buildFilter(filterValues);
+    }
+
+    public ContactDedupeTupleStream(TupleStream stream, String addrField, String countField) {
+        this(stream, addrField, countField, null);
+    }
+
+    private void buildFilter(Collection<String> filterAddrs) {
+        if (filterAddrs == null || filterAddrs.isEmpty()) {
+            filterValues = Sets.newHashSet();
+        }else {
+            filterValues = filterAddrs.stream().map(addr -> normalizeEmail(addr)).collect(Collectors.toSet());
+        }
+    }
+    @Override
+    public StreamExpression toExpression(StreamFactory factory) throws IOException{
+      return toExpression(factory, true);
+    }
+
+    private StreamExpression toExpression(StreamFactory factory, boolean includeStreams) throws IOException {
+      StreamExpression expression = new StreamExpression(factory.getFunctionName(this.getClass()));
+
+      if(includeStreams){
+        if(stream instanceof Expressible){
+          expression.addParameter(((Expressible)stream).toExpression(factory));
+        }
+        else{
+          throw new IOException("ContactDedupeTupleStream contains a non-expressible TupleStream - it cannot be converted to an expression");
+        }
+      }
+      else{
+        expression.addParameter("<stream>");
+      }
+      return expression;
+    }
+
+    @Override
+    public void setStreamContext(StreamContext context) {
+        stream.setStreamContext(context);
+    }
+
+    @Override
+    public List<TupleStream> children() {
+        return Lists.newArrayList(stream);
+    }
+
+    private String getEmailAddr(Tuple tuple) {
+        return tuple.getString(addrField);
+    }
+
+    private long getCount(Tuple tuple) {
+        return tuple.getLong(countField);
+    }
+
+    private String normalizeEmail(String address) {
+        ParsedAddress parsed = new ParsedAddress(address);
+        String normalized = parsed.emailPart;
+        return Strings.isNullOrEmpty(normalized) ? null : normalized.toLowerCase();
+    }
+
+    private void mergeTuples() {
+        Map<String, Collection<Tuple>> map = normalizedMap.asMap();
+        Comparator<Tuple> compByAddrLength = (t1, t2) -> Integer.compare(getEmailAddr(t1).length(), getEmailAddr(t2).length());
+        for (Collection<Tuple> tuples: map.values()) {
+            if (tuples.size() == 1) {
+                merged.push(tuples.iterator().next());
+            } else {
+                if (ZimbraLog.contact.isDebugEnabled()) {
+                    String joined = Joiner.on(", ").join(tuples.stream().map(t -> getEmailAddr(t)).collect(Collectors.toList()));
+                    ZimbraLog.contact.debug("merging related contacts %s", joined);
+                }
+                String longestAddr = getEmailAddr(tuples.stream().max(compByAddrLength).get());
+                long totalCount = tuples.stream().collect(Collectors.summingLong(t -> getCount(t)));
+                Tuple mergedTuple = tuples.iterator().next().clone();
+                mergedTuple.put(addrField, longestAddr);
+                mergedTuple.put(countField, totalCount);
+                merged.push(mergedTuple);
+            }
+        }
+    }
+
+    @Override
+    public void open() throws IOException {
+        stream.open();
+        Tuple tuple = stream.read();
+        while(true) {
+            if (tuple.EOF) {
+                EOF = tuple;
+                break;
+            }
+
+          String normalized = normalizeEmail(getEmailAddr(tuple));
+          if (normalized != null && !filterValues.contains(normalized)) {
+              normalizedMap.put(normalized, tuple);
+          }
+          tuple = stream.read();
+        }
+        mergeTuples();
+    }
+
+    @Override
+    public void close() throws IOException {
+        stream.close();
+        normalizedMap.clear();
+    }
+
+    @Override
+    public Tuple read() throws IOException {
+        if (merged.isEmpty()) {
+            return EOF;
+        } else{
+            return merged.pop();
+        }
+    }
+
+    @Override
+    public StreamComparator getStreamSort() {
+        return stream.getStreamSort();
+    }
+
+    @Override
+    public Explanation toExplanation(StreamFactory factory) throws IOException {
+        return new StreamExplanation(getStreamNodeId().toString())
+        .withChildren(new Explanation[]{
+          stream.toExplanation(factory)
+        })
+        .withFunctionName(factory.getFunctionName(this.getClass()))
+        .withImplementingClass(this.getClass().getName())
+        .withExpressionType(ExpressionType.STREAM_DECORATOR)
+        .withExpression(toExpression(factory, false).toString());
+    }
+}

--- a/store/src/java/com/zimbra/cs/contacts/EventContactAffinityComputationBackend.java
+++ b/store/src/java/com/zimbra/cs/contacts/EventContactAffinityComputationBackend.java
@@ -1,0 +1,22 @@
+package com.zimbra.cs.contacts;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.event.EventStore;
+
+/**
+ * Backend that uses the Solrcloud streaming API to calculate contact affinity from event data
+ */
+public class EventContactAffinityComputationBackend implements ComputationBackend {
+
+    EventStore eventStore;
+
+    public EventContactAffinityComputationBackend(EventStore eventStore) {
+        this.eventStore = eventStore;
+    }
+
+    @Override
+    public RelatedContactsResults calculateContactAffinity(RelatedContactsParams query)
+            throws ServiceException {
+        return eventStore.getContactAffinity(query);
+    }
+}

--- a/store/src/java/com/zimbra/cs/contacts/InMemoryResultsCache.java
+++ b/store/src/java/com/zimbra/cs/contacts/InMemoryResultsCache.java
@@ -1,0 +1,53 @@
+package com.zimbra.cs.contacts;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.google.common.base.Joiner;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.contacts.RelatedContactsParams.AffinityTarget;
+
+/**
+ * In-memory implementation of contact affinity results cache
+ */
+public class InMemoryResultsCache extends ResultsCache {
+
+    private Cache<String, RelatedContactsResults> cache;
+
+    public InMemoryResultsCache() {
+        initCache();
+    }
+
+    private void initCache() {
+        cache = CacheBuilder.newBuilder().build();
+    }
+
+    private String getTargetKeyComponent(AffinityTarget target) {
+        return String.format("%s:%s", target.getAffinityType().name(), target.getContactEmail());
+    }
+
+    private String buildCacheKey(RelatedContactsParams params) {
+        List<String> targets = params.getTargets().stream().map(t->getTargetKeyComponent(t)).collect(Collectors.toList());
+        Collections.sort(targets);
+        String targetStr = Joiner.on(",").join(targets);
+        String affinityType = params.getRequestedAffinityType().name();
+        String acctId = params.getAccountId();
+        return Joiner.on("|").join(acctId, affinityType, targetStr);
+    }
+
+    @Override
+    public RelatedContactsResults get(RelatedContactsParams params)
+            throws ServiceException {
+        String key = buildCacheKey(params);
+        return cache.getIfPresent(key);
+    }
+
+    @Override
+    public void storeInCache(RelatedContactsResults results) throws ServiceException {
+        String key = buildCacheKey(results.getQueryParams());
+        cache.put(key, results);
+    }
+}

--- a/store/src/java/com/zimbra/cs/contacts/RelatedContactsParams.java
+++ b/store/src/java/com/zimbra/cs/contacts/RelatedContactsParams.java
@@ -1,0 +1,176 @@
+package com.zimbra.cs.contacts;
+
+import java.util.List;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Objects;
+import com.google.common.base.Objects.ToStringHelper;
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.soap.mail.type.RelatedContactsTarget;
+
+/**
+ * Class encapsulating parameters of a "related contacts" search
+ */
+public class RelatedContactsParams {
+
+    private String accountId;
+    private List<AffinityTarget> targets;
+    private Long dateCutoff;
+    private int limit;
+    private int minOccurCount = 1;
+    private boolean includeIncomingMsgAffinity;
+    private AffinityType requestedAffinityType = AffinityType.all;
+
+    public RelatedContactsParams(String accountId) {
+        this(accountId, null);
+    }
+
+    public RelatedContactsParams(String accountId, AffinityTarget target) {
+        this.targets = Lists.newArrayList();
+        this.accountId = accountId;
+        if (target != null) {
+            targets.add(target);
+        }
+    }
+
+    public RelatedContactsParams addTarget(AffinityTarget target) {
+        targets.add(target);
+        return this;
+    }
+
+    public RelatedContactsParams setDateCutoff(long dateCutoff) {
+        this.dateCutoff = dateCutoff;
+        return this;
+    }
+
+    public RelatedContactsParams setLimit(int limit) {
+        this.limit = limit;
+        return this;
+    }
+
+    public RelatedContactsParams setRequestedAffinityType(AffinityType affinityType) {
+        this.requestedAffinityType = affinityType;
+        return this;
+    }
+
+    public RelatedContactsParams setMinOccurCount(int minOccurCount) {
+        this.minOccurCount = minOccurCount;
+        return this;
+    }
+
+    public RelatedContactsParams setIncludeIncomingMsgAffinity(boolean include) {
+        this.includeIncomingMsgAffinity = include;
+        return this;
+    }
+
+    public List<AffinityTarget> getTargets() {
+        return targets;
+    }
+
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public boolean hasDateCutoff() {
+        return dateCutoff != null;
+    }
+
+    public long getDateCutoff() {
+        return dateCutoff;
+    }
+
+    public int getLimit() {
+        return limit;
+    }
+
+    public AffinityType getRequestedAffinityType() {
+        return requestedAffinityType;
+    }
+
+    public int getMinOccur() {
+        return minOccurCount;
+    }
+
+    public boolean getIncludeIncomingMsgAffinity() {
+        return includeIncomingMsgAffinity;
+    }
+
+    public static class AffinityTarget {
+
+        private AffinityType affinityType;
+        private String contactEmail;
+
+        public AffinityTarget(AffinityType affinityType, String contactEmail) {
+            this.affinityType = affinityType;
+            this.contactEmail = contactEmail;
+        }
+
+        public String getContactEmail() {
+            return contactEmail;
+        }
+
+        public AffinityType getAffinityType() {
+            return affinityType;
+        }
+
+        public static AffinityTarget fromSOAPTarget(RelatedContactsTarget target) throws ServiceException {
+            String targetEmail = target.getTargetEmail();
+            String affinityStr = target.getAffinity();
+            AffinityType affinity;
+            if (Strings.isNullOrEmpty(affinityStr)) {
+                affinity = AffinityType.all;
+            } else {
+                affinity = AffinityType.of(affinityStr);
+            }
+            return new AffinityTarget(affinity, targetEmail);
+        }
+        @Override
+        public String toString() {
+            if (affinityType == AffinityType.all) {
+                return String.format("[%s]", contactEmail);
+            } else {
+                return String.format("[%s:%s]", affinityType.name(), contactEmail);
+            }
+        }
+    }
+
+    public static enum ScopeMethod {
+        adaptive, widest;
+
+        public static ScopeMethod of(String str) throws ServiceException {
+            for (ScopeMethod policy: ScopeMethod.values()) {
+                if (policy.name().equalsIgnoreCase(str)) {
+                    return policy;
+                }
+            }
+            throw ServiceException.INVALID_REQUEST(String.format("%s is not a valid affinity scope method",  str), null);
+        }
+    }
+
+    public static enum AffinityType {
+        all, to, cc, bcc;
+
+        public static AffinityType of(String typeStr) throws ServiceException {
+            for (AffinityType type: AffinityType.values()) {
+                if (type.name().equalsIgnoreCase(typeStr)) {
+                    return type;
+                }
+            }
+            throw ServiceException.INVALID_REQUEST(String.format("%s is not a valid affinity type",  typeStr), null);
+        }
+    }
+
+    @Override
+    public String toString() {
+        ToStringHelper helper = Objects.toStringHelper(this)
+        .add("acctId", accountId)
+        .add("targets", Joiner.on(",").join(targets))
+        .add("affinityType", requestedAffinityType)
+        .add("dateCutoff", dateCutoff)
+        .add("limit", limit)
+        .add("minOccur", minOccurCount);
+        return helper.toString();
+    }
+}

--- a/store/src/java/com/zimbra/cs/contacts/RelatedContactsResults.java
+++ b/store/src/java/com/zimbra/cs/contacts/RelatedContactsResults.java
@@ -1,0 +1,89 @@
+package com.zimbra.cs.contacts;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Objects;
+import com.zimbra.soap.mail.type.RelatedContactResult;
+
+public class RelatedContactsResults {
+
+    private RelatedContactsParams params;
+    private List<RelatedContact> results;
+    private long dateComputed;
+    private boolean maybeHasMore = true;
+
+    public RelatedContactsResults(RelatedContactsParams params, long dateComputed) {
+        this.results = new ArrayList<>();
+        this.params = params;
+        this.dateComputed = dateComputed;
+    }
+
+    public void addResult(RelatedContact result) {
+        this.results.add(result);
+    }
+
+    public void addResults(List<RelatedContact> results) {
+        this.results.addAll(results);
+    }
+
+    public RelatedContactsParams getQueryParams() {
+        return params;
+    }
+
+    public boolean hasResults() {
+        return !results.isEmpty();
+    }
+
+    public List<RelatedContact> getResults() {
+        return results;
+    }
+
+    public long getDate() {
+        return dateComputed;
+    }
+
+    public int size() {
+        return results.size();
+    }
+
+    public void setMaybeHasMore(boolean bool) {
+        this.maybeHasMore = bool;
+    }
+
+    public boolean maybeHasMore() {
+        return maybeHasMore;
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this)
+                .add("acctId", params.getAccountId())
+                .add("targets", Joiner.on(", ").join(params.getTargets()))
+                .add("affinityType", params.getRequestedAffinityType())
+                .add("results", Joiner.on(", ").join(results))
+                .add("date", dateComputed)
+                .add("size", size())
+                .toString();
+
+    }
+
+    public static class RelatedContact extends RelatedContactResult {
+        private double score;
+
+        public RelatedContact(String email, double score, int scope) {
+            super(email, scope);
+            this.score = score;
+        }
+
+        public double getScore() {
+            return score;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("[%s (%s) scope=%s]", getEmail(), getScore(), getScope());
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/contacts/ResultsCache.java
+++ b/store/src/java/com/zimbra/cs/contacts/ResultsCache.java
@@ -1,0 +1,37 @@
+package com.zimbra.cs.contacts;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+
+/**
+ * Implementations of this class are used for storing/retrieving known contact affinity results.
+ */
+public abstract class ResultsCache {
+
+    protected abstract RelatedContactsResults get(RelatedContactsParams params) throws ServiceException;
+
+    public RelatedContactsResults getFromCache(RelatedContactsParams params) throws ServiceException {
+        RelatedContactsResults results = get(params);
+        if (results == null || isExpired(results)) {
+            return null;
+        } else {
+            return results;
+        }
+    }
+
+    public abstract void storeInCache(RelatedContactsResults contacts) throws ServiceException;
+
+    protected boolean isExpired(RelatedContactsResults results) {
+        Account acct;
+        try {
+            acct = Provisioning.getInstance().getAccountById(results.getQueryParams().getAccountId());
+        } catch (ServiceException e) {
+            ZimbraLog.contact.error("unable to determing zimbraRelatedContactsMaxAge, keeping cache entry");
+            return false;
+        }
+        long maxResultsAge = acct.getRelatedContactsMaxAge();
+        return System.currentTimeMillis() - maxResultsAge > results.getDate();
+    }
+}

--- a/store/src/java/com/zimbra/cs/contacts/ZimbraContactAffinityFactory.java
+++ b/store/src/java/com/zimbra/cs/contacts/ZimbraContactAffinityFactory.java
@@ -1,0 +1,25 @@
+package com.zimbra.cs.contacts;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.event.EventStore;
+
+public class ZimbraContactAffinityFactory extends ContactAffinityStore.Factory {
+
+    private InMemoryResultsCache cacheInstance;
+
+    @Override
+    protected ComputationBackend getComputationBackend(String accountId) throws ServiceException {
+        EventStore eventStore = EventStore.getFactory().getEventStore(accountId);
+        return new EventContactAffinityComputationBackend(eventStore);
+    }
+
+    @Override
+    protected ResultsCache getResultsCache(String accountId) throws ServiceException {
+        if (cacheInstance == null) {
+            synchronized (this) {
+                cacheInstance = new InMemoryResultsCache();
+            }
+        }
+        return cacheInstance;
+    }
+}

--- a/store/src/java/com/zimbra/cs/event/EventStore.java
+++ b/store/src/java/com/zimbra/cs/event/EventStore.java
@@ -8,6 +8,8 @@ import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.Server;
+import com.zimbra.cs.contacts.RelatedContactsParams;
+import com.zimbra.cs.contacts.RelatedContactsResults;
 import com.zimbra.cs.event.logger.EventLogger;
 import com.zimbra.cs.extension.ExtensionUtil;
 
@@ -108,7 +110,7 @@ public abstract class EventStore {
             deleteEventsByAccount();
             EventLogger.getEventLogger().log(Event.generateDeleteAccountEvent(accountId));
         } else {
-            ZimbraLog.event.debug("no event store specifed; skipping deleting events for account %s", accountId);
+            ZimbraLog.event.debug("no event store specified; skipping deleting events for account %s", accountId);
         }
     }
 
@@ -129,6 +131,11 @@ public abstract class EventStore {
      * Delete all events for the specified datasource ID
      */
     protected abstract void deleteEventsByDataSource(String dataSourceId) throws ServiceException;
+
+    /**
+     * Calculate contact affinity based on SENT and AFFINITY events
+     */
+    public abstract RelatedContactsResults getContactAffinity(RelatedContactsParams params) throws ServiceException;
 
     public interface Factory {
 

--- a/store/src/java/com/zimbra/cs/event/SolrCloudEventStore.java
+++ b/store/src/java/com/zimbra/cs/event/SolrCloudEventStore.java
@@ -3,6 +3,9 @@ package com.zimbra.cs.event;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 
 import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.contacts.ContactAffinityQuery;
+import com.zimbra.cs.contacts.RelatedContactsParams;
+import com.zimbra.cs.contacts.RelatedContactsResults;
 import com.zimbra.cs.index.solr.SolrCloudHelper;
 import com.zimbra.cs.index.solr.SolrConstants;
 import com.zimbra.cs.index.solr.SolrRequestHelper;
@@ -12,6 +15,12 @@ public class SolrCloudEventStore extends SolrEventStore {
 
     public SolrCloudEventStore(String accountId, SolrCloudHelper solrHelper) {
         super(accountId, solrHelper);
+    }
+
+    @Override
+    public RelatedContactsResults getContactAffinity(RelatedContactsParams params) throws ServiceException {
+        ContactAffinityQuery query = new ContactAffinityQuery((SolrCloudHelper) solrHelper, params);
+        return query.executeWithExpandingScope();
     }
 
     public static class Factory extends SolrEventStore.Factory {

--- a/store/src/java/com/zimbra/cs/event/SolrEventDocument.java
+++ b/store/src/java/com/zimbra/cs/event/SolrEventDocument.java
@@ -2,14 +2,10 @@ package com.zimbra.cs.event;
 
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import org.apache.solr.common.SolrInputDocument;
 
-import com.google.common.base.Joiner;
 import com.zimbra.common.util.UUIDUtil;
 import com.zimbra.cs.event.Event.EventContextField;
 import com.zimbra.cs.event.Event.UniqueOn;
@@ -17,9 +13,9 @@ import com.zimbra.cs.index.LuceneFields;
 
 public class SolrEventDocument {
     // see schema.xml for static/dynamic field definitions
-    private static String FIELD_EVENT_ID = "id";
-    private static String FIELD_EVENT_TYPE= "ev_type";
-    private static String FIELD_EVENT_TIME= "ev_timestamp";
+    private static String FIELD_EVENT_ID   = LuceneFields.L_EVENT_ID;
+    private static String FIELD_EVENT_TYPE = LuceneFields.L_EVENT_TYPE;
+    private static String FIELD_EVENT_TIME = LuceneFields.L_EVENT_TIME;
     private static String FIELD_MSG_ID = "msg_id";
     private static String DYNAMIC_FIELD_FORMAT = "%s_%s";
     private static DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ISO_INSTANT;
@@ -95,7 +91,7 @@ public class SolrEventDocument {
 
     private void setContextFields() {
         for (Map.Entry<EventContextField, Object> entry: event.getContext().entrySet()) {
-            document.setField(getSolrField(entry.getKey()), entry.getValue());
+            document.setField(getSolrQueryField(entry.getKey()), entry.getValue());
         }
     }
 
@@ -103,13 +99,31 @@ public class SolrEventDocument {
      * Convert a known EventContextField to a dynamic Solr field. This is necessary to avoid
      * having to update the Solr schema every time a new event type is added.
      */
-    private static String getSolrField(EventContextField field) {
+    public static String getSolrQueryField(EventContextField field) {
         SolrFieldType fieldType;
         switch (field) {
         case MSG_ID:
             return FIELD_MSG_ID;
         case RECEIVER:
         case SENDER:
+            fieldType = SolrFieldType.ADDRESS;
+            break;
+        case RECEIVER_TYPE:
+        default:
+            fieldType = SolrFieldType.STRING;
+            break;
+        }
+        return String.format(DYNAMIC_FIELD_FORMAT, field.toString().toLowerCase(), fieldType.suffix);
+    }
+
+    public static String getSolrStoredField(EventContextField field) {
+        SolrFieldType fieldType;
+        switch (field) {
+        case MSG_ID:
+            return FIELD_MSG_ID;
+        case RECEIVER:
+        case SENDER:
+        case RECEIVER_TYPE:
         default:
             fieldType = SolrFieldType.STRING;
             break;
@@ -134,7 +148,8 @@ public class SolrEventDocument {
         BOOLEAN("b"),
         BOOLEANS("bs"),
         DATE("pdt"),
-        DATES("pdts");
+        DATES("pdts"),
+        ADDRESS("zaddr");
 
         private String suffix;
 

--- a/store/src/java/com/zimbra/cs/event/SolrEventStore.java
+++ b/store/src/java/com/zimbra/cs/event/SolrEventStore.java
@@ -24,7 +24,7 @@ import com.zimbra.cs.index.solr.SolrRequestHelper;
  */
 public abstract class SolrEventStore extends EventStore {
 
-    private SolrRequestHelper solrHelper;
+    protected SolrRequestHelper solrHelper;
 
     public SolrEventStore(String accountId, SolrRequestHelper solrHelper) {
         super(accountId);

--- a/store/src/java/com/zimbra/cs/event/StandaloneSolrEventStore.java
+++ b/store/src/java/com/zimbra/cs/event/StandaloneSolrEventStore.java
@@ -4,6 +4,8 @@ import org.apache.http.impl.client.CloseableHttpClient;
 
 import com.zimbra.common.httpclient.ZimbraHttpClientManager;
 import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.contacts.RelatedContactsParams;
+import com.zimbra.cs.contacts.RelatedContactsResults;
 import com.zimbra.cs.index.solr.SolrConstants;
 import com.zimbra.cs.index.solr.SolrRequestHelper;
 import com.zimbra.cs.index.solr.StandaloneSolrHelper;
@@ -16,6 +18,11 @@ public class StandaloneSolrEventStore extends SolrEventStore {
 
     public StandaloneSolrEventStore(String accountId, StandaloneSolrHelper solrHelper) {
         super(accountId, solrHelper);
+    }
+
+    @Override
+    public RelatedContactsResults getContactAffinity(RelatedContactsParams params) throws ServiceException {
+        throw ServiceException.UNSUPPORTED();
     }
 
     public static class Factory extends SolrEventStore.Factory {

--- a/store/src/java/com/zimbra/cs/index/LuceneFields.java
+++ b/store/src/java/com/zimbra/cs/index/LuceneFields.java
@@ -224,6 +224,25 @@ public final class LuceneFields {
      */
     public static final String L_DATASOURCE_ID = "datasource_id";
 
+    /**
+     * id of the event
+     */
+    public static final String L_EVENT_ID = "id";
+
+    /**
+     * id of the message for which the event is logged
+     */
+    public static final String L_EVENT_MESSAGE_ID = "msg_id";
+
+    /**
+     * the type of the event
+     */
+    public static final String L_EVENT_TYPE = "ev_type";
+
+    /**
+     * timestamp of the event in ISO instant format
+     */
+    public static final String L_EVENT_TIME = "ev_timestamp";
 
     public static String valueForBooleanField(boolean value) {
         return value ? "1" : "0";

--- a/store/src/java/com/zimbra/cs/index/solr/SolrCloudHelper.java
+++ b/store/src/java/com/zimbra/cs/index/solr/SolrCloudHelper.java
@@ -3,6 +3,7 @@ package com.zimbra.cs.index.solr;
 import java.io.IOException;
 
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.apache.solr.client.solrj.io.SolrClientCache;
 import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.common.params.CoreAdminParams;
 
@@ -11,15 +12,18 @@ import com.zimbra.common.service.ServiceException;
 public class SolrCloudHelper extends SolrRequestHelper {
 
     private CloudSolrClient cloudClient;
+    private SolrClientCache clientCache;
 
     public SolrCloudHelper(SolrCollectionLocator locator, CloudSolrClient cloudClient, String configSet) {
         super(locator, configSet);
         this.cloudClient = cloudClient;
+        this.clientCache = new SolrClientCache();
     }
 
     @Override
     public void close() throws IOException {
         cloudClient.close();
+        clientCache.close();
     }
 
     @Override
@@ -43,5 +47,9 @@ public class SolrCloudHelper extends SolrRequestHelper {
 
     public String getZkHost() {
         return cloudClient.getZkHost();
+    }
+
+    public SolrClientCache getClientCache() {
+        return clientCache;
     }
 }

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -46,7 +46,6 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Pattern;
 
 import javax.mail.Address;
-import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
 import com.google.common.base.CharMatcher;
@@ -136,8 +135,8 @@ import com.zimbra.cs.index.SortBy;
 import com.zimbra.cs.index.ZimbraQuery;
 import com.zimbra.cs.index.ZimbraQueryResults;
 import com.zimbra.cs.index.history.SavedSearchPromptLog;
-import com.zimbra.cs.index.history.SearchHistory;
 import com.zimbra.cs.index.history.SavedSearchPromptLog.SavedSearchStatus;
+import com.zimbra.cs.index.history.SearchHistory;
 import com.zimbra.cs.index.history.SearchHistory.SearchHistoryParams;
 import com.zimbra.cs.ldap.LdapConstants;
 import com.zimbra.cs.mailbox.CalendarItem.AlarmData;
@@ -147,7 +146,6 @@ import com.zimbra.cs.mailbox.FoldersTagsCache.FoldersTags;
 import com.zimbra.cs.mailbox.MailItem.CustomMetadata;
 import com.zimbra.cs.mailbox.MailItem.PendingDelete;
 import com.zimbra.cs.mailbox.MailItem.TargetConstraint;
-import com.zimbra.cs.mailbox.MailItem.Type;
 import com.zimbra.cs.mailbox.MailItem.UnderlyingData;
 import com.zimbra.cs.mailbox.MailServiceException.NoSuchItemException;
 import com.zimbra.cs.mailbox.MailboxListener.ChangeNotification;
@@ -10703,7 +10701,15 @@ public class Mailbox implements MailboxStore {
                 ZimbraLog.event.warn("no recipient specified for message %d", msg.getId());
             } else {
                 long timestamp = ctxt.getTimestamp() == null ? System.currentTimeMillis() : ctxt.getTimestamp();
-                EventLogger.getEventLogger().log(Event.generateReceivedEvent(msg, recipient, timestamp));
+                EventLogger logger = EventLogger.getEventLogger();
+                logger.log(Event.generateReceivedEvent(msg, recipient, timestamp));
+                try {
+                    if (getAccount().isContactAffinityEventLoggingEnabled()) {
+                        logger.log(Event.generateAffinityEvents(msg, recipient, timestamp));
+                    }
+                } catch (ServiceException e) {
+                    ZimbraLog.event.error("unable to determine whether AFFINITY event logging is enabled", e);
+                }
             }
         }
     }

--- a/store/src/java/com/zimbra/cs/service/mail/GetRelatedContacts.java
+++ b/store/src/java/com/zimbra/cs/service/mail/GetRelatedContacts.java
@@ -1,0 +1,68 @@
+package com.zimbra.cs.service.mail;
+
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.base.Strings;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.contacts.ContactAffinityStore;
+import com.zimbra.cs.contacts.RelatedContactsParams;
+import com.zimbra.cs.contacts.RelatedContactsParams.AffinityTarget;
+import com.zimbra.cs.contacts.RelatedContactsParams.AffinityType;
+import com.zimbra.cs.contacts.RelatedContactsResults;
+import com.zimbra.soap.ZimbraSoapContext;
+import com.zimbra.soap.mail.message.GetRelatedContactsRequest;
+import com.zimbra.soap.mail.message.GetRelatedContactsResponse;
+import com.zimbra.soap.mail.type.RelatedContactResult;
+import com.zimbra.soap.mail.type.RelatedContactsTarget;
+
+public class GetRelatedContacts extends MailDocumentHandler {
+
+    private static final int DEFAULT_CONTACT_SUGGEST_RESULT_LIMIT = 10;
+    private static final int MAX_CONTACT_SUGGEST_RESULT_LIMIT = 500;
+
+    @Override
+    public Element handle(Element request, Map<String, Object> context)
+            throws ServiceException {
+        ZimbraSoapContext zsc = getZimbraSoapContext(context);
+        Account acct = getRequestedAccount(zsc);
+        if (!acct.isFeatureRelatedContactsEnabled()) {
+            throw ServiceException.FAILURE("Related Contacts feature is not enabled", null);
+        }
+        GetRelatedContactsRequest req = zsc.elementToJaxb(request);
+        RelatedContactsParams params = new RelatedContactsParams(acct.getId());
+        List<RelatedContactsTarget> targets = req.getTargets();
+        if (targets.isEmpty()) {
+            throw ServiceException.INVALID_REQUEST("must specify at least one target contact", null);
+        }
+        for (RelatedContactsTarget target: targets) {
+            params.addTarget(AffinityTarget.fromSOAPTarget(target));
+        }
+        String requestedAffinity = req.getRequestedAffinity();
+        if (!Strings.isNullOrEmpty(requestedAffinity)) {
+            params.setRequestedAffinityType(AffinityType.of(requestedAffinity));
+        }
+        params.setLimit(parseLimit(req.getLimit()));
+        long maxAge = acct.getRelatedContactsMaxAge();
+        params.setDateCutoff(System.currentTimeMillis() - maxAge);
+        params.setMinOccurCount(acct.getRelatedContactsMinConcurrenceCount());
+        params.setIncludeIncomingMsgAffinity(acct.isContactAffinityEventLoggingEnabled());
+        ContactAffinityStore store = ContactAffinityStore.getFactory().getContactAffinityStore(acct.getId());
+        GetRelatedContactsResponse resp = new GetRelatedContactsResponse();
+        RelatedContactsResults results = store.getRelatedContacts(params);
+        for (RelatedContactResult result: results.getResults()) {
+            resp.addRelatedContact(result);
+        }
+        return zsc.jaxbToElement(resp);
+    }
+
+    private int parseLimit(Integer providedLimit) {
+        if (providedLimit == null || providedLimit <= 0) {
+            return DEFAULT_CONTACT_SUGGEST_RESULT_LIMIT;
+        } else {
+            return Math.min(providedLimit, MAX_CONTACT_SUGGEST_RESULT_LIMIT);
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/service/mail/MailService.java
+++ b/store/src/java/com/zimbra/cs/service/mail/MailService.java
@@ -104,6 +104,7 @@ public final class MailService implements DocumentService {
         dispatcher.registerHandler(MailConstants.EXPORT_CONTACTS_REQUEST, new ExportContacts());
         dispatcher.registerHandler(MailConstants.IMPORT_CONTACTS_REQUEST, new ImportContacts());
         dispatcher.registerHandler(MailConstants.GET_CONTACT_BACKUP_LIST_REQUEST, new GetContactBackupList());
+        dispatcher.registerHandler(MailConstants.GET_RELATED_CONTACTS_REQUEST, new GetRelatedContacts());
 
         // notes
         if (LC.notes_enabled.booleanValue()) {

--- a/store/src/java/com/zimbra/qa/unittest/TestRelatedContacts.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestRelatedContacts.java
@@ -1,0 +1,357 @@
+package com.zimbra.qa.unittest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.apache.solr.client.solrj.impl.HttpSolrClient.RemoteSolrException;
+import org.apache.solr.client.solrj.request.AbstractUpdateRequest.ACTION;
+import org.apache.solr.client.solrj.request.CollectionAdminRequest;
+import org.apache.solr.client.solrj.request.UpdateRequest;
+import org.apache.solr.common.params.CoreAdminParams;
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.Pair;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.contacts.AffinityScope;
+import com.zimbra.cs.contacts.ContactAffinityQuery;
+import com.zimbra.cs.contacts.RelatedContactsParams;
+import com.zimbra.cs.contacts.RelatedContactsParams.AffinityTarget;
+import com.zimbra.cs.contacts.RelatedContactsParams.AffinityType;
+import com.zimbra.cs.contacts.RelatedContactsResults;
+import com.zimbra.cs.contacts.RelatedContactsResults.RelatedContact;
+import com.zimbra.cs.event.Event;
+import com.zimbra.cs.event.Event.EventType;
+import com.zimbra.cs.event.logger.BatchingEventLogger;
+import com.zimbra.cs.event.logger.SolrEventCallback;
+import com.zimbra.cs.index.solr.JointCollectionLocator;
+import com.zimbra.cs.index.solr.SolrCloudHelper;
+import com.zimbra.cs.index.solr.SolrCollectionLocator;
+import com.zimbra.cs.index.solr.SolrConstants;
+import com.zimbra.cs.index.solr.SolrUtils;
+import com.zimbra.cs.mime.ParsedAddress;
+
+public class TestRelatedContacts {
+    private static CloudSolrClient client;
+    private static String zkHost;
+    private static String USER_NAME = "TestRelatedContacts";
+    private static Account acct;
+    private static BatchingEventLogger eventLogger;
+    private static String EVENT_COLLECTION_NAME = "TestRelatedContacts";
+    private static SolrCloudHelper helper;
+    private int idCounter = 0;
+
+    @BeforeClass
+    public static void init() throws Exception {
+        String solrUrl = Provisioning.getInstance().getLocalServer().getEventBackendURL();
+        Assume.assumeTrue(solrUrl.startsWith("solrcloud"));
+        zkHost = solrUrl.substring("solrcloud:".length());
+        client = SolrUtils.getCloudSolrClient(zkHost);
+        cleanUp();
+        acct = TestUtil.createAccount(USER_NAME);
+        acct.setContactAffinityEventLoggingEnabled(true);
+        CloudSolrClient solrClient = SolrUtils.getCloudSolrClient(zkHost);
+        SolrCollectionLocator locator = new JointCollectionLocator(EVENT_COLLECTION_NAME);
+        helper = new SolrCloudHelper(locator, solrClient, SolrConstants.CONFIGSET_EVENTS);
+        SolrEventCallback callback = new SolrEventCallback(helper);
+        eventLogger = new BatchingEventLogger(10, 1000, callback);
+    }
+
+    private void logOutgoingMsgEvents(int nTimes, long timestamp, Recipient... recipients) throws Exception {
+        for (int i=0; i<nTimes; i++) {
+            for (Event event: getOutgoingEvents(idCounter++, timestamp, recipients)) {
+                eventLogger.log(event);
+            }
+        }
+        eventLogger.sendAllBatched();
+        commit();
+    }
+
+    private void logIncomingMsgEvents(int nTimes, long timestamp, String sender, Recipient... recipients) throws Exception {
+        for (int i=0; i<nTimes; i++) {
+            for (Event event: getIncomingEvents(idCounter++, timestamp, sender, recipients)) {
+                eventLogger.log(event);
+            }
+        }
+        eventLogger.sendAllBatched();
+        commit();
+    }
+
+    private static Recipient recip(String recipType, String name) {
+        return new Recipient(recipType, name);
+    }
+
+    private List<Event> getIncomingEvents(int msgId, long timestamp, String sender, Recipient... recipients) {
+        List<Event> events = new ArrayList<>();
+        for (Recipient recipient: recipients) {
+            Event event = Event.generateEvent(acct.getId(), msgId, sender, recipient.addr, EventType.AFFINITY, null, recipient.type, timestamp);
+            events.add(event);
+        }
+        return events;
+    }
+
+    private List<Event> getOutgoingEvents(int msgId, long timestamp, Recipient... recipients) {
+        List<Event> events = new ArrayList<>();
+        for (Recipient recipient: recipients) {
+            Event event = Event.generateSentEvent(acct.getId(), msgId, acct.getName(), recipient.addr, null, recipient.type, timestamp);
+            events.add(event);
+        }
+        return events;
+    }
+
+    private static void deleteCollection(String collection) {
+        CollectionAdminRequest.Delete deleteCollectionRequest = CollectionAdminRequest.deleteCollection(collection);
+        try {
+            deleteCollectionRequest.process(client);
+        } catch (RemoteSolrException | SolrServerException | IOException e) {
+            //collection may not exist, that's OK
+        }
+    }
+
+    protected void commit() throws Exception {
+        UpdateRequest commitReq = new UpdateRequest();
+        commitReq.setAction(ACTION.COMMIT, true, true);
+        commitReq.setParam(CoreAdminParams.COLLECTION, EVENT_COLLECTION_NAME);
+        commitReq.process(client);
+    }
+
+    public static void cleanUp() throws Exception {
+        TestUtil.deleteAccountIfExists(USER_NAME);
+        deleteCollection(EVENT_COLLECTION_NAME);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        cleanUp();
+        client.close();
+    }
+
+    private void testResult(RelatedContact contact, String expectedName, AffinityScope expectedScope, Integer expectedCount) {
+        assertEquals("wrong affinity scope", expectedScope.getLevel(), contact.getScope());
+        assertEquals("wrong contact", expectedName, contact.getName());
+        if (expectedCount != null) {
+            assertEquals("wrong count", new Double(expectedCount.intValue()), new Double(contact.getScore()));
+        }
+    }
+
+    private List<RelatedContact> runQuery(RelatedContactsParams params, AffinityScope scope) throws Exception {
+        RelatedContactsResults relateContacts = new ContactAffinityQuery(helper, params).execute(scope);
+        return relateContacts.getResults();
+    }
+
+    @Test
+    public void testOutgoingAffinity() throws Exception {
+        long timestamp = System.currentTimeMillis();
+        logOutgoingMsgEvents(4, timestamp, recip("to", "A"), recip("to", "B"), recip("cc", "C"), recip("bcc", "D"));
+        logOutgoingMsgEvents(3, timestamp, recip("to", "A"), recip("to", "B"));
+        logOutgoingMsgEvents(2, timestamp, recip("to", "A"), recip("to", "C"));
+        logOutgoingMsgEvents(1, timestamp, recip("to", "D"), recip("to", "E"), recip("cc", "F"));
+
+        RelatedContactsParams params = new RelatedContactsParams(acct.getId());
+        params.addTarget(new AffinityTarget(AffinityType.to, "A"));
+
+        List<RelatedContact> results = runQuery(params, AffinityScope.OUTGOING_EXACT_MATCH);
+        assertEquals("should see 3 related contacts", 3, results.size());
+        testResult(results.get(0), "B", AffinityScope.OUTGOING_EXACT_MATCH, 7);
+        testResult(results.get(1), "C", AffinityScope.OUTGOING_EXACT_MATCH, 6);
+        testResult(results.get(2), "D", AffinityScope.OUTGOING_EXACT_MATCH, 4);
+
+        params.setRequestedAffinityType(AffinityType.to);
+
+        results = runQuery(params, AffinityScope.OUTGOING_EXACT_MATCH);
+        assertEquals("should see 2 related contacts for 'to' affinity", 2, results.size());
+        testResult(results.get(0), "B", AffinityScope.OUTGOING_EXACT_MATCH, 7);
+        testResult(results.get(1), "C", AffinityScope.OUTGOING_EXACT_MATCH, 2);
+
+        params.setRequestedAffinityType(AffinityType.cc);
+
+        results = runQuery(params, AffinityScope.OUTGOING_EXACT_MATCH);
+        assertEquals("should see 1 related contacts for 'cc' affinity", 1, results.size());
+        testResult(results.get(0), "C", AffinityScope.OUTGOING_EXACT_MATCH, 4);
+
+        params.setRequestedAffinityType(AffinityType.bcc);
+
+        results = runQuery(params, AffinityScope.OUTGOING_EXACT_MATCH);
+        assertEquals("should see 1 related contacts for 'bcc' affinity", 1, results.size());
+        testResult(results.get(0), "D", AffinityScope.OUTGOING_EXACT_MATCH, 4);
+
+        //test multiple targets
+        params.addTarget(new AffinityTarget(AffinityType.to, "B"));
+        params.addTarget(new AffinityTarget(AffinityType.cc, "C"));
+
+        params.setRequestedAffinityType(AffinityType.bcc);
+
+        results = runQuery(params, AffinityScope.OUTGOING_EXACT_MATCH);
+        assertEquals("should see 1 contact related to [A,B,C]", 1, results.size());
+        testResult(results.get(0), "D", AffinityScope.OUTGOING_EXACT_MATCH, 4);
+
+        //test slightly broader affinity scope that doesn't take into account which fields the targets are in
+        params = new RelatedContactsParams(acct.getId());
+        params.addTarget(new AffinityTarget(AffinityType.cc, "A"));
+        params.addTarget(new AffinityTarget(AffinityType.cc, "B"));
+        params.addTarget(new AffinityTarget(AffinityType.cc, "C"));
+        params.setRequestedAffinityType(AffinityType.all);
+
+        results = runQuery(params, AffinityScope.OUTGOING_EXACT_MATCH);
+        assertTrue("shouldn't find any contacts related to [A,B,C] for the wrong fields", results.isEmpty());
+
+        results = runQuery(params, AffinityScope.OUTGOING_EXACT_MATCH_ANY_FIELD);
+        testResult(results.get(0), "D", AffinityScope.OUTGOING_EXACT_MATCH_ANY_FIELD, 4);
+
+        // test broad match affinity
+        params = new RelatedContactsParams(acct.getId());
+        params.addTarget(new AffinityTarget(AffinityType.to, "A"));
+        params.addTarget(new AffinityTarget(AffinityType.to, "D"));
+        params.setRequestedAffinityType(AffinityType.to);
+
+        results = runQuery(params, AffinityScope.OUTGOING_BROAD_MATCH);
+        assertEquals("should see 3 contacts related to [A,D] with broad match", 3, results.size());
+        testResult(results.get(0), "B", AffinityScope.OUTGOING_BROAD_MATCH, 7);
+        testResult(results.get(1), "C", AffinityScope.OUTGOING_BROAD_MATCH, 2);
+        testResult(results.get(2), "E", AffinityScope.OUTGOING_BROAD_MATCH, 1);
+
+        // test broad match affinity ignoring target fields
+        params = new RelatedContactsParams(acct.getId());
+        params.addTarget(new AffinityTarget(AffinityType.cc, "A"));
+        params.addTarget(new AffinityTarget(AffinityType.cc, "D"));
+        params.setRequestedAffinityType(AffinityType.to);
+
+        results = runQuery(params, AffinityScope.OUTGOING_BROAD_MATCH_ANY_FIELD);
+        assertEquals("should see 3 contacts related to [A,D] with broad match", 3, results.size());
+        testResult(results.get(0), "B", AffinityScope.OUTGOING_BROAD_MATCH_ANY_FIELD, 7);
+        testResult(results.get(1), "C", AffinityScope.OUTGOING_BROAD_MATCH_ANY_FIELD, 2);
+        testResult(results.get(2), "E", AffinityScope.OUTGOING_BROAD_MATCH_ANY_FIELD, 1);
+    }
+
+    @Test
+    public void testIncomingAffinity() throws Exception {
+        long timestamp = System.currentTimeMillis();
+        // receiving emails from A that also contain B and C
+        logIncomingMsgEvents(4, timestamp, toAddr("A"), recip("to", "B"), recip("cc", "C"));
+        // receiving emails from D that also contain B and E
+        logIncomingMsgEvents(3, timestamp, toAddr("D"), recip("to", "B"), recip("cc", "E"));
+        // receiving emails from Z that also contain X and Y
+        logIncomingMsgEvents(2, timestamp, toAddr("Z"), recip("to", "X"), recip("to", "Y"));
+
+        RelatedContactsParams params = newParams();
+        params.addTarget(new AffinityTarget(AffinityType.to, "A"));
+        params.addTarget(new AffinityTarget(AffinityType.to, "B"));
+        List<RelatedContact> results = runQuery(params, AffinityScope.INCOMING_FROM_TARGET);
+        assertEquals("should see 1 contact related to [A,B]", 1, results.size());
+        testResult(results.get(0), "C", AffinityScope.INCOMING_FROM_TARGET, 4);
+
+        params = newParams();
+        params.addTarget(new AffinityTarget(AffinityType.to, "B"));
+        results = runQuery(params, AffinityScope.INCOMING_FROM_ANY_SENDER);
+        assertEquals("should see 2 contacts related to [A,B]", 2, results.size());
+        testResult(results.get(0), "C", AffinityScope.INCOMING_FROM_ANY_SENDER, 4);
+        testResult(results.get(1), "E", AffinityScope.INCOMING_FROM_ANY_SENDER, 3);
+
+        //add another target from a different affinity group
+        params.addTarget(new AffinityTarget(AffinityType.to, "X"));
+        results = runQuery(params, AffinityScope.INCOMING_FROM_ANY_SENDER);
+        assertEquals("should see 2 contacts related to [A,B,X]", 3, results.size());
+        testResult(results.get(0), "C", AffinityScope.INCOMING_FROM_ANY_SENDER, 4);
+        testResult(results.get(1), "E", AffinityScope.INCOMING_FROM_ANY_SENDER, 3);
+        testResult(results.get(2), "Y", AffinityScope.INCOMING_FROM_ANY_SENDER, 2);
+    }
+
+    @Test
+    public void testTimeCutoff() throws Exception {
+        long timestamp = System.currentTimeMillis();
+        logOutgoingMsgEvents(2, timestamp-2000, recip("to", "A"), recip("to", "B"), recip("cc", "C"));
+        logOutgoingMsgEvents(1, timestamp, recip("to", "A"), recip("to", "B"));
+
+        RelatedContactsParams params = newParams();
+        params.addTarget(new AffinityTarget(AffinityType.to, "A"));
+        params.setRequestedAffinityType(AffinityType.all);
+
+        //sanity check
+        List<RelatedContact> results = runQuery(params, AffinityScope.OUTGOING_EXACT_MATCH);
+        assertEquals("should see 2 related contacts", 2, results.size());
+        testResult(results.get(0), "B", AffinityScope.OUTGOING_EXACT_MATCH, 3);
+        testResult(results.get(1), "C", AffinityScope.OUTGOING_EXACT_MATCH, 2);
+
+        //this should exclude the first two messages
+        params.setDateCutoff(timestamp-1000);
+        results = runQuery(params, AffinityScope.OUTGOING_EXACT_MATCH);
+        assertEquals("should see 1 related contact", 1, results.size());
+        testResult(results.get(0), "B", AffinityScope.OUTGOING_EXACT_MATCH, 1);
+    }
+
+    @Test
+    public void testMinCooccur() throws Exception {
+        long timestamp = System.currentTimeMillis();
+        logOutgoingMsgEvents(2, timestamp, recip("to", "A"), recip("to", "B"));
+        logOutgoingMsgEvents(1, timestamp, recip("to", "A"), recip("to", "C"));
+
+        RelatedContactsParams params = newParams();
+        params.addTarget(new AffinityTarget(AffinityType.to, "A"));
+        params.setMinOccurCount(2);
+        List<RelatedContact> results = runQuery(params, AffinityScope.OUTGOING_EXACT_MATCH);
+        assertEquals("should see 1 related contact when minOccur=2", 1, results.size());
+        testResult(results.get(0), "B", AffinityScope.OUTGOING_EXACT_MATCH, 2);
+    }
+
+    @Test
+    public void testExpandingScope() throws Exception {
+        long timestamp = System.currentTimeMillis();
+        //exact outgoing match
+        logOutgoingMsgEvents(6, timestamp, recip("to", "A"), recip("to", "B"), recip("to", "C"));
+        //field-agnostic exact outgoing match
+        logOutgoingMsgEvents(5, timestamp, recip("to", "A"), recip("cc", "B"), recip("cc", "D"));
+        //partial outgoing match
+        logOutgoingMsgEvents(4, timestamp, recip("to", "A"), recip("to", "E"));
+        //partial field-agnostic outgoing match
+        logOutgoingMsgEvents(3, timestamp, recip("cc", "A"), recip("to", "F"));
+
+        //incoming match through target
+        logIncomingMsgEvents(2, timestamp, toAddr("A"), recip("to", "B"), recip("cc", "G"));
+        //incoming match though non-target
+        logIncomingMsgEvents(1, timestamp, toAddr("X"), recip("to", "B"), recip("to", "H"));
+
+        RelatedContactsParams params = newParams();
+        params.setLimit(10);
+        params.addTarget(new AffinityTarget(AffinityType.to, "A"));
+        params.addTarget(new AffinityTarget(AffinityType.to, "B"));
+        params.setIncludeIncomingMsgAffinity(true);
+        RelatedContactsResults relatedContacts = new ContactAffinityQuery(helper, params).executeWithExpandingScope();
+        List<RelatedContact> results = relatedContacts.getResults();
+        assertEquals("should see 6 related contacts", 6, results.size());
+        testResult(results.get(0), "C", AffinityScope.OUTGOING_EXACT_MATCH, 6);
+        testResult(results.get(1), "D", AffinityScope.OUTGOING_EXACT_MATCH_ANY_FIELD, 5);
+        testResult(results.get(2), "E", AffinityScope.OUTGOING_BROAD_MATCH, 4);
+        testResult(results.get(3), "F", AffinityScope.OUTGOING_BROAD_MATCH_ANY_FIELD, 3);
+        testResult(results.get(4), "G", AffinityScope.INCOMING_FROM_TARGET, 2);
+        testResult(results.get(5), "H", AffinityScope.INCOMING_FROM_ANY_SENDER, 1);
+    }
+
+    private RelatedContactsParams newParams() {
+        return new RelatedContactsParams(acct.getId());
+    }
+
+    private static String toAddr(String name) {
+        return String.format("%s <%s@zimbra.com>", name, name);
+    }
+    private static class Recipient extends Pair<String, String> {
+
+        private String type;
+        private String addr;
+
+        public Recipient(String recipType, String name) {
+            super(recipType, toAddr(name));
+            this.type = getFirst();
+            this.addr = getSecond();
+        }
+    }
+}

--- a/store/src/java/com/zimbra/qa/unittest/TestSolrCloudEventStore.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestSolrCloudEventStore.java
@@ -1,16 +1,8 @@
 package com.zimbra.qa.unittest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
 
 import org.apache.solr.client.solrj.SolrQuery;
-import org.apache.solr.client.solrj.SolrRequest.METHOD;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.impl.HttpSolrClient.RemoteSolrException;
@@ -19,20 +11,14 @@ import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.client.solrj.response.QueryResponse;
-import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.params.CoreAdminParams;
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.BeforeClass;
-import org.junit.Test;
 
 import com.zimbra.cs.account.Provisioning;
-import com.zimbra.cs.event.Event;
 import com.zimbra.cs.event.SolrCloudEventStore;
-import com.zimbra.cs.event.SolrEventStore;
-import com.zimbra.cs.event.Event.EventContextField;
-import com.zimbra.cs.event.Event.EventType;
 import com.zimbra.cs.event.logger.SolrEventCallback;
 import com.zimbra.cs.index.solr.AccountCollectionLocator;
 import com.zimbra.cs.index.solr.JointCollectionLocator;

--- a/store/src/java/com/zimbra/qa/unittest/ZimbraSuite.java
+++ b/store/src/java/com/zimbra/qa/unittest/ZimbraSuite.java
@@ -164,6 +164,7 @@ public class ZimbraSuite  {
         sClasses.add(TestSearchHistory.class);
         sClasses.add(TestSolrCloudEventStore.class);
         sClasses.add(TestStandaloneSolrEventStore.class);
+        sClasses.add(TestRelatedContacts.class);
     }
 
     /**


### PR DESCRIPTION
This PR introduces "Related Contacts" functionality to ZCS.

### Concepts
This implementation of contact affinity is based on co-occurrence, derived from event data stored in solr and calculated using the Solrcloud Streaming API. This has the benefit of not requiring a separate datastore or dedicated indexes, as the data already exists.

The basic premise is that contacts that co-occur on emails are related. There are various considerations (see "Affinity Scope" below), but the high-level algorithm is this:
1) Given one or more target contacts, find IDs of messages associated with these contacts
2) Find other contacts that were included on these messages, optionally constrained to the requested field (to/cc/bcc)
3) Sort by occurrence count

#### Streaming API
The steps above map neatly to Solr streaming queries.
- IDs of messages associated with the target contacts are fetched using the `search` stream.
- `merge` and `intersect` streams are used to combine the results of multiple `search` streams in cases when there is more than one target contact.
- The `gatherNodes` stream walks from these message IDs to other contacts included on these messages, excluding the targets themselves. Multiple instances of co-occurrence are aggregated in a `count` field.
- The `top` stream decorator lets us sort the results by count, outputting the top related contacts
- The custom `ContactDedupeTupleStream` stream lets us de-duplicate results on email addresses, for cases when the event address data is denormalized. For example, tuples for "ilya.raykin@synacor.com" and "Ilya Raykin <ilya.raykin@synacor.com>" would be merged.

For more information, see https://lucene.apache.org/solr/guide/6_6/streaming-expressions.html

### Affinity Scope 
While the concept of co-occurrence affinity is simple, the devil is in the details.  "Affinity Scope" is introduced to manage the context within which a contact may be related to one or more targets.

#### Incoming vs Outgoing affinity
There are two high-level ways to calculate co-occurrence affinity. 
The first is via outgoing messages. If I often email contacts _A_ and _B_, then _A_ and _B_ are related. This type of affinity can be calculated from the existing `SENT` event data, since these events contains message ID and recipient information.
The second is via incoming messages. The idea is that if I receive messages from _C_ that also include _A_ and _B_ as recipients, then _A_ and _B_ are related. This allows us to make recommendations for contacts that the user has never directly emailed, although the affinity may not be as strong as for outgoing messages.
The downside of incoming message affinity is that it requires a new event type, since we need a separate event for each recipient other than the user. The new `AFFINITY` event is introduced for this purpose. Since this increases the event index size, `AFFINITY` event generation can be turned off, which disables incoming message affinity calculations.

#### Exact Field Matching
The Related Contacts API allows the client to specify which field each target contact is in.
This would be used when composing an email, where each target contact is in one of the _to_, _cc_, or _bcc_ fields. It is then possible to constrain the initial search to only those messages where the contacts occur in the same fields. For example, if the user emails _A_ and cc's _B_ and _C_, this allows us to recommend _C_ _only if_ the user begins to compose and email with _A_ and _B_ in the "to" and "cc" field, respectively.
An affinity scope in which this is turned off would be agnostic of which fields the targets occur in. In the example above, _C_ would be related to _A_ and _B_ even if _A_ and _B_ are both in the "to" field.

#### Union vs Intersection
When calculating outgoing co-occurrence for multiple targets, we can either traverse from messages that _all_ of the targets appear in, or only _some_. The latter provides more results, and is likely to prioritize results which co-occur with more targets, but may have false positives. This is useful when composing an email to a new contact that also includes a group of related contacts.
For example a user often emails _A_, _B_, _C_, but never _X_. If he now writes an email to _X_ that includes _A_ and _B_, _C_ can still be recommended.

#### Incoming Affinity Through Target
The last option pertains only to incoming message affinity. Assume _A_ emails the user with _B_ and _C_ also addressed. If the user composes an email to _A_ and _B_, then _C_ is related _through_ _A_ and would be recommended provided that incoming affinity is enabled. However, if _B_ is the _only_ target, then we have the option of whether to still recommend _C_. This is the loosest form of co-occurrence: incoming message co-occurrence through a sender who is not one of the targets.

#### Currently Defined Scopes
With all that said, here are the affinity scopes that are currently defined, in order of decreasing precedence:

##### OUTGOING_EXACT_MATCH (scope 0)
This scope matches contacts that the user emails along with ALL of the targets, with the targets occurring in the same fields. For example, if the user emails _A_, and cc's _B_ and _C_, then this scope would treat _C_ as a related contact for the targets _to:A_, _cc:B_

##### OUTGOING_EXACT_MATCH_ANY_FIELD (scope 1)
This scope is like the one above, except it is agnostic of which fields the targets appear on in the source messages. With the above example, this scope would treat _C_ as a related contact for the targets _to:A_, _to:B_

##### OUTGOING_BROAD_MATCH (scope 2)
This scope loosens the restriction to match _any_ of the targets. With the above example, it would treat _C_ as a related contact for the targets _to:X_, _to:A_.

##### OUTGOING_BROAD_MATCH_ANY_FIELD (scope 3)
Like above, but agnostic of which fields the targets appear in. _C_ would be a related contact for the targets _to:X_, _cc:A_.

##### INCOMING_FROM_TARGET (scope 4)
This is the first of the two incoming message scopes. If the user receives emails from _A_ that also address _B_ and _C_, then this scope would consider _C_ related to the targets _A_ and _B_. Note that incoming message affinity does not currently take into account the target fields. Also, notice that at least two targets are necessary for this scope, as each target is treated as a potential sender with the other targets as recipients.

##### INCOMING_FROM_ANY_SENDER (scope 5)
Expands on the previous scope to allow for incoming affinity from ANY sender, not just a target. With the previous example, this scope would treat _C_ as related to the target _B_ simply because an external contact _A_ has emailed both of them.

#### Scope Expansion
The API does not actually let the client define the scope. Instead, the client simply requests a number of related contacts to return. The server begins at the narrow-most scope (OUTGOING_EXACT_MATCH) and runs the query. If the number of results at at scope is less than the requested number, the scope is expanded, with the previous results passed in as filters to avoid duplicates. This is repeated until the requested number of contacts is reached or exceeded. The scope at which each result is found is returned in the response as an integer, to allow the client to potentially delineate between different "levels" of affinity.

### Caching
We want to avoid re-running the same contact affinity calculation every time, since it is a non-trivial operation. To this end, a caching layer is included. Results for the same set of targets and for the same target field are cached for a specified time. The cache values include related contacts from all affinity scopes up to and including the scope that found sufficient results, which may exceed the initial number of requested results; the result set is trimmed to the requested number after a cache hit. This allows us to use the cache for a subsequent request that has a higher limit. If there is a cache hit but the requested number exceeds the number of cached related contacts, the query is re-run.
The cache implementation provided with this PR is a simple in-memory cache using Guava. It may be worthwhile to implement a persistent cache that can survive mailbox restarts, but I deemed that outside the scope of this ticket.

### API
The `GetRelatedContactsRequest`takes one or more `targetContact` element, which contains the email of the contact and an optional attribute specifying the field (to/cc/bcc) that contact is in. The request also has an optional `requestedField` attribute that specifies which field the related contacts are requested for. It also takes an optional `limit` attribute that specifies how many related contacts should be returned.

`GetRelatedContactsResponse` contains a list of `relatedContact` elements. Each element contains the email address of the related contact, as well as the personal part (if available) and affinity scope within which the contact was first found. The scope is an integer; the lower the number the more narrow the scope and the closer the relation is between the contact and the targets.

When used to recommend contacts while composing an email, the `requestedField` request attribute and  `field` attribute of target contacts should be set, representing the current set of recipients and the field where the user is typing. When used to find general related contacts, these fields can be left blank.

####  zmmailbox support
The `zmmailbox` CLI supports fetching related contacts. The command is `getRelatedContacts` or `grc`. One or more targets can be specified, optionally prefixed with a colon-separated field. The requested affinity field and limit can be specified with the `field:` and `limit:` options.

### LDAP attributes
Several new LDAP attributes have been added for this feature.
- `zimbraFeatureRelatedContactsEnabled`: whether this feature is enabled for an account/COS
- `zimbraRelatedContactsMinCooccurrenceCount`: the minimum number of co-occurrences that two contacts need in order to be considered related. Defaults to 1.
- `zimbraRelatedContactsMaxAge`: the time window within which co-occurrence is calculated; affinity outside of this range is "forgotten". Defaults to 1 year.
- `zimbraAffinityEventLoggingEnabled`: whether the server should log `AFFINITY` events that allow for incoming message affinity to be calculated.

### Examples
The following two examples are based on an import of my Synacor mailbox into my dev environment.

The first example answers the question "who should I CC on an email where Greg and Gordon are on the 'to' field?"
```
mbox test> grc to:greg.solovyev to:gordon.tillman field:cc
Related Contacts
-----------------------------------------------------
[scope=0] gren.elliot@synacor.com (Gren Elliot)
[scope=0] matthew.fonck@synacor.com (matthew fonck)
[scope=0] travis.mclane@synacor.com (Travis Mclane)
[scope=1] chinmay.pathak@synacor.com (chinmay pathak)
[scope=1] rohan.ambasta@synacor.com (Rohan Ambasta)
[scope=1] tmclane@gmail.com (Travis McLane)
[scope=1] sneha.patil@synacor.com (Sneha Patil)
[scope=1] rupali.desai@synacor.com (Rupali Desai)
[scope=1] sandesh.almeida@synacor.com (Sandesh Almeida)
[scope=1] prashant.surana@synacor.com (Prashant Surana)
```

And here is a more general query for "which contacts are related to Varun?" (my email address shows up because this query is run from a different account; normally it would be filtered out).
```
mbox test> grc varun.risbud                 
Related Contacts
---------------------------------------------------------
[scope=0] michael.medellin@synacor.com (michael medellin)
[scope=0] JMead@synacor.com (Jon Mead)
[scope=0] BWang@synacor.com (Bo Wang)
[scope=0] matthew.fonck@synacor.com (matthew fonck)
[scope=0] michaeltoutonghi@gmail.com (michaeltoutonghi)
[scope=0] john.eastman@synacor.com (John Eastman)
[scope=5] ilya.raykin@synacor.com (ilya raykin)
[scope=5] erynn.petersen@synacor.com (Erynn Petersen)
[scope=5] davide.baldo@zextras.com (Davide Baldo)
[scope=5] sdavi@synacor.com (Steve Davi)
```

#### UPDATE 11/28
As per Gren's recommendation, the `RelatedContact` inner class subclasses the `RelatedContactResult` SOAP class. This removes the need for the `GetRelatedContacts` SOAP handler to convert between the two classes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zimbra/zm-mailbox/436)
<!-- Reviewable:end -->
