### PR TITLE
ZCS-3887-2:Enhancement of SMTP log format

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/Notification.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Notification.java
@@ -525,7 +525,9 @@ public class Notification implements LmtpCallback {
             smtpSession.getProperties().setProperty("mail.smtp.from", envFrom);
 
             Transport.send(out);
-            ZimbraLog.mailbox.info("notification sent dest='" + destination + "' rcpt='" + rcpt + "' mid=" + msg.getId());
+
+            MailSender.logMessage(out, out.getAllRecipients(), envFrom,
+                smtpSession.getProperties().getProperty("mail.smtp.host"), String.valueOf(msg.getId()), null, null, "notify");
         } catch (MessagingException me) {
             nfailed("send failed", destination, rcpt, msg, me);
         }


### PR DESCRIPTION
Handling additional cases that the messages is sent automatically
when the end user sends a message via Web Client.
- User-specified notification message (it is not the one which is supported by the Sieve filter, but the legacy non-conditional notification feature)
- Delivery report message (it is not exactly triggered by SendMsgRequest, but still this is sent from the Web client at his/her own will).

[Manual Test]
Notification message
```
smtp - Sending message to MTA at mail.synacorjapan.com: Message-ID=<1342530317.85.1518698157119.JavaMail.zimbra@mail.synacorjapan.com>, origMsgId=400, sender=user2@synacorjapan.com, nrcpts=1, to=admin@synacorjapan.com, reason=notify
```

Delivery Report message
```
smtp - Sending message to MTA at mail.synacorjapan.com: Message-ID=<887266401.74.1518698096336.JavaMail.zimbra@mail.synacorjapan.com>, origMsgId=442, sender=user9@synacorjapan.com, nrcpts=1, to=user8@synacorjapan.com, reason=read receipt
```

(Reference log output)
SendMsgRequest (send a new message)
```
smtp - Sending message to MTA at mail.synacorjapan.com: Message-ID=<24727957.79.1518698156395.JavaMail.zimbra@synacorjapan.com>, replyType=r, sender=user9@synacorjapan.com, nrcpts=1, to=user2@synacorjapan.com
```
SendMsgRequest (forward)
```
smtp - Sending message to MTA at mail.synacorjapan.com: Message-ID=<1941266336.107.1518699754598.JavaMail.zimbra@synacorjapan.com>, origMsgId=1c2722d0-2cc3-4ecd-a3e2-b43bfd8062ce:441, replyType=w, sender=user9@synacorjapan.com, nrcpts=1, to=user8@synacorjapan.com
```
SendMsgRequest (reply)
```
smtp - Sending message to MTA at mail.synacorjapan.com: Message-ID=<555005995.102.1518699732275.JavaMail.zimbra@synacorjapan.com>, origMsgId=1c2722d0-2cc3-4ecd-a3e2-b43bfd8062ce:441, replyType=r, sender=user9@synacorjapan.com, nrcpts=1, to=user8@synacorjapan.com
```