### PR TITLE
ZCS-3890:fix issue when endSession request is proxied to another server

### DIFF
--- a/store/src/java/com/zimbra/cs/account/AuthToken.java
+++ b/store/src/java/com/zimbra/cs/account/AuthToken.java
@@ -245,7 +245,7 @@ public abstract class AuthToken {
         return null;
     }
 
-    public String getId() {
+    public String getTokenId() {
         return null;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZimbraAuthToken.java
+++ b/store/src/java/com/zimbra/cs/account/ZimbraAuthToken.java
@@ -84,6 +84,7 @@ public class ZimbraAuthToken extends AuthToken implements Cloneable {
     private static final String C_USAGE = "u";
     //cookie ID for keeping track of account's cookies
     private static final String C_TOKEN_ID = "tid";
+    private static final String C_JWT_ID = "jid";
     //mailbox server version where this account resides
     private static final String C_SERVER_VERSION = "version";
     private static final String C_CSRF = "csrf";
@@ -235,16 +236,16 @@ public class ZimbraAuthToken extends AuthToken implements Cloneable {
 
             String tid = (String)map.get(C_TOKEN_ID);
             if(tid !=null) {
-            	try {
-            		tokenID = Integer.parseInt(tid);
-            	} catch (NumberFormatException e) {
-            		tokenID = -1;
-                }
+            try {
+                tokenID = Integer.parseInt(tid);
+            } catch (NumberFormatException e) {
+                tokenID = -1;
+              }
             } else {
-            	tokenID = -1;
+              tokenID = -1;
             }
             server_version = (String)map.get(C_SERVER_VERSION);
-
+            jwtId = (String) map.get(C_JWT_ID);
             String csrf = (String) map.get(C_CSRF);
             if (csrf != null) {
                 csrfTokenEnabled = "1".equals(map.get(C_CSRF));
@@ -467,7 +468,7 @@ public class ZimbraAuthToken extends AuthToken implements Cloneable {
     }
 
     @Override
-    public String getId() {
+    public String getTokenId() {
         if (!StringUtil.isNullOrEmpty(jwtId)) {
             return jwtId;
         } else {
@@ -574,6 +575,9 @@ public class ZimbraAuthToken extends AuthToken implements Cloneable {
         }
 
         BlobMetaData.encodeMetaData(C_TOKEN_ID, tokenID, encodedBuff);
+        if (!StringUtil.isNullOrEmpty(jwtId)) {
+            BlobMetaData.encodeMetaData(C_JWT_ID, jwtId, encodedBuff);
+        }
         BlobMetaData.encodeMetaData(C_EXTERNAL_USER_EMAIL, externalUserEmail, encodedBuff);
         BlobMetaData.encodeMetaData(C_DIGEST, digest, encodedBuff);
         BlobMetaData.encodeMetaData(C_SERVER_VERSION, server_version, encodedBuff);

--- a/store/src/java/com/zimbra/cs/service/ZimbraAuthProvider.java
+++ b/store/src/java/com/zimbra/cs/service/ZimbraAuthProvider.java
@@ -133,6 +133,7 @@ public class ZimbraAuthProvider extends AuthProvider {
                         throw AccountServiceException.NO_SUCH_ACCOUNT(body.getSubject());
                     }
                     at = new ZimbraAuthToken(acct, body.getExpiration().getTime(), tokenType, body.getId());
+                    logger().debug("issued authtoken based on jti %s", body.getId());
                 } catch (ServiceException exception) {
                     throw new AuthTokenException("JWT validation failed", exception);
                 }

--- a/store/src/java/com/zimbra/cs/service/account/EndSession.java
+++ b/store/src/java/com/zimbra/cs/service/account/EndSession.java
@@ -56,13 +56,13 @@ public class EndSession extends AccountDocumentHandler {
             try {
                 AuthToken at = zsc.getAuthToken();
                 if (at.isJWT()) {
-                    String jti = at.getId();
+                    String jti = at.getTokenId();
                     if (jti != null) {
-                        ZimbraLog.security.debug("EndSession: jti: %s",jti);
+                        ZimbraLog.account.debug("EndSession: jti: %s", jti);
                         ZimbraJWT jwt = JWTCache.get(jti);
                         if (jwt != null) {
                             String salt = jwt.getSalt();
-                            ZimbraLog.security.debug("EndSession: found salt in cache for jti: %s",jti);
+                            ZimbraLog.account.debug("EndSession: found salt in cache for jti: %s", jti);
                             String zmJWTCookieValue = null;
                             HttpServletRequest httpReq = (HttpServletRequest) context.get(SoapServlet.SERVLET_REQUEST);
                             HttpServletResponse httpResp = (HttpServletResponse) context.get(SoapServlet.SERVLET_RESPONSE);

--- a/store/src/java/com/zimbra/cs/service/util/JWTUtil.java
+++ b/store/src/java/com/zimbra/cs/service/util/JWTUtil.java
@@ -138,7 +138,7 @@ public class JWTUtil {
                 throw AccountServiceException.NO_SUCH_ACCOUNT(claims.getSubject());
             }
             if (acct.hasInvalidJWTokens(jti)) {
-                ZimbraLog.security.debug("jwt: %s is no longer valid, has been invalidated on logout", jti);
+                ZimbraLog.account.debug("jwt: %s is no longer valid, has been invalidated on logout", jti);
                 throw AuthFailedServiceException.AUTH_FAILED("Token has been invalidated");
             }
             int acctValidityValue = acct.getAuthTokenValidityValue();
@@ -175,10 +175,11 @@ public class JWTUtil {
      */
     private static String getJWTSalt(String jwt, String jti, String salts) throws ServiceException {
         String jwtSpecificSalt = null;
-        ZimbraLog.account.debug("jwt: %s, it's jti: %s, and salt values: %s", jwt, jti, salts);
+        ZimbraLog.account.debug("jwt: %s, it's jti: %s", jwt, jti);
         ZimbraJWT jwtInfo = JWTCache.get(jti);
         if (jwtInfo != null && salts.contains(jwtInfo.getSalt())) {
             jwtSpecificSalt = jwtInfo.getSalt();
+            ZimbraLog.account.debug("found jti in cache %s", jti);
         } else {
             String[] saltArr = salts.split("\\|");
             byte[] tokenKey = getTokenKey();
@@ -190,6 +191,7 @@ public class JWTUtil {
                         Claims claims = Jwts.parser().setSigningKey(key).parseClaimsJws(jwt).getBody();
                         jwtSpecificSalt = salt;
                         JWTCache.put(jti, new ZimbraJWT(salt, claims.getExpiration().getTime()));
+                        ZimbraLog.account.debug("added jti in cache %s", jti);
                         break;
                     } catch(Exception e) {
                         //invalid salt, continue to try another salt value


### PR DESCRIPTION
when request is proxied to other server, auth token encoded string is sent in request. jwt id was not encoded in auth token, hence it was not available when auth token was recreated from encoded string on other server.
changed log level to account, where jti is logged as it's not sensitive information.it can be easily found by decoding jwt.