### PR TITLE
ZCS-4004 - ensure mailbox not modified by another thread

### DIFF
--- a/store/src/java/com/zimbra/cs/imap/ImapListener.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapListener.java
@@ -805,10 +805,12 @@ public abstract class ImapListener extends Session {
     @Override
     public void updateAccessTime() {
         super.updateAccessTime();
-        if (mailbox == null) {
+        // ZESC-460, ZCS-4004: Ensure mailbox was not modified by another thread
+        Mailbox mbox = this.getMailboxOrNull();
+        if (mbox == null) {
             return;
         }
-        mailbox.lock(true);
+        mbox.lock(true);
         try {
             synchronized (this) {
                 PagedFolderData paged = mFolder instanceof PagedFolderData ? (PagedFolderData) mFolder : null;
@@ -817,7 +819,7 @@ public abstract class ImapListener extends Session {
                 }
             }
         } finally {
-            mailbox.unlock();
+            mbox.unlock();
         }
     }
 

--- a/store/src/java/com/zimbra/cs/imap/ImapListener.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapListener.java
@@ -697,12 +697,14 @@ public abstract class ImapListener extends Session {
             int changeId, AddedItems added);
 
     protected ImapFolder reload() throws ImapSessionClosedException {
-        if (mailbox == null) {
+        // ZESC-460, ZCS-4004: Ensure mailbox was not modified by another thread
+        Mailbox mbox = this.getMailboxOrNull();
+        if (mbox == null) {
             throw new ImapSessionClosedException();
         }
         // Mailbox.endTransaction() -> ImapSession.notifyPendingChanges() locks in the order of Mailbox -> ImapSession.
         // Need to lock in the same order here, otherwise can result in deadlock.
-        mailbox.lock(true); // PagedFolderData.replay() locks Mailbox deep inside of it.
+        mbox.lock(true); // PagedFolderData.replay() locks Mailbox deep inside of it.
         try {
             synchronized (this) {
                 // if the data's already paged in, we can short-circuit
@@ -740,7 +742,7 @@ public abstract class ImapListener extends Session {
                 return (ImapFolder) mFolder;
             }
         } finally {
-            mailbox.unlock();
+            mbox.unlock();
         }
     }
 


### PR DESCRIPTION
This ticket covered updating the `updateAccessTime` method.  Found a second method (`reload`) that needed the same update.