### PR TITLE
ZCS-3785 move setup call after commandline processing

### DIFF
--- a/store/src/java/com/zimbra/cs/redolog/util/PlaybackUtil.java
+++ b/store/src/java/com/zimbra/cs/redolog/util/PlaybackUtil.java
@@ -359,7 +359,6 @@ public class PlaybackUtil {
         // Bug: 47051
         // for the CLI utilities we need to set the default soap http transport timeout to 0 (no timeout).
         CliUtil.setCliSoapHttpTransportTimeout();
-        setup();
         try {
             CommandLine cl = parseArgs(cmdlineargs);
             Params params = initParams(cl);
@@ -367,7 +366,7 @@ public class PlaybackUtil {
                 usage(null);
                 System.exit(0);
             }
-
+            setup();
             PlaybackUtil player = new PlaybackUtil(params);
             player.playback();
         } finally {


### PR DESCRIPTION
The 'setup' call initializes all the underlying subsystems which cause the EHCache lock subsystem to hang.

There is no need to execute this before processing the command-line arguments.
Moving the location of the 'setup' call to after the processing of the command-line arguments avoids a thread-lock which was seen when running the `zmplayredo -h` command.

