### PR TITLE
ZCS-4223:CertAuth broken: failing with exception

### DIFF
--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -85,7 +85,7 @@
   <dependency org="com.unboundid" name="unboundid-ldapsdk" rev="2.3.5" />
   <dependency org="org.newsclub" name="junixsocket" rev="1.3" />
   <dependency org="net.freeutils.jtnef" name="tnef" rev="1.8.0" />
-  <dependency org="org.bouncycastle" name="bcprov-jdk15" rev="1.46" />
+  <dependency org="org.bouncycastle" name="bcprov-jdk15on" rev="1.55"/>
   <dependency org="com.googlecode.concurrentlinkedhashmap" name="concurrentlinkedhashmap-lru" rev="1.3.1" />
   <dependency org="org.apache.commons" name="commons-csv" rev="1.2"/>
   <dependency org="ch.ethz.ganymed" name="ganymed-ssh2" rev="build210" />

--- a/store/src/java/com/zimbra/cs/service/authenticator/CertUtil.java
+++ b/store/src/java/com/zimbra/cs/service/authenticator/CertUtil.java
@@ -42,12 +42,12 @@ import org.apache.commons.cli.GnuParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1InputStream;
-import org.bouncycastle.asn1.ASN1Object;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.ASN1TaggedObject;
-import org.bouncycastle.asn1.DEREncodable;
 import org.bouncycastle.asn1.DERIA5String;
-import org.bouncycastle.asn1.DERObjectIdentifier;
 import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.DERUTF8String;
@@ -165,10 +165,10 @@ public class CertUtil {
                 if (GeneralName.otherName == tag.intValue()) {
                     // Value is encoded using ASN.1
                     decoder = new ASN1InputStream((byte[]) generalName.toArray()[1]);
-                    DEREncodable encoded = decoder.readObject();
+                    ASN1Encodable encoded = decoder.readObject();
                     DERSequence derSeq = (DERSequence) encoded;
 
-                    DERObjectIdentifier typeId = DERObjectIdentifier.getInstance(derSeq.getObjectAt(0));
+                    ASN1ObjectIdentifier typeId = ASN1ObjectIdentifier.getInstance(derSeq.getObjectAt(0));
                     String oid = typeId.getId();
 
                     String value = null;
@@ -238,7 +238,7 @@ public class CertUtil {
                         ASN1InputStream decoder = null;
                         try {
                             decoder = new ASN1InputStream(bytes);
-                            DEREncodable encoded = decoder.readObject();
+                            ASN1Encodable encoded = decoder.readObject();
                             DERIA5String str = DERIA5String.getInstance(encoded);
                             return str.getString();
                         } catch (IOException e) {
@@ -400,10 +400,10 @@ public class CertUtil {
                 if (GeneralName.otherName == tag.intValue()) {
                     // Value is encoded using ASN.1
                     decoder = new ASN1InputStream((byte[]) generalName.toArray()[1]);
-                    DEREncodable encoded = decoder.readObject();
+                    ASN1Encodable encoded = decoder.readObject();
                     DERSequence derSeq = (DERSequence) encoded;
 
-                    DERObjectIdentifier typeId = DERObjectIdentifier.getInstance(derSeq.getObjectAt(0));
+                    ASN1ObjectIdentifier typeId = ASN1ObjectIdentifier.getInstance(derSeq.getObjectAt(0));
                     String oid = typeId.getId();
 
                     String value = null;
@@ -459,9 +459,9 @@ public class CertUtil {
              }
          */
 
-        byte[] extnValue = DEROctetString.getInstance(ASN1Object.fromByteArray(extVal)).getOctets();
+        byte[] extnValue = DEROctetString.getInstance(ASN1Primitive.fromByteArray(extVal)).getOctets();
 
-        CRLDistPoint crlDistPoint = CRLDistPoint.getInstance(ASN1Object.fromByteArray(extnValue));
+        CRLDistPoint crlDistPoint = CRLDistPoint.getInstance(ASN1Primitive.fromByteArray(extnValue));
         DistributionPoint[] distPoints = crlDistPoint.getDistributionPoints();
 
         for (DistributionPoint distPoint : distPoints) {
@@ -475,7 +475,7 @@ public class CertUtil {
                 for (GeneralName generalname : names) {
                     int tag = generalname.getTagNo();
                     if (GeneralName.uniformResourceIdentifier == tag) {
-                        DEREncodable name = generalname.getName();
+                        ASN1Encodable name = generalname.getName();
                         DERIA5String str = DERIA5String.getInstance(name);
                         String value = str.getString();
                         outStream.format("    %s\n", value);


### PR DESCRIPTION
Upgrading the bcprov jar version in store repo to 1.55 which is packaged in jetty/common/lib to remove the NoClassDefFoundError as earlier the repo was built with 1.46 version and there were significant changes in bouncy castle classes in version 1.47.

Testing Done: certauth working fine without any exceptions and user is logged in successfully.