### PR TITLE
ZCS-4252: NPE When Deleting Account

### DIFF
--- a/store/src/java/com/zimbra/cs/event/StandaloneSolrEventStore.java
+++ b/store/src/java/com/zimbra/cs/event/StandaloneSolrEventStore.java
@@ -8,10 +8,9 @@ import com.zimbra.cs.contacts.RelatedContactsParams;
 import com.zimbra.cs.contacts.RelatedContactsResults;
 import com.zimbra.cs.event.Event.EventType;
 import com.zimbra.cs.event.analytics.RatioMetric;
-import com.zimbra.cs.index.solr.SolrConstants;
+import com.zimbra.cs.index.solr.SolrIndex.IndexType;
 import com.zimbra.cs.index.solr.SolrRequestHelper;
 import com.zimbra.cs.index.solr.StandaloneSolrHelper;
-import com.zimbra.cs.index.solr.SolrIndex.IndexType;
 
 /**
  * Event store backed by a standalone Solr server. This class does not support
@@ -40,11 +39,9 @@ public class StandaloneSolrEventStore extends SolrEventStore {
             super();
         }
 
-        StandaloneSolrHelper solrHelper;
-
         @Override
         public EventStore getEventStore(String accountId) {
-            return new StandaloneSolrEventStore(accountId, solrHelper);
+            return new StandaloneSolrEventStore(accountId, (StandaloneSolrHelper) solrHelper);
         }
 
         @Override


### PR DESCRIPTION
The bug only happens when the event backend is set to `StandaloneSolrEventStore`. The issue is that `StandaloneSolrEventStore.Factory` erroneously declares its own `solrHelper` variable that shadows the one set in the parent class. The bug is fixed by removing this declaration and casting the underlying `SolrRequestHelper` to `StandaloneSolrHelper` when constructing `StandaloneSolrEventStore`.