### PR TITLE
ZCS-4007: Contact Frequency Changes

### DIFF
--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -224,6 +224,7 @@ import com.zimbra.soap.mail.message.TestDataSourceRequest;
 import com.zimbra.soap.mail.message.TestDataSourceResponse;
 import com.zimbra.soap.mail.type.ActionResult;
 import com.zimbra.soap.mail.type.ActionSelector;
+import com.zimbra.soap.mail.type.ContactFrequencyGraphSpec;
 import com.zimbra.soap.mail.type.ContactSpec;
 import com.zimbra.soap.mail.type.Content;
 import com.zimbra.soap.mail.type.Folder;
@@ -6661,12 +6662,16 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
         return invokeJaxb(req);
     }
 
-    public GetContactFrequencyResponse getContactFrequency(String email, String frequencyBy) throws ServiceException {
-        return invokeJaxb(new GetContactFrequencyRequest(email, frequencyBy));
+    public GetContactFrequencyResponse getContactFrequency(String email, ContactFrequencyGraphSpec... specs) throws ServiceException {
+        return getContactFrequency(email, null, specs);
     }
 
-    public GetContactFrequencyResponse getContactFrequency(String email, String frequencyBy, Integer offsetInMinutes) throws ServiceException {
-        return invokeJaxb(new GetContactFrequencyRequest(email, frequencyBy, offsetInMinutes));
+    public GetContactFrequencyResponse getContactFrequency(String email, Integer offsetInMinutes, ContactFrequencyGraphSpec... specs) throws ServiceException {
+        GetContactFrequencyRequest req = new GetContactFrequencyRequest(email, offsetInMinutes);
+        for (ContactFrequencyGraphSpec spec: specs) {
+            req.addGraphSpec(spec);
+        }
+        return invokeJaxb(req);
     }
 
     public static class OpenIMAPFolderParams {

--- a/common/src/java/com/zimbra/common/soap/MailConstants.java
+++ b/common/src/java/com/zimbra/common/soap/MailConstants.java
@@ -1415,7 +1415,9 @@ public final class MailConstants {
     public static final String E_GET_CONTACT_FREQUENCY_RESPONSE = "GetContactFrequencyResponse";
     public static final QName GET_CONTACT_FREQUENCY_REQUEST = QName.get(E_GET_CONTACT_FREQUENCY_REQUEST, NAMESPACE);
     public static final QName GET_CONTACT_FREQUENCY_RESPONSE = QName.get(E_GET_CONTACT_FREQUENCY_RESPONSE, NAMESPACE);
-    public static final String A_CONTACT_FREQUENCY_BY = "by";
+    public static final String A_CONTACT_FREQUENCY_GRAPH_SPEC = "spec";
+    public static final String A_CONTACT_FREQUENCY_GRAPH_RANGE = "range";
+    public static final String A_CONTACT_FREQUENCY_GRAPH_INTERVAL = "interval";
     public static final String E_CONTACT_FREQUENCY_DATA = "data";
     public static final String E_CONTACT_FREQUENCY_DATA_POINT = "dataPoint";
     public static final String A_CONTACT_FREQUENCY_LABEL = "label";

--- a/soap/src/java/com/zimbra/soap/mail/message/GetContactFrequencyRequest.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/GetContactFrequencyRequest.java
@@ -1,9 +1,14 @@
 package com.zimbra.soap.mail.message;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import com.zimbra.common.soap.MailConstants;
+import com.zimbra.soap.mail.type.ContactFrequencyGraphSpec;
 
 @XmlRootElement(name=MailConstants.E_GET_CONTACT_FREQUENCY_REQUEST)
 public class GetContactFrequencyRequest {
@@ -12,13 +17,12 @@ public class GetContactFrequencyRequest {
      */
     @XmlAttribute(name=MailConstants.A_EMAIL, required=true)
     private String contactEmail;
+
     /**
-     * @zm-api-field-description list of frequency graphs to return. time range values should be concatenated together
-     * Values are one or more of "d(day)w(week)m(month)".
-     * request can have any combination of values "dwm" like "dw", "wm", "mdw", etc.
+     * @zm-api-field-description List of contact frequency graph specifications to return
      */
-    @XmlAttribute(name=MailConstants.A_CONTACT_FREQUENCY_BY, required=true)
-    private String frequencyBy;
+    @XmlElement(name=MailConstants.A_CONTACT_FREQUENCY_GRAPH_SPEC, type=ContactFrequencyGraphSpec.class, required=true)
+    private List<ContactFrequencyGraphSpec> specs = new ArrayList<>();
 
     /**
      * @zm-api-field-description offset in minutes from UTC to user's current timezone.
@@ -28,21 +32,20 @@ public class GetContactFrequencyRequest {
 
     public GetContactFrequencyRequest() {}
 
-    public GetContactFrequencyRequest(String email, String frequencyBy) {
-        this(email, frequencyBy, null);
+    public GetContactFrequencyRequest(String email) {
+        this(email, null);
     }
 
-    public GetContactFrequencyRequest(String email, String frequencyBy, Integer offsetInMinutes) {
+    public GetContactFrequencyRequest(String email, Integer offsetInMinutes) {
         setEmail(email);
-        setFrequencyBy(frequencyBy);
         setOffsetInMinutes(offsetInMinutes);
     }
 
+    public void addGraphSpec(ContactFrequencyGraphSpec graphSpec) { specs.add(graphSpec); }
+    public List<ContactFrequencyGraphSpec> getGraphSpecs() { return specs; }
+
     public String getEmail() { return contactEmail; }
     public void setEmail(String email) { this.contactEmail = email; }
-
-    public String getFrequencyBy() { return frequencyBy; }
-    public void setFrequencyBy(String frequencyBy) { this.frequencyBy = frequencyBy; }
 
     public Integer getOffsetInMinutes() { return offsetInMinutes; }
     public void setOffsetInMinutes(Integer offsetInMinutes) { this.offsetInMinutes = offsetInMinutes; }

--- a/soap/src/java/com/zimbra/soap/mail/type/ContactFrequencyData.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ContactFrequencyData.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 
 import com.zimbra.common.soap.MailConstants;
@@ -12,21 +11,27 @@ import com.zimbra.common.soap.MailConstants;
 @XmlAccessorType(XmlAccessType.NONE)
 public class ContactFrequencyData {
 
-    public ContactFrequencyData() {}
+    /**
+     * @zm-api-field-description The contact frequency graph specification corresponding to this graph
+     */
+    @XmlElement(name=MailConstants.A_CONTACT_FREQUENCY_GRAPH_SPEC, required=true)
+    private ContactFrequencyGraphSpec spec;
 
-    public ContactFrequencyData(String frequencyBy, List<ContactFrequencyDataPoint> dataPoints) {
-        setFrequencyBy(frequencyBy);
-        setDataPoints(dataPoints);
-    }
-
-    @XmlAttribute(name=MailConstants.A_CONTACT_FREQUENCY_BY, required=true)
-    private String frequencyBy;
-
+    /**
+     * @zm-api-field-description List of data points that comprise this graph
+     */
     @XmlElement(name=MailConstants.E_CONTACT_FREQUENCY_DATA_POINT, type=ContactFrequencyDataPoint.class)
     private List<ContactFrequencyDataPoint> dataPoints;
 
-    public String getFrequencyBy() { return frequencyBy; }
-    public void setFrequencyBy(String frequencyBy) { this.frequencyBy = frequencyBy; }
+    public ContactFrequencyData() {}
+
+    public ContactFrequencyData(ContactFrequencyGraphSpec graphSpec, List<ContactFrequencyDataPoint> dataPoints) {
+        setGraphSpec(graphSpec);
+        setDataPoints(dataPoints);
+    }
+
+    public ContactFrequencyGraphSpec getGraphSpec() { return spec; }
+    public void setGraphSpec(ContactFrequencyGraphSpec graphSpec) { this.spec = graphSpec; }
 
     public List<ContactFrequencyDataPoint> getDataPoints() { return dataPoints; }
     public void setDataPoints(List<ContactFrequencyDataPoint> dataPoints) { this.dataPoints = dataPoints; }

--- a/soap/src/java/com/zimbra/soap/mail/type/ContactFrequencyGraphSpec.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ContactFrequencyGraphSpec.java
@@ -1,0 +1,28 @@
+package com.zimbra.soap.mail.type;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+
+import com.zimbra.common.soap.MailConstants;
+
+@XmlAccessorType(XmlAccessType.NONE)
+public class ContactFrequencyGraphSpec {
+
+    @XmlAttribute(name=MailConstants.A_CONTACT_FREQUENCY_GRAPH_RANGE, required=true)
+    private String range;
+
+    @XmlAttribute(name=MailConstants.A_CONTACT_FREQUENCY_GRAPH_INTERVAL, required=true)
+    private String interval;
+
+    public ContactFrequencyGraphSpec(String range, String interval) {
+        this.range = range;
+        this.interval = interval;
+    }
+
+    public String getRange() { return range; }
+    public void setRange(String range) { this.range = range; }
+
+    public String getInterval() { return interval; }
+    public void setInterval(String interval) { this.interval = interval; }
+}

--- a/store/src/java/com/zimbra/cs/event/EventStore.java
+++ b/store/src/java/com/zimbra/cs/event/EventStore.java
@@ -14,6 +14,7 @@ import com.zimbra.cs.contacts.RelatedContactsResults;
 import com.zimbra.cs.event.Event.EventType;
 import com.zimbra.cs.event.analytics.RatioMetric;
 import com.zimbra.cs.event.analytics.contact.ContactAnalytics;
+import com.zimbra.cs.event.analytics.contact.ContactAnalytics.ContactFrequencyGraphSpec;
 import com.zimbra.cs.event.analytics.contact.ContactFrequencyGraphDataPoint;
 import com.zimbra.cs.event.logger.EventLogger;
 import com.zimbra.cs.extension.ExtensionUtil;
@@ -170,7 +171,7 @@ public abstract class EventStore {
      *      EndDate - Current date (today)
      *      Aggregation unit - Per month
      */
-    public abstract List<ContactFrequencyGraphDataPoint> getContactFrequencyGraph(String contact, ContactAnalytics.ContactFrequencyGraphTimeRange timeRange, Integer offsetInMinutes) throws ServiceException;
+    public abstract List<ContactFrequencyGraphDataPoint> getContactFrequencyGraph(String contact, ContactFrequencyGraphSpec graphSpec, Integer offsetInMinutes) throws ServiceException;
 
     /**
      * Returns the average time delta, in seconds, between two event types, for the given contact

--- a/store/src/java/com/zimbra/cs/event/analytics/contact/ContactAnalytics.java
+++ b/store/src/java/com/zimbra/cs/event/analytics/contact/ContactAnalytics.java
@@ -1,5 +1,9 @@
 package com.zimbra.cs.event.analytics.contact;
 
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import com.zimbra.common.calendar.ICalTimeZone;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.Account;
@@ -7,15 +11,45 @@ import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.event.EventStore;
 import com.zimbra.cs.mailbox.calendar.Util;
 
-import java.util.List;
-
 public class ContactAnalytics {
     public static enum ContactFrequencyTimeRange {
         LAST_DAY, LAST_WEEK, LAST_MONTH, FOREVER
     }
 
-    public static enum ContactFrequencyGraphTimeRange {
-        CURRENT_MONTH, LAST_SIX_MONTHS, CURRENT_YEAR
+    public static enum ContactFrequencyGraphInterval {
+        DAY("d"), WEEK("w");
+
+        private String shortRepr;
+
+        private ContactFrequencyGraphInterval(String shortRepr) {
+            this.shortRepr = shortRepr;
+        }
+        public static ContactFrequencyGraphInterval of(String str) throws ServiceException {
+            for (ContactFrequencyGraphInterval interval: ContactFrequencyGraphInterval.values()) {
+                if (interval.shortRepr.equals(str)) {
+                    return interval;
+                }
+            }
+            throw ServiceException.INVALID_REQUEST(str + " is not a valid time interval", null);
+        }
+    }
+
+    public static enum ContactFrequencyGraphTimeRangeUnit {
+        DAY("d"), WEEK("w"), MONTH("m");
+
+        private String shortRepr;
+
+        private ContactFrequencyGraphTimeRangeUnit(String shortRepr) {
+            this.shortRepr = shortRepr;
+        }
+        public static ContactFrequencyGraphTimeRangeUnit of(String str) throws ServiceException {
+            for (ContactFrequencyGraphTimeRangeUnit unit: ContactFrequencyGraphTimeRangeUnit.values()) {
+                if (unit.shortRepr.equals(str)) {
+                    return unit;
+                }
+            }
+            throw ServiceException.INVALID_REQUEST(str + " is not a valid time unit", null);
+        }
     }
 
     public static enum ContactFrequencyEventType {
@@ -29,14 +63,67 @@ public class ContactAnalytics {
     public static Long getContactFrequency(String contact, EventStore eventStore, ContactFrequencyEventType eventType, ContactFrequencyTimeRange timeRange) throws ServiceException {
         return eventStore.getContactFrequencyCount(contact, eventType, timeRange);
     }
-    public static List<ContactFrequencyGraphDataPoint> getContactFrequencyGraph(String contact, ContactFrequencyGraphTimeRange timeRange, EventStore eventStore) throws ServiceException {
+    public static List<ContactFrequencyGraphDataPoint> getContactFrequencyGraph(String contact, ContactFrequencyGraphSpec graphSpec, EventStore eventStore) throws ServiceException {
             Account account = Provisioning.getInstance().getAccountById(eventStore.getAccountId());
             ICalTimeZone userTimeZone = Util.getAccountTimeZone(account);
             Integer userTimeZoneOffsetInMinutes = ((userTimeZone.getStandardOffset() / 1000) / 60);
-            return getContactFrequencyGraph(contact, timeRange, eventStore, userTimeZoneOffsetInMinutes);
+            return getContactFrequencyGraph(contact, graphSpec, eventStore, userTimeZoneOffsetInMinutes);
     }
 
-    public static List<ContactFrequencyGraphDataPoint> getContactFrequencyGraph(String contact, ContactFrequencyGraphTimeRange timeRange, EventStore eventStore, Integer offsetInMinutes) throws ServiceException {
-        return eventStore.getContactFrequencyGraph(contact, timeRange, offsetInMinutes);
+    public static List<ContactFrequencyGraphDataPoint> getContactFrequencyGraph(String contact, ContactFrequencyGraphSpec graphSpec, EventStore eventStore, Integer offsetInMinutes) throws ServiceException {
+        return eventStore.getContactFrequencyGraph(contact, graphSpec, offsetInMinutes);
+    }
+
+    public static class ContactFrequencyGraphTimeRange {
+        private ContactFrequencyGraphTimeRangeUnit unit;
+        private int numUnits;
+        private static Pattern pattern = Pattern.compile("\\d+");
+
+        public ContactFrequencyGraphTimeRange(String input) throws ServiceException {
+            Matcher matcher = pattern.matcher(input);
+            matcher.find();
+            String numStr = matcher.group();
+            String rest = input.substring(matcher.end());
+            try {
+                numUnits = Integer.valueOf(numStr);
+                if (numUnits <= 0) {
+                    throw ServiceException.INVALID_REQUEST("invalid range format", null);
+                }
+            } catch (NumberFormatException e) {
+                throw ServiceException.INVALID_REQUEST("invalid range format", null);
+            }
+            this.unit = ContactFrequencyGraphTimeRangeUnit.of(rest);
+        }
+
+        public ContactFrequencyGraphTimeRange(int numUnits, ContactFrequencyGraphTimeRangeUnit unit) {
+            this.numUnits = numUnits;
+            this.unit = unit;
+        }
+
+        public ContactFrequencyGraphTimeRangeUnit getTimeUnit() {
+            return unit;
+        }
+
+        public int getNumUnits() {
+            return numUnits;
+        }
+    }
+
+    public static class ContactFrequencyGraphSpec {
+
+        private ContactFrequencyGraphTimeRange range;
+        private ContactFrequencyGraphInterval interval;
+
+        public ContactFrequencyGraphSpec(ContactFrequencyGraphTimeRange range, ContactFrequencyGraphInterval interval) {
+            this.range = range;
+            this.interval = interval;
+        }
+        public ContactFrequencyGraphTimeRange getRange() {
+            return range;
+        }
+
+        public ContactFrequencyGraphInterval getInterval() {
+            return interval;
+        }
     }
 }

--- a/store/src/java/com/zimbra/qa/unittest/TestSolrCloudEventStore.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestSolrCloudEventStore.java
@@ -3,6 +3,7 @@ package com.zimbra.qa.unittest;
 import java.io.IOException;
 
 import com.zimbra.cs.account.Account;
+
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
@@ -14,10 +15,10 @@ import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.params.CoreAdminParams;
-
 import org.junit.*;
 
 import com.zimbra.cs.event.analytics.contact.ContactAnalytics;
+import com.zimbra.cs.event.analytics.contact.ContactAnalytics.ContactFrequencyGraphSpec;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.event.SolrCloudEventStore;
 import com.zimbra.cs.event.SolrEventStore;
@@ -157,26 +158,26 @@ public class TestSolrCloudEventStore extends SolrEventStoreTestBase {
 
     @Test
     public void testGetContactFrequencyGraphForAllTimeRanges() throws Exception {
-        for (ContactAnalytics.ContactFrequencyGraphTimeRange timeRange : getContactFrequencyGraphTimeRanges()) {
-            testContactFrequencyGraphForAccountCore(timeRange);
-            testContactFrequencyGraphForCombinedCore(timeRange);
+        for (ContactFrequencyGraphSpec graphSpec : getContactFrequencyGraphSpecs()) {
+            testContactFrequencyGraphForAccountCore(graphSpec);
+            testContactFrequencyGraphForCombinedCore(graphSpec);
         }
     }
 
-    private void testContactFrequencyGraphForAccountCore(ContactAnalytics.ContactFrequencyGraphTimeRange timeRange) throws Exception {
+    private void testContactFrequencyGraphForAccountCore(ContactFrequencyGraphSpec graphSpec) throws Exception {
         cleanUp();
         try (SolrEventCallback eventCallback = getAccountCoreCallback()) {
             String collectionName = getAccountCollectionName(CONTACT_FREQUENCY_GRAPH_TEST_ACCOUNT_ID);
             SolrEventStore eventStore = getAccountEventStore(CONTACT_FREQUENCY_GRAPH_TEST_ACCOUNT_ID);
-            testContactFrequencyGraph(timeRange, eventCallback, collectionName, eventStore);
+            testContactFrequencyGraph(graphSpec, eventCallback, collectionName, eventStore);
         }
     }
 
-    private void testContactFrequencyGraphForCombinedCore(ContactAnalytics.ContactFrequencyGraphTimeRange timeRange) throws Exception {
+    private void testContactFrequencyGraphForCombinedCore(ContactFrequencyGraphSpec graphSpec) throws Exception {
         cleanUp();
         try (SolrEventCallback eventCallback = getCombinedCoreCallback()) {
             SolrEventStore eventStore = getCombinedEventStore(CONTACT_FREQUENCY_GRAPH_TEST_ACCOUNT_ID);
-            testContactFrequencyGraph(timeRange, eventCallback, JOINT_COLLECTION_NAME, eventStore);
+            testContactFrequencyGraph(graphSpec, eventCallback, JOINT_COLLECTION_NAME, eventStore);
         }
     }
 

--- a/store/src/java/com/zimbra/qa/unittest/TestStandaloneSolrEventStore.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestStandaloneSolrEventStore.java
@@ -16,6 +16,7 @@ import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.event.SolrEventStore;
 import com.zimbra.cs.event.analytics.contact.ContactAnalytics;
+import com.zimbra.cs.event.analytics.contact.ContactAnalytics.ContactFrequencyGraphSpec;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.event.StandaloneSolrEventStore;
 import com.zimbra.cs.event.logger.SolrEventCallback;
@@ -154,26 +155,26 @@ public class TestStandaloneSolrEventStore extends SolrEventStoreTestBase {
 
     @Test
     public void testGetContactFrequencyGraphForAllTimeRanges() throws Exception {
-        for (ContactAnalytics.ContactFrequencyGraphTimeRange timeRange : getContactFrequencyGraphTimeRanges()) {
-            testContactFrequencyGraphForAccountCore(timeRange);
-            testContactFrequencyGraphForCombinedCore(timeRange);
+        for (ContactFrequencyGraphSpec graphSpec: getContactFrequencyGraphSpecs()) {
+            testContactFrequencyGraphForAccountCore(graphSpec);
+            testContactFrequencyGraphForCombinedCore(graphSpec);
         }
     }
 
-    private void testContactFrequencyGraphForAccountCore(ContactAnalytics.ContactFrequencyGraphTimeRange timeRange) throws Exception {
+    private void testContactFrequencyGraphForAccountCore(ContactFrequencyGraphSpec graphSpec) throws Exception {
         cleanUp();
         try(SolrEventCallback eventCallback = getAccountCoreCallback()) {
             String collectionName = getAccountCollectionName(CONTACT_FREQUENCY_GRAPH_TEST_ACCOUNT_ID);
             SolrEventStore eventStore = getAccountEventStore(CONTACT_FREQUENCY_GRAPH_TEST_ACCOUNT_ID);
-            testContactFrequencyGraph(timeRange, eventCallback, collectionName, eventStore);
+            testContactFrequencyGraph(graphSpec, eventCallback, collectionName, eventStore);
         }
     }
 
-    private void testContactFrequencyGraphForCombinedCore(ContactAnalytics.ContactFrequencyGraphTimeRange timeRange) throws Exception {
+    private void testContactFrequencyGraphForCombinedCore(ContactFrequencyGraphSpec graphSpec) throws Exception {
         cleanUp();
         try(SolrEventCallback eventCallback = getCombinedCoreCallback()) {
             SolrEventStore eventStore = getCombinedEventStore(CONTACT_FREQUENCY_GRAPH_TEST_ACCOUNT_ID);
-            testContactFrequencyGraph(timeRange, eventCallback, JOINT_COLLECTION_NAME, eventStore);
+            testContactFrequencyGraph(graphSpec, eventCallback, JOINT_COLLECTION_NAME, eventStore);
         }
     }
 


### PR DESCRIPTION
This PR changes the contact frequency graph API to allow clients to specify arbitrary range start times.

Previously, the client could only specify a combination of "d", "w", or "m" flags:
 - "d" returned the current month in day increments
 - "w" returned the last 6 months in week increments
 - "m" returned the _current_ year in month increments

This has been updated so that the client can specify one or more `spec` request elements, each consisting of:
 - A `range` string,  in the format `#(d|w|m)`; for example, "30d" or "25w".
 - An `interval`, which can be one of `d|day|w|week`. Note that aggregations by month are no longer supported. 

Given N time units (day, week, or month), the graph range will encompass N _complete_ units, as well as part of the current unit. In other words, requesting 6 months of data on January 15th would return data from August 1st until January 15th, with buckets for each of the 6 complete months and a partial bucket for January.

#### Update 1/31
Made the `range` parameter case-sensitive (only lower-case `d|w|m` is accepted)
Restricted the `interval` parameter to case-sensitive `d|w`