### PR TITLE
 ZCS-2191 handle ctrl-c gracefully

### DIFF
--- a/store/src/java/com/zimbra/cs/ephemeral/migrate/ShutdownHook.java
+++ b/store/src/java/com/zimbra/cs/ephemeral/migrate/ShutdownHook.java
@@ -1,0 +1,39 @@
+package com.zimbra.cs.ephemeral.migrate;
+
+import com.zimbra.common.util.ZimbraLog;
+
+public class ShutdownHook extends Thread {
+    private AttributeMigration.CSVReports csvReports;
+    private Exception exception;
+    private boolean finished;
+
+    public ShutdownHook () {
+        this.csvReports = null;
+        this.exception = null;
+        this.finished = false;
+    }
+
+    public void setException(Exception exception) {
+        this.exception = exception;
+    }
+
+    public void setFinished(boolean finished) {
+        this.finished = finished;
+    }
+
+    public void setCSVReports(AttributeMigration.CSVReports csvReports) {
+        this.csvReports = csvReports;
+    }
+
+    public void run() {
+        if (this.finished) {
+            csvReports.zimbraLogFinalSummary(true);
+        }
+        else {
+            csvReports.zimbraLogFinalSummary(false);
+            if (this.exception != null) {
+                ZimbraLog.ephemeral.error("Failure during migration: %s", this.exception);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Update zmmigrateattrs to utilize a 'Shutdown-hook' such that when the JVM is exiting it can decide if it was successful or failed in the conversion process.

This enables the utility to output the appropriate message before fully exiting.