### PR TITLE
ZCS-3809 Adding new libs required by JWT

### DIFF
--- a/store/build.xml
+++ b/store/build.xml
@@ -311,11 +311,26 @@
   	<ivy:install organisation="com.sun.jersey" module="jersey-server" revision="1.11" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
   	<ivy:install organisation="com.sun.jersey.contribs" module="jersey-multipart" revision="1.12" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
   	<ivy:install organisation="javax.jws" module="jsr181-api" revision="2.2.6" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
-        <ivy:install organisation="org.ehcache" module="ehcache" revision="3.1.2" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
+    <ivy:install organisation="org.ehcache" module="ehcache" revision="3.1.2" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
   	<ivy:install organisation="javax.ws.rs" module="jsr311-api" revision="1.1.1" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
   	<ivy:install organisation="zimbra" module="zm-soap" revision="latest.integration" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="zimbra" module="zm-client" revision="latest.integration" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
-  	<war warfile="${warfile}" webxml="${war.web.xml}">
+  	
+    <ivy:install organisation="com.fasterxml.jackson.core" module="jackson-core" revision="2.9.2" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
+    <ivy:install organisation="com.fasterxml.jackson.dataformat" module="jackson-dataformat-smile" revision="2.9.2" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
+    <ivy:install organisation="com.fasterxml.jackson.core" module="jackson-databind" revision="2.9.2" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
+    <ivy:install organisation="com.fasterxml.jackson.module" module="jackson-module-jaxb-annotations" revision="2.9.2" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
+    <ivy:install organisation="com.fasterxml.jackson.core" module="jackson-annotations" revision="2.9.2" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
+          
+    <ivy:install organisation="io.jsonwebtoken" module="jjwt" revision="0.7.0" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
+    <ivy:install organisation="org.apache.commons" module="commons-text" revision="1.1" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
+    <ivy:install organisation="org.apache.commons" module="commons-lang3" revision="3.7" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
+    <ivy:install organisation="org.apache.commons" module="commons-rng-client-api" revision="1.0" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
+    <ivy:install organisation="org.apache.commons" module="commons-rng-core" revision="1.0" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
+    <ivy:install organisation="org.apache.commons" module="commons-rng-simple" revision="1.0" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
+
+    
+    <war warfile="${warfile}" webxml="${war.web.xml}">
       <fileset dir="WebRoot"/>
       <lib file="${build.dir}/${jar.file}"/>
       <lib dir="${build.tmp.dir}" includes="*.jar"/>

--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -105,9 +105,9 @@
   <dependency org="org.xmlunit" name="xmlunit-core" rev="2.3.0"/>
   <dependency org="ant-contrib" name="ant-contrib" rev="1.0b3" />
   <dependency org="io.jsonwebtoken" name="jjwt" rev="0.7.0"/>
-  <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.8.6"/>
-  <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.8.6"/>
-  <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.8.6"/>
+  <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.9.2"/>
+  <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.9.2"/>
+  <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.9.2"/>
   <dependency org="org.apache.commons" name="commons-text" rev="1.1"/>
   <dependency org="org.apache.commons" name="commons-lang3" rev="3.7"/>
   <dependency org="org.apache.commons" name="commons-rng-client-api" rev="1.0"/>


### PR DESCRIPTION
ZCS-3809
Adding new libs required by JWT

Maintaining both versions of jackson library for now, so that JWT build can be created
Will create a separate bug to switch to new jackson library and fix compilation and junit  failures in soap

New bug opened for 3840 opened for this.