### PR TITLE
add tests for UID SEARCH and overwrite failing tests for now

### DIFF
--- a/store/src/java/com/zimbra/qa/unittest/TestImapViaEmbeddedRemote.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestImapViaEmbeddedRemote.java
@@ -48,4 +48,16 @@ public class TestImapViaEmbeddedRemote extends SharedImapTests {
     public void statusOnMountpoint() throws ServiceException, IOException, MessagingException {
         super.statusOnMountpoint();
     }
+    @Override
+    @Ignore("ZCS-3810 - virtual folders (search folders) return only up to 1000 items")
+    @Test
+    public void testUidRangeSearch() throws Exception {
+
+    }
+    @Override
+    @Ignore("ZCS-3810 - virtual folders (search folders) return only up to 1000 items")
+    @Test
+    public void testUidRangeSearchOnVirtualFolder() throws Exception {
+
+    }
 }

--- a/store/src/java/com/zimbra/qa/unittest/TestImapViaImapDaemon.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestImapViaImapDaemon.java
@@ -321,4 +321,16 @@ import com.zimbra.soap.admin.type.CacheEntryType;
     public void statusOnMountpoint() throws ServiceException, IOException, MessagingException {
         super.statusOnMountpoint();
     }
+    @Override
+    @Ignore("ZCS-3810 - virtual folders (search folders) return only up to 1000 items")
+    @Test
+    public void testUidRangeSearch() throws Exception {
+
+    }
+    @Override
+    @Ignore("ZCS-3810 - virtual folders (search folders) return only up to 1000 items")
+    @Test
+    public void testUidRangeSearchOnVirtualFolder() throws Exception {
+
+    }
   }


### PR DESCRIPTION
Added SOAP tests to check results returned for "UID SEARCH" with ranges.