### PR TITLE
ZCS-3892:Add year enum to zimbraPrefCalendarInitialView

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -1627,7 +1627,8 @@ public class ZAttrProvisioning {
         week("week"),
         workWeek("workWeek"),
         month("month"),
-        list("list");
+        list("list"),
+        year("year");
         private String mValue;
         private PrefCalendarInitialView(String value) { mValue = value; }
         public String toString() { return mValue; }
@@ -1642,6 +1643,7 @@ public class ZAttrProvisioning {
         public boolean isWorkWeek() { return this == workWeek;}
         public boolean isMonth() { return this == month;}
         public boolean isList() { return this == list;}
+        public boolean isYear() { return this == year;}
     }
 
     public static enum PrefClientType {

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -1405,7 +1405,7 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
   <desc>Data for class that scans attachments during compose</desc>
 </attr>
 
-<attr id="240" name="zimbraPrefCalendarInitialView" type="enum" value="day,week,workWeek,month,list" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable">
+<attr id="240" name="zimbraPrefCalendarInitialView" type="enum" value="day,week,workWeek,month,list,year" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable">
   <defaultCOSValue>workWeek</defaultCOSValue>
   <desc>initial calendar view to use</desc>
 </attr>

--- a/store/src/java-test/com/zimbra/cs/service/ModifyPrefsTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/ModifyPrefsTest.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2017 Synacor, Inc.
+ * Copyright (C) 2017, 2018 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -165,4 +165,17 @@ public class ModifyPrefsTest {
         Assert.assertEquals(FeatureAddressVerificationStatus.pending, acct1.getFeatureAddressVerificationStatus());
     }
 
+    @Test
+    public void testPrefCalendarInitialViewYear() throws Exception {
+        Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct1);
+        ModifyPrefsRequest request = new ModifyPrefsRequest();
+        Pref pref = new Pref(Provisioning.A_zimbraPrefCalendarInitialView, "year");
+        request.addPref(pref);
+        Element req = JaxbUtil.jaxbToElement(request);
+        new ModifyPrefs().handle(req, ServiceTestUtil.getRequestContext(mbox.getAccount()));
+        new ModifyPrefs().handle(req, ServiceTestUtil.getRequestContext(mbox.getAccount()));
+        Assert.assertFalse(acct1.getPrefCalendarInitialView().isDay());
+        Assert.assertTrue(acct1.getPrefCalendarInitialView().isYear());
+    }
 }

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -38956,7 +38956,7 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * initial calendar view to use
      *
-     * <p>Valid values: [day, week, workWeek, month, list]
+     * <p>Valid values: [day, week, workWeek, month, list, year]
      *
      * @return zimbraPrefCalendarInitialView, or ZAttrProvisioning.PrefCalendarInitialView.workWeek if unset and/or has invalid value
      */
@@ -38968,7 +38968,7 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * initial calendar view to use
      *
-     * <p>Valid values: [day, week, workWeek, month, list]
+     * <p>Valid values: [day, week, workWeek, month, list, year]
      *
      * @return zimbraPrefCalendarInitialView, or "workWeek" if unset
      */
@@ -38980,7 +38980,7 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * initial calendar view to use
      *
-     * <p>Valid values: [day, week, workWeek, month, list]
+     * <p>Valid values: [day, week, workWeek, month, list, year]
      *
      * @param zimbraPrefCalendarInitialView new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -38995,7 +38995,7 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * initial calendar view to use
      *
-     * <p>Valid values: [day, week, workWeek, month, list]
+     * <p>Valid values: [day, week, workWeek, month, list, year]
      *
      * @param zimbraPrefCalendarInitialView new value
      * @param attrs existing map to populate, or null to create a new map
@@ -39011,7 +39011,7 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * initial calendar view to use
      *
-     * <p>Valid values: [day, week, workWeek, month, list]
+     * <p>Valid values: [day, week, workWeek, month, list, year]
      *
      * @param zimbraPrefCalendarInitialView new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -39026,7 +39026,7 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * initial calendar view to use
      *
-     * <p>Valid values: [day, week, workWeek, month, list]
+     * <p>Valid values: [day, week, workWeek, month, list, year]
      *
      * @param zimbraPrefCalendarInitialView new value
      * @param attrs existing map to populate, or null to create a new map
@@ -39042,7 +39042,7 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * initial calendar view to use
      *
