### PR TITLE
NICPS-59/Bug 34202 STARTTLS support for outbound mail

### DIFF
--- a/store/src/java-test/com/zimbra/cs/util/JMSessionTest.java
+++ b/store/src/java-test/com/zimbra/cs/util/JMSessionTest.java
@@ -256,11 +256,6 @@ public class JMSessionTest {
         Account account = prov.createAccount(mail, "test123", new HashMap<String, Object>());
         Server server = prov.getLocalServer();
 
-        // Trusted Hosts: undefined
-        server.setSmtpStartTlsModeAsString("only");
-        smtpSession = JMSession.getSmtpSession(account);
-        Assert.assertEquals("zimbraSmtpStartTlsTrustedHosts=-/-: mail.smtp.ssl.trust", null, smtpSession.getProperty("mail.smtp.ssl.trust"));
-
         // Trusted Hosts: Server:*, Domain: undefined
         server.setSmtpStartTlsModeAsString("only");
         server.setSmtpStartTlsTrustedHosts("*");

--- a/store/src/java-test/com/zimbra/cs/util/JMSessionTest.java
+++ b/store/src/java-test/com/zimbra/cs/util/JMSessionTest.java
@@ -183,7 +183,6 @@ public class JMSessionTest {
         smtpSession = JMSession.getSmtpSession(account);
         Assert.assertEquals("zimbraSmtpStartTlsMode=on/on: mail.smtp.starttls.enable", "true", smtpSession.getProperty("mail.smtp.starttls.enable"));
         Assert.assertEquals("zimbraSmtpStartTlsMode=on/on: mail.smtp.starttls.required", "false", smtpSession.getProperty("mail.smtp.starttls.required"));
-        Assert.assertEquals("zimbraSmtpStartTlsMode=on/on: mail.smtp.ssl.trust", "*", smtpSession.getProperty("mail.smtp.ssl.trust"));
 
         // Server:on, Domain:only
         server.setSmtpStartTlsModeAsString("on");
@@ -191,7 +190,6 @@ public class JMSessionTest {
         smtpSession = JMSession.getSmtpSession(account);
         Assert.assertEquals("zimbraSmtpStartTlsMode=on/only: mail.smtp.starttls.enable", "true", smtpSession.getProperty("mail.smtp.starttls.enable"));
         Assert.assertEquals("zimbraSmtpStartTlsMode=on/only: mail.smtp.starttls.required", "true", smtpSession.getProperty("mail.smtp.starttls.required"));
-        Assert.assertEquals("zimbraSmtpStartTlsMode=on/only: mail.smtp.ssl.trust", "*", smtpSession.getProperty("mail.smtp.ssl.trust"));
 
         // Server:only, Domain:off
         server.setSmtpStartTlsModeAsString("only");
@@ -205,7 +203,6 @@ public class JMSessionTest {
         smtpSession = JMSession.getSmtpSession(account);
         Assert.assertEquals("zimbraSmtpStartTlsMode=only/on: mail.smtp.starttls.enable", "true", smtpSession.getProperty("mail.smtp.starttls.enable"));
         Assert.assertEquals("zimbraSmtpStartTlsMode=only/on: mail.smtp.starttls.required", "false", smtpSession.getProperty("mail.smtp.starttls.required"));
-        Assert.assertEquals("zimbraSmtpStartTlsMode=onluy/on: mail.smtp.ssl.trust", "*", smtpSession.getProperty("mail.smtp.ssl.trust"));
 
         // Server:only, Domain:only
         server.setSmtpStartTlsModeAsString("only");
@@ -213,6 +210,5 @@ public class JMSessionTest {
         smtpSession = JMSession.getSmtpSession(account);
         Assert.assertEquals("zimbraSmtpStartTlsMode=only/only: mail.smtp.starttls.enable", "true", smtpSession.getProperty("mail.smtp.starttls.enable"));
         Assert.assertEquals("zimbraSmtpStartTlsMode=only/only: mail.smtp.starttls.required", "true", smtpSession.getProperty("mail.smtp.starttls.required"));
-        Assert.assertEquals("zimbraSmtpStartTlsMode=only/only: mail.smtp.ssl.trust", "*", smtpSession.getProperty("mail.smtp.ssl.trust"));
     }
 }

--- a/store/src/java-test/com/zimbra/cs/util/JMSessionTest.java
+++ b/store/src/java-test/com/zimbra/cs/util/JMSessionTest.java
@@ -137,74 +137,103 @@ public class JMSessionTest {
         
         // Server:on
         server.setSmtpStartTlsModeAsString("on");
+        server.setSmtpStartTlsTrustedHosts("*");
         smtpSession = JMSession.getSmtpSession(account);
         Assert.assertEquals("zimbraSmtpStartTlsMode=on/-: mail.smtp.starttls.enable", "true", smtpSession.getProperty("mail.smtp.starttls.enable"));
         Assert.assertEquals("zimbraSmtpStartTlsMode=on/-: mail.smtp.starttls.required", "false", smtpSession.getProperty("mail.smtp.starttls.required"));
+        Assert.assertEquals("zimbraSmtpStartTlsTrustedHosts=*/-: mail.smtp.ssl.trust", "*", smtpSession.getProperty("mail.smtp.ssl.trust"));
 
         // Server:only
         server.setSmtpStartTlsModeAsString("only");
+        server.setSmtpStartTlsTrustedHosts("*");
         smtpSession = JMSession.getSmtpSession(account);
         Assert.assertEquals("zimbraSmtpStartTlsMode=only/-: mail.smtp.starttls.enable", "true", smtpSession.getProperty("mail.smtp.starttls.enable"));
         Assert.assertEquals("zimbraSmtpStartTlsMode=only/-: mail.smtp.starttls.required", "true", smtpSession.getProperty("mail.smtp.starttls.required"));
+        Assert.assertEquals("zimbraSmtpStartTlsTrustedHosts=*/-: mail.smtp.ssl.trust", "*", smtpSession.getProperty("mail.smtp.ssl.trust"));
 
         // Server:off, Domain:off
         server.setSmtpStartTlsModeAsString("off");
+        server.setSmtpStartTlsTrustedHosts("*");
         domain.setSmtpStartTlsModeAsString("off");
         smtpSession = JMSession.getSmtpSession(account);
         Assert.assertEquals("zimbraSmtpStartTlsMode=off/off: mail.smtp.starttls.enable", "false", smtpSession.getProperty("mail.smtp.starttls.enable"));
 
         // Server:off, Domain:on
         server.setSmtpStartTlsModeAsString("off");
+        server.setSmtpStartTlsTrustedHosts("*");
         domain.setSmtpStartTlsModeAsString("on");
         smtpSession = JMSession.getSmtpSession(account);
         Assert.assertEquals("zimbraSmtpStartTlsMode=off/on: mail.smtp.starttls.enable", "true", smtpSession.getProperty("mail.smtp.starttls.enable"));
         Assert.assertEquals("zimbraSmtpStartTlsMode=off/on: mail.smtp.starttls.required", "false", smtpSession.getProperty("mail.smtp.starttls.required"));
+        Assert.assertEquals("zimbraSmtpStartTlsTrustedHosts=*/-: mail.smtp.ssl.trust", "*", smtpSession.getProperty("mail.smtp.ssl.trust"));
 
         // Server:off, Domain:only
         server.setSmtpStartTlsModeAsString("off");
+        server.setSmtpStartTlsTrustedHosts("*");
         domain.setSmtpStartTlsModeAsString("only");
         smtpSession = JMSession.getSmtpSession(account);
         Assert.assertEquals("zimbraSmtpStartTlsMode=off/only: mail.smtp.starttls.enable", "true", smtpSession.getProperty("mail.smtp.starttls.enable"));
         Assert.assertEquals("zimbraSmtpStartTlsMode=off/only: mail.smtp.starttls.required", "true", smtpSession.getProperty("mail.smtp.starttls.required"));
+        Assert.assertEquals("zimbraSmtpStartTlsTrustedHosts=*/-: mail.smtp.ssl.trust", "*", smtpSession.getProperty("mail.smtp.ssl.trust"));
 
         // Server:on, Domain:off
         server.setSmtpStartTlsModeAsString("on");
+        server.setSmtpStartTlsTrustedHosts("*");
         domain.setSmtpStartTlsModeAsString("off");
         smtpSession = JMSession.getSmtpSession(account);
         Assert.assertEquals("zimbraSmtpStartTlsMode=on/off: mail.smtp.starttls.enable", "false", smtpSession.getProperty("mail.smtp.starttls.enable"));
 
         // Server:on, Domain:on
         server.setSmtpStartTlsModeAsString("on");
+        server.setSmtpStartTlsTrustedHosts("*");
         domain.setSmtpStartTlsModeAsString("on");
         smtpSession = JMSession.getSmtpSession(account);
         Assert.assertEquals("zimbraSmtpStartTlsMode=on/on: mail.smtp.starttls.enable", "true", smtpSession.getProperty("mail.smtp.starttls.enable"));
         Assert.assertEquals("zimbraSmtpStartTlsMode=on/on: mail.smtp.starttls.required", "false", smtpSession.getProperty("mail.smtp.starttls.required"));
+        Assert.assertEquals("zimbraSmtpStartTlsTrustedHosts=*/-: mail.smtp.ssl.trust", "*", smtpSession.getProperty("mail.smtp.ssl.trust"));
 
         // Server:on, Domain:only
         server.setSmtpStartTlsModeAsString("on");
+        server.setSmtpStartTlsTrustedHosts("*");
         domain.setSmtpStartTlsModeAsString("only");
         smtpSession = JMSession.getSmtpSession(account);
         Assert.assertEquals("zimbraSmtpStartTlsMode=on/only: mail.smtp.starttls.enable", "true", smtpSession.getProperty("mail.smtp.starttls.enable"));
         Assert.assertEquals("zimbraSmtpStartTlsMode=on/only: mail.smtp.starttls.required", "true", smtpSession.getProperty("mail.smtp.starttls.required"));
+        Assert.assertEquals("zimbraSmtpStartTlsTrustedHosts=*/-: mail.smtp.ssl.trust", "*", smtpSession.getProperty("mail.smtp.ssl.trust"));
 
         // Server:only, Domain:off
         server.setSmtpStartTlsModeAsString("only");
+        server.setSmtpStartTlsTrustedHosts("*");
         domain.setSmtpStartTlsModeAsString("off");
         smtpSession = JMSession.getSmtpSession(account);
         Assert.assertEquals("zimbraSmtpStartTlsMode=only/off: mail.smtp.starttls.enable", "false", smtpSession.getProperty("mail.smtp.starttls.enable"));
 
         // Server:only, Domain:on
         server.setSmtpStartTlsModeAsString("only");
+        server.setSmtpStartTlsTrustedHosts("*");
         domain.setSmtpStartTlsModeAsString("on");
         smtpSession = JMSession.getSmtpSession(account);
         Assert.assertEquals("zimbraSmtpStartTlsMode=only/on: mail.smtp.starttls.enable", "true", smtpSession.getProperty("mail.smtp.starttls.enable"));
         Assert.assertEquals("zimbraSmtpStartTlsMode=only/on: mail.smtp.starttls.required", "false", smtpSession.getProperty("mail.smtp.starttls.required"));
+        Assert.assertEquals("zimbraSmtpStartTlsTrustedHosts=*/-: mail.smtp.ssl.trust", "*", smtpSession.getProperty("mail.smtp.ssl.trust"));
 
         // Server:only, Domain:only
         server.setSmtpStartTlsModeAsString("only");
+        server.setSmtpStartTlsTrustedHosts("*");
         domain.setSmtpStartTlsModeAsString("only");
         smtpSession = JMSession.getSmtpSession(account);
         Assert.assertEquals("zimbraSmtpStartTlsMode=only/only: mail.smtp.starttls.enable", "true", smtpSession.getProperty("mail.smtp.starttls.enable"));
         Assert.assertEquals("zimbraSmtpStartTlsMode=only/only: mail.smtp.starttls.required", "true", smtpSession.getProperty("mail.smtp.starttls.required"));
+        Assert.assertEquals("zimbraSmtpStartTlsTrustedHosts=*/-: mail.smtp.ssl.trust", "*", smtpSession.getProperty("mail.smtp.ssl.trust"));
+
+        // Trusted Hosts: Server:*, Domain:mta01.test.local
+        server.setSmtpStartTlsModeAsString("only");
+        server.setSmtpStartTlsTrustedHosts("*");
+        domain.setSmtpStartTlsModeAsString("only");
+        domain.setSmtpStartTlsTrustedHosts("mta01.test.local");
+        smtpSession = JMSession.getSmtpSession(account);
+        Assert.assertEquals("zimbraSmtpStartTlsMode=only/only: mail.smtp.starttls.enable", "true", smtpSession.getProperty("mail.smtp.starttls.enable"));
+        Assert.assertEquals("zimbraSmtpStartTlsMode=only/only: mail.smtp.starttls.required", "true", smtpSession.getProperty("mail.smtp.starttls.required"));
+        Assert.assertEquals("zimbraSmtpStartTlsTrustedHosts=*/mta01.test.local: mail.smtp.ssl.trust", "mta01.test.local", smtpSession.getProperty("mail.smtp.ssl.trust"));
     }
 }

--- a/store/src/java-test/com/zimbra/cs/util/JMSessionTest.java
+++ b/store/src/java-test/com/zimbra/cs/util/JMSessionTest.java
@@ -140,14 +140,12 @@ public class JMSessionTest {
         smtpSession = JMSession.getSmtpSession(account);
         Assert.assertEquals("zimbraSmtpStartTlsMode=on/-: mail.smtp.starttls.enable", "true", smtpSession.getProperty("mail.smtp.starttls.enable"));
         Assert.assertEquals("zimbraSmtpStartTlsMode=on/-: mail.smtp.starttls.required", "false", smtpSession.getProperty("mail.smtp.starttls.required"));
-        Assert.assertEquals("zimbraSmtpStartTlsMode=on/-: mail.smtp.ssl.trust", "*", smtpSession.getProperty("mail.smtp.ssl.trust"));
 
         // Server:only
         server.setSmtpStartTlsModeAsString("only");
         smtpSession = JMSession.getSmtpSession(account);
         Assert.assertEquals("zimbraSmtpStartTlsMode=only/-: mail.smtp.starttls.enable", "true", smtpSession.getProperty("mail.smtp.starttls.enable"));
         Assert.assertEquals("zimbraSmtpStartTlsMode=only/-: mail.smtp.starttls.required", "true", smtpSession.getProperty("mail.smtp.starttls.required"));
-        Assert.assertEquals("zimbraSmtpStartTlsMode=only/-: mail.smtp.ssl.trust", "*", smtpSession.getProperty("mail.smtp.ssl.trust"));
 
         // Server:off, Domain:off
         server.setSmtpStartTlsModeAsString("off");
@@ -161,7 +159,6 @@ public class JMSessionTest {
         smtpSession = JMSession.getSmtpSession(account);
         Assert.assertEquals("zimbraSmtpStartTlsMode=off/on: mail.smtp.starttls.enable", "true", smtpSession.getProperty("mail.smtp.starttls.enable"));
         Assert.assertEquals("zimbraSmtpStartTlsMode=off/on: mail.smtp.starttls.required", "false", smtpSession.getProperty("mail.smtp.starttls.required"));
-        Assert.assertEquals("zimbraSmtpStartTlsMode=off/on: mail.smtp.ssl.trust", "*", smtpSession.getProperty("mail.smtp.ssl.trust"));
 
         // Server:off, Domain:only
         server.setSmtpStartTlsModeAsString("off");
@@ -169,7 +166,6 @@ public class JMSessionTest {
         smtpSession = JMSession.getSmtpSession(account);
         Assert.assertEquals("zimbraSmtpStartTlsMode=off/only: mail.smtp.starttls.enable", "true", smtpSession.getProperty("mail.smtp.starttls.enable"));
         Assert.assertEquals("zimbraSmtpStartTlsMode=off/only: mail.smtp.starttls.required", "true", smtpSession.getProperty("mail.smtp.starttls.required"));
-        Assert.assertEquals("zimbraSmtpStartTlsMode=off/only: mail.smtp.ssl.trust", "*", smtpSession.getProperty("mail.smtp.ssl.trust"));
 
         // Server:on, Domain:off
         server.setSmtpStartTlsModeAsString("on");

--- a/store/src/java-test/com/zimbra/cs/util/JMSessionTest.java
+++ b/store/src/java-test/com/zimbra/cs/util/JMSessionTest.java
@@ -120,36 +120,20 @@ public class JMSessionTest {
         mm.saveChanges();
         Assert.assertEquals("message ID contains account domain", domain.getName() + '>', mm.getMessageID().split("@")[1]);
     }
-    
+
     @Test
-    public void testSmtpStartTlsMode() throws Exception {
+    public void testSmtpStartTlsMode_Off() throws Exception {
         Session smtpSession;
         Provisioning prov = Provisioning.getInstance();
         Domain domain = prov.createDomain("example.com", new HashMap<String, Object>());
         String mail = "user1@example.com";
         Account account = prov.createAccount(mail, "test123", new HashMap<String, Object>());
         Server server = prov.getLocalServer();
-        
+
         // Server:off
         server.setSmtpStartTlsModeAsString("off");
         smtpSession = JMSession.getSmtpSession(account);
         Assert.assertEquals("zimbraSmtpStartTlsMode=off/-: mail.smtp.starttls.enable", "false", smtpSession.getProperty("mail.smtp.starttls.enable"));
-        
-        // Server:on
-        server.setSmtpStartTlsModeAsString("on");
-        server.setSmtpStartTlsTrustedHosts("*");
-        smtpSession = JMSession.getSmtpSession(account);
-        Assert.assertEquals("zimbraSmtpStartTlsMode=on/-: mail.smtp.starttls.enable", "true", smtpSession.getProperty("mail.smtp.starttls.enable"));
-        Assert.assertEquals("zimbraSmtpStartTlsMode=on/-: mail.smtp.starttls.required", "false", smtpSession.getProperty("mail.smtp.starttls.required"));
-        Assert.assertEquals("zimbraSmtpStartTlsTrustedHosts=*/-: mail.smtp.ssl.trust", "*", smtpSession.getProperty("mail.smtp.ssl.trust"));
-
-        // Server:only
-        server.setSmtpStartTlsModeAsString("only");
-        server.setSmtpStartTlsTrustedHosts("*");
-        smtpSession = JMSession.getSmtpSession(account);
-        Assert.assertEquals("zimbraSmtpStartTlsMode=only/-: mail.smtp.starttls.enable", "true", smtpSession.getProperty("mail.smtp.starttls.enable"));
-        Assert.assertEquals("zimbraSmtpStartTlsMode=only/-: mail.smtp.starttls.required", "true", smtpSession.getProperty("mail.smtp.starttls.required"));
-        Assert.assertEquals("zimbraSmtpStartTlsTrustedHosts=*/-: mail.smtp.ssl.trust", "*", smtpSession.getProperty("mail.smtp.ssl.trust"));
 
         // Server:off, Domain:off
         server.setSmtpStartTlsModeAsString("off");
@@ -158,6 +142,38 @@ public class JMSessionTest {
         smtpSession = JMSession.getSmtpSession(account);
         Assert.assertEquals("zimbraSmtpStartTlsMode=off/off: mail.smtp.starttls.enable", "false", smtpSession.getProperty("mail.smtp.starttls.enable"));
 
+        // Server:on, Domain:off
+        server.setSmtpStartTlsModeAsString("on");
+        server.setSmtpStartTlsTrustedHosts("*");
+        domain.setSmtpStartTlsModeAsString("off");
+        smtpSession = JMSession.getSmtpSession(account);
+        Assert.assertEquals("zimbraSmtpStartTlsMode=on/off: mail.smtp.starttls.enable", "false", smtpSession.getProperty("mail.smtp.starttls.enable"));
+
+        // Server:only, Domain:off
+        server.setSmtpStartTlsModeAsString("only");
+        server.setSmtpStartTlsTrustedHosts("*");
+        domain.setSmtpStartTlsModeAsString("off");
+        smtpSession = JMSession.getSmtpSession(account);
+        Assert.assertEquals("zimbraSmtpStartTlsMode=only/off: mail.smtp.starttls.enable", "false", smtpSession.getProperty("mail.smtp.starttls.enable"));
+    }
+
+    @Test
+    public void testSmtpStartTlsMode_On() throws Exception {
+        Session smtpSession;
+        Provisioning prov = Provisioning.getInstance();
+        Domain domain = prov.createDomain("example.com", new HashMap<String, Object>());
+        String mail = "user1@example.com";
+        Account account = prov.createAccount(mail, "test123", new HashMap<String, Object>());
+        Server server = prov.getLocalServer();
+
+        // Server:on
+        server.setSmtpStartTlsModeAsString("on");
+        server.setSmtpStartTlsTrustedHosts("*");
+        smtpSession = JMSession.getSmtpSession(account);
+        Assert.assertEquals("zimbraSmtpStartTlsMode=on/-: mail.smtp.starttls.enable", "true", smtpSession.getProperty("mail.smtp.starttls.enable"));
+        Assert.assertEquals("zimbraSmtpStartTlsMode=on/-: mail.smtp.starttls.required", "false", smtpSession.getProperty("mail.smtp.starttls.required"));
+        Assert.assertEquals("zimbraSmtpStartTlsTrustedHosts=*/-: mail.smtp.ssl.trust", "*", smtpSession.getProperty("mail.smtp.ssl.trust"));
+
         // Server:off, Domain:on
         server.setSmtpStartTlsModeAsString("off");
         server.setSmtpStartTlsTrustedHosts("*");
@@ -165,6 +181,42 @@ public class JMSessionTest {
         smtpSession = JMSession.getSmtpSession(account);
         Assert.assertEquals("zimbraSmtpStartTlsMode=off/on: mail.smtp.starttls.enable", "true", smtpSession.getProperty("mail.smtp.starttls.enable"));
         Assert.assertEquals("zimbraSmtpStartTlsMode=off/on: mail.smtp.starttls.required", "false", smtpSession.getProperty("mail.smtp.starttls.required"));
+        Assert.assertEquals("zimbraSmtpStartTlsTrustedHosts=*/-: mail.smtp.ssl.trust", "*", smtpSession.getProperty("mail.smtp.ssl.trust"));
+
+        // Server:on, Domain:on
+        server.setSmtpStartTlsModeAsString("on");
+        server.setSmtpStartTlsTrustedHosts("*");
+        domain.setSmtpStartTlsModeAsString("on");
+        smtpSession = JMSession.getSmtpSession(account);
+        Assert.assertEquals("zimbraSmtpStartTlsMode=on/on: mail.smtp.starttls.enable", "true", smtpSession.getProperty("mail.smtp.starttls.enable"));
+        Assert.assertEquals("zimbraSmtpStartTlsMode=on/on: mail.smtp.starttls.required", "false", smtpSession.getProperty("mail.smtp.starttls.required"));
+        Assert.assertEquals("zimbraSmtpStartTlsTrustedHosts=*/-: mail.smtp.ssl.trust", "*", smtpSession.getProperty("mail.smtp.ssl.trust"));
+
+        // Server:only, Domain:on
+        server.setSmtpStartTlsModeAsString("only");
+        server.setSmtpStartTlsTrustedHosts("*");
+        domain.setSmtpStartTlsModeAsString("on");
+        smtpSession = JMSession.getSmtpSession(account);
+        Assert.assertEquals("zimbraSmtpStartTlsMode=only/on: mail.smtp.starttls.enable", "true", smtpSession.getProperty("mail.smtp.starttls.enable"));
+        Assert.assertEquals("zimbraSmtpStartTlsMode=only/on: mail.smtp.starttls.required", "false", smtpSession.getProperty("mail.smtp.starttls.required"));
+        Assert.assertEquals("zimbraSmtpStartTlsTrustedHosts=*/-: mail.smtp.ssl.trust", "*", smtpSession.getProperty("mail.smtp.ssl.trust"));
+    }
+
+    @Test
+    public void testSmtpStartTlsMode_Only() throws Exception {
+        Session smtpSession;
+        Provisioning prov = Provisioning.getInstance();
+        Domain domain = prov.createDomain("example.com", new HashMap<String, Object>());
+        String mail = "user1@example.com";
+        Account account = prov.createAccount(mail, "test123", new HashMap<String, Object>());
+        Server server = prov.getLocalServer();
+
+        // Server:only
+        server.setSmtpStartTlsModeAsString("only");
+        server.setSmtpStartTlsTrustedHosts("*");
+        smtpSession = JMSession.getSmtpSession(account);
+        Assert.assertEquals("zimbraSmtpStartTlsMode=only/-: mail.smtp.starttls.enable", "true", smtpSession.getProperty("mail.smtp.starttls.enable"));
+        Assert.assertEquals("zimbraSmtpStartTlsMode=only/-: mail.smtp.starttls.required", "true", smtpSession.getProperty("mail.smtp.starttls.required"));
         Assert.assertEquals("zimbraSmtpStartTlsTrustedHosts=*/-: mail.smtp.ssl.trust", "*", smtpSession.getProperty("mail.smtp.ssl.trust"));
 
         // Server:off, Domain:only
@@ -176,22 +228,6 @@ public class JMSessionTest {
         Assert.assertEquals("zimbraSmtpStartTlsMode=off/only: mail.smtp.starttls.required", "true", smtpSession.getProperty("mail.smtp.starttls.required"));
         Assert.assertEquals("zimbraSmtpStartTlsTrustedHosts=*/-: mail.smtp.ssl.trust", "*", smtpSession.getProperty("mail.smtp.ssl.trust"));
 
-        // Server:on, Domain:off
-        server.setSmtpStartTlsModeAsString("on");
-        server.setSmtpStartTlsTrustedHosts("*");
-        domain.setSmtpStartTlsModeAsString("off");
-        smtpSession = JMSession.getSmtpSession(account);
-        Assert.assertEquals("zimbraSmtpStartTlsMode=on/off: mail.smtp.starttls.enable", "false", smtpSession.getProperty("mail.smtp.starttls.enable"));
-
-        // Server:on, Domain:on
-        server.setSmtpStartTlsModeAsString("on");
-        server.setSmtpStartTlsTrustedHosts("*");
-        domain.setSmtpStartTlsModeAsString("on");
-        smtpSession = JMSession.getSmtpSession(account);
-        Assert.assertEquals("zimbraSmtpStartTlsMode=on/on: mail.smtp.starttls.enable", "true", smtpSession.getProperty("mail.smtp.starttls.enable"));
-        Assert.assertEquals("zimbraSmtpStartTlsMode=on/on: mail.smtp.starttls.required", "false", smtpSession.getProperty("mail.smtp.starttls.required"));
-        Assert.assertEquals("zimbraSmtpStartTlsTrustedHosts=*/-: mail.smtp.ssl.trust", "*", smtpSession.getProperty("mail.smtp.ssl.trust"));
-
         // Server:on, Domain:only
         server.setSmtpStartTlsModeAsString("on");
         server.setSmtpStartTlsTrustedHosts("*");
@@ -199,22 +235,6 @@ public class JMSessionTest {
         smtpSession = JMSession.getSmtpSession(account);
         Assert.assertEquals("zimbraSmtpStartTlsMode=on/only: mail.smtp.starttls.enable", "true", smtpSession.getProperty("mail.smtp.starttls.enable"));
         Assert.assertEquals("zimbraSmtpStartTlsMode=on/only: mail.smtp.starttls.required", "true", smtpSession.getProperty("mail.smtp.starttls.required"));
-        Assert.assertEquals("zimbraSmtpStartTlsTrustedHosts=*/-: mail.smtp.ssl.trust", "*", smtpSession.getProperty("mail.smtp.ssl.trust"));
-
-        // Server:only, Domain:off
-        server.setSmtpStartTlsModeAsString("only");
-        server.setSmtpStartTlsTrustedHosts("*");
-        domain.setSmtpStartTlsModeAsString("off");
-        smtpSession = JMSession.getSmtpSession(account);
-        Assert.assertEquals("zimbraSmtpStartTlsMode=only/off: mail.smtp.starttls.enable", "false", smtpSession.getProperty("mail.smtp.starttls.enable"));
-
-        // Server:only, Domain:on
-        server.setSmtpStartTlsModeAsString("only");
-        server.setSmtpStartTlsTrustedHosts("*");
-        domain.setSmtpStartTlsModeAsString("on");
-        smtpSession = JMSession.getSmtpSession(account);
-        Assert.assertEquals("zimbraSmtpStartTlsMode=only/on: mail.smtp.starttls.enable", "true", smtpSession.getProperty("mail.smtp.starttls.enable"));
-        Assert.assertEquals("zimbraSmtpStartTlsMode=only/on: mail.smtp.starttls.required", "false", smtpSession.getProperty("mail.smtp.starttls.required"));
         Assert.assertEquals("zimbraSmtpStartTlsTrustedHosts=*/-: mail.smtp.ssl.trust", "*", smtpSession.getProperty("mail.smtp.ssl.trust"));
 
         // Server:only, Domain:only
@@ -225,15 +245,29 @@ public class JMSessionTest {
         Assert.assertEquals("zimbraSmtpStartTlsMode=only/only: mail.smtp.starttls.enable", "true", smtpSession.getProperty("mail.smtp.starttls.enable"));
         Assert.assertEquals("zimbraSmtpStartTlsMode=only/only: mail.smtp.starttls.required", "true", smtpSession.getProperty("mail.smtp.starttls.required"));
         Assert.assertEquals("zimbraSmtpStartTlsTrustedHosts=*/-: mail.smtp.ssl.trust", "*", smtpSession.getProperty("mail.smtp.ssl.trust"));
+    }
 
-        // Trusted Hosts: Server:*, Domain:mta01.test.local
+    @Test
+    public void testSmtpStartTlsTrustedHosts() throws Exception {
+        Session smtpSession;
+        Provisioning prov = Provisioning.getInstance();
+        Domain domain = prov.createDomain("example.com", new HashMap<String, Object>());
+        String mail = "user1@example.com";
+        Account account = prov.createAccount(mail, "test123", new HashMap<String, Object>());
+        Server server = prov.getLocalServer();
+
+        // Trusted Hosts: Server:*, Domain: undefined
+        server.setSmtpStartTlsModeAsString("only");
+        server.setSmtpStartTlsTrustedHosts("*");
+        smtpSession = JMSession.getSmtpSession(account);
+        Assert.assertEquals("zimbraSmtpStartTlsTrustedHosts=*/-: mail.smtp.ssl.trust", "*", smtpSession.getProperty("mail.smtp.ssl.trust"));
+
+        // Trusted Hosts: Server:*, Domain: mta01.test.local
         server.setSmtpStartTlsModeAsString("only");
         server.setSmtpStartTlsTrustedHosts("*");
         domain.setSmtpStartTlsModeAsString("only");
         domain.setSmtpStartTlsTrustedHosts("mta01.test.local");
         smtpSession = JMSession.getSmtpSession(account);
-        Assert.assertEquals("zimbraSmtpStartTlsMode=only/only: mail.smtp.starttls.enable", "true", smtpSession.getProperty("mail.smtp.starttls.enable"));
-        Assert.assertEquals("zimbraSmtpStartTlsMode=only/only: mail.smtp.starttls.required", "true", smtpSession.getProperty("mail.smtp.starttls.required"));
         Assert.assertEquals("zimbraSmtpStartTlsTrustedHosts=*/mta01.test.local: mail.smtp.ssl.trust", "mta01.test.local", smtpSession.getProperty("mail.smtp.ssl.trust"));
     }
 }

--- a/store/src/java-test/com/zimbra/cs/util/JMSessionTest.java
+++ b/store/src/java-test/com/zimbra/cs/util/JMSessionTest.java
@@ -122,7 +122,7 @@ public class JMSessionTest {
     }
 
     @Test
-    public void testSmtpStartTlsMode_Off() throws Exception {
+    public void testSmtpStartTlsModeOff() throws Exception {
         Session smtpSession;
         Provisioning prov = Provisioning.getInstance();
         Domain domain = prov.createDomain("example.com", new HashMap<String, Object>());
@@ -158,7 +158,7 @@ public class JMSessionTest {
     }
 
     @Test
-    public void testSmtpStartTlsMode_On() throws Exception {
+    public void testSmtpStartTlsModeOn() throws Exception {
         Session smtpSession;
         Provisioning prov = Provisioning.getInstance();
         Domain domain = prov.createDomain("example.com", new HashMap<String, Object>());
@@ -203,7 +203,7 @@ public class JMSessionTest {
     }
 
     @Test
-    public void testSmtpStartTlsMode_Only() throws Exception {
+    public void testSmtpStartTlsModeOnly() throws Exception {
         Session smtpSession;
         Provisioning prov = Provisioning.getInstance();
         Domain domain = prov.createDomain("example.com", new HashMap<String, Object>());

--- a/store/src/java-test/com/zimbra/cs/util/JMSessionTest.java
+++ b/store/src/java-test/com/zimbra/cs/util/JMSessionTest.java
@@ -256,6 +256,11 @@ public class JMSessionTest {
         Account account = prov.createAccount(mail, "test123", new HashMap<String, Object>());
         Server server = prov.getLocalServer();
 
+        // Trusted Hosts: undefined
+        server.setSmtpStartTlsModeAsString("only");
+        smtpSession = JMSession.getSmtpSession(account);
+        Assert.assertEquals("zimbraSmtpStartTlsTrustedHosts=-/-: mail.smtp.ssl.trust", null, smtpSession.getProperty("mail.smtp.ssl.trust"));
+
         // Trusted Hosts: Server:*, Domain: undefined
         server.setSmtpStartTlsModeAsString("only");
         server.setSmtpStartTlsTrustedHosts("*");

--- a/store/src/java/com/zimbra/cs/mailbox/MailSender.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailSender.java
@@ -690,11 +690,6 @@ public class MailSender {
                 mm.removeHeader(PRE_SEND_HEADER); //no need to keep the header in the message at this point
             }
 
-            // Configure STARTTLS properties if needs
-            JMSession.configureStartTls(mSession.getProperties(), 
-                    Provisioning.getInstance().getLocalServer(), 
-                    Provisioning.getInstance().getDomain(acct));
-            
             // actually send the message via SMTP
             Collection<Address> sentAddresses = sendMessage(mbox, mm, rollbacks);
 

--- a/store/src/java/com/zimbra/cs/mailbox/MailSender.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailSender.java
@@ -690,6 +690,11 @@ public class MailSender {
                 mm.removeHeader(PRE_SEND_HEADER); //no need to keep the header in the message at this point
             }
 
+            // Configure STARTTLS properties if needs
+            JMSession.configureStartTls(mSession.getProperties(), 
+                    Provisioning.getInstance().getLocalServer(), 
+                    Provisioning.getInstance().getDomain(acct));
+            
             // actually send the message via SMTP
             Collection<Address> sentAddresses = sendMessage(mbox, mm, rollbacks);
 

--- a/store/src/java/com/zimbra/cs/util/JMSession.java
+++ b/store/src/java/com/zimbra/cs/util/JMSession.java
@@ -34,7 +34,6 @@ import javax.mail.Session;
 import com.google.common.base.Joiner;
 import com.zimbra.common.account.ZAttrProvisioning.DataSourceAuthMechanism;
 import com.zimbra.common.account.ZAttrProvisioning.ShareNotificationMtaConnectionType;
-import com.zimbra.common.account.ZAttrProvisioning.SmtpStartTlsMode;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.net.SocketFactories;
 import com.zimbra.common.service.ServiceException;

--- a/store/src/java/com/zimbra/cs/util/JMSession.java
+++ b/store/src/java/com/zimbra/cs/util/JMSession.java
@@ -370,14 +370,12 @@ public final class JMSession {
         } else if (startTlsMode.isOnly()) {
             props.setProperty("mail.smtp.starttls.enable", "true");
             props.setProperty("mail.smtp.starttls.required", "true");
-            props.setProperty("mail.smtp.ssl.trust", "*");
         } else {
             if (!startTlsMode.isOn()) {
                 ZimbraLog.smtp.warn("invalid value configured for %s. fallback to \"on\".", Provisioning.A_zimbraSmtpStartTlsMode);
             }
             props.setProperty("mail.smtp.starttls.enable", "true");
             props.setProperty("mail.smtp.starttls.required", "false");
-            props.setProperty("mail.smtp.ssl.trust", "*");
         }
 
         return props;

--- a/store/src/java/com/zimbra/cs/util/JMSession.java
+++ b/store/src/java/com/zimbra/cs/util/JMSession.java
@@ -357,13 +357,13 @@ public final class JMSession {
         String sslTrustedHosts = getValue(server, domain, Provisioning.A_zimbraSmtpStartTlsTrustedHosts);
 
         if (startTlsMode != null) {
-            if (startTlsMode == "off") {
+            if (startTlsMode.equals("off")) {
                 props.setProperty("mail.smtp.starttls.enable", "false");
-            } else if (startTlsMode == "only") {
+            } else if (startTlsMode.equals("only")) {
                 props.setProperty("mail.smtp.starttls.enable", "true");
                 props.setProperty("mail.smtp.starttls.required", "true");
             } else {
-                if (startTlsMode != "on") {
+                if (!startTlsMode.equals("on")) {
                     ZimbraLog.smtp.warn("Invalid value for %s. Defaulting to 'on'.", Provisioning.A_zimbraSmtpStartTlsMode);
                 }
                 props.setProperty("mail.smtp.starttls.enable", "true");

--- a/store/src/java/com/zimbra/cs/util/JMSession.java
+++ b/store/src/java/com/zimbra/cs/util/JMSession.java
@@ -240,7 +240,7 @@ public final class JMSession {
         }
 
         Properties props = getJavaMailSessionProperties(server, domain);
-        configureStartTls(props,server,domain);
+        configureStartTls(props, server, domain);
         Session session = Session.getInstance(props);
         setProviders(session);
         if (LC.javamail_smtp_debug.booleanValue()) {
@@ -351,12 +351,13 @@ public final class JMSession {
         if (domain != null) {
             props.setProperty("mail.host", domain.getName());
         }
-        
+
         return props;
     }
 
     private static Properties configureStartTls (Properties props, Server server, Domain domain) {
         SmtpStartTlsMode startTlsMode = null;
+
         if (domain != null) {
             startTlsMode = domain.getSmtpStartTlsMode();
         }
@@ -372,14 +373,13 @@ public final class JMSession {
             props.setProperty("mail.smtp.ssl.trust", "*");
         } else {
             if (!startTlsMode.isOn()) {
-                // Should not be reached here
                 ZimbraLog.smtp.warn("invalid value configured for %s. fallback to \"on\".", Provisioning.A_zimbraSmtpStartTlsMode);
             }
             props.setProperty("mail.smtp.starttls.enable", "true");
             props.setProperty("mail.smtp.starttls.required", "false");
             props.setProperty("mail.smtp.ssl.trust", "*");
         }
-        
+
         return props;
     }
     

--- a/store/src/java/com/zimbra/cs/util/JMSession.java
+++ b/store/src/java/com/zimbra/cs/util/JMSession.java
@@ -357,13 +357,13 @@ public final class JMSession {
         String sslTrustedHosts = getValue(server, domain, Provisioning.A_zimbraSmtpStartTlsTrustedHosts);
 
         if (startTlsMode != null) {
-            if (startTlsMode.equals("off")) {
+            if ("off".equals(startTlsMode)) {
                 props.setProperty("mail.smtp.starttls.enable", "false");
-            } else if (startTlsMode.equals("only")) {
+            } else if ("only".equals(startTlsMode)) {
                 props.setProperty("mail.smtp.starttls.enable", "true");
                 props.setProperty("mail.smtp.starttls.required", "true");
             } else {
-                if (!startTlsMode.equals("on")) {
+                if (!"on".equals(startTlsMode)) {
                     ZimbraLog.smtp.warn("Invalid value for %s. Defaulting to 'on'.", Provisioning.A_zimbraSmtpStartTlsMode);
                 }
                 props.setProperty("mail.smtp.starttls.enable", "true");

--- a/store/src/java/com/zimbra/cs/util/JMSession.java
+++ b/store/src/java/com/zimbra/cs/util/JMSession.java
@@ -355,12 +355,17 @@ public final class JMSession {
 
     private static Properties configureStartTls (Properties props, Server server, Domain domain) {
         SmtpStartTlsMode startTlsMode = null;
+        String sslTrustedHosts = null;
 
         if (domain != null) {
             startTlsMode = domain.getSmtpStartTlsMode();
+            sslTrustedHosts = domain.getSmtpStartTlsTrustedHosts();
         }
         if (startTlsMode == null) {
             startTlsMode = server.getSmtpStartTlsMode();
+        }
+        if (sslTrustedHosts == null) {
+            sslTrustedHosts = server.getSmtpStartTlsTrustedHosts();
         }
 
         if (startTlsMode.isOff()) {
@@ -368,12 +373,18 @@ public final class JMSession {
         } else if (startTlsMode.isOnly()) {
             props.setProperty("mail.smtp.starttls.enable", "true");
             props.setProperty("mail.smtp.starttls.required", "true");
+            if (sslTrustedHosts != null) {
+                props.setProperty("mail.smtp.ssl.trust", sslTrustedHosts);
+            }
         } else {
             if (!startTlsMode.isOn()) {
                 ZimbraLog.smtp.warn("invalid value configured for %s. fallback to \"on\".", Provisioning.A_zimbraSmtpStartTlsMode);
             }
             props.setProperty("mail.smtp.starttls.enable", "true");
             props.setProperty("mail.smtp.starttls.required", "false");
+            if (sslTrustedHosts != null) {
+                props.setProperty("mail.smtp.ssl.trust", sslTrustedHosts);
+            }
         }
 
         return props;

--- a/store/src/java/com/zimbra/cs/util/JMSession.java
+++ b/store/src/java/com/zimbra/cs/util/JMSession.java
@@ -202,6 +202,7 @@ public final class JMSession {
                 props.setProperty("mail.smtp.starttls.enable","true");
                 // props.put("mail.smtp.socketFactory.class", TlsSocketFactory.getInstance());
             }
+
             if (isAuthRequired) {
                 props.setProperty("mail.smtp.auth", "true");
                 props.setProperty("mail.smtp.user", smtpUser);
@@ -354,7 +355,7 @@ public final class JMSession {
         return props;
     }
 
-    public static Properties configureStartTls (Properties props, Server server, Domain domain) {
+    private static Properties configureStartTls (Properties props, Server server, Domain domain) {
         SmtpStartTlsMode startTlsMode = null;
         if (domain != null) {
             startTlsMode = domain.getSmtpStartTlsMode();

--- a/store/src/java/com/zimbra/cs/util/JMSession.java
+++ b/store/src/java/com/zimbra/cs/util/JMSession.java
@@ -140,7 +140,6 @@ public final class JMSession {
         boolean isAuthRequired = ds.isSmtpAuthRequired();
         String smtpUser = ds.getSmtpUsername();
         String smtpPass = ds.getDecryptedSmtpPassword();
-        ds.getDomain();
         if (DataSourceAuthMechanism.XOAUTH2.name().equalsIgnoreCase(ds.getAuthMechanism())) {
             smtpPass = ds.getDecryptedOAuthToken();
         }
@@ -202,7 +201,6 @@ public final class JMSession {
                 props.setProperty("mail.smtp.starttls.enable","true");
                 // props.put("mail.smtp.socketFactory.class", TlsSocketFactory.getInstance());
             }
-
             if (isAuthRequired) {
                 props.setProperty("mail.smtp.auth", "true");
                 props.setProperty("mail.smtp.user", smtpUser);

--- a/store/src/java/com/zimbra/cs/util/JMSession.java
+++ b/store/src/java/com/zimbra/cs/util/JMSession.java
@@ -354,37 +354,25 @@ public final class JMSession {
     }
 
     private static Properties configureStartTls (Properties props, Server server, Domain domain) {
-        SmtpStartTlsMode startTlsMode = null;
-        String sslTrustedHosts = null;
+        String startTlsMode = getValue(server, domain, Provisioning.A_zimbraSmtpStartTlsMode);
+        String sslTrustedHosts = getValue(server, domain, Provisioning.A_zimbraSmtpStartTlsTrustedHosts);
 
-        if (domain != null) {
-            startTlsMode = domain.getSmtpStartTlsMode();
-            sslTrustedHosts = domain.getSmtpStartTlsTrustedHosts();
-        }
-        if (startTlsMode == null) {
-            startTlsMode = server.getSmtpStartTlsMode();
-        }
-        if (sslTrustedHosts == null) {
-            sslTrustedHosts = server.getSmtpStartTlsTrustedHosts();
-        }
-
-        if (startTlsMode.isOff()) {
-            props.setProperty("mail.smtp.starttls.enable", "false");
-        } else if (startTlsMode.isOnly()) {
-            props.setProperty("mail.smtp.starttls.enable", "true");
-            props.setProperty("mail.smtp.starttls.required", "true");
-            if (sslTrustedHosts != null) {
-                props.setProperty("mail.smtp.ssl.trust", sslTrustedHosts);
+        if (startTlsMode != null) {
+            if (startTlsMode == "off") {
+                props.setProperty("mail.smtp.starttls.enable", "false");
+            } else if (startTlsMode == "only") {
+                props.setProperty("mail.smtp.starttls.enable", "true");
+                props.setProperty("mail.smtp.starttls.required", "true");
+            } else {
+                if (startTlsMode != "on") {
+                    ZimbraLog.smtp.warn("Invalid value for %s. Defaulting to 'on'.", Provisioning.A_zimbraSmtpStartTlsMode);
+                }
+                props.setProperty("mail.smtp.starttls.enable", "true");
+                props.setProperty("mail.smtp.starttls.required", "false");
             }
-        } else {
-            if (!startTlsMode.isOn()) {
-                ZimbraLog.smtp.warn("invalid value configured for %s. fallback to \"on\".", Provisioning.A_zimbraSmtpStartTlsMode);
-            }
-            props.setProperty("mail.smtp.starttls.enable", "true");
-            props.setProperty("mail.smtp.starttls.required", "false");
-            if (sslTrustedHosts != null) {
-                props.setProperty("mail.smtp.ssl.trust", sslTrustedHosts);
-            }
+        }
+        if (sslTrustedHosts != null) {
+            props.setProperty("mail.smtp.ssl.trust", sslTrustedHosts);
         }
 
         return props;


### PR DESCRIPTION
Problem
-------
In NICPS-59/Bug 34202, we want to support STARTTLS for sending mail from mailboxd to Zimbra MTA.

Fix
---------
We can activate STARTTLS by configuring appropriate Java Mail properties.
We can use one of the following methods to send mails.

a. static void send(Message msg)
b. static void send(Message, Address[] addrs)
c. static void send(Message msg, Address[] addrs, String user, String password)
d. static void send(Message msg, String user, String password)
e. abstract void sendMessage(Message msg, Address[] addrs)

And only a, b, and e are used in mailboxd code.

In most of the cases, mailboxd calls JMSession.getSmtpSession() to get SMTP Session object.
I add new method configureStartTls() to set starttls properties based on the *zimbraSmtpStartTlsMode* value, and call it from getSmtpSession. You can define trusted host by *zimbraSmtpStartTlsTrustedHosts*.

When mailboxd calls JMSession.getSession(DataSource) to get session, it uses following own ldap attributes to setup JavaMail properties:
- zimbraDataSourceSmtpHost
- zimbraDataSourceSmtpPort
- zimbraDataSourceSmtpConnectionType

And a localconfig:
- javamail_smtp_enable_starttls

We don't change the behavior of getSession(DataSource) in this PR.

Testing done
------------
testing done by developer

Testing to be done by QA
------------------------
testing needed to be done by QA

Linked PR
----------
https://github.com/Zimbra/zm-mailbox/pull/529 To add zimbraSmtpStartTlsMode
https://github.com/Zimbra/zm-mailbox/pull/533 (Obsolete/Closed) Implementation for NICPS-59/Bug 34202
https://github.com/Zimbra/zm-mailbox/pull/540 To add zimbraSmtpStartTlsTrustedHost
