### PR TITLE
ZCS-3456:Attendee's status isn't updated

### DIFF
--- a/store/src/java-test/com/zimbra/cs/mailbox/calendar/Calendar_NewMeetingRequest_RsvpFalse.txt
+++ b/store/src/java-test/com/zimbra/cs/mailbox/calendar/Calendar_NewMeetingRequest_RsvpFalse.txt
@@ -1,5 +1,5 @@
-To: attendee1 <attendee1@zimbra.com>
-Message-ID: <2103105317.2993.1513012884769.JavaMail.zimbra@synacorjapan.com>
+To: attendee1 <attendee1@testdomain.com>
+Message-ID: <2103105317.2993.1513012884769.JavaMail.zimbra@testdomain.com>
 Subject: Party
 MIME-Version: 1.0
 Content-Type: multipart/alternative;
@@ -12,11 +12,11 @@ Content-Transfer-Encoding: 7bit
 The following is a new meeting request:
 
 Subject: Party
-Organizer: org@synacorjapan.com
+Organizer: owner@testdomain.com
 
 Time: Tuesday, December 12, 2017, 10:00:00 AM - 10:30:00 AM GMT +09:00 Japan
 
-Invitees: attendee1@zimbra.com
+Invitees: attendee1@testdomain.com
 
 
 *~*~*~*~*~*~*~*~*~*
@@ -32,7 +32,7 @@ Content-Transfer-Encoding: 7bit
 <p>
 <table border='0'>
 <tr><th align=left>Subject:</th><td>Party </td></tr>
-<tr><th align=left>Organizer:</th><td>org@synacorjapan.com </td></tr>
+<tr><th align=left>Organizer:</th><td>owner@testdomain.com </td></tr>
 </table>
 <p>
 <table border='0'>
@@ -40,7 +40,7 @@ Content-Transfer-Encoding: 7bit
  </td></tr></table>
 <p>
 <table border='0'>
-<tr><th align=left>Invitees:</th><td>attendee1@zimbra.com </td></tr>
+<tr><th align=left>Invitees:</th><td>attendee1@testdomain.com </td></tr>
 </table>
 <div>*~*~*~*~*~*~*~*~*~*</div><br></body></html>
 --=_2eb7dab5-3168-43b0-ba14-80504c7e08da
@@ -63,8 +63,8 @@ BEGIN:VEVENT
 UID:8282cdfc-a5a6-4ed4-84e2-be12c2bc4af8
 SUMMARY:Party
 ATTENDEE;CN=attendee1;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=FALSE:mailto
- :attendee1@zimbra.com
-ORGANIZER:mailto:org@synacorjapan.com
+ :attendee1@testdomain.com
+ORGANIZER:mailto:owner@testdomain.com
 DTSTART;TZID="Asia/Tokyo":20171212T100000
 DTEND;TZID="Asia/Tokyo":20171212T103000
 STATUS:CONFIRMED
@@ -75,16 +75,16 @@ LAST-MODIFIED:20171211T172124Z
 DTSTAMP:20171211T172124Z
 SEQUENCE:0
 DESCRIPTION:The following is a new meeting request:\n\nSubject: Party \nOrg
- anizer: org@synacorjapan.com \n\nTime: Tuesday\, December 12\, 2017\, 10:00:
- 00 AM - 10:30:00 AM GMT +09:00 Japan\n \nInvitees: attendee1@zimbra.com \n\
+ anizer: owner@testdomain.com \n\nTime: Tuesday\, December 12\, 2017\, 10:00:
+ 00 AM - 10:30:00 AM GMT +09:00 Japan\n \nInvitees: attendee1@testdomain.com \n\
  n\n*~*~*~*~*~*~*~*~*~*\n\n\n
 X-ALT-DESC;FMTTYPE=text/html:<html><body id='htmlmode'><h3>The following is 
  a new meeting request:</h3>\n\n<p>\n<table border='0'>\n<tr><th align=left>S
  ubject:</th><td>Party </td></tr>\n<tr><th align=left>Organizer:</th><td>org
