### PR TITLE
Bug 34202 - STARTTLS support for outbound mail sent by mailbox server

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -1627,8 +1627,7 @@ public class ZAttrProvisioning {
         week("week"),
         workWeek("workWeek"),
         month("month"),
-        list("list"),
-        year("year");
+        list("list");
         private String mValue;
         private PrefCalendarInitialView(String value) { mValue = value; }
         public String toString() { return mValue; }
@@ -1643,7 +1642,6 @@ public class ZAttrProvisioning {
         public boolean isWorkWeek() { return this == workWeek;}
         public boolean isMonth() { return this == month;}
         public boolean isList() { return this == list;}
-        public boolean isYear() { return this == year;}
     }
 
     public static enum PrefClientType {
@@ -2296,6 +2294,24 @@ public class ZAttrProvisioning {
         public boolean isCLEARTEXT() { return this == CLEARTEXT;}
         public boolean isSSL() { return this == SSL;}
         public boolean isSTARTTLS() { return this == STARTTLS;}
+    }
+
+    public static enum SmtpStartTlsMode {
+        on("on"),
+        off("off"),
+        only("only");
+        private String mValue;
+        private SmtpStartTlsMode(String value) { mValue = value; }
+        public String toString() { return mValue; }
+        public static SmtpStartTlsMode fromString(String s) throws ServiceException {
+            for (SmtpStartTlsMode value : values()) {
+                if (value.mValue.equals(s)) return value;
+             }
+             throw ServiceException.INVALID_REQUEST("invalid value: "+s+", valid values: "+ Arrays.asList(values()), null);
+        }
+        public boolean isOn() { return this == on;}
+        public boolean isOff() { return this == off;}
+        public boolean isOnly() { return this == only;}
     }
 
     public static enum TableMaintenanceOperation {
@@ -15976,6 +15992,17 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=249)
     public static final String A_zimbraSmtpSendPartial = "zimbraSmtpSendPartial";
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to the
+     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
+     * MTA supports off - doesn&#039;t use starttls only - requires starttls
+     * to send messages
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public static final String A_zimbraSmtpStartTlsMode = "zimbraSmtpStartTlsMode";
 
     /**
      * timeout value in seconds

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -16003,7 +16003,7 @@ public class ZAttrProvisioning {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=3022)
+    @ZAttr(id=4001)
     public static final String A_zimbraSmtpStartTlsMode = "zimbraSmtpStartTlsMode";
 
     /**

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -16003,7 +16003,7 @@ public class ZAttrProvisioning {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=4001)
+    @ZAttr(id=3022)
     public static final String A_zimbraSmtpStartTlsMode = "zimbraSmtpStartTlsMode";
 
     /**

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -1627,7 +1627,8 @@ public class ZAttrProvisioning {
         week("week"),
         workWeek("workWeek"),
         month("month"),
-        list("list");
+        list("list"),
+        year("year");
         private String mValue;
         private PrefCalendarInitialView(String value) { mValue = value; }
         public String toString() { return mValue; }
@@ -1642,6 +1643,7 @@ public class ZAttrProvisioning {
         public boolean isWorkWeek() { return this == workWeek;}
         public boolean isMonth() { return this == month;}
         public boolean isList() { return this == list;}
+        public boolean isYear() { return this == year;}
     }
 
     public static enum PrefClientType {
@@ -15995,9 +15997,9 @@ public class ZAttrProvisioning {
 
     /**
      * Configures the starttls mode on sending messages from mailboxd to the
-     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
-     * MTA supports off - doesn&#039;t use starttls only - requires starttls
-     * to send messages
+     * MTA host specified with zimbraSmtpHostname. ( on - uses starttls if
+     * the MTA supports. off - doesn&#039;t use starttls. only - requires
+     * starttls to send messages. )
      *
      * @since ZCS 8.8.6
      */

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9629,7 +9629,7 @@ TODO: delete them permanently from here
     <desc>Account thumbnail photo</desc>
 </attr>
 
-<attr id="4001" name="zimbraSmtpStartTlsMode" type="enum" value="on,off,only" cardinality="single" optionalIn="globalConfig,server,domain" flags="serverInherited" since="8.8.6">
+<attr id="3022" name="zimbraSmtpStartTlsMode" type="enum" value="on,off,only" cardinality="single" optionalIn="globalConfig,server,domain" flags="serverInherited" since="8.8.6">
   <globalConfigValue>only</globalConfigValue>
   <globalConfigValueUpgrade>off</globalConfigValueUpgrade>
   <desc>Configures the starttls mode on sending messages from mailboxd to the MTA host specified with zimbraSmtpHostname.

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -1405,7 +1405,7 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
   <desc>Data for class that scans attachments during compose</desc>
 </attr>
 
-<attr id="240" name="zimbraPrefCalendarInitialView" type="enum" value="day,week,workWeek,month,list,year" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable">
+<attr id="240" name="zimbraPrefCalendarInitialView" type="enum" value="day,week,workWeek,month,list" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable">
   <defaultCOSValue>workWeek</defaultCOSValue>
   <desc>initial calendar view to use</desc>
 </attr>
@@ -9627,6 +9627,15 @@ TODO: delete them permanently from here
 
 <attr id="3021" name="thumbnailPhoto" type="binary" cardinality="single" optionalIn="account" since="8.8.6">
     <desc>Account thumbnail photo</desc>
+</attr>
+
+<attr id="3022" name="zimbraSmtpStartTlsMode" type="enum" value="on,off,only" cardinality="single" optionalIn="globalConfig,server,domain" flags="serverInherited" since="8.8.6">
+  <globalConfigValue>off</globalConfigValue>
+  <desc>Configures the starttls mode on sending messages from mailboxd to the MTA host specified with zimbraSmtpHostname.
+        ( on   - uses starttls if the MTA supports.
+          off  - doesn't use starttls.
+          only - requires starttls to send messages. )
+  </desc>
 </attr>
 
 </attrs>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9629,7 +9629,7 @@ TODO: delete them permanently from here
     <desc>Account thumbnail photo</desc>
 </attr>
 
-<attr id="3022" name="zimbraSmtpStartTlsMode" type="enum" value="on,off,only" cardinality="single" optionalIn="globalConfig,server,domain" flags="serverInherited" since="8.8.6">
+<attr id="4001" name="zimbraSmtpStartTlsMode" type="enum" value="on,off,only" cardinality="single" optionalIn="globalConfig,server,domain" flags="serverInherited" since="8.8.6">
   <globalConfigValue>only</globalConfigValue>
   <globalConfigValueUpgrade>off</globalConfigValueUpgrade>
   <desc>Configures the starttls mode on sending messages from mailboxd to the MTA host specified with zimbraSmtpHostname.

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -1405,7 +1405,7 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
   <desc>Data for class that scans attachments during compose</desc>
 </attr>
 
-<attr id="240" name="zimbraPrefCalendarInitialView" type="enum" value="day,week,workWeek,month,list" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable">
+<attr id="240" name="zimbraPrefCalendarInitialView" type="enum" value="day,week,workWeek,month,list,year" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable">
   <defaultCOSValue>workWeek</defaultCOSValue>
   <desc>initial calendar view to use</desc>
 </attr>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9630,7 +9630,8 @@ TODO: delete them permanently from here
 </attr>
 
 <attr id="3022" name="zimbraSmtpStartTlsMode" type="enum" value="on,off,only" cardinality="single" optionalIn="globalConfig,server,domain" flags="serverInherited" since="8.8.6">
-  <globalConfigValue>off</globalConfigValue>
+  <globalConfigValue>only</globalConfigValue>
+  <globalConfigValueUpgrade>off</globalConfigValueUpgrade>
   <desc>Configures the starttls mode on sending messages from mailboxd to the MTA host specified with zimbraSmtpHostname.
         ( on   - uses starttls if the MTA supports.
           off  - doesn't use starttls.

--- a/store/src/java-test/com/zimbra/cs/mailbox/MailSenderTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/MailSenderTest.java
@@ -37,7 +37,6 @@ import com.zimbra.common.util.Log.Level;
 import com.zimbra.common.util.Pair;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
-import com.zimbra.cs.account.Domain;
 import com.zimbra.cs.account.MockProvisioning;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.Server;
@@ -384,38 +383,38 @@ public final class MailSenderTest {
 
     @Test
     public void setupStartTlsMode() throws Exception {
-    		Provisioning prov = Provisioning.getInstance();
-    		// I need domain object to run setupSmtpStartTlsMode() without NPE
-    		prov.createDomain("example.com", new HashMap<String, Object>());
-    		Account account = prov.createAccount("test@example.com", "secret", new HashMap<String, Object>());
-    		MailSender sender = new MailSender();
-    		sender.setSession(account);
-    		Session smtpSession = JMSession.getSmtpSession(account);
-    		
-    		// Test "off" mode
-    		smtpSession.getProperties().setProperty("mail.smtp.starttls.enable", "");
-    		prov.getLocalServer().setSmtpStartTlsModeAsString("off");
-    		MailSender.setupStartTlsMode(account,smtpSession);
-    		Assert.assertSame("false", smtpSession.getProperty("mail.smtp.starttls.enable"));
-
-    		// Test "on" mode
-    		smtpSession.getProperties().setProperty("mail.smtp.starttls.enable", "");
-    		smtpSession.getProperties().setProperty("mail.smtp.starttls.required", "");
-    		smtpSession.getProperties().setProperty("mail.smtp.ssl.trust", "");
-    		prov.getLocalServer().setSmtpStartTlsModeAsString("on");
-    		MailSender.setupStartTlsMode(account,smtpSession);
-    		Assert.assertSame("true", smtpSession.getProperty("mail.smtp.starttls.enable"));
-    		Assert.assertSame("false", smtpSession.getProperty("mail.smtp.starttls.required"));
-    		Assert.assertSame("*", smtpSession.getProperty("mail.smtp.ssl.trust"));    		
-    
-    		// Test "only" mode
-    		smtpSession.getProperties().setProperty("mail.smtp.starttls.enable", "");
-    		smtpSession.getProperties().setProperty("mail.smtp.starttls.required", "");
-    		smtpSession.getProperties().setProperty("mail.smtp.ssl.trust", "");
-    		prov.getLocalServer().setSmtpStartTlsModeAsString("only");
-    		MailSender.setupStartTlsMode(account,smtpSession);
-    		Assert.assertSame("true", smtpSession.getProperty("mail.smtp.starttls.enable"));
-    		Assert.assertSame("true", smtpSession.getProperty("mail.smtp.starttls.required"));
-    		Assert.assertSame("*", smtpSession.getProperty("mail.smtp.ssl.trust"));    		
+        Provisioning prov = Provisioning.getInstance();
+        // I need domain object to run setupSmtpStartTlsMode() without NPE
+        prov.createDomain("example.com", new HashMap<String, Object>());
+        Account account = prov.createAccount("test@example.com", "secret", new HashMap<String, Object>());
+        MailSender sender = new MailSender();
+        sender.setSession(account);
+        Session smtpSession = JMSession.getSmtpSession(account);
+        
+        // Test "off" mode
+        smtpSession.getProperties().setProperty("mail.smtp.starttls.enable", "");
+        prov.getLocalServer().setSmtpStartTlsModeAsString("off");
+        MailSender.setupStartTlsMode(account,smtpSession);
+        Assert.assertSame("false", smtpSession.getProperty("mail.smtp.starttls.enable"));
+        
+        // Test "on" mode
+        smtpSession.getProperties().setProperty("mail.smtp.starttls.enable", "");
+        smtpSession.getProperties().setProperty("mail.smtp.starttls.required", "");
+        smtpSession.getProperties().setProperty("mail.smtp.ssl.trust", "");
+        prov.getLocalServer().setSmtpStartTlsModeAsString("on");
+        MailSender.setupStartTlsMode(account,smtpSession);
+        Assert.assertSame("true", smtpSession.getProperty("mail.smtp.starttls.enable"));
+        Assert.assertSame("false", smtpSession.getProperty("mail.smtp.starttls.required"));
+        Assert.assertSame("*", smtpSession.getProperty("mail.smtp.ssl.trust"));    		
+        
+        // Test "only" mode
+        smtpSession.getProperties().setProperty("mail.smtp.starttls.enable", "");
+        smtpSession.getProperties().setProperty("mail.smtp.starttls.required", "");
+        smtpSession.getProperties().setProperty("mail.smtp.ssl.trust", "");
+        prov.getLocalServer().setSmtpStartTlsModeAsString("only");
+        MailSender.setupStartTlsMode(account,smtpSession);
+        Assert.assertSame("true", smtpSession.getProperty("mail.smtp.starttls.enable"));
+        Assert.assertSame("true", smtpSession.getProperty("mail.smtp.starttls.required"));
+        Assert.assertSame("*", smtpSession.getProperty("mail.smtp.ssl.trust"));    		
     }
 }

--- a/store/src/java-test/com/zimbra/cs/mailbox/MailSenderTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/MailSenderTest.java
@@ -385,8 +385,8 @@ public final class MailSenderTest {
     @Test
     public void setupStartTlsMode() throws Exception {
     		Provisioning prov = Provisioning.getInstance();
-    		// domain is required to run setupSmtpStartTlsMode() without NPE
-    		Domain domain = prov.createDomain("example.com", new HashMap<String, Object>());
+    		// I need domain object to run setupSmtpStartTlsMode() without NPE
+    		prov.createDomain("example.com", new HashMap<String, Object>());
     		Account account = prov.createAccount("test@example.com", "secret", new HashMap<String, Object>());
     		MailSender sender = new MailSender();
     		sender.setSession(account);

--- a/store/src/java-test/com/zimbra/cs/mailbox/MailSenderTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/MailSenderTest.java
@@ -28,7 +28,6 @@ import javax.mail.internet.MimeMessage;
 import javax.mail.util.SharedByteArrayInputStream;
 
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/store/src/java-test/com/zimbra/cs/mailbox/MailSenderTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/MailSenderTest.java
@@ -27,6 +27,8 @@ import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 import javax.mail.util.SharedByteArrayInputStream;
 
+import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -37,6 +39,7 @@ import com.zimbra.common.util.Log.Level;
 import com.zimbra.common.util.Pair;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Domain;
 import com.zimbra.cs.account.MockProvisioning;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.Server;
@@ -67,6 +70,17 @@ public final class MailSenderTest {
         attrs.put(Provisioning.A_zimbraPrefAllowAddressForDelegatedSender, "test@zimbra.com");
         attrs.put(Provisioning.A_zimbraPrefAllowAddressForDelegatedSender, "test-alias@zimbra.com");
         prov.createAccount("test@zimbra.com", "secret", attrs);
+    }
+    
+    @After
+    public void tearDown() throws Exception {
+        // We need the domain object for setupStartTlsMode test, but
+        // it causes failures at getSenderHeaderSimpleAuth and getSenderHeadersDelgatedAuth.
+        Provisioning prov = Provisioning.getInstance();
+        Domain domain = prov.getDomainByName("zimbra.com");
+        if (domain != null) {
+            prov.deleteDomain(domain.getId());
+        }
     }
 
     @Test
@@ -384,9 +398,9 @@ public final class MailSenderTest {
     @Test
     public void setupStartTlsMode() throws Exception {
         Provisioning prov = Provisioning.getInstance();
-        // I need domain object to run setupSmtpStartTlsMode() without NPE
-        prov.createDomain("example.com", new HashMap<String, Object>());
-        Account account = prov.createAccount("test@example.com", "secret", new HashMap<String, Object>());
+        prov.createDomain("zimbra.com", new HashMap<String, Object>()); // required to read domain config
+        String mail = "test@zimbra.com";
+        Account account = prov.getAccount(mail);
         MailSender sender = new MailSender();
         sender.setSession(account);
         Session smtpSession = JMSession.getSmtpSession(account);
@@ -405,7 +419,7 @@ public final class MailSenderTest {
         MailSender.setupStartTlsMode(account,smtpSession);
         Assert.assertSame("true", smtpSession.getProperty("mail.smtp.starttls.enable"));
         Assert.assertSame("false", smtpSession.getProperty("mail.smtp.starttls.required"));
-        Assert.assertSame("*", smtpSession.getProperty("mail.smtp.ssl.trust"));    		
+        Assert.assertSame("*", smtpSession.getProperty("mail.smtp.ssl.trust"));
         
         // Test "only" mode
         smtpSession.getProperties().setProperty("mail.smtp.starttls.enable", "");
@@ -415,6 +429,6 @@ public final class MailSenderTest {
         MailSender.setupStartTlsMode(account,smtpSession);
         Assert.assertSame("true", smtpSession.getProperty("mail.smtp.starttls.enable"));
         Assert.assertSame("true", smtpSession.getProperty("mail.smtp.starttls.required"));
-        Assert.assertSame("*", smtpSession.getProperty("mail.smtp.ssl.trust"));    		
+        Assert.assertSame("*", smtpSession.getProperty("mail.smtp.ssl.trust"));
     }
 }

--- a/store/src/java-test/com/zimbra/cs/mailbox/MailSenderTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/MailSenderTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import javax.mail.Session;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 import javax.mail.util.SharedByteArrayInputStream;
@@ -36,6 +37,7 @@ import com.zimbra.common.util.Log.Level;
 import com.zimbra.common.util.Pair;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Domain;
 import com.zimbra.cs.account.MockProvisioning;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.Server;
@@ -377,5 +379,43 @@ public final class MailSenderTest {
         mm.saveChanges();
         ZimbraLog.smtp.setLevel(Level.trace);
         MailSender.relayMessage(mm);
+    }
+    
+
+    @Test
+    public void setupStartTlsMode() throws Exception {
+    		Provisioning prov = Provisioning.getInstance();
+    		// domain is required to run setupSmtpStartTlsMode() without NPE
+    		Domain domain = prov.createDomain("example.com", new HashMap<String, Object>());
+    		Account account = prov.createAccount("test@example.com", "secret", new HashMap<String, Object>());
+    		MailSender sender = new MailSender();
+    		sender.setSession(account);
+    		Session smtpSession = JMSession.getSmtpSession(account);
+    		
+    		// Test "off" mode
+    		smtpSession.getProperties().setProperty("mail.smtp.starttls.enable", "");
+    		prov.getLocalServer().setSmtpStartTlsModeAsString("off");
+    		MailSender.setupStartTlsMode(account,smtpSession);
+    		Assert.assertSame("false", smtpSession.getProperty("mail.smtp.starttls.enable"));
+
+    		// Test "on" mode
+    		smtpSession.getProperties().setProperty("mail.smtp.starttls.enable", "");
+    		smtpSession.getProperties().setProperty("mail.smtp.starttls.required", "");
+    		smtpSession.getProperties().setProperty("mail.smtp.ssl.trust", "");
+    		prov.getLocalServer().setSmtpStartTlsModeAsString("on");
+    		MailSender.setupStartTlsMode(account,smtpSession);
+    		Assert.assertSame("true", smtpSession.getProperty("mail.smtp.starttls.enable"));
+    		Assert.assertSame("false", smtpSession.getProperty("mail.smtp.starttls.required"));
+    		Assert.assertSame("*", smtpSession.getProperty("mail.smtp.ssl.trust"));    		
+    
+    		// Test "only" mode
+    		smtpSession.getProperties().setProperty("mail.smtp.starttls.enable", "");
+    		smtpSession.getProperties().setProperty("mail.smtp.starttls.required", "");
+    		smtpSession.getProperties().setProperty("mail.smtp.ssl.trust", "");
+    		prov.getLocalServer().setSmtpStartTlsModeAsString("only");
+    		MailSender.setupStartTlsMode(account,smtpSession);
+    		Assert.assertSame("true", smtpSession.getProperty("mail.smtp.starttls.enable"));
+    		Assert.assertSame("true", smtpSession.getProperty("mail.smtp.starttls.required"));
+    		Assert.assertSame("*", smtpSession.getProperty("mail.smtp.ssl.trust"));    		
     }
 }

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -68353,7 +68353,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=4001)
+    @ZAttr(id=3022)
     public ZAttrProvisioning.SmtpStartTlsMode getSmtpStartTlsMode() {
         try { String v = getAttr(Provisioning.A_zimbraSmtpStartTlsMode, true, true); return v == null ? ZAttrProvisioning.SmtpStartTlsMode.only : ZAttrProvisioning.SmtpStartTlsMode.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.SmtpStartTlsMode.only; }
     }
@@ -68370,7 +68370,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=4001)
+    @ZAttr(id=3022)
     public String getSmtpStartTlsModeAsString() {
         return getAttr(Provisioning.A_zimbraSmtpStartTlsMode, "only", true);
     }
@@ -68388,7 +68388,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=4001)
+    @ZAttr(id=3022)
     public void setSmtpStartTlsMode(ZAttrProvisioning.SmtpStartTlsMode zimbraSmtpStartTlsMode) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode.toString());
@@ -68409,7 +68409,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=4001)
+    @ZAttr(id=3022)
     public Map<String,Object> setSmtpStartTlsMode(ZAttrProvisioning.SmtpStartTlsMode zimbraSmtpStartTlsMode, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode.toString());
@@ -68429,7 +68429,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=4001)
+    @ZAttr(id=3022)
     public void setSmtpStartTlsModeAsString(String zimbraSmtpStartTlsMode) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode);
