### PR TITLE
ZIMBRA-130: Classifier Support

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -8775,6 +8775,24 @@ public class ZAttrProvisioning {
     public static final String A_zimbraLowestSupportedAuthVersion = "zimbraLowestSupportedAuthVersion";
 
     /**
+     * URL for accessing the machine learning service. First part of the URL
+     * before the first colon identifies the implementation Factory. Only the
+     * &quot;zimbra&quot; prefix is currently supported.
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3052)
+    public static final String A_zimbraMachineLearningBackendURL = "zimbraMachineLearningBackendURL";
+
+    /**
+     * Serialized info about registered classifiers
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3051)
+    public static final String A_zimbraMachineLearningClassifierInfo = "zimbraMachineLearningClassifierInfo";
+
+    /**
      * RFC822 email address of this recipient for accepting mail
      */
     @ZAttr(id=3)

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9785,4 +9785,14 @@ TODO: delete them permanently from here
   <desc>If true, search results will be sorted by relevance if a sortBy value is not provided.</desc>
   <defaultCOSValue>FALSE</defaultCOSValue>
 </attr>
+
+<attr id="3051" name="zimbraMachineLearningClassifierInfo" type="string" cardinality="multi" optionalIn="globalConfig" since="8.8.6">
+  <desc>Serialized info about registered classifiers</desc>
+</attr>
+
+<attr id="3052" name="zimbraMachineLearningBackendURL" type="string" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="8.8.6">
+    <desc>URL for accessing the machine learning service.
+    First part of the URL before the first colon identifies the implementation Factory.
+    Only the "zimbra" prefix is currently supported.</desc>
+</attr>
 </attrs>

--- a/store/src/java-test/com/zimbra/cs/account/MockProvisioning.java
+++ b/store/src/java-test/com/zimbra/cs/account/MockProvisioning.java
@@ -231,7 +231,7 @@ public final class MockProvisioning extends Provisioning {
                     } else {
                         List<Object> list = null;
                         if (existing instanceof Object[]) {
-                            list = Arrays.asList(existing);
+                            list = new ArrayList<>(Arrays.asList(existing));
                         } else if (existing instanceof Object) {
                             list = new ArrayList<Object>();
                             list.add(existing);

--- a/store/src/java-test/com/zimbra/cs/ml/classifier/ClassifierManagerTest.java
+++ b/store/src/java-test/com/zimbra/cs/ml/classifier/ClassifierManagerTest.java
@@ -1,0 +1,194 @@
+package com.zimbra.cs.ml.classifier;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.event.Event.EventType;
+import com.zimbra.cs.event.analytics.contact.ContactAnalytics.ContactFrequencyTimeRange;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.mailbox.Message;
+import com.zimbra.cs.ml.DummyMachineLearningBackend;
+import com.zimbra.cs.ml.MachineLearningBackend;
+import com.zimbra.cs.ml.classifier.Classifier.ClassifiableType;
+import com.zimbra.cs.ml.feature.FeatureParam;
+import com.zimbra.cs.ml.feature.FeatureParam.ParamKey;
+import com.zimbra.cs.ml.feature.FeatureParams;
+import com.zimbra.cs.ml.feature.FeatureSet;
+import com.zimbra.cs.ml.feature.FeatureSpec;
+import com.zimbra.cs.ml.feature.FeatureSpec.KnownFeature;
+import com.zimbra.cs.ml.schema.ClassifierInfo;
+import com.zimbra.cs.ml.schema.ClassifierSpec;
+import com.zimbra.cs.ml.schema.MessageClassificationInput;
+import com.zimbra.cs.ml.schema.TrainingData;
+import com.zimbra.cs.ml.schema.TrainingData.TrainingDocument;
+import com.zimbra.cs.ml.schema.TrainingSetInfo;
+import com.zimbra.cs.ml.schema.TrainingSpec;
+import com.zimbra.qa.unittest.TestUtil;
+
+public class ClassifierManagerTest {
+
+    private static final String USER = "classifierManagerTest";
+
+    private static final String[] EXCLUSIVE_CLASSES = new String[] {"exclusive1", "exclusive2"};
+    private static final String[] OVERLAPPING_CLASSES = new String[] {"overlapping1", "overlapping2"};
+
+    private ClassifierRegistry registry;
+    private ClassifierManager manager;
+
+    @Before
+    public void setUp() throws Exception {
+        MailboxTestUtil.initServer();
+        TestUtil.createAccount(USER);
+        registry = new LdapClassifierRegistry();
+        manager = ClassifierManager.getInstance();
+        MachineLearningBackend.setFactory(DummyMachineLearningBackend.Factory.class.getName());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        for (String id: manager.getAllClassifierInfo().keySet()) {
+            manager.deleteClassifier(id);
+        }
+        MailboxTestUtil.clearData();
+    }
+
+    private FeatureSet<Message> getFeatureSet() throws ServiceException {
+        FeatureSet<Message> fs = new FeatureSet<Message>();
+        fs.addFeatureSpec(new FeatureSpec<Message>(KnownFeature.IS_PART_OF_CONVERSATION));
+        fs.addFeatureSpec(new FeatureSpec<Message>(KnownFeature.COMBINED_FREQUENCY)
+                .addParam(new FeatureParam<>(ParamKey.TIME_RANGE, ContactFrequencyTimeRange.FOREVER)));
+        fs.addFeatureSpec(new FeatureSpec<Message>(KnownFeature.EVENT_RATIO)
+                .addParam(new FeatureParam<>(ParamKey.NUMERATOR, EventType.READ))
+                .addParam(new FeatureParam<>(ParamKey.DENOMINATOR, EventType.SEEN)));
+        return fs;
+    }
+
+    private ClassifierSpec getSpec() {
+        return new ClassifierSpec(8, 52, EXCLUSIVE_CLASSES, OVERLAPPING_CLASSES);
+    }
+
+    private MessageClassifier getClassifier(String id, String label) throws ServiceException {
+        ClassifierInfo info = new ClassifierInfo(id, 8, 52, EXCLUSIVE_CLASSES, OVERLAPPING_CLASSES, 0, 0);
+        return new MessageClassifier(id, label, getFeatureSet(), info);
+    }
+
+    @Test
+    public void testEncodeClassifier() throws Exception {
+        MessageClassifier classifier = getClassifier("id1", "testClassifier");
+        String encoded = registry.encode(classifier);
+        Classifier<?> decodedClassifier = registry.decode(encoded);
+        assertEquals("wrong id in decoded classifier", "id1", decodedClassifier.getId());
+        assertEquals("wrong label in decoded classifier", "testClassifier", decodedClassifier.getLabel());
+        FeatureSet<Message> fs = classifier.getFeatureSet();
+        FeatureSet<?> decodedFeatureSet = decodedClassifier.getFeatureSet();
+        assertEquals("wrong number feature specs in decoded classifier", fs.getAllFeatureSpecs().size(), decodedFeatureSet.getAllFeatureSpecs().size());
+        for (FeatureSpec<Message> spec: fs.getAllFeatureSpecs()) {
+            KnownFeature feature = spec.getFeature();
+            FeatureParams params = spec.getParams();
+            boolean found = false;
+            for(FeatureSpec<?> decodedFeatureSpec: decodedFeatureSet.getFeatureSpecs(feature)) {
+                if (decodedFeatureSpec.getParams().equals(params)) {
+                    found = true;
+                }
+            }
+            if (!found) {
+                fail(spec.toString() + " not found in decoded classifier");
+            }
+        }
+    }
+
+    @Test
+    public void testClassifierRegistry() throws Exception {
+        String id1 = "id1";
+        String id2 = "id2";
+        String label1 = "label1";
+        String label2 = "label2";
+        assertFalse("label1 shouldn't exist in registry", registry.labelExists(label1));
+        MessageClassifier classifier1 = getClassifier(id1, label1);
+        MessageClassifier sameLabel = getClassifier(id2, label1);
+        registry.register(classifier1);
+        assertTrue("label1 should exist in registry", registry.labelExists(label1));
+        assertSame("should see classifier1 by label", classifier1, registry.getByLabel(label1));
+        try {
+            registry.register(sameLabel);
+            fail("should not be able to register a classifier with the same label");
+        } catch (ServiceException e){
+            assertEquals("should see FAILURE error", ServiceException.FAILURE, e.getCode());
+        }
+        MessageClassifier classifier2 = getClassifier(id2, label2);
+        registry.register(classifier2);
+        assertTrue("label2 should exist in registry", registry.labelExists(label2));
+        assertSame("should see classifier2 by label", classifier2, registry.getByLabel(label2));
+        assertSame("should see classifier1", classifier1, registry.getById(id1));
+        assertSame("should see classifier2", classifier2, registry.getById(id2));
+
+        Map<String, Classifier<?>> classifiers = registry.getAllClassifiers();
+        assertEquals("should see 2 classifiers", 2, classifiers.size());
+        assertEquals("id1 should map to classifier1", classifier1, classifiers.get(id1));
+        assertEquals("id2 should map to classifier2", classifier2, classifiers.get(id2));
+
+        registry.delete(id1);
+        assertFalse("label1 should not longer exist", registry.labelExists(label1));
+        try {
+            registry.getById(id1);
+        } catch (ServiceException e){
+            assertEquals("should see FAILURE error", ServiceException.FAILURE, e.getCode());
+        }
+        assertEquals("registry should have one classifier", 1, registry.getAllClassifiers().size());
+    }
+
+    @Test
+    public void testManageClassifiers() throws Exception {
+
+        Classifier<Message> c1 = manager.registerClassifier(new ClassifierData<Message>(ClassifiableType.MESSAGE, "test1", getSpec(), getFeatureSet()));
+        Classifier<Message> c2 = manager.registerClassifier(new ClassifierData<Message>(ClassifiableType.MESSAGE, "test2", getSpec(), getFeatureSet()));
+
+        String id1 = c1.getId();
+        String id2 = c2.getId();
+
+        Map<String, Classifier<?>> classifiers = manager.getAllClassifiers();
+        assertEquals("should see 2 classifiers", 2, classifiers.size());
+        assertTrue("id1 should be in the map", classifiers.containsKey(id1));
+        assertTrue("id2 should be in the map", classifiers.containsKey(id2));
+
+        assertEquals("id1 label is test1", "test1", manager.getClassifierById(id1).getLabel());
+        assertEquals("id2 label is test2", "test2", manager.getClassifierById(id2).getLabel());
+
+        manager.deleteClassifier(id1);
+        classifiers = manager.getAllClassifiers();
+        assertEquals("should see 1 classifier", 1, classifiers.size());
+        assertTrue("id2 should be in the map", classifiers.containsKey(id2));
+    }
+
+    @Test
+    public void testTrainClassifier() throws Exception {
+
+        Classifier<Message> classifier = manager.registerClassifier(new ClassifierData<Message>(ClassifiableType.MESSAGE, "test1", getSpec(), getFeatureSet()));
+
+        TrainingData data = new TrainingData();
+        MessageClassificationInput input1 = new MessageClassificationInput().setText("foo");
+        MessageClassificationInput input2 = new MessageClassificationInput().setText("bar");
+        data.addDoc(new TrainingDocument(input1, EXCLUSIVE_CLASSES[0], OVERLAPPING_CLASSES));
+        data.addDoc(new TrainingDocument(input2, EXCLUSIVE_CLASSES[1], OVERLAPPING_CLASSES));
+        TrainingSpec spec = new TrainingSpec(data);
+        spec.setPercentHoldout((float)0.5);
+        spec.setEpochs(10);
+        spec.setLearningRate((float) 0.5);
+        spec.setPersist(true);
+        ClassifierInfo info = classifier.train(spec);
+        TrainingSetInfo trainingSetInfo = info.getTrainingSet();
+        assertEquals("epoch from dummy handler should be 0", 0, info.getEpoch());
+        assertEquals("should have 1 training doc", 1, trainingSetInfo.getNumTrain());
+        assertEquals("should have 1 test doc", 1, trainingSetInfo.getNumTest());
+    }
+}

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -9547,13 +9547,13 @@ public abstract class ZAttrAccount  extends MailTarget {
      * If true, search results will be sorted by relevance if a sortBy value
      * is not provided.
      *
-     * @return zimbraDefaultSortByRelevance, or true if unset
+     * @return zimbraDefaultSortByRelevance, or false if unset
      *
      * @since ZCS 8.8.6
      */
     @ZAttr(id=3050)
     public boolean isDefaultSortByRelevance() {
-        return getBooleanAttr(Provisioning.A_zimbraDefaultSortByRelevance, true, true);
+        return getBooleanAttr(Provisioning.A_zimbraDefaultSortByRelevance, false, true);
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -27217,6 +27217,222 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * URL for accessing the machine learning service. First part of the URL
+     * before the first colon identifies the implementation Factory. Only the
+     * &quot;zimbra&quot; prefix is currently supported.
+     *
+     * @return zimbraMachineLearningBackendURL, or null if unset
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3052)
+    public String getMachineLearningBackendURL() {
+        return getAttr(Provisioning.A_zimbraMachineLearningBackendURL, null, true);
+    }
+
+    /**
+     * URL for accessing the machine learning service. First part of the URL
+     * before the first colon identifies the implementation Factory. Only the
+     * &quot;zimbra&quot; prefix is currently supported.
+     *
+     * @param zimbraMachineLearningBackendURL new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3052)
+    public void setMachineLearningBackendURL(String zimbraMachineLearningBackendURL) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMachineLearningBackendURL, zimbraMachineLearningBackendURL);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * URL for accessing the machine learning service. First part of the URL
+     * before the first colon identifies the implementation Factory. Only the
+     * &quot;zimbra&quot; prefix is currently supported.
+     *
+     * @param zimbraMachineLearningBackendURL new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3052)
+    public Map<String,Object> setMachineLearningBackendURL(String zimbraMachineLearningBackendURL, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMachineLearningBackendURL, zimbraMachineLearningBackendURL);
+        return attrs;
+    }
+
+    /**
+     * URL for accessing the machine learning service. First part of the URL
+     * before the first colon identifies the implementation Factory. Only the
+     * &quot;zimbra&quot; prefix is currently supported.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3052)
+    public void unsetMachineLearningBackendURL() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMachineLearningBackendURL, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * URL for accessing the machine learning service. First part of the URL
+     * before the first colon identifies the implementation Factory. Only the
+     * &quot;zimbra&quot; prefix is currently supported.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3052)
+    public Map<String,Object> unsetMachineLearningBackendURL(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMachineLearningBackendURL, "");
+        return attrs;
+    }
+
+    /**
+     * Serialized info about registered classifiers
+     *
+     * @return zimbraMachineLearningClassifierInfo, or empty array if unset
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3051)
+    public String[] getMachineLearningClassifierInfo() {
+        return getMultiAttr(Provisioning.A_zimbraMachineLearningClassifierInfo, true, true);
+    }
+
+    /**
+     * Serialized info about registered classifiers
+     *
+     * @param zimbraMachineLearningClassifierInfo new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3051)
+    public void setMachineLearningClassifierInfo(String[] zimbraMachineLearningClassifierInfo) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMachineLearningClassifierInfo, zimbraMachineLearningClassifierInfo);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Serialized info about registered classifiers
+     *
+     * @param zimbraMachineLearningClassifierInfo new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3051)
+    public Map<String,Object> setMachineLearningClassifierInfo(String[] zimbraMachineLearningClassifierInfo, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMachineLearningClassifierInfo, zimbraMachineLearningClassifierInfo);
+        return attrs;
+    }
+
+    /**
+     * Serialized info about registered classifiers
+     *
+     * @param zimbraMachineLearningClassifierInfo new to add to existing values
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3051)
+    public void addMachineLearningClassifierInfo(String zimbraMachineLearningClassifierInfo) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraMachineLearningClassifierInfo, zimbraMachineLearningClassifierInfo);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Serialized info about registered classifiers
+     *
+     * @param zimbraMachineLearningClassifierInfo new to add to existing values
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3051)
+    public Map<String,Object> addMachineLearningClassifierInfo(String zimbraMachineLearningClassifierInfo, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraMachineLearningClassifierInfo, zimbraMachineLearningClassifierInfo);
+        return attrs;
+    }
+
+    /**
+     * Serialized info about registered classifiers
+     *
+     * @param zimbraMachineLearningClassifierInfo existing value to remove
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3051)
+    public void removeMachineLearningClassifierInfo(String zimbraMachineLearningClassifierInfo) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraMachineLearningClassifierInfo, zimbraMachineLearningClassifierInfo);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Serialized info about registered classifiers
+     *
+     * @param zimbraMachineLearningClassifierInfo existing value to remove
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3051)
+    public Map<String,Object> removeMachineLearningClassifierInfo(String zimbraMachineLearningClassifierInfo, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraMachineLearningClassifierInfo, zimbraMachineLearningClassifierInfo);
+        return attrs;
+    }
+
+    /**
+     * Serialized info about registered classifiers
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3051)
+    public void unsetMachineLearningClassifierInfo() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMachineLearningClassifierInfo, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Serialized info about registered classifiers
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3051)
+    public Map<String,Object> unsetMachineLearningClassifierInfo(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMachineLearningClassifierInfo, "");
+        return attrs;
+    }
+
+    /**
      * optional regex used by web client to validate email address
      *
      * @return zimbraMailAddressValidationRegex, or empty array if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -5533,13 +5533,13 @@ public abstract class ZAttrCos extends NamedEntry {
      * If true, search results will be sorted by relevance if a sortBy value
      * is not provided.
      *
-     * @return zimbraDefaultSortByRelevance, or true if unset
+     * @return zimbraDefaultSortByRelevance, or false if unset
      *
      * @since ZCS 8.8.6
      */
     @ZAttr(id=3050)
     public boolean isDefaultSortByRelevance() {
-        return getBooleanAttr(Provisioning.A_zimbraDefaultSortByRelevance, true, true);
+        return getBooleanAttr(Provisioning.A_zimbraDefaultSortByRelevance, false, true);
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -16877,6 +16877,88 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
+     * URL for accessing the machine learning service. First part of the URL
+     * before the first colon identifies the implementation Factory. Only the
+     * &quot;zimbra&quot; prefix is currently supported.
+     *
+     * @return zimbraMachineLearningBackendURL, or null if unset
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3052)
+    public String getMachineLearningBackendURL() {
+        return getAttr(Provisioning.A_zimbraMachineLearningBackendURL, null, true);
+    }
+
+    /**
+     * URL for accessing the machine learning service. First part of the URL
+     * before the first colon identifies the implementation Factory. Only the
+     * &quot;zimbra&quot; prefix is currently supported.
+     *
+     * @param zimbraMachineLearningBackendURL new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3052)
+    public void setMachineLearningBackendURL(String zimbraMachineLearningBackendURL) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMachineLearningBackendURL, zimbraMachineLearningBackendURL);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * URL for accessing the machine learning service. First part of the URL
+     * before the first colon identifies the implementation Factory. Only the
+     * &quot;zimbra&quot; prefix is currently supported.
+     *
+     * @param zimbraMachineLearningBackendURL new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3052)
+    public Map<String,Object> setMachineLearningBackendURL(String zimbraMachineLearningBackendURL, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMachineLearningBackendURL, zimbraMachineLearningBackendURL);
+        return attrs;
+    }
+
+    /**
+     * URL for accessing the machine learning service. First part of the URL
+     * before the first colon identifies the implementation Factory. Only the
+     * &quot;zimbra&quot; prefix is currently supported.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3052)
+    public void unsetMachineLearningBackendURL() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMachineLearningBackendURL, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * URL for accessing the machine learning service. First part of the URL
+     * before the first colon identifies the implementation Factory. Only the
+     * &quot;zimbra&quot; prefix is currently supported.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3052)
+    public Map<String,Object> unsetMachineLearningBackendURL(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMachineLearningBackendURL, "");
+        return attrs;
+    }
+
+    /**
      * Deprecated since: 8.7.8. deprecated in favor of
      * zimbraAdminOutgoingSieveScriptAfter. Orig desc: outgoing sieve script
      * defined by admin (not able to edit and view from the end user) applied

--- a/store/src/java/com/zimbra/cs/ml/DummyMachineLearningBackend.java
+++ b/store/src/java/com/zimbra/cs/ml/DummyMachineLearningBackend.java
@@ -1,0 +1,188 @@
+package com.zimbra.cs.ml;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.mail.MessagingException;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.UUIDUtil;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.mime.Mime;
+import com.zimbra.cs.ml.query.CreateClassifierQuery;
+import com.zimbra.cs.ml.query.DeleteClassifierQuery;
+import com.zimbra.cs.ml.query.GetClassifierQuery;
+import com.zimbra.cs.ml.query.ListClassifiersQuery;
+import com.zimbra.cs.ml.query.MessageClassificationQuery;
+import com.zimbra.cs.ml.query.TrainClassifierQuery;
+import com.zimbra.cs.ml.schema.ClassificationResult;
+import com.zimbra.cs.ml.schema.ClassifierInfo;
+import com.zimbra.cs.ml.schema.ClassifierSpec;
+import com.zimbra.cs.ml.schema.MessageClassificationInput;
+import com.zimbra.cs.ml.schema.OverlappingClassification;
+import com.zimbra.cs.ml.schema.TrainingData;
+import com.zimbra.cs.ml.schema.TrainingData.TrainingDocument;
+import com.zimbra.cs.ml.schema.TrainingSetInfo;
+import com.zimbra.cs.ml.schema.TrainingSpec;
+
+/**
+ * Dummy MachineLearningBackend that returns mock MLQuery responses and stores ClassifierInfo in an in-memory map
+ */
+public class DummyMachineLearningBackend extends MachineLearningBackend {
+
+    private Map<String, ClassifierInfo> knownClassifiers;
+
+    public DummyMachineLearningBackend() {
+        knownClassifiers = new HashMap<>();
+    }
+
+    private void addKnownClassifier(ClassifierInfo info) {
+        ZimbraLog.ml.debug("Dummy ML backend is registering classifier with id=%s", info.getClassifierId());
+        knownClassifiers.put(info.getClassifierId(), info);
+    }
+
+    @Override
+    protected QueryCallback<CreateClassifierQuery, ClassifierInfo> getCreateClassifierCallback() {
+        return new QueryCallback<CreateClassifierQuery, ClassifierInfo>() {
+
+            @Override
+            public ClassifierInfo run(CreateClassifierQuery query) {
+                ClassifierSpec spec = query.getClassifierSpec();
+                String id = spec.getClassifierId() == null ? UUIDUtil.generateUUID() : spec.getClassifierId();
+                ClassifierInfo info = ClassifierInfo.fromSpec(id, spec);
+                addKnownClassifier(info);
+                return info;
+            }
+        };
+    }
+
+    @Override
+    protected QueryCallback<DeleteClassifierQuery, Boolean> getDeleteClassifierCallback() {
+        return new QueryCallback<DeleteClassifierQuery, Boolean>() {
+
+            @Override
+            public Boolean run(DeleteClassifierQuery query) {
+                String idToDelete = query.getClassifierId();
+                ClassifierInfo info = knownClassifiers.remove(idToDelete);
+                return info != null;
+            }
+        };
+    }
+
+    @Override
+    protected QueryCallback<ListClassifiersQuery, List<ClassifierInfo>> getListClassifiersCallback() {
+        return new QueryCallback<ListClassifiersQuery, List<ClassifierInfo>>() {
+
+            @Override
+            public List<ClassifierInfo> run(ListClassifiersQuery query) {
+                return new ArrayList<ClassifierInfo>(knownClassifiers.values());
+            }
+        };
+    }
+
+    @Override
+    protected QueryCallback<TrainClassifierQuery, ClassifierInfo> getTrainClassifierCallback() {
+        return new QueryCallback<TrainClassifierQuery, ClassifierInfo>() {
+
+            @Override
+            public ClassifierInfo run(TrainClassifierQuery query) throws ServiceException {
+                TrainingSpec spec = query.getTrainingSpec();
+                String classifierId = spec.getClassifierId();
+                ClassifierInfo info = knownClassifiers.get(classifierId);
+                if (info == null) {
+                    throw ServiceException.INVALID_REQUEST("no classifier exists with id " + classifierId, null);
+                }
+                TrainingData td = spec.getTrainingData();
+                if (spec.isPersist()) {
+                    float holdout = spec.getPercentHoldout();
+                    List<TrainingDocument> trainingDocs = td.getTrainingDocs();
+                    int numTest = Math.round(trainingDocs.size() * holdout);
+                    int numTrain = trainingDocs.size() - numTest;
+                    TrainingSetInfo trainingSetInfo = new TrainingSetInfo(new Date().toString(), numTrain, numTest);
+                    info.setTrainingSet(trainingSetInfo);
+                }
+                info.setEpoch(0);
+                return info;
+            }
+        };
+    }
+
+    @Override
+    protected QueryCallback<MessageClassificationQuery, ClassificationResult> getClassificationCallback() {
+        return new QueryCallback<MessageClassificationQuery, ClassificationResult>() {
+
+            @Override
+            public ClassificationResult run(MessageClassificationQuery query) throws ServiceException {
+                String classifierId = query.getClassifierId();
+                ClassifierInfo info = knownClassifiers.get(classifierId);
+                if (info == null) {
+                    throw ServiceException.INVALID_REQUEST("no classifier exists with id " + classifierId, null);
+                }
+                MessageClassificationInput input = query.getInput();
+                ClassificationResult classification = new ClassificationResult();
+                classification.setUrl(input.getUrl());
+                String subject;
+                try {
+                    subject = Mime.getSubject(input.getMimeMessage());
+                } catch (MessagingException e) {
+                    ZimbraLog.ml.error("error getting email subject in DummyMachineLearningBackend", e);
+                    return classification;
+                }
+                if (subject != null) {
+                    if (info.getExclusiveClasses() != null && info.getExclusiveClasses().length > 0) {
+                        for (String classLabel: info.getExclusiveClasses()) {
+                            if (subject.contains(classLabel.toLowerCase())) {
+                                classification.setExclusiveClass(classLabel);
+                                break;
+                            }
+                        }
+                    }
+                    if (info.getOverlappingClasses() != null && info.getOverlappingClasses().length > 0) {
+                        List<OverlappingClassification> oc;
+                        oc = Arrays.asList(info.getOverlappingClasses()).stream()
+                                .map(c -> new OverlappingClassification(c, subject.contains(c.toLowerCase()) ? 1f : 0f))
+                                .collect(Collectors.toList());
+                        classification.setOverlappingClasses(oc.toArray(new OverlappingClassification[oc.size()]));
+                    }
+                }
+                return classification;
+            }
+        };
+    }
+
+    @Override
+    protected QueryCallback<GetClassifierQuery, ClassifierInfo> getGetClassifierCallback() {
+        return new QueryCallback<GetClassifierQuery, ClassifierInfo>() {
+
+            @Override
+            public ClassifierInfo run(GetClassifierQuery query)
+                    throws ServiceException {
+                String classifierId = query.getClassifierId();
+                ClassifierInfo info = knownClassifiers.get(classifierId);
+                if (info == null) {
+                    throw ServiceException.INVALID_REQUEST("no classifier exists with id " + classifierId, null);
+                } else {
+                    return info;
+                }
+            }
+        };
+    }
+
+    public static class Factory implements MachineLearningBackend.Factory {
+
+        private DummyMachineLearningBackend instance;
+
+        @Override
+        public MachineLearningBackend getMachineLearningBackend() throws ServiceException {
+            if (instance == null) {
+                instance = new DummyMachineLearningBackend();
+            }
+            return instance;
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/MachineLearningBackend.java
+++ b/store/src/java/com/zimbra/cs/ml/MachineLearningBackend.java
@@ -1,0 +1,133 @@
+package com.zimbra.cs.ml;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.extension.ExtensionUtil;
+import com.zimbra.cs.ml.query.CreateClassifierQuery;
+import com.zimbra.cs.ml.query.DeleteClassifierQuery;
+import com.zimbra.cs.ml.query.GetClassifierQuery;
+import com.zimbra.cs.ml.query.ListClassifiersQuery;
+import com.zimbra.cs.ml.query.MLQuery;
+import com.zimbra.cs.ml.query.MessageClassificationQuery;
+import com.zimbra.cs.ml.query.TrainClassifierQuery;
+import com.zimbra.cs.ml.schema.ClassifierInfo;
+import com.zimbra.cs.ml.schema.ClassificationResult;
+
+public abstract class MachineLearningBackend {
+
+    private static Map<String, String> REGISTERED_FACTORIES = new HashMap<>();
+    private static Factory factory;
+
+    private Map<Class<? extends MLQuery<?>>, QueryCallback<?,?>> map;
+
+    public static void registerFactory(String prefix, String clazz) {
+        if (REGISTERED_FACTORIES.containsKey(prefix)) {
+            ZimbraLog.index.warn(
+                    "Replacing EventStore factory class '%s' registered for prefix '%s' with another factory class: '%s'",
+                    REGISTERED_FACTORIES.get(prefix), prefix, clazz);
+        }
+        REGISTERED_FACTORIES.put(prefix, clazz);
+    }
+
+    public static Factory getFactory() throws ServiceException {
+        if (factory == null) {
+            String factoryClassName = null;
+            String eventURL = Provisioning.getInstance().getLocalServer().getMachineLearningBackendURL();
+            if (eventURL != null) {
+                String[] tokens = eventURL.split(":");
+                if (tokens != null && tokens.length > 0) {
+                    String backendFactoryName = tokens[0];
+                    factoryClassName = REGISTERED_FACTORIES.get(backendFactoryName);
+                }
+            } else {
+                throw ServiceException.FAILURE("Machine Learning Backend is not configured", null);
+            }
+            setFactory(factoryClassName);
+        }
+        return factory;
+    }
+
+    public static void clearFactory() {
+        factory = null;
+    }
+
+    public static void setFactory(String factoryClassName) throws ServiceException {
+        Class<? extends Factory> factoryClass = null;
+        try {
+            try {
+                factoryClass = Class.forName(factoryClassName).asSubclass(Factory.class);
+            } catch (ClassNotFoundException e) {
+                try {
+                    factoryClass = ExtensionUtil.findClass(factoryClassName)
+                            .asSubclass(Factory.class);
+                } catch (ClassNotFoundException cnfe) {
+                    throw ServiceException.FAILURE("unable to find Machine Learning Backend Factory class " + factoryClassName, cnfe);
+                }
+            }
+        } catch (ClassCastException cce) {
+            ZimbraLog.event.error("unable to initialize Machine Learning Backend Factory class %s", factoryClassName, cce);
+        }
+        setFactory(factoryClass);
+    }
+
+    public static void setFactory(Class<? extends Factory> factoryClass) throws ServiceException {
+        if (factoryClass == null) {
+            throw ServiceException.FAILURE("Machine Learning Backend Factory class cannot be null", null);
+        }
+        String className = factoryClass.getName();
+        ZimbraLog.search.debug("setting MachineLearningBackend.Factory class %s", className);
+        try {
+            factory = factoryClass.newInstance();
+        } catch (InstantiationException | IllegalAccessException e) {
+            throw ServiceException.FAILURE(String.format("unable to initialize Machine Learning Backend Factory %s", className), e);
+        }
+    }
+
+    public MachineLearningBackend() {
+        map = new HashMap<>();
+        registerCallbacks();
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T extends MLQuery<Q>, Q> Q executeQuery(T query) throws ServiceException {
+        QueryCallback<T, Q> callback = (QueryCallback<T, Q>) map.get(query.getClass());
+        if (callback == null) {
+            throw ServiceException.INVALID_REQUEST("no handler implemented for query " + query.getClass().getName(), null);
+        }
+        return callback.run(query);
+    }
+
+    protected void registerCallbacks() {
+        addCallback(CreateClassifierQuery.class, getCreateClassifierCallback());
+        addCallback(DeleteClassifierQuery.class, getDeleteClassifierCallback());
+        addCallback(ListClassifiersQuery.class, getListClassifiersCallback());
+        addCallback(TrainClassifierQuery.class, getTrainClassifierCallback());
+        addCallback(MessageClassificationQuery.class, getClassificationCallback());
+        addCallback(GetClassifierQuery.class, getGetClassifierCallback());
+    }
+
+    protected abstract QueryCallback<CreateClassifierQuery, ClassifierInfo> getCreateClassifierCallback();
+    protected abstract QueryCallback<DeleteClassifierQuery, Boolean> getDeleteClassifierCallback();
+    protected abstract QueryCallback<ListClassifiersQuery, List<ClassifierInfo>> getListClassifiersCallback();
+    protected abstract QueryCallback<TrainClassifierQuery, ClassifierInfo> getTrainClassifierCallback();
+    protected abstract QueryCallback<MessageClassificationQuery, ClassificationResult> getClassificationCallback();
+    protected abstract QueryCallback<GetClassifierQuery, ClassifierInfo> getGetClassifierCallback();
+
+    protected void addCallback(Class<? extends MLQuery<?>> queryClass, QueryCallback<?, ?> callback) {
+        map.put(queryClass, callback);
+    }
+
+    public static abstract class QueryCallback<T extends MLQuery<Q>, Q> {
+
+        public abstract Q run(T query) throws ServiceException;
+    }
+
+    public static interface Factory {
+        public MachineLearningBackend getMachineLearningBackend() throws ServiceException;
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/classifier/Classifier.java
+++ b/store/src/java/com/zimbra/cs/ml/classifier/Classifier.java
@@ -1,0 +1,85 @@
+package com.zimbra.cs.ml.classifier;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.ml.Classifiable;
+import com.zimbra.cs.ml.feature.ComputedFeatures;
+import com.zimbra.cs.ml.feature.FeatureSet;
+import com.zimbra.cs.ml.query.AbstractClassificationQuery;
+import com.zimbra.cs.ml.query.TrainClassifierQuery;
+import com.zimbra.cs.ml.schema.ClassifierInfo;
+import com.zimbra.cs.ml.schema.ClassificationResult;
+import com.zimbra.cs.ml.schema.TrainingSpec;
+
+public abstract class Classifier<T extends Classifiable> {
+
+    private String id;
+    private String classifierLabel;
+    private FeatureSet<T> featureSet;
+    private ClassifierInfo info = null;
+    private String description;
+    private ClassifiableType type;
+
+    public static enum ClassifiableType {
+        MESSAGE;
+    }
+
+    public Classifier(String id, String label, ClassifiableType type, FeatureSet<T> featureSet) {
+        this(id, label, type, featureSet, null);
+    }
+
+    public Classifier(String id, String label, ClassifiableType type, FeatureSet<T> featureSet, ClassifierInfo info) {
+        this.id = id;
+        this.classifierLabel = label;
+        this.featureSet = featureSet;
+        this.info = info;
+        this.type = type;
+    }
+
+    public String getLabel() {
+        return classifierLabel;
+    }
+
+    public FeatureSet<T> getFeatureSet() {
+        return featureSet;
+    }
+
+    public void setClassifierInfo(ClassifierInfo info) {
+        this.info = info;
+    }
+
+    public ClassifierInfo getInfo() {
+        return info;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setDescription(String desc) {
+        this.description = desc;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public ClassifiableType getType() {
+        return type;
+    }
+
+    protected abstract AbstractClassificationQuery<T> buildQuery(ComputedFeatures<T> features) throws ServiceException;
+
+    public ClassifierInfo train(TrainingSpec trainingSpec) throws ServiceException {
+        trainingSpec.setClassifierId(getId());
+        TrainClassifierQuery query = new TrainClassifierQuery(trainingSpec);
+        ClassifierInfo info = query.execute();
+        this.info = info;
+        return info;
+    }
+
+    public ClassificationResult classify(T item) throws ServiceException {
+        ComputedFeatures<T> features = getFeatureSet().getFeatures(item);
+        AbstractClassificationQuery<T> query = buildQuery(features);
+        return query.execute();
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/classifier/ClassifierData.java
+++ b/store/src/java/com/zimbra/cs/ml/classifier/ClassifierData.java
@@ -1,0 +1,57 @@
+package com.zimbra.cs.ml.classifier;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.mailbox.Message;
+import com.zimbra.cs.ml.Classifiable;
+import com.zimbra.cs.ml.classifier.Classifier.ClassifiableType;
+import com.zimbra.cs.ml.feature.FeatureSet;
+import com.zimbra.cs.ml.schema.ClassifierInfo;
+import com.zimbra.cs.ml.schema.ClassifierSpec;
+
+/**
+ * Class encompassing all data needed to register a classifier
+ */
+public class ClassifierData<T extends Classifiable> {
+    private String label;
+    private String description;
+    private FeatureSet<T> featureSet;
+    private ClassifierSpec spec;
+    private ClassifiableType type;
+
+    public ClassifierData(ClassifiableType type, String label, ClassifierSpec spec, FeatureSet<T> featureSet) {
+        this(type, label, spec, featureSet, null);
+    }
+
+    public ClassifierData(ClassifiableType type, String label, ClassifierSpec spec, FeatureSet<T> featureSet, String description) {
+        this.type = type;
+        this.label = label;
+        this.description = description;
+        this.featureSet = featureSet;
+        this.spec = spec;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public ClassifierSpec getSpec() {
+        return spec;
+    }
+
+    @SuppressWarnings("unchecked")
+    public Classifier<T> create(ClassifierInfo info) throws ServiceException {
+        Classifier<T> classifier;
+        switch (type) {
+        case MESSAGE:
+            classifier = (Classifier<T>) new MessageClassifier(info.getClassifierId(), label, (FeatureSet<Message>) featureSet);
+            break;
+        default:
+            throw ServiceException.FAILURE(String.format("Cannot create Classifier for ClassifiableType %s; only MESSAGE is supported at this time", type), null);
+        }
+        if (description != null) {
+            classifier.setDescription(description);
+        }
+        classifier.setClassifierInfo(info);
+        return classifier;
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/classifier/ClassifierManager.java
+++ b/store/src/java/com/zimbra/cs/ml/classifier/ClassifierManager.java
@@ -1,0 +1,125 @@
+package com.zimbra.cs.ml.classifier;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.ml.Classifiable;
+import com.zimbra.cs.ml.query.CreateClassifierQuery;
+import com.zimbra.cs.ml.query.DeleteClassifierQuery;
+import com.zimbra.cs.ml.query.ListClassifiersQuery;
+import com.zimbra.cs.ml.schema.ClassifierInfo;
+import com.zimbra.cs.ml.schema.ClassifierSpec;
+
+/**
+ * Primary entry point into the classifier system
+ * @author iraykin
+ */
+public class ClassifierManager {
+
+    private ClassifierRegistry registry;
+
+    private static ClassifierManager instance = null;
+
+    private ClassifierManager() throws ServiceException {
+        this(new LdapClassifierRegistry());
+    }
+
+    private ClassifierManager(ClassifierRegistry registry) {
+        this.registry = registry;
+    }
+
+    public void setRegistry(ClassifierRegistry registry) {
+        this.registry  = registry;
+    }
+
+    public static synchronized ClassifierManager getInstance() throws ServiceException {
+        if (instance == null) {
+            instance = new ClassifierManager();
+        }
+        return instance;
+
+    }
+
+    /**
+     * return a map of registered classifiers keyed by the IDs. Used by the classifier registry
+     * to construct full {@link Classifier} instances
+     */
+    public Map<String, ClassifierInfo> getAllClassifierInfo() throws ServiceException {
+        Map<String, ClassifierInfo> infoMap = new HashMap<>();
+        ListClassifiersQuery query = new ListClassifiersQuery();
+        for (ClassifierInfo info: query.execute()) {
+            infoMap.put(info.getClassifierId(), info);
+        }
+        return infoMap;
+    }
+
+    /**
+     * Register a new classifier. This initializes the associated {@link ClassifierSpec}
+     * on the ML server, and stores information about the classifier in the classifier registry.
+     */
+    public <T extends Classifiable> Classifier<T> registerClassifier(ClassifierData<T> classifierData) throws ServiceException {
+        // 1. Check that the label is not a duplicate
+        String label = classifierData.getLabel();
+        if (registry.labelExists(label)) {
+            throw ServiceException.INVALID_REQUEST("classifier label '" + label + "' already exists", null);
+        }
+        // 2. try to register the spec with the ML server. This returns an ID.
+        CreateClassifierQuery query = new CreateClassifierQuery(classifierData.getSpec());
+        ClassifierInfo info = query.execute();
+        Classifier<T> classifier = classifierData.create(info);
+        // 3. Register the classifier with the registry using this ID.
+        registry.register(classifier);
+        return classifier;
+    }
+
+    /**
+     * Return a Classifier for the given classifier ID.
+     */
+    @SuppressWarnings("unchecked")
+    public <T extends Classifiable> Classifier<T> getClassifierById(String classifierId) throws ServiceException {
+        Classifier<T> classifier = (Classifier<T>) registry.getById(classifierId);
+        if (classifier == null) {
+            throw ServiceException.NOT_FOUND("no classifier registered for ID " + classifierId, null);
+        }
+        return classifier;
+    }
+
+    /**
+     * Return a Classifier for the given classifier ID.
+     */
+    public Classifier<?> getClassifierByLabel(String classifierLabel) throws ServiceException {
+        Classifier<?> classifier = registry.getByLabel(classifierLabel);
+        if (classifier == null) {
+            throw ServiceException.NOT_FOUND("no classifier registered for label " + classifierLabel, null);
+        }
+        return classifier;
+    }
+
+    /**
+     * Get all known classifiers
+     */
+    public Map<String, Classifier<?>> getAllClassifiers() throws ServiceException {
+        return registry.getAllClassifiers();
+    }
+
+    /**
+     * Delete a classifier from the ML server by its ID.
+     */
+    public <T extends Classifiable> Classifier<T> deleteClassifier(String classifierId) throws ServiceException {
+        new DeleteClassifierQuery(classifierId).execute();
+        Classifier<T> deleted = registry.delete(classifierId);
+        if (deleted == null) {
+            ZimbraLog.ml.warn("No classifier with id=%s found in classifier registry", classifierId);
+        }
+        return deleted;
+    }
+
+    /**
+     * Check whether a classifier already exists with the given label;
+     */
+    public boolean labelExists(String label) throws ServiceException {
+        return registry.labelExists(label);
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/classifier/ClassifierRegistry.java
+++ b/store/src/java/com/zimbra/cs/ml/classifier/ClassifierRegistry.java
@@ -1,0 +1,198 @@
+package com.zimbra.cs.ml.classifier;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.BEncoding;
+import com.zimbra.common.util.BEncoding.BEncodingException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.mailbox.Message;
+import com.zimbra.cs.ml.Classifiable;
+import com.zimbra.cs.ml.classifier.Classifier.ClassifiableType;
+import com.zimbra.cs.ml.feature.FeatureSet;
+import com.zimbra.cs.ml.feature.FeatureSpec;
+import com.zimbra.cs.ml.schema.ClassifierInfo;
+
+/**
+ * Registry of classifiers known to be initialized on the ML server.
+ * Subclasses handle persisting/loading classifier info.
+ */
+public abstract class ClassifierRegistry {
+
+    private static final String KEY_ID = "i";
+    private static final String KEY_LABEL = "l";
+    private static final String KEY_FEATURES = "f";
+    private static final String KEY_DESCRIPTION = "d";
+    private static final String KEY_TYPE = "t";
+
+    private Map<String, Classifier<?>> idMap;
+    private Map<String, Classifier<?>> labelMap;
+    private boolean loaded = false;
+
+    public ClassifierRegistry() {
+        idMap = new HashMap<>();
+        labelMap = new HashMap<>();
+    }
+
+    private synchronized void loadKnownClassifiers() throws ServiceException {
+        String[] encodedClassifiers = load();
+        ZimbraLog.ml.info("found known %d classifiers in %s", encodedClassifiers.length, this.getClass().getSimpleName());
+        Map<String, ClassifierInfo> infoMap = ClassifierManager.getInstance().getAllClassifierInfo();
+        ZimbraLog.ml.debug("found %d classifiers registered with ML backend", infoMap.size());
+        for (String encoded: encodedClassifiers) {
+            Classifier<?> decoded = decode(encoded);
+            String id = decoded.getId();
+            ClassifierInfo info = infoMap.get(id);
+            if (info == null) {
+                ZimbraLog.ml.warn("known classifier %s (id=%s) has no entry in ML backend, deleting", decoded.getLabel(), id);
+                deRegister(encoded);
+            } else {
+                ZimbraLog.ml.debug("loaded classifier label=%s id=%s", decoded.getLabel(), id);
+                infoMap.remove(id);
+                idMap.put(id, decoded);
+                labelMap.put(decoded.getLabel(), decoded);
+                decoded.setClassifierInfo(info);
+            }
+        }
+        if (!infoMap.isEmpty()) {
+            for (String cId: infoMap.keySet()) {
+                ZimbraLog.ml.warn("classifier id=%s has no corresponding entry in %s", cId, this.getClass().getSimpleName());
+            }
+        }
+        loaded = true;
+    }
+
+    public Map<String, Classifier<?>> getAllClassifiers() throws ServiceException {
+        if (!loaded) {
+            loadKnownClassifiers();
+        }
+        return idMap;
+    }
+
+    public boolean labelExists(String label) throws ServiceException {
+        if (!loaded) {
+            loadKnownClassifiers();
+        }
+        return labelMap.containsKey(label);
+    }
+
+    /**
+     * return known encoded classifiers
+     */
+    protected abstract String[] load() throws ServiceException;
+
+    /**
+     * Persist the encoded classifier string
+     */
+    protected abstract void save(String encodedClassifier) throws ServiceException;
+
+    /**
+     * Register a classifier
+     */
+    public void register(Classifier<?> classifier) throws ServiceException {
+        if (!loaded) {
+            loadKnownClassifiers();
+        }
+        if (labelExists(classifier.getLabel())) {
+            throw ServiceException.FAILURE("label '" + classifier.getLabel() + "' already exists", null);
+        }
+        idMap.put(classifier.getId(), classifier);
+        labelMap.put(classifier.getLabel(), classifier);
+        save(encode(classifier));
+    }
+
+    protected String encode(Classifier<?> classifier) {
+        Map<String, Object> map = new HashMap<>();
+        map.put(KEY_ID, classifier.getId());
+        map.put(KEY_TYPE, classifier.getType().name());
+        map.put(KEY_LABEL, classifier.getLabel());
+        map.put(KEY_FEATURES, classifier.getFeatureSet().getAllFeatureSpecs().stream().map(feature -> ((FeatureSpec<?>) feature).encode()).collect(Collectors.toList()));
+        map.put(KEY_DESCRIPTION, classifier.getDescription());
+        return BEncoding.encode(map);
+    }
+
+    protected Classifier<?> decode(String encoded) throws ServiceException {
+        Map<String, Object> map;
+        try {
+            map = BEncoding.decode(encoded);
+        } catch (BEncodingException e) {
+            throw ServiceException.FAILURE("unable to decode classifier with encoded value %s" + encoded, null);
+        }
+        if (!map.containsKey(KEY_TYPE)) {
+            throw ServiceException.FAILURE("no ClassifiableType value found during decoding classifier", null);
+
+        }
+        String typeStr = (String) map.get(KEY_TYPE);
+        ClassifiableType type = null;
+        try {
+            type = ClassifiableType.valueOf(typeStr);
+        } catch (IllegalArgumentException e) {
+            throw ServiceException.FAILURE("invalid ClassifiableType value encountered during decoding classifier: " + typeStr, null);
+        }
+        //this may seem unnecessary now, but it allows us to add classifiers for things other than messages in the future
+        switch (type) {
+        case MESSAGE:
+            return decodeMessageClassifier(map);
+        default:
+            throw ServiceException.FAILURE(String.format("unknown ClassifiableType %s; only MESSAGE is supported at this time", type), null);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Classifier<Message> decodeMessageClassifier(Map<String, Object> map) throws ServiceException {
+        String label = (String) map.get(KEY_LABEL);
+        String id = (String) map.get(KEY_ID);
+        String description = map.containsKey(KEY_DESCRIPTION) ? (String) map.get(KEY_DESCRIPTION) : null;
+        FeatureSet<Message> featureSet = new FeatureSet<>();
+        for (String encodedFeatureSpec: (List<String>) map.get(KEY_FEATURES)) {
+            try {
+                featureSet.addFeatureSpec(new FeatureSpec<Message>(encodedFeatureSpec));
+            } catch (ServiceException e) {
+                ZimbraLog.ml.warn("problem decoding feature for classifier %s", label, e);
+            }
+        }
+        Classifier<Message> classifier = new MessageClassifier(id, label, featureSet);
+        if (description != null) {
+            classifier.setDescription(description);
+        }
+        return classifier;
+    }
+
+    public Classifier<?> getById(String classifierId) throws ServiceException {
+        if (!loaded) {
+            loadKnownClassifiers();
+        }
+        if (!idMap.containsKey(classifierId)) {
+            throw ServiceException.FAILURE(String.format("no classifier found with id=%s", classifierId), null);
+        }
+        return idMap.get(classifierId);
+    }
+
+    public Classifier<?> getByLabel(String classifierLabel) throws ServiceException {
+        if (!loaded) {
+            loadKnownClassifiers();
+        }
+        if (!labelMap.containsKey(classifierLabel)) {
+            throw ServiceException.FAILURE(String.format("no classifier found with label=%s", classifierLabel), null);
+        }
+        return labelMap.get(classifierLabel);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T extends Classifiable> Classifier<T> delete(String classifierId) throws ServiceException {
+        if (!loaded) {
+            loadKnownClassifiers();
+        }
+        Classifier<T> classifier = (Classifier<T>) idMap.remove(classifierId);
+        if (classifier != null) {
+            deRegister(encode(classifier));
+            labelMap.remove(classifier.getLabel());
+        }
+        return classifier;
+    }
+
+    protected abstract void deRegister(String encoded) throws ServiceException;
+}

--- a/store/src/java/com/zimbra/cs/ml/classifier/LdapClassifierRegistry.java
+++ b/store/src/java/com/zimbra/cs/ml/classifier/LdapClassifierRegistry.java
@@ -1,0 +1,33 @@
+package com.zimbra.cs.ml.classifier;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.Config;
+import com.zimbra.cs.account.Provisioning;
+
+/**
+ * Stores classifier info in a multivalued LDAP attribute
+ */
+class LdapClassifierRegistry extends ClassifierRegistry {
+
+    private Config config;
+
+    public LdapClassifierRegistry() throws ServiceException {
+        config = Provisioning.getInstance().getConfig();
+    }
+
+    @Override
+    protected String[] load() throws ServiceException {
+        return config.getMachineLearningClassifierInfo();
+    }
+
+    @Override
+    protected void save(String encodedClassifier)
+            throws ServiceException {
+        config.addMachineLearningClassifierInfo(encodedClassifier);
+    }
+
+    @Override
+    protected void deRegister(String encodedClassifier) throws ServiceException {
+        config.removeMachineLearningClassifierInfo(encodedClassifier);
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/classifier/MessageClassifier.java
+++ b/store/src/java/com/zimbra/cs/ml/classifier/MessageClassifier.java
@@ -1,0 +1,26 @@
+package com.zimbra.cs.ml.classifier;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.mailbox.Message;
+import com.zimbra.cs.ml.feature.ComputedFeatures;
+import com.zimbra.cs.ml.feature.FeatureSet;
+import com.zimbra.cs.ml.query.MessageClassificationQuery;
+import com.zimbra.cs.ml.schema.ClassifierInfo;
+import com.zimbra.cs.ml.schema.MessageClassificationInput;
+
+public class MessageClassifier extends Classifier<Message> {
+
+    public MessageClassifier(String id, String label, FeatureSet<Message> featureSet, ClassifierInfo info) {
+        super(id, label, ClassifiableType.MESSAGE, featureSet, info);
+    }
+
+    public MessageClassifier(String id, String label, FeatureSet<Message> featureSet) {
+        super(id, label, ClassifiableType.MESSAGE, featureSet);
+    }
+
+    @Override
+    protected MessageClassificationQuery buildQuery(ComputedFeatures<Message> features) throws ServiceException {
+        Message msg = features.getItem();
+        return new MessageClassificationQuery(getId(), msg.getRecipients(), new MessageClassificationInput(features));
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/query/AbstractClassificationQuery.java
+++ b/store/src/java/com/zimbra/cs/ml/query/AbstractClassificationQuery.java
@@ -1,0 +1,18 @@
+package com.zimbra.cs.ml.query;
+
+import com.zimbra.cs.ml.Classifiable;
+import com.zimbra.cs.ml.schema.AbstractClassificationInput;
+import com.zimbra.cs.ml.schema.ClassificationResult;
+
+public abstract class AbstractClassificationQuery<T extends Classifiable> extends MLQuery<ClassificationResult> {
+
+    protected AbstractClassificationInput<T> input;
+
+    public AbstractClassificationQuery(AbstractClassificationInput<T> input) {
+        this.input = input;
+    }
+
+    public AbstractClassificationInput<T> getInput() {
+        return input;
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/query/CreateClassifierQuery.java
+++ b/store/src/java/com/zimbra/cs/ml/query/CreateClassifierQuery.java
@@ -1,0 +1,21 @@
+package com.zimbra.cs.ml.query;
+
+import com.zimbra.cs.ml.schema.ClassifierInfo;
+import com.zimbra.cs.ml.schema.ClassifierSpec;
+
+
+/**
+ * Create a classifier based on a ClassifierSpec
+ */
+public class CreateClassifierQuery extends MLQuery<ClassifierInfo> {
+
+    private ClassifierSpec classifierSpec;
+
+    public CreateClassifierQuery(ClassifierSpec classifierSpec) {
+        this.classifierSpec = classifierSpec;
+    }
+
+    public ClassifierSpec getClassifierSpec() {
+        return classifierSpec;
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/query/DeleteClassifierQuery.java
+++ b/store/src/java/com/zimbra/cs/ml/query/DeleteClassifierQuery.java
@@ -1,0 +1,18 @@
+package com.zimbra.cs.ml.query;
+
+
+/**
+ * Delete a classifier by its ID
+ */
+public class DeleteClassifierQuery extends MLQuery<Boolean> {
+
+    private String classifierId;
+
+    public DeleteClassifierQuery(String classifierId) {
+        this.classifierId = classifierId;
+    }
+
+    public String getClassifierId() {
+        return classifierId;
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/query/GetClassifierQuery.java
+++ b/store/src/java/com/zimbra/cs/ml/query/GetClassifierQuery.java
@@ -1,0 +1,16 @@
+package com.zimbra.cs.ml.query;
+
+import com.zimbra.cs.ml.schema.ClassifierInfo;
+
+public class GetClassifierQuery extends MLQuery<ClassifierInfo> {
+
+    private String classifierId;
+
+    public GetClassifierQuery(String classifierId) {
+        this.classifierId = classifierId;
+    }
+
+    public String getClassifierId() {
+        return classifierId;
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/query/ListClassifiersQuery.java
+++ b/store/src/java/com/zimbra/cs/ml/query/ListClassifiersQuery.java
@@ -1,0 +1,10 @@
+package com.zimbra.cs.ml.query;
+
+import java.util.List;
+
+import com.zimbra.cs.ml.schema.ClassifierInfo;
+
+/**
+ * Query to return a list of all registered classifiers
+ */
+public class ListClassifiersQuery extends MLQuery<List<ClassifierInfo>> {}

--- a/store/src/java/com/zimbra/cs/ml/query/MLQuery.java
+++ b/store/src/java/com/zimbra/cs/ml/query/MLQuery.java
@@ -1,0 +1,18 @@
+package com.zimbra.cs.ml.query;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.ml.MachineLearningBackend;
+
+/**
+ * Base class for queries to the machine learning server
+ */
+public abstract class MLQuery<T> {
+
+    public T execute() throws ServiceException {
+        ZimbraLog.ml.debug("executing %s", this.getClass().getSimpleName());
+        return MachineLearningBackend.getFactory().getMachineLearningBackend().executeQuery(this);
+    }
+
+}
+

--- a/store/src/java/com/zimbra/cs/ml/query/MessageClassificationQuery.java
+++ b/store/src/java/com/zimbra/cs/ml/query/MessageClassificationQuery.java
@@ -1,0 +1,29 @@
+package com.zimbra.cs.ml.query;
+
+import com.zimbra.cs.mailbox.Message;
+import com.zimbra.cs.ml.schema.MessageClassificationInput;
+
+public class MessageClassificationQuery extends AbstractClassificationQuery<Message> {
+
+    private String classifierId;
+    private String receiverAddr;
+
+    public MessageClassificationQuery(String classifierId, String receiverAddr, MessageClassificationInput input) {
+        super(input);
+        this.classifierId = classifierId;
+        this.receiverAddr = receiverAddr;
+    }
+
+    public String getClassifierId() {
+        return classifierId;
+    }
+
+    public String getReceiverAddress() {
+        return receiverAddr;
+    }
+
+    @Override
+    public MessageClassificationInput getInput() {
+        return (MessageClassificationInput) input;
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/query/TrainClassifierQuery.java
+++ b/store/src/java/com/zimbra/cs/ml/query/TrainClassifierQuery.java
@@ -1,0 +1,20 @@
+package com.zimbra.cs.ml.query;
+
+import com.zimbra.cs.ml.schema.ClassifierInfo;
+import com.zimbra.cs.ml.schema.TrainingSpec;
+
+/**
+ * Query to train a classifier
+ */
+public class TrainClassifierQuery extends MLQuery<ClassifierInfo> {
+
+    private TrainingSpec trainingSpec;
+
+    public TrainClassifierQuery(TrainingSpec trainingSpec) {
+        this.trainingSpec = trainingSpec;
+    }
+
+    public TrainingSpec getTrainingSpec() {
+        return trainingSpec;
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/schema/AbstractClassificationInput.java
+++ b/store/src/java/com/zimbra/cs/ml/schema/AbstractClassificationInput.java
@@ -1,0 +1,24 @@
+package com.zimbra.cs.ml.schema;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.ml.Classifiable;
+import com.zimbra.cs.ml.feature.ComputedFeatures;
+
+public abstract class AbstractClassificationInput<T extends Classifiable> {
+
+    protected List<Float> encodedFeatures;
+
+    public AbstractClassificationInput() {
+        encodedFeatures = new ArrayList<>();
+    }
+
+    public AbstractClassificationInput(ComputedFeatures<T> computedFeatures) throws ServiceException {
+        this();
+        init(computedFeatures);
+    }
+
+    protected abstract void init(ComputedFeatures<T> computedFeatures) throws ServiceException;
+}

--- a/store/src/java/com/zimbra/cs/ml/schema/ClassificationResult.java
+++ b/store/src/java/com/zimbra/cs/ml/schema/ClassificationResult.java
@@ -1,0 +1,34 @@
+package com.zimbra.cs.ml.schema;
+
+/**
+ * The result of classifying an email
+ */
+public class ClassificationResult {
+
+    private String textUrl;
+    private String exclusiveClass;
+    private OverlappingClassification[] overlappingClasses;
+
+    public String getUrl() {
+        return textUrl;
+    }
+    public void setUrl(String textUrl) {
+        this.textUrl = textUrl;
+    }
+
+    public OverlappingClassification[] getOverlappingClasses() {
+        return overlappingClasses;
+    }
+
+    public void setOverlappingClasses(OverlappingClassification[] overlappingClasses) {
+        this.overlappingClasses = overlappingClasses;
+    }
+
+    public String getExclusiveClass() {
+        return exclusiveClass;
+    }
+
+    public void setExclusiveClass(String exclusiveClass) {
+        this.exclusiveClass = exclusiveClass;
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/schema/ClassifierInfo.java
+++ b/store/src/java/com/zimbra/cs/ml/schema/ClassifierInfo.java
@@ -1,0 +1,50 @@
+package com.zimbra.cs.ml.schema;
+
+/**
+ * Information about a registered classifier
+ */
+public class ClassifierInfo extends ClassifierSpec {
+
+    private int epoch;
+    private TrainingSetInfo trainingSet;
+
+    public ClassifierInfo(String classifierId, int numSubjectWords, int numBodyWords,
+            String[] exclusiveClasses, String[] overlappingClasses, Integer lookupDim, Integer lookupSize) {
+        super(numSubjectWords, numBodyWords, exclusiveClasses, overlappingClasses);
+        setClassifierId(classifierId);
+        setLookupDim(lookupDim);
+        setLookupSize(lookupSize);
+    }
+
+
+    public int getEpoch() {
+        return epoch;
+    }
+
+    public void setEpoch(int epoch) {
+        this.epoch = epoch;
+    }
+
+
+    public TrainingSetInfo getTrainingSet() {
+        return trainingSet;
+    }
+
+
+    public void setTrainingSet(TrainingSetInfo trainingSet) {
+        this.trainingSet = trainingSet;
+    }
+
+    public static ClassifierInfo fromSpec(String id, ClassifierSpec spec) {
+        ClassifierInfo info = new ClassifierInfo(id,
+                spec.getNumSubjectWords(),
+                spec.getNumBodyWords(),
+                spec.getExclusiveClasses(),
+                spec.getOverlappingClasses(),
+                spec.getLookupDim(),
+                spec.getLookupSize());
+        info.setNumFeatures(spec.getNumFeatures());
+        info.setVocabPath(spec.getVocabPath());
+        return info;
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/schema/ClassifierSpec.java
+++ b/store/src/java/com/zimbra/cs/ml/schema/ClassifierSpec.java
@@ -1,0 +1,97 @@
+package com.zimbra.cs.ml.schema;
+
+/**
+ * Specification used to register a new classifier.
+ * Mirrors the GraphQL object type defined in zimbra-ml/schema/schema.py.
+ */
+public class ClassifierSpec {
+
+    private String classifierId;
+    private int numSubjectWords;
+    private int numBodyWords;
+    private int numFeatures;
+    private String[] exclusiveClasses;
+    private String[] overlappingClasses;
+    private String vocabPath;
+    private Integer lookupSize; //used for auto lookup table creation from training data
+    private Integer lookupDim; //dimensions of embeddings in the automatic lookup table
+
+    public ClassifierSpec(int numSubjectWords, int numBodyWords,
+            String[] exclusiveClasses, String[] overlappingClasses) {
+        setNumBodyWords(numBodyWords);
+        setNumSubjectWords(numSubjectWords);
+        setExclusiveClasses(exclusiveClasses);
+        setOverlappingClasses(overlappingClasses);
+    }
+
+    public String getClassifierId() {
+        return classifierId;
+    }
+    public void setClassifierId(String classifierId) {
+        this.classifierId = classifierId;
+    }
+    public int getNumSubjectWords() {
+        return numSubjectWords;
+    }
+    public void setNumSubjectWords(int numSubjectWords) {
+        this.numSubjectWords = numSubjectWords;
+    }
+    public int getNumBodyWords() {
+        return numBodyWords;
+    }
+    public void setNumBodyWords(int numBodyWords) {
+        this.numBodyWords = numBodyWords;
+    }
+    public int getNumFeatures() {
+        return numFeatures;
+    }
+    public void setNumFeatures(int numFeatures) {
+        this.numFeatures = numFeatures;
+    }
+    public String[] getExclusiveClasses() {
+        return exclusiveClasses;
+    }
+    public void setExclusiveClasses(String[] exclusiveClasses) {
+        if (exclusiveClasses == null) {
+            this.exclusiveClasses = new String[0];
+        } else {
+            this.exclusiveClasses = exclusiveClasses;
+        }
+    }
+
+    public String[] getOverlappingClasses() {
+        return overlappingClasses;
+    }
+
+    public void setOverlappingClasses(String[] overlappingClasses) {
+        if (overlappingClasses == null) {
+            this.overlappingClasses = new String[0];
+        } else {
+            this.overlappingClasses = overlappingClasses;
+        }
+    }
+
+    public String getVocabPath() {
+        return vocabPath;
+    }
+
+    public void setVocabPath(String vocabPath) {
+        this.vocabPath = vocabPath;
+    }
+
+    public Integer getLookupSize() {
+        return lookupSize;
+    }
+
+    public void setLookupSize(Integer lookupSize) {
+        this.lookupSize = lookupSize;
+    }
+
+    public Integer getLookupDim() {
+        return lookupDim;
+    }
+
+    public void setLookupDim(Integer lookupDim) {
+        this.lookupDim = lookupDim;
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/schema/MessageClassificationInput.java
+++ b/store/src/java/com/zimbra/cs/ml/schema/MessageClassificationInput.java
@@ -1,0 +1,101 @@
+package com.zimbra.cs.ml.schema;
+
+import java.util.List;
+
+import javax.mail.internet.MimeMessage;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.mailbox.Message;
+import com.zimbra.cs.ml.feature.ComputedFeatures;
+import com.zimbra.cs.ml.feature.Feature;
+
+/**
+ * Input into a message ClassificationQuery.
+ *
+ */
+public class MessageClassificationInput extends AbstractClassificationInput<Message> {
+
+    private String url;
+    private String text;
+    private MimeMessage mm;
+
+    public MessageClassificationInput() {
+        super();
+    }
+
+    public MessageClassificationInput(ComputedFeatures<Message> features) throws ServiceException {
+        super(features);
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public MimeMessage getMimeMessage() {
+        return mm;
+    }
+
+    public List<Float> getFeatures() {
+        return encodedFeatures;
+    }
+
+    public MessageClassificationInput setUrl(String url) {
+        this.url = url;
+        return this;
+    }
+
+    public MessageClassificationInput setMimeMessage(MimeMessage mm) {
+        this.mm = mm;
+        return this;
+    }
+
+    public MessageClassificationInput setText(String text) {
+        this.text = text;
+        return this;
+    }
+
+    public void addFloatFeature(float feature) {
+        encodedFeatures.add(feature);
+    }
+
+    public void addIntFeature(int feature) {
+        encodedFeatures.add((float) feature);
+    }
+
+    public void addBoolFeature(boolean feature) {
+        encodedFeatures.add((float) (feature ? 1 : 0));
+    }
+
+    public void addFeature(Object obj) throws ServiceException {
+        if (obj instanceof Boolean) {
+            addBoolFeature((Boolean) obj);
+        } else if (obj instanceof Float) {
+            addFloatFeature((Float) obj);
+        } else if (obj instanceof Integer) {
+            addIntFeature((Integer) obj);
+        } else if (obj instanceof Double) {
+            addFloatFeature(((Double) obj).floatValue());
+        }else {
+            ZimbraLog.ml.warn("cannot encode feature of type " + obj.getClass().getName());
+        }
+
+    }
+
+    @Override
+    protected void init(ComputedFeatures<Message> computedFeatures) throws ServiceException {
+        Message msg = computedFeatures.getItem();
+        setMimeMessage(msg.getMimeMessage());
+        String url = msg.getBlob().getLocator();
+        if (url != null) {
+            setUrl(url);
+        }
+        for (Feature<?> feature: computedFeatures.getFeatures()) {
+            addFeature(feature.getFeatureValue());
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/schema/OverlappingClassification.java
+++ b/store/src/java/com/zimbra/cs/ml/schema/OverlappingClassification.java
@@ -1,0 +1,18 @@
+package com.zimbra.cs.ml.schema;
+
+import com.zimbra.common.util.Pair;
+
+public class OverlappingClassification extends Pair<String, Float> {
+
+    public OverlappingClassification(String label, Float prob) {
+        super(label, prob);
+    }
+
+    public String getLabel() {
+        return getFirst();
+    }
+
+    public float getProb() {
+        return getSecond();
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/schema/TrainingData.java
+++ b/store/src/java/com/zimbra/cs/ml/schema/TrainingData.java
@@ -1,0 +1,54 @@
+package com.zimbra.cs.ml.schema;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Class representing training data to be be passed to a classifier.
+ */
+public class TrainingData {
+
+    private List<TrainingDocument> trainingDocs;
+
+    public TrainingData() {
+        this.trainingDocs = new ArrayList<>();
+    }
+
+    public void addDoc(TrainingDocument doc) {
+        trainingDocs.add(doc);
+    }
+
+    public List<TrainingDocument> getTrainingDocs() {
+        return trainingDocs;
+    }
+
+    /**
+     * Class encompassing a training input document.
+     * Note that the training API expects the text, exclusive targets, and overlapping targets
+     * to each be in their own lists, but this format is more convenient for constructing
+     * the training data.
+     */
+    public static class TrainingDocument {
+        private MessageClassificationInput input;
+        private String exclusiveTarget;
+        private String[] overlappingTargets;
+
+        public TrainingDocument(MessageClassificationInput input, String exclusiveTarget, String[] overlappingTargets) {
+            this.input = input;
+            this.exclusiveTarget = exclusiveTarget;
+            this.overlappingTargets = overlappingTargets;
+        }
+
+        public MessageClassificationInput getInput() {
+            return input;
+        }
+
+        public String[] getOverlappingTargets() {
+            return overlappingTargets;
+        }
+
+        public String getExclusiveTarget() {
+            return exclusiveTarget;
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/schema/TrainingSetInfo.java
+++ b/store/src/java/com/zimbra/cs/ml/schema/TrainingSetInfo.java
@@ -1,0 +1,30 @@
+package com.zimbra.cs.ml.schema;
+
+
+/**
+ * Information about a persisted training set
+ */
+public class TrainingSetInfo {
+
+    public String date;
+    public int numTrain;
+    public int numTest;
+
+    public TrainingSetInfo(String date, int numTrain, int numTest) {
+        this.date = date;
+        this.numTrain = numTrain;
+        this.numTest = numTest;
+    }
+
+    public String getDate() {
+        return date;
+    }
+
+    public int getNumTrain() {
+        return numTrain;
+    }
+
+    public int getNumTest() {
+        return numTest;
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/schema/TrainingSpec.java
+++ b/store/src/java/com/zimbra/cs/ml/schema/TrainingSpec.java
@@ -1,0 +1,73 @@
+package com.zimbra.cs.ml.schema;
+
+/**
+ * All information needed to train a classifier
+ */
+public class TrainingSpec {
+
+    private String classifierId;
+    private TrainingData trainingData;
+    private TrainingData testData;
+    private int epochs;
+    private float learningRate;
+    private float percentHoldout;
+    private boolean persist = false;
+
+    public TrainingSpec(TrainingData trainingData) {
+        this.trainingData = trainingData;
+    }
+
+    public String getClassifierId() {
+        return classifierId;
+    }
+
+    public void setClassifierId(String classifierId) {
+        this.classifierId = classifierId;
+    }
+
+    public TrainingData getTrainingData() {
+        return trainingData;
+    }
+
+    public int getEpochs() {
+        return epochs;
+    }
+
+    public void setEpochs(int epochs) {
+        this.epochs = epochs;
+    }
+
+    public void setTestData(TrainingData testData) {
+        this.testData = testData;
+    }
+
+    public TrainingData getTestData() {
+        return testData;
+    }
+
+    public float getPercentHoldout() {
+        return percentHoldout;
+    }
+
+
+    public void setPercentHoldout(float percentHoldout) {
+        this.percentHoldout = percentHoldout;
+    }
+
+    public float getLearningRate() {
+        return learningRate;
+    }
+
+    public void setLearningRate(float learningRate) {
+        this.learningRate = learningRate;
+    }
+
+    public boolean isPersist() {
+        return persist;
+    }
+
+    public void setPersist(boolean persist) {
+        this.persist = persist;
+    }
+
+}


### PR DESCRIPTION
This PR introduces classifiers to ZCS.

### The ML Server
The actual machine learning work is handled by the ML server found here: https://github.com/Zimbra/zimbra-ml. 

#### Introduction
This ML server uses The _Intel Neon_ deep learning library to build LSTM and Convolutional neural networks. It allows for registering classifiers for a given specification, training them, and classifying inputs with them. It also supports broader classifier management operations, such as listing all registered classifiers, getting detailed info for a classifier by ID, and deleting an existing classifier. It exposes a GraphQL API with a Tornado webserver.

#### Exclusive vs Overlapping Classes
The ML server supports classifying inputs into both _exclusive_ and _overlapping_ classes. A message can be classified into zero or one exclusive class, and into any number of overlapping classes. The distinction is that exclusive classifications are binary, while overlapping classifications include a probability value; the mailbox server must decide whether the probability is high enough to warrant action. 
An example of exclusive classes is folders such as "work", "social", "shopping", and "finance". An email can belong to no more than one of these.
An example of an overlapping class is "important". An email can be long to this class independently of any other classifications.

### Mailbox Client
The ZCS mailbox server acts the client to this backend. While this PR does not include any GraphQL code needed to actually connect to this server (this will be added later), it has all the abstractions necessary to manage classifiers given an _arbitrary_ backend. In short, the code introduced here lays the groundwork for managing classifiers in conjunction with the ML server described above.

First, I will quickly address two packages that don't have much functionality.

#### The `ml/schema` package
This package contains classes that mirror the GraphQL schema defined in
https://github.com/Zimbra/zimbra-ml/blob/master/schema/schema.py.
Since work on both the zimbra-ml repo and the ZCS ML framework is still ongoing, the correlation between these classes and the GraphQL schema may not be exact. These classes are mainly containers for data to be passed to the API, so there is little to no business logic here.

#### The `ml/query` package
This package contains classes representing queries that can be issued to the ML backend.
The all extend the `MLQuery` base class, and are parameterized by the return type of the `execute()` method. The queries correspond to operations that can be performed on the ML server API.

#### Classifier Management
The `ClassifierManager` class is the primary entry point into the machine learning system on ZCS. It is a singleton class that provides methods to manage classifiers, such as creating, deleting, and listing them.

A `ClassifierRegistry` is a helper class used to persist and fetch information about registered classifiers. It is an abstract class; the primary implementation `LdapClassifierRegistry` stores the information in the multivalued LDAP attribute `zimbraMachineLearningClassifierInfo`. The info is stored as a BEncoded string.

### The `Classifier` Class
The most important class introduced in this PR is `Classifier`.

#### Definition & Creation
The first class involved with classifier creation is `ClassifierSpec`. This is the blueprint for a classifier, from the perspective of the ML server. It contains the following fields:
* An ID (optional; if not provided, the server will generate a random one)
* The number of words the classifier will extract from the email subject
* The number of words the classifier will extract from the email content
* The number of other features that the classifier will use
* The overlapping and exclusive class labels that the classifier will output
* An optional path to the vocabulary file on the ML server (if not provided, a default is used), for when we want to use a pre-computed vocabulary
* The size of the lookup table to be created by the classifier for when we create our own word embeddings
* The number of dimensions to be used for word embedding generation

In short, these fields contain all the information required for the ML server to generate the underlying neural network topology. 

When it comes to numeric features, the backend does not care what they represent - only how many there are. The mailbox, however _does_ need to know what the features are, so that it can generate them from messages. This means that a  definition of a classifier on the mailbox is a combination of a `ClassifierSpec` and a `FeatureSet` (introduced in #ZIMBRA-132).

With this in mind, we can construct an instance of the `ClassifierData` class, which represents all the information necessary to register a classifier, both on the mailbox and on the ML backend. The class contains:
* A `ClassifierSpec` instance representing the information needed by the backend
* A `FeatureSet` instance representing the features that will generated for this classifier
* A string label that the classifier will be referred by (distinct from the internal classifier ID)
* A string description of the classifier (this will be useful in a future PR that introduces  a command-line utility for classifier management)

The `ClassifierManager::registerClassifier` method takes a `ClassifierData` instance and does the following:
1.  Checks that the classifier label is not a duplicate
2. Registers the `ClassifierSpec` on the ML backend using a `CreateClassifierQuery`
3. Instantiates a `Classifier` with the ID returned by the backend
4. Registers this classifier with the `ClassifierRegistry`.

A `Classifier`, then, has the following fields, accessible by getters:
* String ID
* String label
* String description
* `FeatureSet` instance
* A `ClassifierInfo` object, which extends the `ClassifierSpec` used during its creation, adding several metadata fields.

#### Training a classifier
The `train` method takes a `TrainingSpec` object. A `TrainingSpec` contains the following fields:
* A `TrainingData` instance, which wraps a list of `TrainingDocument` instances, which contain the actual feature and label information
* The number of epochs to train over
* The learning rate
* An optional percent training data holdout for testing the classifier
* An optional `TrainingData` instance containing data to test on (either this or percent holdout should be specified)
* An optional boolean "persist" flag. If true, the training set will be persisted on the server, so that multiple training runs can be performed without having to send over the entire set every time.

When training is kicked off, the backend returns an updated `ClassifierInfo` response. If the "persist" flag was set, this response will contain a `TrainingSetInfo` object which has metadata about the persisted training set.

#### Classifying an email
The `Classifier::classify` method is used to get classification results for a `Classifiable` item.  This method generates the input features using its `FeatureSet`, and instantiates the appropriate `AbstractClassificationQuery`.
The classification query returns a `ClassificationResult`, which contains:
* The URL of the underlying text (if provided during the query input)
* The exclusive class label, if available
* An array of `OverlappingClassification` instances, each of which contain the class label and a probability assigned to that class label.

#### MachineLearningBackend
The abstract `MachineLearningBackend` class represents a gateway to a ML server. It accepts `MLQuery` subclasses and invokes callbacks on them; these callbacks have the same return type as the `MLQuery.execute()` method. The backend to be used is specified by the new `zimbraMachineLearningBackendURL` LDAP attribute.

The only implementation of `MachineLearningBackend` in this PR is the `DummyMachineLearningBackend`. This is a mock backend that can be used for testing and development. It has an in-memory "registry" of classifiers, and when "classifying" messages, applies the exclusive and overlapping class labels that are present in email subject. For example, if the the classifier supports exclusive classes `shopping`, `work`, `social` and overlapping classes `important`, an email with the subject "important work message" would be classified as "work" and "important". This lets us test the full classifier system without actually being connected to a functional ML backend.

#### Testing
The `ClassifierManagerTest` class contains unit tests for various aspects of classifier management.