- @synacorjapan.com </td></tr>\n</table>\n<p>\n<table border='0'>\n<tr><th ali
+ @testdomain.com </td></tr>\n</table>\n<p>\n<table border='0'>\n<tr><th ali
  gn=left>Time:</th><td>Tuesday\, December 12\, 2017\, 10:00:00 AM - 10:30:00 
  AM GMT +09:00 Japan\n </td></tr></table>\n<p>\n<table border='0'>\n<tr><th a
- lign=left>Invitees:</th><td>attendee1@zimbra.com </td></tr>\n</table>\n<div
+ lign=left>Invitees:</th><td>attendee1@testdomain.com </td></tr>\n</table>\n<div
  >*~*~*~*~*~*~*~*~*~*</div><br></body></html>
 BEGIN:VALARM
 ACTION:DISPLAY

--- a/store/src/java-test/com/zimbra/cs/mailbox/calendar/Calendar_NewMeetingRequest_RsvpFalse.txt
+++ b/store/src/java-test/com/zimbra/cs/mailbox/calendar/Calendar_NewMeetingRequest_RsvpFalse.txt
@@ -1,0 +1,96 @@
+To: attendee1 <attendee1@zimbra.com>
+Message-ID: <2103105317.2993.1513012884769.JavaMail.zimbra@synacorjapan.com>
+Subject: Party
+MIME-Version: 1.0
+Content-Type: multipart/alternative;
+	boundary="=_2eb7dab5-3168-43b0-ba14-80504c7e08da"
+
+--=_2eb7dab5-3168-43b0-ba14-80504c7e08da
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+The following is a new meeting request:
+
+Subject: Party
+Organizer: org@synacorjapan.com
+
+Time: Tuesday, December 12, 2017, 10:00:00 AM - 10:30:00 AM GMT +09:00 Japan
+
+Invitees: attendee1@zimbra.com
+
+
+*~*~*~*~*~*~*~*~*~*
+
+
+
+--=_2eb7dab5-3168-43b0-ba14-80504c7e08da
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+<html><body id='htmlmode'><h3>The following is a new meeting request:</h3>
+
+<p>
+<table border='0'>
+<tr><th align=left>Subject:</th><td>Party </td></tr>
+<tr><th align=left>Organizer:</th><td>org@synacorjapan.com </td></tr>
+</table>
+<p>
+<table border='0'>
+<tr><th align=left>Time:</th><td>Tuesday, December 12, 2017, 10:00:00 AM - 10:30:00 AM GMT +09:00 Japan
+ </td></tr></table>
+<p>
+<table border='0'>
+<tr><th align=left>Invitees:</th><td>attendee1@zimbra.com </td></tr>
+</table>
+<div>*~*~*~*~*~*~*~*~*~*</div><br></body></html>
+--=_2eb7dab5-3168-43b0-ba14-80504c7e08da
+Content-Type: text/calendar; charset=utf-8; method=REQUEST; name=meeting.ics
+Content-Transfer-Encoding: 7bit
+
+BEGIN:VCALENDAR
+PRODID:Zimbra-Calendar-Provider
+VERSION:2.0
+METHOD:REQUEST
+BEGIN:VTIMEZONE
+TZID:Asia/Tokyo
+BEGIN:STANDARD
+DTSTART:16010101T000000
+TZOFFSETTO:+0900
+TZOFFSETFROM:+0900
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+UID:8282cdfc-a5a6-4ed4-84e2-be12c2bc4af8
+SUMMARY:Party
+ATTENDEE;CN=attendee1;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=FALSE:mailto
+ :attendee1@zimbra.com
+ORGANIZER:mailto:org@synacorjapan.com
+DTSTART;TZID="Asia/Tokyo":20171212T100000
+DTEND;TZID="Asia/Tokyo":20171212T103000
+STATUS:CONFIRMED
+CLASS:PUBLIC
+X-MICROSOFT-CDO-INTENDEDSTATUS:BUSY
+TRANSP:OPAQUE
+LAST-MODIFIED:20171211T172124Z
+DTSTAMP:20171211T172124Z
+SEQUENCE:0
+DESCRIPTION:The following is a new meeting request:\n\nSubject: Party \nOrg
+ anizer: org@synacorjapan.com \n\nTime: Tuesday\, December 12\, 2017\, 10:00:
+ 00 AM - 10:30:00 AM GMT +09:00 Japan\n \nInvitees: attendee1@zimbra.com \n\
+ n\n*~*~*~*~*~*~*~*~*~*\n\n\n
+X-ALT-DESC;FMTTYPE=text/html:<html><body id='htmlmode'><h3>The following is 
+ a new meeting request:</h3>\n\n<p>\n<table border='0'>\n<tr><th align=left>S
+ ubject:</th><td>Party </td></tr>\n<tr><th align=left>Organizer:</th><td>org
+ @synacorjapan.com </td></tr>\n</table>\n<p>\n<table border='0'>\n<tr><th ali
+ gn=left>Time:</th><td>Tuesday\, December 12\, 2017\, 10:00:00 AM - 10:30:00 
+ AM GMT +09:00 Japan\n </td></tr></table>\n<p>\n<table border='0'>\n<tr><th a
+ lign=left>Invitees:</th><td>attendee1@zimbra.com </td></tr>\n</table>\n<div
+ >*~*~*~*~*~*~*~*~*~*</div><br></body></html>
+BEGIN:VALARM
+ACTION:DISPLAY
+TRIGGER;RELATED=START:-PT5M
+DESCRIPTION:Reminder
+END:VALARM
+END:VEVENT
+END:VCALENDAR
+--=_2eb7dab5-3168-43b0-ba14-80504c7e08da--

