### PR TITLE
Bugzilla-77129: added zimbraPrefDisplayTimeInMailList

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -12802,6 +12802,14 @@ public class ZAttrProvisioning {
     public static final String A_zimbraPrefDisplayExternalImages = "zimbraPrefDisplayExternalImages";
 
     /**
+     * Display received/sent time in mail list
+     *
+     * @since ZCS 8.8.7
+     */
+    @ZAttr(id=3022)
+    public static final String A_zimbraPrefDisplayTimeInMailList = "zimbraPrefDisplayTimeInMailList";
+
+    /**
      * Specifies the meaning of an external sender. &quot;ALL&quot; means
      * users whose domain doesn&#039;t match the recipient&#039;s or
      * zimbraInternalSendersDomain. &quot;ALLNOTINAB&quot; means

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9629,4 +9629,9 @@ TODO: delete them permanently from here
     <desc>Account thumbnail photo</desc>
 </attr>
 
+<attr id="3022" name="zimbraPrefDisplayTimeInMailList" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited" since="8.8.7">
+  <defaultCOSValue>FALSE</defaultCOSValue>
+  <desc>Display received/sent time in mail list</desc>
+</attr>
+
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -42585,6 +42585,78 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * Display received/sent time in mail list
+     *
+     * @return zimbraPrefDisplayTimeInMailList, or false if unset
+     *
+     * @since ZCS 8.8.7
+     */
+    @ZAttr(id=3022)
+    public boolean isPrefDisplayTimeInMailList() {
+        return getBooleanAttr(Provisioning.A_zimbraPrefDisplayTimeInMailList, false, true);
+    }
+
+    /**
+     * Display received/sent time in mail list
+     *
+     * @param zimbraPrefDisplayTimeInMailList new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.7
+     */
+    @ZAttr(id=3022)
+    public void setPrefDisplayTimeInMailList(boolean zimbraPrefDisplayTimeInMailList) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefDisplayTimeInMailList, zimbraPrefDisplayTimeInMailList ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Display received/sent time in mail list
+     *
+     * @param zimbraPrefDisplayTimeInMailList new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.7
+     */
+    @ZAttr(id=3022)
+    public Map<String,Object> setPrefDisplayTimeInMailList(boolean zimbraPrefDisplayTimeInMailList, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefDisplayTimeInMailList, zimbraPrefDisplayTimeInMailList ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Display received/sent time in mail list
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.7
+     */
+    @ZAttr(id=3022)
+    public void unsetPrefDisplayTimeInMailList() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefDisplayTimeInMailList, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Display received/sent time in mail list
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.7
+     */
+    @ZAttr(id=3022)
+    public Map<String,Object> unsetPrefDisplayTimeInMailList(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefDisplayTimeInMailList, "");
+        return attrs;
+    }
+
+    /**
      * Specifies the meaning of an external sender. &quot;ALL&quot; means
      * users whose domain doesn&#039;t match the recipient&#039;s or
      * zimbraInternalSendersDomain. &quot;ALLNOTINAB&quot; means

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -33204,6 +33204,78 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * Display received/sent time in mail list
+     *
+     * @return zimbraPrefDisplayTimeInMailList, or false if unset
+     *
+     * @since ZCS 8.8.7
+     */
+    @ZAttr(id=3022)
+    public boolean isPrefDisplayTimeInMailList() {
+        return getBooleanAttr(Provisioning.A_zimbraPrefDisplayTimeInMailList, false, true);
+    }
+
+    /**
+     * Display received/sent time in mail list
+     *
+     * @param zimbraPrefDisplayTimeInMailList new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.7
+     */
+    @ZAttr(id=3022)
+    public void setPrefDisplayTimeInMailList(boolean zimbraPrefDisplayTimeInMailList) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefDisplayTimeInMailList, zimbraPrefDisplayTimeInMailList ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Display received/sent time in mail list
+     *
+     * @param zimbraPrefDisplayTimeInMailList new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.7
+     */
+    @ZAttr(id=3022)
+    public Map<String,Object> setPrefDisplayTimeInMailList(boolean zimbraPrefDisplayTimeInMailList, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefDisplayTimeInMailList, zimbraPrefDisplayTimeInMailList ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Display received/sent time in mail list
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.7
+     */
+    @ZAttr(id=3022)
+    public void unsetPrefDisplayTimeInMailList() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefDisplayTimeInMailList, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Display received/sent time in mail list
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.7
+     */
+    @ZAttr(id=3022)
+    public Map<String,Object> unsetPrefDisplayTimeInMailList(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefDisplayTimeInMailList, "");
+        return attrs;
+    }
+
+    /**
      * Specifies the meaning of an external sender. &quot;ALL&quot; means
      * users whose domain doesn&#039;t match the recipient&#039;s or
      * zimbraInternalSendersDomain. &quot;ALLNOTINAB&quot; means


### PR DESCRIPTION
[Adding feature]
- If zimbraPrefDisplayTimeInMailList is TRUE, web client displays not only date but also time of a message received yesterday or before in email list.
- Adding a setting in Preferences -> Mail tab

[Related]
- Jira ticket id: NICPS-30
- Pull requests:
https://github.com/Zimbra/zm-ajax/pull/46
https://github.com/Zimbra/zm-web-client/pull/227