### PR TITLE
Bugfix/zimbra 135 event logger shutdown fix

### DIFF
--- a/store/src/java-test/com/zimbra/cs/event/logger/SolrEventLoggerTest.java
+++ b/store/src/java-test/com/zimbra/cs/event/logger/SolrEventLoggerTest.java
@@ -22,7 +22,7 @@ import com.zimbra.cs.event.Event.EventContextField;
 import com.zimbra.cs.event.Event.EventType;
 import com.zimbra.cs.event.SolrEventDocument;
 import com.zimbra.cs.event.logger.BatchingEventLogger.BatchedEvents;
-import com.zimbra.cs.event.logger.BatchingEventLogger.BatchedEventCallback;;
+import com.zimbra.cs.event.logger.BatchingEventLogger.BatchedEventCallback;
 
 public class SolrEventLoggerTest {
 
@@ -74,12 +74,12 @@ public class SolrEventLoggerTest {
         SolrInputDocument sent = new SolrEventDocument(generateSentEvent(ACCOUNT_ID_1, timestamp, RECIPIENT)).getDocument();
         checkEventType(sent, EventType.SENT);
         checkTimestamp(sent, timestamp);
-        checkDynamicFieldValue(sent, "receiver_s", RECIPIENT);
+        checkDynamicFieldValue(sent, "receiver_zaddr", RECIPIENT);
 
         SolrInputDocument received = new SolrEventDocument(generateReceivedEvent(ACCOUNT_ID_1, timestamp, SENDER)).getDocument();
         checkEventType(received, EventType.RECEIVED);
         checkTimestamp(received, timestamp);
-        checkDynamicFieldValue(received, "sender_s", SENDER);
+        checkDynamicFieldValue(received, "sender_zaddr", SENDER);
     }
 
     @Test

--- a/store/src/java/com/zimbra/cs/event/Event.java
+++ b/store/src/java/com/zimbra/cs/event/Event.java
@@ -45,7 +45,9 @@ public class Event {
         DELETE_ACCOUNT(UniqueOn.ACCOUNT, true),
         //auxiliary event used to allow contact affinity to be calculated from
         //incoming messages
-        AFFINITY(UniqueOn.MSG_AND_RECIPIENT);
+        AFFINITY(UniqueOn.MSG_AND_RECIPIENT),
+        //poison pill needed to stop the executor service in EventLogger class.
+        POISON_PILL(UniqueOn.NONE, true);
 
         private boolean internal;
         private UniqueOn uniqueOn;

--- a/store/src/java/com/zimbra/cs/event/Event.java
+++ b/store/src/java/com/zimbra/cs/event/Event.java
@@ -23,8 +23,7 @@ import com.zimbra.cs.mailbox.Message;
 import com.zimbra.cs.mime.ParsedMessage;
 
 public class Event {
-    public static final String MULTI_VALUE_SEPARATOR = ",";
-
+    public static Event POISON_PILL = new Event("POISON_PILL_ACCOUNT_ID", EventType.POISON_PILL, 1L);
     private String accountId;
     private EventType eventType;
     private long timestamp;

--- a/store/src/java/com/zimbra/cs/event/logger/EventLogger.java
+++ b/store/src/java/com/zimbra/cs/event/logger/EventLogger.java
@@ -1,5 +1,7 @@
 package com.zimbra.cs.event.logger;
 
+import static com.zimbra.cs.event.Event.POISON_PILL;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -161,7 +163,7 @@ public class EventLogger {
         try {
             if(drainQueueBeforeShutdown.get()) {
                 for (int i = 0; i < config.getNumThreads(); i++) {
-                    eventQueue.put(new Event("POISON_PILL_ACCOUNT_ID", Event.EventType.POISON_PILL, System.currentTimeMillis()));
+                    eventQueue.put(POISON_PILL);
                 }
             }
             executorService.awaitTermination(30, TimeUnit.SECONDS);
@@ -208,14 +210,14 @@ public class EventLogger {
                 Event event = null;
                 while (!shutdownExecutor.get()) {
                     event = eventQueue.poll(3, TimeUnit.SECONDS);
-                    if (event != null && event.getEventType() != Event.EventType.POISON_PILL) {
+                    if (event != null && event != POISON_PILL) {
                          notifyEventLogHandlers(event);
                     }
                 }
-                if (drainQueueBeforeShutdown.get() && !(event != null && event.getEventType() == Event.EventType.POISON_PILL)) {
+                if (drainQueueBeforeShutdown.get() && !(event != null && event != POISON_PILL)) {
                     ZimbraLog.event.debug("Draining the queue");
                     event = eventQueue.poll();
-                    while (event != null && event.getEventType() != Event.EventType.POISON_PILL) {
+                    while (event != null && event != POISON_PILL) {
                         notifyEventLogHandlers(event);
                         event = eventQueue.poll();
                     }

--- a/store/src/java/com/zimbra/cs/index/solr/SolrCloudHelper.java
+++ b/store/src/java/com/zimbra/cs/index/solr/SolrCloudHelper.java
@@ -25,7 +25,6 @@ public class SolrCloudHelper extends SolrRequestHelper {
 
     @Override
     public void close() throws IOException {
-        cloudClient.close();
         clientCache.close();
     }
 


### PR DESCRIPTION
While testing the code for the Event backfill from the database an issue with the EventLogger::shutdownEventLogger was uncovered. The shutdownEventLogger method was immediately killing the EventNotifier thread. When the intended behavior was 

1. Initiate shutdown. Notify EventNotifier treads that shutdown was initiated. The thread should try to complete execution of the current task and stop. (Don't drain the event queue)
2. If the drain event queue flag is set it should try to drain the event queue and once its empty it should stop.
3. After initiating the shutdown the executor service would wait for 30 seconds to allow the threads to complete execution. (shutdown gracefully)
4. If the threads don't complete the execution it would call shutdownNow and kill all the threads.

To satisfy this behavior I am using two atomic boolean flags and *poison pill* approach.
1. When the shutdownExecutor flag is set the EventNotifier thread exits from the while loop in which it waits to consume events from the event queue. In order to check frequently the state of the shutdownExecutor poll method with a 3 seconds timeout is used to retrieve events from the event queue. Poll with timeout is used instead of take so in case of event queue the code does not get blocks on it till there is some event added to the queue.
2. If we want to shutdown the executor service as well as drain the event queue before the executor service is killed then drainQueueBeforeShutdown flag is set. In order to determine the end of event queue *poison pills* are added to the event queue. So now EventNotifier thread will consume events from the event queue till it encounters the poison pill. 

#### Cons for this approach

1. Events added to the event queue after poison pill will not be consumed by the EventNotifier. We might lose events in this case. But in a production system EventLogger is closed only when the zm-mailbox shutdown is initiated. It that case we do not expect more events to be generated. 
2. As the event queue is a bounded queue in case of the queue being full, we will not be able to add poison pills immediately to the event queue. We will need to wait till space is available in queue. Offer method with 3 seconds timeout is used. In that case executor shutdown won't happen gracefully for all the EventNotifier threads. But will avoid the case of waiting infinitely for space to because available on the queue and shutdown to happen.