--- a/store/src/java-test/com/zimbra/cs/mailbox/calendar/Calendar_NewMeetingRequest_RsvpTrue.txt
+++ b/store/src/java-test/com/zimbra/cs/mailbox/calendar/Calendar_NewMeetingRequest_RsvpTrue.txt
@@ -1,0 +1,96 @@
+To: attendee1 <attendee1@zimbra.com>
+Message-ID: <2103105317.2993.1513012884769.JavaMail.zimbra@synacorjapan.com>
+Subject: Party
+MIME-Version: 1.0
+Content-Type: multipart/alternative;
+	boundary="=_2eb7dab5-3168-43b0-ba14-80504c7e08da"
+
+--=_2eb7dab5-3168-43b0-ba14-80504c7e08da
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+The following is a new meeting request:
+
+Subject: Party
+Organizer: org@synacorjapan.com
+
+Time: Tuesday, December 12, 2017, 10:00:00 AM - 10:30:00 AM GMT +09:00 Japan
+
+Invitees: attendee1@zimbra.com
+
+
+*~*~*~*~*~*~*~*~*~*
+
+
+
+--=_2eb7dab5-3168-43b0-ba14-80504c7e08da
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+<html><body id='htmlmode'><h3>The following is a new meeting request:</h3>
+
+<p>
+<table border='0'>
+<tr><th align=left>Subject:</th><td>Party </td></tr>
+<tr><th align=left>Organizer:</th><td>org@synacorjapan.com </td></tr>
+</table>
+<p>
+<table border='0'>
+<tr><th align=left>Time:</th><td>Tuesday, December 12, 2017, 10:00:00 AM - 10:30:00 AM GMT +09:00 Japan
+ </td></tr></table>
+<p>
+<table border='0'>
+<tr><th align=left>Invitees:</th><td>attendee1@zimbra.com </td></tr>
+</table>
+<div>*~*~*~*~*~*~*~*~*~*</div><br></body></html>
+--=_2eb7dab5-3168-43b0-ba14-80504c7e08da
+Content-Type: text/calendar; charset=utf-8; method=REQUEST; name=meeting.ics
+Content-Transfer-Encoding: 7bit
+
+BEGIN:VCALENDAR
+PRODID:Zimbra-Calendar-Provider
+VERSION:2.0
+METHOD:REQUEST
+BEGIN:VTIMEZONE
+TZID:Asia/Tokyo
+BEGIN:STANDARD
+DTSTART:16010101T000000
+TZOFFSETTO:+0900
+TZOFFSETFROM:+0900
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+UID:8282cdfc-a5a6-4ed4-84e2-be12c2bc4af8
+SUMMARY:Party
+ATTENDEE;CN=attendee1;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=TRUE:mailto
+ :attendee1@zimbra.com
+ORGANIZER:mailto:org@synacorjapan.com
+DTSTART;TZID="Asia/Tokyo":20171212T100000
+DTEND;TZID="Asia/Tokyo":20171212T103000
+STATUS:CONFIRMED
+CLASS:PUBLIC
+X-MICROSOFT-CDO-INTENDEDSTATUS:BUSY
+TRANSP:OPAQUE
+LAST-MODIFIED:20171211T172124Z
+DTSTAMP:20171211T172124Z
+SEQUENCE:0
+DESCRIPTION:The following is a new meeting request:\n\nSubject: Party \nOrg
+ anizer: org@synacorjapan.com \n\nTime: Tuesday\, December 12\, 2017\, 10:00:
+ 00 AM - 10:30:00 AM GMT +09:00 Japan\n \nInvitees: attendee1@zimbra.com \n\
+ n\n*~*~*~*~*~*~*~*~*~*\n\n\n
+X-ALT-DESC;FMTTYPE=text/html:<html><body id='htmlmode'><h3>The following is 
+ a new meeting request:</h3>\n\n<p>\n<table border='0'>\n<tr><th align=left>S
+ ubject:</th><td>Party </td></tr>\n<tr><th align=left>Organizer:</th><td>org
+ @synacorjapan.com </td></tr>\n</table>\n<p>\n<table border='0'>\n<tr><th ali
+ gn=left>Time:</th><td>Tuesday\, December 12\, 2017\, 10:00:00 AM - 10:30:00 
+ AM GMT +09:00 Japan\n </td></tr></table>\n<p>\n<table border='0'>\n<tr><th a
+ lign=left>Invitees:</th><td>attendee1@zimbra.com </td></tr>\n</table>\n<div
+ >*~*~*~*~*~*~*~*~*~*</div><br></body></html>
+BEGIN:VALARM
+ACTION:DISPLAY
+TRIGGER;RELATED=START:-PT5M
+DESCRIPTION:Reminder
+END:VALARM
+END:VEVENT
+END:VCALENDAR
+--=_2eb7dab5-3168-43b0-ba14-80504c7e08da--

