### PR TITLE
Bugfix/pwsaltlen

### DIFF
--- a/store/src/java/com/zimbra/cs/account/auth/AuthMechanism.java
+++ b/store/src/java/com/zimbra/cs/account/auth/AuthMechanism.java
@@ -245,26 +245,18 @@ public abstract class AuthMechanism {
                         namePassedIn(authCtxt), "missing "+Provisioning.A_userPassword);
             }
 
-            if (PasswordUtil.SSHA512.isSSHA512(encodedPassword)) {
-                if (PasswordUtil.SSHA512.verifySSHA512(encodedPassword, password)) {
-                    return; // good password, RETURN
-                }  else {
-                    throw AuthFailedServiceException.AUTH_FAILED(acct.getName(),
-                            namePassedIn(authCtxt), "invalid password");
-                }
-            } else if (PasswordUtil.SSHA.isSSHA(encodedPassword)) {
-                    if (PasswordUtil.SSHA.verifySSHA(encodedPassword, password)) {
-                        return; // good password, RETURN
-                    }  else {
-                        throw AuthFailedServiceException.AUTH_FAILED(acct.getName(),
-                                namePassedIn(authCtxt), "invalid password");
-                    }
-            } else if (acct instanceof LdapEntry) {
-                // not SSHA/SSHA512, authenticate to Zimbra LDAP
+            Boolean result = PasswordUtil.verify(encodedPassword, password);
+
+            if (result == null && acct instanceof LdapEntry) {
                 prov.zimbraLdapAuthenticate(acct, password, authCtxt);
-                return;  // good password, RETURN
+                return; // good password, RETURN
             }
-            throw AuthFailedServiceException.AUTH_FAILED(acct.getName(), namePassedIn(authCtxt));
+
+            if (result) {
+                return; // good password, RETURN
+            }
+
+            throw AuthFailedServiceException.AUTH_FAILED(acct.getName(), namePassedIn(authCtxt), "invalid password");
         }
 
         @Override

