### PR TITLE
ZIMBRA-129: In-Memory Event Metrics

### DIFF
--- a/store/src/java-test/com/zimbra/cs/event/analytics/EventMetricTest.java
+++ b/store/src/java-test/com/zimbra/cs/event/analytics/EventMetricTest.java
@@ -1,0 +1,263 @@
+package com.zimbra.cs.event.analytics;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.event.Event;
+import com.zimbra.cs.event.Event.EventType;
+import com.zimbra.cs.event.analytics.AccountEventMetrics.MetricKey;
+import com.zimbra.cs.event.analytics.ContactFrequencyMetric.ContactFrequencyParams;
+import com.zimbra.cs.event.analytics.EventDifferenceMetric.EventDifferenceParams;
+import com.zimbra.cs.event.analytics.EventMetric.MetricInitializer;
+import com.zimbra.cs.event.analytics.EventMetric.MetricType;
+import com.zimbra.cs.event.analytics.IncrementableMetric.Increment;
+import com.zimbra.cs.event.analytics.RatioMetric.RatioIncrement;
+import com.zimbra.cs.event.analytics.ValueMetric.IntIncrement;
+import com.zimbra.cs.event.analytics.contact.ContactAnalytics.ContactFrequencyEventType;
+import com.zimbra.cs.event.analytics.contact.ContactAnalytics.ContactFrequencyTimeRange;
+import com.zimbra.cs.event.logger.BatchingEventLogger;
+import com.zimbra.cs.event.logger.EventMetricCallback;
+
+public class EventMetricTest {
+
+    private static final String CONTACT_1 = "test1@zimbra.com";
+    private static final String CONTACT_2 = "test2@zimbra.com";
+    private static final String ACCT_ID = "accountId";
+    private BatchingEventLogger logger;
+    private AccountEventMetrics metrics;
+
+    @Before
+    public void setUp() throws Exception {
+        logger = new BatchingEventLogger(10, 0, new EventMetricCallback());
+        metrics = EventMetricManager.getInstance().getMetrics(ACCT_ID);
+    }
+
+    @Test
+    public void testValueMetric() throws Exception {
+
+        MetricInitializer<ValueMetric, Integer, IntIncrement> initializer = new MetricInitializer<ValueMetric, Integer, IntIncrement>() {
+
+            @Override
+            public ValueMetric getInitialData() {
+                return new ValueMetric(0);
+            }
+
+            @Override
+            public long getMetricLifetime() {
+                return 0;
+            }
+        };
+
+        EventMetric<ValueMetric, Integer, IntIncrement> metric = new EventMetric<ValueMetric, Integer, IntIncrement>("testAccountID", null, initializer) {
+
+            @Override
+            protected IntIncrement getIncrement(List<Event> events) throws ServiceException {
+                return new IntIncrement(1);
+            }
+        };
+
+        assertEquals("initial value should be 0", (Integer)0, metric.getValue());
+        metric.increment(null);
+        metric.increment(null);
+        assertEquals("value after two increments should be 2", (Integer)2, metric.getValue());
+    }
+
+    @Test
+    public void testRatioMetric() throws Exception {
+
+        MetricInitializer<RatioMetric, Double, RatioIncrement> initializer = new MetricInitializer<RatioMetric, Double, RatioIncrement>() {
+
+            @Override
+            public RatioMetric getInitialData() {
+                return new RatioMetric(0d, 1);
+            }
+
+            @Override
+            public long getMetricLifetime() {
+                return 0;
+            }
+        };
+
+        EventMetric<RatioMetric, Double, RatioIncrement> metric = new EventMetric<RatioMetric, Double, RatioIncrement>("testAccountID", null, initializer) {
+
+            @Override
+            protected RatioIncrement getIncrement(List<Event> events) throws ServiceException {
+                return new RatioIncrement(1d, 2);
+            }
+        };
+
+        assertEquals("initial value should be 0", new Double(0), metric.getValue());
+        metric.increment(null);
+        assertEquals("new value should be 1/3", new Double(1d/3), metric.getValue());
+        metric.increment(null);
+        assertEquals("new value should be 2/5", new Double(2d/5), metric.getValue());
+    }
+
+    private void logContactFrequencyEvents(String contactEmail) {
+        logger.log(Event.generateEvent(ACCT_ID, 1, contactEmail, "me@zimbra.com", EventType.RECEIVED, null, null, System.currentTimeMillis()));
+        logger.log(Event.generateSentEvent(ACCT_ID, 2, "me@zimbra.com", contactEmail, null, null, System.currentTimeMillis()));
+        logger.log(Event.generateSentEvent(ACCT_ID, 3, "me@zimbra.com", "other@zimbra.com", null, null, System.currentTimeMillis()));
+        logger.log(Event.generateSentEvent("otherAccountId", 4, "me@zimbra.com", contactEmail, null, null, System.currentTimeMillis()));
+        logger.sendAllBatched();
+    }
+
+    private void logMsgEvents(String contactEmail, int startingMsgId, int numEvents, EventType eventType) {
+        logMsgEvents(contactEmail, startingMsgId, numEvents, eventType, System.currentTimeMillis());
+    }
+
+    private void logMsgEvents(String contactEmail, int startingMsgId, int numEvents, EventType eventType, long timestamp) {
+        for (int i=0; i<numEvents; i++) {
+            logger.log(Event.generateEvent(ACCT_ID, startingMsgId+i, contactEmail, "me@zimbra.com", eventType, null, null, timestamp));
+        }
+        //log an event for a different account id to make it doesn't affect the metrics
+        logger.log(Event.generateEvent("other", startingMsgId, contactEmail, "me@zimbra.com", eventType, null, null, timestamp));
+        logger.sendAllBatched();
+    }
+
+    @Test
+    public void testContactFrequency() throws Exception {
+
+        DummyInitializer<ValueMetric, Integer, IntIncrement> initializer = new DummyValueInitializer();
+
+        ContactFrequencyParams params = new ContactFrequencyParams(CONTACT_1, ContactFrequencyTimeRange.FOREVER, ContactFrequencyEventType.COMBINED);
+        params.setInitializer(initializer);
+        MetricKey<ValueMetric, Integer, IntIncrement> key = new MetricKey<ValueMetric, Integer, IntIncrement>(MetricType.CONTACT_FREQUENCY, params);
+        EventMetric<ValueMetric, Integer, IntIncrement> metric = metrics.getMetric(key);
+
+        assertTrue("initializer.getInitialValue() should have been triggered", initializer.isInitialized());
+        assertEquals("initial value should be 0", (Integer)0, metric.getValue());
+
+        logContactFrequencyEvents(CONTACT_1);
+
+        assertEquals("new value should be 2", (Integer)2, metric.getValue());
+    }
+
+    @Test
+    public void testReadRate() throws Exception {
+
+        DummyInitializer<RatioMetric, Double, RatioIncrement> initializer = new DummyRatioInitializer();
+
+        EventDifferenceParams contactParams = new EventDifferenceParams(EventType.READ, EventType.SEEN, CONTACT_1);
+        contactParams.setInitializer(initializer);
+        MetricKey<RatioMetric, Double, RatioIncrement> key = new MetricKey<RatioMetric, Double, RatioIncrement>(MetricType.EVENT_RATIO, contactParams);
+        EventMetric<RatioMetric, Double, RatioIncrement> contactReadRatio = metrics.getMetric(key);
+
+        EventDifferenceParams globalParams = new EventDifferenceParams(EventType.READ, EventType.SEEN);
+        globalParams.setInitializer(initializer);
+        key = new MetricKey<RatioMetric, Double, RatioIncrement>(MetricType.EVENT_RATIO, globalParams);
+        EventMetric<RatioMetric, Double, RatioIncrement> globalReadRatio = metrics.getMetric(key);
+
+        assertTrue("initializer.getInitialValue() should have been triggered", initializer.isInitialized());
+        assertEquals("initial contact1 read ratio should be 0", new Double(0), contactReadRatio.getValue());
+        assertEquals("initial global read ratio should be 0", new Double(0), globalReadRatio.getValue());
+
+        logMsgEvents(CONTACT_1, 1, 3, EventType.SEEN);
+        logMsgEvents(CONTACT_1, 1, 2, EventType.READ);
+        logMsgEvents(CONTACT_2, 10, 3, EventType.SEEN);
+        logMsgEvents(CONTACT_2, 10, 1, EventType.READ);
+
+        assertEquals("new contact1 read ratio should be 2/3", new Double(2d/3), contactReadRatio.getValue());
+        assertEquals("new global read ratio should be 1/2", new Double(1d/2), globalReadRatio.getValue());
+    }
+
+    @Test
+    public void testTimeToOpen() throws Exception {
+        DummyInitializer<RatioMetric, Double, RatioIncrement> initializer = new DummyRatioInitializer();
+
+        EventDifferenceParams contactParams = new EventDifferenceParams(EventType.SEEN, EventType.READ, CONTACT_1);
+        contactParams.setInitializer(initializer);
+        MetricKey<RatioMetric, Double, RatioIncrement> key = new MetricKey<RatioMetric, Double, RatioIncrement>(MetricType.TIME_DELTA, contactParams);
+        EventMetric<RatioMetric, Double, RatioIncrement> contactTTO = metrics.getMetric(key);
+
+        EventDifferenceParams globalParams = new EventDifferenceParams(EventType.SEEN, EventType.READ);
+        globalParams.setInitializer(initializer);
+        key = new MetricKey<RatioMetric, Double, RatioIncrement>(MetricType.TIME_DELTA, globalParams);
+        EventMetric<RatioMetric, Double, RatioIncrement> globalTTO = metrics.getMetric(key);
+
+        assertTrue("initializer.getInitialValue() should have been triggered", initializer.isInitialized());
+        assertEquals("initial contact1 TTO should be 0", new Double(0), contactTTO.getValue());
+        assertEquals("initial global TTO should be 0", new Double(0), globalTTO.getValue());
+
+        long timestamp = System.currentTimeMillis();
+        //1 second difference for contact1
+        logMsgEvents(CONTACT_1, 1, 1, EventType.SEEN, timestamp-1000);
+        logMsgEvents(CONTACT_1, 1, 1, EventType.READ, timestamp);
+
+        //2 second difference for contact2
+        logMsgEvents(CONTACT_2, 2, 1, EventType.SEEN, timestamp-2000);
+        logMsgEvents(CONTACT_2, 2, 1, EventType.READ, timestamp);
+
+        assertEquals("new contact1 TTO should be 1 second", new Double(1), contactTTO.getValue());
+        assertEquals("new global TTO should be 1.5 seconds", new Double(1.5), globalTTO.getValue());
+    }
+
+    @Test
+    public void testReplyRate() throws Exception {
+        DummyInitializer<RatioMetric, Double, RatioIncrement> initializer = new DummyRatioInitializer();
+
+        EventDifferenceParams contactParams = new EventDifferenceParams(EventType.REPLIED, EventType.SEEN, CONTACT_1);
+        contactParams.setInitializer(initializer);
+        MetricKey<RatioMetric, Double, RatioIncrement> key = new MetricKey<RatioMetric, Double, RatioIncrement>(MetricType.EVENT_RATIO, contactParams);
+        EventMetric<RatioMetric, Double, RatioIncrement> contactReplyRate = metrics.getMetric(key);
+
+        EventDifferenceParams globalParams = new EventDifferenceParams(EventType.REPLIED, EventType.SEEN);
+        globalParams.setInitializer(initializer);
+        key = new MetricKey<RatioMetric, Double, RatioIncrement>(MetricType.EVENT_RATIO, globalParams);
+        EventMetric<RatioMetric, Double, RatioIncrement> globalReplyRate = metrics.getMetric(key);
+
+        assertTrue("initializer.getInitialValue() should have been triggered", initializer.isInitialized());
+        assertEquals("initial contact1 reply rate should be 0", new Double(0), contactReplyRate.getValue());
+        assertEquals("initial global reply rate should be 0", new Double(0), globalReplyRate.getValue());
+
+        logMsgEvents(CONTACT_1, 1, 6, EventType.SEEN);
+        logMsgEvents(CONTACT_1, 1, 1, EventType.REPLIED);
+        logMsgEvents(CONTACT_2, 10, 2, EventType.SEEN);
+        logMsgEvents(CONTACT_2, 10, 1, EventType.REPLIED);
+
+        assertEquals("new contact1 reply rate should be 1/6", new Double(1d/6), contactReplyRate.getValue());
+        assertEquals("new global reply rate should be 1/4", new Double(1d/4), globalReplyRate.getValue());
+    }
+
+    private static abstract class DummyInitializer<M extends IncrementableMetric<T, I>, T, I extends Increment> extends MetricInitializer<M, T, I> {
+
+        protected boolean initialized = false;
+
+        public boolean isInitialized() {
+            return initialized;
+        }
+    }
+
+    private static class DummyValueInitializer extends DummyInitializer<ValueMetric, Integer, IntIncrement> {
+
+        @Override
+        public ValueMetric getInitialData() throws ServiceException {
+            initialized = true;
+            return new ValueMetric(0);
+        }
+
+        @Override
+        public long getMetricLifetime() {
+            return 0;
+        }
+    }
+
+    private static class DummyRatioInitializer extends DummyInitializer<RatioMetric, Double, RatioIncrement> {
+
+        @Override
+        public RatioMetric getInitialData() throws ServiceException {
+            initialized = true;
+            return new RatioMetric(0d, 0);
+        }
+
+        @Override
+        public long getMetricLifetime() {
+            return 0;
+        }
+    }
+}