--- a/store/src/java-test/com/zimbra/cs/mailbox/calendar/Calendar_NewMeetingRequest_RsvpTrue.txt
+++ b/store/src/java-test/com/zimbra/cs/mailbox/calendar/Calendar_NewMeetingRequest_RsvpTrue.txt
@@ -1,5 +1,5 @@
-To: attendee1 <attendee1@zimbra.com>
-Message-ID: <2103105317.2993.1513012884769.JavaMail.zimbra@synacorjapan.com>
+To: attendee1 <attendee1@testdomain.com>
+Message-ID: <2103105317.2993.1513012884769.JavaMail.zimbra@testdomain.com>
 Subject: Party
 MIME-Version: 1.0
 Content-Type: multipart/alternative;
@@ -12,11 +12,11 @@ Content-Transfer-Encoding: 7bit
 The following is a new meeting request:
 
 Subject: Party
-Organizer: org@synacorjapan.com
+Organizer: owner@testdomain.com
 
 Time: Tuesday, December 12, 2017, 10:00:00 AM - 10:30:00 AM GMT +09:00 Japan
 
-Invitees: attendee1@zimbra.com
+Invitees: attendee1@testdomain.com
 
 
 *~*~*~*~*~*~*~*~*~*
@@ -32,7 +32,7 @@ Content-Transfer-Encoding: 7bit
 <p>
 <table border='0'>
 <tr><th align=left>Subject:</th><td>Party </td></tr>
