### PR TITLE
ZCS-3971:Refactor ZimbraAuthToken class

### DIFF
--- a/store/docs/soap.txt
+++ b/store/docs/soap.txt
@@ -454,7 +454,7 @@ global soap/system errors used with zimbra:Error/Code:
 Note:
 when tokenType is set as "JWT", token returned in response is a JWT(JasonWebToken).
 
-when specifiying an account, one of <password> or <preauth> must be specified. see preauth.txt for a discussion of preauth.
+when specifying an account, one of <password> or <preauth> must be specified. see preauth.txt for a discussion of preauth.
 
 An authToken can be passed instead of account/password/preauth to validate an existing auth token.
 If verifyAccount="1", <account> is required and the account in the auth token is compared to the named account.
@@ -462,8 +462,9 @@ Mismatch results in auth failure.  An external app that relies on ZCS for user i
 test if the auth token provided by the user belongs to that user.
 If verifyAccount="0" (default), only the auth token is verified and any <account> element specified is ignored.
 
-JWT can also be passed instead of account/password/preauth to validate an existing auth token.when JWT is passed,
+JWT can also be passed instead of account/password/preauth to validate an existing JWT.when JWT is passed,
  ZM_JWT cookie should be set in the request or jwtSalt should be present in the soap context.
+When token type is JWT, authToken element is not supported i.e. JWT can not be issued on the basis of an auth token.
 
   {persistAuthTokenCookie} = controls whether the auth token cookie in the response should 
                              be persisted when the browser exits.

--- a/store/src/java/com/zimbra/cs/account/AuthToken.java
+++ b/store/src/java/com/zimbra/cs/account/AuthToken.java
@@ -22,6 +22,7 @@ package com.zimbra.cs.account;
 
 import java.util.Map;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.httpclient.HttpClient;
@@ -210,6 +211,27 @@ public abstract class AuthToken {
             boolean secureCookie, boolean rememberMe)
     throws ServiceException;
 
+    /**
+     *  It's overridden in ZimbraJWToken class where actions specific to jwt flow have been implemented.
+     *  For other implementations of AuthToken, this method calls an already existing abstract method.
+     */
+    public void encode(HttpServletRequest reqst, HttpServletResponse resp, boolean isAdminReq, boolean secureCookie, boolean rememberMe)
+    throws ServiceException {
+        encode(resp, isAdminReq, secureCookie, rememberMe);
+    }
+
+    /**
+     * This method is needed for ZimbraJWToken class which overrides this method.
+     * At present, it has no significance for other implementations of AuthToken class.
+     * If any implementation want to use this method, they can override it.
+     * Can't keep this method abstract in AuthToken as that would force all existing implementations
+     * of AuthToken to implement this method and it would break code of other people who have overridden
+     * AuthToken class.
+     */
+    public void encode(HttpServletRequest reqst, HttpServletResponse resp, boolean deregister) throws ServiceException {
+        //do nothing
+    }
+
     public abstract void encodeAuthResp(Element parent, boolean isAdmin) throws ServiceException;
 
     public abstract ZAuthToken toZAuthToken() throws ServiceException;
@@ -233,43 +255,6 @@ public abstract class AuthToken {
 
     public abstract Usage getUsage();
 
-    public TokenType getTokenType() {
-        return TokenType.AUTH;
-    }
-
-    public boolean isJWT() {
-        return false;
-    }
-
-    public String getSalt() {
-        return null;
-    }
-
-    public String getId() {
-        return null;
-    }
-
-    public static enum TokenType {
-        AUTH("auth"), JWT("jwt");
-        private String code;
-
-        private TokenType(String code) {
-            this.code = code;
-        }
-
-        public String getCode() {
-            return code;
-        }
-
-        public static TokenType fromCode(String code) throws ServiceException {
-             if ("jwt".equalsIgnoreCase(code)) {
-                 return TokenType.JWT;
-             } else {
-                 return TokenType.AUTH;
-             }
-        }
-    }
-
     public static enum Usage {
         AUTH("a"), ENABLE_TWO_FACTOR_AUTH("etfa"), TWO_FACTOR_AUTH("tfa");
 
@@ -290,6 +275,27 @@ public abstract class AuthToken {
                 }
             }
             throw ServiceException.FAILURE("unknown auth token usage value: " + code, null);
+        }
+    }
+
+    public static enum TokenType {
+        AUTH("auth"), JWT("jwt");
+        private String code;
+
+        private TokenType(String code) {
+            this.code = code;
+        }
+
+        public String getCode() {
+            return code;
+        }
+
+        public static TokenType fromCode(String code) throws ServiceException {
+             if ("jwt".equalsIgnoreCase(code)) {
+                 return TokenType.JWT;
+             } else {
+                 return TokenType.AUTH;
+             }
         }
     }
 }

