### PR TITLE
ZCS-3840 Updating the jackson libraries to the latest one

### DIFF
--- a/soap/ivy.xml
+++ b/soap/ivy.xml
@@ -17,9 +17,11 @@
   <dependency org="commons-cli" name="commons-cli" rev="1.2" />
   <dependency org="org.freemarker" name="freemarker" rev="2.3.23"/>
   <dependency org="log4j" name="log4j" rev="1.2.16" />
-  <dependency org="org.codehaus.jackson" name="jackson-core-asl" rev="1.9.2" />
-  <dependency org="org.codehaus.jackson" name="jackson-mapper-asl" rev="1.9.2" />
-  <dependency org="org.codehaus.jackson" name="jackson-xc" rev="1.9.2" />
+  <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.9.2"/>
+  <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.9.2"/>
+  <dependency org="com.fasterxml.jackson.module" name="jackson-module-jaxb-annotations" rev="2.8.9"/>
+  <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.9.2"/>
+  <dependency org="com.fasterxml.jackson.dataformat" name="jackson-dataformat-xml" rev="2.9.2"/>
   <dependency org="org.apache.james" name="apache-jsieve-core" rev="0.5"/>
   <dependency org="zimbra" name="zm-common" rev="latest.integration" />
   <dependency org="ant-contrib" name="ant-contrib" rev="1.0b3" />

--- a/soap/soapdocs/src/java/com/zimbra/doc/soap/ValueDescription.java
+++ b/soap/soapdocs/src/java/com/zimbra/doc/soap/ValueDescription.java
@@ -22,11 +22,12 @@ import java.util.ArrayList;
 
 import javax.xml.bind.annotation.XmlEnumValue;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.zimbra.soap.type.ZmBoolean;