@@ -68450,7 +68450,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=4001)
+    @ZAttr(id=3022)
     public Map<String,Object> setSmtpStartTlsModeAsString(String zimbraSmtpStartTlsMode, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode);
@@ -68469,7 +68469,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=4001)
+    @ZAttr(id=3022)
     public void unsetSmtpStartTlsMode() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, "");
@@ -68489,7 +68489,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=4001)
+    @ZAttr(id=3022)
     public Map<String,Object> unsetSmtpStartTlsMode(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, "");

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -68349,13 +68349,13 @@ public abstract class ZAttrConfig extends Entry {
      *
      * <p>Valid values: [on, off, only]
      *
-     * @return zimbraSmtpStartTlsMode, or ZAttrProvisioning.SmtpStartTlsMode.off if unset and/or has invalid value
+     * @return zimbraSmtpStartTlsMode, or ZAttrProvisioning.SmtpStartTlsMode.only if unset and/or has invalid value
      *
      * @since ZCS 8.8.6
      */
     @ZAttr(id=3022)
     public ZAttrProvisioning.SmtpStartTlsMode getSmtpStartTlsMode() {
-        try { String v = getAttr(Provisioning.A_zimbraSmtpStartTlsMode, true, true); return v == null ? ZAttrProvisioning.SmtpStartTlsMode.off : ZAttrProvisioning.SmtpStartTlsMode.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.SmtpStartTlsMode.off; }
+        try { String v = getAttr(Provisioning.A_zimbraSmtpStartTlsMode, true, true); return v == null ? ZAttrProvisioning.SmtpStartTlsMode.only : ZAttrProvisioning.SmtpStartTlsMode.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.SmtpStartTlsMode.only; }
     }
 
     /**
@@ -68366,13 +68366,13 @@ public abstract class ZAttrConfig extends Entry {
      *
      * <p>Valid values: [on, off, only]
      *
-     * @return zimbraSmtpStartTlsMode, or "off" if unset
+     * @return zimbraSmtpStartTlsMode, or "only" if unset
      *
      * @since ZCS 8.8.6
      */
     @ZAttr(id=3022)
     public String getSmtpStartTlsModeAsString() {
-        return getAttr(Provisioning.A_zimbraSmtpStartTlsMode, "off", true);
+        return getAttr(Provisioning.A_zimbraSmtpStartTlsMode, "only", true);
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -68353,7 +68353,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=3022)
+    @ZAttr(id=4001)
     public ZAttrProvisioning.SmtpStartTlsMode getSmtpStartTlsMode() {
         try { String v = getAttr(Provisioning.A_zimbraSmtpStartTlsMode, true, true); return v == null ? ZAttrProvisioning.SmtpStartTlsMode.only : ZAttrProvisioning.SmtpStartTlsMode.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.SmtpStartTlsMode.only; }
     }
@@ -68370,7 +68370,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=3022)
+    @ZAttr(id=4001)
     public String getSmtpStartTlsModeAsString() {
         return getAttr(Provisioning.A_zimbraSmtpStartTlsMode, "only", true);
     }
