### PR TITLE
ZCS-3828:ZWC affected by Mailsploit

### DIFF
--- a/common/src/java/com/zimbra/common/util/StringUtil.java
+++ b/common/src/java/com/zimbra/common/util/StringUtil.java
@@ -28,7 +28,6 @@ import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -1008,5 +1007,42 @@ public class StringUtil {
             ZimbraLog.filter.error("Error while truncating body", e);
         }
         return body;
+    }
+
+    /**
+     * Removes all occurrences of "Other, Control", "Other, Private Use",
+     * "Other, Unassigned", "Other, Format" and "Other, Surrogate"
+     * Replaces all "Separator, *" characters with a simple space (U+0020)
+     *
+     * @param string string to sanitize
+     * @return sanitized string
+     */
+    public static String sanitizeString(String string) {
+        if (string != null) {
+            StringBuilder sanitizedString = new StringBuilder(string.length());
+            for (int offset = 0; offset < string.length();) {
+                int codePoint = string.codePointAt(offset);
+                offset += Character.charCount(codePoint);
+                // Remove invisible control characters and unused code points
+                switch (Character.getType(codePoint)) {
+                    case Character.CONTROL: // \p{Cc}
+                    case Character.FORMAT: // \p{Cf}
+                    case Character.PRIVATE_USE: // \p{Co}
+                    case Character.SURROGATE: // \p{Cs}
+                    case Character.UNASSIGNED: // \p{Cn}
+                        break;
+                    case Character.LINE_SEPARATOR:
+                    case Character.PARAGRAPH_SEPARATOR:
+                    case Character.SPACE_SEPARATOR:
+                        sanitizedString.append(" ");
+                        break;
+                    default:
+                        sanitizedString.append(Character.toChars(codePoint));
+                        break;
+                }
+            }
+            return sanitizedString.toString();
+        }
+        return null;
     }
 }

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -5527,7 +5527,7 @@ TODO: delete them permanently from here
 </attr>
 
 <attr id="1173" name="zimbraPrefShortEmailAddress" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since ="7.0.1">
-  <defaultCOSValue>TRUE</defaultCOSValue>
+  <defaultCOSValue>FALSE</defaultCOSValue>
   <desc>show just the display name of email addresses in the message header area and compose pane</desc>
 </attr>
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -51810,13 +51810,13 @@ public abstract class ZAttrAccount  extends MailTarget {
      * show just the display name of email addresses in the message header
      * area and compose pane
      *
-     * @return zimbraPrefShortEmailAddress, or true if unset
+     * @return zimbraPrefShortEmailAddress, or false if unset
      *
      * @since ZCS 7.0.1
      */
     @ZAttr(id=1173)
     public boolean isPrefShortEmailAddress() {
-        return getBooleanAttr(Provisioning.A_zimbraPrefShortEmailAddress, true, true);
+        return getBooleanAttr(Provisioning.A_zimbraPrefShortEmailAddress, false, true);
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -39940,13 +39940,13 @@ public abstract class ZAttrCos extends NamedEntry {
      * show just the display name of email addresses in the message header
      * area and compose pane
      *
-     * @return zimbraPrefShortEmailAddress, or true if unset
+     * @return zimbraPrefShortEmailAddress, or false if unset
      *
      * @since ZCS 7.0.1
      */
     @ZAttr(id=1173)
     public boolean isPrefShortEmailAddress() {
-        return getBooleanAttr(Provisioning.A_zimbraPrefShortEmailAddress, true, true);
+        return getBooleanAttr(Provisioning.A_zimbraPrefShortEmailAddress, false, true);
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/service/mail/ToXML.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ToXML.java
@@ -70,7 +70,6 @@ import com.zimbra.common.mime.MimeConstants;
 import com.zimbra.common.mime.MimeDetect;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
-import com.zimbra.common.soap.Element.ContainerException;
 import com.zimbra.common.soap.HeaderConstants;
 import com.zimbra.common.soap.MailConstants;
 import com.zimbra.common.util.ArrayUtil;
@@ -2954,14 +2953,17 @@ throws ServiceException {
         Element el = parent.addNonUniqueElement(MailConstants.E_EMAIL);
         if(!StringUtil.isNullOrEmpty(pa.emailPart)) {
             pa.emailPart = ZInternetHeader.decode(pa.emailPart);
+            pa.emailPart = StringUtil.sanitizeString(pa.emailPart);
         }
         el.addAttribute(MailConstants.A_ADDRESS, IDNUtil.toUnicode(pa.emailPart));
         if(!StringUtil.isNullOrEmpty(pa.firstName)) {
             pa.firstName = ZInternetHeader.decode(pa.firstName);
+            pa.firstName = StringUtil.sanitizeString(pa.firstName);
         }
         el.addAttribute(MailConstants.A_DISPLAY, pa.firstName);
         if (!StringUtil.isNullOrEmpty(pa.personalPart)) {
             pa.personalPart = ZInternetHeader.decode(pa.personalPart);
+            pa.personalPart = StringUtil.sanitizeString(pa.personalPart);
         }
         el.addAttribute(MailConstants.A_PERSONAL, pa.personalPart);
         el.addAttribute(MailConstants.A_ADDRESS_TYPE, type.toString());


### PR DESCRIPTION
Stripping these categories altogether: 
"Other, Control", "Other, Private Use", "Other, Unassigned", "Other, Format" and "Other, Surrogate"
Replace all "Separator, *" characters with a simple space (U+0020)

Change the default value of zimbraPrefShortEmailAddress to FALSE

Will be updating unit test