### PR TITLE
ZCS-2655:Recurring all day yearly instance shifts 1 day ahead when ac…

### DIFF
--- a/store/src/java-test/com/zimbra/cs/mailbox/calendar/AllDayAcceptInstanceTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/calendar/AllDayAcceptInstanceTest.java
@@ -1,0 +1,205 @@
+package com.zimbra.cs.mailbox.calendar;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.mail.Address;
+import javax.mail.internet.MimeMessage;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.MethodRule;
+import org.junit.rules.TestName;
+
+import com.google.common.collect.Maps;
+import com.zimbra.common.account.Key;
+import com.zimbra.common.calendar.ICalTimeZone;
+import com.zimbra.common.calendar.ParsedDateTime;
+import com.zimbra.common.calendar.ParsedDuration;
+import com.zimbra.common.calendar.TimeZoneMap;
+import com.zimbra.common.calendar.ZCalendar.ZComponent;
+import com.zimbra.common.calendar.ZCalendar.ZVCalendar;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.index.SortBy;
+import com.zimbra.cs.mailbox.CalendarItem;
+import com.zimbra.cs.mailbox.Folder;
+import com.zimbra.cs.mailbox.MailItem;
+import com.zimbra.cs.mailbox.MailSender;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.mailbox.ScheduledTaskManager;
+import com.zimbra.cs.mailbox.Mailbox.MailboxData;
+import com.zimbra.cs.mailbox.calendar.Recurrence.IRecurrence;
+import com.zimbra.cs.mailbox.calendar.Recurrence.RecurrenceRule;
+import com.zimbra.cs.mailbox.calendar.Recurrence.SimpleRepeatingRule;
+import com.zimbra.cs.util.ZTestWatchman;
+
+public class AllDayAcceptInstanceTest {
+
+    @Rule public TestName testName = new TestName();
+    @Rule public MethodRule watchman = new ZTestWatchman();
+
+    @BeforeClass
+    public static void init() throws Exception {
+        MailboxTestUtil.initServer();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        System.out.println(testName.getMethodName());
+        Provisioning prov = Provisioning.getInstance();
+        Map<String, Object> attrs = Maps.newHashMap();
+        prov.createDomain("zimbra.com", attrs);
+
+        attrs = Maps.newHashMap();
+        attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        prov.createAccount("testZCS2655@zimbra.com", "secret", attrs);
+
+        attrs = Maps.newHashMap();
+        attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        prov.createAccount("test2ZCS2655@zimbra.com", "secret", attrs);
+
+        // this MailboxManager does everything except actually send mail
+        MailboxManager.setInstance(new MailboxManager() {
+            @Override
+            protected Mailbox instantiateMailbox(MailboxData data) {
+                return new Mailbox(data) {
+                    @Override
+                    public MailSender getMailSender() {
+                        return new MailSender() {
+                            @Override
+                            protected Collection<Address> sendMessage(Mailbox mbox, MimeMessage mm,
+                                    Collection<RollbackData> rollbacks) {
+                                try {
+                                    return Arrays.asList(getRecipients(mm));
+                                } catch (Exception e) {
+                                    return Collections.emptyList();
+                                }
+                            }
+                        };
+                    }
+                };
+            }
+        });
+    }
+    
+    @Test
+    public void testZCS2655() throws Exception {
+        
+        ScheduledTaskManager.startup();
+        Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "testZCS2655@zimbra.com");
+        Account acct2 = Provisioning.getInstance().get(Key.AccountBy.name, "test2ZCS2655@zimbra.com");
+        Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
+
+        String desc = "The following is a new meeting request";
+        Folder calendarFolder = mbox1.getCalendarFolders(null, SortBy.NONE).get(0);
+        String fragment = "Some message";
+        ZVCalendar calendar = new ZVCalendar();
+        calendar.addDescription(desc, null);
+        ZComponent comp = new ZComponent("VEVENT");
+        calendar.addComponent(comp);
+
+        Invite invite = MailboxTestUtil.generateInvite(acct1, fragment, calendar);
+        ICalTimeZone pacific = new ICalTimeZone("America/Los_Angeles", -28800000, "16010101T020000",
+            "FREQ=YEARLY;WKST=MO;INTERVAL=1;BYMONTH=11;BYDAY=1SU", "PST", -25200000,
+            "16010101T020000", "FREQ=YEARLY;WKST=MO;INTERVAL=1;BYMONTH=3;BYDAY=2SU", "PDT");
+        TimeZoneMap tzmap = new TimeZoneMap(pacific);
+        ParsedDateTime s = ParsedDateTime.parse("VALUE=DATE:20170701", tzmap);
+        s.forceDateOnly();
+        ParsedDateTime e = ParsedDateTime.parse("VALUE=DATE:20170702", tzmap);
+        e.forceDateOnly();
+        invite.setDtStart(s);
+        invite.setDtEnd(e);
+        invite.setPriority("5");
+        invite.setClassProp("PRI");
+        invite.setOrganizer(new ZOrganizer("test@zimbra.com", null));
+        invite.setUid(UUID.randomUUID().toString());
+        invite.setMethod("REQUEST");
+        invite.setName("Testing");
+        invite.setFreeBusy("B");
+        invite.setIsOrganizer(true);
+        invite.setItemType(MailItem.Type.APPOINTMENT);
+        String uid = UUID.randomUUID().toString();
+        invite.setUid(uid);
+        ZAttendee attendee = new ZAttendee(acct2.getName());
+        invite.addAttendee(attendee);
+        invite.setIsAllDayEvent(true);
+        ParsedDateTime dtStart = ParsedDateTime.parse("VALUE=DATE:20170701", tzmap);
+        dtStart.forceDateOnly();
+        ParsedDuration duration = ParsedDuration.parse("P1D");
+        List<IRecurrence> addRules = new ArrayList<IRecurrence>();
+        List<IRecurrence> subRules = new ArrayList<IRecurrence>();
+        ZRecur rule = new ZRecur("FREQ=WEEKLY;COUNT=4;INTERVAL=1;BYDAY=SA", tzmap);
+        addRules.add(new SimpleRepeatingRule(dtStart, duration, rule, null));
+        RecurrenceRule recurrence = new RecurrenceRule(dtStart, duration, null, addRules, subRules);
+        invite.setRecurrence(recurrence);
+        // Organizer sends All day recurring appointment to test2 account
+        mbox1.addInvite(null, invite, calendarFolder.getId());
+
+        Invite inviteReply = MailboxTestUtil.generateInvite(acct2, fragment, calendar);
+        ParsedDateTime sR = ParsedDateTime.parse("20170701T000000", tzmap);
+        ParsedDateTime eR = ParsedDateTime.parse("20170702T000000", tzmap);
+        inviteReply.setDtStart(sR);
+        inviteReply.setDtEnd(eR);
+        inviteReply.setPriority("5");
+        inviteReply.setClassProp("PRI");
+        inviteReply.setOrganizer(new ZOrganizer("test@zimbra.com", null));
+        inviteReply.setUid(UUID.randomUUID().toString());
+        inviteReply.setMethod("REPLY");
+        inviteReply.setName("Testing");
+        inviteReply.setFreeBusy("B");
+        inviteReply.setIsOrganizer(true);
+        inviteReply.setItemType(MailItem.Type.APPOINTMENT);
+        inviteReply.setUid(uid);
+        RecurId rid = new RecurId(sR, null);
+        inviteReply.setRecurId(rid);
+        ZAttendee attendeeR = new ZAttendee(acct2.getName());
+        attendeeR.setPartStat(IcalXmlStrMap.PARTSTAT_ACCEPTED);
+        inviteReply.addAttendee(attendeeR);
+        inviteReply.setIsAllDayEvent(true);
+        // test2 accepts first invite instance and sends acceptance notification to organizer
+        mbox1.addInvite(null, inviteReply, calendarFolder.getId());
+        List<String> uids = new ArrayList<String>();
+        uids.add(uid);
+        Map<String, CalendarItem> calItems = mbox1.getCalendarItemsByUid(null, uids);
+        CalendarItem calItem = calItems.get(uid);
+        Invite[] invites = calItem.getInvites();
+        Invite exception = null;
+        for(Invite inv : invites) {
+            if(inv.getRecurId() != null) {
+                exception = inv;
+                break;
+            }
+        }
+        if(exception == null) {
+            Assert.fail("Exceptional invite not found");
+        } else {
+            // The exception created in organizers series should not have the timezone in start/end time as sent in acceptance notification
+            Assert.assertEquals(
+                "Start time is not correct[" + exception.getStartTime().toString() + "]",
+                "VALUE=DATE:20170701", exception.getStartTime().toString());
+            Assert.assertEquals("End time is not correct[" + exception.getEndTime().toString() + "]",
+                "VALUE=DATE:20170702", exception.getEndTime().toString());
+        }
+    }
+
+    @After
+    public void tearDown() {
+        try {
+            MailboxTestUtil.clearData();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/mailbox/CalendarItem.java
+++ b/store/src/java/com/zimbra/cs/mailbox/CalendarItem.java
@@ -21,7 +21,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -3470,6 +3469,26 @@ public abstract class CalendarItem extends MailItem {
         }
     }
 
+    private Instance getNearestInstance(Collection<Instance> instancesNear,
+        Instance replyInstance) {
+        long day = (1000 * 60 * 60 * 24);
+        // assuming everything in instancesNear will be much closer than 1 year
+        long min = day * 365;
+        long diff;
+        Instance nearestInstance = null;
+        for (Instance instanceNear : instancesNear) {
+            if (instanceNear.sameTime(replyInstance)) {
+                return instanceNear;
+            }
+            diff = Math.abs(replyInstance.getStart() - instanceNear.getStart());
+            if (diff < min) {
+                nearestInstance = instanceNear;
+                min = diff;
+            }
+        }
+        return nearestInstance;
+    }
+
     /**
      * Bug 94018 - Need an exception to represent a reply to a single instance of an exception, otherwise a decline
      * to a single instance gets forgotten in some cases where the series partstat is used instead.
@@ -3491,21 +3510,31 @@ public abstract class CalendarItem extends MailItem {
             for (int i = 0; i < numInvites(); i++) {
                 Invite cur = getInvite(i);
                 if (cur.getRecurId() == null) {
-                    try {
-                        ParsedDateTime pdt = ParsedDateTime.parseUtcOnly(reply.getRecurId().getDtZ());
+                    Instance replyInstance = Instance.fromInvite(this.getId(), reply);
+                    Instance nearestInstance = getNearestInstance(instancesNear, replyInstance);
+                    if (nearestInstance != null) {
+                        ParsedDateTime pdt = ParsedDateTime.fromUTCTime(nearestInstance.getStart());
+                        if (nearestInstance.getStart() != replyInstance.getStart()) {
+                            ZimbraLog.calendar.info(
+                                "The start time in the reply is: %s. Assuming that it is meant for the series instance with start date: %s",
+                                reply.getStartTime(), pdt);
+                        }
+                        if (nearestInstance.isAllDay()) {
+                            pdt.forceDateOnly();
+                        }
                         Invite localException = cur.makeInstanceInvite(pdt);
                         localException.setDtStamp(System.currentTimeMillis());
                         localException.updateMatchingAttendeesFromReply(reply);
                         localException.setClassPropSetByMe(true); // flag as organizer change
                         mInvites.add(localException);
                         // create a fake ExceptionRule wrapper around the single-instance
-                        recurrenceRule.addException(
-                                new Recurrence.ExceptionRule(reply.getRecurId(), localException.getStartTime(),
-                                        localException.getEffectiveDuration(), new InviteInfo(localException)));
-                    } catch (ParseException e) {
-                        sLog.debug("Unexpected exception - not updating calendar invite with pseudo exception", e);
+                        recurrenceRule.addException(new Recurrence.ExceptionRule(reply.getRecurId(),
+                            localException.getStartTime(), localException.getEffectiveDuration(),
+                            new InviteInfo(localException)));
+                        break;
+                    } else {
+                        ZimbraLog.calendar.info("No nearest instance found for Invite-Reply");
                     }
-                    break;
                 }
             }
         }


### PR DESCRIPTION
ZCS-2655: Recurring all day yearly instance shifts 1 day ahead when accepted from ZWC

Issue:
When the attendee sends acceptance reply for all day single instance, it sends its timezone in reply invite. This creates an exception in series on organizers calendar as only that particular instance is accepted by the attendee with start/end date mentioned in the reply.

Fix:
The exception should be created using the timing information for the nearest instance for the main series, rather than based on what is in the reply.

Added Junit test.
ant test-all passed