### PR TITLE
ZCS-4339: Search History Purge Fix

### DIFF
--- a/store/src/java/com/zimbra/cs/index/history/LuceneSearchHistoryIndex.java
+++ b/store/src/java/com/zimbra/cs/index/history/LuceneSearchHistoryIndex.java
@@ -108,6 +108,9 @@ public class LuceneSearchHistoryIndex implements SearchHistoryIndex {
 
     @Override
     public void delete(Collection<Integer> ids) throws ServiceException {
+        if (ids.isEmpty()) {
+            return;
+        }
         List<Integer> idList = new ArrayList<Integer>(ids);
         try (Indexer indexer = index.openIndexer()) {
             indexer.deleteDocument(idList, LuceneFields.L_SEARCH_ID);

--- a/store/src/java/com/zimbra/cs/index/solr/SolrIndex.java
+++ b/store/src/java/com/zimbra/cs/index/solr/SolrIndex.java
@@ -871,6 +871,9 @@ public class SolrIndex extends IndexStore {
 
         @Override
         public void deleteDocument(List<Integer> ids, String fieldName) throws IOException, ServiceException {
+            if (ids.isEmpty()) {
+                return;
+            }
             UpdateRequest req = new UpdateRequest();
             BooleanQuery.Builder disjunctionBuilder = new BooleanQuery.Builder();
             for (Integer id : ids) {

--- a/store/src/java/com/zimbra/qa/unittest/TestSearchHistory.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestSearchHistory.java
@@ -13,6 +13,7 @@ import com.zimbra.client.ZMailbox;
 import com.zimbra.client.ZSearchParams;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.Account;
+import com.zimbra.cs.mailbox.Mailbox;
 
 public class TestSearchHistory {
 
@@ -81,5 +82,20 @@ public class TestSearchHistory {
         List<String> results = mbox.getSearchSuggestions("");
         String[] expected = {"banana", "green apple", "applesauce", "apple"};
         checkResults(expected, results);
+    }
+
+    @Test
+    public void testPurgeHistory() throws Exception {
+        acct.setSearchHistoryAge("1d");
+        Mailbox mailbox = TestUtil.getMailbox(USER);
+        mailbox.purgeSearchHistory(null); //nothing should be purged
+        String[] expected = {"banana", "green apple", "applesauce", "apple"};
+        List<String> results = mbox.getSearchHistory();
+        checkResults(expected, results);
+
+        acct.setSearchHistoryAge("0d");
+        mailbox.purgeSearchHistory(null); //everything should be purged
+        results = mbox.getSearchHistory();
+        checkResults(new String[0], results);
     }
 }


### PR DESCRIPTION
This bug was caused by `LuceneSearchHistoryIndex` passing an empty ID list to the `SolrIndex::deleteDocument` method, which happens if there is no search history entries to purge. This fix adds a check for list emptiness in two places:
 - in the `LuceneSearchHistoryIndex::delete` method, which addresses this immediate problem by short-circuiting the method before an indexer is even opened
- in the `SolrIndex::deleteDocument` method, to avoid other potential scenarios where an empty ID list is passed in

A unit test `TestSearchHistory::testPurgeHistory` has been added to verify this fix.