### PR TITLE
bugfix/ZCS-4221 - Address uncontrolled heap growth in ImapSessionManager::sessions

### DIFF
--- a/store/src/java/com/zimbra/cs/imap/ImapMailboxStore.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapMailboxStore.java
@@ -111,18 +111,7 @@ public abstract class ImapMailboxStore {
             throws ServiceException;
     public abstract void registerWithImapServerListener(ImapListener listener);
     public abstract void unregisterWithImapServerListener(ImapListener listener);
-
-    public List<ImapListener> getListeners(ItemIdentifier ident) {
-        String acctId = ident.accountId != null ? ident.accountId : getAccountId();
-        try {
-            ImapServerListener listener = ImapServerListenerPool.getInstance().getForAccountId(acctId);
-            return Lists.newArrayList(listener.getListeners(acctId, ident.id));
-        } catch (ServiceException se) {
-            ZimbraLog.imap.debug("Problem getting listeners for folder=%s acct=%s from ImapServerListener",
-                    ident, acctId, se);
-            return Collections.emptyList();
-        }
-    }
+    public abstract List<ImapListener> getListeners(ItemIdentifier ident);
 
     public List<ImapListener> getListeners(FolderStore folder) {
         try {

--- a/store/src/java/com/zimbra/cs/imap/LocalImapMailboxStore.java
+++ b/store/src/java/com/zimbra/cs/imap/LocalImapMailboxStore.java
@@ -17,6 +17,7 @@
 package com.zimbra.cs.imap;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -40,6 +41,7 @@ import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.Metadata;
 import com.zimbra.cs.mailbox.MetadataList;
 import com.zimbra.cs.mailbox.OperationContext;
+import com.zimbra.cs.session.Session;
 import com.zimbra.cs.util.AccountUtil;
 
 public class LocalImapMailboxStore extends ImapMailboxStore {
@@ -94,6 +96,20 @@ public class LocalImapMailboxStore extends ImapMailboxStore {
     @Override
     public void beginTrackingImap() throws ServiceException {
         mailbox.beginTrackingImap();
+    }
+
+    @Override
+    public List<ImapListener> getListeners(ItemIdentifier ident) {
+        List<ImapListener> listeners = new ArrayList<ImapListener>();
+        for (Session listener : mailbox.getListeners(Session.Type.IMAP)) {
+            if (listener instanceof ImapSession) {
+                ImapSession iListener = (ImapSession)listener;
+                if (iListener.getFolderId() == ident.id) {
+                    listeners.add((ImapListener)iListener);
+                }
+            }
+        }
+        return listeners;
     }
 
     @Override

--- a/store/src/java/com/zimbra/cs/imap/RemoteImapMailboxStore.java
+++ b/store/src/java/com/zimbra/cs/imap/RemoteImapMailboxStore.java
@@ -19,11 +19,13 @@ package com.zimbra.cs.imap;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 
 import com.google.common.base.Objects;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.zimbra.client.ZFolder;
@@ -67,6 +69,19 @@ public class RemoteImapMailboxStore extends ImapMailboxStore {
     @Override
     public ImapListener createListener(ImapFolder i4folder, ImapHandler handler) throws ServiceException {
         return new ImapRemoteSession(this, i4folder, handler);
+    }
+
+    @Override
+    public List<ImapListener> getListeners(ItemIdentifier ident) {
+        String acctId = ident.accountId != null ? ident.accountId : getAccountId();
+        try {
+            ImapServerListener listener = ImapServerListenerPool.getInstance().getForAccountId(acctId);
+            return Lists.newArrayList(listener.getListeners(acctId, ident.id));
+        } catch (ServiceException se) {
+            ZimbraLog.imap.debug("Problem getting listeners for folder=%s acct=%s from ImapServerListener",
+                    ident, acctId, se);
+            return Collections.emptyList();
+        }
     }
 
     @Override

--- a/store/src/java/com/zimbra/qa/unittest/SharedImapNotificationTests.java
+++ b/store/src/java/com/zimbra/qa/unittest/SharedImapNotificationTests.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.net.SocketException;
 import java.util.Map;
 
 import org.junit.Test;
@@ -358,7 +359,7 @@ public abstract class SharedImapNotificationTests extends ImapTestBase {
                 try {
                     connection.fetch("1:*", "(ENVELOPE BODY)");
                     return "should not be able to connect; connection should be closed";
-                } catch (CommandFailedException e) {}
+                } catch (SocketException | CommandFailedException e) {} // connection is force closed
                 return null;
             }
         };


### PR DESCRIPTION
- Updated PR to instead provide a concrete implementation of `getListeners(ItemIdentifier ident) ` for `LocalImapMessageStore`.
- Updated `testDeleteFolderNotificationActiveFolder` to capture a disconnect as a `success`.  Test was incorrectly not disconnecting when a selected folder was deleted from another session.

From PR comment:

The problem that this resolved is as follows:

The `closeFolder` method in `ImapSessionManager` asks the
`ImapMailboxStore` for listeners.  The implementation,
defined in `ImapMailboxStore`, worked correctly for remote
IMAP sessions, but not local ones.

This commit moved the implementation that was defined in
ImapMailboxStore to RemoteImapMailboxStore and added the
appropriate implementation to LocalImapMailboxStore.

Once this was done the closeFolder method could correctly detach
the appropriate sessions, which would caused them to be
unloaded from `sessions`.