### PR TITLE
ZCS-3456: Attendee's status isn't updated

### DIFF
--- a/store/src/java-test/com/zimbra/cs/mailbox/calendar/Calendar_ChangeMeetingRequest_WO_Rsvp.txt
+++ b/store/src/java-test/com/zimbra/cs/mailbox/calendar/Calendar_ChangeMeetingRequest_WO_Rsvp.txt
@@ -1,0 +1,73 @@
+Date: Wed, 13 Dec 2017 04:59:25 +0900 (JST)
+From: org@testdomain.com
+To: attendee1 <attendee1@testdomain.com>
+Message-ID: <285397199.93.1513108765004.JavaMail.zimbra@testdomain.com>
+Subject: test111yes - changed
+MIME-Version: 1.0
+Content-Type: multipart/alternative; 
+	boundary="=_e5569d0f-a9cd-40fa-b3e7-0be93b5679d5"
+X-Originating-IP: [192.168.59.1]
+X-Mailer: Zimbra 8.8.6_GA.0000 (ZimbraWebClient - GC62 (Mac)/8.8.2_GA_1822)
+Thread-Index: NTQJKClRfgEbwMY55pLVbcjVU+uVhg==
+Thread-Topic: test111yes - changed
+
+--=_e5569d0f-a9cd-40fa-b3e7-0be93b5679d5
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+The following meeting has been modified:
+
+Subject: test111yes - changed [MODIFIED]
+Organizer: org@testdomain.com 
+
+Time: Thursday, December 14, 2017, 2:16:00 PM - 2:45:00 PM GMT +09:00 Japan [MODIFIED]
+ 
+Invitees: attendee1@testdomain.com 
+
+
+*~*~*~*~*~*~*~*~*~*
+
+
+--=_e5569d0f-a9cd-40fa-b3e7-0be93b5679d5
+Content-Type: text/calendar; charset=utf-8; method=REQUEST; name=meeting.ics
+Content-Transfer-Encoding: 7bit
+
+BEGIN:VCALENDAR
+PRODID:Zimbra-Calendar-Provider
+VERSION:2.0
+METHOD:REQUEST
+BEGIN:VTIMEZONE
+TZID:Asia/Tokyo
+BEGIN:STANDARD
+DTSTART:16010101T000000
+TZOFFSETTO:+0900
+TZOFFSETFROM:+0900
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+UID:ad22c92b-680c-436b-98b0-def254c953d5
+SUMMARY:test111yes - changed
+ATTENDEE;CN=attendee1;ROLE=REQ-PARTICIPANT;PARTSTAT=TENTATIVE:mailto:attendee1@synacor
+ japan.com
+ORGANIZER:mailto:org@testdomain.com
+DTSTART;TZID="Asia/Tokyo":20171214T141600
+DTEND;TZID="Asia/Tokyo":20171214T144500
+STATUS:CONFIRMED
+CLASS:PUBLIC
+X-MICROSOFT-CDO-INTENDEDSTATUS:BUSY
+TRANSP:OPAQUE
+LAST-MODIFIED:20171212T195925Z
+DTSTAMP:20171212T195925Z
+SEQUENCE:1
+DESCRIPTION:The following meeting has been modified:\n\nSubject: test111yes 
+ - changed [MODIFIED]\nOrganizer: org@testdomain.com \n\nTime: Thursday\, D
+ ecember 14\, 2017\, 2:16:00 PM - 2:45:00 PM GMT +09:00 Japan [MODIFIED]\n \n
+ Invitees: attendee1@testdomain.com \n\n\n*~*~*~*~*~*~*~*~*~*\n\n
+BEGIN:VALARM
+ACTION:DISPLAY
+TRIGGER;RELATED=START:-PT5M
+DESCRIPTION:Reminder
+END:VALARM
+END:VEVENT
+END:VCALENDAR
+--=_e5569d0f-a9cd-40fa-b3e7-0be93b5679d5--

