### PR TITLE
ZIMBRA-132: Feature Generation for Machine Learning

### DIFF
--- a/common/src/java/com/zimbra/common/util/ZimbraLog.java
+++ b/common/src/java/com/zimbra/common/util/ZimbraLog.java
@@ -478,6 +478,11 @@ public final class ZimbraLog {
     public static final Log eventlog = LogFactory.getLog("zimbra.eventlog");
 
     /**
+     * the "zimbra.ml" logger. For machine learning-related events
+     */
+    public static final Log ml = LogFactory.getLog("zimbra.ml");
+
+    /**
      * Maps the log category name to its description.
      */
     public static final Map<String, String> CATEGORY_DESCRIPTIONS;
@@ -568,6 +573,7 @@ public final class ZimbraLog {
         descriptions.put(contactbackup.getCategory(), "Contact Backup and restore");
         descriptions.put(event.getCategory(), "Event log operations");
         descriptions.put(eventlog.getCategory(), "Serialized events");
+        descriptions.put(ml.getCategory(), "Machine learning operations");
         CATEGORY_DESCRIPTIONS = Collections.unmodifiableMap(descriptions);
     }
 

--- a/store/src/java-test/com/zimbra/cs/ml/feature/FeatureFactoryTest.java
+++ b/store/src/java-test/com/zimbra/cs/ml/feature/FeatureFactoryTest.java
@@ -1,0 +1,357 @@
+package com.zimbra.cs.ml.feature;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import javax.mail.internet.MimeMessage;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.zimbra.cs.account.MockProvisioning;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.event.Event;
+import com.zimbra.cs.event.Event.EventType;
+import com.zimbra.cs.event.analytics.EventMetric.MetricInitializer;
+import com.zimbra.cs.event.analytics.EventMetricManager;
+import com.zimbra.cs.event.analytics.RatioMetric;
+import com.zimbra.cs.event.analytics.RatioMetric.RatioIncrement;
+import com.zimbra.cs.event.analytics.ValueMetric;
+import com.zimbra.cs.event.analytics.ValueMetric.IntIncrement;
+import com.zimbra.cs.event.analytics.contact.ContactAnalytics.ContactFrequencyEventType;
+import com.zimbra.cs.event.analytics.contact.ContactAnalytics.ContactFrequencyTimeRange;
+import com.zimbra.cs.event.logger.BatchingEventLogger;
+import com.zimbra.cs.event.logger.EventMetricCallback;
+import com.zimbra.cs.mailbox.DeliveryOptions;
+import com.zimbra.cs.mailbox.Flag;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.mailbox.Message;
+import com.zimbra.cs.mime.Mime;
+import com.zimbra.cs.mime.ParsedMessage;
+import com.zimbra.cs.ml.Classifiable;
+import com.zimbra.cs.ml.feature.FeatureParam.ParamKey;
+import com.zimbra.cs.ml.feature.FeatureSpec.KnownFeature;
+import com.zimbra.cs.ml.feature.NumRecipientsFeatureFactory.RecipientCountType;
+import com.zimbra.cs.util.JMSession;
+import com.zimbra.qa.unittest.TestUtil;
+
+public class FeatureFactoryTest {
+
+    private final String USER = "testFeatureFactories@zimbra.com";
+    private Mailbox mbox;
+    private BatchingEventLogger logger;
+    private static final String contactEmail = "test@zimbra.com";
+
+    @Before
+    public void setUp() throws Exception {
+
+        MailboxTestUtil.initServer();
+        Provisioning prov = Provisioning.getInstance();
+        prov.createAccount(USER, "test123", new HashMap<String, Object>());
+        mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        logger = new BatchingEventLogger(10, 0, new EventMetricCallback());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        MailboxTestUtil.clearData();
+        EventMetricManager.getInstance().clearMetrics();
+    }
+
+    private void logReadTimeDelta(List<Event> eventList, String acctId, int msgId, long delta) {
+        long readTime = System.currentTimeMillis();
+        long seenTime = readTime - delta;
+        eventList.add(Event.generateEvent(acctId, msgId, contactEmail, USER, EventType.SEEN, null, null, seenTime));
+        eventList.add(Event.generateEvent(acctId, msgId, contactEmail, USER, EventType.READ, null, null, readTime));
+    }
+
+    private void logMsgEvents(String acctId) {
+        List<Event> events = new ArrayList<Event>();
+        //log 10 received events, 5 sent events, 8 seen events, 4 read events, 2 replied events
+        for (int i=0; i<10; i++) {
+            events.add(Event.generateEvent(acctId, i, contactEmail, USER, EventType.RECEIVED, null, null, System.currentTimeMillis()));
+            if (i < 2) {
+                logReadTimeDelta(events, acctId, 1, 1000L);
+                events.add(Event.generateEvent(acctId, i, contactEmail, USER, EventType.REPLIED, null, null, System.currentTimeMillis()));
+            } else if (i < 4){
+                logReadTimeDelta(events, acctId, 0, 2000L);
+            } else if (i < 8) {
+                events.add(Event.generateEvent(acctId, i, contactEmail, USER, EventType.SEEN, null, null, System.currentTimeMillis()));
+            }
+        }
+
+        for (int i=0; i<5; i++) {
+            events.add(Event.generateSentEvent(acctId, i+20, USER, contactEmail, null, null, System.currentTimeMillis()));
+        }
+
+        for (Event event: events) {
+            logger.log(event);
+        }
+        logger.sendAllBatched();
+    }
+
+    @Test
+    public void testConversationFeature() throws Exception {
+        Message msg1 = TestUtil.addMessage(mbox, "a message");
+        ConversationFeatureFactory factory = new ConversationFeatureFactory();
+        Feature<Boolean> feature = factory.buildFeature(msg1);
+        assertFalse("message 1 should not be part of conversation", feature.getFeatureValue());
+        Message msg2 = TestUtil.addMessage(mbox, "a message");
+        assertFalse("message 1 should be part of conversation", factory.buildFeature(msg1).getFeatureValue());
+        assertFalse("message 2 should be part of conversation", factory.buildFeature(msg2).getFeatureValue());
+    }
+
+    @Test
+    public void testContactFrequencyFeature() throws Exception {
+
+        ContactFrequencyFeatureFactory receivedFactory = new ContactFrequencyFeatureFactory(ContactFrequencyTimeRange.FOREVER, ContactFrequencyEventType.RECEIVED);
+        ContactFrequencyFeatureFactory sentFactory = new ContactFrequencyFeatureFactory(ContactFrequencyTimeRange.FOREVER, ContactFrequencyEventType.SENT);
+        ContactFrequencyFeatureFactory combinedFactory = new ContactFrequencyFeatureFactory(ContactFrequencyTimeRange.FOREVER, ContactFrequencyEventType.COMBINED);
+
+        //initialize to 0, bypassing event store
+        MetricInitializer<ValueMetric, Integer, IntIncrement> initializer = new DummyValueInitializer();
+        receivedFactory.setInitializer(initializer);
+        sentFactory.setInitializer(initializer);
+        combinedFactory.setInitializer(initializer);
+
+        Message msg = TestUtil.addMessage(mbox, USER, contactEmail, "test msg", "msg body", System.currentTimeMillis());
+
+        Feature<Integer> receivedFeature = receivedFactory.buildFeature(msg);
+        Feature<Integer> sentFeature = sentFactory.buildFeature(msg);
+        Feature<Integer> combinedFeature = combinedFactory.buildFeature(msg);
+        assertEquals("initial recieved value should be 0", (Integer)0, receivedFeature.getFeatureValue());
+        assertEquals("initial sent value should be 0", (Integer)0, sentFeature.getFeatureValue());
+        assertEquals("initial combined value should be 0", (Integer)0, combinedFeature.getFeatureValue());
+
+        logMsgEvents(msg.getAccountId());
+
+        assertEquals("new received value should be 10", (Integer)10, receivedFactory.buildFeature(msg).getFeatureValue());
+        assertEquals("new sent value should be 5", (Integer)5, sentFactory.buildFeature(msg).getFeatureValue());
+        assertEquals("new combined value should be 15", (Integer)15, combinedFactory.buildFeature(msg).getFeatureValue());
+    }
+
+    @Test
+    public void testReadRatioFeature() throws Exception {
+
+        EventRatioFeatureFactory factory = new EventRatioFeatureFactory(EventType.READ, EventType.SEEN);
+        factory.setInitializer(new DummyRatioInitializer());
+
+        Message msg = TestUtil.addMessage(mbox, USER, contactEmail, "test msg", "msg body", System.currentTimeMillis());
+
+        Feature<Double> feature = factory.buildFeature(msg);
+        assertEquals("initial value should be 0", new Double(0), feature.getFeatureValue());
+
+        logMsgEvents(msg.getAccountId());
+
+        assertEquals("new value should be .5", new Double(0.5), factory.buildFeature(msg).getFeatureValue());
+    }
+
+    @Test
+    public void testTimeToOpenFeature() throws Exception {
+        EventTimeDeltaFeatureFactory factory = new EventTimeDeltaFeatureFactory(EventType.SEEN, EventType.READ);
+        factory.setInitializer(new DummyRatioInitializer());
+
+        Message msg = TestUtil.addMessage(mbox, USER, contactEmail, "test msg", "msg body", System.currentTimeMillis());
+
+        Feature<Double> feature = factory.buildFeature(msg);
+        assertEquals("initial value should be 0", new Double(0), feature.getFeatureValue());
+
+        logMsgEvents(msg.getAccountId());
+
+        assertEquals("new value should be 1500", new Double(1.5), factory.buildFeature(msg).getFeatureValue());
+    }
+
+    @Test
+    public void testReplyRateFeature() throws Exception {
+        EventRatioFeatureFactory factory = new EventRatioFeatureFactory(EventType.REPLIED, EventType.SEEN);
+        factory.setInitializer(new DummyRatioInitializer());
+
+        Message msg = TestUtil.addMessage(mbox, USER, contactEmail, "test msg", "msg body", System.currentTimeMillis());
+
+        Feature<Double> feature = factory.buildFeature(msg);
+        assertEquals("initial value should be 0", new Double(0), feature.getFeatureValue());
+
+        logMsgEvents(msg.getAccountId());
+
+        assertEquals("new value should be 2/3", new Double(0.25), factory.buildFeature(msg).getFeatureValue());
+    }
+
+    private Message generateIncomingMessage(String fieldUserIsOn) throws Exception {
+        MimeMessage mm = new Mime.FixedMimeMessage(JMSession.getSession());
+        mm.setHeader("From", "test@zimbra.com");
+        if (fieldUserIsOn != null) {
+            mm.setHeader(fieldUserIsOn, mbox.getAccount().getName());
+        }
+        mm.setHeader("Subject", "test message");
+        ParsedMessage pm = new ParsedMessage(mm, false);
+        DeliveryOptions dopt = new DeliveryOptions().setFolderId(Mailbox.ID_FOLDER_INBOX).setFlags(Flag.BITMASK_UNREAD);
+        return mbox.addMessage(null, pm, dopt, null);
+    }
+
+    @Test
+    public void testRecipientFieldFeature() throws Exception {
+        RecipientFieldFeatureFactory factory = new RecipientFieldFeatureFactory();
+        Message msg1 = generateIncomingMessage("To");
+        Message msg2 = generateIncomingMessage("Cc");
+        Message msg3 = generateIncomingMessage("Bcc");
+        Message msg4 = generateIncomingMessage(null);
+        assertEquals(new Integer(0), factory.buildFeature(msg1).getFeatureValue());
+        assertEquals(new Integer(1), factory.buildFeature(msg2).getFeatureValue());
+        assertEquals(new Integer(2), factory.buildFeature(msg3).getFeatureValue());
+        assertEquals(new Integer(3), factory.buildFeature(msg4).getFeatureValue());
+    }
+
+    @Test
+    public void testNumRecipientFieldFeature() throws Exception {
+        MimeMessage mm = new Mime.FixedMimeMessage(JMSession.getSession());
+        mm.setHeader("From", "test@zimbra.com");
+        mm.addHeader("To", "recip1@zimbra.com");
+        mm.addHeader("To", "recip2@zimbra.com");
+        mm.addHeader("Cc", "recip3@zimbra.com");
+        mm.addHeader("Cc", "recip4@zimbra.com");
+        mm.addHeader("Cc", "recip5@zimbra.com");
+        mm.setHeader("Subject", "test message");
+        ParsedMessage pm = new ParsedMessage(mm, false);
+        DeliveryOptions dopt = new DeliveryOptions().setFolderId(Mailbox.ID_FOLDER_INBOX).setFlags(Flag.BITMASK_UNREAD);
+        Message msg = mbox.addMessage(null, pm, dopt, null);
+        assertEquals("TO recipient count should be 2", (Integer) 2, new NumRecipientsFeatureFactory(RecipientCountType.TO).buildFeature(msg).getFeatureValue());
+        assertEquals("CC recipient count should be 3", (Integer) 3, new NumRecipientsFeatureFactory(RecipientCountType.CC).buildFeature(msg).getFeatureValue());
+        assertEquals("total recipient count should be 5", (Integer) 5, new NumRecipientsFeatureFactory(RecipientCountType.ALL).buildFeature(msg).getFeatureValue());
+    }
+
+    private void encodeDecodeFeatureSpec(FeatureSpec<Classifiable> spec) throws Exception {
+        int numParams = spec.getParams().getNumParams();
+        String encoded = spec.encode();
+        FeatureSpec<Message> decoded = new FeatureSpec<>(encoded);
+        assertEquals("wrong KnownFeature on decoded FeatureSpec", spec.getFeature(), decoded.getFeature());
+        assertEquals("wrong number of params on decoded FeatureSpec", numParams, decoded.getParams().getNumParams());
+        for (FeatureParam<?> param: spec.getParams().getParams()) {
+            assertEquals("wrong FeatureParam value", param.getValue(), decoded.getParams().get(param.getKey(), null));
+        }
+    }
+
+    @Test
+    public void testEncodeFeatureSpecs() throws Exception {
+        encodeDecodeFeatureSpec(new FeatureSpec<>(KnownFeature.NUM_RECIPIENTS));
+        encodeDecodeFeatureSpec(new FeatureSpec<>(KnownFeature.IS_PART_OF_CONVERSATION));
+
+        encodeDecodeFeatureSpec(new FeatureSpec<>(KnownFeature.COMBINED_FREQUENCY)
+                .addParam(new FeatureParam<>(ParamKey.TIME_RANGE, ContactFrequencyTimeRange.LAST_DAY)));
+
+        encodeDecodeFeatureSpec(new FeatureSpec<>(KnownFeature.RECEIVED_FREQUENCY)
+                .addParam(new FeatureParam<>(ParamKey.TIME_RANGE, ContactFrequencyTimeRange.LAST_WEEK)));
+
+        encodeDecodeFeatureSpec(new FeatureSpec<>(KnownFeature.SENT_FREQUENCY)
+                .addParam(new FeatureParam<>(ParamKey.TIME_RANGE, ContactFrequencyTimeRange.LAST_MONTH)));
+
+        encodeDecodeFeatureSpec(new FeatureSpec<>(KnownFeature.EVENT_RATIO)
+                .addParam(new FeatureParam<>(ParamKey.NUMERATOR, EventType.READ))
+                .addParam(new FeatureParam<>(ParamKey.DENOMINATOR, EventType.SEEN)));
+
+        encodeDecodeFeatureSpec(new FeatureSpec<>(KnownFeature.TIME_DELTA)
+                .addParam(new FeatureParam<>(ParamKey.FROM_EVENT, EventType.READ))
+                .addParam(new FeatureParam<>(ParamKey.TO_EVENT, EventType.REPLIED)));
+    }
+
+    @Test
+    public void testFeatureSet() throws Exception {
+        Message msg = TestUtil.addMessage(mbox, USER, contactEmail, "one two three four five", "hello darkness my old friend", System.currentTimeMillis());
+        FeatureSet<Message> fs = new FeatureSet<>();
+
+        FeatureParam<ContactFrequencyTimeRange> allTimeFreqParam = new FeatureParam<ContactFrequencyTimeRange>(ParamKey.TIME_RANGE, ContactFrequencyTimeRange.FOREVER);
+        MetricInitializer<ValueMetric, Integer, IntIncrement> dummyValueInitializer = new DummyValueInitializer();
+        MetricInitializer<RatioMetric, Double, RatioIncrement> dummyRatioInitializer = new DummyRatioInitializer();
+
+        //set dummy metric initializers on the MetricFeature factories so we avoid going to the EventStore for data
+        FeatureParam<MetricInitializer<ValueMetric, Integer, IntIncrement>> valueInitParam = new FeatureParam<>(ParamKey.METRIC_INITIALIZER, dummyValueInitializer);
+        FeatureParam<MetricInitializer<RatioMetric, Double, RatioIncrement>> ratioInitParam = new FeatureParam<>(ParamKey.METRIC_INITIALIZER, dummyRatioInitializer);
+
+        //message is part of conversation
+        fs.addFeatureSpec(new FeatureSpec<Message>(KnownFeature.IS_PART_OF_CONVERSATION));
+
+        //# received messages from sender
+        fs.addFeatureSpec(new FeatureSpec<Message>(KnownFeature.RECEIVED_FREQUENCY)
+                .addParam(allTimeFreqParam)
+                .addParam(valueInitParam));
+
+        //# sent messages from sender
+        fs.addFeatureSpec(new FeatureSpec<Message>(KnownFeature.SENT_FREQUENCY)
+                .addParam(allTimeFreqParam)
+                .addParam(valueInitParam));
+
+        //read ratio
+        fs.addFeatureSpec(new FeatureSpec<Message>(KnownFeature.EVENT_RATIO)
+                .addParam(ratioInitParam)
+                .addParam(new FeatureParam<>(ParamKey.NUMERATOR, EventType.READ))
+                .addParam(new FeatureParam<>(ParamKey.DENOMINATOR, EventType.SEEN)));
+
+        //reply rate
+        fs.addFeatureSpec(new FeatureSpec<Message>(KnownFeature.EVENT_RATIO)
+                .addParam(ratioInitParam)
+                .addParam(new FeatureParam<>(ParamKey.NUMERATOR, EventType.REPLIED))
+                .addParam(new FeatureParam<>(ParamKey.DENOMINATOR, EventType.SEEN)));
+
+        //avg time to open
+        fs.addFeatureSpec(new FeatureSpec<Message>(KnownFeature.TIME_DELTA)
+                .addParam(ratioInitParam)
+                .addParam(new FeatureParam<>(ParamKey.FROM_EVENT, EventType.SEEN))
+                .addParam(new FeatureParam<>(ParamKey.TO_EVENT, EventType.READ)));
+
+        assertEquals("wrong number of FeatureSpecs", 6, fs.getAllFeatureSpecs().size());
+        assertEquals("wrong number of FeatureFactories generated by FeatureSet", 6, fs.buildFactories().size());
+
+        List<Feature<?>> features = fs.getFeatures(msg).getFeatures();
+
+        assertFalse("wrong conv feature", (Boolean) features.get(0).getFeatureValue());
+        assertEquals("wrong recipient frequency value", 0, features.get(1).getFeatureValue());
+        assertEquals("wrong sent frequency value", 0, features.get(2).getFeatureValue());
+        assertEquals("wrong read ratio value", new Double(0), features.get(3).getFeatureValue());
+        assertEquals("wrong reply rate value", new Double(0), features.get(4).getFeatureValue());
+        assertEquals("wrong time to open value", new Double(0), features.get(5).getFeatureValue());
+
+        //update metric features
+        logMsgEvents(msg.getAccountId());
+
+        features = fs.getFeatures(msg).getFeatures();
+        //sanity check on values that shouldn't have changed
+        assertFalse("wrong conv feature", (Boolean) features.get(0).getFeatureValue());
+        //updated event metrics!
+        assertEquals("wrong updated recipient frequency value", 10, features.get(1).getFeatureValue());
+        assertEquals("wrong updated sent frequency value", 5, features.get(2).getFeatureValue());
+        assertEquals("wrong updated read ratio value", new Double(0.5), features.get(3).getFeatureValue());
+        assertEquals("wrong updated reply rate value", new Double(0.25), features.get(4).getFeatureValue());
+        assertEquals("wrong updated time to open value", new Double(1.5), features.get(5).getFeatureValue());
+    }
+
+    private static class DummyValueInitializer extends MetricInitializer<ValueMetric, Integer, IntIncrement> {
+        @Override
+        public ValueMetric getInitialData() {
+            return new ValueMetric(0);
+        }
+
+        @Override
+        public long getMetricLifetime() {
+            return 0;
+        }
+    };
+
+    private static class DummyRatioInitializer extends MetricInitializer<RatioMetric, Double, RatioIncrement> {
+
+        @Override
+        public RatioMetric getInitialData() {
+            return new RatioMetric(0d, 0);
+        }
+
+        @Override
+        public long getMetricLifetime() {
+            return 0;
+        }
+    };
+}

--- a/store/src/java/com/zimbra/cs/event/Event.java
+++ b/store/src/java/com/zimbra/cs/event/Event.java
@@ -65,6 +65,15 @@ public class Event {
         public UniqueOn getUniqueOn() {
             return uniqueOn;
         }
+
+        public static EventType of(String str) throws ServiceException {
+            for (EventType type: EventType.values()) {
+                if (type.name().equalsIgnoreCase(str)) {
+                    return type;
+                }
+            }
+            throw ServiceException.INVALID_REQUEST("invalid event type: " + str, null);
+        }
     }
 
     public enum EventContextField {

--- a/store/src/java/com/zimbra/cs/mailbox/Message.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Message.java
@@ -79,6 +79,7 @@ import com.zimbra.cs.mime.ParsedMessage;
 import com.zimbra.cs.mime.ParsedMessageOptions;
 import com.zimbra.cs.mime.TnefConverter;
 import com.zimbra.cs.mime.UUEncodeConverter;
+import com.zimbra.cs.ml.Classifiable;
 import com.zimbra.cs.redolog.RedoLogProvider;
 import com.zimbra.cs.redolog.op.CreateCalendarItemPlayer;
 import com.zimbra.cs.redolog.op.RedoableOp;
@@ -92,7 +93,7 @@ import com.zimbra.cs.util.AccountUtil.AccountAddressMatcher;
 /**
  * @since Jun 13, 2004
  */
-public class Message extends MailItem {
+public class Message extends MailItem implements Classifiable {
 
     static class DraftInfo {
         String accountId;

--- a/store/src/java/com/zimbra/cs/ml/Classifiable.java
+++ b/store/src/java/com/zimbra/cs/ml/Classifiable.java
@@ -1,0 +1,6 @@
+package com.zimbra.cs.ml;
+
+/**
+ * Classes implementing this interface can be classified by the machine learning system
+ */
+public interface Classifiable {}

--- a/store/src/java/com/zimbra/cs/ml/feature/ComputedFeatures.java
+++ b/store/src/java/com/zimbra/cs/ml/feature/ComputedFeatures.java
@@ -1,0 +1,32 @@
+package com.zimbra.cs.ml.feature;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.zimbra.cs.ml.Classifiable;
+
+/**
+ * Class representing features computed for a given classifiable item
+ */
+public class ComputedFeatures<T extends Classifiable> {
+
+    private T item;
+    private List<Feature<?>> features;
+
+    public ComputedFeatures(T item) {
+        this.item = item;
+        this.features = new ArrayList<>();
+    }
+
+    public void add(Feature<?> feature) {
+        features.add(feature);
+    }
+
+    public List<Feature<?>> getFeatures() {
+        return features;
+    }
+
+    public T getItem() {
+        return item;
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/feature/ContactFrequencyFeatureFactory.java
+++ b/store/src/java/com/zimbra/cs/ml/feature/ContactFrequencyFeatureFactory.java
@@ -1,0 +1,65 @@
+package com.zimbra.cs.ml.feature;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.event.analytics.ContactFrequencyMetric.ContactFrequencyParams;
+import com.zimbra.cs.event.analytics.EventMetric.MetricType;
+import com.zimbra.cs.event.analytics.ValueMetric;
+import com.zimbra.cs.event.analytics.ValueMetric.IntIncrement;
+import com.zimbra.cs.event.analytics.contact.ContactAnalytics.ContactFrequencyEventType;
+import com.zimbra.cs.event.analytics.contact.ContactAnalytics.ContactFrequencyTimeRange;
+import com.zimbra.cs.mailbox.Message;
+import com.zimbra.cs.ml.feature.FeatureParam.ParamKey;
+import com.zimbra.cs.ml.feature.FeatureSpec.KnownFeature;
+
+/**
+ * Factory that constructs an integer MetricFeature representing the contact frequency
+ * for the message sender for the specified time range and type.
+ */
+public class ContactFrequencyFeatureFactory extends MetricFeature.Factory<ValueMetric, Integer, IntIncrement> {
+
+    private ContactFrequencyTimeRange timeRange;
+    private ContactFrequencyEventType eventType;
+
+    public ContactFrequencyFeatureFactory() {}
+
+    public ContactFrequencyFeatureFactory(ContactFrequencyTimeRange timeRange, ContactFrequencyEventType eventType) throws ServiceException {
+        setParams(new FeatureParams()
+        .addParam(new FeatureParam<>(ParamKey.TIME_RANGE, timeRange))
+        .addParam(new FeatureParam<>(ParamKey.FREQUENCY_TYPE, eventType)));
+    }
+
+    private KnownFeature getFeatureType() {
+        switch (eventType) {
+        case RECEIVED:
+            return KnownFeature.RECEIVED_FREQUENCY;
+        case SENT:
+            return KnownFeature.SENT_FREQUENCY;
+        case COMBINED:
+        default:
+            return KnownFeature.COMBINED_FREQUENCY;
+        }
+    }
+
+    @Override
+    public Feature<Integer> buildFeature(Message msg) {
+        ContactFrequencyParams params = new ContactFrequencyParams(msg.getSender(), timeRange, eventType);
+        params.setInitializer(initializer);
+        return new MetricFeature<>(getFeatureType(), msg.getAccountId(), MetricType.CONTACT_FREQUENCY, params);
+    }
+
+    @Override
+    public void setMetricParams(FeatureParams params) throws ServiceException {
+        ContactFrequencyTimeRange timeRange = params.get(ParamKey.TIME_RANGE, (ContactFrequencyTimeRange) null);
+        ContactFrequencyEventType eventType = params.get(ParamKey.FREQUENCY_TYPE, (ContactFrequencyEventType) null);
+        if (timeRange == null ){
+            missingParam(ParamKey.TIME_RANGE);
+        } else {
+            this.timeRange = timeRange;
+        }
+        if (eventType == null) {
+            missingParam(ParamKey.FREQUENCY_TYPE);
+        } else {
+            this.eventType = eventType;
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/feature/ConversationFeatureFactory.java
+++ b/store/src/java/com/zimbra/cs/ml/feature/ConversationFeatureFactory.java
@@ -1,0 +1,22 @@
+package com.zimbra.cs.ml.feature;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.mailbox.Message;
+import com.zimbra.cs.ml.feature.FeatureSpec.KnownFeature;
+
+/**
+ * Feature factory that builds a boolean feature that is TRUE if the message
+ * is part of existing conversation thread
+ */
+public class ConversationFeatureFactory extends FeatureFactory<Message, Boolean> {
+
+    @Override
+    public Feature<Boolean> buildFeature(Message msg) {
+        return new PrimitiveFeature<>(KnownFeature.IS_PART_OF_CONVERSATION, msg.getConversationId() > 0);
+    }
+
+    @Override
+    public void setParams(FeatureParams params) throws ServiceException {
+        //nothing to do here
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/feature/EventRatioFeatureFactory.java
+++ b/store/src/java/com/zimbra/cs/ml/feature/EventRatioFeatureFactory.java
@@ -1,0 +1,48 @@
+package com.zimbra.cs.ml.feature;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.event.Event;
+import com.zimbra.cs.event.Event.EventType;
+import com.zimbra.cs.event.analytics.EventDifferenceMetric.EventDifferenceParams;
+import com.zimbra.cs.event.analytics.EventMetric.MetricType;
+import com.zimbra.cs.event.analytics.RatioMetric;
+import com.zimbra.cs.event.analytics.RatioMetric.RatioIncrement;
+import com.zimbra.cs.mailbox.Message;
+import com.zimbra.cs.ml.feature.FeatureParam.ParamKey;
+import com.zimbra.cs.ml.feature.FeatureSpec.KnownFeature;
+
+/**
+ * Factory that constructs a float MetricFeature for the ratio of read emails for the message sender
+ */
+public class EventRatioFeatureFactory extends MetricFeature.Factory<RatioMetric, Double, RatioIncrement> {
+
+    private EventType numerator;
+    private EventType denominator;
+
+    public EventRatioFeatureFactory(EventType numerator, EventType denominator) throws ServiceException {
+        setParams(new FeatureParams()
+        .addParam(new FeatureParam<>(ParamKey.NUMERATOR, numerator))
+        .addParam(new FeatureParam<>(ParamKey.DENOMINATOR, denominator)));
+    }
+
+    public EventRatioFeatureFactory() {}
+
+    @Override
+    public Feature<Double> buildFeature(Message msg) {
+        EventDifferenceParams params = new EventDifferenceParams(numerator, denominator, msg.getSender());
+        params.setInitializer(initializer);
+        return new MetricFeature<>(KnownFeature.EVENT_RATIO, msg.getAccountId(), MetricType.EVENT_RATIO, params);
+    }
+
+    @Override
+    public void setMetricParams(FeatureParams params) throws ServiceException {
+        numerator = params.get(ParamKey.NUMERATOR, null);
+        denominator = params.get(ParamKey.DENOMINATOR, null);
+        if (numerator == null || denominator == null) {
+            throw ServiceException.FAILURE("EventRatioFeatureFactory must have NUMERATOR and DENOMINATOR params", null);
+        }
+        if (numerator.getUniqueOn() != Event.UniqueOn.MESSAGE || denominator.getUniqueOn() != Event.UniqueOn.MESSAGE) {
+            throw ServiceException.FAILURE("EventRatioFeatureFactory event types must have MESSAGE uniqueness scope", null);
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/feature/EventTimeDeltaFeatureFactory.java
+++ b/store/src/java/com/zimbra/cs/ml/feature/EventTimeDeltaFeatureFactory.java
@@ -1,0 +1,60 @@
+package com.zimbra.cs.ml.feature;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.event.Event;
+import com.zimbra.cs.event.Event.EventType;
+import com.zimbra.cs.event.analytics.EventDifferenceMetric.EventDifferenceParams;
+import com.zimbra.cs.event.analytics.EventMetric.MetricType;
+import com.zimbra.cs.event.analytics.RatioMetric;
+import com.zimbra.cs.event.analytics.RatioMetric.RatioIncrement;
+import com.zimbra.cs.mailbox.Message;
+import com.zimbra.cs.ml.feature.FeatureParam.ParamKey;
+import com.zimbra.cs.ml.feature.FeatureSpec.KnownFeature;
+
+public class EventTimeDeltaFeatureFactory  extends MetricFeature.Factory<RatioMetric, Double, RatioIncrement> {
+
+    private boolean globalRatio;
+    private EventType fromEvent;
+    private EventType toEvent;
+
+    public EventTimeDeltaFeatureFactory() {}
+
+    public EventTimeDeltaFeatureFactory(EventType fromEvent, EventType toEvent) throws ServiceException {
+        this(fromEvent, toEvent, false);
+    }
+
+    public EventTimeDeltaFeatureFactory(EventType fromEvent, EventType toEvent, boolean globalRatio) throws ServiceException {
+        setParams(new FeatureParams()
+        .addParam(new FeatureParam<>(ParamKey.FROM_EVENT, fromEvent))
+        .addParam(new FeatureParam<>(ParamKey.TO_EVENT, toEvent))
+        .addParam(new FeatureParam<>(ParamKey.GLOBAL_RATIO, globalRatio)));
+    }
+
+    @Override
+    public Feature<Double> buildFeature(Message msg) {
+        EventDifferenceParams params = new EventDifferenceParams(fromEvent, toEvent, msg.getSender());
+        params.setInitializer(initializer);
+        Feature<Double> contactTimeToOpen = new MetricFeature<>(KnownFeature.TIME_DELTA, msg.getAccountId(), MetricType.TIME_DELTA, params);
+        if (globalRatio) {
+            EventDifferenceParams globalParams = new EventDifferenceParams(fromEvent, toEvent);
+            params.setInitializer(initializer);
+            Feature<Double> globalTimeToOpen = new MetricFeature<>(KnownFeature.TIME_DELTA, msg.getAccountId(), MetricType.TIME_DELTA, globalParams);
+            return new RatioFeature(contactTimeToOpen, globalTimeToOpen);
+        } else {
+            return contactTimeToOpen;
+        }
+    }
+
+    @Override
+    public void setMetricParams(FeatureParams params) throws ServiceException {
+        globalRatio = params.get(ParamKey.GLOBAL_RATIO, false);
+        fromEvent = params.get(ParamKey.FROM_EVENT, null);
+        toEvent = params.get(ParamKey.TO_EVENT, null);
+        if (fromEvent == null || toEvent == null) {
+            throw ServiceException.FAILURE("EventTimeDeltaFeatureFactory must have FROM_EVENT and TO_EVENT params", null);
+        }
+        if (fromEvent.getUniqueOn() != Event.UniqueOn.MESSAGE || toEvent.getUniqueOn() != Event.UniqueOn.MESSAGE) {
+            throw ServiceException.FAILURE("EventTimeDeltaFeatureFactory event types must have MESSAGE uniqueness scope", null);
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/feature/Feature.java
+++ b/store/src/java/com/zimbra/cs/ml/feature/Feature.java
@@ -1,0 +1,31 @@
+package com.zimbra.cs.ml.feature;
+
+import com.google.common.base.Objects;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.ml.feature.FeatureSpec.KnownFeature;
+
+
+/**
+ * A feature used as input into a classifer
+ */
+public abstract class Feature<T> {
+
+    private KnownFeature featureType;
+
+    public Feature(KnownFeature featureType) {
+        this.featureType = featureType;
+    }
+
+    public KnownFeature getFeatureType() {
+        return featureType;
+    }
+
+    public abstract T getFeatureValue() throws ServiceException;
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this)
+                .add("type", featureType)
+                .add("class", this.getClass().getSimpleName()).toString();
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/feature/FeatureFactory.java
+++ b/store/src/java/com/zimbra/cs/ml/feature/FeatureFactory.java
@@ -1,0 +1,21 @@
+package com.zimbra.cs.ml.feature;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.ml.Classifiable;
+import com.zimbra.cs.ml.feature.FeatureParam.ParamKey;
+
+/**
+ * Abstract class used for generating {@link Feature} instances for a given message
+ *
+ * @param <T> The type of Feature this factory returns
+ */
+public abstract class FeatureFactory<C extends Classifiable, T> {
+
+    public abstract void setParams(FeatureParams params) throws ServiceException;
+
+    public abstract Feature<T> buildFeature(C item) throws ServiceException;
+
+    protected void missingParam(ParamKey missingKey) throws ServiceException {
+        throw ServiceException.INVALID_REQUEST("FeatureFactory " + this.getClass().getSimpleName() + " is missing required param " + missingKey.name(), null);
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/feature/FeatureParam.java
+++ b/store/src/java/com/zimbra/cs/ml/feature/FeatureParam.java
@@ -1,0 +1,56 @@
+package com.zimbra.cs.ml.feature;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.Pair;
+
+public class FeatureParam<T> extends Pair<FeatureParam.ParamKey, T> {
+
+    public FeatureParam(ParamKey key, T value) {
+        super(key, value);
+    }
+
+    public ParamKey getKey() {
+        return getFirst();
+    }
+
+    public T getValue() {
+        return getSecond();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s:%s", getKey(), getValue());
+    }
+
+
+    public static enum ParamKey {
+        FREQUENCY_TYPE("tp"),
+        TIME_RANGE("tr"),
+        METRIC_INITIALIZER("i"),
+        RECIPIENT_TYPE("rt"),
+        GLOBAL_RATIO("g"),
+        NUMERATOR("n"),
+        DENOMINATOR("d"),
+        FROM_EVENT("fr"),
+        TO_EVENT("to");
+
+        private String abbrev;
+
+        private ParamKey(String abbrev) {
+            this.abbrev = abbrev;
+        }
+
+        public String getAbbrev() {
+            return abbrev;
+        }
+
+        public static ParamKey of(String name) throws ServiceException {
+            for (ParamKey key: ParamKey.values()) {
+                if (key.name().equalsIgnoreCase(name) || key.abbrev.equalsIgnoreCase(name)) {
+                    return key;
+                }
+            }
+            throw ServiceException.INVALID_REQUEST(name + " is not a valid ParamKey", null);
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/feature/FeatureParams.java
+++ b/store/src/java/com/zimbra/cs/ml/feature/FeatureParams.java
@@ -1,0 +1,61 @@
+package com.zimbra.cs.ml.feature;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.commons.collections.CollectionUtils;
+
+import com.google.common.base.Joiner;
+import com.zimbra.cs.ml.feature.FeatureParam.ParamKey;
+
+public class FeatureParams {
+
+    private Map<ParamKey, Object> paramMap = new HashMap<>();
+    private List<FeatureParam<?>> paramList = new ArrayList<>();
+
+    public FeatureParams addParam(FeatureParam<?> param) {
+        paramMap.put(param.getKey(), param.getValue());
+        paramList.add(param);
+        return this;
+    }
+
+    public <T> T get(ParamKey key, T defaultVal) {
+        return paramMap.containsKey(key) ? (T) paramMap.get(key) : defaultVal;
+    }
+
+    public FeatureParams merge(FeatureParams other) {
+        paramMap.putAll(other.paramMap);
+        return this;
+    }
+
+    public List<FeatureParam<?>> getParams() {
+        return paramList;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other instanceof FeatureParams) {
+            FeatureParams otherParams = (FeatureParams) other;
+            return CollectionUtils.isEqualCollection(paramList, otherParams.paramList);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(paramList.toArray(new FeatureParam[paramList.size()]));
+    }
+
+    public int getNumParams() {
+        return paramList.size();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("{%s}", Joiner.on(", ").join(paramList));
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/feature/FeatureSet.java
+++ b/store/src/java/com/zimbra/cs/ml/feature/FeatureSet.java
@@ -1,0 +1,89 @@
+package com.zimbra.cs.ml.feature;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Objects;
+import com.google.common.collect.ArrayListMultimap;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.ml.Classifiable;
+import com.zimbra.cs.ml.feature.FeatureSpec.KnownFeature;
+
+/**
+ * Class representing features to be used for classification.
+ */
+public class FeatureSet<T extends Classifiable> {
+
+    private List<FeatureSpec<T>> featureList;
+    private ArrayListMultimap<KnownFeature, FeatureSpec<T>> featureMap;
+
+    public FeatureSet() {
+        featureMap = ArrayListMultimap.create();
+        featureList = new ArrayList<>();
+    }
+
+    /**
+     * Add a feature specification to this feature set.
+     * Features will be generated in the same order that their FeatureSpecs
+     * were added using this method.
+     */
+    public void addFeatureSpec(FeatureSpec<T> spec) throws ServiceException {
+        featureMap.put(spec.getFeature(), spec);
+        featureList.add(spec);
+    }
+
+    private void addFeature(ComputedFeatures<T> features, T item, FeatureFactory<T, ?> factory) {
+        try {
+            Feature<?> feature = factory.buildFeature(item);
+            features.add(feature);
+            Object value = feature.getFeatureValue();
+            ZimbraLog.ml.debug("generated feature %s with value %s", feature, value);
+        } catch (ServiceException e) {
+            ZimbraLog.ml.error("Unable to generate feature from factory %s", factory.getClass().getSimpleName(), e);
+        }
+    }
+
+    @VisibleForTesting
+    List<FeatureFactory<T, ?>> buildFactories() throws ServiceException {
+        List<FeatureFactory<T, ?>> factories = new ArrayList<FeatureFactory<T, ?>>();
+        for (FeatureSpec<T> spec: featureList) {
+            factories.add(spec.buildFactory());
+        }
+        return factories;
+    }
+
+    public ComputedFeatures<T> getFeatures(T item) throws ServiceException {
+        ComputedFeatures<T> msgFeatures = new ComputedFeatures<T>(item);
+        for (FeatureFactory<T, ?> factory: buildFactories()) {
+            addFeature(msgFeatures, item, factory);
+        }
+        return msgFeatures;
+    }
+
+    /**
+     * Return a list of all FeatureSpecs in this FeatureSet
+     */
+    public List<FeatureSpec<T>> getAllFeatureSpecs() {
+        return featureList;
+    }
+
+    /**
+     * Return a list of all FeatureSpecs in this FeatureSet
+     * that match the given {@link KnownFeature} type
+     */
+    public List<FeatureSpec<T>> getFeatureSpecs(KnownFeature feature) {
+        return featureMap.get(feature);
+    }
+
+    public int getNumFeatures() {
+        return featureList.size();
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this)
+                .add("features", featureList).toString();
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/feature/FeatureSpec.java
+++ b/store/src/java/com/zimbra/cs/ml/feature/FeatureSpec.java
@@ -1,0 +1,197 @@
+package com.zimbra.cs.ml.feature;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.common.base.Objects;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.BEncoding;
+import com.zimbra.common.util.BEncoding.BEncodingException;
+import com.zimbra.cs.event.Event.EventType;
+import com.zimbra.cs.event.analytics.contact.ContactAnalytics.ContactFrequencyEventType;
+import com.zimbra.cs.event.analytics.contact.ContactAnalytics.ContactFrequencyTimeRange;
+import com.zimbra.cs.mailbox.Message;
+import com.zimbra.cs.ml.Classifiable;
+import com.zimbra.cs.ml.feature.FeatureParam.ParamKey;
+import com.zimbra.cs.ml.feature.NumRecipientsFeatureFactory.RecipientCountType;
+
+/**
+ * Provides the ability to concisely define a feature.
+ * FeatureSpecs can be encoded/decoded as strings for easy persistence.
+ */
+public class FeatureSpec<T extends Classifiable> {
+
+    private static final String KEY_FEATURE = "f";
+
+    /**
+     * Enum of known feature factories.
+     * Only features registered here can be initialized with the FeatureSpec mechanism.
+     */
+    public static enum KnownFeature {
+        IS_PART_OF_CONVERSATION("conv", ConversationFeatureFactory.class),
+        RECIPIENT_FIELD("r", RecipientFieldFeatureFactory.class),
+        NUM_RECIPIENTS("nr", RecipientFieldFeatureFactory.class),
+        SENT_FREQUENCY("sf", ContactFrequencyFeatureFactory.class, new FeatureParam<ContactFrequencyEventType>(ParamKey.FREQUENCY_TYPE, ContactFrequencyEventType.SENT)),
+        RECEIVED_FREQUENCY("rf", ContactFrequencyFeatureFactory.class, new FeatureParam<ContactFrequencyEventType>(ParamKey.FREQUENCY_TYPE, ContactFrequencyEventType.RECEIVED)),
+        COMBINED_FREQUENCY("cf", ContactFrequencyFeatureFactory.class, new FeatureParam<ContactFrequencyEventType>(ParamKey.FREQUENCY_TYPE, ContactFrequencyEventType.COMBINED)),
+        TIME_DELTA("td", EventTimeDeltaFeatureFactory.class),
+        EVENT_RATIO("er", EventRatioFeatureFactory.class);
+
+        private String abbrev;
+        private Class<? extends FeatureFactory<?, ?>> featureFactoryClass;
+        private FeatureParams featureParams;
+
+        private KnownFeature(String abbrev, Class<? extends FeatureFactory<Message, ?>> klass, FeatureParam<?>... initParams) {
+            this.abbrev = abbrev;
+            this.featureFactoryClass = klass;
+            this.featureParams = new FeatureParams();
+            for (FeatureParam<?> param: initParams) {
+                featureParams.addParam(param);
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        public <T extends Classifiable> Class<? extends FeatureFactory<T, ?>> getFeatureFactoryClass() {
+            return (Class<? extends FeatureFactory<T, ?>>) featureFactoryClass;
+        }
+
+        public FeatureParams getParams() {
+            return featureParams;
+        }
+
+        public String getAbbrev() {
+            return abbrev;
+        }
+
+        public static KnownFeature of(String name) throws ServiceException {
+            for (KnownFeature type: values()) {
+                if (type.name().equalsIgnoreCase(name) || type.abbrev.equalsIgnoreCase(name)) {
+                    return type;
+                }
+            }
+            throw ServiceException.INVALID_REQUEST(name + " is not a known feature type", null);
+        }
+    }
+    private KnownFeature feature;
+    private FeatureParams otherParams = new FeatureParams();
+
+    public FeatureSpec(KnownFeature feature) {
+        this.feature = feature;
+    }
+
+    public FeatureSpec<T> addParam(FeatureParam<? >param) {
+        otherParams.addParam(param);
+        return this;
+    }
+
+    public KnownFeature getFeature() {
+        return feature;
+    }
+
+    public FeatureParams getParams() {
+        return otherParams;
+    }
+
+    /**
+     * Return a FeatureFactory instance based on this spec.
+     */
+    public FeatureFactory<T, ?> buildFactory() throws ServiceException {
+        KnownFeature featureType = getFeature();
+        Class<? extends FeatureFactory<T, ?>> factoryClass = featureType.getFeatureFactoryClass();
+        FeatureFactory<T, ?> factory;
+        try {
+            factory = factoryClass.newInstance();
+        } catch (InstantiationException | IllegalAccessException e) {
+            throw ServiceException.FAILURE("unable to initialize class " + factoryClass.getName(), e);
+        }
+        FeatureParams params = feature.getParams();
+        params.merge(otherParams);
+        factory.setParams(params);
+        return factory;
+    }
+
+    public String encode() {
+        Map<Object, Object> map = new HashMap<>();
+        map.put(KEY_FEATURE, feature.getAbbrev());
+        for (FeatureParam<?> param: otherParams.getParams()) {
+            map.put(param.getKey().getAbbrev(), param.getValue());
+        }
+        return BEncoding.encode(map);
+    }
+
+    public FeatureSpec(String encoded) throws ServiceException {
+        decode(encoded);
+    }
+
+    private void decode(String encoded) throws ServiceException {
+        Map<String, Object> map;
+        try {
+             map = BEncoding.decode(encoded);
+        } catch (BEncodingException e) {
+            throw ServiceException.FAILURE(encoded + " is not a valid FeatureSet encoding", e);
+        }
+
+        for (Map.Entry<String, Object> entry: map.entrySet()) {
+            String key = entry.getKey();
+            Object val = entry.getValue();
+            if (key.equals(KEY_FEATURE)) {
+                feature = KnownFeature.of((String) val);
+            } else {
+                try {
+                    FeatureParam<?> param;
+                    ParamKey paramKey = ParamKey.of(key);
+                    switch (paramKey) {
+                    case FREQUENCY_TYPE:
+                        param = new FeatureParam<ContactFrequencyEventType>(paramKey, ContactFrequencyEventType.valueOf((String) val));
+                        break;
+                    case TIME_RANGE:
+                        param = new FeatureParam<ContactFrequencyTimeRange>(paramKey, ContactFrequencyTimeRange.valueOf((String) val));
+                        break;
+                    case RECIPIENT_TYPE:
+                        param = new FeatureParam<RecipientCountType>(paramKey, RecipientCountType.of((String) val));
+                        break;
+                    case FROM_EVENT:
+                    case TO_EVENT:
+                    case NUMERATOR:
+                    case DENOMINATOR:
+                        param = new FeatureParam<EventType>(paramKey, EventType.of((String) val));
+                        break;
+                    default:
+                        param = new FeatureParam<String>(paramKey, (String) val);
+                        break;
+                    }
+                    addParam(param);
+                } catch (IllegalArgumentException e) {
+                    throw ServiceException.FAILURE((String) val + " is not a valid value for ParamKey " + key, null);
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other instanceof FeatureSpec) {
+            FeatureSpec<?> otherSpec = (FeatureSpec<?>) other;
+            if (getFeature() != otherSpec.getFeature()) {
+                return false;
+            } else if (getParams().equals(otherSpec.getParams())) {
+                return false;
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(feature.name(), otherParams);
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this)
+                .add("feature", feature)
+                .add("params", otherParams).toString();
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/feature/MetricFeature.java
+++ b/store/src/java/com/zimbra/cs/ml/feature/MetricFeature.java
@@ -1,0 +1,67 @@
+package com.zimbra.cs.ml.feature;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.event.analytics.AccountEventMetrics;
+import com.zimbra.cs.event.analytics.AccountEventMetrics.MetricKey;
+import com.zimbra.cs.event.analytics.EventMetric.MetricInitializer;
+import com.zimbra.cs.event.analytics.EventMetric.MetricParams;
+import com.zimbra.cs.event.analytics.EventMetric.MetricType;
+import com.zimbra.cs.event.analytics.EventMetricManager;
+import com.zimbra.cs.event.analytics.IncrementableMetric;
+import com.zimbra.cs.event.analytics.IncrementableMetric.Increment;
+import com.zimbra.cs.mailbox.Message;
+import com.zimbra.cs.ml.feature.FeatureParam.ParamKey;
+import com.zimbra.cs.ml.feature.FeatureSpec.KnownFeature;
+
+/**
+ * Classifier feature based off an {@link EventMetric}
+ */
+public class MetricFeature<T extends IncrementableMetric<S, I>, S, I extends Increment> extends Feature<S> {
+
+    private String accountId;
+    private MetricType metricType;
+    private MetricParams<T, S, I> metricParams;
+
+    public MetricFeature(KnownFeature featureType, String accountId, MetricType metricType, MetricParams<T, S, I> metricParams) {
+        super(featureType);
+        this.accountId = accountId;
+        this.metricType = metricType;
+        this.metricParams = metricParams;
+    }
+
+    @Override
+    public S getFeatureValue() throws ServiceException {
+        AccountEventMetrics metrics = EventMetricManager.getInstance().getMetrics(accountId);
+        MetricKey<T, S, I> key = new MetricKey<T, S, I>(metricType, metricParams);
+        return metrics.getMetric(key).getValue();
+    }
+
+    /**
+     * Subclasses of this abstract factory return MetricFeature instances
+     */
+    public static abstract class Factory<M extends IncrementableMetric<S, I>, S, I extends Increment> extends FeatureFactory<Message, S> {
+
+        protected MetricInitializer<M, S, I> initializer = null;
+
+        @Override
+        public void setParams(FeatureParams params) throws ServiceException {
+            //check if a custom initializer is set
+            MetricInitializer<M, S, I> initializer = params.get(ParamKey.METRIC_INITIALIZER, (MetricInitializer<M, S, I>) null);
+            if (initializer != null) {
+                setInitializer(initializer);
+            }
+            setMetricParams(params);
+        }
+
+        protected abstract void setMetricParams(FeatureParams params) throws ServiceException;
+
+        /**
+         * Override the default EventMetric initializer with a custom one
+         */
+        @VisibleForTesting
+        public void setInitializer(MetricInitializer<M, S, I> initializer) {
+            this.initializer = initializer;
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/feature/NumRecipientsFeatureFactory.java
+++ b/store/src/java/com/zimbra/cs/ml/feature/NumRecipientsFeatureFactory.java
@@ -1,0 +1,78 @@
+package com.zimbra.cs.ml.feature;
+
+import javax.mail.Address;
+import javax.mail.Message.RecipientType;
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.mailbox.Message;
+import com.zimbra.cs.ml.feature.FeatureParam.ParamKey;
+import com.zimbra.cs.ml.feature.FeatureSpec.KnownFeature;
+
+/**
+ * Feature factory that builds a feature representing how many recipients there are on the given field
+ */
+public class NumRecipientsFeatureFactory extends FeatureFactory<Message, Integer> {
+
+    private RecipientCountType countType;
+
+    public NumRecipientsFeatureFactory() {}
+
+    public NumRecipientsFeatureFactory(RecipientCountType countType) throws ServiceException {
+        setParams(new FeatureParams().addParam(new FeatureParam<>(ParamKey.RECIPIENT_TYPE, countType)));
+    }
+
+    @Override
+    public void setParams(FeatureParams params) throws ServiceException {
+        countType = params.get(ParamKey.RECIPIENT_TYPE, RecipientCountType.ALL);
+    }
+
+    private int getNumRecipientsForType(MimeMessage mm, RecipientType type, int msgId) throws ServiceException {
+        Address[] recipients;
+        try {
+            recipients = mm.getRecipients(type);
+        } catch (MessagingException e) {
+            throw ServiceException.FAILURE(String.format("unable to get recipients of type %s for message %d", type, msgId), e);
+        }
+        return recipients == null ? 0 : recipients.length;
+    }
+
+    @Override
+    public Feature<Integer> buildFeature(Message msg) throws ServiceException {
+        MimeMessage mm = msg.getMimeMessage();
+        int msgId = msg.getId();
+        int numRecipients;
+        switch (countType) {
+        case TO:
+            numRecipients = getNumRecipientsForType(mm, RecipientType.TO, msgId);
+            break;
+        case CC:
+            numRecipients = getNumRecipientsForType(mm, RecipientType.CC, msgId);
+            break;
+        case ALL:
+        default:
+            Address[] allRecipients;
+            try {
+                allRecipients = mm.getAllRecipients();
+                numRecipients = allRecipients == null ? 0 : allRecipients.length;
+            } catch (MessagingException e) {
+                throw ServiceException.FAILURE(String.format("unable to get all recipients of type %s for message %d", msgId), e);
+            }
+        }
+        return new PrimitiveFeature<Integer>(KnownFeature.NUM_RECIPIENTS, numRecipients);
+    }
+
+    public static enum RecipientCountType {
+        TO, CC, ALL;
+
+        public static RecipientCountType of(String str) throws ServiceException {
+            for (RecipientCountType type: RecipientCountType.values()) {
+                if (str.equalsIgnoreCase(type.name())) {
+                    return type;
+                }
+            }
+            throw ServiceException.INVALID_REQUEST(str + " is not a valid RecpientCountType", null);
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/feature/PrimitiveFeature.java
+++ b/store/src/java/com/zimbra/cs/ml/feature/PrimitiveFeature.java
@@ -1,0 +1,22 @@
+package com.zimbra.cs.ml.feature;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.ml.feature.FeatureSpec.KnownFeature;
+
+/**
+ * A feature for which the value is passed in through the constructor
+ */
+public class PrimitiveFeature<S> extends Feature<S> {
+
+    private S value;
+
+    public PrimitiveFeature(KnownFeature featureType, S value) {
+        super(featureType);
+        this.value = value;
+    }
+
+    @Override
+    public S getFeatureValue() throws ServiceException {
+        return value;
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/feature/RatioFeature.java
+++ b/store/src/java/com/zimbra/cs/ml/feature/RatioFeature.java
@@ -1,0 +1,22 @@
+package com.zimbra.cs.ml.feature;
+
+import com.zimbra.common.service.ServiceException;
+
+public class RatioFeature extends Feature<Double> {
+
+    private Feature<Double> numerator;
+    private Feature<Double> denominator;
+
+    public RatioFeature(Feature<Double> numeratorFeature, Feature<Double> denominatorFeature) {
+        super(numeratorFeature.getFeatureType());
+        numerator = numeratorFeature;
+        denominator = denominatorFeature;
+    }
+
+    @Override
+    public Double getFeatureValue() throws ServiceException {
+        return numerator.getFeatureValue() / denominator.getFeatureValue();
+    }
+
+
+}

--- a/store/src/java/com/zimbra/cs/ml/feature/RecipientFieldFeatureFactory.java
+++ b/store/src/java/com/zimbra/cs/ml/feature/RecipientFieldFeatureFactory.java
@@ -1,0 +1,68 @@
+package com.zimbra.cs.ml.feature;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.mail.Address;
+import javax.mail.Message.RecipientType;
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.mailbox.Message;
+import com.zimbra.cs.mime.ParsedAddress;
+import com.zimbra.cs.ml.feature.FeatureSpec.KnownFeature;
+
+
+/**
+ * Feature factory that builds a feature based off whether the recipient
+ * is on the to/cc field.
+ */
+public class RecipientFieldFeatureFactory extends FeatureFactory<Message, Integer> {
+
+    private String extractEmail(Address addr) {
+        return new ParsedAddress(addr.toString()).emailPart;
+    }
+
+    private boolean isUserOnField(int msgId, MimeMessage mm, String userEmail, RecipientType type) {
+        try {
+            Address[] recipients = mm.getRecipients(type);
+            if (recipients != null) {
+                List<String> addrs = Arrays.asList(recipients).stream().map(addr -> extractEmail(addr)).collect(Collectors.toList());
+                return addrs.contains(userEmail);
+            } else {
+                return false;
+            }
+        } catch (MessagingException e) {
+            ZimbraLog.ml.error("unable to get recipients of type %s for message %d", type, msgId);
+            return false;
+        }
+    }
+
+    @Override
+    public Feature<Integer> buildFeature(Message msg) throws ServiceException {
+        int msgId = msg.getId();
+        Account acct = msg.getAccount();
+        String email = acct.getName();
+        MimeMessage mm = msg.getMimeMessage();
+        int flag;
+        if (isUserOnField(msgId, mm, email, RecipientType.TO)) {
+            flag = 0;
+        } else if (isUserOnField(msgId, mm, email, RecipientType.CC)) {
+            flag = 1;
+        } else if (isUserOnField(msgId, mm, email, RecipientType.BCC)) {
+            flag = 2;
+        } else {
+            flag = 3; //user is on distribution list?
+        }
+        return new PrimitiveFeature<Integer>(KnownFeature.RECIPIENT_FIELD, flag);
+    }
+
+    @Override
+    public void setParams(FeatureParams params) throws ServiceException {
+        //no params necessary for this feature
+    }
+}


### PR DESCRIPTION
This PR builds on the event metric work from #ZIMBRA-129 to introduce classifier feature management. This is a direct prerequisite to adding the concept of "Classifiers" to ZCS.

In machine learning, a _feature_ is some measurable property of the object to be classified. A set of features is the input into a classifier at both the training and classification steps.

For email classification, we need to be able to generate a wide variety of features. Some are event-driven, representing some metric related to the sender of the email. Others are properties of the message itself - how many recipients it has, whether it's part of a conversation, etc.
It should be noted that while content-based features such as subject and body words will certainly be used for classification, the task of parsing text to extract these tokens is left to the machine learning backend. An upcoming PR for classifier management will address this.

The key components in this PR are as follows:

* `Classifiable` is a new marker interface used throughout the ML system. The only class currently implementing this is `Message`.
* A `Feature` is a simple abstract class for some computed value. It is parameterized by `T`, which is the return type of the `getFeatureValue()` method. Subclasses are described below.
* A `FeatureFactory` builds a feature for some `Classifiable` item. It is parameterized by `T` as above, as well as by `C`, which implements `Classifiable`. Subclasses are described below.
* A `FeatureSpec` lets us define a single feature in a declarative way, without directly referencing factories. Its utility will be apparent in future PRs, where we will need to easily define classifier features outside of java code.
* A `FeatureSet` is a combination of one or more FeatureSpecs representing all features used by a classifier.
* `ComputedFeatures` is a wrapper for a list of `Feature` instances created for a given `Classifiable` item.
* `FeatureParam` represents a single key/value pair used as a parameter to a feature factory. It is parameterized by the underlying value type.  The `ParamKey` enum is used as the key; the enum includes a short string representation used for serializing the parameter.
* `FeatureParams` represents a collection of `FeatureParam` instances, used for `FeatureFactory` configuration. More details below.

#### Feature Implementations
The following `Feature` subclasses are provided:
* `PrimitiveFeature` simply exposes some value passed in through the constructor.
* `MetricFeature` is a wrapper for some underlying `EventMetric`.
* `RatioFeature` is a decorator that returns the ratio of two other features.

#### Feature Factories
The following feature factories are defined in this PR:
* `ConversationFeatureFactory` returns a Boolean PrimitiveFeature representing whether the message is part of an existing conversation
* `NumRecipientsFeatureFactory` returns an Integer PrimitiveFeature representing how many recipients the message has. This can be the total number of recipients, or limited to the TO or CC fields.
* `RecipientFieldFeatureFactory` returns an Integer PrimitiveFeature representing which field the recipient is on. It returns 0 if the recipient is on the TO field, 1 if CC, 2 if BCC, and 3 otherwise (for example, if the recipient is part of a distribution list).
* `ContactFrequencyFeatureFactory` returns a MetricFeature wrapping a `ContactFrequencyMetric`.
* `EventRatioFeatureFactory` returns a MetricFeature wrapping an appropriate `EventRatioMetric`
* `EventTimeDeltaFeatureFactory` returns a MetricFeature wrapping an appropriate `TimeDeltaMetric`.

#### Feature Parameters
Feature params that can be used to configure the feature factories described above are:
* `METRIC_INITIALIZER`: sets the `MetricInitializer` used by `MetricFeature` instances
* `FREQUENCY_TYPE`: sets `ContactFrequencyEventType` enum in `ContactFrequencyFeatureFactory`; one of {`SENT`, `RECEIVED`, `COMBINED`}
* `TIME_RANGE`: sets the `ContactFrequencyTimeRange` enum in `ContactFrequencyFeatureFactory`; one of {`LAST_DAY`, `LAST_WEEK`, `LAST_MONTH`, `FOREVER`}
* `RECIPIENT_TYPE`: sets the `RecipientCountType` enum in `NumRecipientsFeatureFactory`; one of {`TO`, `CC`, `ALL`}
* `GLOBAL_RATIO`: optional boolean parameter passed into`EventTimeDeltaFeatureFactory`; if `True`, the contact-specific metric value will be divided by the global account value, "normalizing" it.
* `NUMERATOR`: required `EventType` parameter for `EventRatioFeatureFactory`
* `DENOMINATOR`: required `EventType` parameter for `EventRatioFeatureFactory`
* `FROM_EVENT`: required `EventType` parameter for `EventTimeDeltaFeatureFactory`
* `TO_EVENT`: required `EventType` parameter for `EventTimeDeltaFeatureFactory`

#### FeatureSpec mechanism
The `FeatureSpec` class allows features to be defined without explicitly referencing FeatureFactories. In fact, a `FeatureSet`, representing all features to be generated for a message, is built with FeatureSpec instances.
A `FeatureSpec` is a combination of a `KnownFeature` enum and zero or more `FeatureParam` objects. A `KnownFeature` enum value refers to a combination of some feature factory class along with some hard-coded parameters. 
The `FeatureSpec.buildFactory()` method returns an appropriate `FeatureFactory` instance created from the underlying `KnownFeature` and optional parameters.
`FeatureSpecs` can be serialized/deserialized. This will become important in an upcoming PR where the information about registered classifiers needs to be persisted in LDAP. To enable this, as with the `ParamKey` enum, `KnownFeature` values have a short-form string value.

#### Testing
The `FeatureFactoryTest` suite has tests for each of the `FeatureFactory` implementations, as well as for `FeatureSpec` encoding/decoding and building `ComputedFeatures` results from a given `FeatureSet`.