### PR TITLE
NICPS-59/Bug 34202 - STARTTLS support for outbound mail sent by mailb…

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -2296,6 +2296,24 @@ public class ZAttrProvisioning {
         public boolean isSTARTTLS() { return this == STARTTLS;}
     }
 
+    public static enum SmtpStartTlsMode {
+        on("on"),
+        off("off"),
+        only("only");
+        private String mValue;
+        private SmtpStartTlsMode(String value) { mValue = value; }
+        public String toString() { return mValue; }
+        public static SmtpStartTlsMode fromString(String s) throws ServiceException {
+            for (SmtpStartTlsMode value : values()) {
+                if (value.mValue.equals(s)) return value;
+             }
+             throw ServiceException.INVALID_REQUEST("invalid value: "+s+", valid values: "+ Arrays.asList(values()), null);
+        }
+        public boolean isOn() { return this == on;}
+        public boolean isOff() { return this == off;}
+        public boolean isOnly() { return this == only;}
+    }
+
     public static enum TableMaintenanceOperation {
         ANALYZE("ANALYZE"),
         OPTIMIZE("OPTIMIZE");
@@ -15974,6 +15992,16 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=249)
     public static final String A_zimbraSmtpSendPartial = "zimbraSmtpSendPartial";
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to MTA.
+     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
+     * starttls. only - requires starttls to send messages. )
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5002)
+    public static final String A_zimbraSmtpStartTlsMode = "zimbraSmtpStartTlsMode";
 
     /**
      * timeout value in seconds

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -15994,9 +15994,9 @@ public class ZAttrProvisioning {
     public static final String A_zimbraSmtpSendPartial = "zimbraSmtpSendPartial";
 
     /**
-     * Configures the starttls mode on sending messages from mailboxd to MTA.
-     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
-     * starttls. only - requires starttls to send messages. )
+     * Configures the starttls mode on sending messages from mailboxd to MTA
+     * on - uses starttls if the peer MTA supports off - doesn&#039;t use
+     * starttls only - requires starttls to send messages
      *
      * @since ZCS 8.8.6
      */

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9632,10 +9632,10 @@ TODO: delete them permanently from here
 <attr id="5002" name="zimbraSmtpStartTlsMode" type="enum" value="on,off,only" cardinality="single" optionalIn="globalConfig,server,domain" flags="serverInherited" since="8.8.6">
   <globalConfigValue>only</globalConfigValue>
   <globalConfigValueUpgrade>off</globalConfigValueUpgrade>
-  <desc>Configures the starttls mode on sending messages from mailboxd to MTA.
-        ( on   - uses starttls if the peer MTA supports.
-          off  - doesn't use starttls.
-          only - requires starttls to send messages. )
+  <desc>Configures the starttls mode on sending messages from mailboxd to MTA
+        on   - uses starttls if the peer MTA supports
+        off  - doesn't use starttls
+        only - requires starttls to send messages
   </desc>
 </attr>
 </attrs>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9628,4 +9628,14 @@ TODO: delete them permanently from here
   <defaultCOSValue>FALSE</defaultCOSValue>
   <desc>Display received/sent time in mail list</desc>
 </attr>
+
+<attr id="5002" name="zimbraSmtpStartTlsMode" type="enum" value="on,off,only" cardinality="single" optionalIn="globalConfig,server,domain" flags="serverInherited" since="8.8.6">
+  <globalConfigValue>only</globalConfigValue>
+  <globalConfigValueUpgrade>off</globalConfigValueUpgrade>
+  <desc>Configures the starttls mode on sending messages from mailboxd to MTA.
+        ( on   - uses starttls if the peer MTA supports.
+          off  - doesn't use starttls.
+          only - requires starttls to send messages. )
+  </desc>
+</attr>
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -68342,9 +68342,9 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Configures the starttls mode on sending messages from mailboxd to MTA.
-     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
-     * starttls. only - requires starttls to send messages. )
+     * Configures the starttls mode on sending messages from mailboxd to MTA
+     * on - uses starttls if the peer MTA supports off - doesn&#039;t use
+     * starttls only - requires starttls to send messages
      *
      * <p>Valid values: [on, off, only]
      *
@@ -68358,9 +68358,9 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Configures the starttls mode on sending messages from mailboxd to MTA.
-     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
-     * starttls. only - requires starttls to send messages. )
+     * Configures the starttls mode on sending messages from mailboxd to MTA
+     * on - uses starttls if the peer MTA supports off - doesn&#039;t use
+     * starttls only - requires starttls to send messages
      *
      * <p>Valid values: [on, off, only]
      *
