### PR TITLE
Bugfix/zimbra 128 contact freq graph user time zone fix

### DIFF
--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -6554,6 +6554,10 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
         return invokeJaxb(new GetContactFrequencyRequest(email, frequencyBy));
     }
 
+    public GetContactFrequencyResponse getContactFrequency(String email, String frequencyBy, Integer offsetInMinutes) throws ServiceException {
+        return invokeJaxb(new GetContactFrequencyRequest(email, frequencyBy, offsetInMinutes));
+    }
+
     public static class OpenIMAPFolderParams {
 
         private static final int DEFAULT_LIMIT = 1000;

--- a/common/src/java/com/zimbra/common/soap/MailConstants.java
+++ b/common/src/java/com/zimbra/common/soap/MailConstants.java
@@ -1408,4 +1408,5 @@ public final class MailConstants {
     public static final String E_CONTACT_FREQUENCY_DATA_POINT = "dataPoint";
     public static final String A_CONTACT_FREQUENCY_LABEL = "label";
     public static final String A_CONTACT_FREQUENCY_VALUE = "value";
+    public static final String A_CONTACT_FREQUENCY_OFFSET_IN_MINUTES= "offsetInMinutes";
 }

--- a/soap/src/java/com/zimbra/soap/mail/message/GetContactFrequencyRequest.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/GetContactFrequencyRequest.java
@@ -26,8 +26,9 @@ public class GetContactFrequencyRequest {
     private String contactEmail;
 
     /**
-     * @zm-api-field-description list of frequency graphs to return separated by space.
-     * Values are one or more of "day,week,month".
+     * @zm-api-field-description list of frequency graphs to return. time range values should be concatenated together
+     * Values are one or more of "d(day)w(week)m(month)".
+     * request can have any combination of values "dwm" like "dw", "wm", "mdw", etc.
      */
     @XmlAttribute(name=MailConstants.A_CONTACT_FREQUENCY_BY, required=true)
     private String frequencyBy;

--- a/soap/src/java/com/zimbra/soap/mail/message/GetContactFrequencyRequest.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/GetContactFrequencyRequest.java
@@ -21,7 +21,7 @@ public class GetContactFrequencyRequest {
     private String frequencyBy;
 
     /**
-     * @zm-api-field-description offset in minutes of user's current timezone.
+     * @zm-api-field-description offset in minutes from UTC to user's current timezone.
      */
     @XmlAttribute(name=MailConstants.A_CONTACT_FREQUENCY_OFFSET_IN_MINUTES)
     private Integer offsetInMinutes;

--- a/soap/src/java/com/zimbra/soap/mail/message/GetContactFrequencyRequest.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/GetContactFrequencyRequest.java
@@ -34,7 +34,7 @@ public class GetContactFrequencyRequest {
     private String frequencyBy;
 
     /**
-     * @zm-pai-field-description offset in minutes of user's current timezone.
+     * @zm-api-field-description offset in minutes of user's current timezone.
      */
     @XmlAttribute(name=MailConstants.A_CONTACT_FREQUENCY_OFFSET_IN_MINUTES)
     private Integer offsetInMinutes;

--- a/soap/src/java/com/zimbra/soap/mail/message/GetContactFrequencyRequest.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/GetContactFrequencyRequest.java
@@ -7,24 +7,11 @@ import com.zimbra.common.soap.MailConstants;
 
 @XmlRootElement(name=MailConstants.E_GET_CONTACT_FREQUENCY_REQUEST)
 public class GetContactFrequencyRequest {
-
-    public GetContactFrequencyRequest() {}
-
-    public GetContactFrequencyRequest(String email, String frequencyBy) {
-        this(email, frequencyBy, null);
-    }
-
-    public GetContactFrequencyRequest(String email, String frequencyBy, Integer offsetInMinutes) {
-        setEmail(email);
-        setFrequencyBy(frequencyBy);
-        setOffsetInMinutes(offsetInMinutes);
-    }
     /**
      * @zm-api-field-description Email address of the contact to fetch contact frequency for
      */
     @XmlAttribute(name=MailConstants.A_EMAIL, required=true)
     private String contactEmail;
-
     /**
      * @zm-api-field-description list of frequency graphs to return. time range values should be concatenated together
      * Values are one or more of "d(day)w(week)m(month)".
@@ -38,6 +25,18 @@ public class GetContactFrequencyRequest {
      */
     @XmlAttribute(name=MailConstants.A_CONTACT_FREQUENCY_OFFSET_IN_MINUTES)
     private Integer offsetInMinutes;
+
+    public GetContactFrequencyRequest() {}
+
+    public GetContactFrequencyRequest(String email, String frequencyBy) {
+        this(email, frequencyBy, null);
+    }
+
+    public GetContactFrequencyRequest(String email, String frequencyBy, Integer offsetInMinutes) {
+        setEmail(email);
+        setFrequencyBy(frequencyBy);
+        setOffsetInMinutes(offsetInMinutes);
+    }
 
     public String getEmail() { return contactEmail; }
     public void setEmail(String email) { this.contactEmail = email; }

--- a/soap/src/java/com/zimbra/soap/mail/message/GetContactFrequencyRequest.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/GetContactFrequencyRequest.java
@@ -11,8 +11,13 @@ public class GetContactFrequencyRequest {
     public GetContactFrequencyRequest() {}
 
     public GetContactFrequencyRequest(String email, String frequencyBy) {
+        this(email, frequencyBy, null);
+    }
+
+    public GetContactFrequencyRequest(String email, String frequencyBy, Integer offsetInMinutes) {
         setEmail(email);
         setFrequencyBy(frequencyBy);
+        setOffsetInMinutes(offsetInMinutes);
     }
     /**
      * @zm-api-field-description Email address of the contact to fetch contact frequency for
@@ -21,11 +26,17 @@ public class GetContactFrequencyRequest {
     private String contactEmail;
 
     /**
-     * @zm-api-field-description Comma-separated list of frequency graphs to return.
+     * @zm-api-field-description list of frequency graphs to return separated by space.
      * Values are one or more of "day,week,month".
      */
     @XmlAttribute(name=MailConstants.A_CONTACT_FREQUENCY_BY, required=true)
     private String frequencyBy;
+
+    /**
+     * @zm-pai-field-description offset in minutes of user's current timezone.
+     */
+    @XmlAttribute(name=MailConstants.A_CONTACT_FREQUENCY_OFFSET_IN_MINUTES)
+    private Integer offsetInMinutes;
 
     public String getEmail() { return contactEmail; }
     public void setEmail(String email) { this.contactEmail = email; }
@@ -33,4 +44,6 @@ public class GetContactFrequencyRequest {
     public String getFrequencyBy() { return frequencyBy; }
     public void setFrequencyBy(String frequencyBy) { this.frequencyBy = frequencyBy; }
 
+    public Integer getOffsetInMinutes() { return offsetInMinutes; }
+    public void setOffsetInMinutes(Integer offsetInMinutes) { this.offsetInMinutes = offsetInMinutes; }
 }

--- a/store/src/java/com/zimbra/cs/event/EventStore.java
+++ b/store/src/java/com/zimbra/cs/event/EventStore.java
@@ -169,7 +169,7 @@ public abstract class EventStore {
      *      EndDate - Current date (today)
      *      Aggregation unit - Per month
      */
-    public abstract List<ContactFrequencyGraphDataPoint> getContactFrequencyGraph(String contact, ContactAnalytics.ContactFrequencyGraphTimeRange timeRange) throws ServiceException;
+    public abstract List<ContactFrequencyGraphDataPoint> getContactFrequencyGraph(String contact, ContactAnalytics.ContactFrequencyGraphTimeRange timeRange, Integer offsetInMinutes) throws ServiceException;
 
     /**
      * Returns the percentage of emails opened sent by the contact.

--- a/store/src/java/com/zimbra/cs/event/SolrEventStore.java
+++ b/store/src/java/com/zimbra/cs/event/SolrEventStore.java
@@ -195,8 +195,7 @@ public abstract class SolrEventStore extends EventStore {
 
     private ZonedDateTime getStartDateForCurrentMonth(ZoneId userZoneId) {
         ZonedDateTime userTZNow = ZonedDateTime.now(userZoneId);
-        ZonedDateTime userTZFirstDayOfMonth = userTZNow.with(TemporalAdjusters.firstDayOfMonth()).truncatedTo(ChronoUnit.DAYS);
-        return userTZFirstDayOfMonth;
+        return userTZNow.with(TemporalAdjusters.firstDayOfMonth()).truncatedTo(ChronoUnit.DAYS);
     }
 
     private ZonedDateTime getStartDateForLastSixMonths(ZoneId userZoneId) throws ServiceException {
@@ -211,16 +210,14 @@ public abstract class SolrEventStore extends EventStore {
 
     private ZonedDateTime getStartDateForCurrentYear(ZoneId userZoneId) {
         ZonedDateTime userTZNow = ZonedDateTime.now(userZoneId);
-        ZonedDateTime userTZFirstDayOfCurrentYear = userTZNow.with(TemporalAdjusters.firstDayOfYear()).truncatedTo(ChronoUnit.DAYS);
-        return userTZFirstDayOfCurrentYear;
+        return userTZNow.with(TemporalAdjusters.firstDayOfYear()).truncatedTo(ChronoUnit.DAYS);
     }
 
     private String getSolrTimeZone(Integer offsetInMinutes) {
         String sign = offsetInMinutes >= 0 ? "+" : "-";
         int hours = Math.abs(offsetInMinutes) / 60;
         int minutes = Math.abs(offsetInMinutes) % 60;
-        String solrTimeZone = String.format("GMT%s%02d%02d", sign, hours, minutes); //e.g. format is GMT-0500 for Eastern time zone.
-        return solrTimeZone;
+        return String.format("GMT%s%02d%02d", sign, hours, minutes); //e.g. format is GMT-0500 for Eastern time zone.
     }
 
     private BooleanQuery getQueryToSearchContactAsSenderOrReceiver(String contact) {

--- a/store/src/java/com/zimbra/cs/event/SolrEventStore.java
+++ b/store/src/java/com/zimbra/cs/event/SolrEventStore.java
@@ -219,10 +219,8 @@ public abstract class SolrEventStore extends EventStore {
         String sign = offsetInMinutes >= 0 ? "+" : "-";
         int hours = Math.abs(offsetInMinutes) / 60;
         int minutes = Math.abs(offsetInMinutes) % 60;
-        String timeFormat = "%02d";
-        StringBuilder solrTimeZone = new StringBuilder();
-        solrTimeZone.append("GMT").append(sign).append(String.format(timeFormat, hours)).append(String.format(timeFormat, minutes));
-        return solrTimeZone.toString();
+        String solrTimeZone = String.format("GMT%s%02d%02d", sign, hours, minutes); //e.g. format is GMT-0500 for Eastern time zone.
+        return solrTimeZone;
     }
 
     private BooleanQuery getQueryToSearchContactAsSenderOrReceiver(String contact) {

--- a/store/src/java/com/zimbra/cs/event/SolrEventStore.java
+++ b/store/src/java/com/zimbra/cs/event/SolrEventStore.java
@@ -2,6 +2,7 @@ package com.zimbra.cs.event;
 
 import java.io.IOException;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
@@ -152,7 +153,10 @@ public abstract class SolrEventStore extends EventStore {
             List<RangeFacet.Count> rangeFacetResult = facetRanges.get(0).getCounts();
             graphDataPoints = new ArrayList<>(rangeFacetResult.size());
             for (RangeFacet.Count rangeResult : rangeFacetResult) {
-                graphDataPoints.add(new ContactFrequencyGraphDataPoint(rangeResult.getValue(), rangeResult.getCount()));
+                //Need to convert the start time for range returned by Solr in UTC to Unix timestamp.
+                //Solr returns time in ISO-8601 format which Instant uses by default.
+                Instant instant = Instant.parse(rangeResult.getValue());
+                graphDataPoints.add(new ContactFrequencyGraphDataPoint(String.valueOf(instant.toEpochMilli()), rangeResult.getCount()));
             }
         }
         return graphDataPoints;

--- a/store/src/java/com/zimbra/cs/event/analytics/contact/ContactAnalytics.java
+++ b/store/src/java/com/zimbra/cs/event/analytics/contact/ContactAnalytics.java
@@ -1,7 +1,11 @@
 package com.zimbra.cs.event.analytics.contact;
 
+import com.zimbra.common.calendar.ICalTimeZone;
 import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.event.EventStore;
+import com.zimbra.cs.mailbox.calendar.Util;
 
 import java.util.List;
 
@@ -25,9 +29,15 @@ public class ContactAnalytics {
     public static Long getContactFrequency(String contact, EventStore eventStore, ContactFrequencyEventType eventType, ContactFrequencyTimeRange timeRange) throws ServiceException {
         return eventStore.getContactFrequencyCount(contact, eventType, timeRange);
     }
-
     public static List<ContactFrequencyGraphDataPoint> getContactFrequencyGraph(String contact, ContactFrequencyGraphTimeRange timeRange, EventStore eventStore) throws ServiceException {
-        return eventStore.getContactFrequencyGraph(contact, timeRange);
+            Account account = Provisioning.getInstance().getAccountById(eventStore.getAccountId());
+            ICalTimeZone userTimeZone = Util.getAccountTimeZone(account);
+            Integer userTimeZoneOffsetInMinutes = ((userTimeZone.getStandardOffset() / 1000) / 60);
+            return getContactFrequencyGraph(contact, timeRange, eventStore, userTimeZoneOffsetInMinutes);
+    }
+
+    public static List<ContactFrequencyGraphDataPoint> getContactFrequencyGraph(String contact, ContactFrequencyGraphTimeRange timeRange, EventStore eventStore, Integer offsetInMinutes) throws ServiceException {
+        return eventStore.getContactFrequencyGraph(contact, timeRange, offsetInMinutes);
     }
 
     public static Double getPercentageOpenedEmails(String contact, EventStore eventStore) throws ServiceException {

--- a/store/src/java/com/zimbra/cs/service/mail/GetContactFrequency.java
+++ b/store/src/java/com/zimbra/cs/service/mail/GetContactFrequency.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.Lists;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.util.Pair;
@@ -18,6 +19,7 @@ import com.zimbra.soap.mail.message.GetContactFrequencyRequest;
 import com.zimbra.soap.mail.message.GetContactFrequencyResponse;
 import com.zimbra.soap.mail.type.ContactFrequencyData;
 import com.zimbra.soap.mail.type.ContactFrequencyDataPoint;
+import org.apache.commons.lang.StringUtils;
 
 public class GetContactFrequency extends MailDocumentHandler {
 
@@ -64,12 +66,13 @@ public class GetContactFrequency extends MailDocumentHandler {
         return new ContactFrequencyDataPoint(dataPoint.getLabel(), dataPoint.getValue());
 
     }
-    private List<Pair<String, ContactAnalytics.ContactFrequencyGraphTimeRange>> parseTimeRange(String options) throws ServiceException {
+    private List<Pair<String, ContactAnalytics.ContactFrequencyGraphTimeRange>> parseTimeRange(String ranges) throws ServiceException {
         List<Pair<String, ContactAnalytics.ContactFrequencyGraphTimeRange>> requestedRanges = new ArrayList<>();
-        for (String token: options.split("\\s+")) { //tokenize by whitespace characters
-            ContactAnalytics.ContactFrequencyGraphTimeRange tr = timeRangeMap.get(token);
+        for (Character token: Lists.charactersOf(StringUtils.deleteWhitespace(ranges))) {
+            String timeRange = String.valueOf(token);
+            ContactAnalytics.ContactFrequencyGraphTimeRange tr = timeRangeMap.get(timeRange);
             if (tr != null) {
-                requestedRanges.add(new Pair<String, ContactAnalytics.ContactFrequencyGraphTimeRange>(token, tr));
+                requestedRanges.add(new Pair<String, ContactAnalytics.ContactFrequencyGraphTimeRange>(timeRange, tr));
             } else {
                 throw ServiceException.INVALID_REQUEST(token + " is not a valid time range; accepted values are {d w m}", null);
             }

--- a/store/src/java/com/zimbra/cs/zclient/ZMailboxUtil.java
+++ b/store/src/java/com/zimbra/cs/zclient/ZMailboxUtil.java
@@ -2688,6 +2688,7 @@ public class ZMailboxUtil implements DebugListener {
         for (ContactFrequencyData data: resp.getFrequencyGraphs()) {
             dumpFrequencyGraph(data);
         }
+        stdout.println("Date labels shown in UTC; other clients may show the browser's timezone instead");
     }
 
     private void dumpFrequencyGraph(ContactFrequencyData graphData) {
@@ -2697,7 +2698,6 @@ public class ZMailboxUtil implements DebugListener {
             Instant utcTimestamp = Instant.ofEpochMilli(Long.parseLong(unixTimestamp));
             dataPoint.setLabel(utcTimestamp.toString());
         }
-        stdout.println("Epoch milliseconds are included in the actual response. UTC timestamp shown here are just for demo");
         stdout.println("Frequency By: " + freqBy);
         List<ContactFrequencyDataPoint> dataPoints = graphData.getDataPoints();
         int maxLabelLength = dataPoints.stream().map(p -> p.getLabel().length()).max(Integer::compare).get();

--- a/store/src/java/com/zimbra/cs/zclient/ZMailboxUtil.java
+++ b/store/src/java/com/zimbra/cs/zclient/ZMailboxUtil.java
@@ -33,6 +33,7 @@ import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
@@ -2691,6 +2692,12 @@ public class ZMailboxUtil implements DebugListener {
 
     private void dumpFrequencyGraph(ContactFrequencyData graphData) {
         String freqBy = graphData.getFrequencyBy();
+        for (ContactFrequencyDataPoint dataPoint : graphData.getDataPoints()) {
+            String unixTimestamp = dataPoint.getLabel();
+            Instant utcTimestamp = Instant.ofEpochMilli(Long.parseLong(unixTimestamp));
+            dataPoint.setLabel(utcTimestamp.toString());
+        }
+        stdout.println("Epoch milliseconds are included in the actual response. UTC timestamp shown here are just for demo");
         stdout.println("Frequency By: " + freqBy);
         List<ContactFrequencyDataPoint> dataPoints = graphData.getDataPoints();
         int maxLabelLength = dataPoints.stream().map(p -> p.getLabel().length()).max(Integer::compare).get();

--- a/store/src/java/com/zimbra/cs/zclient/ZMailboxUtil.java
+++ b/store/src/java/com/zimbra/cs/zclient/ZMailboxUtil.java
@@ -431,7 +431,7 @@ public class ZMailboxUtil implements DebugListener {
         GET_ALL_TAGS("getAllTags", "gat", "", "get all tags", Category.TAG, 0, 0, O_VERBOSE),
         GET_APPOINTMENT_SUMMARIES("getAppointmentSummaries", "gaps", "{start-date-spec} {end-date-spec} {folder-path}", "get appointment summaries", Category.APPOINTMENT, 2, 3, O_VERBOSE),
         GET_CONTACTS("getContacts", "gct", "{contact-ids} [attr1 [attr2...]]", "get contact(s)", Category.CONTACT, 1, Integer.MAX_VALUE, O_VERBOSE),
-        GET_CONTACT_FREQUENCY("getContactFrequency", "gcf", "{contactEmail} {frequencyBy}", "get contact frequency graphs", Category.CONTACT, 2, 2),
+        GET_CONTACT_FREQUENCY("getContactFrequency", "gcf", "{contactEmail} {frequencyBy} [{offsetInMinutes}]", "get contact frequency graphs", Category.CONTACT, 2, 3),
         GET_CONVERSATION("getConversation", "gc", "{conv-id}", "get a converation", Category.CONVERSATION, 1, 1, O_VERBOSE),
         GET_IDENTITIES("getIdentities", "gid", "", "get all identites", Category.ACCOUNT, 0, 0, O_VERBOSE),
         GET_INCOMING_FILTER_RULES("getFilterRules", "gfrl", "", "get incoming filter rules", Category.FILTER,  0, 0),
@@ -2677,7 +2677,13 @@ public class ZMailboxUtil implements DebugListener {
     private void doGetContactFrequency(String[] args) throws ServiceException {
         String email = args[0];
         String freqBy = args[1];
-        GetContactFrequencyResponse resp = mMbox.getContactFrequency(email, freqBy);
+        GetContactFrequencyResponse resp;
+        if(args.length > 2) {
+            Integer offsetInMinutes = Integer.parseInt(args[2]);
+            resp = mMbox.getContactFrequency(email, freqBy, offsetInMinutes);
+        } else {
+            resp = mMbox.getContactFrequency(email, freqBy);
+        }
         for (ContactFrequencyData data: resp.getFrequencyGraphs()) {
             dumpFrequencyGraph(data);
         }

--- a/store/src/java/com/zimbra/qa/unittest/SolrEventStoreTestBase.java
+++ b/store/src/java/com/zimbra/qa/unittest/SolrEventStoreTestBase.java
@@ -482,7 +482,7 @@ public abstract class SolrEventStoreTestBase {
         ZonedDateTime now = ZonedDateTime.now(zoneId);
         ZonedDateTime firstDayOfMonth = now.with(TemporalAdjusters.firstDayOfMonth());
         List<Timestamp> daysOfMonth = new ArrayList<>(now.getDayOfMonth());
-        for (int i = 0; i < now.getDayOfMonth(); i++) {
+        for (int i = 0; i < ChronoUnit.DAYS.between(firstDayOfMonth, now) + 1; i++) {
             daysOfMonth.add(Timestamp.from(firstDayOfMonth.plusDays(i).toInstant()));
         }
         return daysOfMonth;


### PR DESCRIPTION
As per discussion with the product team, the contact frequency graph should be displayed as per user's current time zone. This affects the calculation of start date of a time range. User's current time zone will be provided in the soap request as 'offsetInMinutes'. If the timezone (offsetInMinutes) is not provided then the start date of the time range will be calculated as per timezone set by the user in preferences.