--- a/store/src/java-test/com/zimbra/cs/mailbox/calendar/Calendar_NewMeetingRequest_RsvpFalse.txt
+++ b/store/src/java-test/com/zimbra/cs/mailbox/calendar/Calendar_NewMeetingRequest_RsvpFalse.txt
@@ -1,0 +1,97 @@
+To: attendee1 <attendee1@testdomain.com>
+Message-ID: <2103105317.2993.1513012884769.JavaMail.zimbra@testdomain.com>
+Subject: Party
+MIME-Version: 1.0
+Content-Type: multipart/alternative;
+       boundary="=_2eb7dab5-3168-43b0-ba14-80504c7e08da"
+
+--=_2eb7dab5-3168-43b0-ba14-80504c7e08da
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+The following is a new meeting request:
+
+Subject: Party
+Organizer: org@testdomain.com
+
+Time: Tuesday, December 12, 2017, 10:00:00 AM - 10:30:00 AM GMT +09:00 Japan
+
+Invitees: attendee1@testdomain.com
+
+
+*~*~*~*~*~*~*~*~*~*
+
+
+
+--=_2eb7dab5-3168-43b0-ba14-80504c7e08da
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+<html><body id='htmlmode'><h3>The following is a new meeting request:</h3>
+
+<p>
+<table border='0'>
+<tr><th align=left>Subject:</th><td>Party </td></tr>
+<tr><th align=left>Organizer:</th><td>org@testdomain.com </td></tr>
+</table>
+<p>
+<table border='0'>
+<tr><th align=left>Time:</th><td>Tuesday, December 12, 2017, 10:00:00 AM - 10:30:00 AM GMT +09:00 Japan
+ </td></tr></table>
+<p>
+<table border='0'>
+<tr><th align=left>Invitees:</th><td>attendee1@testdomain.com </td></tr>
+</table>
+<div>*~*~*~*~*~*~*~*~*~*</div><br></body></html>
+--=_2eb7dab5-3168-43b0-ba14-80504c7e08da
+Content-Type: text/calendar; charset=utf-8; method=REQUEST; name=meeting.ics
+Content-Transfer-Encoding: 7bit
+
+BEGIN:VCALENDAR
+PRODID:Zimbra-Calendar-Provider
+VERSION:2.0
+METHOD:REQUEST
+BEGIN:VTIMEZONE
+TZID:Asia/Tokyo
+BEGIN:STANDARD
+DTSTART:16010101T000000
+TZOFFSETTO:+0900
+TZOFFSETFROM:+0900
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+UID:8282cdfc-a5a6-4ed4-84e2-be12c2bc4af8
+SUMMARY:Party
+ATTENDEE;CN=attendee1;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=FALSE:mailto
+ :attendee1@testdomain.com
+ORGANIZER:mailto:org@testdomain.com
+DTSTART;TZID="Asia/Tokyo":20171212T100000
+DTEND;TZID="Asia/Tokyo":20171212T103000
+STATUS:CONFIRMED
+CLASS:PUBLIC
+X-MICROSOFT-CDO-INTENDEDSTATUS:BUSY
+TRANSP:OPAQUE
+LAST-MODIFIED:20171211T172124Z
+DTSTAMP:20171211T172124Z
+SEQUENCE:0
+DESCRIPTION:The following is a new meeting request:\n\nSubject: Party \nOrg
+ anizer: org@testdomain.com \n\nTime: Tuesday\, December 12\, 2017\, 10:00:
+ 00 AM - 10:30:00 AM GMT +09:00 Japan\n \nInvitees: attendee1@testdomain.com \n\
+ n\n*~*~*~*~*~*~*~*~*~*\n\n\n
+X-ALT-DESC;FMTTYPE=text/html:<html><body id='htmlmode'><h3>The following is
+ a new meeting request:</h3>\n\n<p>\n<table border='0'>\n<tr><th align=left>S
+ ubject:</th><td>Party </td></tr>\n<tr><th align=left>Organizer:</th><td>org
+ @testdomain.com </td></tr>\n</table>\n<p>\n<table border='0'>\n<tr><th ali
+ gn=left>Time:</th><td>Tuesday\, December 12\, 2017\, 10:00:00 AM - 10:30:00
+ AM GMT +09:00 Japan\n </td></tr></table>\n<p>\n<table border='0'>\n<tr><th a
+ lign=left>Invitees:</th><td>attendee1@testdomain.com </td></tr>\n</table>\n<div
+ >*~*~*~*~*~*~*~*~*~*</div><br></body></html>
+BEGIN:VALARM
+ACTION:DISPLAY
+TRIGGER;RELATED=START:-PT5M
+DESCRIPTION:Reminder
+END:VALARM
+END:VEVENT
+END:VCALENDAR
+--=_2eb7dab5-3168-43b0-ba14-80504c7e08da--
+