@@ -68388,7 +68388,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=3022)
+    @ZAttr(id=4001)
     public void setSmtpStartTlsMode(ZAttrProvisioning.SmtpStartTlsMode zimbraSmtpStartTlsMode) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode.toString());
@@ -68409,7 +68409,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=3022)
+    @ZAttr(id=4001)
     public Map<String,Object> setSmtpStartTlsMode(ZAttrProvisioning.SmtpStartTlsMode zimbraSmtpStartTlsMode, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode.toString());
@@ -68429,7 +68429,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=3022)
+    @ZAttr(id=4001)
     public void setSmtpStartTlsModeAsString(String zimbraSmtpStartTlsMode) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode);
@@ -68450,7 +68450,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=3022)
+    @ZAttr(id=4001)
     public Map<String,Object> setSmtpStartTlsModeAsString(String zimbraSmtpStartTlsMode, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode);
@@ -68469,7 +68469,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=3022)
+    @ZAttr(id=4001)
     public void unsetSmtpStartTlsMode() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, "");
@@ -68489,7 +68489,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=3022)
+    @ZAttr(id=4001)
     public Map<String,Object> unsetSmtpStartTlsMode(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, "");

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -68343,9 +68343,9 @@ public abstract class ZAttrConfig extends Entry {
 
     /**
      * Configures the starttls mode on sending messages from mailboxd to the
-     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
-     * MTA supports off - doesn&#039;t use starttls only - requires starttls
-     * to send messages
+     * MTA host specified with zimbraSmtpHostname. ( on - uses starttls if
+     * the MTA supports. off - doesn&#039;t use starttls. only - requires
+     * starttls to send messages. )
      *
      * <p>Valid values: [on, off, only]
      *
@@ -68360,9 +68360,9 @@ public abstract class ZAttrConfig extends Entry {
 
     /**
      * Configures the starttls mode on sending messages from mailboxd to the
-     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
-     * MTA supports off - doesn&#039;t use starttls only - requires starttls
-     * to send messages
+     * MTA host specified with zimbraSmtpHostname. ( on - uses starttls if
+     * the MTA supports. off - doesn&#039;t use starttls. only - requires
+     * starttls to send messages. )
      *
      * <p>Valid values: [on, off, only]
      *
@@ -68377,9 +68377,9 @@ public abstract class ZAttrConfig extends Entry {
 
     /**
      * Configures the starttls mode on sending messages from mailboxd to the
-     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
-     * MTA supports off - doesn&#039;t use starttls only - requires starttls
-     * to send messages
+     * MTA host specified with zimbraSmtpHostname. ( on - uses starttls if
+     * the MTA supports. off - doesn&#039;t use starttls. only - requires
+     * starttls to send messages. )
      *
      * <p>Valid values: [on, off, only]
      *
@@ -68397,9 +68397,9 @@ public abstract class ZAttrConfig extends Entry {
 
     /**
      * Configures the starttls mode on sending messages from mailboxd to the
-     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
-     * MTA supports off - doesn&#039;t use starttls only - requires starttls
-     * to send messages
+     * MTA host specified with zimbraSmtpHostname. ( on - uses starttls if
+     * the MTA supports. off - doesn&#039;t use starttls. only - requires
+     * starttls to send messages. )
      *
      * <p>Valid values: [on, off, only]
      *
@@ -68418,9 +68418,9 @@ public abstract class ZAttrConfig extends Entry {
 
     /**
      * Configures the starttls mode on sending messages from mailboxd to the
-     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
-     * MTA supports off - doesn&#039;t use starttls only - requires starttls
-     * to send messages
+     * MTA host specified with zimbraSmtpHostname. ( on - uses starttls if
+     * the MTA supports. off - doesn&#039;t use starttls. only - requires
+     * starttls to send messages. )
      *
      * <p>Valid values: [on, off, only]
      *
@@ -68438,9 +68438,9 @@ public abstract class ZAttrConfig extends Entry {
 
     /**
      * Configures the starttls mode on sending messages from mailboxd to the
-     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
-     * MTA supports off - doesn&#039;t use starttls only - requires starttls
-     * to send messages
+     * MTA host specified with zimbraSmtpHostname. ( on - uses starttls if
+     * the MTA supports. off - doesn&#039;t use starttls. only - requires
+     * starttls to send messages. )
      *
      * <p>Valid values: [on, off, only]
      *
@@ -68459,9 +68459,9 @@ public abstract class ZAttrConfig extends Entry {
 
     /**
      * Configures the starttls mode on sending messages from mailboxd to the
-     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
-     * MTA supports off - doesn&#039;t use starttls only - requires starttls
-     * to send messages
+     * MTA host specified with zimbraSmtpHostname. ( on - uses starttls if
+     * the MTA supports. off - doesn&#039;t use starttls. only - requires
+     * starttls to send messages. )
      *
      * <p>Valid values: [on, off, only]
      *
@@ -68478,9 +68478,9 @@ public abstract class ZAttrConfig extends Entry {
 
     /**
      * Configures the starttls mode on sending messages from mailboxd to the
-     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
-     * MTA supports off - doesn&#039;t use starttls only - requires starttls
-     * to send messages
+     * MTA host specified with zimbraSmtpHostname. ( on - uses starttls if
+     * the MTA supports. off - doesn&#039;t use starttls. only - requires
+     * starttls to send messages. )
      *
      * <p>Valid values: [on, off, only]
      *

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -68342,6 +68342,161 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Configures the starttls mode on sending messages from mailboxd to the
+     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
+     * MTA supports off - doesn&#039;t use starttls only - requires starttls
+     * to send messages
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @return zimbraSmtpStartTlsMode, or ZAttrProvisioning.SmtpStartTlsMode.off if unset and/or has invalid value
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public ZAttrProvisioning.SmtpStartTlsMode getSmtpStartTlsMode() {
+        try { String v = getAttr(Provisioning.A_zimbraSmtpStartTlsMode, true, true); return v == null ? ZAttrProvisioning.SmtpStartTlsMode.off : ZAttrProvisioning.SmtpStartTlsMode.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.SmtpStartTlsMode.off; }
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to the
+     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
+     * MTA supports off - doesn&#039;t use starttls only - requires starttls
+     * to send messages
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @return zimbraSmtpStartTlsMode, or "off" if unset
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public String getSmtpStartTlsModeAsString() {
+        return getAttr(Provisioning.A_zimbraSmtpStartTlsMode, "off", true);
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to the
+     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
+     * MTA supports off - doesn&#039;t use starttls only - requires starttls
+     * to send messages
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @param zimbraSmtpStartTlsMode new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public void setSmtpStartTlsMode(ZAttrProvisioning.SmtpStartTlsMode zimbraSmtpStartTlsMode) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode.toString());
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to the
+     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
+     * MTA supports off - doesn&#039;t use starttls only - requires starttls
+     * to send messages
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @param zimbraSmtpStartTlsMode new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public Map<String,Object> setSmtpStartTlsMode(ZAttrProvisioning.SmtpStartTlsMode zimbraSmtpStartTlsMode, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode.toString());
+        return attrs;
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to the
+     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
+     * MTA supports off - doesn&#039;t use starttls only - requires starttls
+     * to send messages
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @param zimbraSmtpStartTlsMode new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public void setSmtpStartTlsModeAsString(String zimbraSmtpStartTlsMode) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to the
+     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
+     * MTA supports off - doesn&#039;t use starttls only - requires starttls
+     * to send messages
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @param zimbraSmtpStartTlsMode new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public Map<String,Object> setSmtpStartTlsModeAsString(String zimbraSmtpStartTlsMode, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode);
+        return attrs;
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to the
+     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
+     * MTA supports off - doesn&#039;t use starttls only - requires starttls
+     * to send messages
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public void unsetSmtpStartTlsMode() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to the
+     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
+     * MTA supports off - doesn&#039;t use starttls only - requires starttls
+     * to send messages
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public Map<String,Object> unsetSmtpStartTlsMode(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, "");
+        return attrs;
+    }
+
+    /**
      * timeout value in seconds
      *
      * @return zimbraSmtpTimeout, or 60 if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -21637,6 +21637,161 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
+     * Configures the starttls mode on sending messages from mailboxd to the
+     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
+     * MTA supports off - doesn&#039;t use starttls only - requires starttls
+     * to send messages
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @return zimbraSmtpStartTlsMode, or null if unset and/or has invalid value
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public ZAttrProvisioning.SmtpStartTlsMode getSmtpStartTlsMode() {
+        try { String v = getAttr(Provisioning.A_zimbraSmtpStartTlsMode, true, true); return v == null ? null : ZAttrProvisioning.SmtpStartTlsMode.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return null; }
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to the
+     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
+     * MTA supports off - doesn&#039;t use starttls only - requires starttls
+     * to send messages
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @return zimbraSmtpStartTlsMode, or null if unset
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public String getSmtpStartTlsModeAsString() {
+        return getAttr(Provisioning.A_zimbraSmtpStartTlsMode, null, true);
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to the
+     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
+     * MTA supports off - doesn&#039;t use starttls only - requires starttls
+     * to send messages
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @param zimbraSmtpStartTlsMode new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public void setSmtpStartTlsMode(ZAttrProvisioning.SmtpStartTlsMode zimbraSmtpStartTlsMode) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode.toString());
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to the
+     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
+     * MTA supports off - doesn&#039;t use starttls only - requires starttls
+     * to send messages
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @param zimbraSmtpStartTlsMode new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public Map<String,Object> setSmtpStartTlsMode(ZAttrProvisioning.SmtpStartTlsMode zimbraSmtpStartTlsMode, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode.toString());
+        return attrs;
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to the
+     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
+     * MTA supports off - doesn&#039;t use starttls only - requires starttls
+     * to send messages
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @param zimbraSmtpStartTlsMode new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public void setSmtpStartTlsModeAsString(String zimbraSmtpStartTlsMode) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to the
+     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
+     * MTA supports off - doesn&#039;t use starttls only - requires starttls
+     * to send messages
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @param zimbraSmtpStartTlsMode new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public Map<String,Object> setSmtpStartTlsModeAsString(String zimbraSmtpStartTlsMode, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode);
+        return attrs;
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to the
+     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
+     * MTA supports off - doesn&#039;t use starttls only - requires starttls
+     * to send messages
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public void unsetSmtpStartTlsMode() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to the
+     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
+     * MTA supports off - doesn&#039;t use starttls only - requires starttls
+     * to send messages
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public Map<String,Object> unsetSmtpStartTlsMode(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, "");
+        return attrs;
+    }
+
+    /**
      * timeout value in seconds
      *
      * @return zimbraSmtpTimeout, or -1 if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -21648,7 +21648,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=4001)
+    @ZAttr(id=3022)
     public ZAttrProvisioning.SmtpStartTlsMode getSmtpStartTlsMode() {
         try { String v = getAttr(Provisioning.A_zimbraSmtpStartTlsMode, true, true); return v == null ? null : ZAttrProvisioning.SmtpStartTlsMode.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return null; }
     }
@@ -21665,7 +21665,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=4001)
+    @ZAttr(id=3022)
     public String getSmtpStartTlsModeAsString() {
         return getAttr(Provisioning.A_zimbraSmtpStartTlsMode, null, true);
     }
@@ -21683,7 +21683,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=4001)
+    @ZAttr(id=3022)
     public void setSmtpStartTlsMode(ZAttrProvisioning.SmtpStartTlsMode zimbraSmtpStartTlsMode) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode.toString());
@@ -21704,7 +21704,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=4001)
+    @ZAttr(id=3022)
     public Map<String,Object> setSmtpStartTlsMode(ZAttrProvisioning.SmtpStartTlsMode zimbraSmtpStartTlsMode, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode.toString());
@@ -21724,7 +21724,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=4001)
+    @ZAttr(id=3022)
     public void setSmtpStartTlsModeAsString(String zimbraSmtpStartTlsMode) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode);
@@ -21745,7 +21745,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=4001)
+    @ZAttr(id=3022)
     public Map<String,Object> setSmtpStartTlsModeAsString(String zimbraSmtpStartTlsMode, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode);
@@ -21764,7 +21764,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=4001)
+    @ZAttr(id=3022)
     public void unsetSmtpStartTlsMode() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, "");
@@ -21784,7 +21784,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=4001)
+    @ZAttr(id=3022)
     public Map<String,Object> unsetSmtpStartTlsMode(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, "");

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -21638,9 +21638,9 @@ public abstract class ZAttrDomain extends NamedEntry {
 
     /**
      * Configures the starttls mode on sending messages from mailboxd to the
-     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
-     * MTA supports off - doesn&#039;t use starttls only - requires starttls
-     * to send messages
+     * MTA host specified with zimbraSmtpHostname. ( on - uses starttls if
+     * the MTA supports. off - doesn&#039;t use starttls. only - requires
+     * starttls to send messages. )
      *
      * <p>Valid values: [on, off, only]
      *
@@ -21655,9 +21655,9 @@ public abstract class ZAttrDomain extends NamedEntry {
 
     /**
      * Configures the starttls mode on sending messages from mailboxd to the
-     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
-     * MTA supports off - doesn&#039;t use starttls only - requires starttls
-     * to send messages
+     * MTA host specified with zimbraSmtpHostname. ( on - uses starttls if
+     * the MTA supports. off - doesn&#039;t use starttls. only - requires
+     * starttls to send messages. )
      *
      * <p>Valid values: [on, off, only]
      *
@@ -21672,9 +21672,9 @@ public abstract class ZAttrDomain extends NamedEntry {
 
     /**
      * Configures the starttls mode on sending messages from mailboxd to the
-     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
-     * MTA supports off - doesn&#039;t use starttls only - requires starttls
-     * to send messages
+     * MTA host specified with zimbraSmtpHostname. ( on - uses starttls if
+     * the MTA supports. off - doesn&#039;t use starttls. only - requires
+     * starttls to send messages. )
      *
      * <p>Valid values: [on, off, only]
      *
@@ -21692,9 +21692,9 @@ public abstract class ZAttrDomain extends NamedEntry {
 
     /**
      * Configures the starttls mode on sending messages from mailboxd to the
-     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
-     * MTA supports off - doesn&#039;t use starttls only - requires starttls
-     * to send messages
+     * MTA host specified with zimbraSmtpHostname. ( on - uses starttls if
+     * the MTA supports. off - doesn&#039;t use starttls. only - requires
+     * starttls to send messages. )
      *
      * <p>Valid values: [on, off, only]
      *
@@ -21713,9 +21713,9 @@ public abstract class ZAttrDomain extends NamedEntry {
 
     /**
      * Configures the starttls mode on sending messages from mailboxd to the
-     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
-     * MTA supports off - doesn&#039;t use starttls only - requires starttls
-     * to send messages
+     * MTA host specified with zimbraSmtpHostname. ( on - uses starttls if
+     * the MTA supports. off - doesn&#039;t use starttls. only - requires
+     * starttls to send messages. )
      *
      * <p>Valid values: [on, off, only]
      *
@@ -21733,9 +21733,9 @@ public abstract class ZAttrDomain extends NamedEntry {
 
     /**
      * Configures the starttls mode on sending messages from mailboxd to the
-     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
-     * MTA supports off - doesn&#039;t use starttls only - requires starttls
-     * to send messages
+     * MTA host specified with zimbraSmtpHostname. ( on - uses starttls if
+     * the MTA supports. off - doesn&#039;t use starttls. only - requires
+     * starttls to send messages. )
      *
      * <p>Valid values: [on, off, only]
      *
@@ -21754,9 +21754,9 @@ public abstract class ZAttrDomain extends NamedEntry {
 
     /**
      * Configures the starttls mode on sending messages from mailboxd to the
-     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
-     * MTA supports off - doesn&#039;t use starttls only - requires starttls
-     * to send messages
+     * MTA host specified with zimbraSmtpHostname. ( on - uses starttls if
+     * the MTA supports. off - doesn&#039;t use starttls. only - requires
+     * starttls to send messages. )
      *
      * <p>Valid values: [on, off, only]
      *
@@ -21773,9 +21773,9 @@ public abstract class ZAttrDomain extends NamedEntry {
 
     /**
      * Configures the starttls mode on sending messages from mailboxd to the
-     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
-     * MTA supports off - doesn&#039;t use starttls only - requires starttls
-     * to send messages
+     * MTA host specified with zimbraSmtpHostname. ( on - uses starttls if
+     * the MTA supports. off - doesn&#039;t use starttls. only - requires
+     * starttls to send messages. )
      *
      * <p>Valid values: [on, off, only]
      *

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -21648,7 +21648,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=3022)
+    @ZAttr(id=4001)
     public ZAttrProvisioning.SmtpStartTlsMode getSmtpStartTlsMode() {
         try { String v = getAttr(Provisioning.A_zimbraSmtpStartTlsMode, true, true); return v == null ? null : ZAttrProvisioning.SmtpStartTlsMode.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return null; }
     }
@@ -21665,7 +21665,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=3022)
+    @ZAttr(id=4001)
     public String getSmtpStartTlsModeAsString() {
         return getAttr(Provisioning.A_zimbraSmtpStartTlsMode, null, true);
     }
@@ -21683,7 +21683,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=3022)
+    @ZAttr(id=4001)
     public void setSmtpStartTlsMode(ZAttrProvisioning.SmtpStartTlsMode zimbraSmtpStartTlsMode) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode.toString());
@@ -21704,7 +21704,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=3022)
+    @ZAttr(id=4001)
     public Map<String,Object> setSmtpStartTlsMode(ZAttrProvisioning.SmtpStartTlsMode zimbraSmtpStartTlsMode, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode.toString());
@@ -21724,7 +21724,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=3022)
+    @ZAttr(id=4001)
     public void setSmtpStartTlsModeAsString(String zimbraSmtpStartTlsMode) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode);
@@ -21745,7 +21745,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=3022)
+    @ZAttr(id=4001)
     public Map<String,Object> setSmtpStartTlsModeAsString(String zimbraSmtpStartTlsMode, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode);
@@ -21764,7 +21764,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=3022)
+    @ZAttr(id=4001)
     public void unsetSmtpStartTlsMode() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, "");
@@ -21784,7 +21784,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=3022)
+    @ZAttr(id=4001)
     public Map<String,Object> unsetSmtpStartTlsMode(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, "");

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -48950,6 +48950,161 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
+     * Configures the starttls mode on sending messages from mailboxd to the
+     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
+     * MTA supports off - doesn&#039;t use starttls only - requires starttls
+     * to send messages
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @return zimbraSmtpStartTlsMode, or ZAttrProvisioning.SmtpStartTlsMode.off if unset and/or has invalid value
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public ZAttrProvisioning.SmtpStartTlsMode getSmtpStartTlsMode() {
+        try { String v = getAttr(Provisioning.A_zimbraSmtpStartTlsMode, true, true); return v == null ? ZAttrProvisioning.SmtpStartTlsMode.off : ZAttrProvisioning.SmtpStartTlsMode.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.SmtpStartTlsMode.off; }
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to the
+     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
+     * MTA supports off - doesn&#039;t use starttls only - requires starttls
+     * to send messages
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @return zimbraSmtpStartTlsMode, or "off" if unset
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public String getSmtpStartTlsModeAsString() {
+        return getAttr(Provisioning.A_zimbraSmtpStartTlsMode, "off", true);
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to the
+     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
+     * MTA supports off - doesn&#039;t use starttls only - requires starttls
+     * to send messages
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @param zimbraSmtpStartTlsMode new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public void setSmtpStartTlsMode(ZAttrProvisioning.SmtpStartTlsMode zimbraSmtpStartTlsMode) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode.toString());
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to the
+     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
+     * MTA supports off - doesn&#039;t use starttls only - requires starttls
+     * to send messages
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @param zimbraSmtpStartTlsMode new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public Map<String,Object> setSmtpStartTlsMode(ZAttrProvisioning.SmtpStartTlsMode zimbraSmtpStartTlsMode, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode.toString());
+        return attrs;
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to the
+     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
+     * MTA supports off - doesn&#039;t use starttls only - requires starttls
+     * to send messages
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @param zimbraSmtpStartTlsMode new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public void setSmtpStartTlsModeAsString(String zimbraSmtpStartTlsMode) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to the
+     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
+     * MTA supports off - doesn&#039;t use starttls only - requires starttls
+     * to send messages
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @param zimbraSmtpStartTlsMode new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public Map<String,Object> setSmtpStartTlsModeAsString(String zimbraSmtpStartTlsMode, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode);
+        return attrs;
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to the
+     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
+     * MTA supports off - doesn&#039;t use starttls only - requires starttls
+     * to send messages
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public void unsetSmtpStartTlsMode() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to the
+     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
+     * MTA supports off - doesn&#039;t use starttls only - requires starttls
+     * to send messages
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=3022)
+    public Map<String,Object> unsetSmtpStartTlsMode(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, "");
+        return attrs;
+    }
+
+    /**
      * timeout value in seconds
      *
      * @return zimbraSmtpTimeout, or 60 if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -48957,13 +48957,13 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * <p>Valid values: [on, off, only]
      *
-     * @return zimbraSmtpStartTlsMode, or ZAttrProvisioning.SmtpStartTlsMode.off if unset and/or has invalid value
+     * @return zimbraSmtpStartTlsMode, or ZAttrProvisioning.SmtpStartTlsMode.only if unset and/or has invalid value
      *
      * @since ZCS 8.8.6
      */
     @ZAttr(id=3022)
     public ZAttrProvisioning.SmtpStartTlsMode getSmtpStartTlsMode() {
-        try { String v = getAttr(Provisioning.A_zimbraSmtpStartTlsMode, true, true); return v == null ? ZAttrProvisioning.SmtpStartTlsMode.off : ZAttrProvisioning.SmtpStartTlsMode.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.SmtpStartTlsMode.off; }
+        try { String v = getAttr(Provisioning.A_zimbraSmtpStartTlsMode, true, true); return v == null ? ZAttrProvisioning.SmtpStartTlsMode.only : ZAttrProvisioning.SmtpStartTlsMode.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.SmtpStartTlsMode.only; }
     }
 
     /**
@@ -48974,13 +48974,13 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * <p>Valid values: [on, off, only]
      *
-     * @return zimbraSmtpStartTlsMode, or "off" if unset
+     * @return zimbraSmtpStartTlsMode, or "only" if unset
      *
      * @since ZCS 8.8.6
      */
     @ZAttr(id=3022)
     public String getSmtpStartTlsModeAsString() {
-        return getAttr(Provisioning.A_zimbraSmtpStartTlsMode, "off", true);
+        return getAttr(Provisioning.A_zimbraSmtpStartTlsMode, "only", true);
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -48961,7 +48961,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=3022)
+    @ZAttr(id=4001)
     public ZAttrProvisioning.SmtpStartTlsMode getSmtpStartTlsMode() {
         try { String v = getAttr(Provisioning.A_zimbraSmtpStartTlsMode, true, true); return v == null ? ZAttrProvisioning.SmtpStartTlsMode.only : ZAttrProvisioning.SmtpStartTlsMode.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.SmtpStartTlsMode.only; }
     }
@@ -48978,7 +48978,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=3022)
+    @ZAttr(id=4001)
     public String getSmtpStartTlsModeAsString() {
         return getAttr(Provisioning.A_zimbraSmtpStartTlsMode, "only", true);
     }
