### PR TITLE
ZCS-3954:Modify SearchAction to support updating read/unread flag

### DIFF
--- a/soap/src/java/com/zimbra/soap/mail/type/BulkAction.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/BulkAction.java
@@ -29,7 +29,7 @@ public class BulkAction {
 
     @XmlEnum
     public static enum Operation {
-        move;
+        move, read, unread;
 
         public static Operation fromString(String s) throws ServiceException {
             try {
@@ -45,6 +45,8 @@ public class BulkAction {
      * @zm-api-field-description Operation to perform
      * <table>
      * <tr><td><b>move</b>           </td><td>move the search result to specified folder location</td></tr>
+     * <tr><td><b>read</b>           </td><td>mark the search result as read</td></tr>
+     * <tr><td><b>unread</b>         </td><td>mark the search result as unread</td></tr>
      * </table>
      */
     @XmlAttribute(name = MailConstants.A_OPERATION /* op */, required = true)
@@ -52,7 +54,8 @@ public class BulkAction {
 
     /**
      * @zm-api-field-tag folder-path
-     * @zm-api-field-description Folder pathname
+     * @zm-api-field-description Required if op="move". Folder pathname where
+     *                           all matching items should be moved.
      */
     @XmlAttribute(name = MailConstants.A_FOLDER /* l */, required = false)
     private String folder;

--- a/store/docs/soap.txt
+++ b/store/docs/soap.txt
@@ -4732,12 +4732,12 @@ Api to get list of available contact backup files
 API to search for mail items and take some bulk action on the search result
 <SearchActionRequest>
 </SearchRequest>
-<BulkAction op={action-to-be-taken-on-search-result} l={folder-path}/>
+<BulkAction op={action-to-be-taken-on-search-result} [l={folder-path}]/>
 </SearchActionRequest>
 
 Note: <SearchRequest> element is nothing but old search request having same attributes and elements.
 In BulkAction, l={folder-path} attribute is optional, it will only be used in actions such as 'move'.
-Valid 'op' values: move
+Valid 'op' values: move, read, unread
 
 <SearchActionResponse>
 </SearchActionResponse>

--- a/store/src/java-test/com/zimbra/cs/service/mail/SearchActionTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/mail/SearchActionTest.java
@@ -18,16 +18,19 @@ package com.zimbra.cs.service.mail;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.MethodRule;
+import org.junit.rules.TestName;
 
 import com.google.common.collect.Maps;
 import com.zimbra.common.soap.Element;
 import com.zimbra.cs.account.Account;
-import com.zimbra.cs.account.MockProvisioning;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.mailbox.DeliveryOptions;
 import com.zimbra.cs.mailbox.Flag;
@@ -35,7 +38,9 @@ import com.zimbra.cs.mailbox.MailItem;
 import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.MailboxManager;
 import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.mailbox.Message;
 import com.zimbra.cs.mailbox.util.TypedIdList;
+import com.zimbra.cs.util.ZTestWatchman;
 import com.zimbra.soap.SoapEngine;
 import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.mail.message.SearchRequest;
@@ -44,26 +49,34 @@ import com.zimbra.soap.type.SearchHit;
 
 public class SearchActionTest {
 
-    @BeforeClass
-    public static void init() throws Exception {
-        MailboxTestUtil.initServer();
-
-        Provisioning prov = Provisioning.getInstance();
-        prov.createAccount("test@zimbra.com", "secret", Maps.<String, Object> newHashMap());
-    }
+    @Rule
+    public TestName testName = new TestName();
+    @Rule
+    public MethodRule watchman = new ZTestWatchman();
 
     @Before
     public void setUp() throws Exception {
+        System.out.println(testName.getMethodName());
+        MailboxTestUtil.initServer();
         MailboxTestUtil.clearData();
+        Provisioning prov = Provisioning.getInstance();
+        Map<String, Object> attrs = Maps.newHashMap();
+        prov.createDomain("zimbra.com", attrs);
+
+        attrs = Maps.newHashMap();
+        attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        prov.createAccount("testMove@zimbra.com", "secret", attrs);
+
+        attrs = Maps.newHashMap();
+        attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        prov.createAccount("testRead@zimbra.com", "secret", attrs);
     }
 
     @Test
-    public void testSearchAction() throws Exception {
-        Account acct = Provisioning.getInstance()
-            .getAccountById(MockProvisioning.DEFAULT_ACCOUNT_ID);
+    public void testSearchActionMove() throws Exception {
+        Account acct = Provisioning.getInstance().getAccountByName("testMove@zimbra.com");
         Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
-        // Add two messages to inbox, one with search match and other with no
-        // match
+        // Add two messages to inbox, one with search match and other with no match
         DeliveryOptions dopt = new DeliveryOptions().setFolderId(Mailbox.ID_FOLDER_INBOX)
             .setFlags(Flag.BITMASK_UNREAD | Flag.BITMASK_MUTED);
         mbox.addMessage(null, MailboxTestUtil.generateMessage("test subject"), dopt, null);
@@ -96,4 +109,48 @@ public class SearchActionTest {
         Assert.assertEquals(1, mailItems.size());
         Assert.assertEquals("test subject", mailItems.get(0).getSubject());
     }
+
+    @Test
+    public void testSearchActionRead() throws Exception {
+        Account acct = Provisioning.getInstance().getAccountByName("testRead@zimbra.com");
+        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+        // Add two messages to inbox, one with search match and other with no match
+        DeliveryOptions dopt = new DeliveryOptions().setFolderId(Mailbox.ID_FOLDER_INBOX)
+            .setFlags(Flag.BITMASK_UNREAD | Flag.BITMASK_MUTED);
+        Message message1 = mbox.addMessage(null, MailboxTestUtil.generateMessage("test subject"),
+            dopt, null);
+        Message message2 = mbox.addMessage(null, MailboxTestUtil.generateMessage("unmatched subject"), dopt, null);
+        TypedIdList ids = mbox.getItemIds(null, 2);
+        Assert.assertEquals(2, ids.size());
+        Assert.assertEquals(true, message1.isUnread());
+        Assert.assertEquals(true, message2.isUnread());
+        SearchRequest sRequest = new SearchRequest();
+        sRequest.setSearchTypes("conversation");
+        // search with query 'test'
+        sRequest.setQuery("test");
+        BulkAction bAction = new BulkAction();
+        // search action - mark search result with 'read'
+        bAction.setOp(BulkAction.Operation.read);
+        Map<String, Object> context = ServiceTestUtil.getRequestContext(acct);
+        ZimbraSoapContext zsc = (ZimbraSoapContext) context.get(SoapEngine.ZIMBRA_CONTEXT);
+        Element searchResponse = new Search().handle(zsc.jaxbToElement(sRequest),
+            ServiceTestUtil.getRequestContext(acct));
+        com.zimbra.soap.mail.message.SearchResponse sResponse = zsc.elementToJaxb(searchResponse);
+        List<SearchHit> searchHits = sResponse.getSearchHits();
+        SearchAction.performAction(bAction, sRequest, searchHits, mbox, null);
+        // check search result message is marked read
+        Assert.assertEquals(false, message1.isUnread());
+        Assert.assertEquals(true, message2.isUnread());
+    }
+
+    @After
+    public void tearDown() {
+        try {
+            MailboxTestUtil.clearData();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
 }
+
+


### PR DESCRIPTION
Added support for 'read' and 'unread' action into SearchAction to mark the messages of the search query result as read/unread.

Updated soap doc.
Added junit test.
ant test-all passed.