### PR TITLE
Feature/zcs 3825

### DIFF
--- a/store/src/java-test/com/zimbra/cs/index/query/ItemQueryTest.java
+++ b/store/src/java-test/com/zimbra/cs/index/query/ItemQueryTest.java
@@ -1,0 +1,183 @@
+package com.zimbra.cs.index.query;
+
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.MockProvisioning;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.index.SortBy;
+import com.zimbra.cs.mailbox.DeliveryOptions;
+import com.zimbra.cs.mailbox.Flag;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.mailbox.Message;
+import com.zimbra.cs.service.mail.Search;
+import com.zimbra.cs.service.mail.ServiceTestUtil;
+import com.zimbra.soap.JaxbUtil;
+import com.zimbra.soap.mail.message.SearchRequest;
+import com.zimbra.soap.mail.message.SearchResponse;
+import com.zimbra.soap.type.SearchHit;
+/**
+ * Unit test for {@link ItemQuery}
+ * @author Greg Solovyev
+ *
+ */
+public class ItemQueryTest {
+    private static Mailbox mailbox;
+    @BeforeClass
+    public static void init() throws Exception {
+        MailboxTestUtil.initServer();
+        MockProvisioning prov = new MockProvisioning();
+        prov.createAccount("zero@zimbra.com", "secret", new HashMap<String, Object>());
+        Provisioning.setInstance(prov);
+        mailbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+    }
+
+    @Test
+    public void testSyntax() throws ServiceException {
+        ItemQuery q = (ItemQuery) ItemQuery.create(mailbox, "1,2");
+        Assert.assertEquals(String.format("Q(ITEMID,%s:1,%s:2)", MockProvisioning.DEFAULT_ACCOUNT_ID, MockProvisioning.DEFAULT_ACCOUNT_ID), q.toString());
+
+        q = (ItemQuery) ItemQuery.create(mailbox, "1");
+        Assert.assertEquals(String.format("Q(ITEMID,%s:1)", MockProvisioning.DEFAULT_ACCOUNT_ID), q.toString());
+
+        q = (ItemQuery) ItemQuery.create(mailbox, "all");
+        Assert.assertEquals("Q(ITEMID,all)", q.toString());
+
+        q = (ItemQuery) ItemQuery.create(mailbox, "none");
+        Assert.assertEquals("Q(ITEMID,none)", q.toString());
+
+        q = (ItemQuery) ItemQuery.create(mailbox, "1--10");
+        Assert.assertEquals(String.format("Q(ITEMID,%s:1--%s:10)", MockProvisioning.DEFAULT_ACCOUNT_ID, MockProvisioning.DEFAULT_ACCOUNT_ID), q.toString());
+    }
+
+    @Test
+    public void testAllItemsQuery() throws Exception {
+        Account acct = Provisioning.getInstance().getAccountById(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+
+        DeliveryOptions dopt = new DeliveryOptions().setFolderId(Mailbox.ID_FOLDER_INBOX).setFlags(Flag.BITMASK_UNREAD);
+        mbox.addMessage(null, MailboxTestUtil.generateMessage("test subject"), dopt, null);
+        mbox.addMessage(null, MailboxTestUtil.generateMessage("test subject2"), dopt, null);
+        
+        SearchResponse resp;
+        List<SearchHit> hits;
+        SearchRequest sr = new SearchRequest();
+        sr.setSearchTypes("message");
+        sr.setQuery("item:{all}");
+        sr.setSortBy(SortBy.ATTACHMENT_ASC.toString());
+        resp = doSearch(sr, acct);
+        hits = resp.getSearchHits();
+        Assert.assertEquals("Number of hits", 2, hits.size());
+    }
+
+    @Test
+    public void testNoneItemsQuery() throws Exception {
+        Account acct = Provisioning.getInstance().getAccountById(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+
+        DeliveryOptions dopt = new DeliveryOptions().setFolderId(Mailbox.ID_FOLDER_INBOX).setFlags(Flag.BITMASK_UNREAD);
+        mbox.addMessage(null, MailboxTestUtil.generateMessage("test subject"), dopt, null);
+
+        SearchResponse resp;
+        List<SearchHit> hits;
+        SearchRequest sr = new SearchRequest();
+        sr.setSearchTypes("message");
+        sr.setQuery("item:{none}");
+        sr.setSortBy(SortBy.ATTACHMENT_ASC.toString());
+        resp = doSearch(sr, acct);
+        hits = resp.getSearchHits();
+        Assert.assertEquals("Number of hits", 0, hits.size());
+    }
+
+    @Test
+    public void testOneItemQuery() throws Exception {
+        Account acct = Provisioning.getInstance().getAccountById(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+
+        DeliveryOptions dopt = new DeliveryOptions().setFolderId(Mailbox.ID_FOLDER_INBOX).setFlags(Flag.BITMASK_UNREAD);
+        mbox.addMessage(null, MailboxTestUtil.generateMessage("test subject"), dopt, null);
+        Message msg2 = mbox.addMessage(null, MailboxTestUtil.generateMessage("test subject2"), dopt, null);
+        mbox.addMessage(null, MailboxTestUtil.generateMessage("test subject3"), dopt, null);
+        
+        SearchResponse resp;
+        List<SearchHit> hits;
+        SearchRequest sr = new SearchRequest();
+        sr.setSearchTypes("message");
+        sr.setQuery(String.format("item:{%d}", msg2.getId()));
+        sr.setSortBy(SortBy.ATTACHMENT_ASC.toString());
+        resp = doSearch(sr, acct);
+        hits = resp.getSearchHits();
+        Assert.assertEquals("Number of hits", 1, hits.size());
+        int msgId = Integer.parseInt(hits.get(0).getId());
+        Assert.assertEquals("correct hit 1", msg2.getId(), msgId);
+    }
+
+    @Test
+    public void testListOfItemsQuery() throws Exception {
+        Account acct = Provisioning.getInstance().getAccountById(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+
+        DeliveryOptions dopt = new DeliveryOptions().setFolderId(Mailbox.ID_FOLDER_INBOX).setFlags(Flag.BITMASK_UNREAD);
+        Message msg1 = mbox.addMessage(null, MailboxTestUtil.generateMessage("test subject"), dopt, null);
+        mbox.addMessage(null, MailboxTestUtil.generateMessage("test subject2"), dopt, null);
+        Message msg3 = mbox.addMessage(null, MailboxTestUtil.generateMessage("test subject3"), dopt, null);
+        
+        SearchResponse resp;
+        List<SearchHit> hits;
+        SearchRequest sr = new SearchRequest();
+        sr.setSearchTypes("message");
+        sr.setQuery(String.format("item:{%d,%d}", msg1.getId(), msg3.getId()));
+        sr.setSortBy(SortBy.ATTACHMENT_ASC.toString());
+        resp = doSearch(sr, acct);
+        hits = resp.getSearchHits();
+        Assert.assertEquals("Number of hits", 2, hits.size());
+        int msgId = Integer.parseInt(hits.get(0).getId());
+        Assert.assertEquals("correct hit 1", msg1.getId(), msgId);
+        msgId = Integer.parseInt(hits.get(1).getId());
+        Assert.assertEquals("correct hit 2", msg3.getId(), msgId);
+    }
+
+    @Test
+    public void testrangeOfItemsQuery() throws Exception {
+        Account acct = Provisioning.getInstance().getAccountById(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+
+        DeliveryOptions dopt = new DeliveryOptions().setFolderId(Mailbox.ID_FOLDER_INBOX).setFlags(Flag.BITMASK_UNREAD);
+        Message msg1 = mbox.addMessage(null, MailboxTestUtil.generateMessage("test subject"), dopt, null);
+        Message msg2 = mbox.addMessage(null, MailboxTestUtil.generateMessage("test subject2"), dopt, null);
+        Message msg3 = mbox.addMessage(null, MailboxTestUtil.generateMessage("test subject3"), dopt, null);
+        mbox.addMessage(null, MailboxTestUtil.generateMessage("test subject4"), dopt, null);
+        
+        SearchResponse resp;
+        List<SearchHit> hits;
+        SearchRequest sr = new SearchRequest();
+        sr.setSearchTypes("message");
+        sr.setQuery(String.format("item:{%d--%d}", msg1.getId(), msg3.getId()));
+        sr.setSortBy(SortBy.ATTACHMENT_ASC.toString());
+        resp = doSearch(sr, acct);
+        hits = resp.getSearchHits();
+        Assert.assertEquals("Number of hits", 3, hits.size());
+        int msgId = Integer.parseInt(hits.get(0).getId());
+        Assert.assertEquals("correct hit 1", msg1.getId(), msgId);
+        msgId = Integer.parseInt(hits.get(1).getId());
+        Assert.assertEquals("correct hit 2", msg2.getId(), msgId);
+        msgId = Integer.parseInt(hits.get(2).getId());
+        Assert.assertEquals("correct hit 3", msg3.getId(), msgId);
+    }
+
+    private static SearchResponse doSearch(SearchRequest request, Account acct) throws Exception {
+        Element response = new Search().handle(JaxbUtil.jaxbToElement(request, Element.XMLElement.mFactory),
+                                ServiceTestUtil.getRequestContext(acct));
+        SearchResponse resp = JaxbUtil.elementToJaxb(response, SearchResponse.class);
+        return resp;
+    }
+}

--- a/store/src/java/com/zimbra/cs/db/DbSearch.java
+++ b/store/src/java/com/zimbra/cs/db/DbSearch.java
@@ -389,6 +389,9 @@ public final class DbSearch {
 
         for (Map.Entry<DbSearchConstraints.RangeType, DbSearchConstraints.Range> entry : constraint.ranges.entries()) {
             switch (entry.getKey()) {
+                case ITEMID:
+                    needAnd = needAnd | encodeIntRange("mi.id", (DbSearchConstraints.NumericRange) entry.getValue(), 1, needAnd);
+                    break;
                 case DATE:
                     needAnd = needAnd | encodeDateRange("mi.date", (DbSearchConstraints.NumericRange) entry.getValue(), needAnd);
                     break;

--- a/store/src/java/com/zimbra/cs/index/DBQueryOperation.java
+++ b/store/src/java/com/zimbra/cs/index/DBQueryOperation.java
@@ -348,6 +348,10 @@ public class DBQueryOperation extends QueryOperation {
         getTopLeafConstraint().addSenderRange(min, minInclusive, max, maxIncluisve, bool);
     }
 
+    public void addItemIdRange(int min, boolean minInclusive, int max, boolean maxInclusive, boolean bool) {
+        allResultsQuery = false;
+        getTopLeafConstraint().addItemIdRange(min, minInclusive, max, maxInclusive, bool);
+    }
     public void addConvId(Mailbox mbox, ItemId convId, boolean truth) {
         allResultsQuery = false;
         if (convId.belongsTo(mbox)) { // LOCAL

--- a/store/src/java/com/zimbra/cs/index/DbSearchConstraints.java
+++ b/store/src/java/com/zimbra/cs/index/DbSearchConstraints.java
@@ -809,6 +809,13 @@ public interface DbSearchConstraints extends Cloneable {
             cursorRange = new CursorRange(min, minInclusive, max, maxInclusive, sort);
         }
 
+        public void addItemIdRange(int min, boolean minInclusive, int max, boolean maxInclusive, boolean bool) {
+            if (min < 0 && max < 0) {
+                return;
+            }
+            ranges.put(RangeType.ITEMID, new NumericRange(min, minInclusive, max, maxInclusive, bool));
+        }
+
         void addConvId(int cid, boolean truth) {
 
             if (truth) {
@@ -1427,7 +1434,7 @@ public interface DbSearchConstraints extends Cloneable {
 
     enum RangeType {
         DATE("DATE"), MDATE("MDATE"), MODSEQ("MODSEQ"), SIZE("SIZE"), CONV_COUNT("CONV-COUNT"),
-        CAL_START_DATE("APPT-START"), CAL_END_DATE("APPT-END"), SUBJECT("SUBJECT"), SENDER("FROM");
+        CAL_START_DATE("APPT-START"), CAL_END_DATE("APPT-END"), SUBJECT("SUBJECT"), SENDER("FROM"), ITEMID("ITEMID");
 
         private final String query;
 

--- a/store/src/java/com/zimbra/cs/index/query/ConvQuery.java
+++ b/store/src/java/com/zimbra/cs/index/query/ConvQuery.java
@@ -50,7 +50,7 @@ public final class ConvQuery extends Query {
             convId = new ItemId(convId.getAccountId(), -1 * convId.getId());
             List<ItemId> iidList = new ArrayList<ItemId>(1);
             iidList.add(convId);
-            return new ItemQuery(false, false, iidList);
+            return new ItemQuery(false, false, false, iidList);
         } else {
             return new ConvQuery(convId);
         }

--- a/store/src/java/com/zimbra/cs/index/query/ItemQuery.java
+++ b/store/src/java/com/zimbra/cs/index/query/ItemQuery.java
@@ -52,17 +52,12 @@ public final class ItemQuery extends Query {
             noneQuery = true;
         } else if(str.indexOf("--") > 0) {
             String[] items = str.split("--");
-            for (int i = 0; i < items.length && i < 2; i++) {
-                if (items[i].length() > 0) {
-                    ItemId iid = new ItemId(items[i], mbox.getAccountId());
-                    itemIds.add(iid);
-                }
+            if(items.length != 2) {
+                throw ServiceException.PARSE_ERROR(String.format("Invalid range expression in search query: %s",  str), null);
             }
-            if (itemIds.size() < 2) {
-                noneQuery = true;
-            } else {
-                rangeQuery = true;
-            }
+            itemIds.add(new ItemId(items[0], mbox.getAccountId()));
+            itemIds.add(new ItemId(items[1], mbox.getAccountId()));
+            rangeQuery = true;
         } else {
             String[] items = str.split(",");
             for (int i = 0; i < items.length; i++) {

--- a/store/src/java/com/zimbra/qa/unittest/SharedImapTests.java
+++ b/store/src/java/com/zimbra/qa/unittest/SharedImapTests.java
@@ -2565,4 +2565,102 @@ public abstract class SharedImapTests extends ImapTestBase {
     protected void flushCacheIfNecessary() throws Exception {
         // overridden by tests running against imapd
     }
+
+    @Test(timeout=100000)
+    public void testUidRangeSearch() throws Exception {
+        String subject = "testUidRangeSearch-%d";
+        Mailbox mbox = TestUtil.getMailbox(USER);
+        int numMessages = 2200;
+        assertNotNull("Mailbox for USER", mbox);
+        for(int i=0;i<numMessages;i++) {
+            TestUtil.addMessage(mbox, String.format(subject, i));
+        }
+
+        connection = connectAndSelectInbox();
+        List<Long> results = connection.uidSearch((Object[]) new String[] { "1:* UNDELETED"} );
+        int oneStarResults = results.size();
+
+        //on remote IMAP this results in a search request with 791 item IDs (see ZCS-3557)
+        results = connection.uidSearch((Object[]) new String[] { "10:800 UNDELETED"} );
+        int ten8HundredResults = results.size();
+
+        //on remote IMAP this results in a search request with 2000 item IDs (see ZCS-3557)
+        results = connection.uidSearch((Object[]) new String[] { "1:2000 UNDELETED"} );
+        int oneTwoThousandResults = results.size();
+
+        //on remote IMAP this results in a search request with 1000 item IDs (see ZCS-3557)
+        results = connection.uidSearch((Object[]) new String[] { "1000:1999 UNDELETED"} );
+        int oneThousand3NineResults = results.size();
+
+        /*
+         * The reason for performing all assertions together and reporting all numbers in each assertion message is to get a more complete picture
+         * when tests fail.
+         */
+        assertEquals(String.format("Wrong number of results for 'UID SEARCH 1:* UNDELETED'. Results are: '1:*' : %d, '10:800' : %d, '1:2000' : %d, '1000:1999' : %d", 
+                oneStarResults, ten8HundredResults, oneTwoThousandResults, oneThousand3NineResults), numMessages, oneStarResults);
+        assertEquals(String.format("Wrong number of results for 'UID SEARCH 10:800 UNDELETED'. Results are: '1:*' : %d, '10:800' : %d, '1:2000' : %d, '1000:1999' : %d", 
+                oneStarResults, ten8HundredResults, oneTwoThousandResults, oneThousand3NineResults), 791, ten8HundredResults);
+        assertEquals(String.format("Wrong number of results for 'UID SEARCH 1:2000 UNDELETED'. Results are: '1:*' : %d, '10:800' : %d, '1:2000' : %d, '1000:1999' : %d", 
+                oneStarResults, ten8HundredResults, oneTwoThousandResults, oneThousand3NineResults), 2000, oneTwoThousandResults);
+        assertEquals(String.format("Wrong number of results for 'UID SEARCH 1000:1999 UNDELETED'. Results are: '1:*' : %d, '1000:1999' : %d, '1:2000' : %d, '1000:1999' : %d", 
+                oneStarResults, ten8HundredResults, oneTwoThousandResults, oneThousand3NineResults), 1000, oneThousand3NineResults);
+    }
+
+    @Test(timeout=100000)
+    public void testUidRangeSearchOnVirtualFolder() throws Exception {
+        String subject = "testUidRangeSearch-%d";
+        Mailbox mbox = TestUtil.getMailbox(USER);
+        int numMessages = 2200;
+        assertNotNull("Mailbox for USER", mbox);
+        for(int i=0;i<numMessages;i++) {
+            TestUtil.addMessage(mbox, String.format(subject, i));
+        }
+        String folderName = "InInboxUnread";
+        mbox.createSearchFolder(null, Mailbox.ID_FOLDER_USER_ROOT, folderName, "IN:INBOX IS:UNREAD", "message", "none", 0, (byte)9);
+        connection = connect();
+        connection.login(PASS);
+
+        doListShouldSucceed(connection, "", folderName, Lists.newArrayList(folderName),
+                "Just search folder");
+        List<ListData> listResult = connection.list("", "*");
+        assertNotNull("list result 'list \"\" \"*\"' should not be null", listResult);
+        boolean seenIt = false;
+        for (ListData listEnt : listResult) {
+            if (folderName.equals(listEnt.getMailbox())) {
+                seenIt = true;
+                break;
+            }
+        }
+        assertTrue(String.format("'%s' mailbox not in result of 'list \"\" \"*\"'", folderName), seenIt);
+        connection.select(folderName);
+        List<Long> results = connection.uidSearch((Object[]) new String[] { "1:* UNDELETED"} );
+        int oneStarResults = results.size();
+
+        results = connection.uidSearch((Object[]) new String[] { "10:800 UNDELETED"} );
+        int ten8HundredResults = results.size();
+
+        results = connection.uidSearch((Object[]) new String[] { "1:2000 UNDELETED"} );
+        int oneTwoThousandResults = results.size();
+
+        results = connection.uidSearch((Object[]) new String[] { "1000:1999 UNDELETED"} );
+        int oneThousand1999 = results.size();
+
+        results = connection.uidSearch((Object[]) new String[] { "1000:2100 UNDELETED"} );
+        int oneThousand2100 = results.size();
+
+        /*
+         * The reason for performing all assertions together and reporting all numbers in each assertion message is to get a more complete picture
+         * when tests fail.
+         */
+        assertEquals(String.format("Wrong number of results for 'UID SEARCH 1:* UNDELETED'. Results are: '1:*' : %d, '10:800' : %d, '1:2000' : %d, '1000:1999' : %d, '1000:2100' : %d", 
+                oneStarResults, ten8HundredResults, oneTwoThousandResults, oneThousand1999, oneThousand2100), numMessages, oneStarResults);
+        assertEquals(String.format("Wrong number of results for 'UID SEARCH 10:800 UNDELETED'. Results are: '1:*' : %d, '10:800' : %d, '1:2000' : %d, '1000:1999' : %d, '1000:2100' : %d", 
+                oneStarResults, ten8HundredResults, oneTwoThousandResults, oneThousand1999, oneThousand2100), 791, ten8HundredResults);
+        assertEquals(String.format("Wrong number of results for 'UID SEARCH 1:2000 UNDELETED'. Results are: '1:*' : %d, '10:800' : %d, '1:2000' : %d, '1000:1999' : %d, '1000:2100' : %d", 
+                oneStarResults, ten8HundredResults, oneTwoThousandResults, oneThousand1999, oneThousand2100), 2000, oneTwoThousandResults);
+        assertEquals(String.format("Wrong number of results for 'UID SEARCH 1000:1999 UNDELETED'. Results are: '1:*' : %d, '10:800' : %d, '1:2000' : %d, '1000:1999' : %d, '1000:2100' : %d", 
+                oneStarResults, ten8HundredResults, oneTwoThousandResults, oneThousand1999, oneThousand2100), 1000, oneThousand1999);
+        assertEquals(String.format("Wrong number of results for 'UID SEARCH 1000:2100 UNDELETED'. Results are: '1:*' : %d, '10:800' : %d, '1:2000' : %d, '1000:1999' : %d, '1000:2100' : %d", 
+                oneStarResults, ten8HundredResults, oneTwoThousandResults, oneThousand1999, oneThousand2100), 1101, oneThousand2100);
+    }
 }

--- a/store/src/java/com/zimbra/qa/unittest/TestImapViaEmbeddedRemote.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestImapViaEmbeddedRemote.java
@@ -5,6 +5,8 @@ import java.io.IOException;
 import org.dom4j.DocumentException;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
 
 import com.zimbra.common.localconfig.ConfigException;
 import com.zimbra.common.localconfig.LC;
@@ -35,5 +37,26 @@ public class TestImapViaEmbeddedRemote extends SharedImapTests {
     @Override
     protected int getImapPort() {
         return imapServer.getImapBindPort();
+    }
+
+    @Override
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")  // checking done in called methods
+    @Ignore("ZCS-3810 - range searches are broken on remote IMAP")
+    @Test
+    /**
+     * this is ignored until ZCS-3810 is fixed
+     */
+    public void testUidRangeSearch() throws Exception {
+
+    }
+    @Override
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")  // checking done in called methods
+    @Ignore("ZCS-3810 - virtual folders (search folders) return only up to 1000 items")
+    @Test
+    /**
+     * this is ignored until ZCS-3810 is fixed
+     */
+    public void testUidRangeSearchOnVirtualFolder() throws Exception {
+
     }
 }

--- a/store/src/java/com/zimbra/qa/unittest/TestImapViaEmbeddedRemote.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestImapViaEmbeddedRemote.java
@@ -40,7 +40,7 @@ public class TestImapViaEmbeddedRemote extends SharedImapTests {
     }
 
     @Override
-    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")  // checking done in called methods
+    @SuppressWarnings("PMD")  // checking done in called methods
     @Ignore("ZCS-3810 - range searches are broken on remote IMAP")
     @Test
     /**
@@ -50,7 +50,7 @@ public class TestImapViaEmbeddedRemote extends SharedImapTests {
 
     }
     @Override
-    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")  // checking done in called methods
+    @SuppressWarnings("PMD")  // checking done in called methods
     @Ignore("ZCS-3810 - virtual folders (search folders) return only up to 1000 items")
     @Test
     /**

--- a/store/src/java/com/zimbra/qa/unittest/TestImapViaImapDaemon.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestImapViaImapDaemon.java
@@ -11,6 +11,7 @@ import java.util.Set;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.google.common.collect.Sets;
@@ -308,4 +309,25 @@ import com.zimbra.soap.admin.type.CacheEntryType;
               }
           }
       }
+
+    @Override
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")  // checking done in called methods
+    @Ignore("ZCS-3810 - range searches are broken on remote IMAP")
+    @Test
+    /**
+     * this is ignored until ZCS-3810 is fixed
+     */
+    public void testUidRangeSearch() throws Exception {
+
+    }
+    @Override
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")  // checking done in called methods
+    @Ignore("ZCS-3810 - virtual folders (search folders) return only up to 1000 items")
+    @Test
+    /**
+     * this is ignored until ZCS-3810 is fixed
+     */
+    public void testUidRangeSearchOnVirtualFolder() throws Exception {
+
+    }
   }

--- a/store/src/java/com/zimbra/qa/unittest/TestImapViaImapDaemon.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestImapViaImapDaemon.java
@@ -311,7 +311,7 @@ import com.zimbra.soap.admin.type.CacheEntryType;
       }
 
     @Override
-    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")  // checking done in called methods
+    @SuppressWarnings("PMD")  // checking done in called methods
     @Ignore("ZCS-3810 - range searches are broken on remote IMAP")
     @Test
     /**
@@ -321,7 +321,7 @@ import com.zimbra.soap.admin.type.CacheEntryType;
 
     }
     @Override
-    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")  // checking done in called methods
+    @SuppressWarnings("PMD")  // checking done in called methods
     @Ignore("ZCS-3810 - virtual folders (search folders) return only up to 1000 items")
     @Test
     /**


### PR DESCRIPTION
For ZCS-3825 add id range query to zimbra query syntax and add unit tests for ItemQuery.
Also added IMAP tests from another branch and kept the failing tests ignored for remote IMAP case.