### PR TITLE
ZCS-4171:Move all Exception stack trace to debug level

### DIFF
--- a/common/src/java/com/zimbra/common/util/Log.java
+++ b/common/src/java/com/zimbra/common/util/Log.java
@@ -369,6 +369,15 @@ public class Log {
         }
     }
 
+    public void errorQuietly(Object o, Throwable t) {
+        if (isDebugEnabled()) {
+            getLogger().error(o, t);
+        } else {
+            getLogger().error(String.format("%s : %s", o, t.getMessage()));
+        }
+    }
+
+
     /**
      * Returns Log4j equivalent of {@code level} or org.apache.log4j.Level.TRACE
      */


### PR DESCRIPTION
Added method to log the stack trace only when the debug is enabled
Reference PR: https://github.com/Zimbra/zm-ews-store/pull/4