@@ -48996,7 +48996,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=3022)
+    @ZAttr(id=4001)
     public void setSmtpStartTlsMode(ZAttrProvisioning.SmtpStartTlsMode zimbraSmtpStartTlsMode) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode.toString());
@@ -49017,7 +49017,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=3022)
+    @ZAttr(id=4001)
     public Map<String,Object> setSmtpStartTlsMode(ZAttrProvisioning.SmtpStartTlsMode zimbraSmtpStartTlsMode, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode.toString());
@@ -49037,7 +49037,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=3022)
+    @ZAttr(id=4001)
     public void setSmtpStartTlsModeAsString(String zimbraSmtpStartTlsMode) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode);
@@ -49058,7 +49058,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=3022)
+    @ZAttr(id=4001)
     public Map<String,Object> setSmtpStartTlsModeAsString(String zimbraSmtpStartTlsMode, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode);
@@ -49077,7 +49077,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=3022)
+    @ZAttr(id=4001)
     public void unsetSmtpStartTlsMode() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, "");
@@ -49097,7 +49097,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=3022)
+    @ZAttr(id=4001)
     public Map<String,Object> unsetSmtpStartTlsMode(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, "");

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -48961,7 +48961,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=4001)
+    @ZAttr(id=3022)
     public ZAttrProvisioning.SmtpStartTlsMode getSmtpStartTlsMode() {
         try { String v = getAttr(Provisioning.A_zimbraSmtpStartTlsMode, true, true); return v == null ? ZAttrProvisioning.SmtpStartTlsMode.only : ZAttrProvisioning.SmtpStartTlsMode.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.SmtpStartTlsMode.only; }
     }
