### PR TITLE
ZCS-2518 initialize LicenseExtension in ImapDaemon

### DIFF
--- a/store/src/java/com/zimbra/cs/imap/ImapDaemon.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapDaemon.java
@@ -22,6 +22,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Properties;
 
+import com.zimbra.cs.extension.ExtensionUtil;
 import org.apache.log4j.PropertyConfigurator;
 
 import com.zimbra.common.calendar.WellKnownTimeZones;
@@ -118,6 +119,11 @@ public class ImapDaemon {
                     ZimbraLog.imap.error("Unable to load timezones from %s.", tzFilePath, t);
                     errorExit("ImapDaemon: imapd service was unable to intialize timezones EXITING.");
                 }
+
+                // Note: This loads the LicenseExtension if present on the system in the case of NETWORK edition
+                //       and for the FOSS edition simply prints a WARN level log statement as follows:
+                //       2018-01-10 11:49:56,792 WARN  [main] [] extensions - unable to locate extension class com.zimbra.cs.network.license.LicenseExtension, not found
+                ExtensionUtil.init("com.zimbra.cs.network.license.LicenseExtension");
 
                 ImapDaemon daemon = new ImapDaemon();
                 int numStarted = daemon.startServers();


### PR DESCRIPTION
Currently this emits a 'WARNING' level message if the extension is not found but continues loading in the case of FOSS and causes the appropriate 'ALERT' to be sent to an IMAP client connecting to the IMAPD when the license is bad / expired.

The rules for the alert appearance are the same as the internal imap server since it is using the same code and mechanism.

IMAPD

    telnet localhost 8143
    Trying ::1...
    Connected to localhost.
    Escape character is '^]'.
    * OK zcs-dev-testbed.dev Zimbra IMAP4rev1 server ready
    * OK [ALERT] Your mail server's license is missing, invalid or expired.

Mailbox / IMAP

    telnet localhost 7143
    Trying ::1...
    Connected to localhost.
    Escape character is '^]'.
    * OK zcs-dev-testbed.dev Zimbra IMAP4rev1 server ready
    * OK [ALERT] Your mail server's license is missing, invalid or expired.