--- a/store/src/java-test/com/zimbra/cs/mailbox/calendar/Calendar_NewMeetingRequest_RsvpTrue.txt
+++ b/store/src/java-test/com/zimbra/cs/mailbox/calendar/Calendar_NewMeetingRequest_RsvpTrue.txt
@@ -1,0 +1,97 @@
+To: attendee1 <attendee1@testdomain.com>
+Message-ID: <2103105317.2993.1513012884769.JavaMail.zimbra@testdomain.com>
+Subject: Party
+MIME-Version: 1.0
+Content-Type: multipart/alternative;
+       boundary="=_2eb7dab5-3168-43b0-ba14-80504c7e08da"
+
+--=_2eb7dab5-3168-43b0-ba14-80504c7e08da
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+The following is a new meeting request:
+
+Subject: Party
+Organizer: org@testdomain.com
+
+Time: Tuesday, December 12, 2017, 10:00:00 AM - 10:30:00 AM GMT +09:00 Japan
+
+Invitees: attendee1@testdomain.com
+
+
+*~*~*~*~*~*~*~*~*~*
+
+
+
+--=_2eb7dab5-3168-43b0-ba14-80504c7e08da
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+<html><body id='htmlmode'><h3>The following is a new meeting request:</h3>
+
+<p>
+<table border='0'>
+<tr><th align=left>Subject:</th><td>Party </td></tr>
+<tr><th align=left>Organizer:</th><td>org@testdomain.com </td></tr>
+</table>
+<p>
+<table border='0'>
+<tr><th align=left>Time:</th><td>Tuesday, December 12, 2017, 10:00:00 AM - 10:30:00 AM GMT +09:00 Japan
+ </td></tr></table>
+<p>
+<table border='0'>
+<tr><th align=left>Invitees:</th><td>attendee1@testdomain.com </td></tr>
+</table>
+<div>*~*~*~*~*~*~*~*~*~*</div><br></body></html>
+--=_2eb7dab5-3168-43b0-ba14-80504c7e08da
+Content-Type: text/calendar; charset=utf-8; method=REQUEST; name=meeting.ics
+Content-Transfer-Encoding: 7bit
+
+BEGIN:VCALENDAR
+PRODID:Zimbra-Calendar-Provider
+VERSION:2.0
+METHOD:REQUEST
+BEGIN:VTIMEZONE
+TZID:Asia/Tokyo
+BEGIN:STANDARD
+DTSTART:16010101T000000
+TZOFFSETTO:+0900
+TZOFFSETFROM:+0900
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+UID:8282cdfc-a5a6-4ed4-84e2-be12c2bc4af8
+SUMMARY:Party
+ATTENDEE;CN=attendee1;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=TRUE:mailto
+ :attendee1@testdomain.com
+ORGANIZER:mailto:org@testdomain.com
+DTSTART;TZID="Asia/Tokyo":20171212T100000
+DTEND;TZID="Asia/Tokyo":20171212T103000
+STATUS:CONFIRMED
+CLASS:PUBLIC
+X-MICROSOFT-CDO-INTENDEDSTATUS:BUSY
+TRANSP:OPAQUE
+LAST-MODIFIED:20171211T172124Z
+DTSTAMP:20171211T172124Z
+SEQUENCE:0
+DESCRIPTION:The following is a new meeting request:\n\nSubject: Party \nOrg
+ anizer: org@testdomain.com \n\nTime: Tuesday\, December 12\, 2017\, 10:00:
+ 00 AM - 10:30:00 AM GMT +09:00 Japan\n \nInvitees: attendee1@testdomain.com \n\
+ n\n*~*~*~*~*~*~*~*~*~*\n\n\n
+X-ALT-DESC;FMTTYPE=text/html:<html><body id='htmlmode'><h3>The following is
+ a new meeting request:</h3>\n\n<p>\n<table border='0'>\n<tr><th align=left>S
+ ubject:</th><td>Party </td></tr>\n<tr><th align=left>Organizer:</th><td>org
+ @testdomain.com </td></tr>\n</table>\n<p>\n<table border='0'>\n<tr><th ali
+ gn=left>Time:</th><td>Tuesday\, December 12\, 2017\, 10:00:00 AM - 10:30:00
+ AM GMT +09:00 Japan\n </td></tr></table>\n<p>\n<table border='0'>\n<tr><th a
+ lign=left>Invitees:</th><td>attendee1@testdomain.com </td></tr>\n</table>\n<div
+ >*~*~*~*~*~*~*~*~*~*</div><br></body></html>
+BEGIN:VALARM
+ACTION:DISPLAY
+TRIGGER;RELATED=START:-PT5M
+DESCRIPTION:Reminder
+END:VALARM
+END:VEVENT
+END:VCALENDAR
+--=_2eb7dab5-3168-43b0-ba14-80504c7e08da--
+

