### PR TITLE
ZCS-4247: Bugfix in DbSearchHistory

### DIFF
--- a/store/src/java/com/zimbra/cs/db/DbSearchHistory.java
+++ b/store/src/java/com/zimbra/cs/db/DbSearchHistory.java
@@ -363,10 +363,7 @@ public final class DbSearchHistory {
             stmt.setShort(pos++, status.getId());
             pos = DbMailItem.setMailboxId(stmt, mailbox, pos);
             stmt.setString(pos++, searchString);
-            int num = stmt.executeUpdate();
-            if (num != 1) {
-                throw ServiceException.FAILURE(String.format("failed to update prompt status for search string '%s' in mailbox %s", searchString, mailbox.getId()), null);
-            }
+            stmt.executeUpdate();
         } catch (SQLException e) {
             throw ServiceException.FAILURE(String.format("failed to update prompt status for search string '%s' in mailbox %s", searchString, mailbox.getId()), e);
         } finally {

--- a/store/src/java/com/zimbra/qa/unittest/TestSearchHistory.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestSearchHistory.java
@@ -1,6 +1,7 @@
 package com.zimbra.qa.unittest;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.List;
@@ -11,9 +12,9 @@ import org.junit.Test;
 
 import com.zimbra.client.ZMailbox;
 import com.zimbra.client.ZSearchParams;
-import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.soap.type.SearchSortBy;
 
 public class TestSearchHistory {
 
@@ -97,5 +98,10 @@ public class TestSearchHistory {
         mailbox.purgeSearchHistory(null); //everything should be purged
         results = mbox.getSearchHistory();
         checkResults(new String[0], results);
+    }
+
+    @Test
+    public void testSearchFolderForUnregisteredSearch() throws Exception {
+        mbox.createSearchFolder("2", "testFolder", "in:inbox", null, SearchSortBy.dateDesc, null);
     }
 }


### PR DESCRIPTION
The DbSearchHistory::setSavedSearchStatus method, which updates a row in the `searches` DB table, would throw and error if the return value of the stmt.executeUpdate() call is zero. This happens if the update doesn't actually affect any rows, meaning that the search has not been registered in search history. This is actually a valid scenario, however, since it's possible to create a search folder for a query that isn't logged in search history, such as "in:inbox". This fix removes the return value check.