### PR TITLE
ZCS-4430:stack overflow registering session

### DIFF
--- a/store/src/java/com/zimbra/cs/session/Session.java
+++ b/store/src/java/com/zimbra/cs/session/Session.java
@@ -22,7 +22,6 @@ import java.util.Date;
 
 import com.google.common.base.Objects;
 import com.zimbra.common.localconfig.LC;
-import com.zimbra.common.mailbox.MailboxLock;
 import com.zimbra.common.mailbox.MailboxStore;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
@@ -149,6 +148,27 @@ public abstract class Session {
                                     mbox.getClass().getName()));
                 }
             }
+        }
+
+        // registering the session automatically sets mSessionId
+        if (isRegisteredInCache()) {
+            addToSessionCache();
+        }
+
+        mIsRegistered = true;
+
+        return this;
+    }
+
+    /** added to avoid potential for stack overflow recursion with {@link #register()} */
+    public Session register(Mailbox mbox) throws ServiceException {
+        if (mIsRegistered) {
+            return this;
+        }
+
+        if (isMailboxListener()) {
+            mailbox = mbox;
+            mbox.addListener(this);
         }
 
         // registering the session automatically sets mSessionId

--- a/store/src/java/com/zimbra/cs/session/WaitSetAccount.java
+++ b/store/src/java/com/zimbra/cs/session/WaitSetAccount.java
@@ -74,7 +74,7 @@ public class WaitSetAccount {
         ZimbraLog.session.debug("Created WaitSetSession %s for waitset %s on account %s", session.getSessionId(), ws.getWaitSetId(), accountId);
         try (final MailboxLock l = mbox.lock(true)) {
             l.lock();
-            session.register();
+            session.register(mbox);
             sessionId = session.getSessionId();
             // must force update here so that initial sync token is checked against current mbox state
             session.update(interests, folderInterests, lastKnownSyncToken);


### PR DESCRIPTION
Use fact that we have a mailbox object when registering an associated
WaitSet session, so that we don't end up creating another mailbox object
which tries to register an associated session...