@@ -68374,9 +68374,9 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Configures the starttls mode on sending messages from mailboxd to MTA.
-     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
-     * starttls. only - requires starttls to send messages. )
+     * Configures the starttls mode on sending messages from mailboxd to MTA
+     * on - uses starttls if the peer MTA supports off - doesn&#039;t use
+     * starttls only - requires starttls to send messages
      *
      * <p>Valid values: [on, off, only]
      *
@@ -68393,9 +68393,9 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Configures the starttls mode on sending messages from mailboxd to MTA.
-     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
-     * starttls. only - requires starttls to send messages. )
+     * Configures the starttls mode on sending messages from mailboxd to MTA
+     * on - uses starttls if the peer MTA supports off - doesn&#039;t use
+     * starttls only - requires starttls to send messages
      *
      * <p>Valid values: [on, off, only]
      *
@@ -68413,9 +68413,9 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Configures the starttls mode on sending messages from mailboxd to MTA.
-     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
-     * starttls. only - requires starttls to send messages. )
+     * Configures the starttls mode on sending messages from mailboxd to MTA
+     * on - uses starttls if the peer MTA supports off - doesn&#039;t use
+     * starttls only - requires starttls to send messages
      *
      * <p>Valid values: [on, off, only]
      *
@@ -68432,9 +68432,9 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Configures the starttls mode on sending messages from mailboxd to MTA.
-     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
-     * starttls. only - requires starttls to send messages. )
+     * Configures the starttls mode on sending messages from mailboxd to MTA
+     * on - uses starttls if the peer MTA supports off - doesn&#039;t use
+     * starttls only - requires starttls to send messages
      *
      * <p>Valid values: [on, off, only]
      *
@@ -68452,9 +68452,9 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Configures the starttls mode on sending messages from mailboxd to MTA.
-     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
-     * starttls. only - requires starttls to send messages. )
+     * Configures the starttls mode on sending messages from mailboxd to MTA
+     * on - uses starttls if the peer MTA supports off - doesn&#039;t use
+     * starttls only - requires starttls to send messages
      *
      * <p>Valid values: [on, off, only]
      *
