### PR TITLE
ZCS-3885:Add connection id for POP3/IMAP log event

### DIFF
--- a/store/src/java/com/zimbra/cs/imap/ImapHandler.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapHandler.java
@@ -4680,6 +4680,7 @@ public abstract class ImapHandler {
     protected void logout() {
         try {
             if (credentials != null) {
+                setLoggingContext();
                 ZimbraLog.imap.info("dropping connection for user " + credentials.getUsername() + " (LOGOUT)");
                 credentials.logout();
                 setCredentials(null);

--- a/store/src/java/com/zimbra/cs/imap/NioImapHandler.java
+++ b/store/src/java/com/zimbra/cs/imap/NioImapHandler.java
@@ -181,6 +181,7 @@ final class NioImapHandler extends ImapHandler implements NioHandler {
     @Override
     public void setLoggingContext() {
         super.setLoggingContext();
+        ZimbraLog.addConnectionIdToContext(String.valueOf(connection.getId()));
     }
 
     @Override

--- a/store/src/java/com/zimbra/cs/pop3/NioPop3Handler.java
+++ b/store/src/java/com/zimbra/cs/pop3/NioPop3Handler.java
@@ -38,6 +38,7 @@ final class NioPop3Handler extends Pop3Handler implements NioHandler {
 
     @Override
     public void connectionOpened() throws IOException {
+        ZimbraLog.addConnectionIdToContext(String.valueOf(connection.getId()));
         if (!startConnection(connection.getRemoteAddress().getAddress())) {
             connection.close();
         }
@@ -116,5 +117,11 @@ final class NioPop3Handler extends Pop3Handler implements NioHandler {
         if (flush) {
             nioutput.flush();
         }
+    }
+
+    @Override
+    public void setLoggingContext() {
+        super.setLoggingContext();
+        ZimbraLog.addConnectionIdToContext(String.valueOf(connection.getId()));
     }
 }

--- a/store/src/java/com/zimbra/cs/pop3/Pop3Handler.java
+++ b/store/src/java/com/zimbra/cs/pop3/Pop3Handler.java
@@ -124,15 +124,9 @@ abstract class Pop3Handler {
 
     public void setLoggingContext() {
         ZimbraLog.clearContext();
-        if (null != accountName) {
-            ZimbraLog.addAccountNameToContext(accountName);
-        }
-        if (null != clientAddress) {
-            ZimbraLog.addIpToContext(clientAddress);
-        }
-        if (null != origRemoteAddress) {
-            ZimbraLog.addOrigIpToContext(origRemoteAddress);
-        }
+        ZimbraLog.addAccountNameToContext(accountName);
+        ZimbraLog.addIpToContext(clientAddress);
+        ZimbraLog.addOrigIpToContext(origRemoteAddress);
     }
 
     boolean processCommand(String line) throws IOException {

--- a/store/src/java/com/zimbra/cs/pop3/Pop3Handler.java
+++ b/store/src/java/com/zimbra/cs/pop3/Pop3Handler.java
@@ -110,7 +110,7 @@ abstract class Pop3Handler {
         // Set the logging context for anything logged before the first command.
         ZimbraLog.clearContext();
         clientAddress = remoteAddr.getHostAddress();
-        ZimbraLog.addIpToContext(clientAddress);
+        setLoggingContext();
 
         ZimbraLog.pop.info("connected");
         if (!config.isServiceEnabled()) {
@@ -124,9 +124,15 @@ abstract class Pop3Handler {
 
     public void setLoggingContext() {
         ZimbraLog.clearContext();
-        ZimbraLog.addAccountNameToContext(accountName);
-        ZimbraLog.addIpToContext(clientAddress);
-        ZimbraLog.addOrigIpToContext(origRemoteAddress);
+        if (null != accountName) {
+            ZimbraLog.addAccountNameToContext(accountName);
+        }
+        if (null != clientAddress) {
+            ZimbraLog.addIpToContext(clientAddress);
+        }
+        if (null != origRemoteAddress) {
+            ZimbraLog.addOrigIpToContext(origRemoteAddress);
+        }
     }
 
     boolean processCommand(String line) throws IOException {


### PR DESCRIPTION
POP3 and IMAP threads are NIO threads.
If the same user accesses via multiple POP3 or IMAP sessions from same
client host (IP), it is impossible to tell which connection is which
POP/IMAP operation.
This fix displays the connection id along with the existing log event
for POP3 and IMAP operations.

[Manual test result]
IMAP4 - accessed from two consoles on the same IP (192.168.59.1) to the same account (admin@synacorjapan.com).   "cid=2" and "cid=3" were logged.
```
2018-02-07 21:13:20,639 INFO  [ImapServer-0] [name=admin@synacorjapan.com;ip=192.168.59.1;cid=2;] imap - user admin@synacorjapan.com authenticated, mechanism=LOGIN
2018-02-07 21:13:20,641 INFO  [ImapServer-0] [name=admin@synacorjapan.com;ip=192.168.59.1;cid=2;] imap - LOGIN elapsed=90
2018-02-07 21:13:51,342 INFO  [ImapServer-0] [name=admin@synacorjapan.com;ip=192.168.59.1;cid=3;] imap - user admin@synacorjapan.com authenticated, mechanism=LOGIN
2018-02-07 21:13:51,343 INFO  [ImapServer-0] [name=admin@synacorjapan.com;ip=192.168.59.1;cid=3;] imap - LOGIN elapsed=2
2018-02-07 21:13:59,071 INFO  [ImapServer-0] [name=admin@synacorjapan.com;ip=192.168.59.1;cid=3;] imap - selected folder INBOX
2018-02-07 21:13:59,072 INFO  [ImapServer-0] [name=admin@synacorjapan.com;ip=192.168.59.1;cid=3;] imap - SELECT elapsed=95
2018-02-07 21:14:07,807 INFO  [ImapServer-0] [name=admin@synacorjapan.com;mid=2;ip=192.168.59.1;cid=3;] imap - LOGOUT elapsed=1
2018-02-07 21:14:07,920 INFO  [ImapServer-0] [name=admin@synacorjapan.com;ip=192.168.59.1;cid=3;] imap - dropping connection for user admin@synacorjapan.com (LOGOUT)
2018-02-07 21:14:18,325 INFO  [ImapServer-0] [name=admin@synacorjapan.com;ip=192.168.59.1;cid=2;] imap - LOGOUT elapsed=1
2018-02-07 21:14:18,327 INFO  [ImapServer-0] [name=admin@synacorjapan.com;ip=192.168.59.1;cid=2;] imap - dropping connection for user admin@synacorjapan.com (LOGOUT)
```

POP3 - "cid=5" and "cid=6" were logged
```
2018-02-07 21:14:52,893 INFO  [Pop3Server-0] [ip=192.168.59.1;cid=5;] pop - connected
2018-02-07 21:14:55,173 INFO  [Pop3Server-0] [ip=192.168.59.1;cid=5;] pop - USER elapsed=0
2018-02-07 21:14:59,772 INFO  [Pop3Server-0] [ip=192.168.59.1;cid=6;] pop - connected
2018-02-07 21:15:01,543 INFO  [Pop3Server-0] [ip=192.168.59.1;cid=6;] pop - USER elapsed=0
2018-02-07 21:15:07,998 INFO  [Pop3Server-0] [name=admin@synacorjapan.com;ip=192.168.59.1;cid=6;] pop - user admin@synacorjapan.com authenticated, mechanism=LOGIN 
2018-02-07 21:15:08,008 INFO  [Pop3Server-0] [name=admin@synacorjapan.com;ip=192.168.59.1;cid=6;] pop - PASS elapsed=12
2018-02-07 21:15:15,557 INFO  [Pop3Server-0] [name=admin@synacorjapan.com;ip=192.168.59.1;cid=5;] pop - user admin@synacorjapan.com authenticated, mechanism=LOGIN 
2018-02-07 21:15:15,562 INFO  [Pop3Server-0] [name=admin@synacorjapan.com;ip=192.168.59.1;cid=5;] pop - PASS elapsed=8
2018-02-07 21:15:21,059 INFO  [Pop3Server-0] [name=admin@synacorjapan.com;ip=192.168.59.1;cid=5;] pop - LIST elapsed=0
2018-02-07 21:15:40,786 INFO  [Pop3Server-0] [name=admin@synacorjapan.com;ip=192.168.59.1;cid=6;] pop - LIST elapsed=0
2018-02-07 21:15:49,725 INFO  [Pop3Server-0] [name=admin@synacorjapan.com;ip=192.168.59.1;cid=5;] pop - LIST elapsed=1
2018-02-07 21:15:53,343 INFO  [Pop3Server-0] [name=admin@synacorjapan.com;ip=192.168.59.1;cid=5;] pop - quit from client
2018-02-07 21:15:53,344 INFO  [Pop3Server-0] [name=admin@synacorjapan.com;ip=192.168.59.1;cid=5;] pop - QUIT elapsed=1
2018-02-07 21:16:00,572 INFO  [Pop3Server-0] [name=admin@synacorjapan.com;ip=192.168.59.1;cid=6;] pop - quit from client
2018-02-07 21:16:00,574 INFO  [Pop3Server-0] [name=admin@synacorjapan.com;ip=192.168.59.1;cid=6;] pop - QUIT elapsed=4
```
