### PR TITLE
Bugfix/zcs 2220wait set cleanup

### DIFF
--- a/store/src/java/com/zimbra/cs/session/SessionCache.java
+++ b/store/src/java/com/zimbra/cs/session/SessionCache.java
@@ -96,6 +96,17 @@ public final class SessionCache {
         return getSessionMap(Session.Type.SOAP).get(accountId);
     }
 
+    public static int countActiveSessionsForAccount(String accountId, Session.Type type) {
+        SessionMap sessionMap = getSessionMap(type);
+        if (sessionMap == null) {
+            return 0;
+        }
+        int num = sessionMap.countActiveSessions(accountId);
+        ZimbraLog.session.trace("SessionCache.countActiveSessionsForAccount(%s,%s)=%d",
+                accountId, type, num);
+        return num;
+    }
+
     public static Collection<Session> getAllSessions(String accountId) {
         if (sShutdown)
             return null;

--- a/store/src/java/com/zimbra/cs/session/SessionCache.java
+++ b/store/src/java/com/zimbra/cs/session/SessionCache.java
@@ -42,6 +42,27 @@ import com.zimbra.cs.util.Zimbra;
  **/
 public final class SessionCache {
 
+    private static final String sRunIdentifier = (System.currentTimeMillis() / 1000) + "." + new java.util.Random().nextInt(100);
+
+    /** The frequency at which we sweep the cache to delete idle sessions. */
+    private static final long SESSION_SWEEP_INTERVAL_MSEC = 1 * Constants.MILLIS_PER_MINUTE;
+
+    private static Log sLog = LogFactory.getLog(SessionCache.class);
+
+    private static final SessionMap[] sSessionMaps;
+        static {
+            sSessionMaps = new SessionMap[Session.Type.values().length];
+            for (Session.Type type : Session.Type.values()) {
+                sSessionMaps[type.getIndex()] = new SessionMap(type);
+            }
+        }
+
+    /** Whether we've received a {@link #shutdown()} call to kill the cache. */
+    private static boolean sShutdown = false;
+
+    /** The ID for the next generated {@link Session}. */
+    private static long sContextSeqNo = 1;
+
     /** Adds a {@link Session} to the cache and assigns it a session ID if it
      *  doesn't already have one.  When a reigistered <code>Session</code> ages
      *  out of the cache due to extended idle time, its {@link Session#doCleanup()}
@@ -50,7 +71,7 @@ public final class SessionCache {
      * @param session  The <code>Session</code> to add to the cache
      * @return the session ID assigned to the <code>Session</code>
      * @see Session#getSessionIdleLifetime() */
-    static String registerSession(Session session) {
+    protected static String registerSession(Session session) {
         if (sShutdown || session == null)
             return null;
 
@@ -126,14 +147,12 @@ public final class SessionCache {
      * @param session  The Session to be removed. */
     public static void clearSession(Session session) {
         Session target = unregisterSession(session);
-        if (target == null)
+        if (target == null) {
             return;
-
-        Session.Type type = target.getSessionType();
-        if (target != null) {
-            assert(!Thread.holdsLock(getSessionMap(type)));
-            target.doCleanup();
         }
+        Session.Type type = target.getSessionType();
+        assert(!Thread.holdsLock(getSessionMap(type)));
+        target.doCleanup();
     }
 
     /** Removes the <tt>Session</tt> from the cache and unsets its session ID.
@@ -181,20 +200,9 @@ public final class SessionCache {
         }
     }
 
-    private static final String sRunIdentifier = (System.currentTimeMillis() / 1000) + "." + new java.util.Random().nextInt(100);
-
-    static String qualifySessionId(String sessionId) {
+    protected static String qualifySessionId(String sessionId) {
         return sRunIdentifier + "." + sessionId;
     }
-
-    //////////////////////////////////////////////////////////////////////////////
-    // Internals below here...
-    //////////////////////////////////////////////////////////////////////////////
-
-    /** The frequency at which we sweep the cache to delete idle sessions. */
-    private static final long SESSION_SWEEP_INTERVAL_MSEC = 1 * Constants.MILLIS_PER_MINUTE;
-
-    static Log sLog = LogFactory.getLog(SessionCache.class);
 
     private static final Session.Type getSessionTypeFromId(String sessionId) {
         if (sessionId == null || sessionId.length() < 2)
@@ -203,33 +211,18 @@ public final class SessionCache {
         return Session.Type.values()[Character.digit(sessionId.charAt(0),10)];
     }
 
-    static final SessionMap[] sSessionMaps;
-        static {
-            sSessionMaps = new SessionMap[Session.Type.values().length];
-            for (Session.Type type : Session.Type.values()) {
-                sSessionMaps[type.getIndex()] = new SessionMap(type);
-            }
-        }
-
     private static final SessionMap getSessionMap(Session.Type type) {
         return sSessionMaps[type.getIndex()];
     }
 
-    /** Whether we've received a {@link #shutdown()} call to kill the cache. */
-    private static boolean sShutdown = false;
-
-    /** The ID for the next generated {@link Session}. */
-    private static long sContextSeqNo = 1;
-
-    synchronized static String getNextSessionId(Session.Type type) {
+    protected synchronized static String getNextSessionId(Session.Type type) {
         return Integer.toString(type.getIndex()) + Long.toString(sContextSeqNo++);
     }
 
-    static void logActiveSessions() {
+    private static void logActiveSessions() {
         StringBuilder accountList = new StringBuilder();
         StringBuilder manySessionsList = new StringBuilder();
         int totalSessions = 0;
-        int totalAccounts = 0;
 
         int sessionTypeCounter[] = new int[Session.Type.values().length];
 
@@ -237,7 +230,6 @@ public final class SessionCache {
             synchronized(sessionMap) {
                 for (SessionMap.AccountSessionMap activeAcct : sessionMap.activeAccounts()) {
                     String accountId = null;
-                    totalAccounts++;
                     int count = 0;
                     for (Session session : activeAcct.values()) {
                         accountId = session.getAuthenticatedAccountId();
@@ -364,9 +356,9 @@ public final class SessionCache {
                     sb.append(typeStr).append("). ").append(totalActive).append(" active sessions remain.");
                     sLog.info(sb.toString());
                 }
+            } catch (OutOfMemoryError e) {
+                Zimbra.halt("Caught out of memory error (in SessionCache timer)", e);
             } catch (Throwable e) { //don't let exceptions kill the timer
-                if (e instanceof OutOfMemoryError)
-                    Zimbra.halt("Caught out of memory error", e);
                 ZimbraLog.session.warn("Caught exception in SessionCache timer", e);
             }
 

--- a/store/src/java/com/zimbra/cs/session/SessionMap.java
+++ b/store/src/java/com/zimbra/cs/session/SessionMap.java
@@ -81,11 +81,13 @@ final class SessionMap {
      *  given user. */
     public synchronized int countActiveSessions(String accountId) {
         AccountSessionMap acctMap = accountSessionMap.get(accountId);
-        if (acctMap != null) {
-            return accountSessionMap.size();
-        } else {
+        if (acctMap == null) {
+            ZimbraLog.session.trace("SessionMap(%s).countActiveSessions(%s) NONE", type, accountId);
             return 0;
         }
+        ZimbraLog.session.trace("SessionMap(%s).countActiveSessions(%s). size=%s",
+                type, accountId, acctMap.size());
+        return acctMap.size();
     }
 
     public synchronized Collection<AccountSessionMap> activeAccounts() {
@@ -119,6 +121,8 @@ final class SessionMap {
      *  returns <tt>null</tt>.  As a side effect, unsets the session ID on
      *  the removed <tt>Session</tt>. */
     public synchronized Session remove(String accountId, String sessionId) {
+        ZimbraLog.session.trace("SessionMap(%s).remove(accountId=%s, sessionId=%s)",
+                type, accountId, sessionId);
         AccountSessionMap acctMap = accountSessionMap.get(accountId);
         if (acctMap != null) {
             Session removed = acctMap.remove(sessionId);
@@ -208,6 +212,8 @@ final class SessionMap {
      *         session ID */
     @VisibleForTesting
     synchronized Session put(String accountId, String sessionId, Session session) {
+        ZimbraLog.session.trace("SessionMap(%s).put(accountId=%s, sessionId=%s, %s)",
+                type, accountId, sessionId, session);
         assert(session != null);
         AccountSessionMap acctMap = accountSessionMap.get(accountId);
         if (acctMap == null) {

--- a/store/src/java/com/zimbra/qa/unittest/TestUtil.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestUtil.java
@@ -1218,61 +1218,43 @@ public class TestUtil extends Assert {
         }
     }
 
-    /**
-     * Returns an authenticated transport for the <tt>zimbra</tt> account.
-     */
-    public static SoapTransport getAdminSoapTransport(Server targetServer) throws SoapFaultException, IOException, ServiceException {
-        SoapHttpTransport transport = new SoapHttpTransport(URLUtil.getAdminURL(targetServer));
-
-        // Create auth element
-        Element auth = new XMLElement(AdminConstants.AUTH_REQUEST);
-        auth.addElement(AdminConstants.E_NAME).setText(LC.zimbra_ldap_user.value());
-        auth.addElement(AdminConstants.E_PASSWORD).setText(LC.zimbra_ldap_password.value());
-
-        // Authenticate and get auth token
-        Element response = transport.invoke(auth);
-        String authToken = response.getElement(AccountConstants.E_AUTH_TOKEN).getText();
-        transport.setAuthToken(authToken);
-        transport.setAdmin(true);
-        return transport;
-    }
-
-    /**
-     * Returns an authenticated transport for the <tt>zimbra</tt> account.
-     */
-    public static SoapTransport getAdminSoapTransport() throws SoapFaultException, IOException, ServiceException {
-        SoapHttpTransport transport = new SoapHttpTransport(getAdminSoapUrl());
-
-        // Create auth element
-        Element auth = new XMLElement(AdminConstants.AUTH_REQUEST);
-        auth.addNonUniqueElement(AdminConstants.E_NAME).setText(LC.zimbra_ldap_user.value());
-        auth.addNonUniqueElement(AdminConstants.E_PASSWORD).setText(LC.zimbra_ldap_password.value());
-
-        // Authenticate and get auth token
-        Element response = transport.invoke(auth);
-        String authToken = response.getElement(AccountConstants.E_AUTH_TOKEN).getText();
-        transport.setAuthToken(authToken);
-        transport.setAdmin(true);
-        return transport;
-    }
-
-    /**
-     * Returns an authenticated transport for the <tt>zimbra</tt> account.
-     */
-    public static SoapTransport getAdminSoapTransport(String adminName, String adminPassword)
-            throws SoapFaultException, IOException, ServiceException {
-        SoapHttpTransport transport = new SoapHttpTransport(getAdminSoapUrl());
-
+    private static SoapTransport getAdminSoapTransport(SoapHttpTransport transport,
+            String adminName, String adminPassword)
+                    throws SoapFaultException, IOException, ServiceException {
         // Create auth element
         Element auth = new XMLElement(AdminConstants.AUTH_REQUEST);
         auth.addNonUniqueElement(AdminConstants.E_NAME).setText(adminName);
         auth.addNonUniqueElement(AdminConstants.E_PASSWORD).setText(adminPassword);
 
         // Authenticate and get auth token
-        Element response = transport.invoke(auth);
+        Element response =  transport.invoke(auth, false /* raw */, true /* noSession value */,
+                null /* requestedAccountId */);
         String authToken = response.getElement(AccountConstants.E_AUTH_TOKEN).getText();
         transport.setAuthToken(authToken);
+        transport.setAdmin(true);
         return transport;
+    }
+
+    /** Returns an authenticated transport for the <tt>zimbra</tt> account. */
+    public static SoapTransport getAdminSoapTransport()
+            throws SoapFaultException, IOException, ServiceException {
+        return getAdminSoapTransport(new SoapHttpTransport(getAdminSoapUrl()),
+                LC.zimbra_ldap_user.value(), LC.zimbra_ldap_password.value());
+    }
+
+    /** Returns an authenticated transport for the <tt>zimbra</tt> account on the target server. */
+    public static SoapTransport getAdminSoapTransport(Server targetServer)
+            throws SoapFaultException, IOException, ServiceException {
+        return getAdminSoapTransport(new SoapHttpTransport(URLUtil.getAdminURL(targetServer)),
+                LC.zimbra_ldap_user.value(), LC.zimbra_ldap_password.value());
+    }
+
+    /**
+     * Returns an authenticated transport for the <tt>adminName</tt> account.
+     */
+    public static SoapTransport getAdminSoapTransport(String adminName, String adminPassword)
+            throws SoapFaultException, IOException, ServiceException {
+        return getAdminSoapTransport(new SoapHttpTransport(getAdminSoapUrl()), adminName, adminPassword);
     }
 
     /**

--- a/store/src/java/com/zimbra/qa/unittest/TestUtil.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestUtil.java
@@ -187,6 +187,7 @@ public class TestUtil extends Assert {
     public static int DEFAULT_WAIT = 200;
     public static final String DEFAULT_PASSWORD = "test123";
     public static boolean fromRunUnitTests = false; /* set if run from within RunUnitTestsRequest */
+    private static boolean sIsCliInitialized = false;
 
     public static boolean accountExists(String userName) throws ServiceException {
         return AccountTestUtil.accountExists(userName);
@@ -336,7 +337,7 @@ public class TestUtil extends Assert {
         return createContact(mbox, Mailbox.ID_FOLDER_CONTACTS, emailAddr);
     }
 
-    static String addDomainIfNecessary(String user) throws ServiceException {
+    protected static String addDomainIfNecessary(String user) throws ServiceException {
         if (StringUtil.isNullOrEmpty(user) || user.contains("@")) {
             return user;
         }
@@ -804,7 +805,7 @@ public class TestUtil extends Assert {
         adminMbox.emptyDumpster();
     }
 
-    static void deleteMessages(ZMailbox mbox, String query) throws ServiceException {
+    protected static void deleteMessages(ZMailbox mbox, String query) throws ServiceException {
         // Delete messages
         ZSearchParams params = new ZSearchParams(query);
         params.setTypes(ZSearchParams.TYPE_MESSAGE);
@@ -817,8 +818,6 @@ public class TestUtil extends Assert {
             mbox.deleteMessage(StringUtil.join(",", ids));
         }
     }
-
-    private static boolean sIsCliInitialized = false;
 
     /**
      * Sets up the environment for command-line unit tests.
@@ -1490,7 +1489,6 @@ public class TestUtil extends Assert {
     public static void updateMailItemChangeDateAndFlag(Mailbox mbox, int itemId, long changeDate, int flagValue)
             throws ServiceException {
         DbConnection conn = DbPool.getConnection(mbox);
-        ;
         try {
             StringBuilder sql = new StringBuilder();
             sql.append("UPDATE ").append(DbMailItem.getMailItemTableName(mbox)).append(" SET change_date = ")
@@ -1534,8 +1532,7 @@ public class TestUtil extends Assert {
     }
 
     public static SoapTransport authUser(String acctName, String password) throws Exception {
-        com.zimbra.soap.type.AccountSelector acct =
-            new com.zimbra.soap.type.AccountSelector(com.zimbra.soap.type.AccountBy.name, acctName);
+        AccountSelector acct = new AccountSelector(com.zimbra.soap.type.AccountBy.name, acctName);
         SoapHttpTransport transport = new SoapHttpTransport(TestUtil.getSoapUrl());
         AuthRequest req = new AuthRequest(acct, password);
         AuthResponse resp = SoapTest.invokeJaxb(transport, req);
@@ -1559,9 +1556,9 @@ public class TestUtil extends Assert {
     }
 
     public static class UserInfo {
-        final String name;
-        Account acct;
-        UserInfo(String acctName) {
+        private final String name;
+        private Account acct;
+        private UserInfo(String acctName) {
             try {
                 acctName = AccountTestUtil.getAddress(acctName);
             } catch (ServiceException e) {
@@ -1570,12 +1567,12 @@ public class TestUtil extends Assert {
             acct = null;
         }
 
-        Mailbox getMailbox() throws ServiceException {
+        protected Mailbox getMailbox() throws ServiceException {
             ensureAcctExists();
             return TestUtil.getMailbox(name);
         }
 
-        ZMailbox getZMailbox() throws ServiceException {
+        protected ZMailbox getZMailbox() throws ServiceException {
             ensureAcctExists();
             return TestUtil.getZMailbox(name);
         }


### PR DESCRIPTION
Various cleanups made whilst investigating ZCS-2220.
Main changes are that SessionMap's countActiveSessions was returning some completely unrelated value and that TestUtil.getAdminSoapTransport was un-necessarily using a session which never gets used (and doesn't get cleaned up until inactivity is spotted) - so stopped that.  Guessing this was the root of why we thought AdminWaitSets were consuming Admin sessions on the mailbox.