### PR TITLE
Another ldap attribute for NICPS-59/Bug 34202: STARTTLS support for outbound mail

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -16014,9 +16014,11 @@ public class ZAttrProvisioning {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
-     * whitespace separated list of hosts, those hosts are trusted. This
-     * parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost.
+     * whitespace separated list of hosts, those hosts are trusted.
+     * Otherwise, trust depends on the certificate the server presents. This
+     * attribute does not affect data source SMTP connections as those are
+     * controlled by zimbraDataSourceSmtpHost,
+     * zimbraDataSourceSmtpConnectionType, etc.
      *
      * @since ZCS 8.8.6
      */

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -16012,6 +16012,17 @@ public class ZAttrProvisioning {
     public static final String A_zimbraSmtpStartTlsMode = "zimbraSmtpStartTlsMode";
 
     /**
+     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * starttls. This parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
+     * - A white space separated list of trusted hosts
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5004)
+    public static final String A_zimbraSmtpStartTlsTrustedHosts = "zimbraSmtpStartTlsTrustedHosts";
+
+    /**
      * timeout value in seconds
      */
     @ZAttr(id=99)

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -16012,7 +16012,7 @@ public class ZAttrProvisioning {
     public static final String A_zimbraSmtpStartTlsMode = "zimbraSmtpStartTlsMode";
 
     /**
-     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
      * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
      * - A white space separated list of trusted hosts

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -16012,7 +16012,7 @@ public class ZAttrProvisioning {
     public static final String A_zimbraSmtpStartTlsMode = "zimbraSmtpStartTlsMode";
 
     /**
-     * Configures trusted hosts sending mail from mailboxd to MTA with
+     * Configures trusted hosts for sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
      * whitespace separated list of hosts, those hosts are trusted.
      * Otherwise, trust depends on the certificate the server presents. This

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -16014,8 +16014,8 @@ public class ZAttrProvisioning {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
-     * - A white space separated list of trusted hosts
+     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
+     * separated list of trusted hosts
      *
      * @since ZCS 8.8.6
      */

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -16013,9 +16013,10 @@ public class ZAttrProvisioning {
 
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
-     * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
-     * separated list of trusted hosts
+     * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
+     * whitespace separated list of hosts, those hosts are trusted. This
+     * parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost.
      *
      * @since ZCS 8.8.6
      */

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9645,7 +9645,7 @@ TODO: delete them permanently from here
 
 <attr id="5004" name="zimbraSmtpStartTlsTrustedHosts" type="string" cardinality="single" optionalIn="globalConfig,server,domain" flags="serverInherited" since="8.8.6">
   <globalConfigValue>*</globalConfigValue>
-  <desc>Configures trusted hosts on sending mail from mailboxd to MTA with starttls.
+  <desc>Configures trusted hosts sending mail from mailboxd to MTA with starttls.
         This parameter doesn't affect on smtp sessions to zimbraDataSourceSmtpHost.
         *   - trust all hosts
         host[&lt;sp&gt;host...] - A white space separated list of trusted hosts

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9645,7 +9645,7 @@ TODO: delete them permanently from here
 
 <attr id="5004" name="zimbraSmtpStartTlsTrustedHosts" type="string" cardinality="single" optionalIn="globalConfig,server,domain" flags="serverInherited" since="8.8.6">
   <globalConfigValue>*</globalConfigValue>
-  <desc>Configures trusted hosts sending mail from mailboxd to MTA with starttls.
+  <desc>Configures trusted hosts for sending mail from mailboxd to MTA with starttls.
         If set to "*", all hosts are trusted. If set to a whitespace separated list of hosts, those hosts are trusted.
         Otherwise, trust depends on the certificate the server presents.
         This attribute does not affect data source SMTP connections as those are controlled by zimbraDataSourceSmtpHost, zimbraDataSourceSmtpConnectionType, etc.

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9648,7 +9648,7 @@ TODO: delete them permanently from here
   <desc>Configures trusted hosts sending mail from mailboxd to MTA with starttls.
         This parameter doesn't affect on smtp sessions to zimbraDataSourceSmtpHost.
         *   - trust all hosts
-        host[&lt;sp&gt;host...] - A white space separated list of trusted hosts
+        host... - A whitespace separated list of trusted hosts
   </desc>
 </attr>
 </attrs>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9647,7 +9647,8 @@ TODO: delete them permanently from here
   <globalConfigValue>*</globalConfigValue>
   <desc>Configures trusted hosts sending mail from mailboxd to MTA with starttls.
         If set to "*", all hosts are trusted. If set to a whitespace separated list of hosts, those hosts are trusted.
-        This parameter doesn't affect on smtp sessions to zimbraDataSourceSmtpHost.
+        Otherwise, trust depends on the certificate the server presents.
+        This attribute does not affect data source SMTP connections as those are controlled by zimbraDataSourceSmtpHost, zimbraDataSourceSmtpConnectionType, etc.
   </desc>
 </attr>
 </attrs>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9646,9 +9646,8 @@ TODO: delete them permanently from here
 <attr id="5004" name="zimbraSmtpStartTlsTrustedHosts" type="string" cardinality="single" optionalIn="globalConfig,server,domain" flags="serverInherited" since="8.8.6">
   <globalConfigValue>*</globalConfigValue>
   <desc>Configures trusted hosts sending mail from mailboxd to MTA with starttls.
+        If set to "*", all hosts are trusted. If set to a whitespace separated list of hosts, those hosts are trusted.
         This parameter doesn't affect on smtp sessions to zimbraDataSourceSmtpHost.
-        *   - trust all hosts
-        host... - A whitespace separated list of trusted hosts
   </desc>
 </attr>
 </attrs>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9642,4 +9642,13 @@ TODO: delete them permanently from here
 <attr id="5003" name="zimbraCustomAppBanner" type="string" max="256" cardinality="single" optionalIn="account,cos,domain" flags="accountInfo,accountCosDomainInherited,domainAdminModifiable" since="8.8.6">
   <desc>Logo app banner URL for web client</desc>
 </attr>
+
+<attr id="5004" name="zimbraSmtpStartTlsTrustedHosts" type="string" cardinality="single" optionalIn="globalConfig,server,domain" flags="serverInherited" since="8.8.6">
+  <globalConfigValue>*</globalConfigValue>
+  <desc>Configures trusted hosts on sending mail from mailboxd to MTA with starttls.
+        This parameter doesn't affect on smtp sessions to zimbraDataSourceSmtpHost.
+        *   - trust all hosts
+        host[&lt;sp&gt;host...] - A white space separated list of trusted hosts
+  </desc>
+</attr>
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -68491,8 +68491,8 @@ public abstract class ZAttrConfig extends Entry {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
-     * - A white space separated list of trusted hosts
+     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
+     * separated list of trusted hosts
      *
      * @return zimbraSmtpStartTlsTrustedHosts, or "*" if unset
      *
@@ -68506,8 +68506,8 @@ public abstract class ZAttrConfig extends Entry {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
-     * - A white space separated list of trusted hosts
+     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
+     * separated list of trusted hosts
      *
      * @param zimbraSmtpStartTlsTrustedHosts new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -68524,8 +68524,8 @@ public abstract class ZAttrConfig extends Entry {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
-     * - A white space separated list of trusted hosts
+     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
+     * separated list of trusted hosts
      *
      * @param zimbraSmtpStartTlsTrustedHosts new value
      * @param attrs existing map to populate, or null to create a new map
@@ -68543,8 +68543,8 @@ public abstract class ZAttrConfig extends Entry {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
-     * - A white space separated list of trusted hosts
+     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
+     * separated list of trusted hosts
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -68560,8 +68560,8 @@ public abstract class ZAttrConfig extends Entry {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
-     * - A white space separated list of trusted hosts
+     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
+     * separated list of trusted hosts
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -68491,9 +68491,11 @@ public abstract class ZAttrConfig extends Entry {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
-     * whitespace separated list of hosts, those hosts are trusted. This
-     * parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost.
+     * whitespace separated list of hosts, those hosts are trusted.
+     * Otherwise, trust depends on the certificate the server presents. This
+     * attribute does not affect data source SMTP connections as those are
+     * controlled by zimbraDataSourceSmtpHost,
+     * zimbraDataSourceSmtpConnectionType, etc.
      *
      * @return zimbraSmtpStartTlsTrustedHosts, or "*" if unset
      *
@@ -68507,9 +68509,11 @@ public abstract class ZAttrConfig extends Entry {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
-     * whitespace separated list of hosts, those hosts are trusted. This
-     * parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost.
+     * whitespace separated list of hosts, those hosts are trusted.
+     * Otherwise, trust depends on the certificate the server presents. This
+     * attribute does not affect data source SMTP connections as those are
+     * controlled by zimbraDataSourceSmtpHost,
+     * zimbraDataSourceSmtpConnectionType, etc.
      *
      * @param zimbraSmtpStartTlsTrustedHosts new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -68526,9 +68530,11 @@ public abstract class ZAttrConfig extends Entry {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
-     * whitespace separated list of hosts, those hosts are trusted. This
-     * parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost.
+     * whitespace separated list of hosts, those hosts are trusted.
+     * Otherwise, trust depends on the certificate the server presents. This
+     * attribute does not affect data source SMTP connections as those are
+     * controlled by zimbraDataSourceSmtpHost,
+     * zimbraDataSourceSmtpConnectionType, etc.
      *
      * @param zimbraSmtpStartTlsTrustedHosts new value
      * @param attrs existing map to populate, or null to create a new map
@@ -68546,9 +68552,11 @@ public abstract class ZAttrConfig extends Entry {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
-     * whitespace separated list of hosts, those hosts are trusted. This
-     * parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost.
+     * whitespace separated list of hosts, those hosts are trusted.
+     * Otherwise, trust depends on the certificate the server presents. This
+     * attribute does not affect data source SMTP connections as those are
+     * controlled by zimbraDataSourceSmtpHost,
+     * zimbraDataSourceSmtpConnectionType, etc.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -68564,9 +68572,11 @@ public abstract class ZAttrConfig extends Entry {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
-     * whitespace separated list of hosts, those hosts are trusted. This
-     * parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost.
+     * whitespace separated list of hosts, those hosts are trusted.
+     * Otherwise, trust depends on the certificate the server presents. This
+     * attribute does not affect data source SMTP connections as those are
+     * controlled by zimbraDataSourceSmtpHost,
+     * zimbraDataSourceSmtpConnectionType, etc.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -68490,9 +68490,10 @@ public abstract class ZAttrConfig extends Entry {
 
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
-     * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
-     * separated list of trusted hosts
+     * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
+     * whitespace separated list of hosts, those hosts are trusted. This
+     * parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost.
      *
      * @return zimbraSmtpStartTlsTrustedHosts, or "*" if unset
      *
@@ -68505,9 +68506,10 @@ public abstract class ZAttrConfig extends Entry {
 
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
-     * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
-     * separated list of trusted hosts
+     * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
+     * whitespace separated list of hosts, those hosts are trusted. This
+     * parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost.
      *
      * @param zimbraSmtpStartTlsTrustedHosts new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -68523,9 +68525,10 @@ public abstract class ZAttrConfig extends Entry {
 
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
-     * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
-     * separated list of trusted hosts
+     * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
+     * whitespace separated list of hosts, those hosts are trusted. This
+     * parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost.
      *
      * @param zimbraSmtpStartTlsTrustedHosts new value
      * @param attrs existing map to populate, or null to create a new map
@@ -68542,9 +68545,10 @@ public abstract class ZAttrConfig extends Entry {
 
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
-     * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
-     * separated list of trusted hosts
+     * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
+     * whitespace separated list of hosts, those hosts are trusted. This
+     * parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -68559,9 +68563,10 @@ public abstract class ZAttrConfig extends Entry {
 
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
-     * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
-     * separated list of trusted hosts
+     * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
+     * whitespace separated list of hosts, those hosts are trusted. This
+     * parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -68489,7 +68489,7 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
      * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
      * - A white space separated list of trusted hosts
@@ -68504,7 +68504,7 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
      * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
      * - A white space separated list of trusted hosts
@@ -68522,7 +68522,7 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
      * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
      * - A white space separated list of trusted hosts
@@ -68541,7 +68541,7 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
      * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
      * - A white space separated list of trusted hosts
@@ -68558,7 +68558,7 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
      * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
      * - A white space separated list of trusted hosts

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -68489,7 +68489,7 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Configures trusted hosts sending mail from mailboxd to MTA with
+     * Configures trusted hosts for sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
      * whitespace separated list of hosts, those hosts are trusted.
      * Otherwise, trust depends on the certificate the server presents. This
@@ -68507,7 +68507,7 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Configures trusted hosts sending mail from mailboxd to MTA with
+     * Configures trusted hosts for sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
      * whitespace separated list of hosts, those hosts are trusted.
      * Otherwise, trust depends on the certificate the server presents. This
@@ -68528,7 +68528,7 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Configures trusted hosts sending mail from mailboxd to MTA with
+     * Configures trusted hosts for sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
      * whitespace separated list of hosts, those hosts are trusted.
      * Otherwise, trust depends on the certificate the server presents. This
@@ -68550,7 +68550,7 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Configures trusted hosts sending mail from mailboxd to MTA with
+     * Configures trusted hosts for sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
      * whitespace separated list of hosts, those hosts are trusted.
      * Otherwise, trust depends on the certificate the server presents. This
@@ -68570,7 +68570,7 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Configures trusted hosts sending mail from mailboxd to MTA with
+     * Configures trusted hosts for sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
      * whitespace separated list of hosts, those hosts are trusted.
      * Otherwise, trust depends on the certificate the server presents. This

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -68489,6 +68489,93 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * starttls. This parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
+     * - A white space separated list of trusted hosts
+     *
+     * @return zimbraSmtpStartTlsTrustedHosts, or "*" if unset
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5004)
+    public String getSmtpStartTlsTrustedHosts() {
+        return getAttr(Provisioning.A_zimbraSmtpStartTlsTrustedHosts, "*", true);
+    }
+
+    /**
+     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * starttls. This parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
+     * - A white space separated list of trusted hosts
+     *
+     * @param zimbraSmtpStartTlsTrustedHosts new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5004)
+    public void setSmtpStartTlsTrustedHosts(String zimbraSmtpStartTlsTrustedHosts) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsTrustedHosts, zimbraSmtpStartTlsTrustedHosts);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * starttls. This parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
+     * - A white space separated list of trusted hosts
+     *
+     * @param zimbraSmtpStartTlsTrustedHosts new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5004)
+    public Map<String,Object> setSmtpStartTlsTrustedHosts(String zimbraSmtpStartTlsTrustedHosts, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsTrustedHosts, zimbraSmtpStartTlsTrustedHosts);
+        return attrs;
+    }
+
+    /**
+     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * starttls. This parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
+     * - A white space separated list of trusted hosts
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5004)
+    public void unsetSmtpStartTlsTrustedHosts() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsTrustedHosts, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * starttls. This parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
+     * - A white space separated list of trusted hosts
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5004)
+    public Map<String,Object> unsetSmtpStartTlsTrustedHosts(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsTrustedHosts, "");
+        return attrs;
+    }
+
+    /**
      * timeout value in seconds
      *
      * @return zimbraSmtpTimeout, or 60 if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -21858,9 +21858,11 @@ public abstract class ZAttrDomain extends NamedEntry {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
-     * whitespace separated list of hosts, those hosts are trusted. This
-     * parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost.
+     * whitespace separated list of hosts, those hosts are trusted.
+     * Otherwise, trust depends on the certificate the server presents. This
+     * attribute does not affect data source SMTP connections as those are
+     * controlled by zimbraDataSourceSmtpHost,
+     * zimbraDataSourceSmtpConnectionType, etc.
      *
      * @return zimbraSmtpStartTlsTrustedHosts, or null if unset
      *
@@ -21874,9 +21876,11 @@ public abstract class ZAttrDomain extends NamedEntry {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
-     * whitespace separated list of hosts, those hosts are trusted. This
-     * parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost.
+     * whitespace separated list of hosts, those hosts are trusted.
+     * Otherwise, trust depends on the certificate the server presents. This
+     * attribute does not affect data source SMTP connections as those are
+     * controlled by zimbraDataSourceSmtpHost,
+     * zimbraDataSourceSmtpConnectionType, etc.
      *
      * @param zimbraSmtpStartTlsTrustedHosts new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -21893,9 +21897,11 @@ public abstract class ZAttrDomain extends NamedEntry {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
-     * whitespace separated list of hosts, those hosts are trusted. This
-     * parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost.
+     * whitespace separated list of hosts, those hosts are trusted.
+     * Otherwise, trust depends on the certificate the server presents. This
+     * attribute does not affect data source SMTP connections as those are
+     * controlled by zimbraDataSourceSmtpHost,
+     * zimbraDataSourceSmtpConnectionType, etc.
      *
      * @param zimbraSmtpStartTlsTrustedHosts new value
      * @param attrs existing map to populate, or null to create a new map
@@ -21913,9 +21919,11 @@ public abstract class ZAttrDomain extends NamedEntry {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
-     * whitespace separated list of hosts, those hosts are trusted. This
-     * parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost.
+     * whitespace separated list of hosts, those hosts are trusted.
+     * Otherwise, trust depends on the certificate the server presents. This
+     * attribute does not affect data source SMTP connections as those are
+     * controlled by zimbraDataSourceSmtpHost,
+     * zimbraDataSourceSmtpConnectionType, etc.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -21931,9 +21939,11 @@ public abstract class ZAttrDomain extends NamedEntry {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
-     * whitespace separated list of hosts, those hosts are trusted. This
-     * parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost.
+     * whitespace separated list of hosts, those hosts are trusted.
+     * Otherwise, trust depends on the certificate the server presents. This
+     * attribute does not affect data source SMTP connections as those are
+     * controlled by zimbraDataSourceSmtpHost,
+     * zimbraDataSourceSmtpConnectionType, etc.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -21856,7 +21856,7 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
      * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
      * - A white space separated list of trusted hosts
@@ -21871,7 +21871,7 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
      * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
      * - A white space separated list of trusted hosts
@@ -21889,7 +21889,7 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
      * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
      * - A white space separated list of trusted hosts
@@ -21908,7 +21908,7 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
      * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
      * - A white space separated list of trusted hosts
@@ -21925,7 +21925,7 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
      * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
      * - A white space separated list of trusted hosts

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -21858,8 +21858,8 @@ public abstract class ZAttrDomain extends NamedEntry {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
-     * - A white space separated list of trusted hosts
+     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
+     * separated list of trusted hosts
      *
      * @return zimbraSmtpStartTlsTrustedHosts, or null if unset
      *
@@ -21873,8 +21873,8 @@ public abstract class ZAttrDomain extends NamedEntry {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
-     * - A white space separated list of trusted hosts
+     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
+     * separated list of trusted hosts
      *
      * @param zimbraSmtpStartTlsTrustedHosts new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -21891,8 +21891,8 @@ public abstract class ZAttrDomain extends NamedEntry {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
-     * - A white space separated list of trusted hosts
+     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
+     * separated list of trusted hosts
      *
      * @param zimbraSmtpStartTlsTrustedHosts new value
      * @param attrs existing map to populate, or null to create a new map
@@ -21910,8 +21910,8 @@ public abstract class ZAttrDomain extends NamedEntry {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
-     * - A white space separated list of trusted hosts
+     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
+     * separated list of trusted hosts
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -21927,8 +21927,8 @@ public abstract class ZAttrDomain extends NamedEntry {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
-     * - A white space separated list of trusted hosts
+     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
+     * separated list of trusted hosts
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -21856,7 +21856,7 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Configures trusted hosts sending mail from mailboxd to MTA with
+     * Configures trusted hosts for sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
      * whitespace separated list of hosts, those hosts are trusted.
      * Otherwise, trust depends on the certificate the server presents. This
@@ -21874,7 +21874,7 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Configures trusted hosts sending mail from mailboxd to MTA with
+     * Configures trusted hosts for sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
      * whitespace separated list of hosts, those hosts are trusted.
      * Otherwise, trust depends on the certificate the server presents. This
@@ -21895,7 +21895,7 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Configures trusted hosts sending mail from mailboxd to MTA with
+     * Configures trusted hosts for sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
      * whitespace separated list of hosts, those hosts are trusted.
      * Otherwise, trust depends on the certificate the server presents. This
@@ -21917,7 +21917,7 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Configures trusted hosts sending mail from mailboxd to MTA with
+     * Configures trusted hosts for sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
      * whitespace separated list of hosts, those hosts are trusted.
      * Otherwise, trust depends on the certificate the server presents. This
@@ -21937,7 +21937,7 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Configures trusted hosts sending mail from mailboxd to MTA with
+     * Configures trusted hosts for sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
      * whitespace separated list of hosts, those hosts are trusted.
      * Otherwise, trust depends on the certificate the server presents. This

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -21856,6 +21856,93 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
+     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * starttls. This parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
+     * - A white space separated list of trusted hosts
+     *
+     * @return zimbraSmtpStartTlsTrustedHosts, or null if unset
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5004)
+    public String getSmtpStartTlsTrustedHosts() {
+        return getAttr(Provisioning.A_zimbraSmtpStartTlsTrustedHosts, null, true);
+    }
+
+    /**
+     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * starttls. This parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
+     * - A white space separated list of trusted hosts
+     *
+     * @param zimbraSmtpStartTlsTrustedHosts new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5004)
+    public void setSmtpStartTlsTrustedHosts(String zimbraSmtpStartTlsTrustedHosts) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsTrustedHosts, zimbraSmtpStartTlsTrustedHosts);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * starttls. This parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
+     * - A white space separated list of trusted hosts
+     *
+     * @param zimbraSmtpStartTlsTrustedHosts new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5004)
+    public Map<String,Object> setSmtpStartTlsTrustedHosts(String zimbraSmtpStartTlsTrustedHosts, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsTrustedHosts, zimbraSmtpStartTlsTrustedHosts);
+        return attrs;
+    }
+
+    /**
+     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * starttls. This parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
+     * - A white space separated list of trusted hosts
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5004)
+    public void unsetSmtpStartTlsTrustedHosts() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsTrustedHosts, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * starttls. This parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
+     * - A white space separated list of trusted hosts
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5004)
+    public Map<String,Object> unsetSmtpStartTlsTrustedHosts(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsTrustedHosts, "");
+        return attrs;
+    }
+
+    /**
      * timeout value in seconds
      *
      * @return zimbraSmtpTimeout, or -1 if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -21857,9 +21857,10 @@ public abstract class ZAttrDomain extends NamedEntry {
 
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
-     * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
-     * separated list of trusted hosts
+     * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
+     * whitespace separated list of hosts, those hosts are trusted. This
+     * parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost.
      *
      * @return zimbraSmtpStartTlsTrustedHosts, or null if unset
      *
@@ -21872,9 +21873,10 @@ public abstract class ZAttrDomain extends NamedEntry {
 
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
-     * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
-     * separated list of trusted hosts
+     * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
+     * whitespace separated list of hosts, those hosts are trusted. This
+     * parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost.
      *
      * @param zimbraSmtpStartTlsTrustedHosts new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -21890,9 +21892,10 @@ public abstract class ZAttrDomain extends NamedEntry {
 
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
-     * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
-     * separated list of trusted hosts
+     * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
+     * whitespace separated list of hosts, those hosts are trusted. This
+     * parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost.
      *
      * @param zimbraSmtpStartTlsTrustedHosts new value
      * @param attrs existing map to populate, or null to create a new map
@@ -21909,9 +21912,10 @@ public abstract class ZAttrDomain extends NamedEntry {
 
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
-     * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
-     * separated list of trusted hosts
+     * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
+     * whitespace separated list of hosts, those hosts are trusted. This
+     * parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -21926,9 +21930,10 @@ public abstract class ZAttrDomain extends NamedEntry {
 
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
-     * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
-     * separated list of trusted hosts
+     * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
+     * whitespace separated list of hosts, those hosts are trusted. This
+     * parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -49097,6 +49097,93 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
+     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * starttls. This parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
+     * - A white space separated list of trusted hosts
+     *
+     * @return zimbraSmtpStartTlsTrustedHosts, or "*" if unset
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5004)
+    public String getSmtpStartTlsTrustedHosts() {
+        return getAttr(Provisioning.A_zimbraSmtpStartTlsTrustedHosts, "*", true);
+    }
+
+    /**
+     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * starttls. This parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
+     * - A white space separated list of trusted hosts
+     *
+     * @param zimbraSmtpStartTlsTrustedHosts new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5004)
+    public void setSmtpStartTlsTrustedHosts(String zimbraSmtpStartTlsTrustedHosts) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsTrustedHosts, zimbraSmtpStartTlsTrustedHosts);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * starttls. This parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
+     * - A white space separated list of trusted hosts
+     *
+     * @param zimbraSmtpStartTlsTrustedHosts new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5004)
+    public Map<String,Object> setSmtpStartTlsTrustedHosts(String zimbraSmtpStartTlsTrustedHosts, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsTrustedHosts, zimbraSmtpStartTlsTrustedHosts);
+        return attrs;
+    }
+
+    /**
+     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * starttls. This parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
+     * - A white space separated list of trusted hosts
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5004)
+    public void unsetSmtpStartTlsTrustedHosts() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsTrustedHosts, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * starttls. This parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
+     * - A white space separated list of trusted hosts
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.6
+     */
+    @ZAttr(id=5004)
+    public Map<String,Object> unsetSmtpStartTlsTrustedHosts(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSmtpStartTlsTrustedHosts, "");
+        return attrs;
+    }
+
+    /**
      * timeout value in seconds
      *
      * @return zimbraSmtpTimeout, or 60 if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -49097,7 +49097,7 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Configures trusted hosts sending mail from mailboxd to MTA with
+     * Configures trusted hosts for sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
      * whitespace separated list of hosts, those hosts are trusted.
      * Otherwise, trust depends on the certificate the server presents. This
@@ -49115,7 +49115,7 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Configures trusted hosts sending mail from mailboxd to MTA with
+     * Configures trusted hosts for sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
      * whitespace separated list of hosts, those hosts are trusted.
      * Otherwise, trust depends on the certificate the server presents. This
@@ -49136,7 +49136,7 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Configures trusted hosts sending mail from mailboxd to MTA with
+     * Configures trusted hosts for sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
      * whitespace separated list of hosts, those hosts are trusted.
      * Otherwise, trust depends on the certificate the server presents. This
@@ -49158,7 +49158,7 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Configures trusted hosts sending mail from mailboxd to MTA with
+     * Configures trusted hosts for sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
      * whitespace separated list of hosts, those hosts are trusted.
      * Otherwise, trust depends on the certificate the server presents. This
@@ -49178,7 +49178,7 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Configures trusted hosts sending mail from mailboxd to MTA with
+     * Configures trusted hosts for sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
      * whitespace separated list of hosts, those hosts are trusted.
      * Otherwise, trust depends on the certificate the server presents. This

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -49098,9 +49098,10 @@ public abstract class ZAttrServer extends NamedEntry {
 
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
-     * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
-     * separated list of trusted hosts
+     * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
+     * whitespace separated list of hosts, those hosts are trusted. This
+     * parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost.
      *
      * @return zimbraSmtpStartTlsTrustedHosts, or "*" if unset
      *
@@ -49113,9 +49114,10 @@ public abstract class ZAttrServer extends NamedEntry {
 
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
-     * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
-     * separated list of trusted hosts
+     * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
+     * whitespace separated list of hosts, those hosts are trusted. This
+     * parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost.
      *
      * @param zimbraSmtpStartTlsTrustedHosts new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -49131,9 +49133,10 @@ public abstract class ZAttrServer extends NamedEntry {
 
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
-     * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
-     * separated list of trusted hosts
+     * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
+     * whitespace separated list of hosts, those hosts are trusted. This
+     * parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost.
      *
      * @param zimbraSmtpStartTlsTrustedHosts new value
      * @param attrs existing map to populate, or null to create a new map
@@ -49150,9 +49153,10 @@ public abstract class ZAttrServer extends NamedEntry {
 
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
-     * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
-     * separated list of trusted hosts
+     * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
+     * whitespace separated list of hosts, those hosts are trusted. This
+     * parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -49167,9 +49171,10 @@ public abstract class ZAttrServer extends NamedEntry {
 
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
-     * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
-     * separated list of trusted hosts
+     * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
+     * whitespace separated list of hosts, those hosts are trusted. This
+     * parameter doesn&#039;t affect on smtp sessions to
+     * zimbraDataSourceSmtpHost.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -49099,9 +49099,11 @@ public abstract class ZAttrServer extends NamedEntry {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
-     * whitespace separated list of hosts, those hosts are trusted. This
-     * parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost.
+     * whitespace separated list of hosts, those hosts are trusted.
+     * Otherwise, trust depends on the certificate the server presents. This
+     * attribute does not affect data source SMTP connections as those are
+     * controlled by zimbraDataSourceSmtpHost,
+     * zimbraDataSourceSmtpConnectionType, etc.
      *
      * @return zimbraSmtpStartTlsTrustedHosts, or "*" if unset
      *
@@ -49115,9 +49117,11 @@ public abstract class ZAttrServer extends NamedEntry {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
-     * whitespace separated list of hosts, those hosts are trusted. This
-     * parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost.
+     * whitespace separated list of hosts, those hosts are trusted.
+     * Otherwise, trust depends on the certificate the server presents. This
+     * attribute does not affect data source SMTP connections as those are
+     * controlled by zimbraDataSourceSmtpHost,
+     * zimbraDataSourceSmtpConnectionType, etc.
      *
      * @param zimbraSmtpStartTlsTrustedHosts new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -49134,9 +49138,11 @@ public abstract class ZAttrServer extends NamedEntry {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
-     * whitespace separated list of hosts, those hosts are trusted. This
-     * parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost.
+     * whitespace separated list of hosts, those hosts are trusted.
+     * Otherwise, trust depends on the certificate the server presents. This
+     * attribute does not affect data source SMTP connections as those are
+     * controlled by zimbraDataSourceSmtpHost,
+     * zimbraDataSourceSmtpConnectionType, etc.
      *
      * @param zimbraSmtpStartTlsTrustedHosts new value
      * @param attrs existing map to populate, or null to create a new map
@@ -49154,9 +49160,11 @@ public abstract class ZAttrServer extends NamedEntry {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
-     * whitespace separated list of hosts, those hosts are trusted. This
-     * parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost.
+     * whitespace separated list of hosts, those hosts are trusted.
+     * Otherwise, trust depends on the certificate the server presents. This
+     * attribute does not affect data source SMTP connections as those are
+     * controlled by zimbraDataSourceSmtpHost,
+     * zimbraDataSourceSmtpConnectionType, etc.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -49172,9 +49180,11 @@ public abstract class ZAttrServer extends NamedEntry {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. If set to &quot;*&quot;, all hosts are trusted. If set to a
-     * whitespace separated list of hosts, those hosts are trusted. This
-     * parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost.
+     * whitespace separated list of hosts, those hosts are trusted.
+     * Otherwise, trust depends on the certificate the server presents. This
+     * attribute does not affect data source SMTP connections as those are
+     * controlled by zimbraDataSourceSmtpHost,
+     * zimbraDataSourceSmtpConnectionType, etc.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -49099,8 +49099,8 @@ public abstract class ZAttrServer extends NamedEntry {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
-     * - A white space separated list of trusted hosts
+     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
+     * separated list of trusted hosts
      *
      * @return zimbraSmtpStartTlsTrustedHosts, or "*" if unset
      *
@@ -49114,8 +49114,8 @@ public abstract class ZAttrServer extends NamedEntry {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
-     * - A white space separated list of trusted hosts
+     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
+     * separated list of trusted hosts
      *
      * @param zimbraSmtpStartTlsTrustedHosts new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -49132,8 +49132,8 @@ public abstract class ZAttrServer extends NamedEntry {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
-     * - A white space separated list of trusted hosts
+     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
+     * separated list of trusted hosts
      *
      * @param zimbraSmtpStartTlsTrustedHosts new value
      * @param attrs existing map to populate, or null to create a new map
@@ -49151,8 +49151,8 @@ public abstract class ZAttrServer extends NamedEntry {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
-     * - A white space separated list of trusted hosts
+     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
+     * separated list of trusted hosts
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -49168,8 +49168,8 @@ public abstract class ZAttrServer extends NamedEntry {
     /**
      * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
-     * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
-     * - A white space separated list of trusted hosts
+     * zimbraDataSourceSmtpHost. * - trust all hosts host... - A whitespace
+     * separated list of trusted hosts
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -49097,7 +49097,7 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
      * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
      * - A white space separated list of trusted hosts
@@ -49112,7 +49112,7 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
      * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
      * - A white space separated list of trusted hosts
@@ -49130,7 +49130,7 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
      * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
      * - A white space separated list of trusted hosts
@@ -49149,7 +49149,7 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
      * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
      * - A white space separated list of trusted hosts
@@ -49166,7 +49166,7 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Configures trusted hosts on sending mail from mailboxd to MTA with
+     * Configures trusted hosts sending mail from mailboxd to MTA with
      * starttls. This parameter doesn&#039;t affect on smtp sessions to
      * zimbraDataSourceSmtpHost. * - trust all hosts host[&lt;sp&gt;host...]
      * - A white space separated list of trusted hosts


### PR DESCRIPTION
Problem : STARTTLS support for outbound mail
Fix : Add a ldap attribute zimbraSmtpStartTlsTrustedHosts to configure mail.smtp.ssl.trust Java Mail property after discussion in #533. Please refer to #533 for details.
Testing done : testing done by developer
Testing to be done by QA : testing needed to be done by QA
Linked PR : #533