-     * <p>Valid values: [day, week, workWeek, month, list]
+     * <p>Valid values: [day, week, workWeek, month, list, year]
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      */
@@ -39056,7 +39056,7 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * initial calendar view to use
      *
-     * <p>Valid values: [day, week, workWeek, month, list]
+     * <p>Valid values: [day, week, workWeek, month, list, year]
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -30011,7 +30011,7 @@ public abstract class ZAttrCos extends NamedEntry {
     /**
      * initial calendar view to use
      *
-     * <p>Valid values: [day, week, workWeek, month, list]
+     * <p>Valid values: [day, week, workWeek, month, list, year]
      *
      * @return zimbraPrefCalendarInitialView, or ZAttrProvisioning.PrefCalendarInitialView.workWeek if unset and/or has invalid value
      */
@@ -30023,7 +30023,7 @@ public abstract class ZAttrCos extends NamedEntry {
     /**
      * initial calendar view to use
      *
-     * <p>Valid values: [day, week, workWeek, month, list]
+     * <p>Valid values: [day, week, workWeek, month, list, year]
      *
      * @return zimbraPrefCalendarInitialView, or "workWeek" if unset
      */
@@ -30035,7 +30035,7 @@ public abstract class ZAttrCos extends NamedEntry {
     /**
      * initial calendar view to use
      *
-     * <p>Valid values: [day, week, workWeek, month, list]
+     * <p>Valid values: [day, week, workWeek, month, list, year]
      *
      * @param zimbraPrefCalendarInitialView new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -30050,7 +30050,7 @@ public abstract class ZAttrCos extends NamedEntry {
     /**
      * initial calendar view to use
      *
-     * <p>Valid values: [day, week, workWeek, month, list]
+     * <p>Valid values: [day, week, workWeek, month, list, year]
      *
      * @param zimbraPrefCalendarInitialView new value
      * @param attrs existing map to populate, or null to create a new map
@@ -30066,7 +30066,7 @@ public abstract class ZAttrCos extends NamedEntry {
     /**
      * initial calendar view to use
      *
-     * <p>Valid values: [day, week, workWeek, month, list]
+     * <p>Valid values: [day, week, workWeek, month, list, year]
      *
      * @param zimbraPrefCalendarInitialView new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -30081,7 +30081,7 @@ public abstract class ZAttrCos extends NamedEntry {
     /**
      * initial calendar view to use
      *
-     * <p>Valid values: [day, week, workWeek, month, list]
+     * <p>Valid values: [day, week, workWeek, month, list, year]
      *
      * @param zimbraPrefCalendarInitialView new value
      * @param attrs existing map to populate, or null to create a new map
@@ -30097,7 +30097,7 @@ public abstract class ZAttrCos extends NamedEntry {
     /**
      * initial calendar view to use
      *
-     * <p>Valid values: [day, week, workWeek, month, list]
+     * <p>Valid values: [day, week, workWeek, month, list, year]
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      */
@@ -30111,7 +30111,7 @@ public abstract class ZAttrCos extends NamedEntry {
     /**
      * initial calendar view to use
      *
-     * <p>Valid values: [day, week, workWeek, month, list]
+     * <p>Valid values: [day, week, workWeek, month, list, year]
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs


### PR DESCRIPTION
Zimbra NextGen supports a year view for calendar, which is stored
under the user preference zimbraPrefCalendarInitialView.

Currently zimbraPrefCalendarInitialView supports: day,week,workWeek,month,list,
we need to add "year" enum to this list.

[manual test]
Before fix
```
$ zmprov desc -a zimbraPrefCalendarInitialView
zimbraPrefCalendarInitialView
    initial calendar view to use

               type : enum
              value : day,week,workWeek,month,list
           callback : 
          immutable : false
        cardinality : single
         requiredIn : 
         optionalIn : cos,account
              flags : accountInherited,domainAdminModifiable
           defaults : workWeek
                min : 
                max : 
                 id : 240
    requiresRestart : 
              since : 
    deprecatedSince : 
```
After fix
```
$ zmprov desc -a zimbraPrefCalendarInitialView
zimbraPrefCalendarInitialView
    initial calendar view to use

               type : enum
              value : day,week,workWeek,month,list,year
           callback : 
          immutable : false
        cardinality : single
         requiredIn : 
         optionalIn : cos,account
              flags : accountInherited,domainAdminModifiable
           defaults : workWeek
                min : 
                max : 
                 id : 240
    requiresRestart : 
              since : 
    deprecatedSince : 
```