### PR TITLE
ZCS-3890:Request Proxy modification to support JWT

### DIFF
--- a/common/src/java/com/zimbra/common/auth/ZAuthToken.java
+++ b/common/src/java/com/zimbra/common/auth/ZAuthToken.java
@@ -57,8 +57,8 @@ public class ZAuthToken {
     private static final String YAHOO_QP_HOSTACCOUNTID = "h";
 
     private String mType;
-    private String mValue;
-    private String mProxyAuthToken;
+    protected String mValue;
+    protected String mProxyAuthToken;
     private Map<String, String> mAttrs;
     
 

--- a/common/src/java/com/zimbra/common/auth/ZJWToken.java
+++ b/common/src/java/com/zimbra/common/auth/ZJWToken.java
@@ -1,0 +1,67 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.common.auth;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.HeaderConstants;
+import com.zimbra.common.util.StringUtil;
+import com.zimbra.common.util.ZimbraCookie;
+
+public class ZJWToken extends ZAuthToken {
+
+    private String salt;
+
+    public ZJWToken(String value, String salt) {
+        super(value, null);
+        this.salt = salt;
+    }
+
+    @Override
+    public Element encodeSoapCtxt(Element ctxt) {
+        Element ejwToken = ctxt.addNonUniqueElement(HeaderConstants.E_JWT_TOKEN);
+        if (mProxyAuthToken != null) {
+            ejwToken.setText(mProxyAuthToken);
+        } else if (mValue != null) {
+            ejwToken.setText(mValue);
+        }
+        Element saltEl = ctxt.addNonUniqueElement(HeaderConstants.E_JWT_SALT);
+        saltEl.setText(salt);
+        return ejwToken;
+    }
+
+    @Override
+    public Element encodeAuthReq(Element authReq, boolean isAdmin) {
+        return encodeSoapCtxt(authReq);
+    }
+
+    @Override
+    public Map<String, String> cookieMap(boolean isAdmin) {
+        Map<String, String> cookieMap = null;
+        if (!StringUtil.isNullOrEmpty(salt)) {
+            cookieMap = new HashMap<String, String>();
+            cookieMap.put(ZimbraCookie.COOKIE_ZM_JWT, salt);
+        }
+        return cookieMap;  
+    }
+
+    public String getSalt() {
+        return salt;
+    }
+}

--- a/common/src/java/com/zimbra/common/util/Constants.java
+++ b/common/src/java/com/zimbra/common/util/Constants.java
@@ -48,7 +48,6 @@ public class Constants {
     public static final String TOKEN_VALIDITY_VALUE_CLAIM = "tvv";
     public static final String AUTH_HEADER = "Authorization";
     public static final String BEARER= "Bearer";
-    public static final String ZM_JWT_COOKIE = "ZM_JWT";
     public static final String JWT_SALT_SEPARATOR = "|";
 
 }

--- a/common/src/java/com/zimbra/common/util/ZimbraCookie.java
+++ b/common/src/java/com/zimbra/common/util/ZimbraCookie.java
@@ -27,6 +27,7 @@ public class ZimbraCookie {
     public static final String COOKIE_ZM_AUTH_TOKEN       = "ZM_AUTH_TOKEN";
     public static final String COOKIE_ZM_ADMIN_AUTH_TOKEN = "ZM_ADMIN_AUTH_TOKEN";
     public static final String COOKIE_ZM_TRUST_TOKEN      = "ZM_TRUST_TOKEN";
+    public static final String COOKIE_ZM_JWT              = "ZM_JWT";
     public static String PATH_ROOT = "/";
 
     public static String authTokenCookieName(boolean isAdminReq) {

--- a/store/src/java-test/com/zimbra/cs/util/JWTBasedAuthTest.java
+++ b/store/src/java-test/com/zimbra/cs/util/JWTBasedAuthTest.java
@@ -198,4 +198,24 @@ public class JWTBasedAuthTest {
             Assert.fail("testGenerateAndValidateJWT failed");
         }
     }
+
+    @Test
+    public void testGetJWTSalt() {
+        Account acct;
+        try {
+            acct = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+            String salt = "s1";
+            AuthTokenKey atkey = AuthTokenUtil.getCurrentKey();
+            byte[] jwtKey = Bytes.concat(atkey.getKey(), salt.getBytes());
+            long issuedAt = System.currentTimeMillis();
+            long expires = issuedAt + 3600000;
+            AuthTokenProperties properties = new AuthTokenProperties(acct, false, null, expires, null, Usage.AUTH);
+            String jwt = JWTUtil.generateJWT(jwtKey, salt, issuedAt, properties, atkey.getVersion());
+            String jwtSalt = JWTUtil.getJWTSalt(jwt);
+            Assert.assertEquals(salt, jwtSalt);
+        } catch (ServiceException | AuthTokenException e) {
+            e.printStackTrace();
+            Assert.fail("testGetJWTSalt failed");
+        }
+    }
 }

--- a/store/src/java/com/zimbra/cs/account/ZimbraJWToken.java
+++ b/store/src/java/com/zimbra/cs/account/ZimbraJWToken.java
@@ -31,6 +31,7 @@ import org.apache.commons.text.RandomStringGenerator;
 
 import com.google.common.primitives.Bytes;
 import com.zimbra.common.auth.ZAuthToken;
+import com.zimbra.common.auth.ZJWToken;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.util.Constants;
@@ -232,12 +233,12 @@ public class ZimbraJWToken extends AuthToken {
     @Override
     public void encode(HttpClient client, HttpMethod method, boolean isAdminReq, String cookieDomain)
             throws ServiceException {
-         // TODO will be implemented as part of request proxy ticket
+         // TODO will be implemented as part of "ZCS-3929: Support JWT in FileUploadServlet"
     }
 
     @Override
     public void encode(HttpState state, boolean isAdminReq, String cookieDomain) throws ServiceException {
-        // TODO will be implemented as part of request proxy ticket
+        // TODO will be implemented as part of "ZCS-3928: Support JWT in UserServlet"
         
     }
 
@@ -263,7 +264,7 @@ public class ZimbraJWToken extends AuthToken {
             } else {
                 finalValue = StringUtil.isNullOrEmpty(zmJwtCookieVal) ? salt : salt + Constants.JWT_SALT_SEPARATOR + zmJwtCookieVal;
             }
-            ZimbraCookie.addHttpOnlyCookie(resp, Constants.ZM_JWT_COOKIE, finalValue, ZimbraCookie.PATH_ROOT, -1, true);
+            ZimbraCookie.addHttpOnlyCookie(resp, ZimbraCookie.COOKIE_ZM_JWT, finalValue, ZimbraCookie.PATH_ROOT, -1, true);
         }
     }
 
@@ -280,8 +281,8 @@ public class ZimbraJWToken extends AuthToken {
 
     @Override
     public ZAuthToken toZAuthToken() throws ServiceException {
-        // TODO will be implemented as part of request proxy ticket
-        return null;
+        String jwt = AuthTokenUtil.getOrigAuthData(this);
+        return new ZJWToken(jwt, JWTUtil.getJWTSalt(jwt));
     }
 
     @Override
@@ -301,17 +302,16 @@ public class ZimbraJWToken extends AuthToken {
 
     @Override
     public void setProxyAuthToken(String encoded) {
-        //TODO implement as part of proxy task
+        properties.setProxyAuthToken(encoded);
     }
 
     @Override
     public String getProxyAuthToken() {
-        //TODO implement as part of proxy task
-        return null;
+        return properties.getProxyAuthToken();
     }
 
     @Override
     public void resetProxyAuthToken() {
-        //TODO implement as part of proxy task
+        properties.setProxyAuthToken(null);
     }
 }


### PR DESCRIPTION
When request flow is using JWT and it has to be proxied to another server, jwt and salt will be populated in soap envelope context instead of auth token. 
Added new class ZJWToken which extends ZAuthToken and overrides all it's public methods to handle the proxy logic as per jwt flow.