### PR TITLE
ZCS-3886:Log about proxying requests to other MBS

### DIFF
--- a/store/src/java/com/zimbra/cs/service/account/GetDistributionListMembers.java
+++ b/store/src/java/com/zimbra/cs/service/account/GetDistributionListMembers.java
@@ -183,7 +183,7 @@ public class GetDistributionListMembers extends GalDocumentHandler {
                 return getMembersFromLdap(account, group);
             } else {
                 // proxy to the home server of the group
-                ZimbraLog.account.debug("Proxying request to home server (%s) of group %s",
+                ZimbraLog.account.info("Proxying request to home server (%s) of group %s",
                         server.getName(), group.getName());
 
                 request.addAttribute(A_PROXIED_TO_HOME_OF_GROUP, true);

--- a/store/src/java/com/zimbra/cs/service/account/GetDistributionListMembers.java
+++ b/store/src/java/com/zimbra/cs/service/account/GetDistributionListMembers.java
@@ -183,8 +183,8 @@ public class GetDistributionListMembers extends GalDocumentHandler {
                 return getMembersFromLdap(account, group);
             } else {
                 // proxy to the home server of the group
-                ZimbraLog.account.info("Proxying request to home server (%s) of group %s",
-                        server.getName(), group.getName());
+                ZimbraLog.account.info("Proxying request: dl.name=%s reason: target=%s",
+                        group.getName(), server.getName());
 
                 request.addAttribute(A_PROXIED_TO_HOME_OF_GROUP, true);
                 try {

--- a/store/src/java/com/zimbra/cs/service/admin/AdminDocumentHandler.java
+++ b/store/src/java/com/zimbra/cs/service/admin/AdminDocumentHandler.java
@@ -588,10 +588,8 @@ public abstract class AdminDocumentHandler extends DocumentHandler implements Ad
             if (acctId != null) {
                 Account acct = getAccount(prov, AccountBy.id, acctId, zsc.getAuthToken());
                 if (acct != null && !Provisioning.onLocalServer(acct, reasons)) {
-                    if (zsc.getHopCount() > 2 || (ZimbraLog.soap.isDebugEnabled())) {
-                        ZimbraLog.soap.info("Proxying request:ProxiedAccountPath=%s reasons:%s",
-                                Joiner.on("/").join(xpath), reasons.getReason());
-                    }
+                    ZimbraLog.soap.info("Proxying request:ProxiedAccountPath=%s reasons:%s",
+                            Joiner.on("/").join(xpath), reasons.getReason());
                     return proxyRequest(request, context, acctId);
                 }
             }
@@ -602,10 +600,8 @@ public abstract class AdminDocumentHandler extends DocumentHandler implements Ad
                 Account acct = getAccount(prov, AccountBy.fromString(acctElt.getAttribute(AdminConstants.A_BY)),
                         acctElt.getText(), zsc.getAuthToken());
                 if (acct != null && !Provisioning.onLocalServer(acct, reasons)) {
-                    if (zsc.getHopCount() > 2 || (ZimbraLog.soap.isDebugEnabled())) {
-                        ZimbraLog.soap.info("Proxying request:ProxiedAccountElementPath=%s acctElt=%s reasons:%s",
-                                Joiner.on("/").join(xpath), acctElt.toString(), reasons.getReason());
-                    }
+                    ZimbraLog.soap.info("Proxying request:ProxiedAccountElementPath=%s acctElt=%s reasons:%s",
+                            Joiner.on("/").join(xpath), acctElt.toString(), reasons.getReason());
                     return proxyRequest(request, context, acct.getId());
                 }
             }
@@ -616,10 +612,8 @@ public abstract class AdminDocumentHandler extends DocumentHandler implements Ad
             if (rsrcId != null) {
                 CalendarResource rsrc = getCalendarResource(prov, Key.CalendarResourceBy.id, rsrcId);
                 if (rsrc != null && !Provisioning.onLocalServer(rsrc, reasons)) {
-                    if (zsc.getHopCount() > 2 || (ZimbraLog.soap.isDebugEnabled())) {
-                        ZimbraLog.soap.info("Proxying request:ProxiedResourcePath=%s rsrcId=%s reasons:%s",
-                                Joiner.on("/").join(xpath), rsrcId, reasons.getReason());
-                    }
+                    ZimbraLog.soap.info("Proxying request:ProxiedResourcePath=%s rsrcId=%s reasons:%s",
+                            Joiner.on("/").join(xpath), rsrcId, reasons.getReason());
                     return proxyRequest(request, context, rsrcId);
                 }
             }
@@ -631,10 +625,8 @@ public abstract class AdminDocumentHandler extends DocumentHandler implements Ad
                         Key.CalendarResourceBy.fromString(resourceElt.getAttribute(AdminConstants.A_BY)),
                         resourceElt.getText());
                 if (rsrc != null && !Provisioning.onLocalServer(rsrc, reasons)) {
-                    if (zsc.getHopCount() > 2 || (ZimbraLog.soap.isDebugEnabled())) {
-                        ZimbraLog.soap.info("Proxying request:ProxiedResourceElementPath=%s resourceElt=%s reasons:%s",
-                                Joiner.on("/").join(xpath), resourceElt.toString(), reasons.getReason());
-                    }
+                    ZimbraLog.soap.info("Proxying request:ProxiedResourceElementPath=%s resourceElt=%s reasons:%s",
+                            Joiner.on("/").join(xpath), resourceElt.toString(), reasons.getReason());
                     return proxyRequest(request, context, rsrc.getId());
                 }
             }
@@ -645,12 +637,10 @@ public abstract class AdminDocumentHandler extends DocumentHandler implements Ad
             if (serverId != null) {
                 Server server = prov.get(Key.ServerBy.id, serverId);
                 if (server != null && !getLocalHostId().equalsIgnoreCase(server.getId())) {
-                    if (zsc.getHopCount() > 2 || (ZimbraLog.soap.isDebugEnabled())) {
-                        ZimbraLog.soap
-                                .info("Proxying request:ProxiedServerPath=%s serverId=%s server=%s server ID=%s != localHostId=%s",
-                                        Joiner.on("/").join(xpath), serverId, server.getName(), server.getId(),
-                                        getLocalHostId());
-                    }
+                    ZimbraLog.soap
+                            .info("Proxying request:ProxiedServerPath=%s serverId=%s server=%s server ID=%s != localHostId=%s",
+                                    Joiner.on("/").join(xpath), serverId, server.getName(), server.getId(),
+                                    getLocalHostId());
                     return proxyRequest(request, context, server);
                 }
             }

--- a/store/src/java/com/zimbra/cs/service/admin/AdminDocumentHandler.java
+++ b/store/src/java/com/zimbra/cs/service/admin/AdminDocumentHandler.java
@@ -588,7 +588,7 @@ public abstract class AdminDocumentHandler extends DocumentHandler implements Ad
             if (acctId != null) {
                 Account acct = getAccount(prov, AccountBy.id, acctId, zsc.getAuthToken());
                 if (acct != null && !Provisioning.onLocalServer(acct, reasons)) {
-                    ZimbraLog.soap.info("Proxying request:ProxiedAccountPath=%s reasons:%s",
+                    ZimbraLog.soap.info("Proxying request: ProxiedAccountPath=%s reason: %s",
                             Joiner.on("/").join(xpath), reasons.getReason());
                     return proxyRequest(request, context, acctId);
                 }
@@ -600,7 +600,7 @@ public abstract class AdminDocumentHandler extends DocumentHandler implements Ad
                 Account acct = getAccount(prov, AccountBy.fromString(acctElt.getAttribute(AdminConstants.A_BY)),
                         acctElt.getText(), zsc.getAuthToken());
                 if (acct != null && !Provisioning.onLocalServer(acct, reasons)) {
-                    ZimbraLog.soap.info("Proxying request:ProxiedAccountElementPath=%s acctElt=%s reasons:%s",
+                    ZimbraLog.soap.info("Proxying request: ProxiedAccountElementPath=%s acctElt=%s reason: %s",
                             Joiner.on("/").join(xpath), acctElt.toString(), reasons.getReason());
                     return proxyRequest(request, context, acct.getId());
                 }
@@ -612,7 +612,7 @@ public abstract class AdminDocumentHandler extends DocumentHandler implements Ad
             if (rsrcId != null) {
                 CalendarResource rsrc = getCalendarResource(prov, Key.CalendarResourceBy.id, rsrcId);
                 if (rsrc != null && !Provisioning.onLocalServer(rsrc, reasons)) {
-                    ZimbraLog.soap.info("Proxying request:ProxiedResourcePath=%s rsrcId=%s reasons:%s",
+                    ZimbraLog.soap.info("Proxying request: ProxiedResourcePath=%s rsrcId=%s reason: %s",
                             Joiner.on("/").join(xpath), rsrcId, reasons.getReason());
                     return proxyRequest(request, context, rsrcId);
                 }
@@ -625,7 +625,7 @@ public abstract class AdminDocumentHandler extends DocumentHandler implements Ad
                         Key.CalendarResourceBy.fromString(resourceElt.getAttribute(AdminConstants.A_BY)),
                         resourceElt.getText());
                 if (rsrc != null && !Provisioning.onLocalServer(rsrc, reasons)) {
-                    ZimbraLog.soap.info("Proxying request:ProxiedResourceElementPath=%s resourceElt=%s reasons:%s",
+                    ZimbraLog.soap.info("Proxying request: ProxiedResourceElementPath=%s resourceElt=%s reason: %s",
                             Joiner.on("/").join(xpath), resourceElt.toString(), reasons.getReason());
                     return proxyRequest(request, context, rsrc.getId());
                 }
@@ -638,7 +638,7 @@ public abstract class AdminDocumentHandler extends DocumentHandler implements Ad
                 Server server = prov.get(Key.ServerBy.id, serverId);
                 if (server != null && !getLocalHostId().equalsIgnoreCase(server.getId())) {
                     ZimbraLog.soap
-                            .info("Proxying request:ProxiedServerPath=%s serverId=%s server=%s server ID=%s != localHostId=%s",
+                            .info("Proxying request: ProxiedServerPath=%s serverId=%s server=%s reason: server ID=%s != localHostId=%s",
                                     Joiner.on("/").join(xpath), serverId, server.getName(), server.getId(),
                                     getLocalHostId());
                     return proxyRequest(request, context, server);

--- a/store/src/java/com/zimbra/cs/service/mail/OpenImapFolder.java
+++ b/store/src/java/com/zimbra/cs/service/mail/OpenImapFolder.java
@@ -30,7 +30,7 @@ public class OpenImapFolder extends MailDocumentHandler {
         OpenIMAPFolderResponse resp = new OpenIMAPFolderResponse();
         ItemId folderId = new ItemId(req.getFolderId(), zsc);
         if (!folderId.belongsTo(mbox)) {
-            ZimbraLog.imap.debug("OpenImapFolder - proxying request for folder %s", folderId);
+            ZimbraLog.imap.info("OpenImapFolder - proxying request for folder %s", folderId);
             return proxyRequest(request, context, folderId.getAccountId());
         }
         int limit = req.getLimit();

--- a/store/src/java/com/zimbra/cs/service/mail/OpenImapFolder.java
+++ b/store/src/java/com/zimbra/cs/service/mail/OpenImapFolder.java
@@ -30,7 +30,7 @@ public class OpenImapFolder extends MailDocumentHandler {
         OpenIMAPFolderResponse resp = new OpenIMAPFolderResponse();
         ItemId folderId = new ItemId(req.getFolderId(), zsc);
         if (!folderId.belongsTo(mbox)) {
-            ZimbraLog.imap.info("OpenImapFolder - proxying request for folder %s", folderId);
+            ZimbraLog.imap.info("Proxying request: OpenImapFolder folder=%s", folderId);
             return proxyRequest(request, context, folderId.getAccountId());
         }
         int limit = req.getLimit();

--- a/store/src/java/com/zimbra/soap/DocumentHandler.java
+++ b/store/src/java/com/zimbra/soap/DocumentHandler.java
@@ -492,10 +492,10 @@ public abstract class DocumentHandler {
             }
             Account authAcct = getAuthenticatedAccount(zsc);
             if (authAcct == null) {
-                ZimbraLog.soap.info("Proxying request: requestedAccountId=%s authAcct <null> reasons:%s",
+                ZimbraLog.soap.info("Proxying request: requestedAccountId=%s authAcct <null> reason: %s",
                         acctId, reasons.getReason());
             } else {
-                ZimbraLog.soap.info("Proxying request: requestedAccountId=%s authAcct name=%s id=%s reasons:%s",
+                ZimbraLog.soap.info("Proxying request: requestedAccountId=%s authAcct name=%s id=%s reason: %s",
                         acctId, authAcct.getName(), authAcct.getId(), reasons.getReason());
             }
             return proxyRequest(request, context, acctId);

--- a/store/src/java/com/zimbra/soap/DocumentHandler.java
+++ b/store/src/java/com/zimbra/soap/DocumentHandler.java
@@ -490,15 +490,13 @@ public abstract class DocumentHandler {
             if (null == zsc.getSoapRequestId()) {
                 zsc.setNewSoapRequestId();
             }
-            if (zsc.getHopCount() > 2 || (ZimbraLog.soap.isDebugEnabled())) {
-                Account authAcct = getAuthenticatedAccount(zsc);
-                if (authAcct == null) {
-                    ZimbraLog.soap.info("Proxying request: requestedAccountId=%s authAcct <null> reasons:%s",
-                            acctId, reasons.getReason());
-                } else {
-                    ZimbraLog.soap.info("Proxying request: requestedAccountId=%s authAcct name=%s id=%s reasons:%s",
-                            acctId, authAcct.getName(), authAcct.getId(), reasons.getReason());
-                }
+            Account authAcct = getAuthenticatedAccount(zsc);
+            if (authAcct == null) {
+                ZimbraLog.soap.info("Proxying request: requestedAccountId=%s authAcct <null> reasons:%s",
+                        acctId, reasons.getReason());
+            } else {
+                ZimbraLog.soap.info("Proxying request: requestedAccountId=%s authAcct name=%s id=%s reasons:%s",
+                        acctId, authAcct.getName(), authAcct.getId(), reasons.getReason());
             }
             return proxyRequest(request, context, acctId);
         }


### PR DESCRIPTION
[Problem]
When the SOAP request is proxied to another server (the account's zimbraMailHost server), ZCS does not log about the proxying information, such as "the request is proxying to which server".
When the ISP operator is tracking down the SOAP request, usually in the course of the trouble shooting around the account provisioning operation etc., they always have a hard time figuring out which SOAP request is proxied to where. If the information about the account name and the target proxying server along with the SOAP request path, it would be much easier for the operator to analyze the issue, provisioning issues.

[Fix]
"Proxying ..." event is now always logged in INFO level.

[Manual test]
* ModifyAccountRequest (admin level SOAP reqeust)
2018-02-01 17:01:38,483 INFO  [qtp1572098393-303:https:https://localhost:7071/service/admin/soap/ModifyAccountRequest] [name=zimbra;ua=zmsoap;soapId=5dfafbd9;] soap - Proxying request:ProxiedAccountPath=id reasons:onLocalSvr=false isLocal=false target=dev15.synacorjapan.com localhost=mail.synacorjapan.com account=test014@synacorjapan.com

* SearchRequest (user level SOAP request)
2018-02-01 17:01:11,158 INFO  [qtp1572098393-221:http://localhost:8080/service/soap/SearchRequest] [name=test014@synacorjapan.com;ua=zmsoap;soapId=5dfafbd7;] soap - Proxying request: requestedAccountId=4473c004-a5d8-4dc2-964e-0cf70b6d6a03 authAcct name=test014@synacorjapan.com id=4473c004-a5d8-4dc2-964e-0cf70b6d6a03 reasons:onLocalSvr=false isLocal=false target=dev15.synacorjapan.com localhost=mail.synacorjapan.com account=test014@synacorjapan.com

* GetDistributionListMembersRequest
2018-02-01 17:00:21,252 INFO  [qtp1572098393-299:https:https://192.168.59.203:8443/service/soap/GetDistributionListMembersRequest] [name=user1@synacorjapan.com;mid=3;ip=192.168.59.1;port=63346;ua=ZimbraWebClient - GC63 (Mac)/8.8.6_GA_1906;soapId=5dfafbd5;] account - Proxying request to home server (dev15.synacorjapan.com) of group dist1@synacorjapan.com