### PR TITLE
ZCS-2478:Invalidate JWT on logout

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -8209,6 +8209,14 @@ public class ZAttrProvisioning {
     public static final String A_zimbraInternalSharingDomain = "zimbraInternalSharingDomain";
 
     /**
+     * list of invalid jwt
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=2133)
+    public static final String A_zimbraInvalidJWTokens = "zimbraInvalidJWTokens";
+
+    /**
      * This attribute is used for failed authentication requests. It
      * indicates the minimum time between current req and last req from the
      * same IP before this suspended IP will be reinstated

--- a/common/src/java/com/zimbra/common/util/Constants.java
+++ b/common/src/java/com/zimbra/common/util/Constants.java
@@ -49,5 +49,6 @@ public class Constants {
     public static final String AUTH_HEADER = "Authorization";
     public static final String BEARER= "Bearer";
     public static final String ZM_JWT_COOKIE = "ZM_JWT";
+    public static final String JWT_SALT_SEPARATOR = "|";
 
 }

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9456,6 +9456,10 @@ TODO: delete them permanently from here
   <desc>Specific domains to which custom out of office message is to be sent</desc>
 </attr>
 
+<attr id="2133" name="zimbraInvalidJWTokens" type="string" cardinality="multi" optionalIn="account" since="8.8.6" flags="ephemeral,dynamic,expirable">
+  <desc>list of invalid jwt</desc>
+</attr>
+
 <attr id="2995" name="zimbraEphemeralBackendURL" type="string" cardinality="single" optionalIn="globalConfig" callback="EphemeralBackendCheck" since="8.7.6">
   <desc>URL of ephemeral storage backend</desc>
   <globalConfigValue>ldap://default</globalConfigValue>

--- a/store/src/java-test/com/zimbra/cs/util/JWTBasedAuthTest.java
+++ b/store/src/java-test/com/zimbra/cs/util/JWTBasedAuthTest.java
@@ -162,5 +162,7 @@ public class JWTBasedAuthTest {
         Assert.assertEquals("s2|s3", JWTUtil.clearSalt(zmJWTCookieValue, salt));
         zmJWTCookieValue = "s1";
         Assert.assertEquals("", JWTUtil.clearSalt(zmJWTCookieValue, salt));
+        zmJWTCookieValue = "s2|s3|s4";
+        Assert.assertEquals("s2|s3|s4", JWTUtil.clearSalt(zmJWTCookieValue, salt));
     }
 }

--- a/store/src/java-test/com/zimbra/cs/util/JWTBasedAuthTest.java
+++ b/store/src/java-test/com/zimbra/cs/util/JWTBasedAuthTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import com.google.common.primitives.Bytes;
 import com.zimbra.common.account.Key;
 import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.AccountConstants;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.HeaderConstants;
 import com.zimbra.cs.account.Account;
@@ -22,7 +23,6 @@ import com.zimbra.cs.account.AccountServiceException.AuthFailedServiceException;
 import com.zimbra.cs.account.AuthToken;
 import com.zimbra.cs.account.AuthToken.TokenType;
 import com.zimbra.cs.account.AuthToken.Usage;
-import com.zimbra.cs.account.AuthTokenException;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.mailbox.MailboxTestUtil;
 import com.zimbra.cs.service.AuthProvider;
@@ -52,7 +52,6 @@ public class JWTBasedAuthTest {
         } catch (ServiceException e) {
             Assert.fail("testGenerateJWTusingProvider failed");
         }
-
     }
 
     @Test
@@ -95,11 +94,13 @@ public class JWTBasedAuthTest {
     private void validateJWT(AuthToken at, String acctId) {
         String jwt;
         try {
-            jwt = at.getEncoded();
+            Element response = new Element.XMLElement(AccountConstants.AUTH_RESPONSE);
+            at.encodeAuthResp(response, false);
+            jwt = response.getElement(AccountConstants.E_AUTH_TOKEN).getText();
             String[] jwtClaims = jwt.split("\\.");
             String jwtBody = StringUtils.newStringUtf8(Base64.decodeBase64(jwtClaims[1]));
             Assert.assertTrue(jwtBody.contains(acctId));
-        } catch (AuthTokenException e) {
+        } catch (ServiceException e) {
             Assert.fail("validation failed");
         }
 
@@ -148,5 +149,18 @@ public class JWTBasedAuthTest {
         engineCtxt.put(SoapServlet.SERVLET_REQUEST, req);
         String saltFound = JWTUtil.getSalt(null, engineCtxt);
         Assert.assertEquals(salt, saltFound);
+    }
+
+    @Test
+    public void testClearSalt() {
+        String salt = "s1";
+        String zmJWTCookieValue = "s2|s3|s1";
+        Assert.assertEquals("s2|s3", JWTUtil.clearSalt(zmJWTCookieValue, salt));
+        zmJWTCookieValue = "s2|s1|s3";
+        Assert.assertEquals("s2|s3", JWTUtil.clearSalt(zmJWTCookieValue, salt));
+        zmJWTCookieValue = "s1|s2|s3";
+        Assert.assertEquals("s2|s3", JWTUtil.clearSalt(zmJWTCookieValue, salt));
+        zmJWTCookieValue = "s1";
+        Assert.assertEquals("", JWTUtil.clearSalt(zmJWTCookieValue, salt));
     }
 }

--- a/store/src/java/com/zimbra/cs/account/Account.java
+++ b/store/src/java/com/zimbra/cs/account/Account.java
@@ -516,6 +516,10 @@ public class Account extends ZAttrAccount implements GroupedEntry, AliasedEntry 
         purgeAuthTokens();
     }
 
+    public void cleanExpiredJWTokens() throws ServiceException {
+        purgeInvalidJWTokens();
+    }
+
     /**
      * Updates the values of the following attributes:
      * - userPassword

--- a/store/src/java/com/zimbra/cs/account/AuthToken.java
+++ b/store/src/java/com/zimbra/cs/account/AuthToken.java
@@ -245,6 +245,10 @@ public abstract class AuthToken {
         return null;
     }
 
+    public String getId() {
+        return null;
+    }
+
     public static enum TokenType {
         AUTH("auth"), JWT("jwt");
         private String code;

--- a/store/src/java/com/zimbra/cs/account/JWTCache.java
+++ b/store/src/java/com/zimbra/cs/account/JWTCache.java
@@ -25,7 +25,6 @@ public class JWTCache {
     private static final Cache <String, ZimbraJWT> JWT_CACHE = CacheBuilder.newBuilder()
                                                                            .maximumSize(LC.zimbra_authtoken_cache_size.intValue())
                                                                            .build();
-    
 
     public static void put(String jti, ZimbraJWT jwtInfo) {
             JWT_CACHE.put(jti, jwtInfo);
@@ -33,5 +32,9 @@ public class JWTCache {
 
     public static ZimbraJWT get(String jti) {
             return JWT_CACHE.getIfPresent(jti);
+    }
+
+    public static void remove(String jti) {
+           JWT_CACHE.invalidate(jti);
     }
 }

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -23105,6 +23105,80 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * list of invalid jwt
+     *
+     * Ephemeral attribute - requests routed to EphemeralStore
+     *
+     * @throws com.zimbra.common.service.ServiceException if error on accessing ephemeral data
+     *
+     * @return zimbraInvalidJWTokens, or empty array if unset
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=2133)
+    public String getInvalidJWTokens(String dynamicComponent) throws com.zimbra.common.service.ServiceException {
+        return getEphemeralAttr(Provisioning.A_zimbraInvalidJWTokens, dynamicComponent).getValue(null);
+    }
+
+    /**
+     * list of invalid jwt
+     *
+     * Ephemeral attribute - requests routed to EphemeralStore
+     *
+     * @param zimbraInvalidJWTokens new to add to existing values
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=2133)
+    public void addInvalidJWTokens(String dynamicComponent, String zimbraInvalidJWTokens, com.zimbra.cs.ephemeral.EphemeralInput.Expiration expiration) throws com.zimbra.common.service.ServiceException {
+        modifyEphemeralAttr(Provisioning.A_zimbraInvalidJWTokens, dynamicComponent, zimbraInvalidJWTokens, true, expiration);
+    }
+
+    /**
+     * list of invalid jwt
+     *
+     * Ephemeral attribute - requests routed to EphemeralStore
+     *
+     * @param zimbraInvalidJWTokens existing value to remove
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=2133)
+    public void removeInvalidJWTokens(String dynamicComponent, String zimbraInvalidJWTokens) throws com.zimbra.common.service.ServiceException {
+        deleteEphemeralAttr(Provisioning.A_zimbraInvalidJWTokens, dynamicComponent, zimbraInvalidJWTokens);
+    }
+
+    /**
+     * list of invalid jwt
+     *
+     * Ephemeral attribute - requests routed to EphemeralStore
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=2133)
+    public boolean hasInvalidJWTokens(String dynamicComponent) throws com.zimbra.common.service.ServiceException {
+        return hasEphemeralAttr(Provisioning.A_zimbraInvalidJWTokens, dynamicComponent);
+    }
+
+    /**
+     * list of invalid jwt
+     *
+     * Ephemeral attribute - requests routed to EphemeralStore
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=2133)
+    public void purgeInvalidJWTokens() throws com.zimbra.common.service.ServiceException {
+        purgeEphemeralAttr(Provisioning.A_zimbraInvalidJWTokens);
+    }
+
+    /**
      * set to true for admin accounts
      *
      * @return zimbraIsAdminAccount, or false if unset

--- a/store/src/java/com/zimbra/cs/service/ZimbraAuthProvider.java
+++ b/store/src/java/com/zimbra/cs/service/ZimbraAuthProvider.java
@@ -132,7 +132,7 @@ public class ZimbraAuthProvider extends AuthProvider {
                     if (acct == null ) {
                         throw AccountServiceException.NO_SUCH_ACCOUNT(body.getSubject());
                     }
-                    at = new ZimbraAuthToken(acct, body.getExpiration().getTime(), false, null, null, Usage.AUTH, tokenType);
+                    at = new ZimbraAuthToken(acct, body.getExpiration().getTime(), tokenType, body.getId());
                 } catch (ServiceException exception) {
                     throw new AuthTokenException("JWT validation failed", exception);
                 }
@@ -164,7 +164,7 @@ public class ZimbraAuthProvider extends AuthProvider {
 
     @Override
     protected AuthToken authToken(Account acct, TokenType tokenType) {
-        return new ZimbraAuthToken(acct, tokenType);
+        return new ZimbraAuthToken(acct, tokenType, null);
     }
 
     @Override
@@ -179,7 +179,7 @@ public class ZimbraAuthProvider extends AuthProvider {
 
     @Override
     protected AuthToken authToken(Account acct, long expires, TokenType tokenType) {
-        return new ZimbraAuthToken(acct, expires, tokenType);
+        return new ZimbraAuthToken(acct, expires, tokenType, null);
     }
 
     @Override
@@ -194,6 +194,6 @@ public class ZimbraAuthProvider extends AuthProvider {
     }
 
     protected AuthToken authToken(Account acct, Usage usage, TokenType tokenType) throws AuthProviderException {
-        return new ZimbraAuthToken(acct, usage, tokenType);
+        return new ZimbraAuthToken(acct, usage, tokenType, null);
     }
 }

--- a/store/src/java/com/zimbra/cs/service/account/Auth.java
+++ b/store/src/java/com/zimbra/cs/service/account/Auth.java
@@ -466,7 +466,7 @@ public class Auth extends AccountDocumentHandler {
                 if (cookies != null) {
                     for (int i = 0; i < cookies.length; i++) {
                         if (cookies[i].getName().equals(Constants.ZM_JWT_COOKIE)) {
-                            salt = salt + "|" + cookies[i].getValue();
+                            salt = salt + Constants.JWT_SALT_SEPARATOR + cookies[i].getValue();
                             break;
                         }
                     }

--- a/store/src/java/com/zimbra/cs/service/account/Auth.java
+++ b/store/src/java/com/zimbra/cs/service/account/Auth.java
@@ -462,15 +462,7 @@ public class Auth extends AccountDocumentHandler {
             }
         } else if (!StringUtil.isNullOrEmpty(at.getSalt())) {
                 String salt = at.getSalt();
-                javax.servlet.http.Cookie cookies[] =  httpReq.getCookies();
-                if (cookies != null) {
-                    for (int i = 0; i < cookies.length; i++) {
-                        if (cookies[i].getName().equals(Constants.ZM_JWT_COOKIE)) {
-                            salt = salt + Constants.JWT_SALT_SEPARATOR + cookies[i].getValue();
-                            break;
-                        }
-                    }
-                }
+                salt = salt + Constants.JWT_SALT_SEPARATOR + JWTUtil.getZMJWTCookieValue(httpReq);
                 ZimbraCookie.addHttpOnlyCookie(httpResp, Constants.ZM_JWT_COOKIE, salt, ZimbraCookie.PATH_ROOT, -1, true);
         }
 

--- a/store/src/java/com/zimbra/cs/service/account/EndSession.java
+++ b/store/src/java/com/zimbra/cs/service/account/EndSession.java
@@ -66,14 +66,8 @@ public class EndSession extends AccountDocumentHandler {
                             String zmJWTCookieValue = null;
                             HttpServletRequest httpReq = (HttpServletRequest) context.get(SoapServlet.SERVLET_REQUEST);
                             HttpServletResponse httpResp = (HttpServletResponse) context.get(SoapServlet.SERVLET_RESPONSE);
-                            javax.servlet.http.Cookie cookies[] =  httpReq.getCookies();
-                            if (salt != null && cookies != null) {
-                                for (int i = 0; i < cookies.length; i++) {
-                                    if (cookies[i].getName().equals(Constants.ZM_JWT_COOKIE)) {
-                                        zmJWTCookieValue = cookies[i].getValue();
-                                        break;
-                                    }
-                                }
+                            if (salt != null) {
+                                zmJWTCookieValue = JWTUtil.getZMJWTCookieValue(httpReq);
                             }
                             ZimbraCookie.addHttpOnlyCookie(httpResp, Constants.ZM_JWT_COOKIE, JWTUtil.clearSalt(zmJWTCookieValue, salt), ZimbraCookie.PATH_ROOT, -1, true);
                             JWTCache.remove(jti);


### PR DESCRIPTION
In order to invalidate JWT on logout, a blacklist of JWT will be maintained in ldap. When user will logout, EndSessionRequest should be sent by client, the JWT JTI and expiry time will be added to the blacklist in ldap. In the response, ZM_JWT cookie will be set with a value which will contain all the salts which were present in the cookie value in request, except the salt corresponding to this user’s JWT.