### PR TITLE
ZCS-3928:Support JWT in REST API - UserServlet

### DIFF
--- a/store/src/java/com/zimbra/cs/account/ZimbraJWToken.java
+++ b/store/src/java/com/zimbra/cs/account/ZimbraJWToken.java
@@ -238,8 +238,8 @@ public class ZimbraJWToken extends AuthToken {
 
     @Override
     public void encode(HttpState state, boolean isAdminReq, String cookieDomain) throws ServiceException {
-        // TODO will be implemented as part of "ZCS-3928: Support JWT in UserServlet"
-        
+        //TODO this method is called only in case of offline provisioning.If it's supported in nextGen, it will
+        //be implemented as part of offline provisioning ticket(ZCS-4240).
     }
 
     @Override

--- a/store/src/java/com/zimbra/cs/service/UserServlet.java
+++ b/store/src/java/com/zimbra/cs/service/UserServlet.java
@@ -115,6 +115,7 @@ import com.zimbra.cs.util.AccountUtil;
  *
  *             {auth-types} = comma-separated list. Legal values are:
  *                            co     cookie
+ *                            jwt    JWT based auth
  *                            ba     basic auth
  *                            nsc    do not set a cookie when using basic auth
  *                            (default is &quot;co,ba&quot;, i.e. check both)
@@ -236,10 +237,12 @@ public class UserServlet extends ZimbraServlet {
     public static final String AUTH_NO_SET_COOKIE = "nsc"; // don't set auth token cookie after basic auth
                                                            // same as ba after bug 42782
 
+    public static final String AUTH_JWT = "jwt"; // auth by jwt
+
     // see https://bugzilla.zimbra.com/show_bug.cgi?id=42782#c11
     public static final String AUTH_SET_COOKIE = "sc"; // set auth token cookie after basic auth
 
-    public static final String AUTH_DEFAULT = "co,nsc,qp"; // all three
+    public static final String AUTH_DEFAULT = "co,jwt,nsc,qp"; // all four
 
     public static final String HTTP_URL = "http_url";
     public static final String HTTP_STATUS_CODE = "http_code";

--- a/store/src/java/com/zimbra/cs/service/UserServletContext.java
+++ b/store/src/java/com/zimbra/cs/service/UserServletContext.java
@@ -70,6 +70,7 @@ public class UserServletContext {
     public FormatType format;
     public Formatter formatter;
     public boolean cookieAuthHappened;
+    public boolean jwtAuthHappened;
     public boolean basicAuthHappened;
     public boolean qpAuthHappened;
     public String accountPath;
@@ -411,6 +412,10 @@ public class UserServletContext {
 
     public boolean cookieAuthAllowed() {
         return getAuth().indexOf(UserServlet.AUTH_COOKIE) != -1;
+    }
+
+    public boolean jwtAuthAllowed() {
+        return getAuth().indexOf(UserServlet.AUTH_JWT) != -1;
     }
 
     public boolean isAuthedAcctGuest() {

--- a/store/src/java/com/zimbra/cs/service/util/UserServletUtil.java
+++ b/store/src/java/com/zimbra/cs/service/util/UserServletUtil.java
@@ -31,6 +31,7 @@ import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.L10nUtil;
 import com.zimbra.common.util.L10nUtil.MsgKey;
 import com.zimbra.common.util.Pair;
+import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.AuthToken;
 import com.zimbra.cs.account.AuthTokenException;
@@ -54,6 +55,7 @@ import com.zimbra.cs.service.formatter.FormatterFactory;
 import com.zimbra.cs.service.formatter.FormatterFactory.FormatType;
 import com.zimbra.cs.servlet.ZimbraServlet;
 import com.zimbra.cs.servlet.util.AuthUtil;
+import com.zimbra.soap.SoapServlet;
 
 public class UserServletUtil {
 
@@ -251,34 +253,47 @@ public class UserServletUtil {
                 try {
                     AuthToken at = AuthProvider.getAuthToken(context.req, isAdminRequest);
                     if (at != null) {
-
-                        if (at.isZimbraUser()) {
-                        	if(!at.isRegistered()) {
-                        		throw new UserServletException(HttpServletResponse.SC_UNAUTHORIZED,
-                                        L10nUtil.getMessage(MsgKey.errMustAuthenticate, context.req));
-                        	}
-                            try {
-                                context.setAuthAccount(AuthProvider.validateAuthToken(Provisioning.getInstance(), at, false));
-                            } catch (ServiceException e) {
-                                throw new UserServletException(HttpServletResponse.SC_UNAUTHORIZED,
-                                        L10nUtil.getMessage(MsgKey.errMustAuthenticate, context.req));
-                            }
-                            context.cookieAuthHappened = true;
-                            context.authToken = at;
-                            return;
-                        } else {
-                            if (at.isExpired()) {
-                                throw new UserServletException(HttpServletResponse.SC_UNAUTHORIZED,
-                                        L10nUtil.getMessage(MsgKey.errMustAuthenticate, context.req));
-                            }
-                            context.setAuthAccount(new GuestAccount(at));
-                            context.basicAuthHappened = true; // pretend that we basic authed
-                            context.authToken = at;
-                            return;
-                        }
+                        validateAuthToken(context, at, Boolean.FALSE);
+                        return;
                     }
                 } catch (AuthTokenException e) {
                     // bug 35917: malformed auth token means auth failure
+                    throw new UserServletException(HttpServletResponse.SC_UNAUTHORIZED,
+                            L10nUtil.getMessage(MsgKey.errMustAuthenticate, context.req));
+                }
+            }
+
+            if (context.jwtAuthAllowed()) {
+                try {
+                    Map <Object, Object> engineCtxt = new HashMap<Object, Object>();
+                    engineCtxt.put(SoapServlet.SERVLET_REQUEST, context.req);
+                    AuthToken at = AuthProvider.getJWToken(null, engineCtxt);
+                    if (at != null) {
+                        validateAuthToken(context, at, Boolean.TRUE);
+                        return;
+                    } else {
+                        String jwt = context.params.get(ZimbraServlet.QP_ZJWT);
+                        if (!StringUtil.isNullOrEmpty(jwt)) {
+                            try {
+                                at = AuthProvider.getJWToken(jwt, JWTUtil.getSalt(null, engineCtxt));
+                                if (at != null) {
+                                    try {
+                                        context.setAuthAccount(AuthProvider.validateAuthToken(Provisioning.getInstance(), at, false));
+                                        context.jwtAuthHappened = true;
+                                        context.authToken = at;
+                                        return;
+                                    } catch (ServiceException e) {
+                                        throw new UserServletException(HttpServletResponse.SC_UNAUTHORIZED,
+                                                L10nUtil.getMessage(MsgKey.errMustAuthenticate, context.req));
+                                    }
+                                }
+                            } catch (AuthTokenException e) {
+                                throw new UserServletException(HttpServletResponse.SC_UNAUTHORIZED,
+                                        L10nUtil.getMessage(MsgKey.errMustAuthenticate, context.req));
+                            }
+                        }
+                    }
+                } catch (AuthTokenException e) {
                     throw new UserServletException(HttpServletResponse.SC_UNAUTHORIZED,
                             L10nUtil.getMessage(MsgKey.errMustAuthenticate, context.req));
                 }
@@ -337,6 +352,35 @@ public class UserServletUtil {
             // there is no credential at this point.  assume anonymous public access and continue.
         } catch (ServiceException e) {
             throw new ServletException(e);
+        }
+    }
+
+    private static void validateAuthToken(UserServletContext context, AuthToken at, boolean isJWT) throws UserServletException, ServiceException {
+        if (at.isZimbraUser()) {
+            if(!at.isRegistered()) {
+                throw new UserServletException(HttpServletResponse.SC_UNAUTHORIZED,
+                        L10nUtil.getMessage(MsgKey.errMustAuthenticate, context.req));
+            }
+            try {
+                context.setAuthAccount(AuthProvider.validateAuthToken(Provisioning.getInstance(), at, false));
+            } catch (ServiceException e) {
+                throw new UserServletException(HttpServletResponse.SC_UNAUTHORIZED,
+                        L10nUtil.getMessage(MsgKey.errMustAuthenticate, context.req));
+            }
+            if (isJWT) {
+                context.jwtAuthHappened = true;
+            } else {
+                context.cookieAuthHappened = true;
+            }
+            context.authToken = at;
+        } else {
+            if (at.isExpired()) {
+                throw new UserServletException(HttpServletResponse.SC_UNAUTHORIZED,
+                        L10nUtil.getMessage(MsgKey.errMustAuthenticate, context.req));
+            }
+            context.setAuthAccount(new GuestAccount(at));
+            context.basicAuthHappened = true; // pretend that we basic authed
+            context.authToken = at;
         }
     }
 

--- a/store/src/java/com/zimbra/cs/servlet/ZimbraServlet.java
+++ b/store/src/java/com/zimbra/cs/servlet/ZimbraServlet.java
@@ -79,6 +79,7 @@ public class ZimbraServlet extends HttpServlet {
     private static final String PARAM_ALLOWED_PORTS  = "allowed.ports";
 
     public static final String QP_ZAUTHTOKEN = "zauthtoken";
+    public static final String QP_ZJWT = "zjwt";
 
     protected String getRealmHeader(String realm)  {
         if (realm == null)


### PR DESCRIPTION
Added support for authentication using JWT in REST API:
   A new value 'jwt' added for the auth parameter. when auth parameter value is 'jwt':
  1. look for jwt in Authorization header of http request. If it's not found, look for 'zjwt' query    
      parameter.
  2. salt value will be sent by the browser in ZM_JWT cookie. 
Also, added junit for auth header flow as well as query param flow.