### PR TITLE
ZCS-4275 DbLogWriter::close set conn to null

### DIFF
--- a/store/src/java/com/zimbra/cs/redolog/logger/DbLogWriter.java
+++ b/store/src/java/com/zimbra/cs/redolog/logger/DbLogWriter.java
@@ -69,6 +69,7 @@ public class DbLogWriter implements LogWriter {
             }
 
             DbPool.quietClose(conn);
+            conn = null;
         }
     }
 


### PR DESCRIPTION
Without this change I was able to reliably reproduce the issue documented in [ZCS-4275](https://jira.corp.synacor.com/browse/ZCS-4275) by executing the following from the `test` container:


    /zimbra/init --run-soap yes --soap Admin/ACL


That was with one or two mailbox replicas.  After deploying this change, the above is no longer triggering the failure.

**Note** Have been trying to execute the full SOAP test run and has yet to run to completion for me. I started a run last night before going to bed and it had not completed this morning.  Am seeing different issues in the log files and will ensure we have tickets for them.