--- a/store/src/java-test/com/zimbra/cs/mailbox/SmartFolderTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/SmartFolderTest.java
@@ -95,7 +95,7 @@ public class SmartFolderTest {
         return new SmartFolderProvider() {
 
             @Override
-            Set<String> getSmartFolderNames() throws ServiceException {
+            public Set<String> getSmartFolderNames() throws ServiceException {
                 return Sets.newHashSet(names);
             }
         };

--- a/store/src/java/com/zimbra/cs/event/EventStore.java
+++ b/store/src/java/com/zimbra/cs/event/EventStore.java
@@ -1,6 +1,7 @@
 package com.zimbra.cs.event;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import com.google.common.base.Strings;
@@ -10,12 +11,12 @@ import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.Server;
 import com.zimbra.cs.contacts.RelatedContactsParams;
 import com.zimbra.cs.contacts.RelatedContactsResults;
+import com.zimbra.cs.event.Event.EventType;
+import com.zimbra.cs.event.analytics.RatioMetric;
 import com.zimbra.cs.event.analytics.contact.ContactAnalytics;
+import com.zimbra.cs.event.analytics.contact.ContactFrequencyGraphDataPoint;
 import com.zimbra.cs.event.logger.EventLogger;
 import com.zimbra.cs.extension.ExtensionUtil;
-import com.zimbra.cs.event.analytics.contact.ContactFrequencyGraphDataPoint;
-
-import java.util.List;
 
 
 /**
@@ -172,28 +173,28 @@ public abstract class EventStore {
     public abstract List<ContactFrequencyGraphDataPoint> getContactFrequencyGraph(String contact, ContactAnalytics.ContactFrequencyGraphTimeRange timeRange, Integer offsetInMinutes) throws ServiceException;
 
     /**
-     * Returns the percentage of emails opened sent by the contact.
-     * The percentage is calculated using (number of Read emails / number of Received emails) from the contact
-     * This data is used by email classifier to mark important emails
+     * Returns the average time delta, in seconds, between two event types, for the given contact
      */
-    public abstract Double getPercentageOpenedEmails(String contact) throws ServiceException;
+    public abstract RatioMetric getEventTimeDelta(EventType firstEventType, EventType secondEventType, String contact) throws ServiceException;
 
     /**
-     * Returns the avg time in seconds to open emails from a contact
+     * Returns the global average time delta, in seconds, between two event types
      */
-    public abstract Double getAvgTimeToOpenEmail(String contact) throws ServiceException;
+    public RatioMetric getGlobalEventTimeDelta(EventType firstEventType, EventType secondEventType) throws ServiceException {
+        return getEventTimeDelta(firstEventType, secondEventType, null);
+    }
 
     /**
-     * Returns the avg time in seconds to open emails for an account(all contacts)
+     * Returns the ratio between two event types, for events matching the given contact
      */
-    public abstract Double getAvgTimeToOpenEmailForAccount() throws ServiceException;
+    public abstract RatioMetric getEventRatio(EventType numeratorEvent, EventType denominatorEvent, String contact) throws ServiceException;
 
     /**
-     * Returns the percentage of replies provided for emails sent by a contact.
-     * The percentage is calculated using (number of Replied emails / number of Received emails) from the contact
-     * This data is used by email classifier to mark important emails
+     * Returns the global ratio between two event types
      */
-    public abstract Double getPercentageRepliedEmails(String contact) throws ServiceException;
+    public RatioMetric getGlobalEventRatio(EventType numeratorEvent, EventType denominatorEvent) throws ServiceException {
+        return getEventRatio(numeratorEvent, denominatorEvent, null);
+    }
 
     public interface Factory {
 

--- a/store/src/java/com/zimbra/cs/event/StandaloneSolrEventStore.java
+++ b/store/src/java/com/zimbra/cs/event/StandaloneSolrEventStore.java
@@ -6,6 +6,8 @@ import com.zimbra.common.httpclient.ZimbraHttpClientManager;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.contacts.RelatedContactsParams;
 import com.zimbra.cs.contacts.RelatedContactsResults;
+import com.zimbra.cs.event.Event.EventType;
+import com.zimbra.cs.event.analytics.RatioMetric;
 import com.zimbra.cs.index.solr.SolrConstants;
 import com.zimbra.cs.index.solr.SolrRequestHelper;
 import com.zimbra.cs.index.solr.StandaloneSolrHelper;
@@ -26,22 +28,8 @@ public class StandaloneSolrEventStore extends SolrEventStore {
     }
 
     @Override
-    public Double getPercentageOpenedEmails(String contact) throws ServiceException {
-        throw ServiceException.UNSUPPORTED();
-    }
-
-    @Override
-    public Double getAvgTimeToOpenEmail(String contact) throws ServiceException {
-        throw ServiceException.UNSUPPORTED();
-    }
-
-    @Override
-    public Double getAvgTimeToOpenEmailForAccount() throws ServiceException {
-        throw ServiceException.UNSUPPORTED();
-    }
-
-    @Override
-    public Double getPercentageRepliedEmails(String contact) throws ServiceException {
+    public RatioMetric getEventTimeDelta(EventType firstEventType, EventType secondEventType, String contact) throws ServiceException {
+        //event time deltas are calculated with the Solr Streaming API, which is not available on Standalone Solr
         throw ServiceException.UNSUPPORTED();
     }
 

--- a/store/src/java/com/zimbra/cs/event/analytics/AccountEventMetrics.java
+++ b/store/src/java/com/zimbra/cs/event/analytics/AccountEventMetrics.java
@@ -1,0 +1,91 @@
+package com.zimbra.cs.event.analytics;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.base.Objects;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.Pair;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.event.Event;
+import com.zimbra.cs.event.analytics.EventMetric.Factory;
+import com.zimbra.cs.event.analytics.EventMetric.MetricParams;
+import com.zimbra.cs.event.analytics.EventMetric.MetricType;
+import com.zimbra.cs.event.analytics.IncrementableMetric.Increment;
+
+/**
+ * Class encapsulating all event metrics for an account
+ */
+public class AccountEventMetrics {
+
+    private String accountId;
+    private Map<EventMetric.MetricType, EventMetric.Factory<?, ?, ?>> factories;
+    private Map<MetricKey<?, ?, ?>, EventMetric<?, ?, ?>> metrics;
+
+    public AccountEventMetrics(String accountId, Map<EventMetric.MetricType, EventMetric.Factory<?, ?, ?>> factories) {
+        this.accountId = accountId;
+        this.factories = factories;
+        this.metrics = new HashMap<>();
+    }
+
+    /**
+     * Return the specified EventMetric instance. If not loaded,
+     * the metric will be initialized first.
+     */
+    @SuppressWarnings("unchecked")
+    public <M extends IncrementableMetric<T, I>, T, I extends Increment> EventMetric<M, T, I> getMetric(MetricKey<M, T, I> key) throws ServiceException {
+        EventMetric<M, T, I> metric = (EventMetric<M, T, I>) metrics.get(key);
+        if (metric == null) {
+            MetricType type = key.getType();
+            EventMetric.Factory<M, T, I> factory = (Factory<M, T, I>) factories.get(type);
+            if (factory == null) {
+                throw ServiceException.FAILURE(String.format("no EventMetric factory found for metric type %s",  type.name()), null);
+            }
+            ZimbraLog.event.debug("initializing event metric %s", key);
+            metric = factory.buildMetric(accountId, key.getParams());
+            metrics.put(key, metric);
+        }
+        return metric;
+    }
+
+    /**
+     * Update all loaded EventMetric instances
+     */
+    public void incrementAll(List<Event> events) throws ServiceException {
+        for (EventMetric<?, ?, ?> metric: metrics.values()) {
+            metric.increment(events);
+        }
+    }
+
+    /**
+     * Cache key used for accessing an EventMetric instance.
+     * If the EventMetric for the given type and parameters does not exist,
+     * it is instantiated using the specified MetricParams.
+     */
+    public static class MetricKey<M extends IncrementableMetric<T, I>, T, I extends Increment> extends Pair<MetricType, MetricParams<M, T, I>> {
+
+        public MetricKey(MetricType type, MetricParams<M, T, I> params) {
+            super(type, params);
+        }
+
+        public MetricType getType() {
+            return getFirst();
+        }
+
+        public MetricParams<M, T, I> getParams() {
+            return getSecond();
+        }
+
+        @Override
+        public String toString() {
+            return Objects.toStringHelper(this)
+                    .add("type", getType())
+                    .add("params", getParams()).toString();
+        }
+    }
+
+    public void evictMetricCache() {
+        metrics.clear();
+    }
+}

--- a/store/src/java/com/zimbra/cs/event/analytics/ContactFrequencyMetric.java
+++ b/store/src/java/com/zimbra/cs/event/analytics/ContactFrequencyMetric.java
@@ -1,0 +1,175 @@
+package com.zimbra.cs.event.analytics;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.base.Objects;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.event.Event;
+import com.zimbra.cs.event.Event.EventContextField;
+import com.zimbra.cs.event.Event.EventType;
+import com.zimbra.cs.event.EventStore;
+import com.zimbra.cs.event.analytics.ValueMetric.IntIncrement;
+import com.zimbra.cs.event.analytics.contact.ContactAnalytics.ContactFrequencyEventType;
+import com.zimbra.cs.event.analytics.contact.ContactAnalytics.ContactFrequencyTimeRange;
+import com.zimbra.cs.mime.ParsedAddress;
+
+/**
+ * EventMetric that tracks contact frequency for the given contact.
+ * The params specify whether to track incoming/outgoing/both messages, and
+ * the time horizon.
+ */
+public class ContactFrequencyMetric extends EventMetric<ValueMetric, Integer, IntIncrement> {
+
+    private String contactEmail;
+    private ContactFrequencyTimeRange freqTimeRange;
+    private ContactFrequencyEventType freqEventType;
+
+    private static final long LAST_DAY_METRIC_LIFETIME = TimeUnit.MILLISECONDS.convert(12, TimeUnit.HOURS);
+    private static final long LAST_WEEK_METRIC_LIFETIME = TimeUnit.MILLISECONDS.convert(1, TimeUnit.DAYS);
+    private static final long LAST_MONTH_METRIC_LIFETIME = TimeUnit.MILLISECONDS.convert(7, TimeUnit.DAYS);
+
+    public ContactFrequencyMetric(String accountId, ContactFrequencyParams params) throws ServiceException {
+        super(accountId, MetricType.CONTACT_FREQUENCY, params.getInitializer());
+        this.contactEmail = params.getContactEmail();
+        this.freqTimeRange = params.getFreqTimeRange();
+        this.freqEventType = params.getFreqEventType();
+    }
+
+    @Override
+    protected IntIncrement getIncrement(List<Event> events) throws ServiceException {
+        int inc = (int) events.stream().filter(event -> eventAffectsContactFrequency(event)).count();
+        return new IntIncrement(inc);
+    }
+
+    private boolean eventAffectsContactFrequency(Event event) {
+        if (!event.getAccountId().equals(accountId)) {
+            return false; //wrong account
+        }
+        EventType type = event.getEventType();
+        if (type != EventType.SENT && type != EventType.RECEIVED) {
+            return false;
+        }
+        if (type == EventType.SENT && freqEventType == ContactFrequencyEventType.RECEIVED) {
+            return false; //don't care about SENT events if we're only calculating recieved frequency
+        }
+        if (type == EventType.RECEIVED && freqEventType == ContactFrequencyEventType.SENT) {
+            return false; //don't care about RECEIVED events if we're only calculating sent frequency
+        }
+        String eventContact = type == EventType.SENT ? (String) event.getContextField(EventContextField.RECEIVER)
+                : (String) event.getContextField(EventContextField.SENDER);
+        return contactEmail.equalsIgnoreCase(new ParsedAddress(eventContact).emailPart);
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this)
+                .add("acctId", accountId)
+                .add("metricType", type)
+                .add("contact", contactEmail)
+                .add("eventType", freqEventType)
+                .add("timeRange", freqTimeRange)
+                .add("value", metricData.getValue()).toString();
+    }
+
+    private static class Initializer extends EventStoreInitializer<ValueMetric, Integer, IntIncrement> {
+
+        private ContactFrequencyParams params;
+
+        public Initializer(EventStore eventStore, ContactFrequencyParams params) {
+            super(eventStore);
+            this.params = params;
+        }
+
+        @Override
+        public ValueMetric getInitialData() throws ServiceException {
+            String contactEmail = params.getContactEmail();
+            Long freq = getEventStore().getContactFrequencyCount(contactEmail, params.getFreqEventType(), params.getFreqTimeRange());
+            return new ValueMetric(freq.intValue());
+        }
+
+        @Override
+        public long getMetricLifetime() {
+            switch (params.freqTimeRange) {
+            case LAST_DAY:
+                return LAST_DAY_METRIC_LIFETIME;
+            case LAST_WEEK:
+                return LAST_WEEK_METRIC_LIFETIME;
+            case LAST_MONTH:
+                return LAST_MONTH_METRIC_LIFETIME;
+            case FOREVER:
+            default:
+                return 0;
+            }
+        }
+    }
+
+    public static class ContactFrequencyParams extends EventMetric.MetricParams<ValueMetric, Integer, IntIncrement> {
+
+        private String contactEmail;
+        private ContactFrequencyTimeRange freqTimeRange;
+        private ContactFrequencyEventType freqEventType;
+
+
+        public ContactFrequencyParams(String contactEmail,
+                ContactFrequencyTimeRange freqTimeRange,
+                ContactFrequencyEventType freqEventType) {
+            this.contactEmail = contactEmail;
+            this.freqTimeRange = freqTimeRange;
+            this.freqEventType = freqEventType;
+        }
+
+        public String getContactEmail() {
+            return contactEmail;
+        }
+
+        public ContactFrequencyTimeRange getFreqTimeRange() {
+            return freqTimeRange;
+        }
+
+        public ContactFrequencyEventType getFreqEventType() {
+            return freqEventType;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(contactEmail, freqTimeRange, freqEventType);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (other instanceof ContactFrequencyParams) {
+                ContactFrequencyParams otherParams = (ContactFrequencyParams) other;
+                return contactEmail.equals(otherParams.getContactEmail())
+                        && freqEventType == otherParams.getFreqEventType()
+                        && freqTimeRange == otherParams.getFreqTimeRange();
+
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public String toString() {
+            return Objects.toStringHelper(this)
+                    .add("contact", contactEmail)
+                    .add("timeRange", freqTimeRange)
+                    .add("eventType", freqEventType).toString();
+        }
+    }
+
+    public static class Factory implements EventMetric.Factory<ValueMetric, Integer, IntIncrement> {
+
+        public String contactEmail;
+
+        @Override
+        public EventMetric<ValueMetric, Integer, IntIncrement> buildMetric(String accountId, MetricParams<ValueMetric, Integer, IntIncrement> params) throws ServiceException {
+            ContactFrequencyParams cfParams = (ContactFrequencyParams) params;
+            if (cfParams.getInitializer() == null) {
+                EventStore eventStore = EventStore.getFactory().getEventStore(accountId);
+                cfParams.setInitializer(new Initializer(eventStore, cfParams));
+            }
+            return new ContactFrequencyMetric(accountId, cfParams);
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/event/analytics/EventDifferenceMetric.java
+++ b/store/src/java/com/zimbra/cs/event/analytics/EventDifferenceMetric.java
@@ -1,0 +1,104 @@
+package com.zimbra.cs.event.analytics;
+
+import com.google.common.base.Objects;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.event.Event;
+import com.zimbra.cs.event.Event.EventContextField;
+import com.zimbra.cs.event.Event.EventType;
+import com.zimbra.cs.event.analytics.RatioMetric.RatioIncrement;
+import com.zimbra.cs.mime.ParsedAddress;
+
+/**
+ * Abstract EventMetric class used for metrics that are derived from two events
+ */
+public abstract class EventDifferenceMetric extends EventMetric<RatioMetric, Double, RatioIncrement> {
+
+    protected String contactEmail;
+    protected EventType firstEventType;
+    protected EventType secondEventType;
+
+    public EventDifferenceMetric(String accountId, MetricType metricType, EventDifferenceParams params) throws ServiceException {
+        super(accountId, metricType, params.getInitializer());
+        this.contactEmail = params.getContactEmail();
+        this.firstEventType = params.getFirstEventType();
+        this.secondEventType = params.getSecondEventType();
+    }
+
+    protected boolean eventMatchesContactAndType(Event event, EventType type) {
+        if (!event.getAccountId().equals(accountId) || event.getEventType() != type) {
+            return false;
+        }
+        if (contactEmail != null) {
+            String eventContact = (String) event.getContextField(EventContextField.SENDER);
+            return contactEmail.equalsIgnoreCase(new ParsedAddress(eventContact).emailPart);
+        } else {
+            return true;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this)
+                .add("acctId", accountId)
+                .add("metricType", type)
+                .add("firstEvent", firstEventType)
+                .add("secondEvent", secondEventType)
+                .add("contact", contactEmail)
+                .add("value", metricData.getValue()).toString();
+    }
+
+    public static class EventDifferenceParams extends EventMetric.MetricParams<RatioMetric, Double, RatioIncrement> {
+
+        private String contactEmail = null;
+        private EventType firstEventType;
+        private EventType secondEventType;
+
+        public EventDifferenceParams(EventType first, EventType second) {
+            this(first, second, null);
+        }
+
+        public EventDifferenceParams(EventType first, EventType second, String contactEmail) {
+            this.firstEventType = first;
+            this.secondEventType = second;
+            this.contactEmail = contactEmail;
+        }
+
+        public String getContactEmail() {
+            return contactEmail;
+        }
+
+        public EventType getFirstEventType() {
+            return firstEventType;
+        }
+
+        public EventType getSecondEventType() {
+            return secondEventType;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(contactEmail);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (other instanceof EventDifferenceParams) {
+                EventDifferenceParams o = (EventDifferenceParams) other;
+                if (firstEventType != o.firstEventType || secondEventType != o.secondEventType) {
+                    return false;
+                }
+                return contactEmail == null ? o.contactEmail == null : contactEmail.equals(o.getContactEmail());
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public String toString() {
+            return Objects.toStringHelper(this)
+                    .add("contact", contactEmail)
+                    .add("eventType1", firstEventType)
+                    .add("eventType2", secondEventType).toString();
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/event/analytics/EventMetric.java
+++ b/store/src/java/com/zimbra/cs/event/analytics/EventMetric.java
@@ -1,0 +1,135 @@
+package com.zimbra.cs.event.analytics;
+
+import java.util.List;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.event.Event;
+import com.zimbra.cs.event.EventStore;
+import com.zimbra.cs.event.analytics.IncrementableMetric.Increment;
+
+/**
+ * Representation of a metric calculated from event data.
+ * A metric can be be incrementally updated in-memory to avoid having to
+ * query the event store every time.
+ * @author iraykin
+ *
+ * @param <M> the type of the underlying {@link IncrementableMetric}
+ * @param <T> the type returned by getValue()
+ * @param <I> the type of the {@link Increment} used to update the internal state of the metric.
+ */
+public abstract class EventMetric<M extends IncrementableMetric<T, I>, T, I extends Increment> {
+
+    public static enum MetricType {
+        CONTACT_FREQUENCY,
+        EVENT_RATIO,
+        TIME_DELTA,
+    }
+
+    protected String accountId;
+    private MetricInitializer<M, T, I> initializer;
+    protected MetricType type;
+    protected M metricData;
+    protected long timeInitialized;
+    protected long metricLifetime;
+
+    public EventMetric(String accountId, MetricType type, MetricInitializer<M, T, I> initializer) throws ServiceException {
+        this.accountId = accountId;
+        this.type = type;
+        this.initializer = initializer;
+        init();
+    }
+
+    public void init() throws ServiceException {
+        this.metricData = initializer.getInitialData();
+        this.timeInitialized = System.currentTimeMillis();
+    }
+
+    /**
+     * Increment the metric value based on one or more events.
+     * It is up to the implementation to determine which events apply the metric
+     * and filter appropriately
+     */
+    public void increment(List<Event> events) throws ServiceException {
+        I inc = getIncrement(events);
+        ZimbraLog.event.debug("incrementing %s by %s", this, inc);
+        metricData.increment(inc);
+    }
+
+    /**
+     * Return the {@link IncrementableMetric.Increment}  from the list of events
+     */
+    protected abstract I getIncrement(List<Event> events) throws ServiceException;
+
+    /**
+     * Get the value of this metric
+     */
+    public T getValue() {
+        long lifetime = initializer.getMetricLifetime();
+        if (lifetime > 0 && timeInitialized + lifetime < System.currentTimeMillis()) {
+            try {
+                ZimbraLog.event.info("re-initializing metric %s", type.name());
+                init();
+            } catch (ServiceException e) {
+                ZimbraLog.event.error("error re-initializing event metric %s, will continue to use known value", type.name(), e);
+            }
+        }
+        return metricData.getValue();
+    }
+
+
+    /**
+     * Helper interface used to initialize EventMetric
+     */
+    public static abstract class MetricInitializer<M extends IncrementableMetric<T, I>, T, I extends Increment> {
+
+        public abstract M getInitialData() throws ServiceException;
+
+        public abstract long getMetricLifetime();
+    }
+
+    /**
+     * Abstract class used to initialize EventMetric values from an EventStore
+     */
+    public static abstract class EventStoreInitializer<M extends IncrementableMetric<T, I>, T, I extends Increment> extends MetricInitializer<M, T, I> {
+
+        private EventStore eventStore;
+
+        public EventStoreInitializer(EventStore eventStore) {
+            this.eventStore = eventStore;
+        }
+
+        protected EventStore getEventStore() {
+            return eventStore;
+        }
+    }
+
+    /**
+     * Class defining parameters for an EventMetric.
+     * The base class lets the caller specify a custom MetricInitializer
+     * and the maximum length of time
+     * subclasses can provide further arguments
+     */
+    public static abstract class MetricParams<M extends IncrementableMetric<T, I>, T, I extends Increment> {
+        private MetricInitializer<M, T, I> initializer;
+
+        public void setInitializer(MetricInitializer<M, T, I> initializer) {
+            this.initializer = initializer;
+        }
+
+        public MetricInitializer<M, T, I> getInitializer() {
+            return initializer;
+        }
+    }
+
+    /**
+     * Factory interface for building EventMetric instances
+     */
+    public static interface Factory<M extends IncrementableMetric<T, I>, T, I extends Increment> {
+
+        /**
+         * Return an EventMetric instance for the specified account ID with the given parameters
+         */
+        public abstract EventMetric<M, T, I> buildMetric(String accountId, MetricParams<M, T, I> params) throws ServiceException;
+    }
+}

--- a/store/src/java/com/zimbra/cs/event/analytics/EventMetricManager.java
+++ b/store/src/java/com/zimbra/cs/event/analytics/EventMetricManager.java
@@ -1,0 +1,59 @@
+package com.zimbra.cs.event.analytics;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.zimbra.cs.event.analytics.EventMetric.MetricType;
+
+public class EventMetricManager {
+
+    private static Map<EventMetric.MetricType, EventMetric.Factory<?, ?, ?>> factories = new HashMap<>();
+
+    static {
+        registerMetricFactory(MetricType.CONTACT_FREQUENCY, new ContactFrequencyMetric.Factory());
+        registerMetricFactory(MetricType.EVENT_RATIO, new EventRatioMetric.Factory());
+        registerMetricFactory(MetricType.TIME_DELTA, new TimeDeltaMetric.Factory());
+    }
+
+    private Map<String, AccountEventMetrics> accountMap;
+
+    private static EventMetricManager instance = new EventMetricManager();
+
+    public static EventMetricManager getInstance() {
+        return instance;
+    }
+
+    private EventMetricManager() {
+        accountMap = new ConcurrentHashMap<>();
+    }
+
+    public AccountEventMetrics getMetrics(String accountId) {
+        AccountEventMetrics metricSet = accountMap.get(accountId);
+        if (metricSet == null) {
+            metricSet = new AccountEventMetrics(accountId, factories);
+            accountMap.put(accountId, metricSet);
+        }
+        return metricSet;
+    }
+
+    public static void registerMetricFactory(MetricType type, EventMetric.Factory<?, ?, ?> factory) {
+        factories.put(type, factory);
+    }
+
+    /**
+     * Remove all EventMetric instances from the cache.
+     */
+    public void clearMetrics() {
+        accountMap.clear();
+    }
+
+    /**
+     * Remove all EventMetric instances for an account
+     */
+    public void clearAccountMetrics(String accountId) {
+        if (accountMap.containsKey(accountId)) {
+            accountMap.get(accountId).evictMetricCache();
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/event/analytics/EventRatioMetric.java
+++ b/store/src/java/com/zimbra/cs/event/analytics/EventRatioMetric.java
@@ -1,0 +1,62 @@
+package com.zimbra.cs.event.analytics;
+
+import java.util.List;
+
+import com.google.common.base.Strings;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.event.Event;
+import com.zimbra.cs.event.EventStore;
+import com.zimbra.cs.event.analytics.RatioMetric.RatioIncrement;
+
+/**
+ * Event metric that calculates the ratio of the count of two event types, either for a given contact or globally
+ * @author iraykin
+ *
+ */
+public class EventRatioMetric extends EventDifferenceMetric {
+
+    public EventRatioMetric(String accountId, EventDifferenceParams params) throws ServiceException {
+        super(accountId, MetricType.EVENT_RATIO, params);
+    }
+
+    @Override
+    protected RatioIncrement getIncrement(List<Event> events) throws ServiceException {
+        int numeratorInc = (int) events.stream().filter(event -> eventMatchesContactAndType(event, firstEventType)).count();
+        int denominatorInc = (int) events.stream().filter(event -> eventMatchesContactAndType(event, secondEventType)).count();
+        return new RatioIncrement((double) numeratorInc, denominatorInc);
+    }
+
+    public static class EventRatioInitializer extends EventStoreInitializer<RatioMetric, Double, RatioIncrement> {
+
+        private EventDifferenceParams params;
+
+        public EventRatioInitializer(EventStore eventStore, EventDifferenceParams params) {
+            super(eventStore);
+            this.params = params;
+        }
+
+        @Override
+        public RatioMetric getInitialData() throws ServiceException {
+            String contact = params.getContactEmail();
+            if (Strings.isNullOrEmpty(contact)) {
+                return getEventStore().getGlobalEventRatio(params.getFirstEventType(), params.getSecondEventType());
+            } else {
+                return getEventStore().getEventRatio(params.getFirstEventType(), params.getSecondEventType(), contact);
+            }
+        }
+
+        @Override
+        public long getMetricLifetime() {
+            return 0;
+        }
+    }
+
+    public static class Factory implements EventMetric.Factory<RatioMetric, Double, RatioIncrement> {
+
+        @Override
+        public EventMetric<RatioMetric, Double, RatioIncrement> buildMetric(String accountId, MetricParams<RatioMetric, Double, RatioIncrement> params) throws ServiceException {
+            EventDifferenceParams eventDiffParams = (EventDifferenceParams) params;
+            return new EventRatioMetric(accountId, eventDiffParams);
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/event/analytics/IncrementableMetric.java
+++ b/store/src/java/com/zimbra/cs/event/analytics/IncrementableMetric.java
@@ -1,0 +1,20 @@
+package com.zimbra.cs.event.analytics;
+
+
+/**
+ * Representation of intermediate data necessary to compute an {@link EventMetric}
+ */
+public interface IncrementableMetric<T, I extends IncrementableMetric.Increment> {
+
+    /**
+     * return the value of the metric
+     */
+    public T getValue();
+
+    /**
+     * Increments the internal metric state
+     */
+    public void increment(I increment);
+
+    public static interface Increment {}
+}

--- a/store/src/java/com/zimbra/cs/event/analytics/RatioMetric.java
+++ b/store/src/java/com/zimbra/cs/event/analytics/RatioMetric.java
@@ -1,0 +1,67 @@
+package com.zimbra.cs.event.analytics;
+
+import com.zimbra.common.util.Pair;
+import com.zimbra.cs.event.analytics.IncrementableMetric.Increment;
+
+/**
+ * Used for EventMetrics representing ratios.
+ */
+public class RatioMetric extends Pair<Double, Integer> implements IncrementableMetric<Double, RatioMetric.RatioIncrement> {
+
+    public RatioMetric(Double numerator, Integer denominator) {
+        super(numerator, denominator);
+    }
+
+    protected Double getNumerator() {
+        return getFirst();
+    }
+
+    protected Integer getDenominator() {
+        return getSecond();
+    }
+
+    protected void setNumerator(Double numerator) {
+        setFirst(numerator);
+    }
+
+    protected void setDenominator(int denominator) {
+        setSecond(denominator);
+    }
+
+    @Override
+    public void increment(RatioIncrement increment) {
+        setNumerator(getNumerator() + increment.getNumeratorInc());
+        setDenominator(getDenominator() + increment.getDenominatorInc());
+    }
+
+    @Override
+    public Double getValue() {
+        if (getDenominator() == 0) {
+            return 0d; //this should be sufficient; no need to introduce NaN handling for division by zero cases
+        }
+        return getNumerator() / getDenominator();
+    }
+
+    public static class RatioIncrement implements Increment {
+        private Double numeratorInc;
+        private int denominatorInc;
+
+        public RatioIncrement(Double numInc, int denomInc) {
+            this.numeratorInc =numInc;
+            this.denominatorInc = denomInc;
+        }
+
+        private Double getNumeratorInc() {
+            return numeratorInc;
+        }
+
+        private int getDenominatorInc() {
+            return denominatorInc;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("num: %s, den:%s", numeratorInc, denominatorInc);
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/event/analytics/TimeDeltaMetric.java
+++ b/store/src/java/com/zimbra/cs/event/analytics/TimeDeltaMetric.java
@@ -1,0 +1,89 @@
+package com.zimbra.cs.event.analytics;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.base.Strings;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.event.Event;
+import com.zimbra.cs.event.Event.EventContextField;
+import com.zimbra.cs.event.EventStore;
+import com.zimbra.cs.event.analytics.RatioMetric.RatioIncrement;
+
+/**
+ * Metric that calculates the average time delta between two message event types.
+ * @author iraykin
+ *
+ */
+public class TimeDeltaMetric extends EventDifferenceMetric {
+
+    private Map<Integer, Long> timestampMap;
+    public static final int MIN_DELTA_MILLIS = 500;
+
+    public TimeDeltaMetric(String accountId, EventDifferenceParams params) throws ServiceException {
+        super(accountId, MetricType.TIME_DELTA, params);
+        timestampMap = new HashMap<>();
+    }
+
+    @Override
+    protected RatioIncrement getIncrement(List<Event> events) throws ServiceException {
+        double cumulativeDelta = 0d;
+        int numMsgs = 0;
+        for (Event event: events) {
+            if (eventMatchesContactAndType(event, firstEventType)) {
+                timestampMap.put((Integer) event.getContextField(EventContextField.MSG_ID), event.getTimestamp());
+            }
+         }
+        for (Event event: events) {
+            if (eventMatchesContactAndType(event, secondEventType)) {
+                Long firstEventTimestamp = timestampMap.get(event.getContextField(EventContextField.MSG_ID));
+                if (firstEventTimestamp != null) {
+                    long delta = event.getTimestamp() - firstEventTimestamp;
+                    if (delta >= MIN_DELTA_MILLIS) {
+                        cumulativeDelta += delta;
+                        numMsgs++;
+                    }
+                }
+            }
+         }
+        return new RatioIncrement(cumulativeDelta / 1000, numMsgs);
+    }
+
+    public static class TimeDeltaInitializer extends EventStoreInitializer<RatioMetric, Double, RatioIncrement> {
+
+        private EventDifferenceParams params;
+
+        public TimeDeltaInitializer(EventStore eventStore, EventDifferenceParams params) {
+            super(eventStore);
+            this.params = params;
+        }
+
+        @Override
+        public RatioMetric getInitialData() throws ServiceException {
+            String contact = params.getContactEmail();
+            if (Strings.isNullOrEmpty(contact)) {
+                return getEventStore().getGlobalEventTimeDelta(params.getFirstEventType(), params.getSecondEventType());
+            } else {
+                return getEventStore().getEventTimeDelta(params.getFirstEventType(), params.getSecondEventType(), contact);
+            }
+        }
+
+        @Override
+        public long getMetricLifetime() {
+            return 0;
+        }
+    }
+
+
+    public static class Factory implements EventMetric.Factory<RatioMetric, Double, RatioIncrement> {
+
+        public String contactEmail;
+
+        @Override
+        public EventMetric<RatioMetric, Double, RatioIncrement> buildMetric(String accountId, MetricParams<RatioMetric, Double, RatioIncrement> params) throws ServiceException {
+            EventDifferenceParams rrParams = (EventDifferenceParams) params;
+            return new TimeDeltaMetric(accountId, rrParams);
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/event/analytics/ValueMetric.java
+++ b/store/src/java/com/zimbra/cs/event/analytics/ValueMetric.java
@@ -1,0 +1,39 @@
+package com.zimbra.cs.event.analytics;
+
+
+/**
+ * IncrementableMetric to be used when the underlying data is an integer
+ */
+public class ValueMetric implements IncrementableMetric<Integer, ValueMetric.IntIncrement> {
+    private int val;
+
+    public ValueMetric(int val) {
+        this.val = val;
+    }
+    @Override
+    public Integer getValue() {
+        return val;
+    }
+
+    @Override
+    public void increment(IntIncrement increment) {
+        val += increment.getIncrement();
+    }
+
+    public static class IntIncrement implements IncrementableMetric.Increment {
+        private int inc;
+
+        public IntIncrement(int inc) {
+            this.inc = inc;
+        }
+
+        private int getIncrement() {
+            return inc;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(inc);
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/event/analytics/contact/ContactAnalytics.java
+++ b/store/src/java/com/zimbra/cs/event/analytics/contact/ContactAnalytics.java
@@ -10,15 +10,15 @@ import com.zimbra.cs.mailbox.calendar.Util;
 import java.util.List;
 
 public class ContactAnalytics {
-    public enum ContactFrequencyTimeRange {
+    public static enum ContactFrequencyTimeRange {
         LAST_DAY, LAST_WEEK, LAST_MONTH, FOREVER
     }
 
-    public enum ContactFrequencyGraphTimeRange {
+    public static enum ContactFrequencyGraphTimeRange {
         CURRENT_MONTH, LAST_SIX_MONTHS, CURRENT_YEAR
     }
 
-    public enum ContactFrequencyEventType {
+    public static enum ContactFrequencyEventType {
         SENT, RECEIVED, COMBINED
     }
 
@@ -38,27 +38,5 @@ public class ContactAnalytics {
 
     public static List<ContactFrequencyGraphDataPoint> getContactFrequencyGraph(String contact, ContactFrequencyGraphTimeRange timeRange, EventStore eventStore, Integer offsetInMinutes) throws ServiceException {
         return eventStore.getContactFrequencyGraph(contact, timeRange, offsetInMinutes);
-    }
-
-    public static Double getPercentageOpenedEmails(String contact, EventStore eventStore) throws ServiceException {
-        return eventStore.getPercentageOpenedEmails(contact);
-    }
-
-    public static Double getAvgTimeToOpenEmailForAccount(EventStore eventStore) throws ServiceException {
-        return eventStore.getAvgTimeToOpenEmailForAccount();
-    }
-
-    public static Double getAvgTimeToOpenEmail(String contact, EventStore eventStore) throws ServiceException {
-        return eventStore.getAvgTimeToOpenEmail(contact);
-    }
-
-    public static Double getRatioOfAvgTimeToOpenEmailToGlobalAvg(String contact, EventStore eventStore) throws ServiceException {
-        Double avgTimeToOpenEmailForAllContacts = eventStore.getAvgTimeToOpenEmailForAccount();
-        Double avgTimeToOpenEmailFromAContact = eventStore.getAvgTimeToOpenEmail(contact);
-        return avgTimeToOpenEmailFromAContact / avgTimeToOpenEmailForAllContacts;
-    }
-
-    public static Double getPercentageRepliedEmails(String contact, EventStore eventStore) throws ServiceException {
-        return eventStore.getPercentageRepliedEmails(contact);
     }
 }

--- a/store/src/java/com/zimbra/cs/event/logger/EventLogger.java
+++ b/store/src/java/com/zimbra/cs/event/logger/EventLogger.java
@@ -289,6 +289,8 @@ public class EventLogger {
                 String handlerConfig = tokens.length == 2 ? tokens[1] : "";
                 configInfoMap.put(handlerFactoryName, handlerConfig);
             }
+            //EventMetric update logger is added by default
+            configInfoMap.put("metrics", "");
             return configInfoMap.asMap();
         }
 

--- a/store/src/java/com/zimbra/cs/event/logger/EventMetricCallback.java
+++ b/store/src/java/com/zimbra/cs/event/logger/EventMetricCallback.java
@@ -1,0 +1,32 @@
+package com.zimbra.cs.event.logger;
+
+import java.io.IOException;
+import java.util.List;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.event.Event;
+import com.zimbra.cs.event.analytics.AccountEventMetrics;
+import com.zimbra.cs.event.analytics.EventMetricManager;
+
+/**
+ * Callback for a BatchingEventLogger used to update in-memory EventMetric instances
+ */
+public class EventMetricCallback implements BatchingEventLogger.BatchedEventCallback {
+
+    @Override
+    public void close() throws IOException {
+        //nothing to do here
+    }
+
+    @Override
+    public void execute(String accountId, List<Event> events) {
+        AccountEventMetrics metrics = EventMetricManager.getInstance().getMetrics(accountId);
+        try {
+            metrics.incrementAll(events);
+        } catch (ServiceException e) {
+            ZimbraLog.event.error("error incrementing EventMetrics for account %s", accountId);
+        }
+    }
+
+}

--- a/store/src/java/com/zimbra/cs/event/logger/EventMetricUpdateFactory.java
+++ b/store/src/java/com/zimbra/cs/event/logger/EventMetricUpdateFactory.java
@@ -1,0 +1,13 @@
+package com.zimbra.cs.event.logger;
+
+import com.zimbra.cs.event.logger.BatchingEventLogger.BatchedEventCallback;
+import com.zimbra.cs.event.logger.BatchingEventLogger.BatchingHandlerFactory;
+
+public class EventMetricUpdateFactory extends BatchingHandlerFactory {
+
+    @Override
+    protected BatchedEventCallback createCallback(String config) {
+        return new EventMetricCallback();
+    }
+
+}

--- a/store/src/java/com/zimbra/cs/util/Zimbra.java
+++ b/store/src/java/com/zimbra/cs/util/Zimbra.java
@@ -53,6 +53,7 @@ import com.zimbra.cs.event.EventStore;
 import com.zimbra.cs.event.SolrCloudEventStore;
 import com.zimbra.cs.event.StandaloneSolrEventStore;
 import com.zimbra.cs.event.logger.EventLogger;
+import com.zimbra.cs.event.logger.EventMetricUpdateFactory;
 import com.zimbra.cs.event.logger.FileEventLogHandler;
 import com.zimbra.cs.event.logger.SolrCloudEventHandlerFactory;
 import com.zimbra.cs.event.logger.SolrEventHandlerFactory;
@@ -315,6 +316,7 @@ public final class Zimbra {
         EventLogger.registerHandlerFactory("file", new FileEventLogHandler.Factory());
         EventLogger.registerHandlerFactory("solr", new StandaloneSolrEventHandlerFactory());
         EventLogger.registerHandlerFactory("solrcloud", new SolrCloudEventHandlerFactory());
+        EventLogger.registerHandlerFactory("metrics", new EventMetricUpdateFactory());
         EventLogger.getEventLogger().startupEventNotifierExecutor();
 
         System.setProperty("ical4j.unfolding.relaxed", "true");

--- a/store/src/java/com/zimbra/qa/unittest/TestSolrCloudEventStore.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestSolrCloudEventStore.java
@@ -204,12 +204,6 @@ public class TestSolrCloudEventStore extends SolrEventStoreTestBase {
     }
 
     @Test
-    public void testRatioOfAvgTimeToOpenEmailToGlobalAvg() throws Exception {
-        ExecuteTest getAvgTimeToOpenEmail = (ec, cn, es) -> testGetRatioOfAvgTimeToOpenEmailToGlobalAvg(ec, cn, es);
-        testForBothCores(getAvgTimeToOpenEmail);
-    }
-
-    @Test
     public void testPercentageRepliedEmails() throws Exception {
         ExecuteTest getPercentageRepliedEmails = (ec, cn, es) -> testPercentageRepliedEmails(ec, cn, es);
         testForBothCores(getPercentageRepliedEmails);


### PR DESCRIPTION
Adding machine learning to ZCS requires the ability to generate features to be used as inputs to classifiers. One important category of features are those calculated from event data to drive "important email" classification, such as sender contact frequency, read rate, or reply rate. Since these features potentially need to be generated for each incoming message, the mailbox server needs to be able to efficiently calculate this data without issuing a Solr query every time, which may be prohibitively expensive.

To enable event-driven ML features described above, This PR introduces the concept of  an `EventMetric`, which is an in-memory representation of some calculation derived from event data, which can be incrementally updated by the event stream. 

This code relies heavily on generics. This is done in order to provide as much flexibility as possible in handling different metric types, and to allow future development of other calculated metrics.

#### Incremental Metrics
A low-level `IncrementableMetric` interface represents a wrapper for some internal state that can expose some value. It can be queried for this value, and updated with an `Increment`, which updates the internal state accordingly. Since metric calculations differ in what they return and how they are updated, `IncrementMetric` is parameterized by both `T`, the return type, and `I`, the `Increment` type.

Two `IncrementableMetric` implementations are used in this PR:
* `ValueMetric` tracks a value represented by an `Integer`, with `IntIncrement` used to simply add the increment to the current value
* `RatioMetric` is used when the underlying calculation is a fraction. The return type is a `Double`; the update process adds the current numerator and denominator to the ones passed in by the provided `RatioIncrement`.

#### EventMetric
An `EventMetric` is the primary focus of this PR. It contains an underlying state stored in an `IncrementableMetric` field, and has the ability to increment this state with an `Increment` derived from a list of events.
`EventMetric` is parameterized by three types:
* `M` is the type of the underlying `IncrementableMetric`
* `T` is the return type of the `getValue()` method
* `I` is the type of `Increment` the underlying metric is incremented by

Three subclasses of `EventMetric` are implemented:
* `ContactFrequencyMetric` that tracks the number of sent/received/total interactions with the a contact over one of several time horizons 
* `EventRatioMetric` that calculates the ratio between two message event types (seen, read, replied), either globally or for a given contact
* `TimeDeltaMetric` that calculates the average time delta between two message event types, either globally or for a given contact.

##### EventMetric Initialization
The initial `IncrementableMetric` value underlying an `EventMetric` is fetched using a `MetricInitializer` class.  In production, an `EventStoreInitializer` is used, which executes the appropriate `EventStore` calls to get the initial data. For unit tests, a dummy initializer is provided. 
This initializer has three methods:
* `getInitialData()`returns an `IncrementableMetric` of type `M`
* `getTimestamp()` returns the millisecond timestamp of when the initialization happened
* `getMetricLifetime()` returns a lifetime, in milliseconds, of how long the initialized value is valid for (see "EventMetric Expiration" below)

#### EventMetric Parameters
An `EventMetric` has parameters passed to it. For example, `ContactFrequencyMetric` requires a `ContactFrequencyTimeRange` and `ContactFrequencyEventType` parameters. Likewise, both `EventRatioMetric` and `TimeDeltaMetric` are defined by two `EventType` values ( numerator/denominator and from/to, respectively). Additionally, All of the concrete `EventMetric` subclasses take a String "contact" parameter. This is required by `ContactFrequencyMetric`, but optional for the other two; this allows us to calculate a ratio or time delta metric for the sender of a message relative to the global account value.

#### EventMetric Expiration
A metric like "contact frequency" may have a timeframe associated with it (for example, "sent frequency for the last 24 hours"). For time-based metrics, we don't want to increment them indefinitely, as we will exceed the "window" the metric represents. In fact, we cannot have a truly accurate time-based metric without keeping a record of the timestamps of each data point that contributes to the total - and while this is theoretically possible (we could implement an `IncrementableMetric` that does this), it seems unnecessary.

Instead, `MetricInitializer` defines an optional millisecond lifetime value for the data it returns. If the lifetime is positive, then when sufficient time passes, the `EventMetric.getValue()` method will re-fetch a fresh value from the initializer instead of using the internal `IncrementableMetric` value, "resetting" it to the ground truth.

Specifically, the lifetimes are currently configured as follows:
* "last day" contact frequency has a lifetime of 12 hours
* "last week" contact frequency has a lifetime of 1 day
* "last month" contact frequency has a lifetime of 7 days

It should be noted that this may result in these time-bounded metrics going "outside the bounds" of their time window somewhat. However, given what these metrics are used for, this should not pose any real problems.

#### Updating EventMetrics
EventMetrics are updated using the `increment` method, which takes a list of `Event` objects. It is up to the implementation to filter this event list accordingly construct an `Increment` of parameterized type `I`, which is then used to update the internal `IncrementableMetric`. 
For example, `EventRatioMetric` calculates how many events in the provided list match the numerator and denominator conditions, and create a `RatioIncrement` that updates the `RatioMetric` value.

#### EventMetric management
The `EventMetricManager` is a singleton class used to manage event metrics. It contains a registry of Factory classes used to instantiate `EventMetric` instances; these are mapped from `MetricType` enums.
The `EventMetricManager::getMetrics` method takes an account ID and returns a cached `AccountEventMetrics` instance. This, in turn, provides access to all the currently loaded metrics for a given account. A metric can then be retrieved by a `MetricKey`, which is parameterized on the same three type parameters as `EventMetric`. This is done so that the key contains all the information necessary to instantiate the requested metric instance with the appropriate Factory if it does not exist in the cache.
The `AccountEventMetrics::incrementAll` method is used to increment all metrics currently loaded for the account with the given event list.

#### Updating Log Handler
A special `EventLogHandler` instance is used to update event metrics currently loaded into memory. This log handler is created by default alongside the other user-configured ones. It uses the existing `BatchingEventLogger`, with a `BatchedEventCallback` that calls `AccountEventMetrics::incrementAll` appropriately. Note that this means that an EventMetric may not always represent the most up-to-date view of the data, as event batching introduces a lag. As with the metric lifetime issue described above, this should be OK.

#### Changes to EventStore interface
A slight change has been made to the `EventStore` interface to allow for calculating arbitrary ratios and time deltas. Previously, the interface had methods for specific calculations such as `getPercentageRepliedEmails` and `getAvgTimeToOpenEmail`. These have been replaced with more general methods `getEventRatio` and `getEventTimeDeta`. `SolrEventStore` doesn't change in any meaningful way, as it already had private methods that supported these calculations; these methods have simply been made public. Additionally, the return type of these methods has been changed from `Double` to `RatioMetric` so that they can be used by EventMetric initializers.

#### Testing
`EventMetricTest` is a unit test class containing test methods for each implementation of `IncrementableMetric` as well as every `EventMetric` type.

#### UPDATE 1/10
Removed `MetricInitializer.getTimestamp() method, small fixes to unit tests

#### UPDATE 1/11
Rebased on top of new `feature/solr` branch head