--- a/store/src/java-test/com/zimbra/cs/mailbox/calendar/ZAttendeeTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/calendar/ZAttendeeTest.java
@@ -16,19 +16,54 @@
  */
 package com.zimbra.cs.mailbox.calendar;
 
-import org.junit.Assert;
-import org.junit.Test;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Iterator;
+import java.util.List;
 
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.internal.matchers.StringContains;
+import org.junit.rules.MethodRule;
+import org.junit.rules.TestName;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.zimbra.common.calendar.TimeZoneMap;
+import com.zimbra.common.calendar.WellKnownTimeZones;
 import com.zimbra.common.calendar.ZCalendar.ICalTok;
+import com.zimbra.common.calendar.ZCalendar.ZComponent;
 import com.zimbra.common.calendar.ZCalendar.ZParameter;
 import com.zimbra.common.calendar.ZCalendar.ZProperty;
 import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ByteUtil;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.MailItem;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.mime.ParsedMessage;
+import com.zimbra.cs.mime.ParsedMessage.CalendarPartInfo;
+import com.zimbra.cs.util.ZTestWatchman;
 
 public class ZAttendeeTest {
 
+    @Rule public TestName testName = new TestName();
+    @Rule public MethodRule watchman = new ZTestWatchman();
+
+    @Before
+    public void setUp() throws Exception {
+        MailboxTestUtil.initServer();
+        MailboxTestUtil.clearData();
+        System.out.println(testName.getMethodName());
+        Provisioning prov = Provisioning.getInstance();
+        prov.createAccount("test@testdomain.com", "secret", Maps.<String, Object>newHashMap());
+    }
+
+
     @Test
     public void resourceRsvpTest() throws ServiceException {
-        ZAttendee attendee = new ZAttendee ("test-resource@zimbra.com", "testResource", null, null, null, "RES", "NON", "AC", Boolean.TRUE,
+        ZAttendee attendee = new ZAttendee ("test-resource@testdomain.com", "testResource", null, null, null, "RES", "NON", "AC", Boolean.TRUE,
                                             null, null, null, null);
         ZProperty prop = new ZProperty("ATTENDEE");
         attendee.setProperty(prop);
@@ -36,4 +71,65 @@ public class ZAttendeeTest {
         Assert.assertTrue(Boolean.parseBoolean(rsvpParam.getValue()));
     }
 
+    @Test
+    public void resourceRsvpTest2() throws ServiceException, IOException {
+        InputStream is = getClass().getResourceAsStream("Calendar_NewMeetingRequest_RsvpTrue.txt");
+        ParsedMessage pm = new ParsedMessage(ByteUtil.getContent(is, -1), false);
+        CalendarPartInfo cpi = pm.getCalendarPartInfo();
+        Iterator<ZComponent> compIter = cpi.cal.getComponentIterator();
+        while(compIter.hasNext()) {
+            ZComponent comp = compIter.next();
+            List<ZProperty> properties = Lists.newArrayList(comp.getPropertyIterator());
+            for (ZProperty prop : properties) {
+                if (prop.getName().equalsIgnoreCase("ATTENDEE")) {
+                    ZAttendee attendee = new ZAttendee (prop);
+                    Assert.assertTrue(attendee.getRsvp());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void resourceRsvpTest3() throws Exception {
+        InputStream is = getClass().getResourceAsStream("Calendar_NewMeetingRequest_RsvpFalse.txt");
+        ParsedMessage pm = new ParsedMessage(ByteUtil.getContent(is, -1), false);
+        CalendarPartInfo cpi = pm.getCalendarPartInfo();
+        Iterator<ZComponent> compIter = cpi.cal.getComponentIterator();
+        while(compIter.hasNext()) {
+            ZComponent comp = compIter.next();
+            List<ZProperty> properties = Lists.newArrayList(comp.getPropertyIterator());
+            for (ZProperty prop : properties) {
+                if (prop.getName().equalsIgnoreCase("ATTENDEE")) {
+                    ZAttendee attendee = new ZAttendee (prop);
+                    Assert.assertFalse(attendee.getRsvp());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void resourceRsvpTest4() throws Exception {
+        InputStream is = getClass().getResourceAsStream("Calendar_ChangeMeetingRequest_WO_Rsvp.txt");
+        ParsedMessage pm = new ParsedMessage(ByteUtil.getContent(is, -1), false);
+        CalendarPartInfo cpi = pm.getCalendarPartInfo();
+        Iterator<ZComponent> compIter = cpi.cal.getComponentIterator();
+        while(compIter.hasNext()) {
+            ZComponent comp = compIter.next();
+            List<ZProperty> properties = Lists.newArrayList(comp.getPropertyIterator());
+            for (ZProperty prop : properties) {
+                if (prop.getName().equalsIgnoreCase("ATTENDEE")) {
+                    ZAttendee attendee = new ZAttendee (prop);
+                    Assert.assertNull(attendee.getRsvp());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void nullRsvp() throws Exception {
+        TimeZoneMap tzMap = new TimeZoneMap(WellKnownTimeZones.getTimeZoneById("JST"));
+        Invite inv = new Invite(MailItem.Type.APPOINTMENT, ICalTok.ACCEPTED.toString(),
+                tzMap, false);
+        Assert.assertThat(inv.toString(), StringContains.containsString("rsvp: (not specified)"));
+    }
 }

--- a/store/src/java/com/zimbra/cs/mailbox/CalendarItem.java
+++ b/store/src/java/com/zimbra/cs/mailbox/CalendarItem.java
@@ -2098,7 +2098,9 @@ public abstract class CalendarItem extends MailItem {
                 // metadata rather than in the iCal MIME part must be
                 // carried over from the last invite to the new one.
                 newInvite.setPartStat(prev.getPartStat());
-                newInvite.setRsvp(prev.getRsvp());
+                if (prev.hasRsvp()) {
+                    newInvite.setRsvp(prev.getRsvp());
+                }
                 newInvite.getCalendarItem().saveMetadata();
                 // No need to mark invite as modified item in mailbox as
                 // it has already been marked as a created item.
@@ -2115,6 +2117,9 @@ public abstract class CalendarItem extends MailItem {
                 if (!prev.isPublic() && prev.classPropSetByMe()) {
                     newInvite.setClassProp(prev.getClassProp());
                     newInvite.setClassPropSetByMe(true);
+                }
+                if (!newInvite.hasRsvp()) {
+                    newInvite.setRsvp(prev.getRsvp());
                 }
             }
 

--- a/store/src/java/com/zimbra/cs/mailbox/calendar/Invite.java
+++ b/store/src/java/com/zimbra/cs/mailbox/calendar/Invite.java
@@ -112,7 +112,7 @@ public class Invite {
             String priority, String pctComplete, long completed, String freebusy, String transp, String classProp,
             ParsedDateTime start, ParsedDateTime end, ParsedDuration duration, Recurrence.IRecurrence recurrence,
             boolean isOrganizer, ZOrganizer org, List<ZAttendee> attendees, String name, String loc, int flags,
-            String partStat, boolean rsvp, RecurId recurrenceId, long dtstamp, long lastModified,
+            String partStat, Boolean rsvp, RecurId recurrenceId, long dtstamp, long lastModified,
             int seqno, int lastFullSeqno, int mailboxId, int mailItemId,
             int componentNum, boolean sentByMe, String description, String descHtml, String fragment,
             List<String> comments, List<String> categories, List<String> contacts, Geo geo, String url) {
@@ -358,7 +358,9 @@ public class Invite {
         meta.put(FN_LOCATION, inv.mLocation);
         meta.put(FN_APPT_FLAGS, inv.getFlags());
         meta.put(FN_PARTSTAT, inv.getPartStat());
-        meta.put(FN_RSVP, inv.getRsvp());
+        if (inv.hasRsvp()) {
+            meta.put(FN_RSVP, inv.getRsvp());
+        }
 
         meta.put(FN_TZMAP, Util.encodeAsMetadata(inv.mTzMap));
 
@@ -898,7 +900,9 @@ public class Invite {
         } else {
             ZAttendee at = getMatchingAttendee(acct);
             if (at != null) {
-                setRsvp(at.hasRsvp() ? at.getRsvp().booleanValue() : false);
+                if (at.getRsvp() != null) {
+                    setRsvp(at.getRsvp().booleanValue());
+                }
                 //
                 // for BUG 4866 -- basically, if the incoming invite doesn't have a
                 // PARTSTAT for us, assume it is "NEEDS-ACTION" iff this Invite supports
@@ -943,8 +947,9 @@ public class Invite {
     public int getFlags() { return mFlags; }
     public void setFlags(int flags) { mFlags = flags; }
     public String getPartStat() { return mPartStat; }
-    public boolean getRsvp() { return mRsvp; }
-    public void setRsvp(boolean rsvp) { mRsvp = rsvp; }
+    public boolean hasRsvp() { return mRsvp != null; }
+    public Boolean getRsvp() { return mRsvp; }
+    public void setRsvp(Boolean rsvp) { mRsvp = rsvp; }
     public String getUid() { return mUid; };
     public void setUid(String uid) { mUid = uid; }
     public String getName() { return mName; };
@@ -1182,7 +1187,12 @@ public class Invite {
         sb.append(", uid: ").append(this.mUid);
         sb.append(", status: ").append(getStatus());
         sb.append(", partStat: ").append(getPartStat());
-        sb.append(", rsvp: ").append(getRsvp());
+        sb.append(", rsvp: ");
+        if (hasRsvp()) {
+            sb.append(getRsvp());
+        } else {
+            sb.append("(not specified)");
+        }
         sb.append(", freeBusy: ").append(mFreeBusy);
         sb.append(", transp: ").append(getTransparency());
         sb.append(", class: ").append(getClassProp());
@@ -1267,7 +1277,7 @@ public class Invite {
     // For meeting organizer, this should always be "AC".  (accepted)
     protected String mPartStat = IcalXmlStrMap.PARTSTAT_NEEDS_ACTION;
 
-    protected boolean mRsvp = false;
+    protected Boolean mRsvp = null;
 
     // not in metadata:
     protected int mMailboxId = 0;

--- a/store/src/java/com/zimbra/cs/mailbox/calendar/ZAttendee.java
+++ b/store/src/java/com/zimbra/cs/mailbox/calendar/ZAttendee.java
@@ -142,11 +142,14 @@ public class ZAttendee extends CalendarUser {
         setRole(prop.paramVal(ICalTok.ROLE, null));
         setPartStat(prop.paramVal(ICalTok.PARTSTAT, null));
 
-        String rsvpStr = prop.paramVal(ICalTok.RSVP, "FALSE");
+        String rsvpStr = prop.paramVal(ICalTok.RSVP, null);
         boolean rsvp = false;
-        if (rsvpStr.equalsIgnoreCase("TRUE"))
-            rsvp = true;
-        setRsvp(rsvp);
+        if (null != rsvpStr) {
+            if (rsvpStr.equalsIgnoreCase("TRUE")) {
+                rsvp = true;
+            }
+            setRsvp(rsvp);
+        }
 
         setMember(prop.paramVal(ICalTok.MEMBER, null));
         setDelegatedTo(prop.paramVal(ICalTok.DELEGATED_TO, null));

--- a/store/src/java/com/zimbra/cs/service/mail/SendInviteReply.java
+++ b/store/src/java/com/zimbra/cs/service/mail/SendInviteReply.java
@@ -246,7 +246,9 @@ public class SendInviteReply extends CalendarRequest {
             }
 
             // check if invite organizer requested rsvp or not
-            updateOrg = updateOrg && oldInv.getRsvp();
+            if (oldInv.hasRsvp()) {
+                updateOrg = updateOrg && oldInv.getRsvp();
+            }
 
             // Don't allow creating/editing a private appointment on behalf of another user,
             // unless that other user is a calendar resource.

--- a/store/src/java/com/zimbra/cs/service/mail/ToXML.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ToXML.java
@@ -2185,7 +2185,9 @@ public final class ToXML {
         Element e = parent.addNonUniqueElement(MailConstants.E_INVITE_COMPONENT);
         e.addAttribute(MailConstants.A_CAL_METHOD, invite.getMethod());
         e.addAttribute(MailConstants.A_CAL_COMPONENT_NUM, invite.getComponentNum());
-        e.addAttribute(MailConstants.A_CAL_RSVP, invite.getRsvp());
+        if (invite.hasRsvp()) {
+            e.addAttribute(MailConstants.A_CAL_RSVP, invite.getRsvp());
+        }
 
         boolean allowPrivateAccess = calItem != null ? allowPrivateAccess(octxt, calItem) : true;
         if (allFields) {


### PR DESCRIPTION
[Bug]
Organizer sees the attendee's status as Tentative instead of Accepted
even when the attendee proposed a new time in invite and the organizer
accepted it.

[Root cause]
In general, the RSVP info is not conveyed along with the communications
between the organizer and attendee(s) after the CreateAppointmentRequest.

When an attendee sent a "New Time Proposed" email (generated by the
CounterAppointmentRequest), the organizer accepted by the
ModifyAppointmentRequest and sent another email to the attendees, but
this modified invitation did not contain the RSVP info (because organizer
didn't change the RSVP status); and attendee did not send back the acceptance
email based on it.

Correctly, when the invitation email does not contains the RSVP info, if the
attendee has received the invitation before, the previous RSVP info should
be referred.

[Fix]
If the received invitation does not have a RSVP info, use the RSVP info
in the original invitation.  If there is no original invitation, then leave
the RSVP info "unset" (null).

[Manual test]
A. RSVP=TRUE --> PASS
 1. (organizer) Create Appointment with RSVP=TRUE
 2. (attendee)  Counter proposal
 3. (organizer) Accept the proposal and change the contents
 4. (attendee)  Accept the modified appointment
 5. (organizer) Verify that the status of the attendee is "Accepted"

B. RSVP=FALSE --> PASS
 1. (organizer) Create Appointment with RSVP=FALSE
 2. (attendee)  Counter proposal
 3. (organizer) Accept the proposal and change the contents
 4. (attendee)  Accept the modified appointment
 5. (organizer) Verify that the acceptance email from the attendee is not received.

C. no RSVP --> PASS
 1. Send a new appointment email with no RSVP parameter
 ```
 ATTENDEE;CN=att1;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION:mailto:att1@synacorjapan.com
 ```
 2. (attendee) Verify that the appointment is in the calendar view, and
    the "Accept" button in the invitation email on the ZWC is not clickable.