-<tr><th align=left>Organizer:</th><td>org@synacorjapan.com </td></tr>
+<tr><th align=left>Organizer:</th><td>owner@testdomain.com </td></tr>
 </table>
 <p>
 <table border='0'>
@@ -40,7 +40,7 @@ Content-Transfer-Encoding: 7bit
  </td></tr></table>
 <p>
 <table border='0'>
-<tr><th align=left>Invitees:</th><td>attendee1@zimbra.com </td></tr>
+<tr><th align=left>Invitees:</th><td>attendee1@testdomain.com </td></tr>
 </table>
 <div>*~*~*~*~*~*~*~*~*~*</div><br></body></html>
 --=_2eb7dab5-3168-43b0-ba14-80504c7e08da
@@ -63,8 +63,8 @@ BEGIN:VEVENT
 UID:8282cdfc-a5a6-4ed4-84e2-be12c2bc4af8
 SUMMARY:Party
 ATTENDEE;CN=attendee1;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=TRUE:mailto
- :attendee1@zimbra.com
-ORGANIZER:mailto:org@synacorjapan.com
+ :attendee1@testdomain.com
+ORGANIZER:mailto:owner@testdomain.com
 DTSTART;TZID="Asia/Tokyo":20171212T100000
 DTEND;TZID="Asia/Tokyo":20171212T103000
 STATUS:CONFIRMED
@@ -75,16 +75,16 @@ LAST-MODIFIED:20171211T172124Z
 DTSTAMP:20171211T172124Z
 SEQUENCE:0
 DESCRIPTION:The following is a new meeting request:\n\nSubject: Party \nOrg
- anizer: org@synacorjapan.com \n\nTime: Tuesday\, December 12\, 2017\, 10:00:
- 00 AM - 10:30:00 AM GMT +09:00 Japan\n \nInvitees: attendee1@zimbra.com \n\
+ anizer: owner@testdomain.com \n\nTime: Tuesday\, December 12\, 2017\, 10:00:
+ 00 AM - 10:30:00 AM GMT +09:00 Japan\n \nInvitees: attendee1@testdomain.com \n\
  n\n*~*~*~*~*~*~*~*~*~*\n\n\n
 X-ALT-DESC;FMTTYPE=text/html:<html><body id='htmlmode'><h3>The following is 
  a new meeting request:</h3>\n\n<p>\n<table border='0'>\n<tr><th align=left>S
  ubject:</th><td>Party </td></tr>\n<tr><th align=left>Organizer:</th><td>org
- @synacorjapan.com </td></tr>\n</table>\n<p>\n<table border='0'>\n<tr><th ali
+ @testdomain.com </td></tr>\n</table>\n<p>\n<table border='0'>\n<tr><th ali
  gn=left>Time:</th><td>Tuesday\, December 12\, 2017\, 10:00:00 AM - 10:30:00 
  AM GMT +09:00 Japan\n </td></tr></table>\n<p>\n<table border='0'>\n<tr><th a
- lign=left>Invitees:</th><td>attendee1@zimbra.com </td></tr>\n</table>\n<div
+ lign=left>Invitees:</th><td>attendee1@testdomain.com </td></tr>\n</table>\n<div
  >*~*~*~*~*~*~*~*~*~*</div><br></body></html>
 BEGIN:VALARM
 ACTION:DISPLAY

--- a/store/src/java-test/com/zimbra/cs/mailbox/calendar/ZAttendeeTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/calendar/ZAttendeeTest.java
@@ -21,7 +21,6 @@ import java.io.InputStream;
 import java.util.Iterator;
 import java.util.List;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;

