### PR TITLE
Bugfix/zimbra 127 imp email analytics

### DIFF
--- a/store/src/java/com/zimbra/cs/event/Event.java
+++ b/store/src/java/com/zimbra/cs/event/Event.java
@@ -317,6 +317,13 @@ public class Event {
         }
     }
 
+    /**
+     * Convenience method to generate a single READ event
+     */
+    public static Event generateReadEvent(String accountId, int messageId, String sender, String dsId, Long timestamp) {
+        return generateEvent(accountId, messageId, sender, null, EventType.READ, dsId, null, timestamp);
+    }
+
     @Override
     public boolean equals(Object other) {
         if (other instanceof Event) {

--- a/store/src/java/com/zimbra/cs/event/Event.java
+++ b/store/src/java/com/zimbra/cs/event/Event.java
@@ -328,7 +328,7 @@ public class Event {
      * Convenience method to generate a single SEEN event
      */
     public static Event generateSeenEvent(String accountId, int messageId, String sender, String dsId, Long timestamp) {
-        return generateEvent(accountId, messageId, sender, null, EventType.SEEN, dsId, timestamp);
+        return generateEvent(accountId, messageId, sender, null, EventType.SEEN, dsId, null, timestamp);
     }
 
     @Override

--- a/store/src/java/com/zimbra/cs/event/Event.java
+++ b/store/src/java/com/zimbra/cs/event/Event.java
@@ -324,6 +324,13 @@ public class Event {
         return generateEvent(accountId, messageId, sender, null, EventType.READ, dsId, null, timestamp);
     }
 
+    /**
+     * Convenience method to generate a single SEEN event
+     */
+    public static Event generateSeenEvent(String accountId, int messageId, String sender, String dsId, Long timestamp) {
+        return generateEvent(accountId, messageId, sender, null, EventType.SEEN, dsId, timestamp);
+    }
+
     @Override
     public boolean equals(Object other) {
         if (other instanceof Event) {

--- a/store/src/java/com/zimbra/cs/event/Event.java
+++ b/store/src/java/com/zimbra/cs/event/Event.java
@@ -331,6 +331,13 @@ public class Event {
         return generateEvent(accountId, messageId, sender, null, EventType.SEEN, dsId, null, timestamp);
     }
 
+    /**
+     * Convenience method to generate a single REPLIED event
+     */
+    public static Event generateRepliedEvent(String accountId, int messageId, String sender, String dsId, Long timestamp) {
+        return generateEvent(accountId, messageId, sender, null, EventType.REPLIED, dsId, null, timestamp);
+    }
+
     @Override
     public boolean equals(Object other) {
         if (other instanceof Event) {

--- a/store/src/java/com/zimbra/cs/event/EventStore.java
+++ b/store/src/java/com/zimbra/cs/event/EventStore.java
@@ -178,6 +178,16 @@ public abstract class EventStore {
      */
     public abstract Double getPercentageOpenedEmails(String contact) throws ServiceException;
 
+    /**
+     * Returns the avg time in seconds to open emails from a contact
+     */
+    public abstract Double getAvgTimeToOpenEmail(String contact) throws ServiceException;
+
+    /**
+     *Returns the avg time in seconds to open emails for an account(all contacts)
+     */
+    public abstract Double getAvgTimeToOpenEmailForAccount() throws ServiceException;
+
     public interface Factory {
 
         public EventStore getEventStore(String accountId);

--- a/store/src/java/com/zimbra/cs/event/EventStore.java
+++ b/store/src/java/com/zimbra/cs/event/EventStore.java
@@ -171,6 +171,13 @@ public abstract class EventStore {
      */
     public abstract List<ContactFrequencyGraphDataPoint> getContactFrequencyGraph(String contact, ContactAnalytics.ContactFrequencyGraphTimeRange timeRange) throws ServiceException;
 
+    /**
+     * Returns the percentage of emails opened sent by the contact.
+     * The percentage is calculated using (number of Read emails / number of Received emails) from the contact
+     * This data is used by email classifier to mark important emails
+     */
+    public abstract Double getPercentageOpenedEmails(String contact) throws ServiceException;
+
     public interface Factory {
 
         public EventStore getEventStore(String accountId);

--- a/store/src/java/com/zimbra/cs/event/EventStore.java
+++ b/store/src/java/com/zimbra/cs/event/EventStore.java
@@ -188,6 +188,13 @@ public abstract class EventStore {
      */
     public abstract Double getAvgTimeToOpenEmailForAccount() throws ServiceException;
 
+    /**
+     * Returns the percentage of replies provided for emails sent by a contact.
+     * The percentage is calculated using (number of Replied emails / number of Received emails) from the contact
+     * This data is used by email classifier to mark important emails
+     */
+    public abstract Double getPercentageRepliedEmails(String contact) throws ServiceException;
+
     public interface Factory {
 
         public EventStore getEventStore(String accountId);

--- a/store/src/java/com/zimbra/cs/event/SolrEventStore.java
+++ b/store/src/java/com/zimbra/cs/event/SolrEventStore.java
@@ -181,7 +181,7 @@ public abstract class SolrEventStore extends EventStore {
         case LAST_SIX_MONTHS:
             return getStartDateForLastSixMonths();
         case CURRENT_YEAR:
-            return getStartDateForCurrentyear();
+            return getStartDateForCurrentYear();
         default:
             throw ServiceException.INVALID_REQUEST("Time range not supported " + timeRange, null);
         }

--- a/store/src/java/com/zimbra/cs/event/SolrEventStore.java
+++ b/store/src/java/com/zimbra/cs/event/SolrEventStore.java
@@ -257,7 +257,7 @@ public abstract class SolrEventStore extends EventStore {
 
         solrQuery.setFacet(true);
         solrQuery.addFacetField(LuceneFields.L_EVENT_TYPE);
-        System.out.println(solrQuery);
+
         QueryResponse response = (QueryResponse) solrHelper.executeRequest(accountId, solrQuery);
         if(response.getResults().getNumFound() <= 1) {
             return 0.0;

--- a/store/src/java/com/zimbra/cs/event/SolrEventStore.java
+++ b/store/src/java/com/zimbra/cs/event/SolrEventStore.java
@@ -239,7 +239,7 @@ public abstract class SolrEventStore extends EventStore {
 
     @Override
     public Double getPercentageOpenedEmails(String contact) throws ServiceException {
-        TermQuery searchContactInSenderField = new TermQuery(new Term(SolrEventDocument.getSolrField(Event.EventContextField.SENDER), contact));
+        TermQuery searchContactInSenderField = new TermQuery(new Term(SolrEventDocument.getSolrQueryField(Event.EventContextField.SENDER), contact));
 
         BooleanQuery.Builder filterByEventTypes = new BooleanQuery.Builder();
         filterByEventTypes.add(new TermQuery(new Term(LuceneFields.L_EVENT_TYPE, Event.EventType.RECEIVED.name())), Occur.SHOULD);

--- a/store/src/java/com/zimbra/cs/event/StandaloneSolrEventStore.java
+++ b/store/src/java/com/zimbra/cs/event/StandaloneSolrEventStore.java
@@ -25,6 +25,16 @@ public class StandaloneSolrEventStore extends SolrEventStore {
         throw ServiceException.UNSUPPORTED();
     }
 
+    @Override
+    public Double getAvgTimeToOpenEmail(String contact) throws ServiceException {
+        throw ServiceException.UNSUPPORTED();
+    }
+
+    @Override
+    public Double getAvgTimeToOpenEmailForAccount() throws ServiceException {
+        throw ServiceException.UNSUPPORTED();
+    }
+
     public static class Factory extends SolrEventStore.Factory {
 
         public Factory() throws ServiceException {

--- a/store/src/java/com/zimbra/cs/event/StandaloneSolrEventStore.java
+++ b/store/src/java/com/zimbra/cs/event/StandaloneSolrEventStore.java
@@ -26,12 +26,22 @@ public class StandaloneSolrEventStore extends SolrEventStore {
     }
 
     @Override
+    public Double getPercentageOpenedEmails(String contact) throws ServiceException {
+        throw ServiceException.UNSUPPORTED();
+    }
+
+    @Override
     public Double getAvgTimeToOpenEmail(String contact) throws ServiceException {
         throw ServiceException.UNSUPPORTED();
     }
 
     @Override
     public Double getAvgTimeToOpenEmailForAccount() throws ServiceException {
+        throw ServiceException.UNSUPPORTED();
+    }
+
+    @Override
+    public Double getPercentageRepliedEmails(String contact) throws ServiceException {
         throw ServiceException.UNSUPPORTED();
     }
 

--- a/store/src/java/com/zimbra/cs/event/analytics/contact/ContactAnalytics.java
+++ b/store/src/java/com/zimbra/cs/event/analytics/contact/ContactAnalytics.java
@@ -1,16 +1,9 @@
 package com.zimbra.cs.event.analytics.contact;
 
 import com.zimbra.common.service.ServiceException;
-import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.event.EventStore;
 
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalAdjusters;
-import java.time.temporal.WeekFields;
-import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 
 public class ContactAnalytics {
     public enum ContactFrequencyTimeRange {
@@ -35,5 +28,9 @@ public class ContactAnalytics {
 
     public static List<ContactFrequencyGraphDataPoint> getContactFrequencyGraph(String contact, ContactFrequencyGraphTimeRange timeRange, EventStore eventStore) throws ServiceException {
         return eventStore.getContactFrequencyGraph(contact, timeRange);
+    }
+
+    public static Double getPercentageOpenedEmails(String contact, EventStore eventStore) throws ServiceException {
+        return eventStore.getPercentageOpenedEmails(contact);
     }
 }

--- a/store/src/java/com/zimbra/cs/event/analytics/contact/ContactAnalytics.java
+++ b/store/src/java/com/zimbra/cs/event/analytics/contact/ContactAnalytics.java
@@ -37,4 +37,14 @@ public class ContactAnalytics {
     public static Double getAvgTimeToOpenEmailForAccount(EventStore eventStore) throws ServiceException {
         return eventStore.getAvgTimeToOpenEmailForAccount();
     }
+
+    public static Double getAvgTimeToOpenEmail(String contact, EventStore eventStore) throws ServiceException {
+        return eventStore.getAvgTimeToOpenEmailForAccount();
+    }
+
+    public static Double getRatioOfAvgTimeToOpenEmailToGlobalAvg(String contact, EventStore eventStore) throws ServiceException {
+        Double avgTimeToOpenEmailForAllContacts = eventStore.getAvgTimeToOpenEmailForAccount();
+        Double avgTimeToOpenEmailFromAContact = eventStore.getAvgTimeToOpenEmail(contact);
+        return avgTimeToOpenEmailFromAContact / avgTimeToOpenEmailForAllContacts;
+    }
 }

--- a/store/src/java/com/zimbra/cs/event/analytics/contact/ContactAnalytics.java
+++ b/store/src/java/com/zimbra/cs/event/analytics/contact/ContactAnalytics.java
@@ -47,4 +47,8 @@ public class ContactAnalytics {
         Double avgTimeToOpenEmailFromAContact = eventStore.getAvgTimeToOpenEmail(contact);
         return avgTimeToOpenEmailFromAContact / avgTimeToOpenEmailForAllContacts;
     }
+
+    public static Double getPercentageRepliedEmails(String contact, EventStore eventStore) throws ServiceException {
+        return eventStore.getPercentageRepliedEmails(contact);
+    }
 }

--- a/store/src/java/com/zimbra/cs/event/analytics/contact/ContactAnalytics.java
+++ b/store/src/java/com/zimbra/cs/event/analytics/contact/ContactAnalytics.java
@@ -39,7 +39,7 @@ public class ContactAnalytics {
     }
 
     public static Double getAvgTimeToOpenEmail(String contact, EventStore eventStore) throws ServiceException {
-        return eventStore.getAvgTimeToOpenEmailForAccount();
+        return eventStore.getAvgTimeToOpenEmail(contact);
     }
 
     public static Double getRatioOfAvgTimeToOpenEmailToGlobalAvg(String contact, EventStore eventStore) throws ServiceException {

--- a/store/src/java/com/zimbra/cs/event/analytics/contact/ContactAnalytics.java
+++ b/store/src/java/com/zimbra/cs/event/analytics/contact/ContactAnalytics.java
@@ -33,4 +33,8 @@ public class ContactAnalytics {
     public static Double getPercentageOpenedEmails(String contact, EventStore eventStore) throws ServiceException {
         return eventStore.getPercentageOpenedEmails(contact);
     }
+
+    public static Double getAvgTimeToOpenEmailForAccount(EventStore eventStore) throws ServiceException {
+        return eventStore.getAvgTimeToOpenEmailForAccount();
+    }
 }

--- a/store/src/java/com/zimbra/qa/unittest/SolrEventStoreTestBase.java
+++ b/store/src/java/com/zimbra/qa/unittest/SolrEventStoreTestBase.java
@@ -312,11 +312,11 @@ public abstract class SolrEventStoreTestBase {
         List<Event> events = new ArrayList<>(timestamps.size());
         //generate 15 received events
         for (int i = 0; i < timestamps.size(); i++) {
-            Event.generateReceivedEvent(ACCOUNT_ID_1, i, "testSender@zcs-dev.test", "testRecipient@zcs-dev.test", "testDSId", timestamps.get(i).getTime());
+            events.add(Event.generateReceivedEvent(ACCOUNT_ID_1, i, "testSender@zcs-dev.test", "testRecipient@zcs-dev.test", "testDSId", timestamps.get(i).getTime()));
         }
         //generate 9 read events
         for (int i = 0; i < timestamps.size() - 6; i++) {
-            Event.generateReadEvent(ACCOUNT_ID_1, i, "testSender@zcs-dev.test", "testDSId", timestamps.get(i).getTime());
+            events.add(Event.generateReadEvent(ACCOUNT_ID_1, i, "testSender@zcs-dev.test", "testDSId", timestamps.get(i).getTime()));
         }
 
         eventCallback.execute(ACCOUNT_ID_1, events);

--- a/store/src/java/com/zimbra/qa/unittest/SolrEventStoreTestBase.java
+++ b/store/src/java/com/zimbra/qa/unittest/SolrEventStoreTestBase.java
@@ -331,22 +331,49 @@ public abstract class SolrEventStoreTestBase {
     }
 
     protected void testGetAvgTimeToOpenEmailForAccount(SolrEventCallback eventCallback, String collectionName, SolrEventStore eventStore) throws Exception {
-        List<Event> events = new ArrayList<>(6);
-        events.add(Event.generateSeenEvent(ACCOUNT_ID_1, 1, "test1@zcs-dev.test", "testDSId", 100000L));
-        events.add(Event.generateReadEvent(ACCOUNT_ID_1, 1, "test1@zcs-dev.test", "testDSId", 300000L));
-        events.add(Event.generateSeenEvent(ACCOUNT_ID_1, 2, "test1@zcs-dev.test", "testDSId", 100000L));
-        events.add(Event.generateReadEvent(ACCOUNT_ID_1, 2, "test1@zcs-dev.test", "testDSId", 400000L));
-        events.add(Event.generateSeenEvent(ACCOUNT_ID_1, 3, "test1@zcs-dev.test", "testDSId", 100000L));
-        events.add(Event.generateReadEvent(ACCOUNT_ID_1, 3, "test1@zcs-dev.test", "testDSId", 500000L));
-
-        eventCallback.execute(ACCOUNT_ID_1, events);
+        eventCallback.execute(ACCOUNT_ID_1, getTestEventsForOpenEmails());
         commit(collectionName);
         SolrDocumentList results = queryEvents(collectionName);
-        assertEquals("should see 6 events in test-id-1 collection", 6, (int) results.getNumFound());
+        assertEquals("should see 8 events in test-id-1 collection", 8, (int) results.getNumFound());
 
         Double avgTimeToOpenEmails = ContactAnalytics.getAvgTimeToOpenEmailForAccount(eventStore);
         assertNotNull(avgTimeToOpenEmails);
-        assertEquals("Mismatch in average time to opened emails", Double.valueOf(300), avgTimeToOpenEmails);
+        assertEquals("Mismatch in average time to opened emails", Double.valueOf(250), avgTimeToOpenEmails);
+    }
+
+    protected void testGetAvgTimeToOpenEmail(SolrEventCallback eventCallback, String collectionName, SolrEventStore eventStore) throws Exception {
+        eventCallback.execute(ACCOUNT_ID_1, getTestEventsForOpenEmails());
+        commit(collectionName);
+        SolrDocumentList results = queryEvents(collectionName);
+        assertEquals("should see 8 events in test-id-1 collection", 8, (int) results.getNumFound());
+
+        Double avgTimeToOpenEmails = ContactAnalytics.getAvgTimeToOpenEmail("test1@zcs-dev.test", eventStore);
+        assertNotNull(avgTimeToOpenEmails);
+        assertEquals("Mismatch in average time to opened emails", Double.valueOf(150), avgTimeToOpenEmails);
+    }
+
+    protected void testGetRatioOfAvgTimeToOpenEmailToGlobalAvg(SolrEventCallback eventCallback, String collectionName, SolrEventStore eventStore) throws Exception {
+        eventCallback.execute(ACCOUNT_ID_1, getTestEventsForOpenEmails());
+        commit(collectionName);
+        SolrDocumentList results = queryEvents(collectionName);
+        assertEquals("should see 8 events in test-id-1 collection", 8, (int) results.getNumFound());
+
+        Double avgTimeToOpenEmails = ContactAnalytics.getRatioOfAvgTimeToOpenEmailToGlobalAvg("test1@zcs-dev.test", eventStore);
+        assertNotNull(avgTimeToOpenEmails);
+        assertEquals("Mismatch in average time to opened emails", Double.valueOf(0.6), avgTimeToOpenEmails);
+    }
+
+    private List<Event> getTestEventsForOpenEmails() {
+        List<Event> events = new ArrayList<>(6);
+        events.add(Event.generateSeenEvent(ACCOUNT_ID_1, 1, "test1@zcs-dev.test", "testDSId", 100000L));
+        events.add(Event.generateReadEvent(ACCOUNT_ID_1, 1, "test1@zcs-dev.test", "testDSId", 200000L));
+        events.add(Event.generateSeenEvent(ACCOUNT_ID_1, 2, "test1@zcs-dev.test", "testDSId", 100000L));
+        events.add(Event.generateReadEvent(ACCOUNT_ID_1, 2, "test1@zcs-dev.test", "testDSId", 300000L));
+        events.add(Event.generateSeenEvent(ACCOUNT_ID_1, 3, "test2@zcs-dev.test", "testDSId", 100000L));
+        events.add(Event.generateReadEvent(ACCOUNT_ID_1, 3, "test2@zcs-dev.test", "testDSId", 400000L));
+        events.add(Event.generateSeenEvent(ACCOUNT_ID_1, 4, "test3@zcs-dev.test", "testDSId", 100000L));
+        events.add(Event.generateReadEvent(ACCOUNT_ID_1, 4, "test3@zcs-dev.test", "testDSId", 500000L));
+        return events;
     }
 
     private List<Timestamp> getTimestampsForContactFrequencyCountTest(ContactAnalytics.ContactFrequencyTimeRange timeRange) throws ServiceException {

--- a/store/src/java/com/zimbra/qa/unittest/TestSolrCloudEventStore.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestSolrCloudEventStore.java
@@ -179,4 +179,24 @@ public class TestSolrCloudEventStore extends SolrEventStoreTestBase {
             testContactFrequencyGraph(timeRange, eventCallback, JOINT_COLLECTION_NAME, eventStore);
         }
     }
+
+    @Test
+    public void testPercentageOpenedEmails() throws Exception {
+        testPercentageOpenedEmailsForAccountCore();
+        testPercentageOpenedEmailsForCombinedCore();
+    }
+
+    public void testPercentageOpenedEmailsForAccountCore() throws Exception {
+        cleanUp();
+        try(SolrEventCallback eventCallback = getAccountCoreCallback()) {
+            testPercentageOpenedEmails(eventCallback, getAccountCollectionName(ACCOUNT_ID_1), getAccountEventStore(ACCOUNT_ID_1));
+        }
+    }
+
+    public void testPercentageOpenedEmailsForCombinedCore() throws Exception {
+        cleanUp();
+        try(SolrEventCallback eventCallback = getCombinedCoreCallback()) {
+            testPercentageOpenedEmails(eventCallback, JOINT_COLLECTION_NAME, getCombinedEventStore(ACCOUNT_ID_1));
+        }
+    }
 }

--- a/store/src/java/com/zimbra/qa/unittest/TestSolrCloudEventStore.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestSolrCloudEventStore.java
@@ -186,17 +186,37 @@ public class TestSolrCloudEventStore extends SolrEventStoreTestBase {
         testPercentageOpenedEmailsForCombinedCore();
     }
 
-    public void testPercentageOpenedEmailsForAccountCore() throws Exception {
+    private void testPercentageOpenedEmailsForAccountCore() throws Exception {
         cleanUp();
         try(SolrEventCallback eventCallback = getAccountCoreCallback()) {
             testPercentageOpenedEmails(eventCallback, getAccountCollectionName(ACCOUNT_ID_1), getAccountEventStore(ACCOUNT_ID_1));
         }
     }
 
-    public void testPercentageOpenedEmailsForCombinedCore() throws Exception {
+    private void testPercentageOpenedEmailsForCombinedCore() throws Exception {
         cleanUp();
         try(SolrEventCallback eventCallback = getCombinedCoreCallback()) {
             testPercentageOpenedEmails(eventCallback, JOINT_COLLECTION_NAME, getCombinedEventStore(ACCOUNT_ID_1));
+        }
+    }
+
+    @Test
+    public void testGetAvgTimeToOpenEmailForAccount() throws Exception {
+        testGetAvgTimeToOpenEmailForAccountForAccountCore();
+        testGetAvgTimeToOpenEmailForAccountForCombinedCore();
+    }
+
+    private void testGetAvgTimeToOpenEmailForAccountForAccountCore() throws Exception {
+        cleanUp();
+        try(SolrEventCallback eventCallback = getAccountCoreCallback()) {
+            testGetAvgTimeToOpenEmailForAccount(eventCallback, getAccountCollectionName(ACCOUNT_ID_1), getAccountEventStore(ACCOUNT_ID_1));
+        }
+    }
+
+    private void testGetAvgTimeToOpenEmailForAccountForCombinedCore() throws Exception {
+        cleanUp();
+        try(SolrEventCallback eventCallback = getCombinedCoreCallback()) {
+            testGetAvgTimeToOpenEmailForAccount(eventCallback, JOINT_COLLECTION_NAME, getCombinedEventStore(ACCOUNT_ID_1));
         }
     }
 }

--- a/store/src/java/com/zimbra/qa/unittest/TestSolrCloudEventStore.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestSolrCloudEventStore.java
@@ -212,6 +212,12 @@ public class TestSolrCloudEventStore extends SolrEventStoreTestBase {
         testForBothCores(getAvgTimeToOpenEmail);
     }
 
+    @Test
+    public void testPercentageRepliedEmails() throws Exception {
+        ExecuteTest getPercentageRepliedEmails = (ec, cn, es) -> testPercentageRepliedEmails(ec, cn, es);
+        testForBothCores(getPercentageRepliedEmails);
+    }
+
     private void testForBothCores(ExecuteTest test) throws Exception {
         testForAccountCore(test);
         testForCombinedCore(test);

--- a/store/src/java/com/zimbra/qa/unittest/TestSolrCloudEventStore.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestSolrCloudEventStore.java
@@ -1,8 +1,11 @@
 package com.zimbra.qa.unittest;
 
 import java.io.IOException;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 import com.zimbra.cs.account.Account;
+import com.zimbra.cs.event.EventStore;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
@@ -210,6 +213,10 @@ public class TestSolrCloudEventStore extends SolrEventStoreTestBase {
         cleanUp();
         try(SolrEventCallback eventCallback = getAccountCoreCallback()) {
             testGetAvgTimeToOpenEmailForAccount(eventCallback, getAccountCollectionName(ACCOUNT_ID_1), getAccountEventStore(ACCOUNT_ID_1));
+            cleanUp();
+            testGetAvgTimeToOpenEmail(eventCallback, getAccountCollectionName(ACCOUNT_ID_1), getAccountEventStore(ACCOUNT_ID_1));
+            cleanUp();
+            testGetRatioOfAvgTimeToOpenEmailToGlobalAvg(eventCallback, getAccountCollectionName(ACCOUNT_ID_1), getAccountEventStore(ACCOUNT_ID_1));
         }
     }
 
@@ -217,6 +224,10 @@ public class TestSolrCloudEventStore extends SolrEventStoreTestBase {
         cleanUp();
         try(SolrEventCallback eventCallback = getCombinedCoreCallback()) {
             testGetAvgTimeToOpenEmailForAccount(eventCallback, JOINT_COLLECTION_NAME, getCombinedEventStore(ACCOUNT_ID_1));
+            cleanUp();
+            testGetAvgTimeToOpenEmail(eventCallback, JOINT_COLLECTION_NAME, getCombinedEventStore(ACCOUNT_ID_1));
+            cleanUp();
+            testGetRatioOfAvgTimeToOpenEmailToGlobalAvg(eventCallback, JOINT_COLLECTION_NAME, getCombinedEventStore(ACCOUNT_ID_1));
         }
     }
 }

--- a/store/src/java/com/zimbra/qa/unittest/TestSolrCloudEventStore.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestSolrCloudEventStore.java
@@ -183,51 +183,51 @@ public class TestSolrCloudEventStore extends SolrEventStoreTestBase {
         }
     }
 
+    @FunctionalInterface
+    public interface ExecuteTest {
+        void execute(SolrEventCallback eventCallback, String collectionName, SolrEventStore eventStore) throws Exception;
+    }
+
     @Test
     public void testPercentageOpenedEmails() throws Exception {
-        testPercentageOpenedEmailsForAccountCore();
-        testPercentageOpenedEmailsForCombinedCore();
-    }
-
-    private void testPercentageOpenedEmailsForAccountCore() throws Exception {
-        cleanUp();
-        try(SolrEventCallback eventCallback = getAccountCoreCallback()) {
-            testPercentageOpenedEmails(eventCallback, getAccountCollectionName(ACCOUNT_ID_1), getAccountEventStore(ACCOUNT_ID_1));
-        }
-    }
-
-    private void testPercentageOpenedEmailsForCombinedCore() throws Exception {
-        cleanUp();
-        try(SolrEventCallback eventCallback = getCombinedCoreCallback()) {
-            testPercentageOpenedEmails(eventCallback, JOINT_COLLECTION_NAME, getCombinedEventStore(ACCOUNT_ID_1));
-        }
+        ExecuteTest percentageOpenedEmails = (ec, cn, es) -> testPercentageOpenedEmails(ec, cn, es);
+        testForBothCores(percentageOpenedEmails);
     }
 
     @Test
-    public void testGetAvgTimeToOpenEmailForAccount() throws Exception {
-        testGetAvgTimeToOpenEmailForAccountForAccountCore();
-        testGetAvgTimeToOpenEmailForAccountForCombinedCore();
+    public void testGetAvgTimeToOpenEmailForAcc() throws Exception {
+        ExecuteTest getAvgTimeToOpenEmailForAccount = (ec, cn, es) -> testGetAvgTimeToOpenEmailForAccount(ec, cn, es);
+        testForBothCores(getAvgTimeToOpenEmailForAccount);
     }
 
-    private void testGetAvgTimeToOpenEmailForAccountForAccountCore() throws Exception {
+    @Test
+    public void testGetAvgTimeToOpenEmailForContact() throws Exception {
+        ExecuteTest getAvgTimeToOpenEmail = (ec, cn, es) -> testGetAvgTimeToOpenEmail(ec, cn, es);
+        testForBothCores(getAvgTimeToOpenEmail);
+    }
+
+    @Test
+    public void testRatioOfAvgTimeToOpenEmailToGlobalAvg() throws Exception {
+        ExecuteTest getAvgTimeToOpenEmail = (ec, cn, es) -> testGetRatioOfAvgTimeToOpenEmailToGlobalAvg(ec, cn, es);
+        testForBothCores(getAvgTimeToOpenEmail);
+    }
+
+    private void testForBothCores(ExecuteTest test) throws Exception {
+        testForAccountCore(test);
+        testForCombinedCore(test);
+    }
+
+    private void testForAccountCore(ExecuteTest test) throws Exception {
         cleanUp();
-        try(SolrEventCallback eventCallback = getAccountCoreCallback()) {
-            testGetAvgTimeToOpenEmailForAccount(eventCallback, getAccountCollectionName(ACCOUNT_ID_1), getAccountEventStore(ACCOUNT_ID_1));
-            cleanUp();
-            testGetAvgTimeToOpenEmail(eventCallback, getAccountCollectionName(ACCOUNT_ID_1), getAccountEventStore(ACCOUNT_ID_1));
-            cleanUp();
-            testGetRatioOfAvgTimeToOpenEmailToGlobalAvg(eventCallback, getAccountCollectionName(ACCOUNT_ID_1), getAccountEventStore(ACCOUNT_ID_1));
+        try (SolrEventCallback eventCallback = getAccountCoreCallback()) {
+            test.execute(eventCallback, getAccountCollectionName(ACCOUNT_ID_1), getAccountEventStore(ACCOUNT_ID_1));
         }
     }
 
-    private void testGetAvgTimeToOpenEmailForAccountForCombinedCore() throws Exception {
+    private void testForCombinedCore(ExecuteTest test) throws Exception {
         cleanUp();
         try(SolrEventCallback eventCallback = getCombinedCoreCallback()) {
-            testGetAvgTimeToOpenEmailForAccount(eventCallback, JOINT_COLLECTION_NAME, getCombinedEventStore(ACCOUNT_ID_1));
-            cleanUp();
-            testGetAvgTimeToOpenEmail(eventCallback, JOINT_COLLECTION_NAME, getCombinedEventStore(ACCOUNT_ID_1));
-            cleanUp();
-            testGetRatioOfAvgTimeToOpenEmailToGlobalAvg(eventCallback, JOINT_COLLECTION_NAME, getCombinedEventStore(ACCOUNT_ID_1));
+            test.execute(eventCallback, JOINT_COLLECTION_NAME, getCombinedEventStore(ACCOUNT_ID_1));
         }
     }
 }

--- a/store/src/java/com/zimbra/qa/unittest/TestStandaloneSolrEventStore.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestStandaloneSolrEventStore.java
@@ -176,4 +176,24 @@ public class TestStandaloneSolrEventStore extends SolrEventStoreTestBase {
             testContactFrequencyGraph(timeRange, eventCallback, JOINT_COLLECTION_NAME, eventStore);
         }
     }
+
+    @Test
+    public void testPercentageOpenedEmails() throws Exception {
+        testPercentageOpenedEmailsForAccountCore();
+        testPercentageOpenedEmailsForCombinedCore();
+    }
+
+    public void testPercentageOpenedEmailsForAccountCore() throws Exception {
+        cleanUp();
+        try(SolrEventCallback eventCallback = getAccountCoreCallback()) {
+            testPercentageOpenedEmails(eventCallback, getAccountCollectionName(ACCOUNT_ID_1), getAccountEventStore(ACCOUNT_ID_1));
+        }
+    }
+
+    public void testPercentageOpenedEmailsForCombinedCore() throws Exception {
+        cleanUp();
+        try(SolrEventCallback eventCallback = getCombinedCoreCallback()) {
+            testPercentageOpenedEmails(eventCallback, JOINT_COLLECTION_NAME, getCombinedEventStore(ACCOUNT_ID_1));
+        }
+    }
 }


### PR DESCRIPTION
This PR adds 4 email analytics which are needed by the machine learning module to classify emails. This PR is built on top of work done in bugfix/ZIMBRA-94-contactFrequencyGraph. No new classes are added.

#### Contact Analytics ####
- `Percentage Open Emails` - Provides the percentage of emails read to received from a contact.

- `Average Time to Open Emails for a Contact` - Provides the mean of the delta of time when email was read to the time when email was received. This is calculated using the Solr streaming queries. It creates an inner join of the stream of the read events to the stream of received events on message id. It calculates the difference between the timestamp of the read event to the timestamp of the received event. If the delta is less then 500ms then that event pair is ignored. Then a mean delta is calculated.

- `Average Time to Open Emails for an Account` - Same as `Average Time to Open Emails for a Contact`, except for getting read and received events for a specific contact, all the read and received events for an account(all contacts) are used.

- `Ratio of Avg Time to Open Emails for a Contact to Avg Time to Open Emails for an Account` - Provides a ratio of above two analytics. Smaller the ratio more importance can be assigned to the emails from that contact. This is assuming a User will read an email from important contact immediately after it is received. 

- `Percentage Replied Emails for a Contact` - Provides the percentage of emails replied to emails received from a contact.