### PR TITLE
ZCS-3951:Validating name parameter in AutoCompleteRequest

### DIFF
--- a/store/src/java-test/com/zimbra/cs/service/mail/AutoCompleteTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/mail/AutoCompleteTest.java
@@ -1,0 +1,86 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.service.mail;
+
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.MethodRule;
+import org.junit.rules.TestName;
+
+import com.google.common.collect.Maps;
+import com.zimbra.common.account.Key;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.MailConstants;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.util.ZTestWatchman;
+
+import junit.framework.Assert;
+
+public class AutoCompleteTest {
+
+    @Rule
+    public TestName testName = new TestName();
+    @Rule
+    public MethodRule watchman = new ZTestWatchman();
+
+    @Before
+    public void setUp() throws Exception {
+        System.out.println(testName.getMethodName());
+        MailboxTestUtil.initServer();
+        MailboxTestUtil.clearData();
+        Provisioning prov = Provisioning.getInstance();
+        Map<String, Object> attrs = Maps.newHashMap();
+        prov.createDomain("zimbra.com", attrs);
+
+        attrs = Maps.newHashMap();
+        attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        prov.createAccount("test3951@zimbra.com", "secret", attrs);
+    }
+
+    @Test
+    public void test3951() throws Exception {
+        Account acct = Provisioning.getInstance().get(Key.AccountBy.name, "test3951@zimbra.com");
+        Element request = new Element.XMLElement(MailConstants.AUTO_COMPLETE_REQUEST);
+        request.addAttribute("name", " ");
+        boolean exceptionThrown;
+        try {
+            new AutoComplete().handle(request, ServiceTestUtil.getRequestContext(acct));
+            exceptionThrown = false;
+        } catch (ServiceException e) {
+            exceptionThrown = true;
+            Assert.assertEquals("invalid request: name parameter is empty", e.getMessage());
+        }
+        Assert.assertEquals(true, exceptionThrown);
+    }
+
+    @After
+    public void tearDown() {
+        try {
+            MailboxTestUtil.clearData();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/service/mail/AutoComplete.java
+++ b/store/src/java/com/zimbra/cs/service/mail/AutoComplete.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2008, 2009, 2010, 2011, 2013, 2014, 2015, 2016 Synacor, Inc.
+ * Copyright (C) 2008, 2009, 2010, 2011, 2013, 2014, 2015, 2016, 2018 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -19,11 +19,12 @@ package com.zimbra.cs.service.mail;
 import java.util.ArrayList;
 import java.util.Map;
 
+import org.apache.commons.lang.StringUtils;
+
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.MailConstants;
 import com.zimbra.common.soap.Element;
 import com.zimbra.cs.account.Account;
-import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.mailbox.ContactAutoComplete;
 import com.zimbra.cs.mailbox.OperationContext;
 import com.zimbra.cs.mailbox.ContactAutoComplete.AutoCompleteResult;
@@ -44,6 +45,10 @@ public class AutoComplete extends MailDocumentHandler {
 
         // remove commas (bug 46540)
         name = name.replace(",", " ").trim();
+
+        if (StringUtils.isEmpty(name)) {
+            throw ServiceException.INVALID_REQUEST("name parameter is empty", null);
+        }
 
         GalSearchType type = GalSearchType.fromString(request.getAttribute(MailConstants.A_TYPE, "account"));
         int limit = account.getContactAutoCompleteMaxResults();


### PR DESCRIPTION
The name parameter is required attribute in AutoCompleteRequest, but it was missing validation for empty value. Added it.

Added junit test.
Ant test-all passed.