### PR TITLE
ZCS-3870:message correction and logging

### DIFF
--- a/store/src/java-test/com/zimbra/cs/service/mail/SaveProfileImageTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/mail/SaveProfileImageTest.java
@@ -106,7 +106,6 @@ public class SaveProfileImageTest {
         InputStream is = getClass().getResourceAsStream("img.jpg");
         FileUploadServlet.Upload up = FileUploadServlet.saveUpload(is, "img.jpg", "image/jpeg",
             acct.getId());
-        NativeFormatter.getResizedImageData(up.getInputStream(), "image/jpeg", "abc", 50, 50);
         PowerMockito.stub(PowerMockito.method(MimeDetect.class, "detect", InputStream.class))
             .toReturn("image/jpeg");
         byte[] bytes = IOUtils.toByteArray(up.getInputStream());

--- a/store/src/java/com/zimbra/cs/service/formatter/NativeFormatter.java
+++ b/store/src/java/com/zimbra/cs/service/formatter/NativeFormatter.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PushbackInputStream;
 import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
@@ -95,6 +96,7 @@ public final class NativeFormatter extends Formatter {
     public static final String ATTR_CONTENTTYPE = "contenttype";
     public static final String ATTR_CONTENTLENGTH = "contentlength";
     public static final String ATTR_LOCALE  = "locale";
+    public static final String RETURN_CODE_NO_RESIZE = "NO_RESIZE";
 
     private static final Log log = LogFactory.getLog(NativeFormatter.class);
 
@@ -256,7 +258,12 @@ public final class NativeFormatter extends Formatter {
 
                     // Return the data, or resized image if available.
                     long size;
+                    String returnCode = null;
                     if (data != null) {
+                        returnCode = new String(Arrays.copyOfRange(data, 0,
+                            NativeFormatter.RETURN_CODE_NO_RESIZE.length()), "UTF-8");
+                    }
+                    if (data != null && !NativeFormatter.RETURN_CODE_NO_RESIZE.equals(returnCode)) {
                         in = new ByteArrayInputStream(data);
                         size = data.length;
                     } else {
@@ -318,7 +325,7 @@ public final class NativeFormatter extends Formatter {
             if (width <= maxWidth && height <= maxHeight) {
                 log.debug("Image %dx%d is less than max %dx%d.  Not resizing.",
                           width, height, maxWidth, maxHeight);
-                return null;
+                return RETURN_CODE_NO_RESIZE.getBytes();
             }
 
             // Resize.
@@ -367,12 +374,17 @@ public final class NativeFormatter extends Formatter {
                     && (doc.getSize() < LC.max_image_size_to_resize.intValue())) {
                     byte[] data = getResizedImageData(is, doc.getContentType(), doc.getName(),
                         context.getMaxWidth(), context.getMaxHeight());
+                    String returnCode = null;
                     if (data != null) {
-                        InputStream profileInputStream = new ByteArrayInputStream(data);
-                        long size = data.length;
-                        sendbackBinaryData(context.req, context.resp, profileInputStream,
-                            contentType, null, doc.getName(), size);
-                        return;
+                        returnCode = new String(Arrays.copyOfRange(data, 0,
+                            NativeFormatter.RETURN_CODE_NO_RESIZE.length()), "UTF-8");
+                    }
+                    if (data != null && !NativeFormatter.RETURN_CODE_NO_RESIZE.equals(returnCode)) {
+                            InputStream profileInputStream = new ByteArrayInputStream(data);
+                            long size = data.length;
+                            sendbackBinaryData(context.req, context.resp, profileInputStream,
+                                contentType, null, doc.getName(), size);
+                            return;
                     }
                 }
             } catch (Exception e) {


### PR DESCRIPTION
Making the soap fault message more generic
Added logging for different failure reasons
If the image is not resized since its equal or less than the resize dimensions, update the actual image to LDAP