### PR TITLE
snickers: NICPS-30: added zimbraPrefDisplayTimeInMailList

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -12792,6 +12792,14 @@ public class ZAttrProvisioning {
     public static final String A_zimbraPrefDisplayExternalImages = "zimbraPrefDisplayExternalImages";
 
     /**
+     * Display received/sent time in mail list
+     *
+     * @since ZCS 8.8.7
+     */
+    @ZAttr(id=3021)
+    public static final String A_zimbraPrefDisplayTimeInMailList = "zimbraPrefDisplayTimeInMailList";
+
+    /**
      * Specifies the meaning of an external sender. &quot;ALL&quot; means
      * users whose domain doesn&#039;t match the recipient&#039;s or
      * zimbraInternalSendersDomain. &quot;ALLNOTINAB&quot; means

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -12796,7 +12796,7 @@ public class ZAttrProvisioning {
      *
      * @since ZCS 8.8.7
      */
-    @ZAttr(id=3021)
+    @ZAttr(id=5001)
     public static final String A_zimbraPrefDisplayTimeInMailList = "zimbraPrefDisplayTimeInMailList";
 
     /**

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -12794,7 +12794,7 @@ public class ZAttrProvisioning {
     /**
      * Display received/sent time in mail list
      *
-     * @since ZCS 8.8.7
+     * @since ZCS 8.8.6
      */
     @ZAttr(id=5001)
     public static final String A_zimbraPrefDisplayTimeInMailList = "zimbraPrefDisplayTimeInMailList";

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9624,7 +9624,7 @@ TODO: delete them permanently from here
   </desc>
 </attr>
 
-<attr id="3021" name="zimbraPrefDisplayTimeInMailList" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited" since="8.8.7">
+<attr id="5001" name="zimbraPrefDisplayTimeInMailList" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited" since="8.8.7">
   <defaultCOSValue>FALSE</defaultCOSValue>
   <desc>Display received/sent time in mail list</desc>
 </attr>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9624,7 +9624,7 @@ TODO: delete them permanently from here
   </desc>
 </attr>
 
-<attr id="5001" name="zimbraPrefDisplayTimeInMailList" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited" since="8.8.7">
+<attr id="5001" name="zimbraPrefDisplayTimeInMailList" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited" since="8.8.6">
   <defaultCOSValue>FALSE</defaultCOSValue>
   <desc>Display received/sent time in mail list</desc>
 </attr>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9623,4 +9623,9 @@ TODO: delete them permanently from here
     for all unconfigured host names. See also related attributes 'zimbraVirtualHostname' and 'zimbraVirtualIPAddress'.
   </desc>
 </attr>
+
+<attr id="3021" name="zimbraPrefDisplayTimeInMailList" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited" since="8.8.7">
+  <defaultCOSValue>FALSE</defaultCOSValue>
+  <desc>Display received/sent time in mail list</desc>
+</attr>
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -42501,6 +42501,78 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * Display received/sent time in mail list
+     *
+     * @return zimbraPrefDisplayTimeInMailList, or false if unset
+     *
+     * @since ZCS 8.8.7
+     */
+    @ZAttr(id=3021)
+    public boolean isPrefDisplayTimeInMailList() {
+        return getBooleanAttr(Provisioning.A_zimbraPrefDisplayTimeInMailList, false, true);
+    }
+
+    /**
+     * Display received/sent time in mail list
+     *
+     * @param zimbraPrefDisplayTimeInMailList new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.7
+     */
+    @ZAttr(id=3021)
+    public void setPrefDisplayTimeInMailList(boolean zimbraPrefDisplayTimeInMailList) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefDisplayTimeInMailList, zimbraPrefDisplayTimeInMailList ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Display received/sent time in mail list
+     *
+     * @param zimbraPrefDisplayTimeInMailList new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.7
+     */
+    @ZAttr(id=3021)
+    public Map<String,Object> setPrefDisplayTimeInMailList(boolean zimbraPrefDisplayTimeInMailList, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefDisplayTimeInMailList, zimbraPrefDisplayTimeInMailList ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Display received/sent time in mail list
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.7
+     */
+    @ZAttr(id=3021)
+    public void unsetPrefDisplayTimeInMailList() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefDisplayTimeInMailList, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Display received/sent time in mail list
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.7
+     */
+    @ZAttr(id=3021)
+    public Map<String,Object> unsetPrefDisplayTimeInMailList(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefDisplayTimeInMailList, "");
+        return attrs;
+    }
+
+    /**
      * Specifies the meaning of an external sender. &quot;ALL&quot; means
      * users whose domain doesn&#039;t match the recipient&#039;s or
      * zimbraInternalSendersDomain. &quot;ALLNOTINAB&quot; means

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -42505,7 +42505,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @return zimbraPrefDisplayTimeInMailList, or false if unset
      *
-     * @since ZCS 8.8.7
+     * @since ZCS 8.8.6
      */
     @ZAttr(id=5001)
     public boolean isPrefDisplayTimeInMailList() {
@@ -42518,7 +42518,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param zimbraPrefDisplayTimeInMailList new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.8.7
+     * @since ZCS 8.8.6
      */
     @ZAttr(id=5001)
     public void setPrefDisplayTimeInMailList(boolean zimbraPrefDisplayTimeInMailList) throws com.zimbra.common.service.ServiceException {
@@ -42534,7 +42534,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.8.7
+     * @since ZCS 8.8.6
      */
     @ZAttr(id=5001)
     public Map<String,Object> setPrefDisplayTimeInMailList(boolean zimbraPrefDisplayTimeInMailList, Map<String,Object> attrs) {
@@ -42548,7 +42548,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.8.7
+     * @since ZCS 8.8.6
      */
     @ZAttr(id=5001)
     public void unsetPrefDisplayTimeInMailList() throws com.zimbra.common.service.ServiceException {
@@ -42563,7 +42563,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.8.7
+     * @since ZCS 8.8.6
      */
     @ZAttr(id=5001)
     public Map<String,Object> unsetPrefDisplayTimeInMailList(Map<String,Object> attrs) {

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -42507,7 +42507,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 8.8.7
      */
-    @ZAttr(id=3021)
+    @ZAttr(id=5001)
     public boolean isPrefDisplayTimeInMailList() {
         return getBooleanAttr(Provisioning.A_zimbraPrefDisplayTimeInMailList, false, true);
     }
@@ -42520,7 +42520,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 8.8.7
      */
-    @ZAttr(id=3021)
+    @ZAttr(id=5001)
     public void setPrefDisplayTimeInMailList(boolean zimbraPrefDisplayTimeInMailList) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraPrefDisplayTimeInMailList, zimbraPrefDisplayTimeInMailList ? TRUE : FALSE);
@@ -42536,7 +42536,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 8.8.7
      */
-    @ZAttr(id=3021)
+    @ZAttr(id=5001)
     public Map<String,Object> setPrefDisplayTimeInMailList(boolean zimbraPrefDisplayTimeInMailList, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraPrefDisplayTimeInMailList, zimbraPrefDisplayTimeInMailList ? TRUE : FALSE);
@@ -42550,7 +42550,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 8.8.7
      */
-    @ZAttr(id=3021)
+    @ZAttr(id=5001)
     public void unsetPrefDisplayTimeInMailList() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraPrefDisplayTimeInMailList, "");
@@ -42565,7 +42565,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 8.8.7
      */
-    @ZAttr(id=3021)
+    @ZAttr(id=5001)
     public Map<String,Object> unsetPrefDisplayTimeInMailList(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraPrefDisplayTimeInMailList, "");

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -33204,6 +33204,78 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * Display received/sent time in mail list
+     *
+     * @return zimbraPrefDisplayTimeInMailList, or false if unset
+     *
+     * @since ZCS 8.8.7
+     */
+    @ZAttr(id=3021)
+    public boolean isPrefDisplayTimeInMailList() {
+        return getBooleanAttr(Provisioning.A_zimbraPrefDisplayTimeInMailList, false, true);
+    }
+
+    /**
+     * Display received/sent time in mail list
+     *
+     * @param zimbraPrefDisplayTimeInMailList new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.7
+     */
+    @ZAttr(id=3021)
+    public void setPrefDisplayTimeInMailList(boolean zimbraPrefDisplayTimeInMailList) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefDisplayTimeInMailList, zimbraPrefDisplayTimeInMailList ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Display received/sent time in mail list
+     *
+     * @param zimbraPrefDisplayTimeInMailList new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.7
+     */
+    @ZAttr(id=3021)
+    public Map<String,Object> setPrefDisplayTimeInMailList(boolean zimbraPrefDisplayTimeInMailList, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefDisplayTimeInMailList, zimbraPrefDisplayTimeInMailList ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Display received/sent time in mail list
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.7
+     */
+    @ZAttr(id=3021)
+    public void unsetPrefDisplayTimeInMailList() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefDisplayTimeInMailList, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Display received/sent time in mail list
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.7
+     */
+    @ZAttr(id=3021)
+    public Map<String,Object> unsetPrefDisplayTimeInMailList(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefDisplayTimeInMailList, "");
+        return attrs;
+    }
+
+    /**
      * Specifies the meaning of an external sender. &quot;ALL&quot; means
      * users whose domain doesn&#039;t match the recipient&#039;s or
      * zimbraInternalSendersDomain. &quot;ALLNOTINAB&quot; means

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -33210,7 +33210,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 8.8.7
      */
-    @ZAttr(id=3021)
+    @ZAttr(id=5001)
     public boolean isPrefDisplayTimeInMailList() {
         return getBooleanAttr(Provisioning.A_zimbraPrefDisplayTimeInMailList, false, true);
     }
@@ -33223,7 +33223,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 8.8.7
      */
-    @ZAttr(id=3021)
+    @ZAttr(id=5001)
     public void setPrefDisplayTimeInMailList(boolean zimbraPrefDisplayTimeInMailList) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraPrefDisplayTimeInMailList, zimbraPrefDisplayTimeInMailList ? TRUE : FALSE);
@@ -33239,7 +33239,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 8.8.7
      */
-    @ZAttr(id=3021)
+    @ZAttr(id=5001)
     public Map<String,Object> setPrefDisplayTimeInMailList(boolean zimbraPrefDisplayTimeInMailList, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraPrefDisplayTimeInMailList, zimbraPrefDisplayTimeInMailList ? TRUE : FALSE);
@@ -33253,7 +33253,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 8.8.7
      */
-    @ZAttr(id=3021)
+    @ZAttr(id=5001)
     public void unsetPrefDisplayTimeInMailList() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraPrefDisplayTimeInMailList, "");
@@ -33268,7 +33268,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 8.8.7
      */
-    @ZAttr(id=3021)
+    @ZAttr(id=5001)
     public Map<String,Object> unsetPrefDisplayTimeInMailList(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraPrefDisplayTimeInMailList, "");

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -33208,7 +33208,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @return zimbraPrefDisplayTimeInMailList, or false if unset
      *
-     * @since ZCS 8.8.7
+     * @since ZCS 8.8.6
      */
     @ZAttr(id=5001)
     public boolean isPrefDisplayTimeInMailList() {
@@ -33221,7 +33221,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param zimbraPrefDisplayTimeInMailList new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.8.7
+     * @since ZCS 8.8.6
      */
     @ZAttr(id=5001)
     public void setPrefDisplayTimeInMailList(boolean zimbraPrefDisplayTimeInMailList) throws com.zimbra.common.service.ServiceException {
@@ -33237,7 +33237,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.8.7
+     * @since ZCS 8.8.6
      */
     @ZAttr(id=5001)
     public Map<String,Object> setPrefDisplayTimeInMailList(boolean zimbraPrefDisplayTimeInMailList, Map<String,Object> attrs) {
@@ -33251,7 +33251,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.8.7
+     * @since ZCS 8.8.6
      */
     @ZAttr(id=5001)
     public void unsetPrefDisplayTimeInMailList() throws com.zimbra.common.service.ServiceException {
@@ -33266,7 +33266,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.8.7
+     * @since ZCS 8.8.6
      */
     @ZAttr(id=5001)
     public Map<String,Object> unsetPrefDisplayTimeInMailList(Map<String,Object> attrs) {


### PR DESCRIPTION
Problem : display received/sent time of all messages in email list. Before the fix, only (year/)month/day is shown if the message was received yesterday or before.
Fix : 
- added new attribute: zimbraPrefDisplayTimeInMailList
- If zimbraPrefDisplayTimeInMailList is TRUE, web client displays not only date but also time of a message received yesterday or before in email list.

Testing done : testing done by developer.
Testing to be done by QA: testing needed to be done by QA
Link:
- Set of PRs : https://github.com/Zimbra/zm-ajax/pull/47, https://github.com/Zimbra/zm-web-client/pull/231, https://github.com/Zimbra/zm-mailbox/pull/525
- RP to develop branch: https://github.com/Zimbra/zm-ajax/pull/46, https://github.com/Zimbra/zm-web-client/pull/227, https://github.com/Zimbra/zm-mailbox/pull/511
