### PR TITLE
ZCS-4004 Update to initial fix

### DIFF
--- a/store/src/java/com/zimbra/cs/imap/ImapListener.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapListener.java
@@ -698,7 +698,7 @@ public abstract class ImapListener extends Session {
 
     protected ImapFolder reload() throws ImapSessionClosedException {
         // ZESC-460, ZCS-4004: Ensure mailbox was not modified by another thread
-        Mailbox mbox = this.getMailboxOrNull();
+        MailboxStore mbox = mailbox;
         if (mbox == null) {
             throw new ImapSessionClosedException();
         }
@@ -808,7 +808,7 @@ public abstract class ImapListener extends Session {
     public void updateAccessTime() {
         super.updateAccessTime();
         // ZESC-460, ZCS-4004: Ensure mailbox was not modified by another thread
-        Mailbox mbox = this.getMailboxOrNull();
+        MailboxStore mbox = mailbox;
         if (mbox == null) {
             return;
         }


### PR DESCRIPTION
Replaced call to `this.getMailboxOrNull`, as we need to have a `MailboxStore`.  Original implementation was breaking the `TestImapViaEmbeddedRemote` SOAP tests.

Verified that unit tests and all of the enabled IMAP-related SOAP tests pass.