### PR TITLE
ZIMBRA-131: SmartFolder functionality

### DIFF
--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -76,6 +76,7 @@ import com.zimbra.client.event.ZCreateFolderEvent;
 import com.zimbra.client.event.ZCreateMessageEvent;
 import com.zimbra.client.event.ZCreateMountpointEvent;
 import com.zimbra.client.event.ZCreateSearchFolderEvent;
+import com.zimbra.client.event.ZCreateSmartFolderEvent;
 import com.zimbra.client.event.ZCreateTagEvent;
 import com.zimbra.client.event.ZCreateTaskEvent;
 import com.zimbra.client.event.ZDeleteEvent;
@@ -89,6 +90,7 @@ import com.zimbra.client.event.ZModifyMailboxEvent;
 import com.zimbra.client.event.ZModifyMessageEvent;
 import com.zimbra.client.event.ZModifyMountpointEvent;
 import com.zimbra.client.event.ZModifySearchFolderEvent;
+import com.zimbra.client.event.ZModifySmartFolderEvent;
 import com.zimbra.client.event.ZModifyTagEvent;
 import com.zimbra.client.event.ZModifyTaskEvent;
 import com.zimbra.client.event.ZModifyVoiceMailItemEvent;
@@ -191,6 +193,8 @@ import com.zimbra.soap.mail.message.GetRelatedContactsRequest;
 import com.zimbra.soap.mail.message.GetRelatedContactsResponse;
 import com.zimbra.soap.mail.message.GetSearchHistoryRequest;
 import com.zimbra.soap.mail.message.GetSearchHistoryResponse;
+import com.zimbra.soap.mail.message.GetSmartFoldersRequest;
+import com.zimbra.soap.mail.message.GetSmartFoldersResponse;
 import com.zimbra.soap.mail.message.IMAPCopyRequest;
 import com.zimbra.soap.mail.message.IMAPCopyResponse;
 import com.zimbra.soap.mail.message.ImportContactsRequest;
@@ -230,6 +234,7 @@ import com.zimbra.soap.mail.type.NewContactAttr;
 import com.zimbra.soap.mail.type.NewContactGroupMember;
 import com.zimbra.soap.mail.type.NewSearchFolderSpec;
 import com.zimbra.soap.mail.type.RelatedContactsTarget;
+import com.zimbra.soap.mail.type.TagInfo;
 import com.zimbra.soap.mail.type.TestDataSource;
 import com.zimbra.soap.type.AccountSelector;
 import com.zimbra.soap.type.AccountWithModifications;
@@ -284,6 +289,7 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
     private SoapHttpTransport mTransport;
     private SessionPreference mNotifyPreference;
     private Map<String, ZTag> mNameToTag;
+    private Map<String, ZSmartFolder> mNameToSmartFolder;
     private ItemCache mItemCache;
     private ZGetInfoResult mGetInfoResult;
     private ZFolder mUserRoot;
@@ -1051,6 +1057,8 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
                 event = new ZModifyAppointmentEvent(e);
             } else if (e.getName().equals(MailConstants.E_TASK)) {
                 event = new ZModifyTaskEvent(e);
+            } else if (e.getName().equals(MailConstants.E_SMART_FOLDER)) {
+                event = new ZModifySmartFolderEvent(e);
             }
             if (event != null) {
                 handleEvent(event);
@@ -1119,6 +1127,9 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
             } else if (e.getName().equals(MailConstants.E_TAG)) {
                 event = new ZCreateTagEvent(new ZTag(e, this));
                 addTag(((ZCreateTagEvent)event).getTag());
+            } else if (e.getName().equals(MailConstants.E_SMART_FOLDER)) {
+                event = new ZCreateSmartFolderEvent(new ZSmartFolder(e, this));
+                addSmartFolder(((ZCreateSmartFolderEvent)event).getSmartFolder());
             }
             if (event != null) {
                 if (events == null) {
@@ -1194,6 +1205,7 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
         public synchronized void handleRefresh(ZRefreshEvent event, ZMailbox mailbox) {
             ZFolder root = event.getUserRoot();
             List<ZTag> tags = event.getTags();
+            List<ZSmartFolder> smartFolders = event.getSmartFolders();
 
             mItemCache.clear();
             mMessageCache.clear();
@@ -1212,6 +1224,16 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
                 }
                 for (ZTag tag : tags) {
                     addTag(tag);
+                }
+            }
+            if (smartFolders != null) {
+                if (mNameToSmartFolder == null) {
+                    mNameToSmartFolder = new HashMap<String, ZSmartFolder>();
+                } else {
+                    mNameToSmartFolder.clear();
+                }
+                for (ZSmartFolder smartFolder: smartFolders) {
+                    addSmartFolder(smartFolder);
                 }
             }
         }
@@ -1262,6 +1284,12 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
                 if (contact != null) {
                     contact.modifyNotification(mce);
                 }
+            } else if (event instanceof ZModifySmartFolderEvent) {
+                ZModifySmartFolderEvent msfe = (ZModifySmartFolderEvent) event;
+                ZSmartFolder smartFolder = getSmartFolderById(msfe.getId());
+                if (smartFolder != null) {
+                    smartFolder.modifyNotification(msfe);
+                }
             }
         }
 
@@ -1284,6 +1312,8 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
                     }
                 } else if ((item instanceof ZTag) && (mNameToTag != null)) {
                     mNameToTag.remove(((ZTag) item).getName());
+                } else if ((item instanceof ZSmartFolder) && (mNameToSmartFolder != null)) {
+                    mNameToSmartFolder.remove(((ZSmartFolder) item).getName());
                 }
                 if (item != null) {
                     mItemCache.removeById(item.getId());
@@ -1297,6 +1327,13 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
             mNameToTag.put(tag.getName(), tag);
         }
         addItemIdMapping(tag);
