### PR TITLE
ZCS-4307:Add converter for zimbraInvalidJWTokens ephemeral attribute

### DIFF
--- a/store/src/java/com/zimbra/cs/ephemeral/migrate/AttributeMigration.java
+++ b/store/src/java/com/zimbra/cs/ephemeral/migrate/AttributeMigration.java
@@ -84,6 +84,7 @@ public class AttributeMigration {
     private static Map<String, AttributeConverter> converterMap = new HashMap<String, AttributeConverter>();
     static {
         registerConverter(Provisioning.A_zimbraAuthTokens, new AuthTokenConverter());
+        registerConverter(Provisioning.A_zimbraInvalidJWTokens, new AuthTokenConverter());
         registerConverter(Provisioning.A_zimbraCsrfTokenData, new CsrfTokenConverter());
         registerConverter(Provisioning.A_zimbraLastLogonTimestamp, new StringAttributeConverter());
     }


### PR DESCRIPTION
Registered converter for zimbraInvalidJWTokens ephemeral attribute in AttributeMigration class.Reused the converter for zimbraAuthToken as both tokens are stored in same format.