--- a/store/src/java-test/com/zimbra/cs/mailbox/calendar/ZAttendeeTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/calendar/ZAttendeeTest.java
@@ -48,10 +48,6 @@ public class ZAttendeeTest {
     @Rule public TestName testName = new TestName();
     @Rule public MethodRule watchman = new ZTestWatchman();
 
-    @BeforeClass
-    public static void init() throws Exception {
-    }
-
     @Before
     public void setUp() throws Exception {
         MailboxTestUtil.initServer();

--- a/store/src/java-test/com/zimbra/cs/mailbox/calendar/ZAttendeeTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/calendar/ZAttendeeTest.java
@@ -21,10 +21,14 @@ import java.io.InputStream;
 import java.util.Iterator;
 import java.util.List;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.MethodRule;
+import org.junit.rules.TestName;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -38,25 +42,30 @@ import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.mailbox.MailboxTestUtil;
 import com.zimbra.cs.mime.ParsedMessage;
 import com.zimbra.cs.mime.ParsedMessage.CalendarPartInfo;
+import com.zimbra.cs.util.ZTestWatchman;
 
 public class ZAttendeeTest {
 
+    @Rule public TestName testName = new TestName();
+    @Rule public MethodRule watchman = new ZTestWatchman();
+
     @BeforeClass
     public static void init() throws Exception {
-        MailboxTestUtil.initServer();
-        Provisioning prov = Provisioning.getInstance();
-
-        prov.createAccount("test@zimbra.com", "secret", Maps.<String, Object>newHashMap());
     }
 
     @Before
     public void setUp() throws Exception {
+        MailboxTestUtil.initServer();
         MailboxTestUtil.clearData();
+        System.out.println(testName.getMethodName());
+
+        Provisioning prov = Provisioning.getInstance();
+        prov.createAccount("test@testdomain.com", "secret", Maps.<String, Object>newHashMap());
     }
 
     @Test
     public void resourceRsvpTest() throws ServiceException {
-        ZAttendee attendee = new ZAttendee ("test-resource@zimbra.com", "testResource", null, null, null, "RES", "NON", "AC", Boolean.TRUE,
+        ZAttendee attendee = new ZAttendee ("test-resource@testdomain.com", "testResource", null, null, null, "RES", "NON", "AC", Boolean.TRUE,
                                             null, null, null, null);
         ZProperty prop = new ZProperty("ATTENDEE");
         attendee.setProperty(prop);

--- a/store/src/java/com/zimbra/cs/mailbox/calendar/ZAttendee.java
+++ b/store/src/java/com/zimbra/cs/mailbox/calendar/ZAttendee.java
@@ -142,10 +142,10 @@ public class ZAttendee extends CalendarUser {
         setRole(prop.paramVal(ICalTok.ROLE, null));
         setPartStat(prop.paramVal(ICalTok.PARTSTAT, null));
 
-        String rsvpStr = prop.paramVal(ICalTok.RSVP, "FALSE");
-        boolean rsvp = false;
-        if (rsvpStr.equalsIgnoreCase("TRUE"))
-            rsvp = true;
+        String rsvpStr = prop.paramVal(ICalTok.RSVP, "TRUE");
+        boolean rsvp = true;
+        if (rsvpStr.equalsIgnoreCase("FALSE"))
+            rsvp = false;
         setRsvp(rsvp);
 
         setMember(prop.paramVal(ICalTok.MEMBER, null));


### PR DESCRIPTION
[Bug]
Organizer see the attendee's status as Tentative instead of Accepted
even when the attendee proposed a new time in invite and the organizer
accepted it.

[Root cause]
The the CounterAppointmentRequest proposed by the attendee contains
the attendee info ("PROPERTY:ATTENDEE(ATTENDEE)"), but it does not
contain the data of RSVP in it; that should be acceptable, and expected
behaviour because such an information has not been updated on the attendee
side.  On the other hand, when the organizer received the counter
appointment (via email), if there is no RSVP data in the attendee info,
the organizer turned the RSVP off for to the corresponding appointment
object.  Therefore, if the attendee later sent the acceptance, the
organizer ignored it even the acceptance email asked to update the
RSVP data on the organizer ("updateOrganizer":"TRUE").

[Fix]
Changed the default value of the RSVP data to true.