@@ -48978,7 +48978,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=4001)
+    @ZAttr(id=3022)
     public String getSmtpStartTlsModeAsString() {
         return getAttr(Provisioning.A_zimbraSmtpStartTlsMode, "only", true);
     }
@@ -48996,7 +48996,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=4001)
+    @ZAttr(id=3022)
     public void setSmtpStartTlsMode(ZAttrProvisioning.SmtpStartTlsMode zimbraSmtpStartTlsMode) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode.toString());
@@ -49017,7 +49017,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=4001)
+    @ZAttr(id=3022)
     public Map<String,Object> setSmtpStartTlsMode(ZAttrProvisioning.SmtpStartTlsMode zimbraSmtpStartTlsMode, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode.toString());
@@ -49037,7 +49037,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=4001)
+    @ZAttr(id=3022)
     public void setSmtpStartTlsModeAsString(String zimbraSmtpStartTlsMode) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode);
@@ -49058,7 +49058,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=4001)
+    @ZAttr(id=3022)
     public Map<String,Object> setSmtpStartTlsModeAsString(String zimbraSmtpStartTlsMode, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode);
@@ -49077,7 +49077,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=4001)
+    @ZAttr(id=3022)
     public void unsetSmtpStartTlsMode() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, "");
@@ -49097,7 +49097,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @since ZCS 8.8.6
      */
