### PR TITLE
Bug 102931: Add missing angle brackets to Return-Path

### DIFF
--- a/store/src/java/com/zimbra/cs/lmtpserver/LmtpHandler.java
+++ b/store/src/java/com/zimbra/cs/lmtpserver/LmtpHandler.java
@@ -485,12 +485,11 @@ public abstract class LmtpHandler extends ProtocolHandler {
         StringBuilder headers = new StringBuilder();
 
         // Assemble Return-Path header
+        String sender = "";
         if (mEnvelope.hasSender()) {
-            String sender = mEnvelope.getSender().getEmailAddress();
-            if (!StringUtil.isNullOrEmpty(sender)) {
-                headers.append(String.format("Return-Path: %s\r\n", sender));
-            }
+            sender = mEnvelope.getSender().getEmailAddress();
         }
+        headers.append(String.format("Return-Path: <%s>\r\n", sender));
 
         // Assemble Received header
         String localHostname = "unknown";


### PR DESCRIPTION
For quite a while now Zimbra has generated a broken `Return-Path` header without the mandatory angle brackets.  Additionally, it didn't add a `Return-Path` at all for an empty envelope sender. This tends to confuse some scripts I have.

[RFC 5322 section 3.6.7.](https://tools.ietf.org/html/rfc5322#section-3.6.7) says:
> The "Return-Path:" header field contains a pair of angle brackets
> that enclose an optional addr-spec.

This patch makes sure the `Return-Path` header is always set and the (optional) address value is enclosed in angle brackets.

To verify this I used the following `swaks` invocations:

**With regular Envelope Sender**
```bash
swaks --to admin@$(hostname -f) --from test@example.com --protocol LMTP --server 127.0.0.1 --port 7025
```
Before:
```
Return-Path: test@example.com
Received: from localhost (LHLO zm-build-2.labs.msquadrat.de) (127.0.0.1) by
 zm-build-2.labs.msquadrat.de with LMTP; Thu, 23 Nov 2017 11:03:34 +0100
 (CET)
```
After:
```
Return-Path: <test@example.com>
Received: from localhost (LHLO zm-build-2.labs.msquadrat.de) (127.0.0.1) by
 zm-build-2.labs.msquadrat.de with LMTP; Thu, 23 Nov 2017 11:37:18 +0100
 (CET)
```

**With empty Envelope Sender**
```bash
swaks --to admin@$(hostname -f) --from '<>' --protocol LMTP --server 127.0.0.1 --port 7025
```
Before:
```
Received: from localhost (LHLO zm-build-2.labs.msquadrat.de) (127.0.0.1) by
 zm-build-2.labs.msquadrat.de with LMTP; Thu, 23 Nov 2017 11:14:23 +0100
 (CET)
```
After:
```
Return-Path: <>
Received: from localhost (LHLO zm-build-2.labs.msquadrat.de) (127.0.0.1) by
 zm-build-2.labs.msquadrat.de with LMTP; Thu, 23 Nov 2017 11:37:13 +0100
 (CET)
```
