### PR TITLE
ZCS-2655:fixing timezone

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/CalendarItem.java
+++ b/store/src/java/com/zimbra/cs/mailbox/CalendarItem.java
@@ -3518,7 +3518,11 @@ public abstract class CalendarItem extends MailItem {
                     Instance replyInstance = Instance.fromInvite(this.getId(), reply);
                     Instance nearestInstance = getNearestInstance(instancesNear, replyInstance);
                     if (nearestInstance != null) {
-                        ParsedDateTime pdt = ParsedDateTime.fromUTCTime(nearestInstance.getStart());
+                        ParsedDateTime pdt = (cur.getTimeZoneMap() != null
+                            && cur.getTimeZoneMap().getLocalTimeZone() != null)
+                                ? ParsedDateTime.fromUTCTime(nearestInstance.getStart(),
+                                    cur.getTimeZoneMap().getLocalTimeZone())
+                                : ParsedDateTime.fromUTCTime(nearestInstance.getStart());
                         if (nearestInstance.getStart() != replyInstance.getStart()) {
                             ZimbraLog.calendar.info(
                                 "The start time in the reply is: %s. Assuming that it is meant for the series instance with start date: %s",


### PR DESCRIPTION
This is in consequence with https://github.com/Zimbra/zm-mailbox/pull/447
The exceptional invite should have the timezone of start time same as current invite.
Unit test already in place.