### PR TITLE
Bugfix/zimbra 94 contact frequency graph

### DIFF
--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -169,6 +169,8 @@ import com.zimbra.soap.mail.message.CreateSearchFolderResponse;
 import com.zimbra.soap.mail.message.DeleteDataSourceRequest;
 import com.zimbra.soap.mail.message.GetAppointmentRequest;
 import com.zimbra.soap.mail.message.GetAppointmentResponse;
+import com.zimbra.soap.mail.message.GetContactFrequencyRequest;
+import com.zimbra.soap.mail.message.GetContactFrequencyResponse;
 import com.zimbra.soap.mail.message.GetDataSourcesRequest;
 import com.zimbra.soap.mail.message.GetDataSourcesResponse;
 import com.zimbra.soap.mail.message.GetFilterRulesRequest;
@@ -6546,6 +6548,10 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
             req.setLimit(limit);
         }
         return invokeJaxb(req);
+    }
+
+    public GetContactFrequencyResponse getContactFrequency(String email, String frequencyBy) throws ServiceException {
+        return invokeJaxb(new GetContactFrequencyRequest(email, frequencyBy));
     }
 
     public static class OpenIMAPFolderParams {

--- a/common/src/java/com/zimbra/common/soap/MailConstants.java
+++ b/common/src/java/com/zimbra/common/soap/MailConstants.java
@@ -1396,4 +1396,15 @@ public final class MailConstants {
     public static final String E_RELATED_CONTACTS = "relatedContacts";
     public static final String E_RELATED_CONTACT = "relatedContact";
     public static final String A_AFFINITY_SCOPE = "scope";
+
+    // Contact Analytics
+    public static final String E_GET_CONTACT_FREQUENCY_REQUEST = "GetContactFrequencyRequest";
+    public static final String E_GET_CONTACT_FREQUENCY_RESPONSE = "GetContactFrequencyResponse";
+    public static final QName GET_CONTACT_FREQUENCY_REQUEST = QName.get(E_GET_CONTACT_FREQUENCY_REQUEST, NAMESPACE);
+    public static final QName GET_CONTACT_FREQUENCY_RESPONSE = QName.get(E_GET_CONTACT_FREQUENCY_RESPONSE, NAMESPACE);
+    public static final String A_CONTACT_FREQUENCY_BY = "by";
+    public static final String E_CONTACT_FREQUENCY_DATA = "data";
+    public static final String E_CONTACT_FREQUENCY_DATA_POINT = "dataPoint";
+    public static final String A_CONTACT_FREQUENCY_LABEL = "label";
+    public static final String A_CONTACT_FREQUENCY_VALUE = "value";
 }

--- a/soap/src/java/com/zimbra/soap/JaxbUtil.java
+++ b/soap/src/java/com/zimbra/soap/JaxbUtil.java
@@ -846,6 +846,8 @@ public final class JaxbUtil {
             com.zimbra.soap.mail.message.GetCommentsResponse.class,
             com.zimbra.soap.mail.message.GetContactBackupListRequest.class,
             com.zimbra.soap.mail.message.GetContactBackupListResponse.class,
+            com.zimbra.soap.mail.message.GetContactFrequencyRequest.class,
+            com.zimbra.soap.mail.message.GetContactFrequencyResponse.class,
             com.zimbra.soap.mail.message.GetContactsRequest.class,
             com.zimbra.soap.mail.message.GetContactsResponse.class,
             com.zimbra.soap.mail.message.GetConvRequest.class,

--- a/soap/src/java/com/zimbra/soap/mail/message/GetContactFrequencyRequest.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/GetContactFrequencyRequest.java
@@ -1,0 +1,36 @@
+package com.zimbra.soap.mail.message;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.MailConstants;
+
+@XmlRootElement(name=MailConstants.E_GET_CONTACT_FREQUENCY_REQUEST)
+public class GetContactFrequencyRequest {
+
+    public GetContactFrequencyRequest() {}
+
+    public GetContactFrequencyRequest(String email, String frequencyBy) {
+        setEmail(email);
+        setFrequencyBy(frequencyBy);
+    }
+    /**
+     * @zm-api-field-description Email address of the contact to fetch contact frequency for
+     */
+    @XmlAttribute(name=MailConstants.A_EMAIL, required=true)
+    private String contactEmail;
+
+    /**
+     * @zm-api-field-description Comma-separated list of frequency graphs to return.
+     * Values are one or more of "day,week,month".
+     */
+    @XmlAttribute(name=MailConstants.A_CONTACT_FREQUENCY_BY, required=true)
+    private String frequencyBy;
+
+    public String getEmail() { return contactEmail; }
+    public void setEmail(String email) { this.contactEmail = email; }
+
+    public String getFrequencyBy() { return frequencyBy; }
+    public void setFrequencyBy(String frequencyBy) { this.frequencyBy = frequencyBy; }
+
+}

--- a/soap/src/java/com/zimbra/soap/mail/message/GetContactFrequencyResponse.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/GetContactFrequencyResponse.java
@@ -1,0 +1,22 @@
+package com.zimbra.soap.mail.message;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.MailConstants;
+import com.zimbra.soap.mail.type.ContactFrequencyData;
+
+@XmlRootElement(name=MailConstants.E_GET_CONTACT_FREQUENCY_RESPONSE)
+public class GetContactFrequencyResponse {
+
+    public GetContactFrequencyResponse() {}
+
+    @XmlElement(name=MailConstants.E_CONTACT_FREQUENCY_DATA, type=ContactFrequencyData.class)
+    private List<ContactFrequencyData> frequencyGraphs = new ArrayList<>();
+
+    public List<ContactFrequencyData> getFrequencyGraphs() { return frequencyGraphs; }
+    public void addFrequencyGraph(ContactFrequencyData data) { this.frequencyGraphs.add(data); }
+}

--- a/soap/src/java/com/zimbra/soap/mail/type/ContactFrequencyData.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ContactFrequencyData.java
@@ -1,0 +1,33 @@
+package com.zimbra.soap.mail.type;
+
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+
+import com.zimbra.common.soap.MailConstants;
+
+@XmlAccessorType(XmlAccessType.NONE)
+public class ContactFrequencyData {
+
+    public ContactFrequencyData() {}
+
+    public ContactFrequencyData(String frequencyBy, List<ContactFrequencyDataPoint> dataPoints) {
+        setFrequencyBy(frequencyBy);
+        setDataPoints(dataPoints);
+    }
+
+    @XmlAttribute(name=MailConstants.A_CONTACT_FREQUENCY_BY, required=true)
+    private String frequencyBy;
+
+    @XmlElement(name=MailConstants.E_CONTACT_FREQUENCY_DATA_POINT, type=ContactFrequencyDataPoint.class)
+    private List<ContactFrequencyDataPoint> dataPoints;
+
+    public String getFrequencyBy() { return frequencyBy; }
+    public void setFrequencyBy(String frequencyBy) { this.frequencyBy = frequencyBy; }
+
+    public List<ContactFrequencyDataPoint> getDataPoints() { return dataPoints; }
+    public void setDataPoints(List<ContactFrequencyDataPoint> dataPoints) { this.dataPoints = dataPoints; }
+}

--- a/soap/src/java/com/zimbra/soap/mail/type/ContactFrequencyDataPoint.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ContactFrequencyDataPoint.java
@@ -1,0 +1,29 @@
+package com.zimbra.soap.mail.type;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+
+import com.zimbra.common.soap.MailConstants;
+
+@XmlAccessorType(XmlAccessType.NONE)
+public class ContactFrequencyDataPoint {
+
+    public ContactFrequencyDataPoint() {}
+
+    public ContactFrequencyDataPoint(String label, int value) {
+        this.label = label;
+        this.value = value;
+    }
+    @XmlAttribute(name=MailConstants.A_CONTACT_FREQUENCY_LABEL, required=true)
+    private String label;
+
+    @XmlAttribute(name=MailConstants.A_CONTACT_FREQUENCY_VALUE, required=true)
+    private int value;
+
+    public String getLabel() { return label; }
+    public void setLabel(String label) { this.label = label; }
+
+    public int getValue() { return value; }
+    public void setValue(int value) { this.value = value; }
+}

--- a/store/src/java/com/zimbra/cs/event/Event.java
+++ b/store/src/java/com/zimbra/cs/event/Event.java
@@ -242,6 +242,13 @@ public class Event {
     /**
      * Convenience method to generate a single RECEIVED event
      */
+    public static Event generateReceivedEvent(String accountId, int messageId, String sender, String recipient, String dsId, Long timestamp) {
+        return generateEvent(accountId, messageId, sender, recipient, EventType.RECEIVED, dsId, null, timestamp);
+    }
+
+    /**
+     * Convenience method to generate a single RECEIVED event
+     */
     public static Event generateReceivedEvent(Message msg, String recipient, Long timestamp) {
         ParsedMessage pm;
         try {

--- a/store/src/java/com/zimbra/cs/event/EventStore.java
+++ b/store/src/java/com/zimbra/cs/event/EventStore.java
@@ -10,8 +10,13 @@ import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.Server;
 import com.zimbra.cs.contacts.RelatedContactsParams;
 import com.zimbra.cs.contacts.RelatedContactsResults;
+import com.zimbra.cs.event.analytics.contact.ContactAnalytics;
 import com.zimbra.cs.event.logger.EventLogger;
 import com.zimbra.cs.extension.ExtensionUtil;
+import com.zimbra.cs.event.analytics.contact.ContactFrequencyGraphDataPoint;
+
+import java.util.List;
+
 
 /**
  * Interface to an event storage backend that allows for querying and deleting of
@@ -26,6 +31,10 @@ public abstract class EventStore {
 
     public EventStore(String accountId) {
         this.accountId = accountId;
+    }
+
+    public String getAccountId() {
+        return accountId;
     }
 
     public static void registerFactory(String prefix, String clazz) {
@@ -45,7 +54,7 @@ public abstract class EventStore {
                 String[] tokens = eventURL.split(":");
                 if (tokens != null && tokens.length > 0) {
                     String backendFactoryName = tokens[0];
-                     factoryClassName = REGISTERED_FACTORIES.get(backendFactoryName);
+                    factoryClassName = REGISTERED_FACTORIES.get(backendFactoryName);
                 }
             } else {
                 throw ServiceException.FAILURE("EventStore is not configured", null);
@@ -122,6 +131,7 @@ public abstract class EventStore {
             ZimbraLog.event.debug("no event store specifed; skipping deleting events for account %s, dsId=%s", accountId, dataSourceId);
         }
     }
+
     /**
      * Delete all event data for this account
      */
@@ -136,6 +146,30 @@ public abstract class EventStore {
      * Calculate contact affinity based on SENT and AFFINITY events
      */
     public abstract RelatedContactsResults getContactAffinity(RelatedContactsParams params) throws ServiceException;
+
+    public abstract Long getContactFrequencyCount(String contact, ContactAnalytics.ContactFrequencyEventType combined, ContactAnalytics.ContactFrequencyTimeRange timeRange) throws ServiceException;
+
+    /**
+     * Get the frequency of emails sent and received from a contact for
+     * 1) Current Month
+     *      StartDate - First day of Month
+     *      EndDate - Current date (today)
+     *      Aggregation Unit - Per day
+     *
+     * 2) Last 6 Months
+     *      StartDate - First day of the week 6 months back from the first day of week for the current week
+     *      EndDate - First day of the week of current week
+     *      Aggregation Unit - Per week
+     *      Optional int FirstDayOfWeek - day of the week set as first day of week for attribute 'zimbraPrefCalendarFirstDayOfWeek'
+     *      Default first day of week should be set to Sunday.
+     *      As per 'zimbraPrefCalendarFirstDayOfWeek' 0 = Sunday...6 = Saturday
+     *
+     * 3) Current year
+     *      StartDate - First day of the year
+     *      EndDate - Current date (today)
+     *      Aggregation unit - Per month
+     */
+    public abstract List<ContactFrequencyGraphDataPoint> getContactFrequencyGraph(String contact, ContactAnalytics.ContactFrequencyGraphTimeRange timeRange) throws ServiceException;
 
     public interface Factory {
 

--- a/store/src/java/com/zimbra/cs/event/SolrEventDocument.java
+++ b/store/src/java/com/zimbra/cs/event/SolrEventDocument.java
@@ -13,10 +13,10 @@ import com.zimbra.cs.index.LuceneFields;
 
 public class SolrEventDocument {
     // see schema.xml for static/dynamic field definitions
-    private static String FIELD_EVENT_ID   = LuceneFields.L_EVENT_ID;
-    private static String FIELD_EVENT_TYPE = LuceneFields.L_EVENT_TYPE;
-    private static String FIELD_EVENT_TIME = LuceneFields.L_EVENT_TIME;
-    private static String FIELD_MSG_ID = "msg_id";
+    private static String FIELD_EVENT_ID = LuceneFields.L_EVENT_ID;
+    private static String FIELD_EVENT_TYPE= LuceneFields.L_EVENT_TYPE;
+    private static String FIELD_EVENT_TIME= LuceneFields.L_EVENT_TIME;
+    private static String FIELD_MSG_ID = LuceneFields.L_EVENT_MESSAGE_ID;
     private static String DYNAMIC_FIELD_FORMAT = "%s_%s";
     private static DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ISO_INSTANT;
 

--- a/store/src/java/com/zimbra/cs/event/SolrEventStore.java
+++ b/store/src/java/com/zimbra/cs/event/SolrEventStore.java
@@ -1,15 +1,33 @@
 package com.zimbra.cs.event;
 
 import java.io.IOException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAdjusters;
+import java.time.temporal.WeekFields;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TermRangeQuery;
+
+import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.request.UpdateRequest;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.client.solrj.response.RangeFacet;
 
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.event.analytics.contact.ContactAnalytics;
+import com.zimbra.cs.event.analytics.contact.ContactFrequencyGraphDataPoint;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.Server;
 import com.zimbra.cs.index.LuceneFields;
@@ -18,6 +36,7 @@ import com.zimbra.cs.index.solr.JointCollectionLocator;
 import com.zimbra.cs.index.solr.SolrCollectionLocator;
 import com.zimbra.cs.index.solr.SolrConstants;
 import com.zimbra.cs.index.solr.SolrRequestHelper;
+
 
 /**
  * Base class for SolrCloud / Standalone Solr event backends
@@ -56,6 +75,163 @@ public abstract class SolrEventStore extends EventStore {
         builder.add(new TermQuery(new Term(LuceneFields.L_DATASOURCE_ID, dataSourceId)), Occur.MUST);
         req.deleteByQuery(builder.build().toString());
         solrHelper.execute(accountId, req);
+    }
+
+    @Override
+    public Long getContactFrequencyCount(String contact, ContactAnalytics.ContactFrequencyEventType eventType, ContactAnalytics.ContactFrequencyTimeRange timeRange) throws ServiceException {
+        SolrQuery solrQuery = new SolrQuery();
+        solrQuery.setRows(0);
+        solrQuery.setQuery(getContactFrequencyQueryForTimeRange(timeRange));
+        solrQuery.addFilterQuery(getQueryToSearchContact(contact, eventType));
+
+        if (solrHelper.needsAccountFilter()) {
+            solrQuery.addFilterQuery(getAccountFilter(accountId));
+        }
+
+        QueryResponse response = (QueryResponse) solrHelper.executeRequest(accountId, solrQuery);
+        return response.getResults().getNumFound();
+    }
+
+    private String getQueryToSearchContact(String contact, ContactAnalytics.ContactFrequencyEventType eventType) {
+        switch (eventType) {
+        case SENT:
+            return searchContactByEventType(contact, Event.EventType.SENT, Event.EventContextField.RECEIVER).toString();
+        case RECEIVED:
+            return searchContactByEventType(contact, Event.EventType.RECEIVED, Event.EventContextField.SENDER).toString();
+        default:
+            return getQueryToSearchContactAsSenderOrReceiver(contact).toString();
+        }
+    }
+
+    private String getContactFrequencyQueryForTimeRange(ContactAnalytics.ContactFrequencyTimeRange timeRange) throws ServiceException {
+        if(ContactAnalytics.ContactFrequencyTimeRange.FOREVER.equals(timeRange)) {
+            return new MatchAllDocsQuery().toString();
+        }
+        TermRangeQuery rangeQuery = TermRangeQuery.newStringRange(LuceneFields.L_EVENT_TIME, getContactFrequencyQueryStartDate(timeRange), "NOW", true, true);
+        return rangeQuery.toString();
+    }
+
+    private String getContactFrequencyQueryStartDate(ContactAnalytics.ContactFrequencyTimeRange timeRange) throws ServiceException {
+        switch (timeRange) {
+        case LAST_DAY:
+            return "NOW-1DAY";
+        case LAST_WEEK:
+            return "NOW-7DAY";
+        case LAST_MONTH:
+            return "NOW-1MONTH";
+        default:
+            throw ServiceException.INVALID_REQUEST("Time range not supported " + timeRange, null);
+        }
+    }
+
+    @Override
+    public List<ContactFrequencyGraphDataPoint> getContactFrequencyGraph(String contact, ContactAnalytics.ContactFrequencyGraphTimeRange timeRange) throws ServiceException {
+        LocalDateTime startDate = getStartDateForContactFrequencyGraphTimeRange(timeRange);
+        LocalDateTime endDate = LocalDateTime.now();
+        String aggregationBucket = getAggregationBucketForContactFrequencyGraphTimeRange(timeRange);
+
+        SolrQuery solrQuery = new SolrQuery();
+        solrQuery.setQuery(new MatchAllDocsQuery().toString());
+        solrQuery.addDateRangeFacet(LuceneFields.L_EVENT_TIME, Timestamp.valueOf(startDate), Timestamp.valueOf(endDate), aggregationBucket);
+        solrQuery.addFilterQuery(getQueryToSearchContactAsSenderOrReceiver(contact).toString());
+
+        if (solrHelper.needsAccountFilter()) {
+            solrQuery.addFilterQuery(getAccountFilter(accountId));
+        }
+
+        QueryResponse response = (QueryResponse) solrHelper.executeRequest(accountId, solrQuery);
+
+        List<ContactFrequencyGraphDataPoint> graphDataPoints = Collections.emptyList();
+        List<RangeFacet> facetRanges = response.getFacetRanges();
+        if(facetRanges != null && facetRanges.size() > 0) {
+            List<RangeFacet.Count> rangeFacetResult = facetRanges.get(0).getCounts();
+            graphDataPoints = new ArrayList<>(rangeFacetResult.size());
+            for (RangeFacet.Count rangeResult : rangeFacetResult) {
+                graphDataPoints.add(new ContactFrequencyGraphDataPoint(rangeResult.getValue(), rangeResult.getCount()));
+            }
+        }
+        return graphDataPoints;
+    }
+
+    //returns the GAP string needed by solr range facet query. It uses "GAP/ROUNDING UNIT" format.
+    private String getAggregationBucketForContactFrequencyGraphTimeRange(ContactAnalytics.ContactFrequencyGraphTimeRange timeRange) throws ServiceException {
+        switch (timeRange) {
+        //For current month time range we want to group the results by per day and round the start of day to midnight
+        case CURRENT_MONTH:
+            return "+1DAY/DAY";
+        //For the last six months range we want to group the results by per week(7 days) and round the start of day to midnight.
+        //Solr does not have a notion of week, since we need to express it in terms of days.
+        case LAST_SIX_MONTHS:
+            return "+7DAY/DAY";
+        //For the current year time range we want to group the results by per month and round the start of the month to the first day of month.
+        case CURRENT_YEAR:
+            return "+1MONTH/MONTH";
+        default:
+            throw ServiceException.INVALID_REQUEST("Time range not supported " + timeRange, null);
+        }
+    }
+
+    private LocalDateTime getStartDateForContactFrequencyGraphTimeRange(ContactAnalytics.ContactFrequencyGraphTimeRange timeRange) throws ServiceException {
+        switch (timeRange) {
+        case CURRENT_MONTH:
+            return getStartDateForCurrentMonth();
+        case LAST_SIX_MONTHS:
+            return getStartDateForLastSixMonths();
+        case CURRENT_YEAR:
+            return getStartDateForCurrentyear();
+        default:
+            throw ServiceException.INVALID_REQUEST("Time range not supported " + timeRange, null);
+        }
+    }
+
+    private LocalDateTime getStartDateForCurrentMonth() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime firstDayOfMonth = now.with(TemporalAdjusters.firstDayOfMonth()).truncatedTo(ChronoUnit.DAYS);
+        return firstDayOfMonth;
+    }
+
+    private LocalDateTime getStartDateForLastSixMonths() throws ServiceException {
+        //attr id="261" name="zimbraPrefCalendarFirstDayOfWeek". sunday = 0...saturday = 6
+        int firstDayOfWeek = Provisioning.getInstance().getAccountById(accountId).getPrefCalendarFirstDayOfWeek();
+        //As per "zimbraPrefCalendarFirstDayOfWeek" sunday = 0...saturday = 6. But WeekFields takes days as sunday = 1....saturday = 7
+        int firstDayOfWeekAdjusted = firstDayOfWeek + 1;
+        LocalDateTime firstDayOfCurrentWeekAsConfigured = LocalDateTime.now().with(WeekFields.of(Locale.US).dayOfWeek(), firstDayOfWeekAdjusted).truncatedTo(ChronoUnit.DAYS);
+        LocalDateTime firstDayOfWeek6MonthsBack = firstDayOfCurrentWeekAsConfigured.minusMonths(6).with(WeekFields.of(Locale.US).dayOfWeek(), firstDayOfWeekAdjusted);
+        return firstDayOfWeek6MonthsBack;
+    }
+
+    private LocalDateTime getStartDateForCurrentyear() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime firstDayOfCurrentYear = now.with(TemporalAdjusters.firstDayOfYear()).truncatedTo(ChronoUnit.DAYS);
+        return firstDayOfCurrentYear;
+    }
+
+    private BooleanQuery getQueryToSearchContactAsSenderOrReceiver(String contact) {
+        BooleanQuery sentEventWithContactInReceiverField = searchContactByEventType(contact, Event.EventType.SENT, Event.EventContextField.RECEIVER);
+        BooleanQuery receivedEventWithContactInSenderField = searchContactByEventType(contact, Event.EventType.RECEIVED, Event.EventContextField.SENDER);
+
+        BooleanQuery.Builder searchForContactAsSenderOrReceiver = new BooleanQuery.Builder();
+        searchForContactAsSenderOrReceiver.add(sentEventWithContactInReceiverField, Occur.SHOULD);
+        searchForContactAsSenderOrReceiver.add(receivedEventWithContactInSenderField, Occur.SHOULD);
+
+        return searchForContactAsSenderOrReceiver.build();
+    }
+
+    private BooleanQuery searchContactByEventType(String contact, Event.EventType eventType, Event.EventContextField eventContextField) {
+        TermQuery searchForContactInEventContextField = new TermQuery(new Term(SolrEventDocument.getSolrQueryField(eventContextField), contact));
+        TermQuery searchForEventType = new TermQuery(new Term(LuceneFields.L_EVENT_TYPE, eventType.name()));
+
+        BooleanQuery.Builder searchContactForAnEventTypeInAContextField = new BooleanQuery.Builder();
+        searchContactForAnEventTypeInAContextField.add(searchForContactInEventContextField, Occur.MUST);
+        searchContactForAnEventTypeInAContextField.add(searchForEventType, Occur.MUST);
+
+        return searchContactForAnEventTypeInAContextField.build();
+    }
+
+    private String getAccountFilter(String accountId) {
+        BooleanQuery.Builder accountFilter = new BooleanQuery.Builder();
+        accountFilter.add(new TermQuery(new Term(LuceneFields.L_ACCOUNT_ID, accountId)), Occur.MUST);
+        return accountFilter.build().toString();
     }
 
     public abstract static class Factory implements EventStore.Factory {

--- a/store/src/java/com/zimbra/cs/event/analytics/contact/ContactAnalytics.java
+++ b/store/src/java/com/zimbra/cs/event/analytics/contact/ContactAnalytics.java
@@ -1,0 +1,39 @@
+package com.zimbra.cs.event.analytics.contact;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.event.EventStore;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAdjusters;
+import java.time.temporal.WeekFields;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+public class ContactAnalytics {
+    public enum ContactFrequencyTimeRange {
+        LAST_DAY, LAST_WEEK, LAST_MONTH, FOREVER
+    }
+
+    public enum ContactFrequencyGraphTimeRange {
+        CURRENT_MONTH, LAST_SIX_MONTHS, CURRENT_YEAR
+    }
+
+    public enum ContactFrequencyEventType {
+        SENT, RECEIVED, COMBINED
+    }
+
+    public static Long getContactFrequency(String contact, EventStore eventStore) throws ServiceException {
+        return eventStore.getContactFrequencyCount(contact, ContactFrequencyEventType.COMBINED, ContactFrequencyTimeRange.FOREVER);
+    }
+
+    public static Long getContactFrequency(String contact, EventStore eventStore, ContactFrequencyEventType eventType, ContactFrequencyTimeRange timeRange) throws ServiceException {
+        return eventStore.getContactFrequencyCount(contact, eventType, timeRange);
+    }
+
+    public static List<ContactFrequencyGraphDataPoint> getContactFrequencyGraph(String contact, ContactFrequencyGraphTimeRange timeRange, EventStore eventStore) throws ServiceException {
+        return eventStore.getContactFrequencyGraph(contact, timeRange);
+    }
+}

--- a/store/src/java/com/zimbra/cs/event/analytics/contact/ContactFrequencyGraphDataPoint.java
+++ b/store/src/java/com/zimbra/cs/event/analytics/contact/ContactFrequencyGraphDataPoint.java
@@ -1,0 +1,27 @@
+package com.zimbra.cs.event.analytics.contact;
+
+public class ContactFrequencyGraphDataPoint {
+    String label;
+    int value;
+
+    public ContactFrequencyGraphDataPoint(String label, int value) {
+        this.label = label;
+        this.value = value;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public void setValue(int value) {
+        this.value = value;
+    }
+}

--- a/store/src/java/com/zimbra/cs/index/solr/SolrCloudHelper.java
+++ b/store/src/java/com/zimbra/cs/index/solr/SolrCloudHelper.java
@@ -2,8 +2,11 @@ package com.zimbra.cs.index.solr;
 
 import java.io.IOException;
 
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrResponse;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.io.SolrClientCache;
+import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.common.params.CoreAdminParams;
 
@@ -36,6 +39,12 @@ public class SolrCloudHelper extends SolrRequestHelper {
             throws ServiceException {
         request.setParam(CoreAdminParams.COLLECTION, locator.getCoreName(accountId));
         SolrUtils.executeCloudRequestWithRetry(cloudClient, request, locator.getCoreName(accountId), configSet);
+    }
+
+    @Override
+    public SolrResponse executeRequest(String accountId, SolrQuery query) throws ServiceException {
+        query.setParam(CoreAdminParams.COLLECTION, locator.getCoreName(accountId));
+        return SolrUtils.executeCloudRequestWithRetry(cloudClient, new QueryRequest(query), locator.getCoreName(accountId), configSet);
     }
 
     @Override

--- a/store/src/java/com/zimbra/cs/index/solr/SolrRequestHelper.java
+++ b/store/src/java/com/zimbra/cs/index/solr/SolrRequestHelper.java
@@ -2,6 +2,8 @@ package com.zimbra.cs.index.solr;
 
 import java.io.Closeable;
 
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrResponse;
 import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.common.SolrInputDocument;
 
@@ -35,6 +37,8 @@ public abstract class SolrRequestHelper implements Closeable {
         }
         executeRequest(accountId, request);
     }
+
+    public abstract SolrResponse executeRequest(String accountId, SolrQuery query) throws ServiceException;
 
     public String getCoreName(String accountId) {
         return locator.getCoreName(accountId);

--- a/store/src/java/com/zimbra/cs/index/solr/StandaloneSolrHelper.java
+++ b/store/src/java/com/zimbra/cs/index/solr/StandaloneSolrHelper.java
@@ -4,6 +4,9 @@ import java.io.IOException;
 
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrResponse;
+import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.request.UpdateRequest;
 
 import com.zimbra.common.service.ServiceException;
@@ -30,6 +33,16 @@ public class StandaloneSolrHelper extends SolrRequestHelper {
         String coreName = locator.getCoreName(accountId);
         try(SolrClient solrClient = SolrUtils.getSolrClient(httpClient, baseUrl, coreName)) {
             SolrUtils.executeRequestWithRetry(solrClient, request, baseUrl, coreName, configSet);
+        } catch (IOException e) {
+            throw ServiceException.FAILURE(String.format("unable to execute Solr request for account %s", accountId), e);
+        }
+    }
+
+    @Override
+    public SolrResponse executeRequest(String accountId, SolrQuery query) throws ServiceException {
+        String coreName = locator.getCoreName(accountId);
+        try(SolrClient solrClient = SolrUtils.getSolrClient(httpClient, baseUrl, coreName)) {
+            return SolrUtils.executeRequestWithRetry(solrClient, new QueryRequest(query), baseUrl, coreName, configSet);
         } catch (IOException e) {
             throw ServiceException.FAILURE(String.format("unable to execute Solr request for account %s", accountId), e);
         }

--- a/store/src/java/com/zimbra/cs/service/mail/GetContactFrequency.java
+++ b/store/src/java/com/zimbra/cs/service/mail/GetContactFrequency.java
@@ -1,0 +1,73 @@
+package com.zimbra.cs.service.mail;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.util.Pair;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.event.EventStore;
+import com.zimbra.cs.event.analytics.contact.ContactAnalytics;
+import com.zimbra.cs.event.analytics.contact.ContactFrequencyGraphDataPoint;
+import com.zimbra.soap.ZimbraSoapContext;
+import com.zimbra.soap.mail.message.GetContactFrequencyRequest;
+import com.zimbra.soap.mail.message.GetContactFrequencyResponse;
+import com.zimbra.soap.mail.type.ContactFrequencyData;
+import com.zimbra.soap.mail.type.ContactFrequencyDataPoint;
+
+public class GetContactFrequency extends MailDocumentHandler {
+
+    private static final Map<String, ContactAnalytics.ContactFrequencyGraphTimeRange> timeRangeMap = new HashMap<>();
+    static {
+        timeRangeMap.put("d", ContactAnalytics.ContactFrequencyGraphTimeRange.CURRENT_MONTH);
+        timeRangeMap.put("w", ContactAnalytics.ContactFrequencyGraphTimeRange.LAST_SIX_MONTHS);
+        timeRangeMap.put("m", ContactAnalytics.ContactFrequencyGraphTimeRange.CURRENT_YEAR);
+    }
+
+    @Override
+    public Element handle(Element request, Map<String, Object> context)
+            throws ServiceException {
+        ZimbraSoapContext zsc = getZimbraSoapContext(context);
+        Account acct = getRequestedAccount(zsc);
+        GetContactFrequencyRequest req = zsc.elementToJaxb(request);
+        String contactEmail = req.getEmail();
+        String freqByCSV = req.getFrequencyBy();
+        EventStore eventStore = EventStore.getFactory().getEventStore(acct.getId());
+        GetContactFrequencyResponse resp = new GetContactFrequencyResponse();
+        for (Pair<String, ContactAnalytics.ContactFrequencyGraphTimeRange> timeRange: parseTimeRange(freqByCSV)) {
+            String freqBy = timeRange.getFirst();
+            ContactAnalytics.ContactFrequencyGraphTimeRange range = timeRange.getSecond();
+            List<ContactFrequencyDataPoint> dataPoints = getGraphData(contactEmail, range, eventStore);
+            ContactFrequencyData graphData = new ContactFrequencyData(freqBy, dataPoints);
+            resp.addFrequencyGraph(graphData);
+        }
+        return zsc.jaxbToElement(resp);
+    }
+
+    private List<ContactFrequencyDataPoint> getGraphData(String email, ContactAnalytics.ContactFrequencyGraphTimeRange timeRange, EventStore eventStore) throws ServiceException {
+        List<ContactFrequencyGraphDataPoint> dataPoints = ContactAnalytics.getContactFrequencyGraph(email, timeRange, eventStore);
+        List<ContactFrequencyDataPoint> soapDataPoints = dataPoints.stream().map(dp -> toSOAPDataPoint(dp)).collect(Collectors.toList());
+        return soapDataPoints;
+    }
+
+    private ContactFrequencyDataPoint toSOAPDataPoint(ContactFrequencyGraphDataPoint dataPoint) {
+        return new ContactFrequencyDataPoint(dataPoint.getLabel(), dataPoint.getValue());
+
+    }
+    private List<Pair<String, ContactAnalytics.ContactFrequencyGraphTimeRange>> parseTimeRange(String csv) throws ServiceException {
+        List<Pair<String, ContactAnalytics.ContactFrequencyGraphTimeRange>> requestedRanges = new ArrayList<>();
+        for (String token: csv.split(",")) {
+            ContactAnalytics.ContactFrequencyGraphTimeRange tr = timeRangeMap.get(token);
+            if (tr != null) {
+                requestedRanges.add(new Pair<String, ContactAnalytics.ContactFrequencyGraphTimeRange>(token, tr));
+            } else {
+                throw ServiceException.INVALID_REQUEST(token + " is not a valid time range; accepted values are {d,w,m}", null);
+            }
+        }
+        return requestedRanges;
+    }
+}

--- a/store/src/java/com/zimbra/cs/service/mail/MailService.java
+++ b/store/src/java/com/zimbra/cs/service/mail/MailService.java
@@ -243,5 +243,8 @@ public final class MailService implements DocumentService {
 
         // SearchAction API
         dispatcher.registerHandler(MailConstants.SEARCH_ACTION_REQUEST, new SearchAction());
+
+        // Contact Analytics
+        dispatcher.registerHandler(MailConstants.GET_CONTACT_FREQUENCY_REQUEST, new GetContactFrequency());
     }
 }

--- a/store/src/java/com/zimbra/qa/unittest/TestStandaloneSolrEventStore.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestStandaloneSolrEventStore.java
@@ -9,12 +9,13 @@ import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocumentList;
-import org.junit.After;
-import org.junit.Assume;
-import org.junit.BeforeClass;
+import org.junit.*;
 
 import com.zimbra.common.httpclient.ZimbraHttpClientManager;
 import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.event.SolrEventStore;
+import com.zimbra.cs.event.analytics.contact.ContactAnalytics;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.event.StandaloneSolrEventStore;
 import com.zimbra.cs.event.logger.SolrEventCallback;
@@ -28,6 +29,9 @@ import com.zimbra.cs.index.solr.StandaloneSolrHelper;
 
 public class TestStandaloneSolrEventStore extends SolrEventStoreTestBase {
 
+    private static String CONTACT_FREQUENCY_GRAPH_TEST_ACCOUNT_USERNAME = "contactFrequencyGraphTestAccount";
+    private static Account CONTACT_FREQUENCY_GRAPH_TEST_ACCOUNT;
+
     private static String baseUrl;
     private static CloseableHttpClient httpClient;
 
@@ -37,6 +41,9 @@ public class TestStandaloneSolrEventStore extends SolrEventStoreTestBase {
         Assume.assumeTrue(solrUrl.startsWith("solr"));
         baseUrl = solrUrl.substring("solr:".length());
         httpClient = ZimbraHttpClientManager.getInstance().getInternalHttpClient();
+        TestUtil.deleteAccountIfExists(CONTACT_FREQUENCY_GRAPH_TEST_ACCOUNT_USERNAME);
+        CONTACT_FREQUENCY_GRAPH_TEST_ACCOUNT = TestUtil.createAccount(CONTACT_FREQUENCY_GRAPH_TEST_ACCOUNT_USERNAME);
+        CONTACT_FREQUENCY_GRAPH_TEST_ACCOUNT_ID = CONTACT_FREQUENCY_GRAPH_TEST_ACCOUNT.getId();
         cleanUp();
     }
 
@@ -59,11 +66,17 @@ public class TestStandaloneSolrEventStore extends SolrEventStoreTestBase {
         deleteCore(JOINT_COLLECTION_NAME);
         deleteCore(getAccountCollectionName(ACCOUNT_ID_1));
         deleteCore(getAccountCollectionName(ACCOUNT_ID_2));
+        deleteCore(getAccountCollectionName(CONTACT_FREQUENCY_GRAPH_TEST_ACCOUNT_ID));
     }
 
     @After
     public void tearDown() throws Exception {
         cleanUp();
+    }
+
+    @AfterClass
+    public static void clean() throws Exception {
+        TestUtil.deleteAccountIfExists(CONTACT_FREQUENCY_GRAPH_TEST_ACCOUNT_USERNAME);
     }
 
     @Override
@@ -115,5 +128,52 @@ public class TestStandaloneSolrEventStore extends SolrEventStoreTestBase {
         SolrClient client = getSolrClient(coreName);
         QueryResponse resp = req.process(client);
         return resp.getResults();
+    }
+
+    @Test
+    public void testContactFrequencyCountForAllTimeRanges() throws Exception {
+        for (ContactAnalytics.ContactFrequencyTimeRange timeRange : getContactFrequencyCountTimeRanges()) {
+            testContactFrequencyCountForAccountCore(timeRange);
+            testContactFrequencyCountForCombinedCore(timeRange);
+        }
+    }
+
+    public void testContactFrequencyCountForAccountCore(ContactAnalytics.ContactFrequencyTimeRange timeRange) throws Exception {
+        cleanUp();
+        try(SolrEventCallback eventCallback = getAccountCoreCallback()) {
+            testContactFrequencyCount(timeRange, eventCallback, getAccountCollectionName(ACCOUNT_ID_1), getAccountEventStore(ACCOUNT_ID_1));
+        }
+    }
+
+    public void testContactFrequencyCountForCombinedCore(ContactAnalytics.ContactFrequencyTimeRange timeRange) throws Exception {
+        cleanUp();
+        try(SolrEventCallback eventCallback = getCombinedCoreCallback()) {
+            testContactFrequencyCount(timeRange, eventCallback, JOINT_COLLECTION_NAME, getCombinedEventStore(ACCOUNT_ID_1));
+        }
+    }
+
+    @Test
+    public void testGetContactFrequencyGraphForAllTimeRanges() throws Exception {
+        for (ContactAnalytics.ContactFrequencyGraphTimeRange timeRange : getContactFrequencyGraphTimeRanges()) {
+            testContactFrequencyGraphForAccountCore(timeRange);
+            testContactFrequencyGraphForCombinedCore(timeRange);
+        }
+    }
+
+    private void testContactFrequencyGraphForAccountCore(ContactAnalytics.ContactFrequencyGraphTimeRange timeRange) throws Exception {
+        cleanUp();
+        try(SolrEventCallback eventCallback = getAccountCoreCallback()) {
+            String collectionName = getAccountCollectionName(CONTACT_FREQUENCY_GRAPH_TEST_ACCOUNT_ID);
+            SolrEventStore eventStore = getAccountEventStore(CONTACT_FREQUENCY_GRAPH_TEST_ACCOUNT_ID);
+            testContactFrequencyGraph(timeRange, eventCallback, collectionName, eventStore);
+        }
+    }
+
+    private void testContactFrequencyGraphForCombinedCore(ContactAnalytics.ContactFrequencyGraphTimeRange timeRange) throws Exception {
+        cleanUp();
+        try(SolrEventCallback eventCallback = getCombinedCoreCallback()) {
+            SolrEventStore eventStore = getCombinedEventStore(CONTACT_FREQUENCY_GRAPH_TEST_ACCOUNT_ID);
+            testContactFrequencyGraph(timeRange, eventCallback, JOINT_COLLECTION_NAME, eventStore);
+        }
     }
 }


### PR DESCRIPTION
This PR provides the **Contact Analytics** needed by the machine learning module to classify the emails. It also provides data to display **Contact Frequency Graph** for a contact to the front-end. Two types of analytics are implemented in this PR.

#### Contact Analytics ####
1. **Contact Frequency Count**: It provides the count of the number of emails sent or received to/from a contact in a given time range. It provides four time-ranges:
  - `LAST_DAY(NOW-24hours)`
  - `LAST_WEEK(NOW-7DAYS)`
  - `LAST_MONTH(NOW-1MONTH)`
  - `FOREVER(MATCHES ALL EMAILS)`

You can also specify if you want the **SENT email count** or **RECEIVED email count** or **Both (COMBINED)**. 

2. **Contact Frequency Graph**: It provides the count of the number of emails sent and received to/from a contact for 3 time-ranges grouped by aggregation unit associated with the time range.
  - `CURENT_MONTH` - From the 1st day of the current month to the current day. Grouped by `DAY`.
  - `LAST_SIX_MONTHS` - Zimbra calendar provides the functionality to configure the first day of the week (`zimbraPrefCalendarFirstDayOfWeek`). As per that config first day of the current week is calculated. From the first day of the current week, 6 months are subtracted to get the start date. We group the contact frequency by `WEEK`. 
  - `CURRENT_YEAR` - From the 1st day of the current year to the current day. Grouped by `MONTH`.

#### New Classes ####
A new package `com.zimbra.cs.event.analytics.contact` contains following classes:
 - `ContactAnalytics` - Class that provides methods to fetch the different contact analytics from the event store. 
 - `ContactFrequencyGraphDataPoint` - Represent a data point of the graph which has `label` and `value`.

Classes added to `com.zimbra.soap.mail.message`:
 - `GetContactFrequencyRequest` - Represents the SOAP request.
 - `GetContactFrequencyResponse` - Represents the SOAP response.

Classes added to `com.zimbra.soap.mail.type`
 - `ContactFrequencyData` - Represents the format in which contact frequency graph data will be returned.
 - `ContactFrequencyDataPoint` - Represent a data point for the graph which has `label` and `value`. Same as `ContactFrequencyGraphDataPoint`.

Classes added to `com.zimbra.cs.service.mail`:
 - `GetContactFrequncy` - Request handler to get the contact frequncy graph for a contact. It provides three time ranges `d (CURRENT_MONTH), w (LAST_SIX_MONTHS), m (CURRENT_YEAR)`.