-import org.codehaus.jackson.annotate.JsonIgnore;
+
 
 public class ValueDescription {
     @JsonIgnore

--- a/soap/soapdocs/src/java/com/zimbra/doc/soap/apidesc/SoapApiAttribute.java
+++ b/soap/soapdocs/src/java/com/zimbra/doc/soap/apidesc/SoapApiAttribute.java
@@ -16,11 +16,12 @@
  */
 package com.zimbra.doc.soap.apidesc;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.zimbra.doc.soap.ValueDescription;
 import com.zimbra.doc.soap.XmlAttributeDescription;
 import com.zimbra.soap.JaxbUtil;
 
-import org.codehaus.jackson.annotate.JsonIgnore;
+
 
 public class SoapApiAttribute {
     private final String name;

--- a/soap/soapdocs/src/java/com/zimbra/doc/soap/apidesc/SoapApiCommand.java
+++ b/soap/soapdocs/src/java/com/zimbra/doc/soap/apidesc/SoapApiCommand.java
@@ -16,8 +16,9 @@
  */
 package com.zimbra.doc.soap.apidesc;
 
-import org.codehaus.jackson.annotate.JsonIgnore;
 
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Strings;
 import com.zimbra.doc.soap.Command;
 

--- a/soap/soapdocs/src/java/com/zimbra/doc/soap/apidesc/SoapApiDescription.java
+++ b/soap/soapdocs/src/java/com/zimbra/doc/soap/apidesc/SoapApiDescription.java
@@ -26,13 +26,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
 
-import org.codehaus.jackson.JsonGenerationException;
-import org.codehaus.jackson.JsonParseException;
-import org.codehaus.jackson.map.JsonMappingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.SerializationConfig;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.zimbra.doc.soap.Command;
@@ -149,8 +148,8 @@ public class SoapApiDescription {
     public void serializeToJson(File outFile)
     throws JsonGenerationException, JsonMappingException, IOException {
         ObjectMapper mapper = new ObjectMapper(); // can reuse, share globally
-        mapper.setSerializationInclusion(JsonSerialize.Inclusion.NON_NULL); // no more null-valued properties
-        mapper.setSerializationConfig(mapper.getSerializationConfig().with(SerializationConfig.Feature.INDENT_OUTPUT));
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL); // no more null-valued properties
+        mapper.configure(SerializationFeature.INDENT_OUTPUT, false);
         mapper.writeValue(outFile, this);
     }
 

--- a/soap/soapdocs/src/java/com/zimbra/doc/soap/apidesc/SoapApiElementArtifact.java
+++ b/soap/soapdocs/src/java/com/zimbra/doc/soap/apidesc/SoapApiElementArtifact.java
@@ -16,7 +16,8 @@
  */
 package com.zimbra.doc.soap.apidesc;
 
-import org.codehaus.jackson.annotate.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
 /**
  * Used for conveying element related information appropriate at a certain level.
  * For instance, ordinary elements have an associated data type

--- a/soap/soapdocs/src/java/com/zimbra/doc/soap/changelog/SoapApiChangeLog.java
+++ b/soap/soapdocs/src/java/com/zimbra/doc/soap/changelog/SoapApiChangeLog.java
@@ -29,9 +29,9 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.PosixParser;
-import org.codehaus.jackson.JsonParseException;
-import org.codehaus.jackson.map.JsonMappingException;
 
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.zimbra.doc.soap.apidesc.SoapApiCommand;

--- a/soap/src/java-test/com/zimbra/soap/JaxbToJsonTest.java
+++ b/soap/src/java-test/com/zimbra/soap/JaxbToJsonTest.java
@@ -35,16 +35,9 @@ import javax.xml.bind.annotation.XmlElements;
 import javax.xml.bind.annotation.XmlMixed;
 import javax.xml.parsers.DocumentBuilder;
 
-import junit.framework.Assert;
-
 import org.apache.log4j.BasicConfigurator;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.codehaus.jackson.map.AnnotationIntrospector;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.SerializationConfig;
-import org.codehaus.jackson.map.introspect.JacksonAnnotationIntrospector;
-import org.codehaus.jackson.xc.JaxbAnnotationIntrospector;
 import org.dom4j.QName;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -52,6 +45,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.zimbra.common.service.ServiceException;
@@ -111,6 +109,8 @@ import com.zimbra.soap.mail.type.FilterTests;
 import com.zimbra.soap.mail.type.InstanceDataInfo;
 import com.zimbra.soap.type.GranteeType;
 import com.zimbra.soap.type.KeyValuePair;
+
+import junit.framework.Assert;
 
 public class JaxbToJsonTest {
     @Rule public TestName testName = new TestName();
@@ -771,9 +771,9 @@ Extract from mailbox.log for creation of this DL by ZWC - demonstrating the diff
         Element eDL = elem.addElement(AdminConstants.E_DL);
         eDL.addAttribute(AdminConstants.A_NAME, "my name");
         eDL.addAttribute(AdminConstants.A_ID, "myId");
-        eDL.addAttribute(AdminConstants.A_DYNAMIC, true);
         eDL.addKeyValuePair("mail", "fun@example.test", AccountConstants.E_A, AccountConstants.A_N);
         eDL.addKeyValuePair("zimbraMailStatus", "enabled", AccountConstants.E_A, AccountConstants.A_N);
+        eDL.addAttribute(AdminConstants.A_DYNAMIC, true);
     }
 
     /**
@@ -1976,7 +1976,7 @@ header="X-Spam-Score"/>
         ObjectMapper mapper = new ObjectMapper();
         mapper.setAnnotationIntrospector(
                 AnnotationIntrospector.pair(new JacksonAnnotationIntrospector(), new JaxbAnnotationIntrospector()));
-        mapper.enable(SerializationConfig.Feature.INDENT_OUTPUT);
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
         return mapper;
     }
 

--- a/soap/src/java/com/zimbra/soap/account/message/GetInfoResponse.java
+++ b/soap/src/java/com/zimbra/soap/account/message/GetInfoResponse.java
@@ -29,8 +29,7 @@ import javax.xml.bind.annotation.XmlElements;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.codehaus.jackson.annotate.JsonPropertyOrder;
-
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -74,7 +73,7 @@ import com.zimbra.soap.type.ZmBoolean;
         "soapURL", "publicURL", "changePasswordURL", "license", "adminURL", "boshURL"})
 @JsonPropertyOrder({"version", "id", "name", "crumb", "lifetime", "adminDelegated", "docSizeLimit", "attSizeLimit",
         "rest", "used", "isTrackingIMAP", "prevSession", "accessed", "recent", "cos", "prefs", "attrs", "zimlets", "props", "identities",
-        "signatures", "dataSources", "childAccounts", "rights", "soapURL", "publicURL", "license", "adminURL", "boshURL"})
+        "signatures", "dataSources", "childAccounts", "discoveredRights", "soapURL", "publicURL", "license", "adminURL", "boshURL"})
 public final class GetInfoResponse {
 
     /**

--- a/soap/src/java/com/zimbra/soap/account/type/AccountZimletDesc.java
+++ b/soap/src/java/com/zimbra/soap/account/type/AccountZimletDesc.java
@@ -17,12 +17,6 @@
 
 package com.zimbra.soap.account.type;
 
-import com.google.common.base.Objects;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-
-import org.codehaus.jackson.annotate.JsonPropertyOrder;
-
 import java.util.Collections;
 import java.util.List;
 
@@ -34,6 +28,10 @@ import javax.xml.bind.annotation.XmlElementRef;
 import javax.xml.bind.annotation.XmlElementRefs;
 import javax.xml.bind.annotation.XmlType;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.google.common.base.Objects;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.zimbra.common.soap.ZimletConstants;
 import com.zimbra.soap.base.ZimletDesc;
 

--- a/soap/src/java/com/zimbra/soap/account/type/Identity.java
+++ b/soap/src/java/com/zimbra/soap/account/type/Identity.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
 
 import com.zimbra.common.soap.AccountConstants;
 
@@ -35,6 +36,7 @@ import com.zimbra.common.soap.AccountConstants;
 
  */
 @XmlAccessorType(XmlAccessType.NONE)
+@XmlType(propOrder = {"name", "id"})
 public class Identity extends AttrsImpl {
 
     // TODO:Want constructor for old style Identity

--- a/soap/src/java/com/zimbra/soap/account/type/ZimletServerExtension.java
+++ b/soap/src/java/com/zimbra/soap/account/type/ZimletServerExtension.java
@@ -17,14 +17,13 @@
 
 package com.zimbra.soap.account.type;
 
-import com.google.common.base.Objects;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 
-import org.codehaus.jackson.annotate.JsonPropertyOrder;
-
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.google.common.base.Objects;
 import com.zimbra.common.soap.ZimletConstants;
 import com.zimbra.soap.base.ZimletServerExtensionInterface;
 

--- a/soap/src/java/com/zimbra/soap/json/JacksonUtil.java
+++ b/soap/src/java/com/zimbra/soap/json/JacksonUtil.java
@@ -22,9 +22,9 @@ import java.io.StringWriter;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlSchema;
 
-import org.codehaus.jackson.map.AnnotationIntrospector;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.SerializationConfig;
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.base.Strings;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
@@ -168,7 +168,7 @@ public final class JacksonUtil {
     public static ObjectMapper getObjectMapper() {
         ObjectMapper mapper = new ObjectMapper();
         mapper.setAnnotationIntrospector(getZimbraIntrospector());
-        mapper.enable(SerializationConfig.Feature.INDENT_OUTPUT);
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
         ZimbraJsonModule zimbraModule = new ZimbraJsonModule();
         // Doesn't appear to work. ZimbraBeanPropertyWriter uses this directly instead.
         // zimbraModule.addSerializer(org.w3c.dom.Element.class, new ZmDomElementJsonSerializer());
@@ -179,7 +179,7 @@ public final class JacksonUtil {
     public static ObjectMapper getWrapRootObjectMapper() {
         ObjectMapper mapper = getObjectMapper();
         // Enable this next line to get everything wrapped with the name of the root element.
-        mapper.enable(SerializationConfig.Feature.WRAP_ROOT_VALUE);
+        mapper.enable(SerializationFeature.WRAP_ROOT_VALUE);
         return mapper;
     }
 }

--- a/soap/src/java/com/zimbra/soap/json/jackson/NameInfo.java
+++ b/soap/src/java/com/zimbra/soap/json/jackson/NameInfo.java
@@ -31,9 +31,9 @@ import javax.xml.bind.annotation.XmlMixed;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.namespace.QName;
 
-import org.codehaus.jackson.map.AnnotationIntrospector;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.introspect.AnnotatedMember;
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import com.google.common.collect.Maps;
 import com.zimbra.soap.json.jackson.annotate.ZimbraJsonArrayForWrapper;
 import com.zimbra.soap.json.jackson.annotate.ZimbraJsonAttribute;

--- a/soap/src/java/com/zimbra/soap/json/jackson/ZimbraBeanPropertyWriter.java
+++ b/soap/src/java/com/zimbra/soap/json/jackson/ZimbraBeanPropertyWriter.java
@@ -22,18 +22,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import javax.xml.namespace.QName;
 import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElements;
 import javax.xml.bind.annotation.XmlElementRef;
 import javax.xml.bind.annotation.XmlElementWrapper;
-import org.codehaus.jackson.JsonGenerationException;
-import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.map.JsonSerializer;
-import org.codehaus.jackson.map.SerializerProvider;
-import org.codehaus.jackson.map.ser.BeanPropertyWriter;
-import org.codehaus.jackson.map.ser.impl.PropertySerializerMap;
+import javax.xml.bind.annotation.XmlElements;
+import javax.xml.namespace.QName;
 
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
+import com.fasterxml.jackson.databind.ser.impl.PropertySerializerMap;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.Element.JSONElement;
 import com.zimbra.common.util.Log;
@@ -75,37 +75,38 @@ import com.zimbra.soap.util.JaxbInfo;
 public class ZimbraBeanPropertyWriter
     extends BeanPropertyWriter
 {
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 7679426432153926727L;
+
     private static final Log LOG = ZimbraLog.soap;
 
     protected final NameInfo nameInfo;
     protected QName wrapperName = null;
     protected QName wrappedName = null;
 
+
     public ZimbraBeanPropertyWriter(BeanPropertyWriter wrapped, NameInfo nameInfo) {
         super(wrapped);
         this.nameInfo = nameInfo;
-        // super-class SHOULD copy this, but just in case it didn't (as was the case with 1.8.0 and 1.8.1):
-        if (_includeInViews == null) {
-            _includeInViews = wrapped.getViews();
-        }
+
     }
 
     public ZimbraBeanPropertyWriter(BeanPropertyWriter wrapped, NameInfo nameInfo, JsonSerializer<Object> serializer) {
-        super(wrapped, serializer);
+        super(wrapped);
+        _serializer = serializer;
         this.nameInfo = nameInfo;
-        // super-class SHOULD copy this, but just in case it didn't (as was the case with 1.8.0 and 1.8.1):
-        if (_includeInViews == null) {
-            _includeInViews = wrapped.getViews();
-        }
     }
 
+    
     @Override
-    public BeanPropertyWriter withSerializer(JsonSerializer<Object> ser) {
+    public void assignSerializer(JsonSerializer<Object> ser) {
         // sanity check to ensure sub-classes override...
         if (getClass() != ZimbraBeanPropertyWriter.class) {
             throw new IllegalStateException("Sub-class does not override 'withSerializer()'; needs to!");
         }
-        return new ZimbraBeanPropertyWriter(this, nameInfo, ser);
+        _serializer = ser;
     }
 
     /**
@@ -122,14 +123,6 @@ public class ZimbraBeanPropertyWriter
             }
             return;
         }
-        // For non-nulls, first: simple check for direct cycles
-        if (value == bean) {
-            _reportSelfReference(bean);
-        }
-        if (_suppressableValue != null && _suppressableValue.equals(value)) {
-            return;
-        }
-
         JsonSerializer<Object> ser = _serializer;
         if (ser == null) {
             Class<?> cls = value.getClass();
@@ -138,6 +131,16 @@ public class ZimbraBeanPropertyWriter
             if (ser == null) {
                 ser = _findAndAddDynamic(map, cls, prov);
             }
+        }
+        // For non-nulls, first: simple check for direct cycles
+        if (value == bean) {
+            if (_handleSelfReference(bean, jgen, prov, ser)) {
+                return;
+            }
+        }
+        
+        if (_suppressableValue != null && _suppressableValue.equals(value)) {
+            return;
         }
 
         if (_typeSerializer != null) {

--- a/soap/src/java/com/zimbra/soap/json/jackson/ZimbraBeanPropertyWriter.java
+++ b/soap/src/java/com/zimbra/soap/json/jackson/ZimbraBeanPropertyWriter.java
@@ -133,10 +133,8 @@ public class ZimbraBeanPropertyWriter
             }
         }
         // For non-nulls, first: simple check for direct cycles
-        if (value == bean) {
-            if (_handleSelfReference(bean, jgen, prov, ser)) {
+        if ((value == bean) && (_handleSelfReference(bean, jgen, prov, ser))) {
                 return;
-            }
         }
         
         if (_suppressableValue != null && _suppressableValue.equals(value)) {

--- a/soap/src/java/com/zimbra/soap/json/jackson/ZimbraBeanSerializer.java
+++ b/soap/src/java/com/zimbra/soap/json/jackson/ZimbraBeanSerializer.java
@@ -18,17 +18,24 @@ package com.zimbra.soap.json.jackson;
 
 import java.io.IOException;
 
-import org.codehaus.jackson.JsonGenerationException;
-import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.map.SerializerProvider;
-import org.codehaus.jackson.map.ser.BeanSerializer;
-
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.BeanSerializer;
 import com.zimbra.common.soap.Element;
 
 /**
  * Zimbra specific BeanSerializer
  */
 public class ZimbraBeanSerializer extends BeanSerializer {
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 52939088950238993L;
+
+
+
+
     public ZimbraBeanSerializer(BeanSerializer src) {
         super(src);
     }

--- a/soap/src/java/com/zimbra/soap/json/jackson/ZimbraBeanSerializerModifier.java
+++ b/soap/src/java/com/zimbra/soap/json/jackson/ZimbraBeanSerializerModifier.java
@@ -18,14 +18,15 @@ package com.zimbra.soap.json.jackson;
 
 import java.util.List;
 
-import org.codehaus.jackson.map.AnnotationIntrospector;
-import org.codehaus.jackson.map.SerializationConfig;
-import org.codehaus.jackson.map.introspect.AnnotatedMember;
-import org.codehaus.jackson.map.introspect.BasicBeanDescription;
-import org.codehaus.jackson.map.ser.BeanPropertyWriter;
-import org.codehaus.jackson.map.ser.BeanSerializer;
-import org.codehaus.jackson.map.ser.BeanSerializerModifier;
-import org.codehaus.jackson.map.JsonSerializer;
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
+import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
+import com.fasterxml.jackson.databind.ser.BeanSerializer;
+import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
+
 
 /**
  * We need a {@link BeanSerializerModifier} to replace default <code>BeanSerializer</code>
@@ -39,21 +40,20 @@ public class ZimbraBeanSerializerModifier extends BeanSerializerModifier
     /* Overridden methods
     /**********************************************************
      */
-
+    
     /**
-     * First thing to do is to find annotations regarding XML serialization,
-     * and wrap collection serializers.
-     */
+      * First thing to do is to find annotations regarding XML serialization,
+      * and wrap collection serializers.
+      */
     @Override
     public List<BeanPropertyWriter> changeProperties(SerializationConfig config,
-            BasicBeanDescription beanDesc, List<BeanPropertyWriter> beanProperties)
-    {
+        BeanDescription beanDesc, List<BeanPropertyWriter> beanProperties) {
         AnnotationIntrospector intr = config.getAnnotationIntrospector();
         for (int i = 0, len = beanProperties.size(); i < len; ++i) {
             BeanPropertyWriter bpw = beanProperties.get(i);
             final AnnotatedMember member = bpw.getMember();
             NameInfo nameInfo = new NameInfo(intr, member, bpw.getName());
-            if (! nameInfo.needSpecialHandling()) {
+            if (!nameInfo.needSpecialHandling()) {
                 continue;
             }
             beanProperties.set(i, new ZimbraBeanPropertyWriter(bpw, nameInfo));
@@ -62,9 +62,8 @@ public class ZimbraBeanSerializerModifier extends BeanSerializerModifier
     }
 
     @Override
-    public JsonSerializer<?> modifySerializer(SerializationConfig config,
-            BasicBeanDescription beanDesc, JsonSerializer<?> serializer)
-    {
+    public JsonSerializer<?> modifySerializer(SerializationConfig config, BeanDescription beanDesc,
+        JsonSerializer<?> serializer) {
         /* First things first: we can only handle real BeanSerializers; question
          * is, what to do if it's not one: throw exception or bail out?
          * For now let's do latter.

--- a/soap/src/java/com/zimbra/soap/json/jackson/ZimbraJsonModule.java
+++ b/soap/src/java/com/zimbra/soap/json/jackson/ZimbraJsonModule.java
@@ -16,14 +16,18 @@
  */
 package com.zimbra.soap.json.jackson;
 
-import org.codehaus.jackson.Version;
-import org.codehaus.jackson.map.module.SimpleModule;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 
 /**
  * Module that augments basic module to handle differences between
  * Zimbra-style JSON and standard Jackson-style JSON.
  */
 public class ZimbraJsonModule extends SimpleModule {
+    /**
+     * 
+     */
+    private static final long serialVersionUID = -4809416138833975969L;
     private final static Version VERSION = new Version(0, 1, 0, null);
 
     public ZimbraJsonModule() {

--- a/soap/src/java/com/zimbra/soap/json/jackson/ZmBooleanSerializer.java
+++ b/soap/src/java/com/zimbra/soap/json/jackson/ZmBooleanSerializer.java
@@ -19,11 +19,10 @@ package com.zimbra.soap.json.jackson;
 
 import java.io.IOException;
 
-import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.map.JsonSerializer;
-import org.codehaus.jackson.map.SerializerProvider;
-
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
 import com.zimbra.soap.type.ZmBoolean;
 
 /**

--- a/soap/src/java/com/zimbra/soap/json/jackson/ZmDomElementJsonSerializer.java
+++ b/soap/src/java/com/zimbra/soap/json/jackson/ZmDomElementJsonSerializer.java
@@ -20,12 +20,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
-
-import org.codehaus.jackson.JsonGenerationException;
-import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.map.SerializerProvider;
-import org.codehaus.jackson.map.ser.std.SerializerBase;
 
 import org.w3c.dom.Attr;
 import org.w3c.dom.Element;
@@ -33,21 +27,35 @@ import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-
 import com.zimbra.common.soap.Element.JSONElement;
 
 public class ZmDomElementJsonSerializer
-extends SerializerBase<Element>
+extends StdSerializer<Element>
 {
+
+
+    /**
+     * 
+     */
+    private static final long serialVersionUID = -2141574675978397686L;
+
+
     public ZmDomElementJsonSerializer() {
         super(Element.class);
     }
-
+    
+    /* (non-Javadoc)
+     * @see com.fasterxml.jackson.databind.ser.std.StdSerializer#serialize(java.lang.Object, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
+     */
     @Override
     public void serialize(Element value, JsonGenerator jgen, SerializerProvider provider)
-    throws IOException, JsonGenerationException {
+        throws IOException {
         jgen.writeStartArray();
         serializeInner(value, jgen, provider, null /* parent namespaceURI */);
         jgen.writeEndArray();

--- a/soap/src/java/com/zimbra/soap/json/jackson/ZmPairAnnotationIntrospector.java
+++ b/soap/src/java/com/zimbra/soap/json/jackson/ZmPairAnnotationIntrospector.java
@@ -16,17 +16,21 @@
  */
 package com.zimbra.soap.json.jackson;
 
+import java.lang.reflect.Field;
+import java.util.HashMap;
+
+import javax.xml.bind.annotation.XmlEnumValue;
 import javax.xml.bind.annotation.XmlValue;
 
-import org.codehaus.jackson.map.AnnotationIntrospector;
-import org.codehaus.jackson.map.introspect.Annotated;
-import org.codehaus.jackson.map.introspect.AnnotatedField;
-import org.codehaus.jackson.map.introspect.AnnotatedMethod;
-import org.codehaus.jackson.map.introspect.JacksonAnnotationIntrospector;
-
-import org.codehaus.jackson.xc.JaxbAnnotationIntrospector;
-
+import com.fasterxml.jackson.databind.PropertyName;
+import com.fasterxml.jackson.databind.introspect.Annotated;
+import com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.databind.util.ClassUtil;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 import com.zimbra.common.soap.Element;
+
 
     /**
      * Zimbra specific annotation introspector.  Mostly based on a pair of annotation introspectors
@@ -36,67 +40,82 @@ import com.zimbra.common.soap.Element;
      * 
      * Enum value handling - Use JaxbAnnotationIntrospector's handling in preference to JacksonAnnotationIntrospector's
      */
-public final class ZmPairAnnotationIntrospector
-extends AnnotationIntrospector.Pair {
+public final class ZmPairAnnotationIntrospector extends AnnotationIntrospectorPair {
+    /**
+         * 
+         */
+        private static final long serialVersionUID = -3110570221665228877L;
+
     public ZmPairAnnotationIntrospector() {
-        super(new JacksonAnnotationIntrospector(), new JaxbAnnotationIntrospector());
+
+        super(new JacksonAnnotationIntrospector(), new
+            JaxbAnnotationIntrospector(TypeFactory.defaultInstance()));
     }
 
-    /**
-     * Pair's findEnumValue won't try for the secondary's results if the primary's results are non-null, but
-     * we need the XmlEnumValue values if available - which only the JaxbAnnotationIntrospector can provide
-     */
-    @Override
-    public String findEnumValue(Enum<?> e) {
-        return super._secondary.findEnumValue(e);
+
+    @Override // since 2.7
+    public String[] findEnumValues(Class<?> enumType, Enum<?>[] enumValues, String[] names) {
+        HashMap<String,String> expl = null;
+        for (Field f : ClassUtil.getDeclaredFields(enumType)) {
+            if (!f.isEnumConstant()) {
+                continue;
+            }
+            XmlEnumValue enumValue = f.getAnnotation(XmlEnumValue.class);
+            if (enumValue == null) {
+                continue;
+            }
+            String n = enumValue.value();
+            if (expl == null) {
+                expl = new HashMap<String,String>();
+            }
+            expl.put(f.getName(), n);
+        }
+        // and then stitch them together if and as necessary
+        if (expl != null) {
+            for (int i = 0, end = enumValues.length; i < end; ++i) {
+                String defName = enumValues[i].name();
+                String explValue = expl.get(defName);
+                if (explValue != null) {
+                    names[i] = explValue;
+                }
+            }
+        }
+        return names;
     }
 
-    /**
-     * We use "_content" for @XmlValue, so need to over-ride JaxbAnnotationIntrospector default "value"
-     * Note: We skip any visibility check if the @XmlValue annotation is present - but that should be safe.
-     */
+
+
+    
     @Override
-    public String findGettablePropertyName(AnnotatedMethod am) {
+    public PropertyName findNameForSerialization(Annotated am) {
         String name = findJaxbValueName(am);
-        return (name != null) ? name : super.findGettablePropertyName(am);
+        PropertyName propName = new PropertyName(name);
+        propName = (!propName.isEmpty()) ? propName : super.findNameForSerialization(am);
+        return propName;
     }
+     
 
-    /**
-     * We use "_content" for @XmlValue, so need to over-ride JaxbAnnotationIntrospector default "value"
-     * Note: We skip any visibility check if the @XmlValue annotation is present - but that should be safe.
-     */
     @Override
-    public String findSerializablePropertyName(AnnotatedField af) {
+    public PropertyName findNameForDeserialization(Annotated af) {
         String name = findJaxbValueName(af);
-        return (name != null) ? name : super.findSerializablePropertyName(af);
+        PropertyName propName = new PropertyName(name);
+        return (!propName.isEmpty()) ? propName : super.findNameForDeserialization(af);
     }
 
-    /**
-     * We use "_content" for @XmlValue, so need to over-ride JaxbAnnotationIntrospector default "value"
-     * Note: We skip any visibility check if the @XmlValue annotation is present - but that should be safe.
-     */
-    @Override
-    public String findSettablePropertyName(AnnotatedMethod am) {
-        String name = findJaxbValueName(am);
-        return (name != null) ? name : super.findSettablePropertyName(am);
-    }
-
-    /**
-     * We use "_content" for @XmlValue, so need to over-ride JaxbAnnotationIntrospector default "value"
-     * Note: We skip any visibility check if the @XmlValue annotation is present - but that should be safe.
-     */
-    @Override
-    public String findDeserializablePropertyName(AnnotatedField af) {
-        String name = findJaxbValueName(af);
-        return (name != null) ? name : super.findDeserializablePropertyName(af);
-    }
-
+    
     /**
      * @return "_content" if the XmlValue annotation is found, otherwise null
      */
     private static String findJaxbValueName(Annotated ae) {
         XmlValue valueInfo = ae.getAnnotation(XmlValue.class);
         return (valueInfo != null) ? Element.JSONElement.A_CONTENT : null;
+    }
+
+    @Override
+    public String findPropertyDefaultValue(Annotated ann) {
+        String name = findJaxbValueName(ann);
+      return (name != null) ? name : super.findPropertyDefaultValue(ann);
+
     }
 
 }

--- a/soap/src/java/com/zimbra/soap/json/jackson/ZmPairAnnotationIntrospector.java
+++ b/soap/src/java/com/zimbra/soap/json/jackson/ZmPairAnnotationIntrospector.java
@@ -72,7 +72,8 @@ public final class ZmPairAnnotationIntrospector extends AnnotationIntrospectorPa
         }
         // and then stitch them together if and as necessary
         if (expl != null) {
-            for (int i = 0, end = enumValues.length; i < end; ++i) {
+            int end = enumValues.length;
+            for (int i = 0; i < end; ++i) {
                 String defName = enumValues[i].name();
                 String explValue = expl.get(defName);
                 if (explValue != null) {

--- a/soap/src/java/com/zimbra/soap/json/jackson/annotate/ZimbraJsonArrayForWrapper.java
+++ b/soap/src/java/com/zimbra/soap/json/jackson/annotate/ZimbraJsonArrayForWrapper.java
@@ -20,9 +20,12 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
 import javax.xml.bind.annotation.XmlElementWrapper;
 
-import org.codehaus.jackson.annotate.JacksonAnnotation;
+import com.fasterxml.jackson.annotation.JacksonAnnotation;
+
+
 
 /**
  * <p>Marker annotation used in Zimbra JAXB classes to affect how they are serialized to Zimbra style JSON.</p>

--- a/soap/src/java/com/zimbra/soap/json/jackson/annotate/ZimbraJsonAttribute.java
+++ b/soap/src/java/com/zimbra/soap/json/jackson/annotate/ZimbraJsonAttribute.java
@@ -20,14 +20,16 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementRef;
 
+import com.fasterxml.jackson.annotation.JacksonAnnotation;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.Element.JSONElement;
 import com.zimbra.common.soap.Element.XMLElement;
 
-import org.codehaus.jackson.annotate.JacksonAnnotation;
+
 
 /**
  * <p>Marker annotation used in Zimbra JAXB classes to affect how they are serialized to Zimbra style JSON.</p>

--- a/soap/src/java/com/zimbra/soap/json/jackson/annotate/ZimbraKeyValuePairs.java
+++ b/soap/src/java/com/zimbra/soap/json/jackson/annotate/ZimbraKeyValuePairs.java
@@ -20,7 +20,9 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.codehaus.jackson.annotate.JacksonAnnotation;
+
+import com.fasterxml.jackson.annotation.JacksonAnnotation;
+
 
 /**
  * <p>Marker annotation used in Zimbra JAXB classes to affect how they are serialized to Zimbra style JSON.</p>

--- a/soap/src/java/com/zimbra/soap/json/jackson/annotate/ZimbraUniqueElement.java
+++ b/soap/src/java/com/zimbra/soap/json/jackson/annotate/ZimbraUniqueElement.java
@@ -20,12 +20,13 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementRef;
 
+import com.fasterxml.jackson.annotation.JacksonAnnotation;
 import com.zimbra.common.soap.Element.JSONElement;
 
-import org.codehaus.jackson.annotate.JacksonAnnotation;
 
 /**
  * <p>Marker annotation used in Zimbra JAXB classes to affect how they are serialized to Zimbra style JSON.</p>

--- a/soap/src/java/com/zimbra/soap/mail/type/EditheaderTest.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/EditheaderTest.java
@@ -11,8 +11,8 @@ import javax.xml.bind.annotation.XmlType;
 
 import org.apache.jsieve.comparators.ComparatorNames;
 import org.apache.jsieve.comparators.MatchTypeTags;
-import org.codehaus.jackson.annotate.JsonPropertyOrder;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.google.common.base.Objects;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AdminConstants;

--- a/soap/src/java/com/zimbra/soap/mail/type/FilterAction.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/FilterAction.java
@@ -25,8 +25,7 @@ import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlValue;
 
-import org.codehaus.jackson.annotate.JsonPropertyOrder;
-
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.google.common.base.Objects;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AdminConstants;

--- a/soap/src/java/com/zimbra/soap/mail/type/FilterRule.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/FilterRule.java
@@ -17,9 +17,6 @@
 
 package com.zimbra.soap.mail.type;
 
-import com.google.common.base.Objects;
-import com.google.common.collect.Lists;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -28,15 +25,16 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElements;
 import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlElements;
 import javax.xml.bind.annotation.XmlType;
 
-import org.codehaus.jackson.annotate.JsonPropertyOrder;
-
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.google.common.base.Objects;
+import com.google.common.collect.Lists;
 import com.zimbra.common.soap.MailConstants;
-import com.zimbra.soap.type.ZmBoolean;
 import com.zimbra.soap.json.jackson.annotate.ZimbraJsonArrayForWrapper;
+import com.zimbra.soap.type.ZmBoolean;
 
 // JsonPropertyOrder added to make sure JaxbToJsonTest.bug65572_BooleanAndXmlElements passes
 @XmlAccessorType(XmlAccessType.NONE)

--- a/soap/src/java/com/zimbra/soap/mail/type/FilterTest.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/FilterTest.java
@@ -28,8 +28,7 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlEnum;
 
-import org.codehaus.jackson.annotate.JsonPropertyOrder;
-
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 import com.zimbra.common.service.ServiceException;

--- a/soap/src/java/com/zimbra/soap/mail/type/FilterTests.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/FilterTests.java
@@ -26,12 +26,14 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElements;
+import javax.xml.bind.annotation.XmlType;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 import com.zimbra.common.soap.MailConstants;
 
 @XmlAccessorType(XmlAccessType.NONE)
+@XmlType(propOrder={"condition", "tests"})
 public final class FilterTests {
 
     /**

--- a/soap/src/java/com/zimbra/soap/mail/type/FilterVariable.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/FilterVariable.java
@@ -22,8 +22,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
 
-import org.codehaus.jackson.annotate.JsonPropertyOrder;
-
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.google.common.base.Objects;
 import com.zimbra.common.soap.MailConstants;
 

--- a/soap/src/java/com/zimbra/soap/mail/type/FilterVariables.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/FilterVariables.java
@@ -26,8 +26,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.codehaus.jackson.annotate.JsonPropertyOrder;
-
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 import com.zimbra.common.soap.MailConstants;

--- a/soap/src/java/com/zimbra/soap/mail/type/NestedRule.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/NestedRule.java
@@ -28,8 +28,7 @@ import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlElements;
 import javax.xml.bind.annotation.XmlType;
 
-import org.codehaus.jackson.annotate.JsonPropertyOrder;
-
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 import com.zimbra.common.soap.MailConstants;

--- a/soap/src/java/com/zimbra/soap/type/ShareInfo.java
+++ b/soap/src/java/com/zimbra/soap/type/ShareInfo.java
@@ -21,8 +21,7 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 
-import org.codehaus.jackson.annotate.JsonPropertyOrder;
-
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.google.common.base.Objects;
 import com.zimbra.common.soap.AccountConstants;
 import com.zimbra.common.soap.MailConstants;

--- a/soap/src/java/com/zimbra/soap/type/ZmBoolean.java
+++ b/soap/src/java/com/zimbra/soap/type/ZmBoolean.java
@@ -21,8 +21,7 @@ import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
 import javax.xml.bind.annotation.XmlType;
 
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.zimbra.soap.json.jackson.ZmBooleanSerializer;
 
 /**

--- a/store/build.xml
+++ b/store/build.xml
@@ -280,10 +280,6 @@
     <ivy:install organisation="org.apache.curator" module="curator-client" revision="2.0.1-incubating" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.apache.curator" module="curator-x-discovery" revision="2.0.1-incubating" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.apache.curator" module="curator-framework" revision="2.0.1-incubating" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
-    <ivy:install organisation="org.codehaus.jackson" module="jackson-core-asl" revision="1.9.2" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
-    <ivy:install organisation="org.codehaus.jackson" module="jackson-smile" revision="1.9.2" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
-    <ivy:install organisation="org.codehaus.jackson" module="jackson-mapper-asl" revision="1.9.2" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
-    <ivy:install organisation="org.codehaus.jackson" module="jackson-xc" revision="1.9.2" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="asm" module="asm" revision="3.3.1" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="oauth" module="oauth" revision="1.4" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="com.googlecode.owasp-java-html-sanitizer" module="owasp-java-html-sanitizer" revision="r239" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>

--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -26,10 +26,6 @@
   <dependency org="org.json" name="json" rev="20090211" />
   <dependency org="javax.servlet" name="javax.servlet-api" rev="3.1.0" />
   <dependency org="ical4j" name="ical4j" rev="0.9.16-patched" />
-  <dependency org="org.codehaus.jackson" name="jackson-core-asl" rev="1.9.2"/>
-  <dependency org="org.codehaus.jackson" name="jackson-smile" rev="1.9.2"/>
-  <dependency org="org.codehaus.jackson" name="jackson-mapper-asl" rev="1.9.2"/>
-  <dependency org="org.codehaus.jackson" name="jackson-xc" rev="1.9.2"/>
   <dependency org="net.spy" name="spymemcached" rev="2.12.1" />
   <dependency org="org.gnu.inet" name="libidn" rev="1.24" />
   <dependency org="commons-cli" name="commons-cli" rev="1.2"/>
@@ -108,6 +104,8 @@
   <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.9.2"/>
   <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.9.2"/>
   <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.9.2"/>
+  <dependency org="com.fasterxml.jackson.dataformat" name="jackson-dataformat-smile" rev="2.9.2" />
+  <dependency org="com.fasterxml.jackson.module" name="jackson-module-jaxb-annotations" rev="2.8.9"/>
   <dependency org="org.apache.commons" name="commons-text" rev="1.1"/>
   <dependency org="org.apache.commons" name="commons-lang3" rev="3.7"/>
   <dependency org="org.apache.commons" name="commons-rng-client-api" rev="1.0"/>

--- a/store/src/java/com/zimbra/cs/index/TermInfo.java
+++ b/store/src/java/com/zimbra/cs/index/TermInfo.java
@@ -22,15 +22,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.base.Objects;
-import com.zimbra.common.util.ZimbraLog;
-
-import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
 import org.apache.lucene.document.Fieldable;
-import org.codehaus.jackson.annotate.JsonProperty;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+import com.zimbra.common.util.ZimbraLog;
+
 
 /**
  * Record of information related to search terms

--- a/store/src/java/com/zimbra/cs/mailbox/Contact.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Contact.java
@@ -32,12 +32,12 @@ import javax.activation.DataSource;
 import javax.mail.internet.MimeMessage;
 import javax.mail.util.ByteArrayDataSource;
 
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Objects;
 import com.google.common.base.Strings;
 import com.google.common.collect.ArrayListMultimap;
@@ -928,7 +928,7 @@ public class Contact extends MailItem {
         ObjectMapper mapper = new ObjectMapper();
         try {
             JsonNode node = mapper.readTree(xpropStr);
-            Iterator<String> fieldNames = node.getFieldNames();
+            Iterator<String> fieldNames = node.fieldNames();
             while (fieldNames.hasNext()) {
                 String fieldName = fieldNames.next();
                 String fieldValue = node.get(fieldName).asText();

--- a/store/src/java/com/zimbra/cs/zookeeper/Service.java
+++ b/store/src/java/com/zimbra/cs/zookeeper/Service.java
@@ -17,7 +17,7 @@
 
 package com.zimbra.cs.zookeeper;
 
-import org.codehaus.jackson.map.annotate.JsonRootName;
+import com.fasterxml.jackson.annotation.JsonRootName;
 
 @JsonRootName("details")
 public class Service {


### PR DESCRIPTION
Remove old jars
jackson-mapper-asl-1.9.13.jar, jackson-core-asl-1.9.13.jar, jackson-xc-1.9.13.jar, jackson-smile-1.9.13.jar
and replaced with new jars jackson-core-2.9.2.jar, jackson-annotations-2.9.2.jar, jackson-databind-2.9.2.jar, jackson-dataformat-smile-2.9.2.jar and jackson-module-jaxb-annotations-2.8.9.jar
Fixed compilation errors and fixed failing unit tests.
Verified all unit tests in soap and store modules pass.
Also verified that soap docs are correctly created.


Tests | Failures | Errors | Skipped | Success rate | Time
1282 | 0 | 0 | 10 | 100.00% | 269.955