+    }
+
+    private void addSmartFolder(ZSmartFolder folder) {
+        if (mNameToSmartFolder != null) {
+            mNameToSmartFolder.put(folder.getName(), folder);
+        }
+        addItemIdMapping(folder);
     }
 
     protected void addItemIdMapping(ZItem item) {
@@ -1557,6 +1594,23 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
         ZItem item = mItemCache.getById(id);
         if (item instanceof ZTag) {
             return (ZTag) item;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * returns the smart folder with the specified id, or null if no such tag exists.
+     *
+     * @param id the smart folder id
+     * @return tag with given id, or null
+     * @throws com.zimbra.common.service.ServiceException on error
+     */
+    public ZSmartFolder getSmartFolderById(String id) throws ServiceException {
+        populateSmartFolderCache();
+        ZItem item = mItemCache.getById(id);
+        if (item instanceof ZSmartFolder) {
+            return (ZSmartFolder) item;
         } else {
             return null;
         }
@@ -4072,6 +4126,28 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
         ZFolder userRoot = (root != null ? new ZFolder(root, null, this) : null);
 
         ZRefreshEvent event = new ZRefreshEvent(mSize, userRoot, null);
+        for (ZEventHandler handler : mHandlers) {
+            handler.handleRefresh(event, this);
+        }
+    }
+
+    private void populateSmartFolderCache() throws ServiceException {
+        if (mNameToSmartFolder != null) {
+            return;
+        }
+        if (mNotifyPreference == null || mNotifyPreference == SessionPreference.full) {
+            noOp();
+            if (mNameToSmartFolder != null) {
+                return;
+            }
+        }
+
+        List<ZSmartFolder> smartFolders = new ArrayList<ZSmartFolder>();
+        GetSmartFoldersResponse response = invokeJaxb(new GetSmartFoldersRequest());
+        for (TagInfo t : response.getSmartFolders()) {
+            smartFolders.add(new ZSmartFolder(t, this));
+        }
+        ZRefreshEvent event = new ZRefreshEvent(mSize, null, null, smartFolders);
         for (ZEventHandler handler : mHandlers) {
             handler.handleRefresh(event, this);
         }
@@ -6599,6 +6675,15 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
             result.add(item.getImapUid());
         }
         return result;
+    }
+
+    public List<ZSmartFolder> getSmartFolders() throws ServiceException {
+        GetSmartFoldersResponse resp = invokeJaxb(new GetSmartFoldersRequest());
+        List<ZSmartFolder> tags = new ArrayList<>();
+        for (TagInfo tagInfo: resp.getSmartFolders()) {
+            tags.add(new ZSmartFolder(tagInfo, this));
+        }
+        return tags;
     }
 
     public static class TagSpecifier {

--- a/client/src/java/com/zimbra/client/ZSmartFolder.java
+++ b/client/src/java/com/zimbra/client/ZSmartFolder.java
@@ -1,0 +1,40 @@
+package com.zimbra.client;
+
+import org.json.JSONException;
+
+import com.zimbra.client.event.ZModifySmartFolderEvent;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.soap.mail.type.TagInfo;
+
+public class ZSmartFolder extends ZTagInfo implements Comparable<ZSmartFolder> {
+
+    public ZSmartFolder(TagInfo tagInfo, ZMailbox mbox) throws ServiceException {
+        super(tagInfo, mbox);
+    }
+
+    public ZSmartFolder(Element e, ZMailbox mbox) throws ServiceException {
+        super(e, mbox);
+    }
+
+    public void modifyNotification(ZModifySmartFolderEvent event) throws ServiceException {
+        unreadCount = event.getUnreadCount(unreadCount);
+        retentionPolicy = event.getRetentionPolicy(retentionPolicy);
+    }
+
+    @Override
+    public int compareTo(ZSmartFolder other) {
+        return getName().compareToIgnoreCase(other.getName());
+    }
+
+
+    @Override
+    public ZJSONObject toZJSONObject() throws JSONException {
+        ZJSONObject zjo = new ZJSONObject();
+        zjo.put("id", id);
+        zjo.put("name", name);
+        zjo.put("unreadCount", unreadCount);
+        return zjo;
+    }
+
+}

--- a/client/src/java/com/zimbra/client/ZTag.java
+++ b/client/src/java/com/zimbra/client/ZTag.java
@@ -21,22 +21,15 @@ import java.util.Map;
 
 import org.json.JSONException;
 
-import com.zimbra.client.event.ZModifyEvent;
 import com.zimbra.client.event.ZModifyTagEvent;
 import com.zimbra.common.mailbox.ZimbraTag;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.MailConstants;
-import com.zimbra.soap.mail.type.RetentionPolicy;
 
-public class ZTag implements Comparable<ZTag>, ZItem, ZimbraTag, ToZJSONObject {
+public class ZTag extends ZTagInfo implements Comparable<ZTag>, ZimbraTag {
 
     private Color mColor;
-    private String mId;
-    private String mName;
-    private int mUnreadCount;
-    private ZMailbox mMailbox;
-    private RetentionPolicy mRetentionPolicy = new RetentionPolicy();
 
     public enum Color {
 
@@ -86,7 +79,7 @@ public class ZTag implements Comparable<ZTag>, ZItem, ZimbraTag, ToZJSONObject {
     }
 
     public ZTag(Element e, ZMailbox mailbox) throws ServiceException {
-        mMailbox = mailbox;
+        super(e, mailbox);
         String rgb = e.getAttribute(MailConstants.A_RGB, null);
         // Server reports color or rgb attribute on mail items but not both.
         // If rgb, map the color to the rgb value. If the attr is color, return the value as is.
@@ -96,52 +89,13 @@ public class ZTag implements Comparable<ZTag>, ZItem, ZimbraTag, ToZJSONObject {
             String s = e.getAttribute(MailConstants.A_COLOR, "0");
             mColor = Color.values()[(byte)Long.parseLong(s)];
         }
-        mId = e.getAttribute(MailConstants.A_ID);
-        mName = e.getAttribute(MailConstants.A_NAME);
-        mUnreadCount = (int) e.getAttributeLong(MailConstants.A_UNREAD, 0);
-
-        Element rpEl = e.getOptionalElement(MailConstants.E_RETENTION_POLICY);
-        if (rpEl != null) {
-            mRetentionPolicy = new RetentionPolicy(rpEl);
-        }
     }
 
     public void modifyNotification(ZModifyTagEvent tevent) throws ServiceException {
 	    mColor = tevent.getColor(mColor);
-	    mName = tevent.getName(mName);
-	    mUnreadCount = tevent.getUnreadCount(mUnreadCount);
-	    mRetentionPolicy = tevent.getRetentionPolicy(mRetentionPolicy);
-    }
-
-    @Override
-    public String getId() {
-        return mId;
-    }
-
-    @Override
-    public String getUuid() {
-        return null;
-    }
-
-    public ZMailbox getMailbox() {
-        return mMailbox;
-    }
-
-    /** Returns the folder's name.  Note that this is the folder's
-     *  name (e.g. <code>"foo"</code>), not its absolute pathname
-     *  (e.g. <code>"/baz/bar/foo"</code>).
-     *
-     *
-     */
-    public String getName() {
-        return mName;
-    }
-
-    /**
-     * @return number of unread items in folder
-     */
-    public int getUnreadCount() {
-        return mUnreadCount;
+	    name = tevent.getName(name);
+	    unreadCount = tevent.getUnreadCount(unreadCount);
+	    retentionPolicy = tevent.getRetentionPolicy(retentionPolicy);
     }
 
     public Color getColor() {
@@ -151,20 +105,16 @@ public class ZTag implements Comparable<ZTag>, ZItem, ZimbraTag, ToZJSONObject {
     @Override
     public ZJSONObject toZJSONObject() throws JSONException {
         ZJSONObject zjo = new ZJSONObject();
-        zjo.put("id", mId);
-        zjo.put("name", mName);
+        zjo.put("id", id);
+        zjo.put("name", name);
         zjo.put("color", mColor.name());
-        zjo.put("unreadCount", mUnreadCount);
+        zjo.put("unreadCount", unreadCount);
         return zjo;
     }
 
     @Override
     public String toString() {
-        return String.format("[ZTag %s]", mName);
-    }
-
-    public String dump() {
-        return ZJSONObject.toString(this);
+        return String.format("[ZTag %s]", name);
     }
 
     @Override
@@ -172,23 +122,15 @@ public class ZTag implements Comparable<ZTag>, ZItem, ZimbraTag, ToZJSONObject {
         return getName().compareToIgnoreCase(other.getName());
     }
 
-    public void delete() throws ServiceException { mMailbox.deleteTag(mId); }
+    public void delete() throws ServiceException { mailbox.deleteTag(id); }
 
     public void deleteItem() throws ServiceException { delete(); }
 
-    public void markRead() throws ServiceException { mMailbox.markTagRead(mId); }
+    public void markRead() throws ServiceException { mailbox.markTagRead(id); }
 
-    public void modifyColor(ZTag.Color color) throws ServiceException { mMailbox.modifyTagColor(mId, color); }
+    public void modifyColor(ZTag.Color color) throws ServiceException { mailbox.modifyTagColor(id, color); }
 
-    public void rename(String newName) throws ServiceException { mMailbox.renameTag(mId, newName); }
-
-    public RetentionPolicy getRetentionPolicy() {
-        return mRetentionPolicy;
-    }
-
-    public void setRetentionPolicy(RetentionPolicy rp) {
-        mRetentionPolicy = rp;
-    }
+    public void rename(String newName) throws ServiceException { mailbox.renameTag(id, newName); }
 
     @Override
     public int getTagId() {

--- a/client/src/java/com/zimbra/client/ZTagInfo.java
+++ b/client/src/java/com/zimbra/client/ZTagInfo.java
@@ -1,0 +1,73 @@
+package com.zimbra.client;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.MailConstants;
+import com.zimbra.soap.mail.type.RetentionPolicy;
+import com.zimbra.soap.mail.type.TagInfo;
+
+public abstract class ZTagInfo implements  ZItem, ToZJSONObject {
+    protected String id;
+    protected String name;
+    protected int unreadCount;
+    protected RetentionPolicy retentionPolicy = new RetentionPolicy();
+    protected ZMailbox mailbox;
+
+    public ZTagInfo(TagInfo tagInfo, ZMailbox mbox) throws ServiceException {
+        this.id = tagInfo.getId();
+        this.name = tagInfo.getName();
+        this.unreadCount = tagInfo.getUnread() == null ? 0 : tagInfo.getUnread();
+        this.retentionPolicy = tagInfo.getRetentionPolicy();
+        this.mailbox = mbox;
+    }
+
+    public ZTagInfo(Element e, ZMailbox mbox) throws ServiceException {
+        id = e.getAttribute(MailConstants.A_ID);
+        name = e.getAttribute(MailConstants.A_NAME);
+        unreadCount = (int) e.getAttributeLong(MailConstants.A_UNREAD, 0);
+        Element rpEl = e.getOptionalElement(MailConstants.E_RETENTION_POLICY);
+        if (rpEl != null) {
+            retentionPolicy = new RetentionPolicy(rpEl);
+        }
+        this.mailbox = mbox;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public String getUuid() {
+        return null;
+    }
+
+    public ZMailbox getMailbox() {
+        return mailbox;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @return number of unread items in folder
+     */
+    public int getUnreadCount() {
+        return unreadCount;
+    }
+
+    public RetentionPolicy getRetentionPolicy() {
+        return retentionPolicy;
+    }
+
+    public void setRetentionPolicy(RetentionPolicy rp) {
+        retentionPolicy = rp;
+    }
+
+    public String dump() {
+        return ZJSONObject.toString(this);
+    }
+}
+
+

--- a/client/src/java/com/zimbra/client/event/ZCreateSmartFolderEvent.java
+++ b/client/src/java/com/zimbra/client/event/ZCreateSmartFolderEvent.java
@@ -1,0 +1,54 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2006, 2007, 2009, 2010, 2011, 2013, 2014, 2016, 2017, 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.client.event;
+
+import com.zimbra.client.ZItem;
+import com.zimbra.client.ZSmartFolder;
+import com.zimbra.common.service.ServiceException;
+
+public class ZCreateSmartFolderEvent implements ZCreateItemEvent {
+
+    protected ZSmartFolder smartFolder;
+
+    public ZCreateSmartFolderEvent(ZSmartFolder smartFolder) throws ServiceException {
+        this.smartFolder = smartFolder;
+    }
+
+    /**
+     * @return tag id of created tag.
+     * @throws com.zimbra.common.service.ServiceException
+     */
+    @Override
+    public String getId() throws ServiceException {
+        return smartFolder.getId();
+    }
+
+    @Override
+    public ZItem getItem() throws ServiceException {
+        return smartFolder;
+    }
+
+    public ZSmartFolder getSmartFolder() {
+        return smartFolder;
+    }
+
+    @Override
+    public String toString() {
+        return smartFolder.toString();
+    }
+}

--- a/client/src/java/com/zimbra/client/event/ZModifySmartFolderEvent.java
+++ b/client/src/java/com/zimbra/client/event/ZModifySmartFolderEvent.java
@@ -1,0 +1,91 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2013, 2014, 2016 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.client.event;
+
+import org.json.JSONException;
+
+import com.zimbra.client.ToZJSONObject;
+import com.zimbra.client.ZJSONObject;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.MailConstants;
+import com.zimbra.soap.mail.type.RetentionPolicy;
+
+public class ZModifySmartFolderEvent implements ZModifyItemEvent, ToZJSONObject {
+
+    protected Element mSmartFolderEl;
+
+    public ZModifySmartFolderEvent(Element e) {
+        mSmartFolderEl = e;
+    }
+
+    /**
+     * @return folder id of modified smart folder
+     * @throws com.zimbra.common.service.ServiceException
+     */
+    @Override
+    public String getId() throws ServiceException {
+        return mSmartFolderEl.getAttribute(MailConstants.A_ID);
+    }
+
+    /**
+     * Returns the modified retention policy, or {@code defaultValue} if it hasn't
+     * been modified.
+     */
+    public RetentionPolicy getRetentionPolicy(RetentionPolicy defaultValue) throws ServiceException {
+        Element rpEl = mSmartFolderEl.getOptionalElement(MailConstants.E_RETENTION_POLICY);
+        if (rpEl == null) {
+            return defaultValue;
+        }
+        return new RetentionPolicy(rpEl);
+    }
+
+    /**
+     * @param defaultValue value to return if unchanged
+     * @return new unread count, or defaultVslue if unchanged
+     * @throws com.zimbra.common.service.ServiceException on error
+     */
+    public int getUnreadCount(int defaultValue) throws ServiceException {
+        return (int) mSmartFolderEl.getAttributeLong(MailConstants.A_UNREAD, defaultValue);
+    }
+
+    @Override
+    public ZJSONObject toZJSONObject() throws JSONException {
+        try {
+            ZJSONObject zjo = new ZJSONObject();
+            zjo.put("id", getId());
+            if (getUnreadCount(-1) != -1) zjo.put("unreadCount", getUnreadCount(-1));
+            return zjo;
+        } catch (ServiceException se) {
+            throw new JSONException(se);
+        }
+    }
+
+    @Override
+    public String toString() {
+        try {
+            return String.format("[ZModifySmartFolderEvent %s]", getId());
+        } catch (ServiceException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String dump() {
+        return ZJSONObject.toString(this);
+    }
+}

--- a/client/src/java/com/zimbra/client/event/ZRefreshEvent.java
+++ b/client/src/java/com/zimbra/client/event/ZRefreshEvent.java
@@ -20,7 +20,9 @@ package com.zimbra.client.event;
 import com.zimbra.client.ToZJSONObject;
 import com.zimbra.client.ZFolder;
 import com.zimbra.client.ZJSONObject;
+import com.zimbra.client.ZSmartFolder;
 import com.zimbra.client.ZTag;
+
 import org.json.JSONException;
 
 import java.util.List;
@@ -30,11 +32,17 @@ public class ZRefreshEvent implements ToZJSONObject {
     private long mSize;
     private ZFolder mUserRoot;
     private List<ZTag> mTags;
+    private List<ZSmartFolder> mSmartFolders;
 
     public ZRefreshEvent(long size, ZFolder userRoot, List<ZTag> tags) {
+        this(size, userRoot, tags, null);
+    }
+
+    public ZRefreshEvent(long size, ZFolder userRoot, List<ZTag> tags, List<ZSmartFolder> smartFolders) {
     	mSize = size;
     	mUserRoot = userRoot;
     	mTags = tags;
+    	mSmartFolders = smartFolders;
     }
 
     /**
@@ -55,15 +63,22 @@ public class ZRefreshEvent implements ToZJSONObject {
     public List<ZTag> getTags() {
         return mTags;
     }
-    
+
+    public List<ZSmartFolder> getSmartFolders() {
+        return mSmartFolders;
+    }
+
+    @Override
     public ZJSONObject toZJSONObject() throws JSONException {
         ZJSONObject zjo = new ZJSONObject();
         zjo.put("size", getSize());
     	zjo.put("userRoot", mUserRoot);
     	zjo.put("tags", mTags);
+    	zjo.put("smartFolders", mSmartFolders);
     	return zjo;
     }
 
+    @Override
     public String toString() {
         return "[ZRefreshEvent]";
     }

--- a/common/src/java/com/zimbra/common/mailbox/MailItemType.java
+++ b/common/src/java/com/zimbra/common/mailbox/MailItemType.java
@@ -36,5 +36,6 @@ public enum MailItemType {
         TASK, /** Item is a Task */
         CHAT, /** Item is a Chat */
         COMMENT, /** Item is a Comment */
-        LINK; /** Item is a Link pointing to a Document */
+        LINK, /** Item is a Link pointing to a Document */
+        SMARTFOLDER; /** Item a smart folder */
 }

--- a/common/src/java/com/zimbra/common/soap/MailConstants.java
+++ b/common/src/java/com/zimbra/common/soap/MailConstants.java
@@ -280,6 +280,8 @@ public final class MailConstants {
     public static final String E_GET_SHARE_NOTIFICATIONS_RESPONSE = "GetShareNotificationsResponse";
     public static final String E_GET_DATA_SOURCE_USAGE_REQUEST = "GetDataSourceUsageRequest";
     public static final String E_GET_DATA_SOURCE_USAGE_RESPONSE = "GetDataSourceUsageResponse";
+    public static final String E_GET_SMART_FOLDERS_REQUEST = "GetSmartFoldersRequest";
+    public static final String E_GET_SMART_FOLDERS_RESPONSE = "GetSmartFoldersResponse";
 
     // IMAP
     public static final String E_LIST_IMAP_SUBSCRIPTIONS_REQUEST = "ListIMAPSubscriptionsRequest";
@@ -394,6 +396,9 @@ public final class MailConstants {
     public static final QName GET_TAG_RESPONSE = QName.get(E_GET_TAG_RESPONSE, NAMESPACE);
     public static final QName TAG_ACTION_REQUEST = QName.get(E_TAG_ACTION_REQUEST, NAMESPACE);
     public static final QName TAG_ACTION_RESPONSE = QName.get(E_TAG_ACTION_RESPONSE, NAMESPACE);
+    // smart folders
+    public static final QName GET_SMART_FOLDERS_REQUEST = QName.get(E_GET_SMART_FOLDERS_REQUEST, NAMESPACE);
+    public static final QName GET_SMART_FOLDERS_RESPONSE = QName.get(E_GET_SMART_FOLDERS_RESPONSE, NAMESPACE);
     // saved searches
     public static final QName CREATE_SEARCH_FOLDER_REQUEST = QName.get(E_CREATE_SEARCH_FOLDER_REQUEST, NAMESPACE);
     public static final QName CREATE_SEARCH_FOLDER_RESPONSE = QName.get(E_CREATE_SEARCH_FOLDER_RESPONSE, NAMESPACE);
@@ -628,6 +633,7 @@ public final class MailConstants {
     public static final String E_MOUNT = "link";
     public static final String E_COMMENT = "comment";
     public static final String E_LINK = "lk";
+    public static final String E_SMART_FOLDER = "sf";
 
     public static final String E_INFO = "info";
     public static final String E_LOCALE = "locale";

--- a/soap/src/java/com/zimbra/soap/JaxbUtil.java
+++ b/soap/src/java/com/zimbra/soap/JaxbUtil.java
@@ -910,6 +910,8 @@ public final class JaxbUtil {
             com.zimbra.soap.mail.message.GetShareDetailsResponse.class,
             com.zimbra.soap.mail.message.GetShareNotificationsRequest.class,
             com.zimbra.soap.mail.message.GetShareNotificationsResponse.class,
+            com.zimbra.soap.mail.message.GetSmartFoldersRequest.class,
+            com.zimbra.soap.mail.message.GetSmartFoldersResponse.class,
             com.zimbra.soap.mail.message.GetSpellDictionariesRequest.class,
             com.zimbra.soap.mail.message.GetSpellDictionariesResponse.class,
             com.zimbra.soap.mail.message.GetSystemRetentionPolicyRequest.class,

--- a/soap/src/java/com/zimbra/soap/mail/message/GetSmartFoldersRequest.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/GetSmartFoldersRequest.java
@@ -1,0 +1,8 @@
+package com.zimbra.soap.mail.message;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.MailConstants;
+
+@XmlRootElement(name=MailConstants.E_GET_SMART_FOLDERS_REQUEST)
+public class GetSmartFoldersRequest {}

--- a/soap/src/java/com/zimbra/soap/mail/message/GetSmartFoldersResponse.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/GetSmartFoldersResponse.java
@@ -1,0 +1,48 @@
+package com.zimbra.soap.mail.message;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.zimbra.common.soap.MailConstants;
+import com.zimbra.soap.mail.type.TagInfo;
+
+@XmlRootElement(name=MailConstants.E_GET_SMART_FOLDERS_RESPONSE)
+public class GetSmartFoldersResponse {
+    /**
+     * @zm-api-field-description Information about smart folders
+     */
+    @XmlElement(name=MailConstants.E_SMART_FOLDER, required=false)
+    private List<TagInfo> smartFolders = Lists.newArrayList();
+
+    public GetSmartFoldersResponse() {
+    }
+
+    public void setSmartFolders(Iterable <TagInfo> tags) {
+        this.smartFolders.clear();
+        if (tags != null) {
+            Iterables.addAll(this.smartFolders, tags);
+        }
+    }
+
+    public GetSmartFoldersResponse addSmartFolder(TagInfo tag) {
+        this.smartFolders.add(tag);
+        return this;
+    }
+
+    public List<TagInfo> getSmartFolders() {
+        return Collections.unmodifiableList(smartFolders);
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this)
+            .add("smartFolders", smartFolders)
+            .toString();
+    }
+}

--- a/store/src/java-test/com/zimbra/cs/mailbox/SmartFolderTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/SmartFolderTest.java
@@ -1,0 +1,120 @@
+package com.zimbra.cs.mailbox;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.Sets;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.MockProvisioning;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.MailItem.Type;
+import com.zimbra.cs.mailbox.MailServiceException.NoSuchItemException;
+import com.zimbra.qa.unittest.TestUtil;
+
+public class SmartFolderTest {
+
+    private static final String USER = "SmartFolderTest";
+    private Mailbox mbox;
+
+    @Before
+    public void setUp() throws Exception {
+        MailboxTestUtil.initServer();
+        Provisioning prov = Provisioning.getInstance();
+        prov.createAccount(USER, "test123", new HashMap<String, Object>());
+        mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        MailboxTestUtil.clearData();
+    }
+
+    @Test
+    public void testCreateSmartFolder() throws Exception {
+        String smartFolderName = "finance";
+        SmartFolder smartFolder = mbox.createSmartFolder(null, smartFolderName);
+        assertEquals("wrong name", SmartFolder.getInternalTagName(smartFolderName), smartFolder.getName());
+        assertEquals("wrong external name", smartFolderName, smartFolder.getSmartFolderName());
+
+        SmartFolder sf = mbox.getSmartFolder(null, smartFolderName);
+        assertEquals("wrong SmartFolder ID", smartFolder.getId(), sf.getId());
+        assertEquals("wrong SmartFolder name", smartFolder.getSmartFolderName(), sf.getSmartFolderName());
+
+        List<SmartFolder> smartFolders = mbox.getSmartFolders(null);
+        assertEquals("should see 1 smart folder", 1, smartFolders.size());
+        assertEquals("wrong ID", smartFolder.getId(), smartFolders.get(0).getId());
+        assertEquals("wrong external name", smartFolder.getSmartFolderName(), smartFolders.get(0).getSmartFolderName());
+        mbox.delete(null, smartFolder.getId(), MailItem.Type.SMARTFOLDER);
+        try {
+            mbox.getSmartFolder(null, smartFolderName);
+            fail("should not be able to get deleted smartfolder");
+        } catch (NoSuchItemException e) {}
+    }
+
+    @Test
+    public void testTagWithSmartFolder() throws Exception {
+        Message msg = TestUtil.addMessage(mbox, MailboxTestUtil.generateMessage("smartfolder test"));
+        SmartFolder smartFolder = mbox.createSmartFolder(null, "finance");
+        mbox.alterTag(null, msg.getId(), Type.MESSAGE, smartFolder.getName(), true, null);
+        assertEquals("message should not have any tags", 0, msg.getTags().length);
+        String[] smartFolders = msg.getSmartFolders();
+        assertEquals("message should have one tag", 1, smartFolders.length);
+        assertEquals("wrong internal tag name", SmartFolder.getInternalTagName("finance"), smartFolders[0]);
+    }
+
+    @Test
+    public void testNameCollision() throws ServiceException {
+        SmartFolder smartFolder = mbox.createSmartFolder(null, "finance");
+        //should be able to create a tag with the same name without a collision
+        Tag tag = mbox.createTag(null, "finance", (byte)0);
+        List<Tag> tags = mbox.getTagList(null);
+        assertEquals("should see 1 tag", 1, tags.size());
+        assertEquals("wrong tag ID", tag.getId(), tags.get(0).getId());
+        List<SmartFolder> smartFolders = mbox.getSmartFolders(null);
+        assertEquals("should see 1 smart folder", 1, smartFolders.size());
+        assertEquals("wrong ID", smartFolder.getId(), smartFolders.get(0).getId());
+    }
+
+    private Map<String, SmartFolder> getSmartFolders() throws Exception {
+        Map<String, SmartFolder> map = new HashMap<>();
+        for (SmartFolder sf: mbox.getSmartFolders(null)) {
+            map.put(sf.getSmartFolderName(), sf);
+        }
+        return map;
+    }
+
+    private SmartFolderProvider getProvider(String... names) {
+        return new SmartFolderProvider() {
+
+            @Override
+            Set<String> getSmartFolderNames() throws ServiceException {
+                return Sets.newHashSet(names);
+            }
+        };
+    }
+
+    private void syncSmartFolders(String... smartFolderNames) throws Exception {
+        mbox.syncSmartFolders(null, getProvider(smartFolderNames));
+        Map<String, SmartFolder> smartFolders = getSmartFolders();
+        assertEquals(String.format("should see %d smart folders", smartFolderNames.length), smartFolderNames.length, smartFolders.size());
+        for (String name: smartFolderNames) {
+            assertTrue(String.format("%s should exist", name), smartFolders.containsKey(name));
+        }
+    }
+
+    @Test
+    public void testSyncSmartFolders() throws Exception {
+        syncSmartFolders("folder1");
+        syncSmartFolders("folder1", "folder2");
+        syncSmartFolders("folder2");
+        syncSmartFolders("folder3");
+    }
+}

--- a/store/src/java/com/zimbra/cs/index/DBQueryOperation.java
+++ b/store/src/java/com/zimbra/cs/index/DBQueryOperation.java
@@ -618,6 +618,7 @@ public class DBQueryOperation extends QueryOperation {
                 case FOLDER:
                 case SEARCHFOLDER:
                 case TAG:
+                case SMARTFOLDER:
                     result.add(MailItem.Type.UNKNOWN);
                     break;
                 case CONVERSATION:

--- a/store/src/java/com/zimbra/cs/mailbox/Folder.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Folder.java
@@ -835,7 +835,7 @@ public class Folder extends MailItem implements FolderStore {
      * @param type the type of object, e.g. {@link MailItem#TYPE_TAG}
      */
     boolean canContain(Type type) {
-        if ((type == Type.TAG) != (mId == Mailbox.ID_FOLDER_TAGS)) {
+        if ((type == Type.TAG || type == Type.SMARTFOLDER) != (mId == Mailbox.ID_FOLDER_TAGS)) {
             return false;
         } else if ((type == Type.CONVERSATION) != (mId == Mailbox.ID_FOLDER_CONVERSATIONS)) {
             return false;

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -44,11 +44,13 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import javax.mail.Address;
 import javax.mail.internet.MimeMessage;
 
 import com.google.common.base.CharMatcher;
+import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -190,6 +192,7 @@ import com.zimbra.cs.redolog.op.CreateMessage;
 import com.zimbra.cs.redolog.op.CreateMountpoint;
 import com.zimbra.cs.redolog.op.CreateNote;
 import com.zimbra.cs.redolog.op.CreateSavedSearch;
+import com.zimbra.cs.redolog.op.CreateSmartFolder;
 import com.zimbra.cs.redolog.op.CreateTag;
 import com.zimbra.cs.redolog.op.DateItem;
 import com.zimbra.cs.redolog.op.DeleteConfig;
@@ -2181,6 +2184,7 @@ public class Mailbox implements MailboxStore {
                     break;
                 case FLAG:
                 case TAG:
+                case SMARTFOLDER:
                     clearTagCache();
                     break;
                 default:
@@ -2758,6 +2762,7 @@ public class Mailbox implements MailboxStore {
             case TAG:
             case FLAG:
             case MOUNTPOINT:
+            case SMARTFOLDER:
                 return true;
             default:
                 return false;
@@ -2864,7 +2869,7 @@ public class Mailbox implements MailboxStore {
                     snapshot.recordCreated(snapshotted);
                 } else if (item instanceof Tag) {
                     Tag tag = (Tag) item;
-                    if (tag.isListed() || tag.isImapVisible()) {
+                    if (tag.isImapVisible() || isListedTagOrSmartFolder(tag)) {
                         snapshot.recordCreated(snapshotItem(tag));
                     }
                 } else if (item instanceof MailItem){
@@ -2895,7 +2900,7 @@ public class Mailbox implements MailboxStore {
                     }
                     snapshot.recordModified(folder, chg.why, (MailItem) chg.preModifyObj);
                 } else if (item instanceof Tag) {
-                    if (((Tag) item).isListed()) {
+                    if (isListedTagOrSmartFolder(item)) {
                         snapshot.recordModified(snapshotItem(item), chg.why, (MailItem) chg.preModifyObj);
                     }
                 } else {
@@ -3292,6 +3297,7 @@ public class Mailbox implements MailboxStore {
                 return getCachedItem(key);
             case FLAG:
             case TAG:
+            case SMARTFOLDER:
                 if (key < 0) {
                     item = Flag.of(this, key);
                 } else if (mTagCache != null) {
@@ -3570,7 +3576,7 @@ public class Mailbox implements MailboxStore {
                     result = new ArrayList<MailItem>(mTagCache.size() / 2);
                     for (Map.Entry<Object, Tag> entry : mTagCache.entrySet()) {
                         Tag tag = entry.getValue();
-                        if (entry.getKey() instanceof String && tag.isListed()) {
+                        if (entry.getKey() instanceof String && tag.isListed() && !(tag instanceof SmartFolder)) {
                             result.add(tag);
                         }
                     }
@@ -3584,6 +3590,19 @@ public class Mailbox implements MailboxStore {
                     result = new ArrayList<MailItem>(allFlags.size());
                     for (Flag flag : allFlags) {
                         result.add(flag);
+                    }
+                    success = true;
+                    break;
+                case SMARTFOLDER:
+                    if (folderId != -1 && folderId != ID_FOLDER_TAGS) {
+                        return Collections.emptyList();
+                    }
+                    result = new ArrayList<MailItem>(mTagCache.size() / 2);
+                    for (Map.Entry<Object, Tag> entry : mTagCache.entrySet()) {
+                        Tag tag = entry.getValue();
+                        if (entry.getKey() instanceof String && tag instanceof SmartFolder) {
+                            result.add(tag);
+                        }
                     }
                     success = true;
                     break;
@@ -4164,7 +4183,7 @@ public class Mailbox implements MailboxStore {
     }
 
     Tag getTagByName(String name) throws ServiceException {
-        Tag tag = name.startsWith(Tag.FLAG_NAME_PREFIX) ? Flag.of(this, name) : mTagCache.get(name.toLowerCase());
+        Tag tag = (name.startsWith(Tag.FLAG_NAME_PREFIX) && !name.startsWith(Tag.SMARTFOLDER_NAME_PREFIX)) ? Flag.of(this, name) : mTagCache.get(name.toLowerCase());
         if (tag == null) {
             throw MailServiceException.NO_SUCH_TAG(name);
         }
@@ -10671,6 +10690,81 @@ public class Mailbox implements MailboxStore {
     @Override
     public void markMsgSeen(OpContext octxt, ItemIdentifier itemId) throws ServiceException {
         markMsgSeen(OperationContext.asOperationContext(octxt), itemId.id);
+    }
+
+    public void syncSmartFolders(OperationContext octxt, SmartFolderProvider provider) throws ServiceException {
+        Set<String> existing = getSmartFolders(octxt).stream().map(sf -> sf.getSmartFolderName()).collect(Collectors.toSet());
+        Set<String> provided = provider.getSmartFolderNames();
+        Set<String> toAdd = Sets.difference(provided, existing);
+        Set<String> toDelete = Sets.difference(existing, provided);
+        for (String name: toAdd){
+            createSmartFolder(octxt, name);
+        }
+        for (String name: toDelete) {
+            SmartFolder sf = getSmartFolder(octxt, name);
+            delete(null, sf.getId(), MailItem.Type.SMARTFOLDER);
+        }
+    }
+
+    public SmartFolder createSmartFolder(OperationContext octxt, String smartFolderName) throws ServiceException {
+        if (smartFolderName.isEmpty()) {
+            throw ServiceException.FAILURE("Cannot have an empty SmartFolder name", null);
+        }
+        //check if this smart folder already exists
+        if (mTagCache.containsKey(SmartFolder.getInternalTagName(smartFolderName).toLowerCase())) {
+            throw MailServiceException.ALREADY_EXISTS(smartFolderName);
+        }
+
+        CreateSmartFolder redoRecorder = new CreateSmartFolder(mId, smartFolderName);
+
+        boolean success = false;
+        try {
+            beginTransaction("createSmartFolder", octxt);
+            CreateSmartFolder redoPlayer = (CreateSmartFolder) currentChange().getRedoPlayer();
+            int smartFolderId = redoPlayer == null ? ID_AUTO_INCREMENT : redoPlayer.getId();
+            SmartFolder folder = SmartFolder.create(this, getNextItemId(smartFolderId), smartFolderName);
+            redoRecorder.setId(folder.getId());
+            success = true;
+            return folder;
+        } finally {
+            endTransaction(success);
+        }
+    }
+
+    public List<SmartFolder> getSmartFolders(OperationContext octxt) throws ServiceException {
+        List<SmartFolder> smartFolders = new ArrayList<>();
+        for (MailItem item : getItemList(octxt, MailItem.Type.SMARTFOLDER)) {
+            smartFolders.add((SmartFolder) item);
+        }
+        return smartFolders;
+    }
+
+    public SmartFolder getSmartFolder(OperationContext octxt, String name) throws ServiceException {
+        if (Strings.isNullOrEmpty(name)) {
+            throw ServiceException.INVALID_REQUEST("smart folder name may not be null", null);
+        }
+
+        boolean success = false;
+        try {
+            beginReadTransaction("getSmartFolderByName", octxt);
+            if (!hasFullAccess()) {
+                throw ServiceException.PERM_DENIED("you do not have sufficient permissions");
+            }
+            SmartFolder sf = (SmartFolder) checkAccess(getTagByName(SmartFolder.getInternalTagName(name)));
+            success = true;
+            return sf;
+        } finally {
+            endTransaction(success);
+        }
+    }
+
+    private boolean isListedTagOrSmartFolder(MailItem item) {
+        if (item instanceof Tag) {
+            Tag tag = (Tag) item;
+            return tag.isListed() || tag instanceof SmartFolder;
+        } else {
+            return false;
+        }
     }
 
     public interface MessageCallback {

--- a/store/src/java/com/zimbra/cs/mailbox/MailboxOperation.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailboxOperation.java
@@ -115,7 +115,9 @@ public enum MailboxOperation {
     AddSearchHistoryEntry(94),
     PurgeSearchHistory(95),
     DeleteSearchHistory(96),
-    SetSavedSearchStatus(97);
+    SetSavedSearchStatus(97),
+    //SmartFolders
+    CreateSmartFolder(98);
 
 
     private MailboxOperation(int c) {

--- a/store/src/java/com/zimbra/cs/mailbox/SmartFolder.java
+++ b/store/src/java/com/zimbra/cs/mailbox/SmartFolder.java
@@ -1,0 +1,75 @@
+package com.zimbra.cs.mailbox;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.StringUtil;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.db.DbTag;
+
+/**
+ * Subclass of Tag used for filing messages into one or more categories based on the output of
+ * a {@link ClassificationTask}.
+ * We need a subclass for this because it should be possible for SmartFolders and Tags
+ * to share a name.
+ * @author iraykin
+ *
+ */
+public class SmartFolder extends Tag {
+
+    SmartFolder(Mailbox mbox, UnderlyingData ud) throws ServiceException {
+        super(mbox, ud);
+        init();
+    }
+
+    SmartFolder(Mailbox mbox, UnderlyingData ud, boolean skipCache) throws ServiceException {
+        super(mbox, ud, skipCache);
+        init();
+    }
+
+    SmartFolder(Account acc, UnderlyingData data, int mailboxId) throws ServiceException {
+        super(acc, data, mailboxId);
+        init();
+    }
+
+    private void init() {
+        if (mData.type != Type.SMARTFOLDER.toByte()) {
+            throw new IllegalArgumentException();
+        }
+    }
+
+
+    static SmartFolder create(Mailbox mbox, int id, String requestedName) throws ServiceException {
+        if (requestedName == null || requestedName != StringUtil.stripControlCharacters(requestedName) || requestedName.contains(FLAG_NAME_PREFIX)) {
+            throw MailServiceException.INVALID_NAME(requestedName);
+        }
+        String name = getInternalTagName(requestedName);
+        UnderlyingData data = new UnderlyingData();
+        data.id = id;
+        data.type = Type.SMARTFOLDER.toByte();
+        data.folderId = Mailbox.ID_FOLDER_TAGS;
+        data.name = name;
+        data.setSubject(name);
+        data.contentChanged(mbox);
+        ZimbraLog.mailop.info("Adding SmartFolder %s: id=%d.", name, data.id);
+        DbTag.createTag(mbox, data, null, false);
+        SmartFolder smartFolder = new SmartFolder(mbox, data);
+        smartFolder.finishCreation(null);
+        return smartFolder;
+    }
+
+    @Override
+    /**
+     * This returns the name of the tag that represents this SmartFolder.
+     */
+    public String getName() {
+        return mData.name;
+    }
+
+    public String getSmartFolderName() {
+        return mData.name.substring(2);
+    }
+
+    public static String getInternalTagName(String externalName) {
+        return SMARTFOLDER_NAME_PREFIX + externalName;
+    }
+}

--- a/store/src/java/com/zimbra/cs/mailbox/SmartFolderProvider.java
+++ b/store/src/java/com/zimbra/cs/mailbox/SmartFolderProvider.java
@@ -1,0 +1,13 @@
+package com.zimbra.cs.mailbox;
+
+import java.util.Set;
+
+import com.zimbra.common.service.ServiceException;
+
+/**
+ * Interface providing the names of SmartFolders that should be present for the account
+ */
+public abstract class SmartFolderProvider {
+
+    public abstract Set<String> getSmartFolderNames() throws ServiceException;
+}

--- a/store/src/java/com/zimbra/cs/mailbox/Tag.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Tag.java
@@ -138,7 +138,7 @@ public class Tag extends MailItem implements ZimbraTag {
     }
 
     private void init() throws ServiceException {
-        if (mData.type != Type.TAG.toByte() && mData.type != Type.FLAG.toByte()) {
+        if (mData.type != Type.TAG.toByte() && mData.type != Type.FLAG.toByte() && mData.type != Type.SMARTFOLDER.toByte()) {
             throw new IllegalArgumentException();
         }
         if (retentionPolicy == null) {
@@ -317,6 +317,9 @@ public class Tag extends MailItem implements ZimbraTag {
     }
 
     static final String FLAG_NAME_PREFIX = "\\";
+
+    //extends flag prefix to avoid potential name collisions with existing tags
+    static final String SMARTFOLDER_NAME_PREFIX = "\\\\";
 
     private static final CharMatcher INVALID_TAG_CHARS = CharMatcher.anyOf(":\\");
 

--- a/store/src/java/com/zimbra/cs/redolog/op/CreateSmartFolder.java
+++ b/store/src/java/com/zimbra/cs/redolog/op/CreateSmartFolder.java
@@ -1,0 +1,70 @@
+package com.zimbra.cs.redolog.op;
+
+import java.io.IOException;
+
+import com.zimbra.cs.mailbox.MailServiceException;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailbox.MailboxOperation;
+import com.zimbra.cs.redolog.RedoLogInput;
+import com.zimbra.cs.redolog.RedoLogOutput;
+
+public class CreateSmartFolder extends RedoableOp {
+
+    private int mId;
+    private String mName;
+
+    public CreateSmartFolder() {
+        super(MailboxOperation.CreateSmartFolder);
+        mId = UNKNOWN_ID;
+    }
+
+    public CreateSmartFolder(int mailboxId, String name) {
+        this();
+        setMailboxId(mailboxId);
+        mId = UNKNOWN_ID;
+        mName = name != null ? name : "";
+    }
+
+    public int getId() {
+        return mId;
+    }
+
+    public void setId(int id) {
+        mId = id;
+    }
+
+    @Override protected String getPrintableData() {
+        StringBuffer sb = new StringBuffer("id=").append(mId);
+        sb.append(", name=").append(mName);
+        return sb.toString();
+    }
+
+    @Override protected void serializeData(RedoLogOutput out) throws IOException {
+        out.writeInt(mId);
+        out.writeUTF(mName);
+    }
+
+    @Override protected void deserializeData(RedoLogInput in) throws IOException {
+        mId = in.readInt();
+        mName = in.readUTF();
+    }
+
+    @Override public void redo() throws Exception {
+        int mboxId = getMailboxId();
+        Mailbox mbox = MailboxManager.getInstance().getMailboxById(mboxId);
+
+        try {
+            mbox.createSmartFolder(getOperationContext(), mName);
+        } catch (MailServiceException e) {
+            String code = e.getCode();
+            if (code.equals(MailServiceException.ALREADY_EXISTS)) {
+                if (mLog.isInfoEnabled())
+                    mLog.info("SmartFolder " + mId + " already exists in mailbox " + mboxId);
+            } else {
+                throw e;
+            }
+        }
+    }
+}
+

--- a/store/src/java/com/zimbra/cs/service/formatter/ArchiveFormatter.java
+++ b/store/src/java/com/zimbra/cs/service/formatter/ArchiveFormatter.java
@@ -102,6 +102,7 @@ import com.zimbra.cs.mailbox.Mountpoint;
 import com.zimbra.cs.mailbox.Note;
 import com.zimbra.cs.mailbox.OperationContext;
 import com.zimbra.cs.mailbox.SearchFolder;
+import com.zimbra.cs.mailbox.SmartFolder;
 import com.zimbra.cs.mailbox.Tag;
 import com.zimbra.cs.mailbox.Task;
 import com.zimbra.cs.mailbox.WikiItem;
@@ -1518,6 +1519,17 @@ public abstract class ArchiveFormatter extends Formatter {
                     }
                     break;
 
+                case SMARTFOLDER:
+                    SmartFolder smartFolder = (SmartFolder) mi;
+                    try {
+                        SmartFolder oldSmartFolder = mbox.getSmartFolder(octxt, smartFolder.getSmartFolderName());
+                        oldItem = oldSmartFolder;
+                    } catch (Exception e) {
+                    }
+                    if (oldItem == null) {
+                        newItem = mbox.createSmartFolder(octxt, smartFolder.getSmartFolderName());
+                    }
+                    break;
                 case VIRTUAL_CONVERSATION:
                     return;
             }

--- a/store/src/java/com/zimbra/cs/service/mail/GetSmartFolders.java
+++ b/store/src/java/com/zimbra/cs/service/mail/GetSmartFolders.java
@@ -1,0 +1,38 @@
+package com.zimbra.cs.service.mail;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.OperationContext;
+import com.zimbra.cs.mailbox.SmartFolder;
+import com.zimbra.soap.ZimbraSoapContext;
+import com.zimbra.soap.mail.message.GetSmartFoldersResponse;
+import com.zimbra.soap.mail.type.TagInfo;
+
+public class GetSmartFolders extends MailDocumentHandler {
+
+    @Override
+    public Element handle(Element request, Map<String, Object> context)
+            throws ServiceException {
+        ZimbraSoapContext zsc = getZimbraSoapContext(context);
+        Mailbox mbox = getRequestedMailbox(zsc);
+        OperationContext octxt = getOperationContext(zsc, context);
+        List<SmartFolder> smartFolders = new ArrayList<>();
+        for (SmartFolder sf: mbox.getSmartFolders(octxt)) {
+            smartFolders.add(sf);
+        }
+        GetSmartFoldersResponse resp = new GetSmartFoldersResponse();
+        for (SmartFolder sf: smartFolders) {
+            TagInfo ti = new TagInfo(String.valueOf(sf.getId()));
+            ti.setName(sf.getSmartFolderName());
+            ti.setUnread(sf.getUnreadCount());
+            ti.setCount(sf.getItemCount());
+            resp.addSmartFolder(ti);
+        }
+        return zsc.jaxbToElement(resp);
+    }
+}

--- a/store/src/java/com/zimbra/cs/service/mail/MailService.java
+++ b/store/src/java/com/zimbra/cs/service/mail/MailService.java
@@ -246,5 +246,8 @@ public final class MailService implements DocumentService {
 
         // Contact Analytics
         dispatcher.registerHandler(MailConstants.GET_CONTACT_FREQUENCY_REQUEST, new GetContactFrequency());
+
+        //Smart Folders
+        dispatcher.registerHandler(MailConstants.GET_SMART_FOLDERS_REQUEST, new GetSmartFolders());
     }
 }

--- a/store/src/java/com/zimbra/cs/service/mail/Sync.java
+++ b/store/src/java/com/zimbra/cs/service/mail/Sync.java
@@ -74,7 +74,7 @@ public class Sync extends MailDocumentHandler {
         // the sync token is of the form "last fully synced change id" (e.g. "32425") or
         // last fully synced change id-last item synced in next change id" (e.g. "32425-99213") or
         // last fully synced change id-last item synced in next change id and last fully synced delete change id" (e.g. "32425-99213:d1231232") or
-        // last fully synced change id-last item synced in next change id and 
+        // last fully synced change id-last item synced in next change id and
         // last fully synced delete id-last item synced in next delete id (e.g. "32425-99213:d12312-82134")
         SyncToken syncToken = null;
         int tokenInt = 0;
@@ -94,7 +94,7 @@ public class Sync extends MailDocumentHandler {
             deleleLimit = DebugConfig.syncMaximumDeleteCount;
         }
 
-        // Client can specify change page limit. If unspecified by client or 
+        // Client can specify change page limit. If unspecified by client or
         // client specify more than DebugConfig.syncMaximumChangeCount It will use DebugConfig.syncMaximumChangeCount
         if (changeLimit <= 0 || changeLimit > DebugConfig.syncMaximumChangeCount) {
             changeLimit = DebugConfig.syncMaximumChangeCount;
@@ -440,6 +440,7 @@ public class Sync extends MailDocumentHandler {
                 return MailConstants.E_MOUNT;
             case FLAG:
             case TAG:
+            case SMARTFOLDER:
                 return MailConstants.E_TAG;
             case VIRTUAL_CONVERSATION:
             case CONVERSATION:

--- a/store/src/java/com/zimbra/cs/service/mail/ToXML.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ToXML.java
@@ -137,6 +137,7 @@ import com.zimbra.cs.mailbox.OperationContextData;
 import com.zimbra.cs.mailbox.RetentionPolicyManager;
 import com.zimbra.cs.mailbox.SearchFolder;
 import com.zimbra.cs.mailbox.SenderList;
+import com.zimbra.cs.mailbox.SmartFolder;
 import com.zimbra.cs.mailbox.Tag;
 import com.zimbra.cs.mailbox.WikiItem;
 import com.zimbra.cs.mailbox.calendar.Alarm;
@@ -212,6 +213,8 @@ public final class ToXML {
             int fields) throws ServiceException {
         if (item instanceof Folder) {
             return encodeFolder(parent, ifmt, octxt, (Folder) item, fields);
+        } else if (item instanceof SmartFolder) {
+            return encodeSmartFolder(parent, ifmt, octxt, (SmartFolder) item, fields);
         } else if (item instanceof Tag) {
             return encodeTag(parent, ifmt, octxt, (Tag) item, fields);
         } else if (item instanceof Note) {
@@ -1010,47 +1013,58 @@ public final class ToXML {
         return encodeTag(parent, ifmt, octxt, tag, NOTIFY_FIELDS);
     }
 
-    public static Element encodeTag(Element parent, ItemIdFormatter ifmt, OperationContext octxt, Tag tag, int fields)
-    throws ServiceException {
-        Element el = parent.addNonUniqueElement(MailConstants.E_TAG);
+    private static void encodeTagBase(Element el, ItemIdFormatter ifmt, OperationContext octxt, Tag item, int fields) throws ServiceException {
         // FIXME: eventually remove tag ID from serialization
-        el.addAttribute(MailConstants.A_ID, ifmt.formatItemId(tag));
-        // always encode the name now that we're switching away from IDs
-        el.addAttribute(MailConstants.A_NAME, tag.getName());
-        encodeColor(el, tag, fields);
+        el.addAttribute(MailConstants.A_ID, ifmt.formatItemId(item));
         if (needToOutput(fields, Change.UNREAD)) {
-            int unreadCount = tag.getUnreadCount();
+            int unreadCount = item.getUnreadCount();
             if (unreadCount > 0 || fields != NOTIFY_FIELDS) {
                 el.addAttribute(MailConstants.A_UNREAD, unreadCount);
             }
         }
         if (needToOutput(fields, Change.SIZE)) {
-            long num = tag.getItemCount();
+            long num = item.getItemCount();
             if (num > 0 || fields != NOTIFY_FIELDS) {
                 el.addAttribute(MailConstants.A_NUM, num);
             }
         }
         if (needToOutput(fields, Change.CONFLICT)) {
-            el.addAttribute(MailConstants.A_DATE, tag.getDate());
-            el.addAttribute(MailConstants.A_REVISION, tag.getSavedSequence());
-            el.addAttribute(MailConstants.A_CHANGE_DATE, tag.getChangeDate() / 1000);
-            el.addAttribute(MailConstants.A_MODIFIED_SEQUENCE, tag.getModifiedSequence());
+            el.addAttribute(MailConstants.A_DATE, item.getDate());
+            el.addAttribute(MailConstants.A_REVISION, item.getSavedSequence());
+            el.addAttribute(MailConstants.A_CHANGE_DATE, item.getChangeDate() / 1000);
+            el.addAttribute(MailConstants.A_MODIFIED_SEQUENCE, item.getModifiedSequence());
         }
         if (needToOutput(fields, Change.METADATA)) {
-            encodeAllCustomMetadata(el, tag, fields);
+            encodeAllCustomMetadata(el, item, fields);
         }
-        boolean remote = octxt != null && octxt.isDelegatedRequest(tag.getMailbox());
+        boolean remote = octxt != null && octxt.isDelegatedRequest(item.getMailbox());
         boolean canAdminister = !remote;
         if (canAdminister) {
             if (needToOutput(fields, Change.RETENTION_POLICY)) {
-                RetentionPolicy rp = tag.getRetentionPolicy();
+                RetentionPolicy rp = item.getRetentionPolicy();
                 if (fields != NOTIFY_FIELDS || rp.isSet()) {
                     // Only output retention policy if it's being modified, or if we're returning all
                     // folder data and policy is set.
-                    encodeRetentionPolicy(el, RetentionPolicyManager.getInstance().getCompleteRetentionPolicy(tag.getAccount(), rp));
+                    encodeRetentionPolicy(el, RetentionPolicyManager.getInstance().getCompleteRetentionPolicy(item.getAccount(), rp));
                 }
             }
         }
+    }
+
+    public static Element encodeSmartFolder(Element parent, ItemIdFormatter ifmt, OperationContext octxt, SmartFolder smartFolder, int fields)
+    throws ServiceException {
+        Element el = parent.addNonUniqueElement(MailConstants.E_SMART_FOLDER);
+        encodeTagBase(el, ifmt, octxt, smartFolder, fields);
+        el.addAttribute(MailConstants.A_NAME, smartFolder.getSmartFolderName());
+        return el;
+    }
+
+    public static Element encodeTag(Element parent, ItemIdFormatter ifmt, OperationContext octxt, Tag tag, int fields)
+    throws ServiceException {
+        Element el = parent.addNonUniqueElement(MailConstants.E_TAG);
+        encodeTagBase(el, ifmt, octxt, tag, fields);
+        el.addAttribute(MailConstants.A_NAME, tag.getName());
+        encodeColor(el, tag, fields);
         return el;
     }
 

--- a/store/src/java/com/zimbra/cs/zclient/ZMailboxUtil.java
+++ b/store/src/java/com/zimbra/cs/zclient/ZMailboxUtil.java
@@ -101,6 +101,7 @@ import com.zimbra.client.ZSearchPagerResult;
 import com.zimbra.client.ZSearchParams;
 import com.zimbra.client.ZSearchResult;
 import com.zimbra.client.ZSignature;
+import com.zimbra.client.ZSmartFolder;
 import com.zimbra.client.ZTag;
 import com.zimbra.client.ZTag.Color;
 import com.zimbra.client.event.ZCreateEvent;
@@ -429,6 +430,7 @@ public class ZMailboxUtil implements DebugListener {
         FLAG_MESSAGE("flagMessage", "fm", "{msg-ids} [0|1*]", "flag/unflag message(s)", Category.MESSAGE, 1, 2),
         GET_ALL_CONTACTS("getAllContacts", "gact", "[attr1 [attr2...]]", "get all contacts", Category.CONTACT, 0, Integer.MAX_VALUE, O_VERBOSE, O_FOLDER),
         GET_ALL_FOLDERS("getAllFolders", "gaf", "", "get all folders", Category.FOLDER, 0, 0, O_VERBOSE),
+        GET_ALL_SMART_FOLDERS("getAllSmartFolders", "gasf", "", "get all smart folders", Category.TAG, 0, 0, O_VERBOSE),
         GET_ALL_TAGS("getAllTags", "gat", "", "get all tags", Category.TAG, 0, 0, O_VERBOSE),
         GET_APPOINTMENT_SUMMARIES("getAppointmentSummaries", "gaps", "{start-date-spec} {end-date-spec} {folder-path}", "get appointment summaries", Category.APPOINTMENT, 2, 3, O_VERBOSE),
         GET_CONTACTS("getContacts", "gct", "{contact-ids} [attr1 [attr2...]]", "get contact(s)", Category.CONTACT, 1, Integer.MAX_VALUE, O_VERBOSE),
@@ -1205,6 +1207,9 @@ public class ZMailboxUtil implements DebugListener {
             break;
         case GET_ALL_FOLDERS:
             doGetAllFolders();
+            break;
+        case GET_ALL_SMART_FOLDERS:
+            doGetAllSmartFolders();
             break;
         case GET_ALL_TAGS:
             doGetAllTags();
@@ -2485,6 +2490,26 @@ public class ZMailboxUtil implements DebugListener {
             }
         }
         stdout.println();
+    }
+
+    private void doGetAllSmartFolders() throws ServiceException {
+        if (verboseOpt()) {
+            StringBuilder sb = new StringBuilder();
+            for (ZSmartFolder sf: mMbox.getSmartFolders()) {
+                if (sb.length() > 0) sb.append(",\n");
+                sb.append(sf.dump());
+            }
+            stdout.format("[%n%s%n]%n", sb.toString());
+        } else {
+            List<ZSmartFolder> smartFolders = mMbox.getSmartFolders();
+            if (smartFolders.isEmpty()) return;
+            String hdrFormat = "%10.10s  %10.10s  %s%n";
+            stdout.format(hdrFormat, "Id", "Unread", "Name");
+            stdout.format(hdrFormat, "----------", "----------", "----------");
+            for (ZSmartFolder sf: smartFolders) {
+                stdout.format("%10.10s  %10d  %s%n", sf.getId(), sf.getUnreadCount(), sf.getName());
+            }
+        }
     }
 
     private void doGetAllTags() throws ServiceException {

--- a/store/src/java/com/zimbra/qa/unittest/TestSmartFolders.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestSmartFolders.java
@@ -1,0 +1,112 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2014, 2016 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.qa.unittest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.zimbra.client.ZMailbox;
+import com.zimbra.client.ZSmartFolder;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.mailbox.MailItem.Type;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.Message;
+import com.zimbra.cs.mailbox.SmartFolder;
+
+public class TestSmartFolders {
+    private static final String USER_NAME = TestSmartFolders.class.getSimpleName();
+    private Mailbox mbox;
+    private ZMailbox zmbox;
+
+    @Before
+    public void setUp() throws Exception {
+        cleanUp();
+        mbox = TestUtil.getMailbox(USER_NAME);
+        zmbox = TestUtil.getZMailbox(USER_NAME);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        cleanUp();
+    }
+
+    private void cleanUp() throws Exception {
+        TestUtil.deleteAccountIfExists(USER_NAME);
+    }
+
+    private Map<String, ZSmartFolder> getSmartFolders() throws Exception {
+        Map<String, ZSmartFolder> tagMap = new HashMap<>();
+        for (ZSmartFolder sf: zmbox.getSmartFolders()) {
+            tagMap.put(sf.getName(), sf);
+        }
+        return tagMap;
+    }
+
+    @Test
+    public void testSmartFolders() throws Exception {
+        String smartFolderName1 = "finance";
+        String smartFolderName2 = "important";
+        String tagName = "testTag";
+        SmartFolder smartFolder1 = mbox.createSmartFolder(null, smartFolderName1);
+        SmartFolder smartFolder2 = mbox.createSmartFolder(null, smartFolderName2);
+        mbox.createTag(null, tagName, (byte)0); //shouldn't be included in response
+        Map<String, ZSmartFolder> sfMap = getSmartFolders();
+        assertEquals("should see 2 SmartFolders", 2, sfMap.size());
+        assertTrue("should see SmartFolder finance", sfMap.containsKey(smartFolderName1));
+        assertTrue("should see SmartFolder important", sfMap.containsKey(smartFolderName2));
+        assertEquals("incorrect finance SmartFolder ID", String.valueOf(smartFolder1.getId()), sfMap.get(smartFolderName1).getId());
+        assertEquals("incorrect important SmartFolder ID", String.valueOf(smartFolder2.getId()), sfMap.get(smartFolderName2).getId());
+   }
+
+    private ZSmartFolder getZSmartFolder(SmartFolder sf) throws Exception {
+        return zmbox.getSmartFolderById(String.valueOf(sf.getId()));
+    }
+
+    @Test
+    public void testNotifications() throws Exception {
+        SmartFolder sf1 = mbox.createSmartFolder(null, "testfolder");
+
+        //test modifications
+        Message msg = TestUtil.addMessage(mbox, "smartfolder test");
+        assertEquals("unread count should be 0", 0, getZSmartFolder(sf1).getUnreadCount());
+        mbox.alterTag(null, msg.getId(), Type.MESSAGE, sf1.getName(), true, null);
+        zmbox.getSmartFolderById(String.valueOf(sf1.getId())).getUnreadCount();
+        assertEquals("unread count should be 0", 0, getZSmartFolder(sf1).getUnreadCount());
+        zmbox.noOp();
+        assertEquals("unread count should be 1", 1, getZSmartFolder(sf1).getUnreadCount());
+
+        //test creation of a second folder, since the first folder triggers the initial populateSmartFolderCache() call
+        SmartFolder sf2 = mbox.createSmartFolder(null, "testfolder2");
+        assertEquals("zmailbox should not be aware of testfolder2", null, getZSmartFolder(sf2));
+        zmbox.noOp();
+        assertEquals("zmailbox should not be aware of testfolder2", String.valueOf(sf2.getId()), getZSmartFolder(sf2).getId());
+
+        //test deletion
+        mbox.delete(null, sf1.getId(), Type.SMARTFOLDER);
+        assertFalse("smartfolder should be not deleted", zmbox.getSmartFolderById(String.valueOf(sf1.getId())) == null);
+        zmbox.noOp();
+        assertTrue("smartfolder should be deleted", zmbox.getSmartFolderById(String.valueOf(sf1.getId())) == null);
+    }
+}

--- a/store/src/java/com/zimbra/qa/unittest/ZimbraSuite.java
+++ b/store/src/java/com/zimbra/qa/unittest/ZimbraSuite.java
@@ -166,6 +166,7 @@ public class ZimbraSuite  {
         sClasses.add(TestStandaloneSolrEventStore.class);
         sClasses.add(TestRelatedContacts.class);
         sClasses.add(TestSearchSortByRelevance.class);
+        sClasses.add(TestSmartFolders.class);
     }
 
     /**


### PR DESCRIPTION
Upcoming NextGen work requires the server to use machine learning to classify incoming emails into one or more configurable "smart folders", such as `important`, `social`, or `finance`.  This makes a smart folder very similar to tag, with the difference being that the tagging is performed by the server instead of by the client.

#### Implementation as Tags
`SmartFolder` subclasses `Tag` to enable us to take advantage of the existing tagging infrastructure. To avoid potential name collisions between smart folders and user-created tags, the internal tag corresponding to a smart folder has its name prefixed with two backslashes `\\`. This places smart folders into the namespace carved out for Flags, which begin with a single backslash. The method `SmartFolder.getSmartFolderName()` returns the "external" name which does not include the leading backslashes. This makes it possible for there to be a tag and smart folder with the same user-facing name.

While smart folder names are stored alongside tags in the database, the `UnderlyingData::setTags` method separates the input into two distinct `tags` and `smartFolders` arrays. This ensures that smart folders can only be reached by the new `MailItem::getSmartFolders` method, without polluting tag-related calls.

#### SmartFolder management
`Mailbox.java` has a new method `syncSmartFolders`that takes a `SmartFolderProvider` instance. The provider exposes a set of strings representing the smart folders that should be present on account. These names are compared to the existing smart folders, which are then created/deleted as necessary.
It should be noted that this PR does not provide any concrete implementations of `SmartFolderProvider`, but a future PR will include an implementation that gets these values from LDAP. That PR will also include actually calling `syncSmartFolders` at the appropriate time.

#### SOAP endpoint
As smart folders are currently read-only, the only new  API endpoint is `GetSmartFoldersRequest`, lets the client fetch a list of all smart folders on the account. 

#### Notifications
Notifications about changes to smart folders are returned in SOAP response context headers. These  notifications are a subset of tag notifications, without support for renaming or changing color.

#### ZClient updates
`ZMailbox` has a new method `getSmartFolders()` that invokes `GetSmartFoldersRequest`. Smart folders are cached with the same mechanism used for caching folders and tags. Response header notifications update this cache accordingly. The method `getSmartFolderById` retrieves smart folders from this cache.

#### Tests
The `SmartFolderTest` unit test class includes tests for creating/deleting smart folders, tagging items with smart folders, creating a smart folder with the same names as a tag, and testing the `Mailbox::syncSmartFolders` method.
The `TestSmartFolders` SOAP test class has tests for `GetSmartFolderRequest` and for response header notifications.

#### UPDATE 1/8/2018
* `ZTag` and `ZSmartFolder` now subclass new `ZTagInfo` class to reduce code duplication
* New method`ToXML::encodeTagBase` encodes fields common to both tags and smart folders
* Disallows empty smart folder names
* Several changes recommended by Codacy.
* Rebased on new head of `feature/solr`
  
  
  