-    @ZAttr(id=4001)
+    @ZAttr(id=3022)
     public Map<String,Object> unsetSmtpStartTlsMode(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, "");

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -48951,9 +48951,9 @@ public abstract class ZAttrServer extends NamedEntry {
 
     /**
      * Configures the starttls mode on sending messages from mailboxd to the
-     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
-     * MTA supports off - doesn&#039;t use starttls only - requires starttls
-     * to send messages
+     * MTA host specified with zimbraSmtpHostname. ( on - uses starttls if
+     * the MTA supports. off - doesn&#039;t use starttls. only - requires
+     * starttls to send messages. )
      *
      * <p>Valid values: [on, off, only]
      *
@@ -48968,9 +48968,9 @@ public abstract class ZAttrServer extends NamedEntry {
 
     /**
      * Configures the starttls mode on sending messages from mailboxd to the
-     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
-     * MTA supports off - doesn&#039;t use starttls only - requires starttls
-     * to send messages
+     * MTA host specified with zimbraSmtpHostname. ( on - uses starttls if
+     * the MTA supports. off - doesn&#039;t use starttls. only - requires
+     * starttls to send messages. )
      *
      * <p>Valid values: [on, off, only]
      *
@@ -48985,9 +48985,9 @@ public abstract class ZAttrServer extends NamedEntry {
 
     /**
      * Configures the starttls mode on sending messages from mailboxd to the
-     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
-     * MTA supports off - doesn&#039;t use starttls only - requires starttls
-     * to send messages
+     * MTA host specified with zimbraSmtpHostname. ( on - uses starttls if
+     * the MTA supports. off - doesn&#039;t use starttls. only - requires
+     * starttls to send messages. )
      *
      * <p>Valid values: [on, off, only]
      *
@@ -49005,9 +49005,9 @@ public abstract class ZAttrServer extends NamedEntry {
 
     /**
      * Configures the starttls mode on sending messages from mailboxd to the
-     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
-     * MTA supports off - doesn&#039;t use starttls only - requires starttls
-     * to send messages
+     * MTA host specified with zimbraSmtpHostname. ( on - uses starttls if
+     * the MTA supports. off - doesn&#039;t use starttls. only - requires
+     * starttls to send messages. )
      *
      * <p>Valid values: [on, off, only]
      *
@@ -49026,9 +49026,9 @@ public abstract class ZAttrServer extends NamedEntry {
 
     /**
      * Configures the starttls mode on sending messages from mailboxd to the
-     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
-     * MTA supports off - doesn&#039;t use starttls only - requires starttls
-     * to send messages
+     * MTA host specified with zimbraSmtpHostname. ( on - uses starttls if
+     * the MTA supports. off - doesn&#039;t use starttls. only - requires
+     * starttls to send messages. )
      *
      * <p>Valid values: [on, off, only]
      *
@@ -49046,9 +49046,9 @@ public abstract class ZAttrServer extends NamedEntry {
 
     /**
      * Configures the starttls mode on sending messages from mailboxd to the
-     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
-     * MTA supports off - doesn&#039;t use starttls only - requires starttls
-     * to send messages
+     * MTA host specified with zimbraSmtpHostname. ( on - uses starttls if
+     * the MTA supports. off - doesn&#039;t use starttls. only - requires
+     * starttls to send messages. )
      *
      * <p>Valid values: [on, off, only]
      *
@@ -49067,9 +49067,9 @@ public abstract class ZAttrServer extends NamedEntry {
 
     /**
      * Configures the starttls mode on sending messages from mailboxd to the
-     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
-     * MTA supports off - doesn&#039;t use starttls only - requires starttls
-     * to send messages
+     * MTA host specified with zimbraSmtpHostname. ( on - uses starttls if
+     * the MTA supports. off - doesn&#039;t use starttls. only - requires
+     * starttls to send messages. )
      *
      * <p>Valid values: [on, off, only]
      *
@@ -49086,9 +49086,9 @@ public abstract class ZAttrServer extends NamedEntry {
 
     /**
      * Configures the starttls mode on sending messages from mailboxd to the
-     * MTA host specified with zimbraSmtpHostname. on - uses starttls if the
-     * MTA supports off - doesn&#039;t use starttls only - requires starttls
-     * to send messages
+     * MTA host specified with zimbraSmtpHostname. ( on - uses starttls if
+     * the MTA supports. off - doesn&#039;t use starttls. only - requires
+     * starttls to send messages. )
      *
      * <p>Valid values: [on, off, only]
      *

--- a/store/src/java/com/zimbra/cs/mailbox/MailSender.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailSender.java
@@ -1418,23 +1418,23 @@ public class MailSender {
     public static void setupStartTlsMode(Account account, Session smtpSession) throws ServiceException {
         SmtpStartTlsMode startTlsMode = Provisioning.getInstance().getDomain(account).getSmtpStartTlsMode();
         if (startTlsMode == null) {
-        		startTlsMode = Provisioning.getInstance().getLocalServer().getSmtpStartTlsMode();
+            startTlsMode = Provisioning.getInstance().getLocalServer().getSmtpStartTlsMode();
         }
-
-		smtpSession.getProperties().setProperty("mail.smtp.ssl.trust", "*");
+        
+        smtpSession.getProperties().setProperty("mail.smtp.ssl.trust", "*");
         if (startTlsMode.isOff()) {
-    			smtpSession.getProperties().setProperty("mail.smtp.starttls.enable", "false");
+            smtpSession.getProperties().setProperty("mail.smtp.starttls.enable", "false");
         } else if (startTlsMode.isOn()) {
-        		smtpSession.getProperties().setProperty("mail.smtp.starttls.enable", "true");
-        		smtpSession.getProperties().setProperty("mail.smtp.starttls.required", "false");
+            smtpSession.getProperties().setProperty("mail.smtp.starttls.enable", "true");
+            smtpSession.getProperties().setProperty("mail.smtp.starttls.required", "false");
         } else if (startTlsMode.isOnly()) {
-    			smtpSession.getProperties().setProperty("mail.smtp.starttls.enable", "true");
-    			smtpSession.getProperties().setProperty("mail.smtp.starttls.required", "true");
+            smtpSession.getProperties().setProperty("mail.smtp.starttls.enable", "true");
+            smtpSession.getProperties().setProperty("mail.smtp.starttls.required", "true");
         } else {
-        		// Should not be reached here
-        		ZimbraLog.smtp.warn("invalid value configured for %s. fallback to \"on\".", Provisioning.A_zimbraSmtpStartTlsMode);
-        		smtpSession.getProperties().setProperty("mail.smtp.starttls.enable", "true");
-        		smtpSession.getProperties().setProperty("mail.smtp.starttls.required", "false");
+            // Should not be reached here
+            ZimbraLog.smtp.warn("invalid value configured for %s. fallback to \"on\".", Provisioning.A_zimbraSmtpStartTlsMode);
+            smtpSession.getProperties().setProperty("mail.smtp.starttls.enable", "true");
+            smtpSession.getProperties().setProperty("mail.smtp.starttls.required", "false");
         }
     }
 }

--- a/store/src/java/com/zimbra/cs/mailbox/MailSender.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailSender.java
@@ -1207,7 +1207,7 @@ public class MailSender {
 
     private void sendMessageToHost(String hostname, MimeMessage mm, Address[] rcptAddresses)
     throws MessagingException, ServiceException {
-    	    mSession.getProperties().setProperty("mail.smtp.host", hostname);
+        mSession.getProperties().setProperty("mail.smtp.host", hostname);
         if (mEnvelopeFrom != null) {
             mSession.getProperties().setProperty("mail.smtp.from", mEnvelopeFrom);
         }

--- a/store/src/java/com/zimbra/cs/mailbox/Notification.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Notification.java
@@ -523,6 +523,10 @@ public class Notification implements LmtpCallback {
                 ZimbraLog.mailbox.warn("error encoutered looking up return path configuration, using null return path instead", se);
             }
             smtpSession.getProperties().setProperty("mail.smtp.from", envFrom);
+            
+            MailSender.setupStartTlsMode(account, smtpSession);
+            ZimbraLog.smtp.debug("Sending message %s to SMTP host %s with properties: %s",
+            		mm.getMessageID(), smtpSession.getProperties().getProperty("mail.smtp.host"), smtpSession.getProperties());
 
             Transport.send(out);
             ZimbraLog.mailbox.info("notification sent dest='" + destination + "' rcpt='" + rcpt + "' mid=" + msg.getId());


### PR DESCRIPTION
This fix add a new ldap attribute: zimbraSmtpStartTlsMode

> 
> Configures the starttls mode on sending messages from mailboxd to the
> MTA host specified with zimbraSmtpHostname. ( on - uses starttls if
> the MTA supports. off - doesn't use starttls. only - requires starttls
> to send messages. )
> 
>                type : enum
>               value : on,off,only
>            callback :
>           immutable : false
>         cardinality : single
>          requiredIn :
>          optionalIn : domain,globalConfig,server
>               flags : serverInherited
>            defaults : off
>                 min :
>                 max :
>                  id : 3022
>     requiresRestart :
>               since : 8.8.6
>     deprecatedSince :