### PR TITLE
Bug 80485: Introduce attribute to disable local auth fallback for administrators

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -2936,6 +2936,15 @@ public class ZAttrProvisioning {
     public static final String A_zimbraAdminAccessControlMech = "zimbraAdminAccessControlMech";
 
     /**
+     * Fall back to local auth if external mech fails for an administrator
+     * account
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public static final String A_zimbraAdminAuthFallbackToLocal = "zimbraAdminAuthFallbackToLocal";
+
+    /**
      * lifetime of newly created admin auth tokens. Must be in valid duration
      * format: {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h -
      * hours, m - minutes, s - seconds, d - days, ms - milliseconds. If time

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9638,6 +9638,10 @@ TODO: delete them permanently from here
 <attr id="3023" name="zimbraLDAPSchemaVersion" type="string" cardinality="single" requiredIn="globalConfig" since="8.8.8">
   <desc>LDAP schema version for the system.</desc>
   <globalConfigValue>1518163473</globalConfigValue>
+
+<attr id="3024" name="zimbraAdminAuthFallbackToLocal" type="boolean" cardinality="single" optionalIn="globalConfig,domain" since="8.8.8">
+  <desc>Fall back to local auth if external mech fails for an administrator account</desc>
+  <globalConfigValue>TRUE</globalConfigValue>
 </attr>
 
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -1207,6 +1207,83 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Fall back to local auth if external mech fails for an administrator
+     * account
+     *
+     * @return zimbraAdminAuthFallbackToLocal, or true if unset
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public boolean isAdminAuthFallbackToLocal() {
+        return getBooleanAttr(Provisioning.A_zimbraAdminAuthFallbackToLocal, true, true);
+    }
+
+    /**
+     * Fall back to local auth if external mech fails for an administrator
+     * account
+     *
+     * @param zimbraAdminAuthFallbackToLocal new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public void setAdminAuthFallbackToLocal(boolean zimbraAdminAuthFallbackToLocal) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminAuthFallbackToLocal, zimbraAdminAuthFallbackToLocal ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Fall back to local auth if external mech fails for an administrator
+     * account
+     *
+     * @param zimbraAdminAuthFallbackToLocal new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public Map<String,Object> setAdminAuthFallbackToLocal(boolean zimbraAdminAuthFallbackToLocal, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminAuthFallbackToLocal, zimbraAdminAuthFallbackToLocal ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Fall back to local auth if external mech fails for an administrator
+     * account
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public void unsetAdminAuthFallbackToLocal() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminAuthFallbackToLocal, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Fall back to local auth if external mech fails for an administrator
+     * account
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public Map<String,Object> unsetAdminAuthFallbackToLocal(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminAuthFallbackToLocal, "");
+        return attrs;
+    }
+
+    /**
      * whether to show catchall addresses in admin console
      *
      * @return zimbraAdminConsoleCatchAllAddressEnabled, or false if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -298,6 +298,83 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
+     * Fall back to local auth if external mech fails for an administrator
+     * account
+     *
+     * @return zimbraAdminAuthFallbackToLocal, or false if unset
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public boolean isAdminAuthFallbackToLocal() {
+        return getBooleanAttr(Provisioning.A_zimbraAdminAuthFallbackToLocal, false, true);
+    }
+
+    /**
+     * Fall back to local auth if external mech fails for an administrator
+     * account
+     *
+     * @param zimbraAdminAuthFallbackToLocal new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public void setAdminAuthFallbackToLocal(boolean zimbraAdminAuthFallbackToLocal) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminAuthFallbackToLocal, zimbraAdminAuthFallbackToLocal ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Fall back to local auth if external mech fails for an administrator
+     * account
+     *
+     * @param zimbraAdminAuthFallbackToLocal new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public Map<String,Object> setAdminAuthFallbackToLocal(boolean zimbraAdminAuthFallbackToLocal, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminAuthFallbackToLocal, zimbraAdminAuthFallbackToLocal ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Fall back to local auth if external mech fails for an administrator
+     * account
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public void unsetAdminAuthFallbackToLocal() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminAuthFallbackToLocal, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Fall back to local auth if external mech fails for an administrator
+     * account
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public Map<String,Object> unsetAdminAuthFallbackToLocal(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAdminAuthFallbackToLocal, "");
+        return attrs;
+    }
+
+    /**
      * whether to show catchall addresses in admin console
      *
      * @return zimbraAdminConsoleCatchAllAddressEnabled, or false if unset


### PR DESCRIPTION
Zimbra has a surprising feature: On a domain which is configured for LDAP authentication and where `zimbraAuthFallbackToLocal` is false, a user who is either an admin or a domain admin still login with the local password. As I commented on [bug 80485](https://bugzilla.zimbra.com/show_bug.cgi?id=80485) do I consider this a security issue since when you auto provision your accounts via scripting you have to specify a password for `zmprov createAcount` and since it is never used, you might just choose some trivial dummy value. And suddenly you've got an unexpected backdoor to your system.

These changes introduce an extra attribute `zimbraAdminAuthFallbackToLocal` (domain and global config) which still defaults to true for two reasons:
* To keep backwards compatibility
* To make sure an admin can still access the admin console in case LDAP doesn't work since the existing attribute `zimbraAdminConsoleLDAPAuthEnabled` is ignored.

To reproduce this issue and verify the fix:

1. Create a test domain, say `example.com`.
2. Create an admin account with a password like `test1234`.
3. Make sure you can use this account to log in to both the Web UI and Admin UI.
4. Configure the domain for a broken AD authentication: `zmprov md example.com zimbraAuthMech ad zimbraAuthLdapBindDn "%u@test.local" zimbraAuthLdapURL "ldap://localhost:1389"`
5. Just to be sure call `zmprov fc -a all`.
6. Try to login with the local password. This should still work. for both the Web UI and Admin UI.
7. Change the attribute to false: `zmprov md example.com zimbraAuthFallbackToLocal FALSE zimbraAdminAuthFallbackToLocal FALSE`.
8. Just to be sure call `zmprov fc -a all`.
9. Try to log in. This should now fail for both the Web UI and Admin UI.