### PR TITLE
ZCS-3890:fix issue when request is proxied to another server

### DIFF
--- a/common/src/java/com/zimbra/common/auth/ZAuthToken.java
+++ b/common/src/java/com/zimbra/common/auth/ZAuthToken.java
@@ -182,7 +182,14 @@ public class ZAuthToken {
     public Element encodeSoapCtxt(Element ctxt) {
         return toSoap(ctxt, HeaderConstants.E_AUTH_TOKEN, HeaderConstants.E_A, HeaderConstants.A_N);
     }
-    
+
+    public Element encodeSoapCtxt(Element ctxt, String salt) {
+        Element jwt = toSoap(ctxt, HeaderConstants.E_JWT_TOKEN, HeaderConstants.E_A, HeaderConstants.A_N);
+        Element saltEl = ctxt.addElement(HeaderConstants.E_JWT_SALT);
+        saltEl.setText(salt);
+        return jwt;
+    }
+
     public Element encodeAuthReq(Element authReq, boolean isAdmin) {
         String authTokenElem = isAdmin?AdminConstants.E_AUTH_TOKEN:AccountConstants.E_AUTH_TOKEN;
         String attrElem = isAdmin?AdminConstants.E_A:AccountConstants.E_A;

--- a/store/src/java-test/com/zimbra/cs/util/JWTBasedAuthTest.java
+++ b/store/src/java-test/com/zimbra/cs/util/JWTBasedAuthTest.java
@@ -1,3 +1,19 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2017 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
 package com.zimbra.cs.util;
 
 import java.util.HashMap;

--- a/store/src/java/com/zimbra/cs/account/AuthToken.java
+++ b/store/src/java/com/zimbra/cs/account/AuthToken.java
@@ -245,7 +245,7 @@ public abstract class AuthToken {
         return null;
     }
 
-    public String getId() {
+    public String getTokenId() {
         return null;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZimbraJWToken.java
+++ b/store/src/java/com/zimbra/cs/account/ZimbraJWToken.java
@@ -1,0 +1,145 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2017 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.account;
+
+import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.simple.RandomSource;
+import org.apache.commons.text.RandomStringGenerator;
+
+import com.google.common.primitives.Bytes;
+import com.zimbra.common.account.Key.AccountBy;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.StringUtil;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.auth.AuthMechanism.AuthMech;
+import com.zimbra.cs.ephemeral.EphemeralInput.AbsoluteExpiration;
+import com.zimbra.cs.ephemeral.EphemeralInput.Expiration;
+import com.zimbra.cs.service.util.JWTUtil;
+
+import io.jsonwebtoken.Claims;
+
+public class ZimbraJWToken extends ZimbraAuthToken {
+    private static final int  SALT_LENGTH = 20;
+    private TokenType tokenType;
+    private String salt = null;
+    private String jwtId = null;
+    private long issuedAt;
+
+    @Override
+    public TokenType getTokenType() {
+        return tokenType;
+    }
+
+    @Override
+    public boolean isJWT() {
+        return TokenType.JWT.equals(this.tokenType);
+    }
+
+    @Override
+    public String getSalt() {
+        return salt;
+    }
+
+    @Override
+    public String getTokenId() {
+        return jwtId;
+    }
+
+    public ZimbraJWToken(Account acct) {
+        this(acct, 0, null, null);
+    }
+
+    public ZimbraJWToken(Account acct, long expires) {
+        this(acct, expires, false, null, null, Usage.AUTH, null, null);
+    }
+
+    public ZimbraJWToken(Account acct, Usage usage) {
+        this(acct, 0, false, null, null, usage, null, null);
+    }
+
+    public ZimbraJWToken(Account acct, long expires, String tokenId, String jwt) {
+        this(acct, expires, false, null, null, Usage.AUTH, tokenId, jwt);
+    }
+
+    public ZimbraJWToken(Account acct, long expires, boolean isAdmin, Account adminAcct,
+            AuthMech authMech, Usage usage, String tokenId, String jwt) {
+        this.tokenType = TokenType.JWT;
+        long expireTime = expires;
+        if (!StringUtil.isNullOrEmpty(tokenId)) {
+            jwtId = tokenId;
+        }
+        if(expireTime == 0) {
+            long lifetime = acct.getTimeInterval(Provisioning.A_zimbraAuthTokenLifetime, DEFAULT_AUTH_LIFETIME * 1000);
+            issuedAt = System.currentTimeMillis();
+            expireTime = issuedAt + lifetime;
+        }
+        initAuthToken(acct, isAdmin, adminAcct, expireTime, authMech, usage);
+        this.encoded = jwt;
+    }
+
+    @Override
+    public void deRegister() throws AuthTokenException {
+        try {
+            Account acct = Provisioning.getInstance().getAccountById(accountId);
+            if(acct != null) {
+                acct.cleanExpiredJWTokens();
+                Expiration expiration = new AbsoluteExpiration(this.expires);
+                acct.addInvalidJWTokens(jwtId, server_version, expiration);
+                ZimbraLog.account.debug("added jti: %s to invalid list", jwtId);
+                if(acct.getBooleanAttr(Provisioning.A_zimbraLogOutFromAllServers, false)) {
+                    AuthTokenRegistry.addTokenToQueue(this);
+                }
+            }
+        } catch (ServiceException e) {
+            throw new AuthTokenException("unable to de-register auth token", e);
+        }
+    }
+
+    @Override
+    public String getEncoded() throws AuthTokenException {
+        if (encoded == null) {
+            try {
+                Account acct = Provisioning.getInstance().get(AccountBy.id, accountId);
+                ZimbraLog.account.debug("auth: generating jwt token for account id: %s", accountId);
+                UniformRandomProvider rng = RandomSource.create(RandomSource.MWC_256);
+                RandomStringGenerator generator = new RandomStringGenerator.Builder().withinRange('a', 'z').usingRandom(rng::nextInt).build();
+                salt = generator.generate(SALT_LENGTH);
+                byte[] finalKey = Bytes.concat(getCurrentKey().getKey(), salt.getBytes());
+                encoded = JWTUtil.generateJWT(finalKey, salt, issuedAt, expires, acct);
+            } catch (ServiceException e) {
+                throw new AuthTokenException("unable to generate jwt", e);
+            }
+        }
+        return encoded;
+    }
+
+    public static AuthToken getAuthToken(String jwt, String salt) throws AuthTokenException {
+        AuthToken at = null;
+        try {
+            Claims body = JWTUtil.validateJWT(jwt, salt);
+            Account acct = Provisioning.getInstance().getAccountById(body.getSubject());
+            if (acct == null ) {
+                throw AccountServiceException.NO_SUCH_ACCOUNT(body.getSubject());
+            }
+            at = new ZimbraJWToken(acct, body.getExpiration().getTime(), body.getId(), jwt);
+            ZimbraLog.account.debug("issued authtoken based on jti %s", body.getId());
+        } catch (ServiceException exception) {
+            throw new AuthTokenException("JWT validation failed", exception);
+        }
+        return at;
+    }
+}

--- a/store/src/java/com/zimbra/cs/service/account/EndSession.java
+++ b/store/src/java/com/zimbra/cs/service/account/EndSession.java
@@ -56,13 +56,13 @@ public class EndSession extends AccountDocumentHandler {
             try {
                 AuthToken at = zsc.getAuthToken();
                 if (at.isJWT()) {
-                    String jti = at.getId();
+                    String jti = at.getTokenId();
                     if (jti != null) {
-                        ZimbraLog.security.debug("EndSession: jti: %s",jti);
+                        ZimbraLog.account.debug("EndSession: jti: %s", jti);
                         ZimbraJWT jwt = JWTCache.get(jti);
                         if (jwt != null) {
                             String salt = jwt.getSalt();
-                            ZimbraLog.security.debug("EndSession: found salt in cache for jti: %s",jti);
+                            ZimbraLog.account.debug("EndSession: found salt in cache for jti: %s", jti);
                             String zmJWTCookieValue = null;
                             HttpServletRequest httpReq = (HttpServletRequest) context.get(SoapServlet.SERVLET_REQUEST);
                             HttpServletResponse httpResp = (HttpServletResponse) context.get(SoapServlet.SERVLET_RESPONSE);

--- a/store/src/java/com/zimbra/soap/ProxyTarget.java
+++ b/store/src/java/com/zimbra/soap/ProxyTarget.java
@@ -146,16 +146,18 @@ public final class ProxyTarget {
                 transport.setTimeout((int) Math.min(mTimeout, Integer.MAX_VALUE));
 
             transport.setResponseProtocol(zsc.getResponseProtocol());
-            AuthToken authToken = AuthToken.getCsrfUnsecuredAuthToken(zsc.getAuthToken());
-            if (authToken != null && !StringUtil.isNullOrEmpty(authToken.getProxyAuthToken())) {
-                transport.setAuthToken(authToken.getProxyAuthToken());
+            if (!zsc.getAuthToken().isJWT()) {
+                AuthToken authToken = AuthToken.getCsrfUnsecuredAuthToken(zsc.getAuthToken());
+                if (authToken != null && !StringUtil.isNullOrEmpty(authToken.getProxyAuthToken())) {
+                    transport.setAuthToken(authToken.getProxyAuthToken());
+                }
+                disableCsrfFlagInAuthToken(envelope, authToken, request.getQName());
             }
+
             if (ZimbraLog.soap.isDebugEnabled()) {
                 ZimbraLog.soap.debug("Proxying request: proxy=%s targetAcctId=%s",
                         toString(), zsc.getRequestedAccountId());
             }
-
-            disableCsrfFlagInAuthToken(envelope, authToken, request.getQName());
 
             Element response = transport.invokeRaw(envelope);
             Element body = transport.extractBodyElement(response);


### PR DESCRIPTION
removed JWT related changes from ZimbraAuthToken. Added ZimbraJWToken class which extends ZimbraAuthToken for now. (created ZCS-3971 to refactor ZimbraAuthToken to remove this dependency).
As far as request proxy is concerned, when request flow using jwt is proxied to another server, jwt and it's salt will be added in the envelope context instead of auth token.