--- a/store/src/java/com/zimbra/cs/account/auth/PasswordUtil.java
+++ b/store/src/java/com/zimbra/cs/account/auth/PasswordUtil.java
@@ -29,10 +29,11 @@ import com.zimbra.cs.ldap.unboundid.InMemoryLdapServer;
 
 public class PasswordUtil {
 
-	private static final Scheme DEFAULT_SCHEME = Scheme.SSHA512;
+    private static final Scheme DEFAULT_SCHEME = Scheme.SSHA512;
     private static final byte[] FIXED_SALT = {127,127,127,127};
 
     public enum Scheme {
+        // Hardcode digest lengths to avoid exception handling in constructor
         SSHA512 ("SHA-512", 64, 8),
         SSHA    ("SHA1",    20, 4),
         SHA1    ("SHA1",    20, 0),
@@ -71,6 +72,7 @@ public class PasswordUtil {
 
             byte[] digested;
 
+            // Bail out if encoded string too short for scheme
             if (buff.length < LENGTH)
                 return false;
 
@@ -121,16 +123,15 @@ public class PasswordUtil {
                 // this shouldn't happen unless JDK is foobar
                 throw new RuntimeException(e);
             }
-                
         }
-
     }
 
     public static Scheme getScheme(String encodedPassword) {
         int index = encodedPassword.indexOf("}");
 
-        if (index < 1 )
+        if (index < 1 ) {
             return null;
+        }
 
         String schemeName = encodedPassword.substring(1,index);
         try {
@@ -143,15 +144,16 @@ public class PasswordUtil {
     public static boolean verify(String encodedPassword, String password) {
         Scheme scheme = getScheme(encodedPassword);
 
-        if (scheme == null)
+        if (scheme == null) {
             return false;
+        }
 
         return scheme.verify(encodedPassword, password);
     }
 
-	public static String generate(String password) {
-		return DEFAULT_SCHEME.generate(password);
-	}
+    public static String generate(String password) {
+        return DEFAULT_SCHEME.generate(password);
+    }
 
     public static void main(String[] args) {
         boolean result;

--- a/store/src/java/com/zimbra/cs/account/auth/PasswordUtil.java
+++ b/store/src/java/com/zimbra/cs/account/auth/PasswordUtil.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2009, 2010, 2011, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2009, 2010, 2011, 2013, 2014, 2016, 2018 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -17,9 +17,11 @@
 package com.zimbra.cs.account.auth;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.util.Arrays;
 
 import org.apache.commons.codec.binary.Base64;
 
@@ -27,235 +29,160 @@ import com.zimbra.cs.ldap.unboundid.InMemoryLdapServer;
 
 public class PasswordUtil {
 
-    /*
-     * SSHA  (salted-SHA1)
-     */
-    public static class SSHA {
+	private static final Scheme DEFAULT_SCHEME = Scheme.SSHA512;
+    private static final byte[] FIXED_SALT = {127,127,127,127};
 
-        private static int SALT_LEN = 4; // to match LDAP SSHA password encoding
-        private static String SSHA_ENCODING = "{SSHA}";
+    public enum Scheme {
+        SSHA512 ("SHA-512", 64, 8),
+        SSHA    ("SHA1",    20, 4),
+        SHA1    ("SHA1",    20, 0),
+        SHA     ("SHA1",    20, 0),
+        MD5     ("MD5",     16, 0);
 
-        public static boolean isSSHA(String encodedPassword) {
-            return encodedPassword.startsWith(SSHA_ENCODING);
+        private final String ALGORITHM;
+        private final int LENGTH;
+        private final int DEFAULT_SALT_LENGTH;
+        private final boolean SALTED;
+        private final String PREFIX;
+
+        Scheme(String algorithm, int len, int slen) {
+            ALGORITHM = algorithm;
+            LENGTH = len;
+            DEFAULT_SALT_LENGTH = slen;
+            SALTED = (DEFAULT_SALT_LENGTH == 0);
+            PREFIX = "{" + this.name() + "}";
         }
 
-        public static boolean verifySSHA(String encodedPassword, String password) {
-            if (!encodedPassword.startsWith(SSHA_ENCODING))
+        public boolean isSalted() {
+            return SALTED;
+        }
+
+        public boolean validate(String encodedPassword) {
+            return encodedPassword.startsWith(PREFIX);
+        }
+
+        public boolean verify(String encodedPassword, String password) {
+            int index = encodedPassword.indexOf("}");
+            if (index == -1)
                 return false;
-            byte[] encodedBuff = encodedPassword.substring(SSHA_ENCODING.length()).getBytes();
+
+            byte[] encodedBuff = encodedPassword.substring(index).getBytes();
             byte[] buff = Base64.decodeBase64(encodedBuff);
-            if (buff.length <= SALT_LEN)
+
+            byte[] digested;
+
+            if (buff.length < LENGTH)
                 return false;
-            int slen = (buff.length == 28) ? 8 : SALT_LEN;
+
+            // Don't bother special casing unsalted passwords; not the normal case now
+            int slen = buff.length - LENGTH;
             byte[] salt = new byte[slen];
             System.arraycopy(buff, buff.length-slen, salt, 0, slen);
-            String generated = generateSSHA(password, salt);
-            return generated.equals(encodedPassword);
+            digested = digest(password, salt);
+
+            return Arrays.equals(buff, digested);
+        }    
+
+        public String generate(String password) {
+            return generate(password, null);
         }
 
-        public static String generateSSHA(String password, byte[] salt) {
-            try {
-                MessageDigest md = MessageDigest.getInstance("SHA1");
-                if (salt == null) {
+        public String generate(String password, byte[] salt) {
+            return PREFIX + new String(Base64.encodeBase64(digest(password, salt)));
+        }
 
-                    if (InMemoryLdapServer.isOn()) {
-                        // use a fixed salt
-                        salt = new byte[]{127,127,127,127};
-                    } else {
-                        salt = new byte[SALT_LEN];
-                        SecureRandom sr = new SecureRandom();
-                        sr.nextBytes(salt);
-                    }
+        private byte[] digest(String password) {
+            return digest(password, null);
+        }
+
+        private byte[] digest(String password, byte[] salt) {
+            if (salt == null) {
+                if (InMemoryLdapServer.isOn()) {
+                    salt = FIXED_SALT;
+                } else {
+                    salt = new byte[DEFAULT_SALT_LENGTH];
+                    SecureRandom sr = new SecureRandom();
+                    sr.nextBytes(salt);
                 }
-                md.update(password.getBytes("UTF-8"));
+            }
+
+            try {
+                MessageDigest md = MessageDigest.getInstance(ALGORITHM);
+
+                md.update(password.getBytes(StandardCharsets.UTF_8));
                 md.update(salt);
+
                 byte[] digest = md.digest();
                 byte[] buff = new byte[digest.length + salt.length];
                 System.arraycopy(digest, 0, buff, 0, digest.length);
                 System.arraycopy(salt, 0, buff, digest.length, salt.length);
-                return SSHA_ENCODING + new String(Base64.encodeBase64(buff));
+                return buff;
             } catch (NoSuchAlgorithmException e) {
                 // this shouldn't happen unless JDK is foobar
                 throw new RuntimeException(e);
-            } catch (UnsupportedEncodingException e) {
-                // this shouldn't happen unless JDK is foobar
-                throw new RuntimeException(e);
             }
+                
         }
 
     }
 
-    /*
-     * SSHA512  (salted-SHA512)
-     */
-    public static class SSHA512 {
+    public static Scheme getScheme(String encodedPassword) {
+        int index = encodedPassword.indexOf("}");
 
-        private static int SALT_LEN = 8; // to match LDAP SSHA512 password encoding
-        private static String SSHA512_ENCODING = "{SSHA512}";
+        if (index < 1 )
+            return null;
 
-        public static boolean isSSHA512(String encodedPassword) {
-            return encodedPassword.startsWith(SSHA512_ENCODING);
-        }
-
-        public static boolean verifySSHA512(String encodedPassword, String password) {
-            if (!encodedPassword.startsWith(SSHA512_ENCODING))
-                return false;
-            byte[] encodedBuff = encodedPassword.substring(SSHA512_ENCODING.length()).getBytes();
-            byte[] buff = Base64.decodeBase64(encodedBuff);
-            if (buff.length <= SALT_LEN)
-                return false;
-            int slen = (buff.length == 28) ? 8 : SALT_LEN;
-            byte[] salt = new byte[slen];
-            System.arraycopy(buff, buff.length-slen, salt, 0, slen);
-            String generated = generateSSHA512(password, salt);
-            return generated.equals(encodedPassword);
-        }
-
-        public static String generateSSHA512(String password, byte[] salt) {
-            try {
-                MessageDigest md = MessageDigest.getInstance("SHA-512");
-                if (salt == null) {
-
-                    if (InMemoryLdapServer.isOn()) {
-                        // use a fixed salt
-                        salt = new byte[]{127,127,127,127};
-                    } else {
-                        salt = new byte[SALT_LEN];
-                        SecureRandom sr = new SecureRandom();
-                        sr.nextBytes(salt);
-                    }
-                }
-                md.update(password.getBytes("UTF-8"));
-                md.update(salt);
-                byte[] digest = md.digest();
-                byte[] buff = new byte[digest.length + salt.length];
-                System.arraycopy(digest, 0, buff, 0, digest.length);
-                System.arraycopy(salt, 0, buff, digest.length, salt.length);
-                return SSHA512_ENCODING + new String(Base64.encodeBase64(buff));
-            } catch (NoSuchAlgorithmException e) {
-                // this shouldn't happen unless JDK is foobar
-                throw new RuntimeException(e);
-            } catch (UnsupportedEncodingException e) {
-                // this shouldn't happen unless JDK is foobar
-                throw new RuntimeException(e);
-            }
-        }
-
-    }
-
-    /*
-     * SHA1 (unseeded)
-     */
-    public static class SHA1 {
-
-        private static String SHA1_ENCODING = "{SHA1}";
-        private static String SHA_ENCODING = "{SHA}";
-
-        public static boolean isSHA1(String encodedPassword) {
-            return encodedPassword.startsWith(SHA1_ENCODING) ||
-				encodedPassword.startsWith(SHA_ENCODING);
-        }
-
-        public static boolean verifySHA1(String encodedPassword, String password) {
-            byte[] encodedBuff;
-			String prefix = SHA1_ENCODING;
-            if (encodedPassword.startsWith(SHA1_ENCODING))
-				prefix = SHA1_ENCODING;
-			else if (encodedPassword.startsWith(SHA_ENCODING))
-				prefix = SHA_ENCODING;
-			else
-				return false;
-			encodedBuff = encodedPassword.substring(prefix.length()).getBytes();
-            byte[] buff = Base64.decodeBase64(encodedBuff);
-            String generated = generateSHA1(password, prefix);
-            return generated.equals(encodedPassword);
-        }
-
-        public static String generateSHA1(String password) {
-			return generateSHA1(password, SHA1_ENCODING);
-		}
-
-        public static String generateSHA1(String password, String prefix) {
-			if (prefix == null) prefix = SHA1_ENCODING;
-            try {
-                MessageDigest md = MessageDigest.getInstance("SHA1");
-                md.update(password.getBytes("UTF-8"));
-
-                byte[] digest = md.digest();
-                return prefix + new String(Base64.encodeBase64(digest));
-            } catch (NoSuchAlgorithmException e) {
-                // this shouldn't happen unless JDK is foobar
-                throw new RuntimeException(e);
-            } catch (UnsupportedEncodingException e) {
-                // this shouldn't happen unless JDK is foobar
-                throw new RuntimeException(e);
-            }
+        String schemeName = encodedPassword.substring(1,index);
+        try {
+            return Scheme.valueOf(schemeName);
+        } catch (Exception e) {
+            return null;
         }
     }
 
-    /*
-     * MD5
-     */
-    public static class MD5 {
+    public static boolean verify(String encodedPassword, String password) {
+        Scheme scheme = getScheme(encodedPassword);
 
-        private static String MD5_ENCODING = "{MD5}";
+        if (scheme == null)
+            return false;
 
-        public static boolean isMD5(String encodedPassword) {
-            return encodedPassword.startsWith(MD5_ENCODING);
-        }
-
-        public static boolean verifyMD5(String encodedPassword, String password) {
-            if (!encodedPassword.startsWith(MD5_ENCODING))
-                return false;
-            byte[] encodedBuff = encodedPassword.substring(MD5_ENCODING.length()).getBytes();
-            byte[] buff = Base64.decodeBase64(encodedBuff);
-            String generated = generateMD5(password);
-            return generated.equals(encodedPassword);
-        }
-
-        public static String generateMD5(String password) {
-            try {
-                MessageDigest md = MessageDigest.getInstance("MD5");
-                md.update(password.getBytes("UTF-8"));
-
-                byte[] digest = md.digest();
-                return MD5_ENCODING + new String(Base64.encodeBase64(digest));
-            } catch (NoSuchAlgorithmException e) {
-                // this shouldn't happen unless JDK is foobar
-                throw new RuntimeException(e);
-            } catch (UnsupportedEncodingException e) {
-                // this shouldn't happen unless JDK is foobar
-                throw new RuntimeException(e);
-            }
-        }
+        return scheme.verify(encodedPassword, password);
     }
 
-    public static void main(String args[]) {
+	public static String generate(String password) {
+		return DEFAULT_SCHEME.generate(password);
+	}
 
-        String plain = "test123";
-        System.out.println("plain:        " + plain);
-        System.out.println("encoded SSHA: " + SSHA.generateSSHA(plain, null));
-        System.out.println("encoded SSHA512: " + SSHA512.generateSSHA512(plain, null));
-        System.out.println("encoded SSH1: " + SHA1.generateSHA1(plain));
-        System.out.println("encoded MD5:  " + MD5.generateMD5(plain));
+    public static void main(String[] args) {
+        boolean result;
+        String plain;
+        String encoded;
+
+        plain = "test123";
+        System.out.println("plain: " + plain);
+        for (Scheme s: Scheme.values()) {
+            encoded = s.generate(plain);
+            result = verify (encoded, plain);
+            System.out.printf("[%s] %10s: %s\n", (result?"PASS":"FAIL"), s.name(), s.generate(plain));
+        }
         System.out.println();
 
         plain = "helloWorld";
-        System.out.println("plain:        " + plain);
-        System.out.println("encoded SSHA: " + SSHA.generateSSHA(plain, null));
-        System.out.println("encoded SSHA512: " + SSHA512.generateSSHA512(plain, null));
-        System.out.println("encoded SSH1: " + SHA1.generateSHA1(plain));
-        System.out.println("encoded MD5:  " + MD5.generateMD5(plain));
+        System.out.println("plain: " + plain);
+        for (Scheme s: Scheme.values()) {
+            encoded = s.generate(plain);
+            result = verify (encoded, plain);
+            System.out.printf("[%s] %10s: %s\n", (result?"PASS":"FAIL"), s.name(), s.generate(plain));
+        }
         System.out.println();
 
         plain = "testme";
-        String encodedSHA1 = SHA1.generateSHA1(plain, SHA1.SHA1_ENCODING);
-        String encodedSHA  = SHA1.generateSHA1(plain, SHA1.SHA_ENCODING);
-        boolean result;
-        result = SHA1.verifySHA1(encodedSHA1, plain);
+        String encodedSHA1 = Scheme.SHA1.generate(plain);
+        String encodedSHA  = Scheme.SHA.generate(plain);
+
+        result = Scheme.SHA1.verify(encodedSHA1, plain);
         System.out.println("result is " + (result?"good":"bad"));
-        result = SHA1.verifySHA1(encodedSHA, plain);
+        result = Scheme.SHA1.verify(encodedSHA, plain);
         System.out.println("result is " + (result?"good":"bad"));
     }
-
 }

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapLockoutPolicy.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapLockoutPolicy.java
@@ -34,7 +34,7 @@ import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.Provisioning;
-import com.zimbra.cs.account.auth.PasswordUtil.SSHA512;
+import com.zimbra.cs.account.auth.PasswordUtil;
 import com.zimbra.cs.account.auth.twofactor.TwoFactorAuth;
 import com.zimbra.cs.ldap.LdapDateUtil;
 
@@ -159,11 +159,11 @@ public class LdapLockoutPolicy {
                             synchronized (pwds) {
                                 int cacheSize = pwds.size();
                                 if (cacheSize == 0) {
-                                    pwds.add(SSHA512.generateSSHA512(password, null));
+                                    pwds.add(PasswordUtil.generate(password));
                                     ZimbraLog.account.debug("Created entry in password lockout cache");
                                 } else {
                                     for (String pwd : pwds) {
-                                        if (SSHA512.verifySSHA512(pwd, password)) {
+                                        if (PasswordUtil.verify(pwd, password)) {
                                             return true;
                                         }
                                     }
@@ -176,7 +176,7 @@ public class LdapLockoutPolicy {
                                     }
                                     ZimbraLog.account.debug("Password lockout suppression cache size = %s (max = %s)", cacheSize, maxCacheSize);
                                     if (cacheSize < maxCacheSize) {
-                                        pwds.add(SSHA512.generateSSHA512(password, null));
+                                        pwds.add(PasswordUtil.generate(password));
                                         ZimbraLog.account.debug("Added entry in password lockout cache");
                                     }
                                 }

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -3611,7 +3611,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
         deleteDomain(zimbraId, true);
     }
 
-	@Override
+    @Override
     public void deleteDomainAfterRename(String zimbraId) throws ServiceException {
         deleteDomain(zimbraId, false);
     }
@@ -5758,14 +5758,13 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
             int sepIndex = history[i].indexOf(':');
             if (sepIndex != -1)  {
                 String encoded = history[i].substring(sepIndex+1);
-                if (PasswordUtil.SSHA.isSSHA(encoded)) {
-                    if (PasswordUtil.SSHA.verifySSHA(encoded, newPassword))
-                        throw AccountServiceException.PASSWORD_RECENTLY_USED();
-                } else if (PasswordUtil.SSHA512.isSSHA512(encoded)) {
-                    if (PasswordUtil.SSHA512.verifySSHA512(encoded, newPassword))
-                        throw AccountServiceException.PASSWORD_RECENTLY_USED();
-                } else {
-                    ZimbraLog.account.debug("password hash neither SSHA nor SSHA512; ignored for password history");
+
+                Boolean result = PasswordUtil.verify(encoded, newPassword);
+                if (result == null) {
+                    ZimbraLog.account.debug("password hash not supported; ignored for password history");
+                }
+                if (result) {
+                    throw AccountServiceException.PASSWORD_RECENTLY_USED();
                 }
             }
         }

--- a/store/src/java/com/zimbra/cs/ldap/unboundid/InMemoryLdapServer.java
+++ b/store/src/java/com/zimbra/cs/ldap/unboundid/InMemoryLdapServer.java
@@ -163,7 +163,7 @@ public class InMemoryLdapServer {
             if (password.startsWith(NON_SSHA_PASSWORD_PREFIX)) {
                 return password;
             } else {
-                return PasswordUtil.SSHA.generateSSHA(password, null);
+                return PasswordUtil.Scheme.SSHA.generate(password);
             }
         }
     }


### PR DESCRIPTION
While we were on-boarding a new client we discovered that Zimbra would not authenticate against their pre-hashed SSHA passwords even though we could bind to the address via LDAP.  Further investigation showed that the PasswordUtil class only works on passwords created with a salt length of 4 or 8 characters.

This patch goes beyond the scope of our immediate problem by supporting arbitrary salt lengths for all password schemes and modifies the interface so calling code no longer has to explicitly check individual password schemes.  The also simplifies adding new schemes in the future; e.g. support for SHA3-512 could be added with a single line to one class.