### PR TITLE
ZIMBRA-133: Classification Tasks

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -8793,6 +8793,15 @@ public class ZAttrProvisioning {
     public static final String A_zimbraMachineLearningClassifierInfo = "zimbraMachineLearningClassifierInfo";
 
     /**
+     * The names of classifiers to be used for handling known classification
+     * tasks. Format is taskName:classifierLabel[:probThreshold].
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3053)
+    public static final String A_zimbraMachineLearningTaskConfig = "zimbraMachineLearningTaskConfig";
+
+    /**
      * RFC822 email address of this recipient for accepting mail
      */
     @ZAttr(id=3)

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9795,4 +9795,9 @@ TODO: delete them permanently from here
     First part of the URL before the first colon identifies the implementation Factory.
     Only the "zimbra" prefix is currently supported.</desc>
 </attr>
+
+<attr id="3053" name="zimbraMachineLearningTaskConfig" type="string" cardinality="multi" optionalIn="server,globalConfig" flags="serverInherited" since="8.8.6">
+    <desc>The names of classifiers to be used for handling known classification tasks.
+      Format is taskName:classifierLabel[:probThreshold].</desc>
+</attr>
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -27433,6 +27433,149 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * The names of classifiers to be used for handling known classification
+     * tasks. Format is taskName:classifierLabel[:probThreshold].
+     *
+     * @return zimbraMachineLearningTaskConfig, or empty array if unset
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3053)
+    public String[] getMachineLearningTaskConfig() {
+        return getMultiAttr(Provisioning.A_zimbraMachineLearningTaskConfig, true, true);
+    }
+
+    /**
+     * The names of classifiers to be used for handling known classification
+     * tasks. Format is taskName:classifierLabel[:probThreshold].
+     *
+     * @param zimbraMachineLearningTaskConfig new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3053)
+    public void setMachineLearningTaskConfig(String[] zimbraMachineLearningTaskConfig) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMachineLearningTaskConfig, zimbraMachineLearningTaskConfig);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * The names of classifiers to be used for handling known classification
+     * tasks. Format is taskName:classifierLabel[:probThreshold].
+     *
+     * @param zimbraMachineLearningTaskConfig new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3053)
+    public Map<String,Object> setMachineLearningTaskConfig(String[] zimbraMachineLearningTaskConfig, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMachineLearningTaskConfig, zimbraMachineLearningTaskConfig);
+        return attrs;
+    }
+
+    /**
+     * The names of classifiers to be used for handling known classification
+     * tasks. Format is taskName:classifierLabel[:probThreshold].
+     *
+     * @param zimbraMachineLearningTaskConfig new to add to existing values
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3053)
+    public void addMachineLearningTaskConfig(String zimbraMachineLearningTaskConfig) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraMachineLearningTaskConfig, zimbraMachineLearningTaskConfig);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * The names of classifiers to be used for handling known classification
+     * tasks. Format is taskName:classifierLabel[:probThreshold].
+     *
+     * @param zimbraMachineLearningTaskConfig new to add to existing values
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3053)
+    public Map<String,Object> addMachineLearningTaskConfig(String zimbraMachineLearningTaskConfig, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraMachineLearningTaskConfig, zimbraMachineLearningTaskConfig);
+        return attrs;
+    }
+
+    /**
+     * The names of classifiers to be used for handling known classification
+     * tasks. Format is taskName:classifierLabel[:probThreshold].
+     *
+     * @param zimbraMachineLearningTaskConfig existing value to remove
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3053)
+    public void removeMachineLearningTaskConfig(String zimbraMachineLearningTaskConfig) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraMachineLearningTaskConfig, zimbraMachineLearningTaskConfig);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * The names of classifiers to be used for handling known classification
+     * tasks. Format is taskName:classifierLabel[:probThreshold].
+     *
+     * @param zimbraMachineLearningTaskConfig existing value to remove
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3053)
+    public Map<String,Object> removeMachineLearningTaskConfig(String zimbraMachineLearningTaskConfig, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraMachineLearningTaskConfig, zimbraMachineLearningTaskConfig);
+        return attrs;
+    }
+
+    /**
+     * The names of classifiers to be used for handling known classification
+     * tasks. Format is taskName:classifierLabel[:probThreshold].
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3053)
+    public void unsetMachineLearningTaskConfig() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMachineLearningTaskConfig, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * The names of classifiers to be used for handling known classification
+     * tasks. Format is taskName:classifierLabel[:probThreshold].
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3053)
+    public Map<String,Object> unsetMachineLearningTaskConfig(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMachineLearningTaskConfig, "");
+        return attrs;
+    }
+
+    /**
      * optional regex used by web client to validate email address
      *
      * @return zimbraMailAddressValidationRegex, or empty array if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -16959,6 +16959,149 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
+     * The names of classifiers to be used for handling known classification
+     * tasks. Format is taskName:classifierLabel[:probThreshold].
+     *
+     * @return zimbraMachineLearningTaskConfig, or empty array if unset
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3053)
+    public String[] getMachineLearningTaskConfig() {
+        return getMultiAttr(Provisioning.A_zimbraMachineLearningTaskConfig, true, true);
+    }
+
+    /**
+     * The names of classifiers to be used for handling known classification
+     * tasks. Format is taskName:classifierLabel[:probThreshold].
+     *
+     * @param zimbraMachineLearningTaskConfig new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3053)
+    public void setMachineLearningTaskConfig(String[] zimbraMachineLearningTaskConfig) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMachineLearningTaskConfig, zimbraMachineLearningTaskConfig);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * The names of classifiers to be used for handling known classification
+     * tasks. Format is taskName:classifierLabel[:probThreshold].
+     *
+     * @param zimbraMachineLearningTaskConfig new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3053)
+    public Map<String,Object> setMachineLearningTaskConfig(String[] zimbraMachineLearningTaskConfig, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMachineLearningTaskConfig, zimbraMachineLearningTaskConfig);
+        return attrs;
+    }
+
+    /**
+     * The names of classifiers to be used for handling known classification
+     * tasks. Format is taskName:classifierLabel[:probThreshold].
+     *
+     * @param zimbraMachineLearningTaskConfig new to add to existing values
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3053)
+    public void addMachineLearningTaskConfig(String zimbraMachineLearningTaskConfig) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraMachineLearningTaskConfig, zimbraMachineLearningTaskConfig);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * The names of classifiers to be used for handling known classification
+     * tasks. Format is taskName:classifierLabel[:probThreshold].
+     *
+     * @param zimbraMachineLearningTaskConfig new to add to existing values
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3053)
+    public Map<String,Object> addMachineLearningTaskConfig(String zimbraMachineLearningTaskConfig, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraMachineLearningTaskConfig, zimbraMachineLearningTaskConfig);
+        return attrs;
+    }
+
+    /**
+     * The names of classifiers to be used for handling known classification
+     * tasks. Format is taskName:classifierLabel[:probThreshold].
+     *
+     * @param zimbraMachineLearningTaskConfig existing value to remove
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3053)
+    public void removeMachineLearningTaskConfig(String zimbraMachineLearningTaskConfig) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraMachineLearningTaskConfig, zimbraMachineLearningTaskConfig);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * The names of classifiers to be used for handling known classification
+     * tasks. Format is taskName:classifierLabel[:probThreshold].
+     *
+     * @param zimbraMachineLearningTaskConfig existing value to remove
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3053)
+    public Map<String,Object> removeMachineLearningTaskConfig(String zimbraMachineLearningTaskConfig, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraMachineLearningTaskConfig, zimbraMachineLearningTaskConfig);
+        return attrs;
+    }
+
+    /**
+     * The names of classifiers to be used for handling known classification
+     * tasks. Format is taskName:classifierLabel[:probThreshold].
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3053)
+    public void unsetMachineLearningTaskConfig() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMachineLearningTaskConfig, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * The names of classifiers to be used for handling known classification
+     * tasks. Format is taskName:classifierLabel[:probThreshold].
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3053)
+    public Map<String,Object> unsetMachineLearningTaskConfig(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMachineLearningTaskConfig, "");
+        return attrs;
+    }
+
+    /**
      * Deprecated since: 8.7.8. deprecated in favor of
      * zimbraAdminOutgoingSieveScriptAfter. Orig desc: outgoing sieve script
      * defined by admin (not able to edit and view from the end user) applied

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -50,7 +50,6 @@ import javax.mail.Address;
 import javax.mail.internet.MimeMessage;
 
 import com.google.common.base.CharMatcher;
-import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -172,6 +171,8 @@ import com.zimbra.cs.mime.ParsedMessage;
 import com.zimbra.cs.mime.ParsedMessage.CalendarPartInfo;
 import com.zimbra.cs.mime.ParsedMessageDataSource;
 import com.zimbra.cs.mime.ParsedMessageOptions;
+import com.zimbra.cs.ml.ClassificationExecutionContext;
+import com.zimbra.cs.ml.classifier.ClassifierManager;
 import com.zimbra.cs.pop3.Pop3Message;
 import com.zimbra.cs.redolog.op.AddDocumentRevision;
 import com.zimbra.cs.redolog.op.AddSearchHistoryEntry;
@@ -10808,6 +10809,14 @@ public class Mailbox implements MailboxStore {
                 } catch (ServiceException e) {
                     ZimbraLog.event.error("unable to determine whether AFFINITY event logging is enabled", e);
                 }
+            }
+            try {
+                ClassificationExecutionContext<Message> executionContext = ClassifierManager.getInstance().getExecutionContext(msg);
+                if (executionContext.hasResolvedTasks()) {
+                    executionContext.execute(msg);
+                }
+            } catch (ServiceException e) {
+                ZimbraLog.ml.error("unable to classify message %s", msg.getId(), e);
             }
         }
     }

--- a/store/src/java/com/zimbra/cs/ml/ClassificationExecutionContext.java
+++ b/store/src/java/com/zimbra/cs/ml/ClassificationExecutionContext.java
@@ -1,0 +1,103 @@
+package com.zimbra.cs.ml;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.ml.classifier.Classifier;
+
+/**
+ * This class is a bridge between the mailbox and the classification system.
+ * It provides a mapping of {@link Classifier} instances to corresponding {@link ClassificationHandler} instances
+ * that lets us execute the known {@link ClassificationTask} definitions.
+ * This abstracts away the details of which classifiers are invoked, as there may not be a one-to-one
+ * correspondence between tasks and classifiers.
+ */
+public class ClassificationExecutionContext<C extends Classifiable> {
+    private Map<String, ClassifierUsageInfo<C>> classifierMap;
+
+    public ClassificationExecutionContext() {
+        classifierMap = new HashMap<>();
+    }
+
+    /**
+     * Link a {@link ClassificationTask} to a {@link Classifier}
+     */
+    public void addClassifierForTask(ClassificationTask<C> task, Classifier<C> classifier) {
+        ClassifierUsageInfo<C> usageInfo = classifierMap.get(classifier.getId());
+        if (usageInfo == null) {
+            usageInfo = new ClassifierUsageInfo<>(classifier);
+            classifierMap.put(classifier.getId(), usageInfo);
+        }
+        usageInfo.addTask(task);
+    }
+
+    /**
+     * Invoke each classifier and handle the classification output accordingly.
+     */
+    public void execute(C item) throws ServiceException {
+        for (ClassifierUsageInfo<C> info: classifierMap.values()) {
+            ClassificationHandler<C> handler = info.getHandler();
+            handler.handle(item, info.getClassifier().classify(item));
+        }
+    }
+
+    /**
+     * Get the {@link ClassificationHandler} for the given classifier
+     */
+    public ClassificationHandler<C> getHandler(Classifier<C> classifier) {
+        ClassifierUsageInfo<C> info = classifierMap.get(classifier.getId());
+        return info == null ? null : info.getHandler();
+    }
+
+    /**
+     * Return a list of all {@link ClassifierUsageInfo} for this execution context
+     */
+    public List<ClassifierUsageInfo<C>> getInfo() {
+        return new ArrayList<ClassifierUsageInfo<C>>(classifierMap.values());
+    }
+
+    /**
+     * Return the {@link ClassifierUsageInfo} for the given classifier for this execution context
+     */
+    public ClassifierUsageInfo<C> getClassifierUsage(Classifier<C> classifier) {
+        return classifierMap.containsKey(classifier.getId()) ? classifierMap.get(classifier.getId()) : new ClassifierUsageInfo<C>(classifier);
+    }
+
+    /**
+     * Returns false if this execution context does not result in any tasks being processed
+     */
+    public boolean hasResolvedTasks() {
+        return !classifierMap.isEmpty();
+    }
+
+    public static class ClassifierUsageInfo<C extends Classifiable> {
+        private Classifier<C> classifier;
+        private ClassificationHandler<C> handler;
+        private List<ClassificationTask<C>> tasks;
+
+        ClassifierUsageInfo(Classifier<C> classifier) {
+            this.classifier = classifier;
+            this.handler = new ClassificationHandler<>();
+            this.tasks = new ArrayList<>();
+        }
+
+        public Classifier<C> getClassifier() {
+            return classifier;
+        }
+
+        public ClassificationHandler<C> getHandler() {
+            return handler;
+        }
+
+        public void addTask(ClassificationTask<C> task) {
+            tasks.add(task);
+        }
+
+        public List<ClassificationTask<C>> getTasks() {
+            return tasks;
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/ClassificationHandler.java
+++ b/store/src/java/com/zimbra/cs/ml/ClassificationHandler.java
@@ -1,0 +1,83 @@
+package com.zimbra.cs.ml;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.ml.callback.ExclusiveClassCallback;
+import com.zimbra.cs.ml.callback.OverlappingClassCallback;
+import com.zimbra.cs.ml.schema.ClassificationResult;
+import com.zimbra.cs.ml.schema.OverlappingClassification;
+
+/**
+ * This class reads classification results represented by {@link TextClasses}
+ * and invokes callbacks based on the class labels.
+ */
+public class ClassificationHandler<C extends Classifiable> {
+
+    private ExclusiveClassCallback<C> exclusiveCallback;
+    private Map<String, OverlappingClassCallback<C>> overlappingCallbacks;
+
+    public ClassificationHandler() {
+        this.overlappingCallbacks = new HashMap<>();
+    }
+
+    public boolean hasExclusiveCallback() {
+        return exclusiveCallback != null;
+    }
+
+    public int getNumOverlappingClassCallbacks() {
+        return overlappingCallbacks.size();
+    }
+
+    public ExclusiveClassCallback<C> getExclusiveClassCallback() {
+        return exclusiveCallback;
+    }
+
+    public Map<String, OverlappingClassCallback<C>> getOverlappingClassCallbacks() {
+        return overlappingCallbacks;
+    }
+
+    public ClassificationHandler(ExclusiveClassCallback<C> exclusiveCallback, Map<String, OverlappingClassCallback<C>> overlappingCallbacks) {
+        this.exclusiveCallback = exclusiveCallback;
+        this.overlappingCallbacks = new HashMap<>();
+        if (overlappingCallbacks != null) {
+            this.overlappingCallbacks.putAll(overlappingCallbacks);
+        }
+    }
+
+    public void setExclusiveClassCallback(ExclusiveClassCallback<C> callback) {
+        this.exclusiveCallback = callback;
+    }
+
+    public void addOverlappingClassCallback(OverlappingClassCallback<C> callback) {
+        overlappingCallbacks.put(callback.getOverlappingClass().toLowerCase(), callback);
+    }
+
+    public void handle(C item, ClassificationResult classification) throws ServiceException {
+        String exclusiveClass = classification.getExclusiveClass();
+        if (exclusiveClass != null && exclusiveCallback != null) {
+            ZimbraLog.ml.debug("executing %s for exclusive class [%s]", exclusiveCallback.getClass().getSimpleName(), exclusiveClass);
+            exclusiveCallback.handle(item, exclusiveClass);
+        }
+        OverlappingClassification[] overlapping = classification.getOverlappingClasses();
+        if (overlapping != null) {
+            for (OverlappingClassification c: overlapping) {
+                OverlappingClassCallback<C> callback = overlappingCallbacks.get(c.getLabel().toLowerCase());
+                if (callback == null) {
+                    ZimbraLog.ml.debug("no callback specified for overlapping class [%s]", c.getLabel());
+                } else {
+                    float threshold = callback.getThreshold();
+                    if (threshold == 0) {
+                        ZimbraLog.ml.debug("probability threshold not set for overlapping class [%s]", c.getLabel());
+                        continue;
+                    } else if (c.getProb() >= threshold) {
+                        ZimbraLog.ml.debug("prob %.2f > threshold %.2f, executing %s for overlapping class [%s]", c.getProb(), threshold, callback.getClass().getSimpleName(), callback.getOverlappingClass());
+                        callback.handle(item);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/ClassificationTask.java
+++ b/store/src/java/com/zimbra/cs/ml/ClassificationTask.java
@@ -1,0 +1,158 @@
+package com.zimbra.cs.ml;
+
+import java.util.Set;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.Sets;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.ml.callback.ClassificationCallback;
+import com.zimbra.cs.ml.callback.ExclusiveClassCallback;
+import com.zimbra.cs.ml.callback.OverlappingClassCallback;
+import com.zimbra.cs.ml.classifier.Classifier;
+import com.zimbra.cs.ml.classifier.ClassifierManager;
+import com.zimbra.cs.ml.schema.ClassifierInfo;
+
+/**
+ * This class represents a known task to be performed with the classification system.
+ */
+public abstract class ClassificationTask<C extends Classifiable> {
+
+    private String taskName;
+    private ClassificationType taskType;
+    protected ExclusiveClassCallback<C> exclusiveCallback;
+
+    public static enum ClassificationType {
+        BINARY, MULTI_LABEL;
+    }
+
+    public ClassificationTask(String taskName, ClassificationType taskType) {
+        this.taskName = taskName;
+        this.taskType = taskType;
+    }
+
+    public String getTaskName() {
+        return taskName;
+    }
+
+    public ClassificationType getTaskType() {
+        return taskType;
+    }
+
+    public ClassificationTask<C> withExclusiveClassCallback(ExclusiveClassCallback<C> callback) {
+        this.exclusiveCallback = callback;
+        return this;
+    }
+
+    public boolean supportsClassifier(Classifier<C> classifier) {
+        if (exclusiveCallback == null) {
+            return false;
+        }
+        Set<String> classifierExclusiveClasses = Sets.newHashSet(classifier.getInfo().getExclusiveClasses());
+        return classifierExclusiveClasses.containsAll(exclusiveCallback.getExclusiveClasses());
+    }
+
+    protected abstract void checkCanRegister() throws ServiceException;
+
+    public void register() {
+        try {
+            checkCanRegister();
+            ZimbraLog.ml.info("registering classification task %s", taskName);
+            ClassifierManager.getInstance().registerClassificationTask(this);
+        } catch (ServiceException e) {
+            ZimbraLog.ml.error("unable to register classification task %s", taskName, e);
+        }
+    }
+
+    /**
+     * Given a classifier, return the appropriate callback
+     */
+    public ClassificationCallback<C> resolveCallback(Classifier<C> classifier) throws ServiceException {
+        String[] exclusiveClasses = classifier.getInfo().getExclusiveClasses();
+        if (exclusiveClasses == null) {
+            String errMsg = String.format("cannot determine classification callback for task '%s' with classifier '%s'", taskName, classifier.getLabel());
+            throw ServiceException.FAILURE(errMsg, null);
+        } else {
+            return exclusiveCallback;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this)
+                .add("task", taskName)
+                .add("type", taskType.name()).toString();
+    }
+
+    /**
+     * Definition of a multi-label classification task where the output is zero or one of
+     * a set of possible labels.
+     * Multi-label classification tasks must be handled with exclusive class callbacks.
+     */
+    public static class MultilabelClassificationTask<C extends Classifiable> extends ClassificationTask<C> {
+
+        public MultilabelClassificationTask(String taskName) {
+            super(taskName, ClassificationType.MULTI_LABEL);
+        }
+
+        @Override
+        protected void checkCanRegister() throws ServiceException {
+            if (exclusiveCallback == null) {
+                throw ServiceException.FAILURE("ExclusiveClassCallback must be specified prior to registering MultilabelClassificationTask", null);
+            }
+        }
+    }
+
+    /**
+     * Definition of a binary classification task.
+     * Binary classification tasks can be handled with either overlapping or exclusive class callbacks.
+     */
+    public static class BinaryClassificationTask<C extends Classifiable> extends ClassificationTask<C> {
+
+        private OverlappingClassCallback<C> overlappingCallback;
+
+        public BinaryClassificationTask(String taskName) {
+            super(taskName, ClassificationType.BINARY);
+        }
+
+        @Override
+        public ClassificationCallback<C> resolveCallback(Classifier<C> classifier) throws ServiceException {
+            ClassifierInfo info = classifier.getInfo();
+            String[] overlappingClasses = info.getOverlappingClasses();
+            if (overlappingClasses != null && overlappingCallback != null) {
+                for (String oc: overlappingClasses) {
+                    if (oc.equalsIgnoreCase(overlappingCallback.getOverlappingClass())) {
+                        return overlappingCallback;
+                    }
+                }
+            }
+            return super.resolveCallback(classifier);
+        }
+
+        public BinaryClassificationTask<C> withOverlappingClassCallback(OverlappingClassCallback<C> callback) {
+            this.overlappingCallback = callback;
+            return this;
+        }
+
+        @Override
+        public boolean supportsClassifier(Classifier<C> classifier) {
+            //the classifier needs to match EITHER the matching or exclusive callback class labels
+            boolean matchesOverlappingCallback = false;
+            boolean matchesExclusiveCallback = false;
+            if (overlappingCallback != null) {
+                String overlappingClassLabel = overlappingCallback.getOverlappingClass();
+                Set<String> classifierOverlappingLabels = Sets.newHashSet(classifier.getInfo().getOverlappingClasses());
+                matchesOverlappingCallback = classifierOverlappingLabels.contains(overlappingClassLabel);
+            }
+            matchesExclusiveCallback = super.supportsClassifier(classifier);
+            return matchesOverlappingCallback || matchesExclusiveCallback;
+        }
+
+        @Override
+        protected void checkCanRegister() throws ServiceException {
+            if (exclusiveCallback == null && overlappingCallback == null) {
+                throw ServiceException.FAILURE("ExclusiveClassCallback or OverlappingClassCallback must be specified prior to registering BinaryClassificationTask", null);
+            }
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/ClassificationTaskConfigProvider.java
+++ b/store/src/java/com/zimbra/cs/ml/ClassificationTaskConfigProvider.java
@@ -1,0 +1,61 @@
+package com.zimbra.cs.ml;
+
+import java.util.Map;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.Pair;
+import com.zimbra.cs.ml.classifier.Classifier;
+import com.zimbra.cs.ml.classifier.ClassifierManager;
+
+public abstract class ClassificationTaskConfigProvider {
+
+    /**
+     * Provides a mapping of classification tasks to the labels of classifiers to use for each task
+     */
+    public abstract Map<String, TaskConfig> getConfigMap();
+
+    /**
+     * Assign a classifier to a task with a given overlapping class threshold
+     */
+    @SuppressWarnings("unchecked")
+    public <C extends Classifiable> void assignClassifier(String taskName, Classifier<C> classifier, Float threshold) throws ServiceException {
+        ClassificationTask<C> task = (ClassificationTask<C>) ClassifierManager.getInstance().getTaskByName(taskName);
+        if (!task.supportsClassifier(classifier)) {
+            throw ServiceException.FAILURE(String.format("classifier \"%s\" cannot be assigned to task \"%s\"", classifier.getLabel(), taskName), null);
+        }
+        assign(taskName, classifier.getLabel(), threshold);
+    }
+
+    /**
+     * Assign a classifier to a task
+     */
+    public <C extends Classifiable> void assignClassifier(String taskName, Classifier<C> classifier) throws ServiceException {
+        assignClassifier(taskName, classifier, null);
+    }
+
+    protected abstract void assign(String taskName, String classifierLabel, Float threshold) throws ServiceException;
+
+    /**
+     * Remove the classifier assigned to the given task
+     */
+    public abstract void clearAssignment(String taskName) throws ServiceException;
+
+    public static class TaskConfig extends Pair<String, Float> {
+
+        public TaskConfig(String classifierLabel) {
+            this(classifierLabel, null);
+        }
+
+        public TaskConfig(String classifierLabel, Float threshold) {
+            super(classifierLabel, threshold);
+        }
+
+        public String getClassifierLabel() {
+            return getFirst();
+        }
+
+        public Float getThreshold() {
+            return getSecond();
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/LdapClassificationTaskConfigProvider.java
+++ b/store/src/java/com/zimbra/cs/ml/LdapClassificationTaskConfigProvider.java
@@ -1,0 +1,96 @@
+package com.zimbra.cs.ml;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.common.base.Strings;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.Server;
+
+/**
+ * Classification task configuration stored in the zimbraMachineLearningTaskConfig LDAP attribute.
+ */
+public class LdapClassificationTaskConfigProvider extends ClassificationTaskConfigProvider {
+
+    private Map<String, TaskConfig> taskClassifierMap = new HashMap<>();
+    private Map<String, String> ldapValueMap = new HashMap<>();
+
+    public LdapClassificationTaskConfigProvider() throws ServiceException {
+        parseConfigs(getLocalServer().getMachineLearningTaskConfig());
+    }
+
+    private Server getLocalServer() throws ServiceException {
+        return Provisioning.getInstance().getLocalServer();
+    }
+
+    private static String toLdapValue(String taskName, String classifierLabel) {
+        return String.format("%s:%s", taskName, classifierLabel);
+    }
+
+    private static String toLdapValue(String taskName, String classifierLabel, float threshold) {
+        return String.format("%s:%s:%.2f", taskName, classifierLabel, threshold);
+    }
+
+    private void parseConfigs(String[] configStrings) {
+        if (configStrings == null) {
+            ZimbraLog.ml.warn("no classifier configuration found in LDAP");
+        }
+        for (String configString: configStrings) {
+            parseConfig(configString);
+        }
+    }
+
+    private void parseConfig(String configStr) {
+        String[] toks = configStr.split(":");
+        if (toks.length < 2 || toks.length > 3) {
+            ZimbraLog.ml.warn("incorrect classifier configuration string: %s", configStr);
+            return;
+        }
+        String taskName = toks[0];
+        String classifierLabel = toks[1];
+        TaskConfig taskConfig;
+        if (toks.length == 3) {
+            float threshold;
+            try {
+                threshold = Float.parseFloat(toks[2]);
+            } catch (NumberFormatException e) {
+                ZimbraLog.ml.warn("incorrect probability threshold: %s", toks[2]);
+                return;
+            }
+            taskConfig = new TaskConfig(classifierLabel, threshold);
+        } else {
+            taskConfig = new TaskConfig(classifierLabel);
+        }
+        taskClassifierMap.put(taskName, taskConfig);
+        ldapValueMap.put(taskName, configStr);
+    }
+
+    @Override
+    public Map<String, TaskConfig> getConfigMap() {
+        return taskClassifierMap;
+    }
+
+
+    @Override
+    protected void assign(String taskName, String classifierLabel, Float threshold) throws ServiceException {
+        TaskConfig curAssignment = taskClassifierMap.get(taskName);
+        if (curAssignment != null) {
+            clearAssignment(taskName);
+        }
+        String encoded = threshold != null ? toLdapValue(taskName, classifierLabel, threshold) : toLdapValue(taskName, classifierLabel);
+        ldapValueMap.put(taskName, encoded);
+        taskClassifierMap.put(taskName,  new TaskConfig(classifierLabel, threshold));
+        getLocalServer().addMachineLearningTaskConfig(encoded);
+    }
+
+    @Override
+    public void clearAssignment(String taskName) throws ServiceException {
+        String assignedClassifier = ldapValueMap.get(taskName);
+        if (!Strings.isNullOrEmpty(assignedClassifier)) {
+            getLocalServer().removeMachineLearningTaskConfig(ldapValueMap.get(taskName));
+            taskClassifierMap.remove(taskName);
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/ml/callback/ClassificationCallback.java
+++ b/store/src/java/com/zimbra/cs/ml/callback/ClassificationCallback.java
@@ -1,0 +1,5 @@
+package com.zimbra.cs.ml.callback;
+
+import com.zimbra.cs.ml.Classifiable;
+
+public abstract class ClassificationCallback<C extends Classifiable> {}

--- a/store/src/java/com/zimbra/cs/ml/callback/ExclusiveClassCallback.java
+++ b/store/src/java/com/zimbra/cs/ml/callback/ExclusiveClassCallback.java
@@ -1,0 +1,26 @@
+package com.zimbra.cs.ml.callback;
+
+import java.util.Set;
+
+import com.google.common.collect.Sets;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.ml.Classifiable;
+
+public abstract class ExclusiveClassCallback<C extends Classifiable> extends ClassificationCallback<C> {
+
+    private Set<String> exclusiveClasses;
+
+    public ExclusiveClassCallback(String... exclusiveClasses) {
+        this(Sets.newHashSet(exclusiveClasses));
+    }
+
+    public ExclusiveClassCallback(Set<String> exclusiveClasses) {
+        this.exclusiveClasses = exclusiveClasses;
+    }
+
+    public Set<String> getExclusiveClasses() {
+        return exclusiveClasses;
+    }
+
+    public abstract void handle(C item, String exclusiveClassLabel) throws ServiceException;
+}

--- a/store/src/java/com/zimbra/cs/ml/callback/OverlappingClassCallback.java
+++ b/store/src/java/com/zimbra/cs/ml/callback/OverlappingClassCallback.java
@@ -1,0 +1,33 @@
+package com.zimbra.cs.ml.callback;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.ml.Classifiable;
+
+public abstract class OverlappingClassCallback<C extends Classifiable> extends ClassificationCallback<C> {
+
+    private float threshold;
+    private String overlappingClass;
+
+    public OverlappingClassCallback(String label) {
+        this(label, 0);
+    }
+
+    public OverlappingClassCallback(String overlappingClass, float threshold) {
+        this.overlappingClass = overlappingClass;
+        this.threshold = threshold;
+    }
+
+    public String getOverlappingClass() {
+        return overlappingClass;
+    }
+
+    public void setThreshold(float threshold) {
+        this.threshold = threshold;
+    }
+
+    public float getThreshold() {
+        return threshold;
+    }
+
+    public abstract void handle(C item) throws ServiceException;
+}

--- a/store/src/java/com/zimbra/cs/ml/classifier/ClassifierManager.java
+++ b/store/src/java/com/zimbra/cs/ml/classifier/ClassifierManager.java
@@ -1,11 +1,28 @@
 package com.zimbra.cs.ml.classifier;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Joiner;
+import com.google.common.collect.Sets;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.ml.Classifiable;
+import com.zimbra.cs.ml.ClassificationExecutionContext;
+import com.zimbra.cs.ml.ClassificationExecutionContext.ClassifierUsageInfo;
+import com.zimbra.cs.ml.ClassificationHandler;
+import com.zimbra.cs.ml.ClassificationTask;
+import com.zimbra.cs.ml.ClassificationTaskConfigProvider;
+import com.zimbra.cs.ml.ClassificationTaskConfigProvider.TaskConfig;
+import com.zimbra.cs.ml.LdapClassificationTaskConfigProvider;
+import com.zimbra.cs.ml.callback.ClassificationCallback;
+import com.zimbra.cs.ml.callback.ExclusiveClassCallback;
+import com.zimbra.cs.ml.callback.OverlappingClassCallback;
 import com.zimbra.cs.ml.query.CreateClassifierQuery;
 import com.zimbra.cs.ml.query.DeleteClassifierQuery;
 import com.zimbra.cs.ml.query.ListClassifiersQuery;
@@ -19,8 +36,12 @@ import com.zimbra.cs.ml.schema.ClassifierSpec;
 public class ClassifierManager {
 
     private ClassifierRegistry registry;
+    private Map<String, ClassificationTask<?>> taskNameMap;
 
     private static ClassifierManager instance = null;
+
+    //type-safe map of classification execution contexts keyed by their parameterized types
+    private Map<Class<? extends Classifiable>, ClassificationExecutionContext<? extends Classifiable>> executionContextCache;
 
     private ClassifierManager() throws ServiceException {
         this(new LdapClassifierRegistry());
@@ -28,6 +49,8 @@ public class ClassifierManager {
 
     private ClassifierManager(ClassifierRegistry registry) {
         this.registry = registry;
+        this.taskNameMap = new HashMap<>();
+        this.executionContextCache = new HashMap<>();
     }
 
     public void setRegistry(ClassifierRegistry registry) {
@@ -40,6 +63,119 @@ public class ClassifierManager {
         }
         return instance;
 
+    }
+
+    private <T extends Classifiable> void storeExecutionContext(Class<T> key, ClassificationExecutionContext<T> context) {
+        executionContextCache.put(key, context);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T extends Classifiable> ClassificationExecutionContext<T> getExecutionContext(T item) throws ServiceException {
+        Class<T> klass = (Class<T>) item.getClass();
+        ClassificationExecutionContext<T> context = (ClassificationExecutionContext<T>) executionContextCache.get(klass);
+        if (context == null) {
+            context = resolveConfig(new LdapClassificationTaskConfigProvider());
+            storeExecutionContext(klass, context);
+        }
+        return context;
+    }
+
+    public <T extends Classifiable> void clearExecutionContextCache() {
+        executionContextCache.clear();
+    }
+
+    /**
+     * Register a known {@link MachineLearningTask} with the classifier system.
+     */
+    public <T extends Classifiable> void registerClassificationTask(ClassificationTask<T> task) throws ServiceException {
+        String taskName = task.getTaskName();
+        if (taskNameMap.containsKey(taskName)) {
+            throw ServiceException.FAILURE(String.format("Classification task with name \"%s\" already exists", taskName), null);
+        }
+        taskNameMap.put(taskName, task);
+    }
+
+    /**
+     * Delete a given classification task and clear its task assignment from the given {@link ClassificationTaskConfigProvider}
+     */
+    public void deleteClassificationTask(String taskName, ClassificationTaskConfigProvider taskConfig) throws ServiceException {
+        taskNameMap.remove(taskName);
+        taskConfig.clearAssignment(taskName);
+    }
+
+    /**
+     * Return a {@link ClassificationExecutionContext} for the given classification configuration.
+     */
+    @SuppressWarnings("unchecked")
+    @VisibleForTesting
+    <T extends Classifiable> ClassificationExecutionContext<T> resolveConfig(ClassificationTaskConfigProvider configProvider) throws ServiceException {
+        //TODO: this is OK while only Message implements Classifiable, this method uses unsafe casts.
+        //Need to figure out how to get the execution context for a specific Classifiable type.
+        Set<String> resolvedTasks = new HashSet<>();
+        ClassificationExecutionContext<T> context = new ClassificationExecutionContext<T>();
+        Map<String, TaskConfig> configMap = configProvider.getConfigMap();
+        for (Map.Entry<String, TaskConfig> configEntry: configMap.entrySet()) {
+            String taskName = configEntry.getKey();
+            TaskConfig config = configEntry.getValue();
+            String classifierLabel = config.getClassifierLabel();
+            Classifier<T> classifier = null;
+            if (!taskNameMap.containsKey(taskName)) {
+                ZimbraLog.ml.warn("classification config references non-existent classification task \"%s\"", taskName);
+                continue;
+            }
+            try {
+                classifier = (Classifier<T>) getClassifierByLabel(classifierLabel);
+            } catch (ServiceException e) {
+                ZimbraLog.ml.warn("unable to locate classifier \"%s\" to use for classification task '%s'", classifierLabel, taskName);
+                continue;
+            }
+            ClassificationTask<T> task = (ClassificationTask<T>) taskNameMap.get(taskName);
+            context.addClassifierForTask(task, classifier);
+            try {
+                ClassificationCallback<?> callback = task.resolveCallback(classifier);
+                ClassificationHandler<T> handler = context.getHandler(classifier);
+                if (callback instanceof OverlappingClassCallback<?>) {
+                    OverlappingClassCallback<T> ocCallback = (OverlappingClassCallback<T>) callback;
+                    Float threshold = config.getThreshold();
+                    if (threshold == null) {
+                        ZimbraLog.ml.error("probability threshold not specified for classification task \"%s\" for classifier '%s'", taskName, classifier.getLabel());
+                        continue;
+                    }
+                    ocCallback.setThreshold(threshold);
+                    handler.addOverlappingClassCallback(ocCallback);
+                } else if (callback instanceof ExclusiveClassCallback<?>) {
+                    if (handler.hasExclusiveCallback()) {
+                        ZimbraLog.ml.error("classifier resolution found multiple exclusive class callbacks for classifier \"%s\"", classifierLabel);
+                    }
+                    handler.setExclusiveClassCallback((ExclusiveClassCallback<T>) callback);
+                }
+                resolvedTasks.add(task.getTaskName());
+            } catch (ServiceException e) {
+                ZimbraLog.ml.error("unable to resolve callback for classification task '%s' with classifier '%s'", taskName, classifierLabel, e);
+            }
+        }
+        Set<String> unresolved = Sets.difference(taskNameMap.keySet(), resolvedTasks);
+        if (unresolved.size() == 1) {
+            ZimbraLog.ml.warn("classification task %s is not resolved", unresolved.iterator().next());
+        } else if (unresolved.size() > 1) {
+            ZimbraLog.ml.warn("classification tasks %s are not resolved", Joiner.on(", ").join(unresolved));
+        }
+        return context;
+    }
+
+    /**
+     * Retrieve known classification tasks
+     */
+    public List<ClassificationTask<?>> getAllTasks() {
+        return new ArrayList<>(taskNameMap.values());
+    }
+
+    public ClassificationTask<?> getTaskByName(String taskName) throws ServiceException {
+        ClassificationTask<?> task = taskNameMap.get(taskName);
+        if (task == null) {
+            throw ServiceException.FAILURE(String.format("classification task \"%s\" not found", taskName), null);
+        }
+        return task;
     }
 
     /**
@@ -108,8 +244,19 @@ public class ClassifierManager {
      * Delete a classifier from the ML server by its ID.
      */
     public <T extends Classifiable> Classifier<T> deleteClassifier(String classifierId) throws ServiceException {
+        Classifier<T> toDelete = getClassifierById(classifierId);
+        //1. Remove any task assignments for this classifier
+        ClassificationTaskConfigProvider taskConfig = new LdapClassificationTaskConfigProvider();
+        ClassificationExecutionContext<T> context = resolveConfig(taskConfig);
+        ClassifierUsageInfo<T> usage = context.getClassifierUsage(toDelete);
+        for (ClassificationTask<T> task: usage.getTasks()) {
+            ZimbraLog.ml.info("removing classifier %s from task %s", toDelete.getLabel(), task.getTaskName());
+            taskConfig.clearAssignment(task.getTaskName());
+        }
+        //2. Delete the classifier from the ML backend
         new DeleteClassifierQuery(classifierId).execute();
         Classifier<T> deleted = registry.delete(classifierId);
+        //3. Remove the classifier from the local registry
         if (deleted == null) {
             ZimbraLog.ml.warn("No classifier with id=%s found in classifier registry", classifierId);
         }


### PR DESCRIPTION
This PR builds on ZIMBRA-130 to introduce the concept of a _Classification Task_ to the mailbox.

A `ClassificationTask` represents some piece of mailbox functionality that is powered by machine learning; for example, tagging emails with SmartFolders. This task can then be _assigned_ a classifier, at runtime, to power it. Classifier development is an iterative process, requiring experimentation with feature engineering and hyper-parameter tuning; this mechanism allows for classifiers to be "plugging in" without any changes to the mailbox code.

#### Binary vs Multi-Label Tasks
`ClassificationTask` has two subclasses: `BinaryClassificationTask` and` MultilabelClassificationTask`.
The difference between them is that a multi-label task _must_ be handled by exclusive class labels, while a binary task can be handled by either overlapping or exclusive class labels. This is because a binary task can be represented by a single thresholded overlapping class, or by two exclusive classes representing a positive vs negative prediction.

#### Task Registration
A classification task must first be _registered_ with the `ClassifierManager` with a unique name. This allows for tasks to be defined in zimlets or server extensions. When first registered, a task is "unassigned"; that is, no classifier is designated to handle it.

#### Classifier-Task Assignment
A task can be _assigned_ to a classifier using a `ClassificationTaskConfigProvider`. This is an abstract class that manages a mapping from classification task names to `TaskConfig` instances, which are wrappers around a classifier label and an optional probability threshold (used for overlapping class labels).
It is important to note that multiple tasks may be assigned to the same classifier. This is possible due to the classifiers' ability to classify into exclusive/overlapping labels. For example, two binary tasks may be handled by a single classifier as two overlapping labels, or by two classifiers, each using positive/negative exclusive labels.
A classifier can only be assigned to a task if it is _compatible_ with it, which is determined by whether the exclusive/overlapping class labels expected by the task are a subset of the class labels used by the classifier.

The `LdapClassificationTaskConfigProvider` implementation stores task-classifier mappings in the multivalued `zimbraMachineLearningTaskConfig` LDAP attribute.

#### Classification Callbacks
Classification tasks interact with the mailbox using a callback system.
A `ClassificationCallback` represents logic to be invoked depending on class labels returned by `ClassificationResult`. These callbacks are registered during `ClassificationTask` definition.
There are two abstract subclasses:
* An `ExclusiveClassCallback` is instantiated with a set of the possible exclusive class labels; the `handle` method is passed the classified item and the class label. It is up to the method logic to determine what action to take based on this label.
* An `OverlappingClassCallback` is instantiated with a single class label; the `handle` method is invoked with the classified item only if the label probability exceeds the threshold.

#### ClassificationHandler class
A `ClassificationHandler` wraps all callbacks registered for a task. Its `handle` method takes a `Classifiable` item and its corresponding `ClassificationResult` instance and invokes all necessary callbacks.

#### ClassificationExecutionContext class
This is the primary class through which the mailbox should interact with the machine learning system. 
The need for this class arises from the fact that there is not a one-to-one mapping between tasks and classifiers. As described above, a classifier may be assigned to multiple tasks; likewise, some tasks may not have any classifier assignments at all. A `ClassificationExecutionContext` abstracts away the details of task/classifier assignments from the mailbox caller.
A `ClassificationExecutionContext` is constructed using the `ClassifierManager::resolveConfig` method, which takes a `ClassificationTaskConfigProvider` instance. This method iterates over the classifier mappings and assembles a `ClassificationHandler` for each unique classifier. The `execute` method iterates over each classifier and invokes the correct handler.
`ClassificationExecutionContext` instances are cached in `ClassifierManager` using a type-safe heterogeneous map, keyed off the `Classifiable` type that they handle. This avoids having to resolve the classifiers for every incoming message. The `getExecutionContext` method handles fetching an existing context from this cache and resolving it if necessary. The `clearExecutionContextCache` method should be invoked when task assignments are changed.

#### Invocation from Mailbox
The `ReceivedMessageCallback` in the `Mailbox` class invokes `ClassificationExecutionContext::execute` for each incoming email.

#### Testing
The `ClassifierManagerTest` class has been updated with methods for testing classification task registration, assignment, and execution.