### PR TITLE
ZCS-3663 more user friendly SSL error messages for external accounts

### DIFF
--- a/store/src/java/com/zimbra/cs/mailclient/MailConnection.java
+++ b/store/src/java/com/zimbra/cs/mailclient/MailConnection.java
@@ -24,8 +24,10 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketException;
+import java.security.cert.CertificateException;
 
 import javax.net.SocketFactory;
+import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 import javax.security.auth.login.LoginException;
@@ -90,14 +92,23 @@ public abstract class MailConnection {
                 }
                 break;
             }
-        } catch (IOException e) {
+        }
+        catch (SSLHandshakeException e) {
+            if (getLogger().isDebugEnabled()) {
+                getLogger().debug(String.format("SSL Handshake Exception: %s", e.getMessage()), e);
+            }
+            throw new IOException(String.format("Encrypted connection to %s:%s failed. Please check the SSL certificate on the external server.",
+                    config.getHost(), config.getPort()));
+        }
+        catch (IOException e ) {
             if (getLogger().isDebugEnabled()) {
                 getLogger().debug("MailConnect failed for config='%s' - exception Class=%s Msg='%s'", config,
-                        e.getClass().getName(), e.getMessage());
+                        e.getClass().getName(), e.getMessage(), e);
             }
             close();
             throw e;
         }
+
     }
 
     protected void startTls() throws IOException {


### PR DESCRIPTION
Update the code to catch the SSL related certificate exceptions and create a new
IOException that contains a more user-friendly message such that the end user isn't
shown a message that is meaningless. The message shown to the user should empower them
to inform the administrator of their server that their SSL certificate is invalid.

Messages shown to user:
 Encrypted connection: Encrypted connection failed. Please check the SSL certificate on the external server
 STARTTLS: STARTTLS failed. Please check the SSL certificate on the external server.