--- a/store/src/java/com/zimbra/cs/account/AuthTokenProperties.java
+++ b/store/src/java/com/zimbra/cs/account/AuthTokenProperties.java
@@ -1,0 +1,278 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.account;
+
+import java.util.Map;
+import java.util.Random;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.AuthToken.Usage;
+import com.zimbra.cs.account.auth.AuthMechanism.AuthMech;
+
+public class AuthTokenProperties implements Cloneable {
+
+    public static final String C_TYPE_ZIMBRA_USER = "zimbra";
+    public static final String C_TYPE_EXTERNAL_USER = "external";
+    public static final String C_TYPE_ZMG_APP = "zmgapp";
+    public static final String C_ID  = "id";
+    // original admin id
+    public static final String C_AID  = "aid";
+    public static final String C_EXP = "exp";
+    public static final String C_ADMIN = "admin";
+    public static final String C_DOMAIN = "domain";
+    public static final String C_DLGADMIN = "dlgadmin";
+    public static final String C_TYPE = "type";
+    public static final String C_EXTERNAL_USER_EMAIL = "email";
+    public static final String C_DIGEST = "digest";
+    public static final String C_VALIDITY_VALUE  = "vv";
+    public static final String C_AUTH_MECH = "am";
+    public static final String C_USAGE = "u";
+    //cookie ID for keeping track of account's cookies
+    public static final String C_TOKEN_ID = "tid";
+    //mailbox server version where this account resides
+    public static final String C_SERVER_VERSION = "version";
+    public static final String C_CSRF = "csrf";
+    public static final String C_KEY_VERSION = "kv";
+ 
+    private String accountId;
+    private String adminAccountId;
+    private int validityValue = -1;
+    private long expires;
+    private String encoded;
+    private boolean isAdmin;
+    private boolean isDomainAdmin;
+    private boolean isDelegatedAdmin;
+    private String type;
+    private String externalUserEmail;
+    private String digest;
+    private String accessKey; // just a dummy placeholder for now until accesskey auth is implemented in ZimbraAuthToken
+    private String proxyAuthToken;
+    private AuthMech authMech;
+    private Integer tokenID = -1;
+    private String server_version;   // version of the mailbox server where this account resides
+    private boolean csrfTokenEnabled;
+    private Usage usage; // what this token will be used for
+
+    public AuthTokenProperties(Account acct, boolean isAdmin, Account adminAcct, long expires, AuthMech authMech, Usage usage) {
+        if (acct != null) {
+            accountId = acct.getId();
+            validityValue = acct.getAuthTokenValidityValue();
+            this.isAdmin = isAdmin && "TRUE".equals(acct.getAttr(Provisioning.A_zimbraIsAdminAccount));
+            isDomainAdmin = isAdmin && "TRUE".equals(acct.getAttr(Provisioning.A_zimbraIsDomainAdminAccount));
+            isDelegatedAdmin = isAdmin && "TRUE".equals(acct.getAttr(Provisioning.A_zimbraIsDelegatedAdminAccount));
+            if (acct instanceof GuestAccount) {
+                type = C_TYPE_EXTERNAL_USER;
+                GuestAccount g = (GuestAccount) acct;
+                digest = g.getDigest();
+                accessKey = g.getAccessKey();
+                externalUserEmail = g.getName();
+            } else {
+                type = C_TYPE_ZIMBRA_USER;
+            }
+            server_version = getServerVersion(acct);
+        }
+        adminAccountId = adminAcct != null ? adminAcct.getId() : null;
+        this.expires = expires;
+        this.authMech = authMech;
+        this.usage = usage;
+        encoded = null;
+        tokenID = new Random().nextInt(Integer.MAX_VALUE-1) + 1;
+    }
+
+    public AuthTokenProperties(String acctId, boolean zmgApp, String externalEmail, String pass, String digest, long expires) {
+        accountId = acctId;
+        this.expires = expires;
+        externalUserEmail = externalEmail == null && !zmgApp ? "public" : externalEmail;
+        this.digest = digest != null ? digest : AuthToken.generateDigest(externalEmail, pass);
+        this.type = zmgApp ? C_TYPE_ZMG_APP : C_TYPE_EXTERNAL_USER;
+        tokenID = new Random().nextInt(Integer.MAX_VALUE-1) + 1;
+        try {
+            Account acct = Provisioning.getInstance().getAccountById(accountId);
+            if (acct != null) {
+                server_version = getServerVersion(acct);
+            }
+        } catch (ServiceException e) {
+            ZimbraLog.account.error("Unable to get the user account: %s", accountId, e);
+        }
+    }
+
+    public AuthTokenProperties(Map<?, ?> map) throws AuthTokenException {
+        accountId = (String) map.get(C_ID);
+        adminAccountId = (String) map.get(C_AID);
+        expires = Long.parseLong((String) map.get(C_EXP));
+        String ia = (String) map.get(C_ADMIN);
+        isAdmin = "1".equals(ia);
+        String da = (String) map.get(C_DOMAIN);
+        isDomainAdmin = "1".equals(da);
+        String dlga = (String) map.get(C_DLGADMIN);
+        isDelegatedAdmin = "1".equals(dlga);
+        type = (String)map.get(C_TYPE);
+
+        try {
+            String authMechStr = (String)map.get(C_AUTH_MECH);
+            authMech = AuthMech.fromString(authMechStr);
+            String usageCode = (String)map.get(C_USAGE);
+            if (usageCode != null) {
+                usage = Usage.fromCode(usageCode);
+            } else {
+                usage = Usage.AUTH;
+            }
+        } catch (ServiceException e) {
+            throw new AuthTokenException("service exception", e);
+        }
+        externalUserEmail = (String)map.get(C_EXTERNAL_USER_EMAIL);
+        digest = (String)map.get(C_DIGEST);
+        String vv = (String)map.get(C_VALIDITY_VALUE);
+        if (vv != null) {
+            try {
+                validityValue = Integer.parseInt(vv);
+            } catch (NumberFormatException e) {
+                ZimbraLog.account.debug("invalid validity value : %s", vv, e);
+                validityValue = -1;
+            }
+        } else {
+            validityValue = -1;
+        }
+
+        String tid = (String)map.get(C_TOKEN_ID);
+        if(tid !=null) {
+            try {
+                tokenID = Integer.parseInt(tid);
+            } catch (NumberFormatException e) {
+                ZimbraLog.account.debug("invalid token id : %s", tid, e);
+                tokenID = -1;
+            }
+        } else {
+            tokenID = -1;
+        }
+        server_version = (String)map.get(C_SERVER_VERSION);
+
+        String csrf = (String) map.get(C_CSRF);
+        if (csrf != null) {
+            csrfTokenEnabled = "1".equals(map.get(C_CSRF));
+        }
+    }
+
+    private String getServerVersion(Account acct) {
+        String server_version = null;
+        try {
+            Server server = acct.getServer();
+            if (server != null) {
+                server_version = server.getServerVersion();
+            } else {
+                server_version = Provisioning.getInstance().getLocalServer().getServerVersion();
+            }
+        } catch (ServiceException e) {
+            ZimbraLog.account.error("Unable to fetch server version for the user account", e);
+        }
+        return server_version;
+    }
+
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public String getAdminAccountId() {
+        return adminAccountId;
+    }
+
+    public int getValidityValue() {
+        return validityValue;
+    }
+
+    public long getExpires() {
+        return expires;
+    }
+
+    public String getEncoded() {
+        return encoded;
+    }
+
+    public boolean isAdmin() {
+        return isAdmin;
+    }
+
+    public boolean isDomainAdmin() {
+        return isDomainAdmin;
+    }
+
+    public boolean isDelegatedAdmin() {
+        return isDelegatedAdmin;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getExternalUserEmail() {
+        return externalUserEmail;
+    }
+
+    public String getDigest() {
+        return digest;
+    }
+
+    public String getAccessKey() {
+        return accessKey;
+    }
+
+    public String getProxyAuthToken() {
+        return proxyAuthToken;
+    }
+
+    public AuthMech getAuthMech() {
+        return authMech;
+    }
+
+    public Integer getTokenID() {
+        return tokenID;
+    }
+
+    public String getServerVersion() {
+        return server_version;
+    }
+
+    public boolean isCsrfTokenEnabled() {
+        return csrfTokenEnabled;
+    }
+
+    public Usage getUsage() {
+        return usage;
+    }
+
+    public void setEncoded(String encoded) {
+        this.encoded = encoded;
+    }
+
+    public void setProxyAuthToken(String proxyAuthToken) {
+        this.proxyAuthToken = proxyAuthToken;
+    }
+
+    public void setCsrfTokenEnabled(boolean csrfTokenEnabled) {
+        this.csrfTokenEnabled = csrfTokenEnabled;
+    }
+
+    public void setTokenID(Integer tokenID) {
+        this.tokenID = tokenID;
+    }
+
+    @Override
+    public AuthTokenProperties clone() throws CloneNotSupportedException {
+        return (AuthTokenProperties) super.clone();
+    }
+}

--- a/store/src/java/com/zimbra/cs/account/AuthTokenRegistry.java
+++ b/store/src/java/com/zimbra/cs/account/AuthTokenRegistry.java
@@ -40,13 +40,13 @@ import com.zimbra.soap.admin.message.RefreshRegisteredAuthTokensRequest;
 public final class AuthTokenRegistry {
     private static final Log mLOG = LogFactory.getLog(AuthTokenRegistry.class);
     //queue of deregistered authtokens
-    final private static ConcurrentLinkedQueue<ZimbraAuthToken> deregisteredOutAuthTokens = new ConcurrentLinkedQueue<ZimbraAuthToken>();
+    final private static ConcurrentLinkedQueue<AuthToken> deregisteredOutAuthTokens = new ConcurrentLinkedQueue<AuthToken>();
 
     /**
      * adds a token to the queue of deregistered tokens
      * @param token
      */
-    final public static void addTokenToQueue(ZimbraAuthToken token) {
+    final public static void addTokenToQueue(AuthToken token) {
         while(deregisteredOutAuthTokens.size() > LC.zimbra_deregistered_authtoken_queue_size.intValue() && !deregisteredOutAuthTokens.isEmpty()) {
             //throw out oldest tokens to make space
             deregisteredOutAuthTokens.remove();
@@ -90,8 +90,8 @@ public final class AuthTokenRegistry {
                         soapProv.soapZimbraAdminAuthenticate();
                         RefreshRegisteredAuthTokensRequest req = new RefreshRegisteredAuthTokensRequest();
                         for(Object ztoken : copy) {
-                            if(!((ZimbraAuthToken)ztoken).isExpired()) {//no need to broadcast expired tokens, since they will be cleaned up automatically
-                                req.addToken(((ZimbraAuthToken)ztoken).getEncoded());
+                            if(!((AuthToken)ztoken).isExpired()) {//no need to broadcast expired tokens, since they will be cleaned up automatically
+                                req.addToken(((AuthToken)ztoken).getEncoded());
                             }
                         }
                         for(Server server : mailServers) {

--- a/store/src/java/com/zimbra/cs/account/AuthTokenUtil.java
+++ b/store/src/java/com/zimbra/cs/account/AuthTokenUtil.java
@@ -1,0 +1,58 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.account;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.AccountConstants;
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.util.StringUtil;
+import com.zimbra.common.util.ZimbraLog;
+
+public class AuthTokenUtil {
+
+    public static void encodeAuthResp(AuthToken at, Element parent, boolean isAdmin)  throws ServiceException {
+        parent.addNonUniqueElement(isAdmin ? AdminConstants.E_AUTH_TOKEN : AccountConstants.E_AUTH_TOKEN).setText(getOrigAuthData(at));
+    }
+
+    public static String getOrigAuthData(AuthToken at) throws ServiceException {
+        String origAuthData = null;
+        try {
+            origAuthData = at.getEncoded();
+            if (origAuthData == null) {
+                throw ServiceException.FAILURE("unable to get encoded auth token", null);
+            }
+        } catch (AuthTokenException e) {
+            throw ServiceException.FAILURE("unable to get encoded auth token", e);
+        }
+        return origAuthData;
+    }
+
+    public static boolean isZimbraUser(String type) {
+        return StringUtil.isNullOrEmpty(type) || AuthTokenProperties.C_TYPE_ZIMBRA_USER.equals(type) || AuthTokenProperties.C_TYPE_ZMG_APP.equals(type);
+    }
+
+    public static AuthTokenKey getCurrentKey() throws AuthTokenException {
+        try {
+            AuthTokenKey key = AuthTokenKey.getCurrentKey();
+            return key;
+        } catch (ServiceException e) {
+            ZimbraLog.account.error("unable to get latest AuthTokenKey", e);
+            throw new AuthTokenException("unable to get AuthTokenKey", e);
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/account/JWTCache.java
+++ b/store/src/java/com/zimbra/cs/account/JWTCache.java
@@ -22,15 +22,15 @@ import com.zimbra.common.localconfig.LC;
 
 public class JWTCache {
 
-    private static final Cache <String, ZimbraJWT> JWT_CACHE = CacheBuilder.newBuilder()
+    private static final Cache <String, JWTInfo> JWT_CACHE = CacheBuilder.newBuilder()
                                                                            .maximumSize(LC.zimbra_authtoken_cache_size.intValue())
                                                                            .build();
 
-    public static void put(String jti, ZimbraJWT jwtInfo) {
+    public static void put(String jti, JWTInfo jwtInfo) {
             JWT_CACHE.put(jti, jwtInfo);
     }
 
-    public static ZimbraJWT get(String jti) {
+    public static JWTInfo get(String jti) {
             return JWT_CACHE.getIfPresent(jti);
     }
 

--- a/store/src/java/com/zimbra/cs/account/JWTInfo.java
+++ b/store/src/java/com/zimbra/cs/account/JWTInfo.java
@@ -16,12 +16,12 @@
  */
 package com.zimbra.cs.account;
 
-public class ZimbraJWT {
+public class JWTInfo {
 
     private String salt;
     private long expiryTime;
 
-    public ZimbraJWT(String salt, long expiryTime) {
+    public JWTInfo(String salt, long expiryTime) {
         this.salt = salt;
         this.expiryTime = expiryTime;
     }

--- a/store/src/java/com/zimbra/cs/account/ZimbraAuthToken.java
+++ b/store/src/java/com/zimbra/cs/account/ZimbraAuthToken.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016 Synacor, Inc.
+ * Copyright (C) 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -30,26 +30,18 @@ import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpMethod;
 import org.apache.commons.httpclient.HttpState;
 import org.apache.commons.httpclient.cookie.CookiePolicy;
-import org.apache.commons.rng.UniformRandomProvider;
-import org.apache.commons.rng.simple.RandomSource;
-import org.apache.commons.text.RandomStringGenerator;
 
 import com.google.common.base.Objects;
-import com.google.common.primitives.Bytes;
 import com.zimbra.common.account.Key.AccountBy;
 import com.zimbra.common.auth.ZAuthToken;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
-import com.zimbra.common.soap.AccountConstants;
-import com.zimbra.common.soap.AdminConstants;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.util.BlobMetaData;
 import com.zimbra.common.util.Log;
 import com.zimbra.common.util.LogFactory;
 import com.zimbra.common.util.MapUtil;
-import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraCookie;
-import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.auth.AuthMechanism.AuthMech;
 import com.zimbra.cs.ephemeral.EphemeralInput;
 import com.zimbra.cs.ephemeral.EphemeralInput.AbsoluteExpiration;
@@ -58,86 +50,37 @@ import com.zimbra.cs.ephemeral.EphemeralKey;
 import com.zimbra.cs.ephemeral.EphemeralLocation;
 import com.zimbra.cs.ephemeral.EphemeralStore;
 import com.zimbra.cs.ephemeral.LdapEntryLocation;
-import com.zimbra.cs.service.util.JWTUtil;
 
 /**
  * @since May 30, 2004
  * @author schemers
  */
 public class ZimbraAuthToken extends AuthToken implements Cloneable {
-    private static final String C_ID  = "id";
-    // original admin id
-    private static final String C_AID  = "aid";
-    private static final String C_EXP = "exp";
-    private static final String C_ADMIN = "admin";
-    private static final String C_DOMAIN = "domain";
-    private static final String C_DLGADMIN = "dlgadmin";
-    private static final String C_TYPE = "type";
-    private static final String C_TOKEN_TYPE = "tokenType";
-    private static final String C_TYPE_ZIMBRA_USER = "zimbra";
-    private static final String C_TYPE_EXTERNAL_USER = "external";
-    private static final String C_TYPE_ZMG_APP = "zmgapp";
-    private static final String C_EXTERNAL_USER_EMAIL = "email";
-    private static final String C_DIGEST = "digest";
-    private static final String C_VALIDITY_VALUE  = "vv";
-    private static final String C_AUTH_MECH = "am";
-    private static final String C_USAGE = "u";
-    //cookie ID for keeping track of account's cookies
-    private static final String C_TOKEN_ID = "tid";
-    //mailbox server version where this account resides
-    private static final String C_SERVER_VERSION = "version";
-    private static final String C_CSRF = "csrf";
     private static final Map<String, ZimbraAuthToken> CACHE = MapUtil.newLruMap(LC.zimbra_authtoken_cache_size.intValue());
     private static final Log LOG = LogFactory.getLog(AuthToken.class);
-    private static final int  SALT_LENGTH = 20;
+    private AuthTokenProperties properties;
 
-    private String accountId;
-    private String adminAccountId;
-    private int validityValue = -1;
-    private long expires;
-    private long issuedAt;
-    private String encoded;
-    private boolean isAdmin;
-    private boolean isDomainAdmin;
-    private boolean isDelegatedAdmin;
-    private String type;
-    private String externalUserEmail;
-    private String digest;
-    private String accessKey; // just a dummy placeholder for now until accesskey auth is implemented in ZimbraAuthToken
-    private String proxyAuthToken;
-    private AuthMech authMech;
-    private Integer tokenID = -1;
-    private String server_version;   // version of the mailbox server where this account resides
-    private boolean csrfTokenEnabled;
-    private Usage usage; // what this token will be used for
-    private TokenType tokenType; // Auth token or JWT
-    private String salt = null;
-    private String jwtId = null;
+    public AuthTokenProperties getProperties() {
+        return properties;
+    }
 
-    @Override
-    public TokenType getTokenType() {
-        return tokenType;
+    public void setProperties(AuthTokenProperties properties) {
+        this.properties = properties;
     }
 
     @Override
     public String toString() {
         return Objects.toStringHelper(this)
-            .add("acct", accountId)
-            .add("admin", adminAccountId)
-            .add("exp", expires)
-            .add("isAdm", isAdmin)
-            .add("isDlgAd", isDelegatedAdmin)
+            .add("acct", properties.getAccountId())
+            .add("admin", properties.getAdminAccountId())
+            .add("exp", properties.getExpires())
+            .add("isAdm", properties.isAdmin())
+            .add("isDlgAd", properties.isDelegatedAdmin())
             .toString();
     }
 
     protected static AuthTokenKey getCurrentKey() throws AuthTokenException {
-        try {
-            AuthTokenKey key = AuthTokenKey.getCurrentKey();
-            return key;
-        } catch (ServiceException e) {
-            LOG.fatal("unable to get latest AuthTokenKey", e);
-            throw new AuthTokenException("unable to get AuthTokenKey", e);
-        }
+        return AuthTokenUtil.getCurrentKey();
     }
 
     /**
@@ -173,7 +116,6 @@ public class ZimbraAuthToken extends AuthToken implements Cloneable {
 
     protected ZimbraAuthToken(String encoded) throws AuthTokenException {
         try {
-            this.encoded = encoded;
             int pos = encoded.indexOf('_');
             if (pos == -1) {
                 throw new AuthTokenException("invalid authtoken format");
@@ -196,59 +138,8 @@ public class ZimbraAuthToken extends AuthToken implements Cloneable {
                 throw new AuthTokenException("hmac failure");
             }
             Map<?, ?> map = TokenUtil.getAttrs(data);
-
-            accountId = (String) map.get(C_ID);
-            adminAccountId = (String) map.get(C_AID);
-            expires = Long.parseLong((String) map.get(C_EXP));
-            String ia = (String) map.get(C_ADMIN);
-            isAdmin = "1".equals(ia);
-            String da = (String) map.get(C_DOMAIN);
-            isDomainAdmin = "1".equals(da);
-            String dlga = (String) map.get(C_DLGADMIN);
-            isDelegatedAdmin = "1".equals(dlga);
-            type = (String)map.get(C_TYPE);
-
-            String authMechStr = (String)map.get(C_AUTH_MECH);
-            authMech = AuthMech.fromString(authMechStr);
-            String usageCode = (String)map.get(C_USAGE);
-            if (usageCode != null) {
-                usage = Usage.fromCode(usageCode);
-            } else {
-                usage = Usage.AUTH;
-            }
-            String tokenTypeCode = (String)map.get(C_TOKEN_TYPE);
-            if (tokenTypeCode != null) {
-                tokenType = TokenType.fromCode(tokenTypeCode);
-            }
-            externalUserEmail = (String)map.get(C_EXTERNAL_USER_EMAIL);
-            digest = (String)map.get(C_DIGEST);
-            String validityValueCode = (String)map.get(C_VALIDITY_VALUE);
-            if (validityValueCode != null) {
-                try {
-                    validityValue = Integer.parseInt(validityValueCode);
-                } catch (NumberFormatException e) {
-                    validityValue = -1;
-                }
-            } else {
-                validityValue = -1;
-            }
-
-            String tid = (String)map.get(C_TOKEN_ID);
-            if(tid !=null) {
-            	try {
-            		tokenID = Integer.parseInt(tid);
-            	} catch (NumberFormatException e) {
-            		tokenID = -1;
-                }
-            } else {
-            	tokenID = -1;
-            }
-            server_version = (String)map.get(C_SERVER_VERSION);
-
-            String csrf = (String) map.get(C_CSRF);
-            if (csrf != null) {
-                csrfTokenEnabled = "1".equals(map.get(C_CSRF));
-            }
+            properties = new AuthTokenProperties(map);
+            properties.setEncoded(encoded);
         } catch (ServiceException e) {
             throw new AuthTokenException("service exception", e);
         }
@@ -258,16 +149,8 @@ public class ZimbraAuthToken extends AuthToken implements Cloneable {
         this(acct, false, null);
     }
 
-    public ZimbraAuthToken(Account acct, TokenType tokenType, String tokenId) {
-        this(acct, 0, false, null, null, Usage.AUTH, tokenType, tokenId);
-    }
-
     public ZimbraAuthToken(Account acct, Usage usage) {
         this(acct, 0, false, null, null, usage);
-    }
-
-    public ZimbraAuthToken(Account acct, Usage usage, TokenType tokenType, String tokenId) {
-        this(acct, 0, false, null, null, usage, tokenType, tokenId);
     }
 
     public ZimbraAuthToken(Account acct, boolean isAdmin, AuthMech authMech) {
@@ -278,18 +161,9 @@ public class ZimbraAuthToken extends AuthToken implements Cloneable {
         this(acct, expires, false, null, null);
     }
 
-    public ZimbraAuthToken(Account acct, long expires, TokenType tokenType, String tokenId) {
-        this(acct, expires, false, null, null, Usage.AUTH, tokenType, tokenId);
-    }
-
     public ZimbraAuthToken(Account acct, long expires, boolean isAdmin, Account adminAcct,
             AuthMech authMech) {
         this(acct, expires, isAdmin, adminAcct, authMech, Usage.AUTH);
-    }
-
-    public ZimbraAuthToken(Account acct, long expires, boolean isAdmin, Account adminAcct,
-            AuthMech authMech, Usage usage) {
-        this(acct, expires, isAdmin, adminAcct, authMech, usage, TokenType.AUTH, null);
     }
 
     /**
@@ -301,68 +175,28 @@ public class ZimbraAuthToken extends AuthToken implements Cloneable {
      * @throws AuthTokenException
      */
     public ZimbraAuthToken(Account acct, long expires, boolean isAdmin, Account adminAcct,
-            AuthMech authMech, Usage usage, TokenType tokenType, String tokenId) {
-        this.tokenType = tokenType;
-        if (!StringUtil.isNullOrEmpty(tokenId)) {
-            jwtId = tokenId;
-        }
-        if(expires == 0) {
+            AuthMech authMech, Usage usage) {
+        long expireTime = expires;
+        if(expireTime == 0) {
             long lifetime;
-            if (isJWT()) {
-                lifetime = acct.getTimeInterval(Provisioning.A_zimbraAuthTokenLifetime, DEFAULT_AUTH_LIFETIME * 1000);
-            } else {
-                switch (usage) {
-                case ENABLE_TWO_FACTOR_AUTH:
-                    lifetime = acct.getTimeInterval(Provisioning.A_zimbraTwoFactorAuthTokenLifetime, DEFAULT_TWO_FACTOR_AUTH_LIFETIME * 1000);
-                    break;
-                case TWO_FACTOR_AUTH:
-                    lifetime = acct.getTimeInterval(Provisioning.A_zimbraTwoFactorAuthEnablementTokenLifetime, DEFAULT_TWO_FACTOR_ENABLEMENT_AUTH_LIFETIME * 1000);
-                    break;
-                case AUTH:
-                default:
-                    lifetime = isAdmin || isDomainAdmin || isDelegatedAdmin ?
-                            acct.getTimeInterval(Provisioning.A_zimbraAdminAuthTokenLifetime, DEFAULT_AUTH_LIFETIME * 1000) :
-                            acct.getTimeInterval(Provisioning.A_zimbraAuthTokenLifetime, DEFAULT_AUTH_LIFETIME * 1000);
-                    break;
-                }
+            switch (usage) {
+            case ENABLE_TWO_FACTOR_AUTH:
+                lifetime = acct.getTimeInterval(Provisioning.A_zimbraTwoFactorAuthTokenLifetime, DEFAULT_TWO_FACTOR_AUTH_LIFETIME * 1000);
+                break;
+            case TWO_FACTOR_AUTH:
+                lifetime = acct.getTimeInterval(Provisioning.A_zimbraTwoFactorAuthEnablementTokenLifetime, DEFAULT_TWO_FACTOR_ENABLEMENT_AUTH_LIFETIME * 1000);
+                break;
+            case AUTH:
+            default:
+                lifetime = isAdmin ?
+                        acct.getTimeInterval(Provisioning.A_zimbraAdminAuthTokenLifetime, DEFAULT_AUTH_LIFETIME * 1000) :
+                        acct.getTimeInterval(Provisioning.A_zimbraAuthTokenLifetime, DEFAULT_AUTH_LIFETIME * 1000);
+                break;
             }
-            issuedAt = System.currentTimeMillis();
-            expires = issuedAt + lifetime;
+            expireTime = System.currentTimeMillis() + lifetime;
         }
-        accountId = acct.getId();
-        adminAccountId = adminAcct != null ? adminAcct.getId() : null;
-        validityValue = acct.getAuthTokenValidityValue();
-        this.expires = expires;
-        this.isAdmin = isAdmin && "TRUE".equals(acct.getAttr(Provisioning.A_zimbraIsAdminAccount));
-        isDomainAdmin = isAdmin && "TRUE".equals(acct.getAttr(Provisioning.A_zimbraIsDomainAdminAccount));
-        isDelegatedAdmin = isAdmin && "TRUE".equals(acct.getAttr(Provisioning.A_zimbraIsDelegatedAdminAccount));
-        this.authMech = authMech;
-        this.usage = usage;
-        encoded = null;
-        if (acct instanceof GuestAccount) {
-            type = C_TYPE_EXTERNAL_USER;
-            GuestAccount g = (GuestAccount) acct;
-            digest = g.getDigest();
-            accessKey = g.getAccessKey();
-            externalUserEmail = g.getName();
-        } else {
-            type = C_TYPE_ZIMBRA_USER;
-        }
-        tokenID = new Random().nextInt(Integer.MAX_VALUE-1) + 1;
-        try {
-            Server server = acct.getServer();
-            if (server != null) {
-                server_version = server.getServerVersion();
-            } else {
-                server_version = Provisioning.getInstance().getLocalServer().getServerVersion();
-            }
-        } catch (ServiceException e) {
-            LOG.error("Unable to fetch server version for the user account", e);
-        }
-
-        if (!isJWT()) {
-            register();
-        }
+        properties = new AuthTokenProperties(acct, isAdmin, adminAcct, expireTime, authMech, usage);
+        register();
     }
 
     public ZimbraAuthToken(String acctId, String externalEmail, String pass, String digest, long expires)  {
@@ -370,109 +204,74 @@ public class ZimbraAuthToken extends AuthToken implements Cloneable {
     }
 
     public ZimbraAuthToken(String acctId, boolean zmgApp, String externalEmail, String pass, String digest, long expires)  {
-        accountId = acctId;
-        this.expires = expires;
-        externalUserEmail = externalEmail == null && !zmgApp ? "public" : externalEmail;
-        this.digest = digest != null ? digest : generateDigest(externalEmail, pass);
-        this.type = zmgApp ? C_TYPE_ZMG_APP : C_TYPE_EXTERNAL_USER;
-        tokenID = new Random().nextInt(Integer.MAX_VALUE-1) + 1;
-        try {
-            Account acct = Provisioning.getInstance().getAccountById(accountId);
-            if (acct != null) {
-                Server server = acct.getServer();
-                if (server != null) {
-                    server_version = server.getAttr(Provisioning.A_zimbraServerVersion, "");
-                }
-        	}
-        } catch (ServiceException e) {
-            LOG.error("Unable to fetch server version for the user account", e);
-        }
+           properties = new AuthTokenProperties(acctId, zmgApp, externalEmail, pass, digest, expires);
     }
 
     @Override
     public String getAccountId() {
-        return accountId;
+        return properties.getAccountId();
     }
 
     @Override
     public String getAdminAccountId() {
-        return adminAccountId;
+        return properties.getAdminAccountId();
     }
 
     @Override
     public long getExpires() {
-        return expires;
+        return properties.getExpires();
     }
 
     @Override
     public int getValidityValue() {
-        return validityValue;
+        return properties.getValidityValue();
     }
 
     @Override
     public boolean isExpired() {
-        return System.currentTimeMillis() > expires;
+        return System.currentTimeMillis() > properties.getExpires();
     }
 
     @Override
     public boolean isAdmin() {
-        return isAdmin;
+        return properties.isAdmin();
     }
 
     @Override
     public boolean isDomainAdmin() {
-        return isDomainAdmin;
+        return properties.isDomainAdmin();
     }
 
     @Override
     public boolean isDelegatedAdmin() {
-        return isDelegatedAdmin;
+        return properties.isDelegatedAdmin();
     }
 
     @Override
     public boolean isZimbraUser() {
-        return type == null || C_TYPE_ZIMBRA_USER.equals(type) || C_TYPE_ZMG_APP.equals(type);
         // C_TYPE_ZMG_APP type indicates the bootstrap auth token issued for ZMG app. Technically
         // that too represents a Zimbra account/user
+        return AuthTokenUtil.isZimbraUser(properties.getType());
     }
 
     @Override
     public String getExternalUserEmail() {
-        return externalUserEmail;
+        return properties.getExternalUserEmail();
     }
 
     @Override
     public String getDigest() {
-        return digest;
+        return properties.getDigest();
     }
 
     @Override
     public String getAccessKey() {
-        return accessKey;
+        return properties.getAccessKey();
     }
 
     @Override
     public AuthMech getAuthMech() {
-        return authMech;
-    }
-
-    @Override
-    public boolean isJWT() {
-        return TokenType.JWT.equals(this.tokenType);
-    }
-
-    @Override
-    public String getSalt() {
-        return salt;
-    }
-
-    @Override
-    public String getId() {
-        if (!StringUtil.isNullOrEmpty(jwtId)) {
-            return jwtId;
-        } else {
-            return String.valueOf(tokenID);
-        }
+        return properties.getAuthMech();
     }
 
     private void register() {
@@ -480,15 +279,15 @@ public class ZimbraAuthToken extends AuthToken implements Cloneable {
             return;
         }
         try {
-            Account acct = Provisioning.getInstance().get(AccountBy.id, accountId);
+            Account acct = Provisioning.getInstance().get(AccountBy.id, properties.getAccountId());
             if (Provisioning.getInstance().getLocalServer().getLowestSupportedAuthVersion() > 1) {
                 try {
                     acct.cleanExpiredTokens(); //house keeping. If we are issuing a new token, clean up old ones.
                 } catch (ServiceException e) {
                     LOG.error("unable to de-register auth token", e);
                 }
-                Expiration expiration = new AbsoluteExpiration(this.expires);
-                acct.addAuthTokens(String.valueOf(tokenID), server_version, expiration);
+                Expiration expiration = new AbsoluteExpiration(properties.getExpires());
+                acct.addAuthTokens(String.valueOf(properties.getTokenID()), properties.getServerVersion(), expiration);
             }
         } catch (ServiceException e) {
             LOG.error("unable to register auth token", e);
@@ -499,16 +298,9 @@ public class ZimbraAuthToken extends AuthToken implements Cloneable {
     @Override
     public void deRegister() throws AuthTokenException {
         try {
-            Account acct = Provisioning.getInstance().getAccountById(accountId);
+            Account acct = Provisioning.getInstance().getAccountById(properties.getAccountId());
             if(acct != null) {
-                if (isJWT()) {
-                    acct.cleanExpiredJWTokens();
-                    Expiration expiration = new AbsoluteExpiration(this.expires);
-                    acct.addInvalidJWTokens(jwtId, server_version, expiration);
-                    ZimbraLog.account.debug("added jti: %s to invalid list", jwtId);
-                } else {
-                    acct.removeAuthTokens(String.valueOf(tokenID), server_version);
-                }
+                acct.removeAuthTokens(String.valueOf(properties.getTokenID()), properties.getServerVersion());
                 if(acct.getBooleanAttr(Provisioning.A_zimbraLogOutFromAllServers, false)) {
                     AuthTokenRegistry.addTokenToQueue(this);
                 }
@@ -520,71 +312,47 @@ public class ZimbraAuthToken extends AuthToken implements Cloneable {
 
     @Override
     public String getEncoded() throws AuthTokenException {
-        if (encoded == null) {
-            encoded = generateEncodedData();
-        }
-        return encoded;
-    }
+        if (properties.getEncoded() == null) {
+            StringBuilder encodedBuff = new StringBuilder(64);
+            BlobMetaData.encodeMetaData(AuthTokenProperties.C_ID, properties.getAccountId(), encodedBuff);
+            BlobMetaData.encodeMetaData(AuthTokenProperties.C_EXP, Long.toString(properties.getExpires()), encodedBuff);
+            if (properties.getAdminAccountId() != null) {
+                BlobMetaData.encodeMetaData(AuthTokenProperties.C_AID, properties.getAdminAccountId(), encodedBuff);
+            }
+            if (properties.isAdmin()) {
+                BlobMetaData.encodeMetaData(AuthTokenProperties.C_ADMIN, "1", encodedBuff);
+            }
+            if (properties.isDomainAdmin()) {
+                BlobMetaData.encodeMetaData(AuthTokenProperties.C_DOMAIN, "1", encodedBuff);
+            }
+            if (properties.isDelegatedAdmin()) {
+                BlobMetaData.encodeMetaData(AuthTokenProperties.C_DLGADMIN, "1", encodedBuff);
+            }
+            if (properties.getValidityValue() != -1) {
+                BlobMetaData.encodeMetaData(AuthTokenProperties.C_VALIDITY_VALUE, properties.getValidityValue(), encodedBuff);
+            }
+            BlobMetaData.encodeMetaData(AuthTokenProperties.C_TYPE, properties.getType(), encodedBuff);
 
-    private String getJWT() throws ServiceException {
-        try {
-            Account acct = Provisioning.getInstance().get(AccountBy.id, accountId);
-            ZimbraLog.account.debug("auth: generating jwt token for account id: %s", accountId);
-            UniformRandomProvider rng = RandomSource.create(RandomSource.MWC_256);
-            RandomStringGenerator generator = new RandomStringGenerator.Builder().withinRange('a', 'z').usingRandom(rng::nextInt).build();
-            salt = generator.generate(SALT_LENGTH);
-            byte[] finalKey = Bytes.concat(getCurrentKey().getKey(), salt.getBytes());
-            return JWTUtil.generateJWT(finalKey, salt, issuedAt, expires, acct);
-        } catch (AuthTokenException e) {
-            throw ServiceException.FAILURE("unable to generate jwt", e);
-        }
-    }
+            if (properties.getAuthMech() != null) {
+                BlobMetaData.encodeMetaData(AuthTokenProperties.C_AUTH_MECH, properties.getAuthMech().name(), encodedBuff);
+            }
 
-    private String generateEncodedData() throws AuthTokenException {
-        StringBuilder encodedBuff = new StringBuilder(64);
-        BlobMetaData.encodeMetaData(C_ID, accountId, encodedBuff);
-        BlobMetaData.encodeMetaData(C_EXP, Long.toString(expires), encodedBuff);
-        if (adminAccountId != null) {
-            BlobMetaData.encodeMetaData(C_AID, adminAccountId, encodedBuff);
+            if (properties.getUsage() != null) {
+                BlobMetaData.encodeMetaData(AuthTokenProperties.C_USAGE, properties.getUsage().getCode(), encodedBuff);
+            }
+            BlobMetaData.encodeMetaData(AuthTokenProperties.C_TOKEN_ID, properties.getTokenID(), encodedBuff);
+            BlobMetaData.encodeMetaData(AuthTokenProperties.C_EXTERNAL_USER_EMAIL, properties.getExternalUserEmail(), encodedBuff);
+            BlobMetaData.encodeMetaData(AuthTokenProperties.C_DIGEST, properties.getDigest(), encodedBuff);
+            BlobMetaData.encodeMetaData(AuthTokenProperties.C_SERVER_VERSION, properties.getServerVersion(), encodedBuff);
+            if (properties.isCsrfTokenEnabled()) {
+                BlobMetaData.encodeMetaData(AuthTokenProperties.C_CSRF, "1", encodedBuff);
+            }
+            String data = new String(Hex.encodeHex(encodedBuff.toString().getBytes()));
+            AuthTokenKey key = getCurrentKey();
+            String hmac = TokenUtil.getHmac(data, key.getKey());
+            properties.setEncoded(key.getVersion() + "_" + hmac + "_" + data);
         }
-        if (isAdmin) {
-            BlobMetaData.encodeMetaData(C_ADMIN, "1", encodedBuff);
-        }
-        if (isDomainAdmin) {
-            BlobMetaData.encodeMetaData(C_DOMAIN, "1", encodedBuff);
-        }
-        if (isDelegatedAdmin) {
-            BlobMetaData.encodeMetaData(C_DLGADMIN, "1", encodedBuff);
-        }
-        if (validityValue != -1) {
-            BlobMetaData.encodeMetaData(C_VALIDITY_VALUE, validityValue, encodedBuff);
-        }
-        BlobMetaData.encodeMetaData(C_TYPE, type, encodedBuff);
-
-        if (tokenType != null) {
-            BlobMetaData.encodeMetaData(C_TOKEN_TYPE, tokenType.getCode(), encodedBuff);
-        }
-
-        if (authMech != null) {
-            BlobMetaData.encodeMetaData(C_AUTH_MECH, authMech.name(), encodedBuff);
-        }
-
-        if (usage != null) {
-            BlobMetaData.encodeMetaData(C_USAGE, usage.getCode(), encodedBuff);
-        }
-
-        BlobMetaData.encodeMetaData(C_TOKEN_ID, tokenID, encodedBuff);
-        BlobMetaData.encodeMetaData(C_EXTERNAL_USER_EMAIL, externalUserEmail, encodedBuff);
-        BlobMetaData.encodeMetaData(C_DIGEST, digest, encodedBuff);
-        BlobMetaData.encodeMetaData(C_SERVER_VERSION, server_version, encodedBuff);
-        if (this.csrfTokenEnabled) {
-            BlobMetaData.encodeMetaData(C_CSRF, "1", encodedBuff);
-        }
-
-        String data = new String(Hex.encodeHex(encodedBuff.toString().getBytes()));
-        AuthTokenKey key = getCurrentKey();
-        String hmac = TokenUtil.getHmac(data, key.getKey());
-        return key.getVersion() + "_" + hmac + "_" + data;
+        return properties.getEncoded();
     }
 
     @Override
@@ -602,18 +370,6 @@ public class ZimbraAuthToken extends AuthToken implements Cloneable {
         }
     }
 
-    private String getOrigAuthData() throws ServiceException {
-        String origAuthData = null;
-        try {
-             origAuthData = getEncoded();
-             if (origAuthData == null)
-                throw ServiceException.FAILURE("unable to get encoded auth token", null);
-        } catch (AuthTokenException e) {
-            throw ServiceException.FAILURE("unable to get encoded auth token", e);
-        }
-        return origAuthData;
-    }
-
     @Override
     public boolean isRegistered() {
         if (!isZimbraUser() || isZMGAppBootstrap()) {
@@ -627,7 +383,7 @@ public class ZimbraAuthToken extends AuthToken implements Cloneable {
             if (localServer.getLowestSupportedAuthVersion() < 2) {
                 return true;
             }
-            Account acct = prov.getAccountById(accountId);
+            Account acct = prov.getAccountById(properties.getAccountId());
             if (acct != null) {
                 if (isRegisteredInternal(acct)) {
                     return true;
@@ -650,13 +406,13 @@ public class ZimbraAuthToken extends AuthToken implements Cloneable {
     }
 
     private boolean isRegisteredInternal(Account acct) throws ServiceException {
-        return acct.hasAuthTokens(String.valueOf(tokenID));
+        return acct.hasAuthTokens(String.valueOf(properties.getTokenID()));
     }
 
     @Override
     public void encode(HttpClient client, HttpMethod method, boolean isAdminReq, String cookieDomain)
     throws ServiceException {
-        String origAuthData = getOrigAuthData();
+        String origAuthData = AuthTokenUtil.getOrigAuthData(this);
 
         HttpState state = new HttpState();
         client.setState(state);
@@ -668,7 +424,7 @@ public class ZimbraAuthToken extends AuthToken implements Cloneable {
 
     @Override
     public void encode(HttpState state, boolean isAdminReq, String cookieDomain) throws ServiceException {
-        String origAuthData = getOrigAuthData();
+        String origAuthData = AuthTokenUtil.getOrigAuthData(this);
         state.addCookie(new org.apache.commons.httpclient.Cookie(cookieDomain,
                 ZimbraCookie.authTokenCookieName(isAdminReq), origAuthData, "/", null, false));
     }
@@ -677,11 +433,11 @@ public class ZimbraAuthToken extends AuthToken implements Cloneable {
     public void encode(HttpServletResponse resp, boolean isAdminReq,
             boolean secureCookie, boolean rememberMe)
     throws ServiceException {
-        String origAuthData = getOrigAuthData();
+        String origAuthData = AuthTokenUtil.getOrigAuthData(this);
 
         Integer maxAge;
         if (rememberMe) {
-            long timeLeft = expires - System.currentTimeMillis();
+            long timeLeft = properties.getExpires() - System.currentTimeMillis();
             maxAge = Integer.valueOf((int)(timeLeft/1000));
         } else {
             maxAge = Integer.valueOf(-1);
@@ -694,37 +450,27 @@ public class ZimbraAuthToken extends AuthToken implements Cloneable {
 
     @Override
     public void encodeAuthResp(Element parent, boolean isAdmin)  throws ServiceException {
-        String text = null;
-        if (isJWT()) {
-            text = getJWT();
-        } else {
-            text = getOrigAuthData();
-        }
-        if (isAdmin) {
-            parent.addElement(AdminConstants.E_AUTH_TOKEN).setText(text);
-        } else {
-            parent.addElement(AccountConstants.E_AUTH_TOKEN).setText(text);
-        }
+        AuthTokenUtil.encodeAuthResp(this, parent, isAdmin);
     }
 
     @Override
     public ZAuthToken toZAuthToken() throws ServiceException {
-        return new ZAuthToken(getOrigAuthData(), proxyAuthToken);
+        return new ZAuthToken(AuthTokenUtil.getOrigAuthData(this), properties.getProxyAuthToken());
     }
 
     @Override
     public void setProxyAuthToken(String encoded) {
-        proxyAuthToken = encoded;
+        properties.setProxyAuthToken(encoded);
     }
 
     @Override
     public String getProxyAuthToken() {
-        return proxyAuthToken;
+        return properties.getProxyAuthToken();
     }
 
     @Override
     public void resetProxyAuthToken() {
-        proxyAuthToken = null;
+        properties.setProxyAuthToken(null);
     }
 
     /* (non-Javadoc)
@@ -732,26 +478,26 @@ public class ZimbraAuthToken extends AuthToken implements Cloneable {
      */
     @Override
     public boolean isCsrfTokenEnabled() {
-        return csrfTokenEnabled;
+        return properties.isCsrfTokenEnabled();
     }
 
     @Override
     public void setCsrfTokenEnabled(boolean csrfEnabled) {
-        if (csrfEnabled != csrfTokenEnabled) {
+        if (csrfEnabled != properties.isCsrfTokenEnabled()) {
             synchronized (ZimbraAuthToken.class) {
-                if (encoded != null) {
-                    CACHE.remove(encoded);
+                if (properties.getEncoded() != null) {
+                    CACHE.remove(properties.getEncoded());
                 }
             }
-            csrfTokenEnabled = csrfEnabled;
+            properties.setCsrfTokenEnabled(csrfEnabled);
             // force re-encoding of the token
-            encoded = null;
+            properties.setEncoded(null);
         }
     }
 
     @Override
     public Usage getUsage() {
-        return usage;
+        return properties.getUsage();
     }
 
     /**
@@ -762,14 +508,14 @@ public class ZimbraAuthToken extends AuthToken implements Cloneable {
      * Cached encoded string is also reset as the due to change in TokenID.
      */
     public void resetTokenId() {
-         tokenID = new Random().nextInt(Integer.MAX_VALUE-1) + 1;
-         encoded = null;
+         properties.setTokenID(new Random().nextInt(Integer.MAX_VALUE-1) + 1);
+         properties.setEncoded(null);
          this.register();
     }
 
     @Override
     public boolean isZMGAppBootstrap() {
-        return C_TYPE_ZMG_APP.equals(type);
+        return AuthTokenProperties.C_TYPE_ZMG_APP.equals(properties.getType());
     }
 
 
@@ -800,7 +546,9 @@ public class ZimbraAuthToken extends AuthToken implements Cloneable {
 
     @Override
     public ZimbraAuthToken clone() throws CloneNotSupportedException {
-        return (ZimbraAuthToken)super.clone();
+        ZimbraAuthToken at = (ZimbraAuthToken) super.clone();
+        at.setProperties(properties.clone());
+        return at;
     }
 
     /*
@@ -808,11 +556,11 @@ public class ZimbraAuthToken extends AuthToken implements Cloneable {
      * ephemeral backend
      */
     public void registerWithEphemeralStore(EphemeralStore store) throws ServiceException {
-        Account acct = Provisioning.getInstance().get(AccountBy.id, accountId);
-        Expiration expiration = new AbsoluteExpiration(this.expires);
+        Account acct = Provisioning.getInstance().get(AccountBy.id, properties.getAccountId());
+        Expiration expiration = new AbsoluteExpiration(properties.getExpires());
         EphemeralLocation location = new LdapEntryLocation(acct);
-        EphemeralKey key = new EphemeralKey(Provisioning.A_zimbraAuthTokens, String.valueOf(tokenID));
-        EphemeralInput input = new EphemeralInput(key, server_version, expiration);
+        EphemeralKey key = new EphemeralKey(Provisioning.A_zimbraAuthTokens, String.valueOf(properties.getTokenID()));
+        EphemeralInput input = new EphemeralInput(key, properties.getServerVersion(), expiration);
         store.update(input, location);
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZimbraJWToken.java
+++ b/store/src/java/com/zimbra/cs/account/ZimbraJWToken.java
@@ -1,0 +1,317 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.account;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.HttpState;
+import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.simple.RandomSource;
+import org.apache.commons.text.RandomStringGenerator;
+
+import com.google.common.primitives.Bytes;
+import com.zimbra.common.auth.ZAuthToken;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.util.Constants;
+import com.zimbra.common.util.StringUtil;
+import com.zimbra.common.util.ZimbraCookie;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.auth.AuthMechanism.AuthMech;
+import com.zimbra.cs.ephemeral.EphemeralInput.AbsoluteExpiration;
+import com.zimbra.cs.ephemeral.EphemeralInput.Expiration;
+import com.zimbra.cs.service.util.JWTUtil;
+
+import io.jsonwebtoken.Claims;
+
+public class ZimbraJWToken extends AuthToken {
+    private static final int  SALT_LENGTH = 20;
+    private long issuedAt;
+    private String salt;
+    private AuthTokenProperties properties;
+
+    public ZimbraJWToken(Account acct) {
+        this(acct, 0);
+    }
+
+    public ZimbraJWToken(Account acct, long expires) {
+        this(acct, expires, false, null, null, Usage.AUTH);
+    }
+
+    public ZimbraJWToken(Account acct, Usage usage) {
+        this(acct, 0, false, null, null, usage);
+    }
+
+    ZimbraJWToken(Account acct, long expires, boolean isAdmin, Account adminAcct,
+            AuthMech authMech, Usage usage) {
+        long expireTime = expires;
+        if(expireTime == 0) {
+            long lifetime = acct.getTimeInterval(Provisioning.A_zimbraAuthTokenLifetime, DEFAULT_AUTH_LIFETIME * 1000);
+            issuedAt = System.currentTimeMillis();
+            expireTime = issuedAt + lifetime;
+        }
+        properties = new AuthTokenProperties(acct, isAdmin, adminAcct, expireTime, authMech, usage);
+    }
+
+    ZimbraJWToken(Claims body, String jwt) throws AuthTokenException {
+        Map<Object, Object> map = new HashMap<Object, Object>();
+        map.put(AuthTokenProperties.C_ID, body.getSubject());
+        if (body.getExpiration() != null) {
+            map.put(AuthTokenProperties.C_EXP, String.valueOf(body.getExpiration().getTime()));
+        }
+        if ((boolean) body.get(AuthTokenProperties.C_ADMIN)) {
+            map.put(AuthTokenProperties.C_ADMIN, "1");
+        }
+        if ((boolean) body.get(AuthTokenProperties.C_DOMAIN)) {
+            map.put(AuthTokenProperties.C_DOMAIN, "1");
+        }
+        if ((boolean) body.get(AuthTokenProperties.C_DLGADMIN)) {
+            map.put(AuthTokenProperties.C_DLGADMIN, "1");
+        }
+        if ((boolean) body.get(AuthTokenProperties.C_CSRF)) {
+            map.put(AuthTokenProperties.C_CSRF, "1");
+        }
+        populateMap(map, body, AuthTokenProperties.C_AID);
+        populateMap(map, body, AuthTokenProperties.C_AUTH_MECH);
+        populateMap(map, body, AuthTokenProperties.C_USAGE);
+        populateMap(map, body, AuthTokenProperties.C_EXTERNAL_USER_EMAIL);
+        populateMap(map, body, AuthTokenProperties.C_VALIDITY_VALUE);
+        populateMap(map, body, AuthTokenProperties.C_SERVER_VERSION);
+        properties = new AuthTokenProperties(map);
+        properties.setEncoded(jwt);
+    }
+
+    private void populateMap(Map<Object, Object> map, Claims body, String key) {
+        map.put(key, body.get(key));
+    }
+
+    public static AuthToken getJWToken(String jwt, String currentSalt) throws AuthTokenException {
+        AuthToken at = null;
+        try {
+            Claims body = JWTUtil.validateJWT(jwt, currentSalt);
+            at = new ZimbraJWToken(body, jwt);
+        } catch (ServiceException exception) {
+            throw new AuthTokenException("JWT validation failed", exception);
+        }
+        return at;
+    }
+
+    @Override
+    public void deRegister() throws AuthTokenException {
+        if (!isExpired()) {
+               try {
+                   Account acct = Provisioning.getInstance().getAccountById(properties.getAccountId());
+                   if(acct != null) {
+                       acct.cleanExpiredJWTokens();
+                       String jwtId = JWTUtil.getJTI(properties.getEncoded());
+                       if (jwtId != null) {
+                           Expiration expiration = new AbsoluteExpiration(properties.getExpires());
+                           acct.addInvalidJWTokens(jwtId, properties.getServerVersion(), expiration);
+                           JWTCache.remove(jwtId);
+                           ZimbraLog.account.debug("added jti: %s to invalid list", jwtId);
+                           if(acct.getBooleanAttr(Provisioning.A_zimbraLogOutFromAllServers, false)) {
+                               AuthTokenRegistry.addTokenToQueue(this);
+                           }
+                       }
+                   }
+               } catch (ServiceException e) {
+                   throw new AuthTokenException("unable to de-register auth token", e);
+               }
+           }
+    }
+
+    @Override
+    public String getEncoded() throws AuthTokenException {
+        if (properties.getEncoded() == null) {
+            try {
+                ZimbraLog.account.debug("auth: generating jwt token for account id: %s", properties.getAccountId());
+                UniformRandomProvider rng = RandomSource.create(RandomSource.MWC_256);
+                RandomStringGenerator generator = new RandomStringGenerator.Builder().withinRange('a', 'z').usingRandom(rng::nextInt).build();
+                salt = generator.generate(SALT_LENGTH);
+                AuthTokenKey key = AuthTokenUtil.getCurrentKey();
+                byte[] finalKey = Bytes.concat(key.getKey(), salt.getBytes());
+                String jwt = JWTUtil.generateJWT(finalKey, salt, issuedAt, properties, key.getVersion());
+                properties.setEncoded(jwt);
+            } catch (ServiceException e) {
+                throw new AuthTokenException("unable to generate jwt", e);
+            }
+        }
+        return properties.getEncoded();
+    }
+
+    @Override
+    public String toString() {
+        return properties.getEncoded();
+    }
+
+    @Override
+    public String getAccountId() {
+        return properties.getAccountId();
+    }
+
+    @Override
+    public String getAdminAccountId() {
+        return properties.getAdminAccountId();
+    }
+
+    @Override
+    public long getExpires() {
+        return properties.getExpires();
+    }
+
+    @Override
+    public boolean isRegistered() {
+        return true;
+    }
+
+    @Override
+    public boolean isExpired() {
+        return System.currentTimeMillis() > properties.getExpires();
+    }
+
+    @Override
+    public boolean isAdmin() {
+        return properties.isAdmin();
+    }
+
+    @Override
+    public boolean isDomainAdmin() {
+        return properties.isDomainAdmin();
+    }
+
+    @Override
+    public boolean isDelegatedAdmin() {
+        return properties.isDelegatedAdmin();
+    }
+
+    @Override
+    public boolean isZimbraUser() {
+        return AuthTokenUtil.isZimbraUser(properties.getType());
+    }
+
+    @Override
+    public String getExternalUserEmail() {
+        return properties.getExternalUserEmail();
+    }
+
+    @Override
+    public String getDigest() {
+        return properties.getDigest();
+    }
+
+    @Override
+    public String getCrumb() throws AuthTokenException {
+        return properties.getEncoded();
+    }
+
+    @Override
+    public int getValidityValue() {
+        return properties.getValidityValue();
+    }
+
+    @Override
+    public void encode(HttpClient client, HttpMethod method, boolean isAdminReq, String cookieDomain)
+            throws ServiceException {
+         // TODO will be implemented as part of request proxy ticket
+    }
+
+    @Override
+    public void encode(HttpState state, boolean isAdminReq, String cookieDomain) throws ServiceException {
+        // TODO will be implemented as part of request proxy ticket
+        
+    }
+
+    @Override
+    public void encode(HttpServletRequest reqst, HttpServletResponse resp, boolean isAdminReq, boolean secureCookie, boolean rememberMe)
+    throws ServiceException {
+        encode(reqst, resp, false);
+    }
+
+    @Override
+    public void encode(HttpServletRequest reqst, HttpServletResponse resp, boolean deregister)
+    throws ServiceException {
+        if (reqst != null && resp != null) {
+            String finalValue = null;
+            String zmJwtCookieVal = JWTUtil.getZMJWTCookieValue(reqst);
+            if (deregister) {
+                String jwtId = JWTUtil.getJTI(properties.getEncoded());
+                JWTInfo jwt = JWTCache.get(jwtId);
+                if (jwt != null) {
+                    finalValue = JWTUtil.clearSalt(zmJwtCookieVal, jwt.getSalt());
+                    ZimbraLog.security.debug("EndSession: found salt in cache for jti: %s",jwtId);
+                }
+            } else {
+                finalValue = StringUtil.isNullOrEmpty(zmJwtCookieVal) ? salt : salt + Constants.JWT_SALT_SEPARATOR + zmJwtCookieVal;
+            }
+            ZimbraCookie.addHttpOnlyCookie(resp, Constants.ZM_JWT_COOKIE, finalValue, ZimbraCookie.PATH_ROOT, -1, true);
+        }
+    }
+
+    @Override
+    public void encode(HttpServletResponse resp, boolean isAdminReq, boolean secureCookie, boolean rememberMe)
+            throws ServiceException {
+        encode(null, resp, false);
+    }
+
+    @Override
+    public void encodeAuthResp(Element parent, boolean isAdmin) throws ServiceException {
+        AuthTokenUtil.encodeAuthResp(this, parent, isAdmin);
+    }
+
+    @Override
+    public ZAuthToken toZAuthToken() throws ServiceException {
+        // TODO will be implemented as part of request proxy ticket
+        return null;
+    }
+
+    @Override
+    public Usage getUsage() {
+        return properties.getUsage();
+    }
+
+    @Override
+    public AuthMech getAuthMech() {
+        return properties.getAuthMech();
+    }
+
+    @Override
+    public String getAccessKey() {
+        return properties.getAccessKey();
+    }
+
+    @Override
+    public void setProxyAuthToken(String encoded) {
+        //TODO implement as part of proxy task
+    }
+
+    @Override
+    public String getProxyAuthToken() {
+        //TODO implement as part of proxy task
+        return null;
+    }
+
+    @Override
+    public void resetProxyAuthToken() {
+        //TODO implement as part of proxy task
+    }
+}

--- a/store/src/java/com/zimbra/cs/service/account/EndSession.java
+++ b/store/src/java/com/zimbra/cs/service/account/EndSession.java
@@ -24,14 +24,8 @@ import javax.servlet.http.HttpServletResponse;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AccountConstants;
 import com.zimbra.common.soap.Element;
-import com.zimbra.common.util.Constants;
-import com.zimbra.common.util.ZimbraCookie;
-import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.AuthToken;
 import com.zimbra.cs.account.AuthTokenException;
-import com.zimbra.cs.account.JWTCache;
-import com.zimbra.cs.account.ZimbraJWT;
-import com.zimbra.cs.service.util.JWTUtil;
 import com.zimbra.cs.session.Session;
 import com.zimbra.soap.SoapServlet;
 import com.zimbra.soap.ZimbraSoapContext;
@@ -55,25 +49,9 @@ public class EndSession extends AccountDocumentHandler {
             context.put(SoapServlet.INVALIDATE_COOKIES, true);
             try {
                 AuthToken at = zsc.getAuthToken();
-                if (at.isJWT()) {
-                    String jti = at.getId();
-                    if (jti != null) {
-                        ZimbraLog.security.debug("EndSession: jti: %s",jti);
-                        ZimbraJWT jwt = JWTCache.get(jti);
-                        if (jwt != null) {
-                            String salt = jwt.getSalt();
-                            ZimbraLog.security.debug("EndSession: found salt in cache for jti: %s",jti);
-                            String zmJWTCookieValue = null;
-                            HttpServletRequest httpReq = (HttpServletRequest) context.get(SoapServlet.SERVLET_REQUEST);
-                            HttpServletResponse httpResp = (HttpServletResponse) context.get(SoapServlet.SERVLET_RESPONSE);
-                            if (salt != null) {
-                                zmJWTCookieValue = JWTUtil.getZMJWTCookieValue(httpReq);
-                            }
-                            ZimbraCookie.addHttpOnlyCookie(httpResp, Constants.ZM_JWT_COOKIE, JWTUtil.clearSalt(zmJWTCookieValue, salt), ZimbraCookie.PATH_ROOT, -1, true);
-                            JWTCache.remove(jti);
-                        }
-                    }
-                }
+                HttpServletRequest httpReq = (HttpServletRequest) context.get(SoapServlet.SERVLET_REQUEST);
+                HttpServletResponse httpResp = (HttpServletResponse) context.get(SoapServlet.SERVLET_RESPONSE);
+                at.encode(httpReq, httpResp, true);
                 at.deRegister();
             } catch (AuthTokenException e) {
                 throw ServiceException.FAILURE("Failed to de-register an auth token", e);

--- a/store/src/java/com/zimbra/qa/unittest/TestAccessKeyGrant.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestAccessKeyGrant.java
@@ -23,8 +23,6 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import junit.framework.TestCase;
-
 import org.apache.commons.httpclient.Credentials;
 import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpClient;
@@ -54,6 +52,8 @@ import com.zimbra.cs.service.AuthProvider;
 import com.zimbra.cs.service.AuthProviderException;
 import com.zimbra.cs.service.UserServlet;
 import com.zimbra.cs.servlet.ZimbraServlet;
+
+import junit.framework.TestCase;
 
 /*
  * To test key grant:

--- a/store/src/java/com/zimbra/qa/unittest/prov/ldap/ACLTestUtil.java
+++ b/store/src/java/com/zimbra/qa/unittest/prov/ldap/ACLTestUtil.java
@@ -25,8 +25,6 @@ import java.util.Set;
 
 import javax.servlet.http.HttpServletResponse;
 
-import junit.framework.AssertionFailedError;
-
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpMethod;
 import org.apache.commons.httpclient.HttpState;
@@ -45,6 +43,8 @@ import com.zimbra.cs.account.accesscontrol.RightModifier;
 import com.zimbra.cs.account.accesscontrol.Rights.Admin;
 import com.zimbra.cs.account.accesscontrol.Rights.User;
 import com.zimbra.cs.account.accesscontrol.TargetType;
+
+import junit.framework.AssertionFailedError;
 
 public class ACLTestUtil {
 

--- a/store/src/java/com/zimbra/soap/ZimbraSoapContext.java
+++ b/store/src/java/com/zimbra/soap/ZimbraSoapContext.java
@@ -39,7 +39,6 @@ import com.zimbra.cs.account.AccessManager;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.AccountServiceException;
 import com.zimbra.cs.account.AuthToken;
-import com.zimbra.cs.account.AuthToken.TokenType;
 import com.zimbra.cs.account.AuthTokenException;
 import com.zimbra.cs.account.GuestAccount;
 import com.zimbra.cs.account.Provisioning;
@@ -280,12 +279,12 @@ public final class ZimbraSoapContext {
         try {
             mAuthToken = AuthProvider.getAuthToken(ctxt, context);
             if (mAuthToken == null) {
-                mAuthToken = AuthProvider.getAuthToken(ctxt, context, TokenType.JWT);
+                mAuthToken = AuthProvider.getJWToken(ctxt, context);
             }
             if (mAuthToken != null) {
                 boolean isRegistered = mAuthToken.isRegistered();
                 boolean isExpired = mAuthToken.isExpired();
-                if (!mAuthToken.isJWT() && (isExpired || !isRegistered)) {
+                if (isExpired || !isRegistered) {
                     boolean voidOnExpired = false;
 
                     if (ctxt != null) {


### PR DESCRIPTION
1. Refactored ZimbraAuthToken class to remove dependency of ZimbraJWToken class on ZimbraAuthToken class. Moved out common code and properties needed for for auth token and JWT in a separate class AuthTokenProperties. 
2. Removed at.isJWT() check from implementation at several places, where it was added earlier.
3. added unit test to cover new methods added.

executed ant test-all. all unit tests passed.