@@ -68470,9 +68470,9 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Configures the starttls mode on sending messages from mailboxd to MTA.
-     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
-     * starttls. only - requires starttls to send messages. )
+     * Configures the starttls mode on sending messages from mailboxd to MTA
+     * on - uses starttls if the peer MTA supports off - doesn&#039;t use
+     * starttls only - requires starttls to send messages
      *
      * <p>Valid values: [on, off, only]
      *

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -68342,6 +68342,153 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Configures the starttls mode on sending messages from mailboxd to MTA.
+     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
+     * starttls. only - requires starttls to send messages. )
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @return zimbraSmtpStartTlsMode, or ZAttrProvisioning.SmtpStartTlsMode.only if unset and/or has invalid value
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5002)
+    public ZAttrProvisioning.SmtpStartTlsMode getSmtpStartTlsMode() {
+        try { String v = getAttr(Provisioning.A_zimbraSmtpStartTlsMode, true, true); return v == null ? ZAttrProvisioning.SmtpStartTlsMode.only : ZAttrProvisioning.SmtpStartTlsMode.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.SmtpStartTlsMode.only; }
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to MTA.
+     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
+     * starttls. only - requires starttls to send messages. )
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @return zimbraSmtpStartTlsMode, or "only" if unset
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5002)
+    public String getSmtpStartTlsModeAsString() {
+        return getAttr(Provisioning.A_zimbraSmtpStartTlsMode, "only", true);
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to MTA.
+     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
+     * starttls. only - requires starttls to send messages. )
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @param zimbraSmtpStartTlsMode new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5002)
+    public void setSmtpStartTlsMode(ZAttrProvisioning.SmtpStartTlsMode zimbraSmtpStartTlsMode) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode.toString());
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to MTA.
+     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
+     * starttls. only - requires starttls to send messages. )
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @param zimbraSmtpStartTlsMode new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5002)
+    public Map<String,Object> setSmtpStartTlsMode(ZAttrProvisioning.SmtpStartTlsMode zimbraSmtpStartTlsMode, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode.toString());
+        return attrs;
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to MTA.
+     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
+     * starttls. only - requires starttls to send messages. )
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @param zimbraSmtpStartTlsMode new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5002)
+    public void setSmtpStartTlsModeAsString(String zimbraSmtpStartTlsMode) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to MTA.
+     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
+     * starttls. only - requires starttls to send messages. )
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @param zimbraSmtpStartTlsMode new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5002)
+    public Map<String,Object> setSmtpStartTlsModeAsString(String zimbraSmtpStartTlsMode, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode);
+        return attrs;
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to MTA.
+     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
+     * starttls. only - requires starttls to send messages. )
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5002)
+    public void unsetSmtpStartTlsMode() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to MTA.
+     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
+     * starttls. only - requires starttls to send messages. )
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5002)
+    public Map<String,Object> unsetSmtpStartTlsMode(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, "");
+        return attrs;
+    }
+
+    /**
      * timeout value in seconds
      *
      * @return zimbraSmtpTimeout, or 60 if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -21637,9 +21637,9 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Configures the starttls mode on sending messages from mailboxd to MTA.
-     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
-     * starttls. only - requires starttls to send messages. )
+     * Configures the starttls mode on sending messages from mailboxd to MTA
+     * on - uses starttls if the peer MTA supports off - doesn&#039;t use
+     * starttls only - requires starttls to send messages
      *
      * <p>Valid values: [on, off, only]
      *
@@ -21653,9 +21653,9 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Configures the starttls mode on sending messages from mailboxd to MTA.
-     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
-     * starttls. only - requires starttls to send messages. )
+     * Configures the starttls mode on sending messages from mailboxd to MTA
+     * on - uses starttls if the peer MTA supports off - doesn&#039;t use
+     * starttls only - requires starttls to send messages
      *
      * <p>Valid values: [on, off, only]
      *
@@ -21669,9 +21669,9 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Configures the starttls mode on sending messages from mailboxd to MTA.
-     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
-     * starttls. only - requires starttls to send messages. )
+     * Configures the starttls mode on sending messages from mailboxd to MTA
+     * on - uses starttls if the peer MTA supports off - doesn&#039;t use
+     * starttls only - requires starttls to send messages
      *
      * <p>Valid values: [on, off, only]
      *
@@ -21688,9 +21688,9 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Configures the starttls mode on sending messages from mailboxd to MTA.
-     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
-     * starttls. only - requires starttls to send messages. )
+     * Configures the starttls mode on sending messages from mailboxd to MTA
+     * on - uses starttls if the peer MTA supports off - doesn&#039;t use
+     * starttls only - requires starttls to send messages
      *
      * <p>Valid values: [on, off, only]
      *
@@ -21708,9 +21708,9 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Configures the starttls mode on sending messages from mailboxd to MTA.
-     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
-     * starttls. only - requires starttls to send messages. )
+     * Configures the starttls mode on sending messages from mailboxd to MTA
+     * on - uses starttls if the peer MTA supports off - doesn&#039;t use
+     * starttls only - requires starttls to send messages
      *
      * <p>Valid values: [on, off, only]
      *
@@ -21727,9 +21727,9 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Configures the starttls mode on sending messages from mailboxd to MTA.
-     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
-     * starttls. only - requires starttls to send messages. )
+     * Configures the starttls mode on sending messages from mailboxd to MTA
+     * on - uses starttls if the peer MTA supports off - doesn&#039;t use
+     * starttls only - requires starttls to send messages
      *
      * <p>Valid values: [on, off, only]
      *
@@ -21747,9 +21747,9 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Configures the starttls mode on sending messages from mailboxd to MTA.
-     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
-     * starttls. only - requires starttls to send messages. )
+     * Configures the starttls mode on sending messages from mailboxd to MTA
+     * on - uses starttls if the peer MTA supports off - doesn&#039;t use
+     * starttls only - requires starttls to send messages
      *
      * <p>Valid values: [on, off, only]
      *
@@ -21765,9 +21765,9 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Configures the starttls mode on sending messages from mailboxd to MTA.
-     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
-     * starttls. only - requires starttls to send messages. )
+     * Configures the starttls mode on sending messages from mailboxd to MTA
+     * on - uses starttls if the peer MTA supports off - doesn&#039;t use
+     * starttls only - requires starttls to send messages
      *
      * <p>Valid values: [on, off, only]
      *

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -21637,6 +21637,153 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
+     * Configures the starttls mode on sending messages from mailboxd to MTA.
+     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
+     * starttls. only - requires starttls to send messages. )
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @return zimbraSmtpStartTlsMode, or null if unset and/or has invalid value
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5002)
+    public ZAttrProvisioning.SmtpStartTlsMode getSmtpStartTlsMode() {
+        try { String v = getAttr(Provisioning.A_zimbraSmtpStartTlsMode, true, true); return v == null ? null : ZAttrProvisioning.SmtpStartTlsMode.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return null; }
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to MTA.
+     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
+     * starttls. only - requires starttls to send messages. )
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @return zimbraSmtpStartTlsMode, or null if unset
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5002)
+    public String getSmtpStartTlsModeAsString() {
+        return getAttr(Provisioning.A_zimbraSmtpStartTlsMode, null, true);
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to MTA.
+     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
+     * starttls. only - requires starttls to send messages. )
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @param zimbraSmtpStartTlsMode new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5002)
+    public void setSmtpStartTlsMode(ZAttrProvisioning.SmtpStartTlsMode zimbraSmtpStartTlsMode) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode.toString());
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to MTA.
+     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
+     * starttls. only - requires starttls to send messages. )
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @param zimbraSmtpStartTlsMode new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5002)
+    public Map<String,Object> setSmtpStartTlsMode(ZAttrProvisioning.SmtpStartTlsMode zimbraSmtpStartTlsMode, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode.toString());
+        return attrs;
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to MTA.
+     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
+     * starttls. only - requires starttls to send messages. )
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @param zimbraSmtpStartTlsMode new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5002)
+    public void setSmtpStartTlsModeAsString(String zimbraSmtpStartTlsMode) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to MTA.
+     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
+     * starttls. only - requires starttls to send messages. )
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @param zimbraSmtpStartTlsMode new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5002)
+    public Map<String,Object> setSmtpStartTlsModeAsString(String zimbraSmtpStartTlsMode, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode);
+        return attrs;
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to MTA.
+     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
+     * starttls. only - requires starttls to send messages. )
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5002)
+    public void unsetSmtpStartTlsMode() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to MTA.
+     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
+     * starttls. only - requires starttls to send messages. )
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5002)
+    public Map<String,Object> unsetSmtpStartTlsMode(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, "");
+        return attrs;
+    }
+
+    /**
      * timeout value in seconds
      *
      * @return zimbraSmtpTimeout, or -1 if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -48950,9 +48950,9 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Configures the starttls mode on sending messages from mailboxd to MTA.
-     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
-     * starttls. only - requires starttls to send messages. )
+     * Configures the starttls mode on sending messages from mailboxd to MTA
+     * on - uses starttls if the peer MTA supports off - doesn&#039;t use
+     * starttls only - requires starttls to send messages
      *
      * <p>Valid values: [on, off, only]
      *
@@ -48966,9 +48966,9 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Configures the starttls mode on sending messages from mailboxd to MTA.
-     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
-     * starttls. only - requires starttls to send messages. )
+     * Configures the starttls mode on sending messages from mailboxd to MTA
+     * on - uses starttls if the peer MTA supports off - doesn&#039;t use
+     * starttls only - requires starttls to send messages
      *
      * <p>Valid values: [on, off, only]
      *
@@ -48982,9 +48982,9 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Configures the starttls mode on sending messages from mailboxd to MTA.
-     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
-     * starttls. only - requires starttls to send messages. )
+     * Configures the starttls mode on sending messages from mailboxd to MTA
+     * on - uses starttls if the peer MTA supports off - doesn&#039;t use
+     * starttls only - requires starttls to send messages
      *
      * <p>Valid values: [on, off, only]
      *
@@ -49001,9 +49001,9 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Configures the starttls mode on sending messages from mailboxd to MTA.
-     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
-     * starttls. only - requires starttls to send messages. )
+     * Configures the starttls mode on sending messages from mailboxd to MTA
+     * on - uses starttls if the peer MTA supports off - doesn&#039;t use
+     * starttls only - requires starttls to send messages
      *
      * <p>Valid values: [on, off, only]
      *
@@ -49021,9 +49021,9 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Configures the starttls mode on sending messages from mailboxd to MTA.
-     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
-     * starttls. only - requires starttls to send messages. )
+     * Configures the starttls mode on sending messages from mailboxd to MTA
+     * on - uses starttls if the peer MTA supports off - doesn&#039;t use
+     * starttls only - requires starttls to send messages
      *
      * <p>Valid values: [on, off, only]
      *
@@ -49040,9 +49040,9 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Configures the starttls mode on sending messages from mailboxd to MTA.
-     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
-     * starttls. only - requires starttls to send messages. )
+     * Configures the starttls mode on sending messages from mailboxd to MTA
+     * on - uses starttls if the peer MTA supports off - doesn&#039;t use
+     * starttls only - requires starttls to send messages
      *
      * <p>Valid values: [on, off, only]
      *
@@ -49060,9 +49060,9 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Configures the starttls mode on sending messages from mailboxd to MTA.
-     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
-     * starttls. only - requires starttls to send messages. )
+     * Configures the starttls mode on sending messages from mailboxd to MTA
+     * on - uses starttls if the peer MTA supports off - doesn&#039;t use
+     * starttls only - requires starttls to send messages
      *
      * <p>Valid values: [on, off, only]
      *
@@ -49078,9 +49078,9 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Configures the starttls mode on sending messages from mailboxd to MTA.
-     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
-     * starttls. only - requires starttls to send messages. )
+     * Configures the starttls mode on sending messages from mailboxd to MTA
+     * on - uses starttls if the peer MTA supports off - doesn&#039;t use
+     * starttls only - requires starttls to send messages
      *
      * <p>Valid values: [on, off, only]
      *

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -48950,6 +48950,153 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
+     * Configures the starttls mode on sending messages from mailboxd to MTA.
+     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
+     * starttls. only - requires starttls to send messages. )
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @return zimbraSmtpStartTlsMode, or ZAttrProvisioning.SmtpStartTlsMode.only if unset and/or has invalid value
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5002)
+    public ZAttrProvisioning.SmtpStartTlsMode getSmtpStartTlsMode() {
+        try { String v = getAttr(Provisioning.A_zimbraSmtpStartTlsMode, true, true); return v == null ? ZAttrProvisioning.SmtpStartTlsMode.only : ZAttrProvisioning.SmtpStartTlsMode.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.SmtpStartTlsMode.only; }
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to MTA.
+     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
+     * starttls. only - requires starttls to send messages. )
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @return zimbraSmtpStartTlsMode, or "only" if unset
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5002)
+    public String getSmtpStartTlsModeAsString() {
+        return getAttr(Provisioning.A_zimbraSmtpStartTlsMode, "only", true);
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to MTA.
+     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
+     * starttls. only - requires starttls to send messages. )
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @param zimbraSmtpStartTlsMode new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5002)
+    public void setSmtpStartTlsMode(ZAttrProvisioning.SmtpStartTlsMode zimbraSmtpStartTlsMode) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode.toString());
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to MTA.
+     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
+     * starttls. only - requires starttls to send messages. )
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @param zimbraSmtpStartTlsMode new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5002)
+    public Map<String,Object> setSmtpStartTlsMode(ZAttrProvisioning.SmtpStartTlsMode zimbraSmtpStartTlsMode, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode.toString());
+        return attrs;
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to MTA.
+     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
+     * starttls. only - requires starttls to send messages. )
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @param zimbraSmtpStartTlsMode new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5002)
+    public void setSmtpStartTlsModeAsString(String zimbraSmtpStartTlsMode) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to MTA.
+     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
+     * starttls. only - requires starttls to send messages. )
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @param zimbraSmtpStartTlsMode new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5002)
+    public Map<String,Object> setSmtpStartTlsModeAsString(String zimbraSmtpStartTlsMode, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, zimbraSmtpStartTlsMode);
+        return attrs;
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to MTA.
+     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
+     * starttls. only - requires starttls to send messages. )
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5002)
+    public void unsetSmtpStartTlsMode() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures the starttls mode on sending messages from mailboxd to MTA.
+     * ( on - uses starttls if the peer MTA supports. off - doesn&#039;t use
+     * starttls. only - requires starttls to send messages. )
+     *
+     * <p>Valid values: [on, off, only]
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5002)
+    public Map<String,Object> unsetSmtpStartTlsMode(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsMode, "");
+        return attrs;
+    }
+
+    /**
      * timeout value in seconds
      *
      * @return zimbraSmtpTimeout, or 60 if unset


### PR DESCRIPTION
(title)
NICPS-59/Bug 34202 - STARTTLS support for outbound mail sent by mailbox server

(description)
Problem : Mailboxd doesn't use STARTTLS on sending user's mail to MTA.
Fix : Add a new ldap attribute zimbraSmtpStartTlsMode to control the behavior of mailboxd.
In JMSession, add appropriate Java Mail starttls properties using the new
ldap attribute.
The new attribute is relevant with zimbraSmtpHostname, zimbraSmtpPort, and zimbraSmtpTimeout. So we should make them consistent as:
- optionalIn="global,server,domain"
- flags="serverInherited"

This PR only contains the new ldap attribute definition.
Another PR will be made for the implementation.

Testing done : testing done by developer
Testing to be done by QA : testing needed to be done by QA
Linked PR : na
