### PR TITLE
ZCS-4385: Refactored Header Search

### DIFF
--- a/store/src/java/com/zimbra/cs/index/IndexDocument.java
+++ b/store/src/java/com/zimbra/cs/index/IndexDocument.java
@@ -194,6 +194,11 @@ public final class IndexDocument {
         document.addField(LuceneFields.L_VERSION, String.valueOf(value));
     }
 
+    public void addIntHeader(String headerField, int value) {
+        String fieldName = "header_" + headerField;
+        document.addField(fieldName, value);
+    }
+
     public String get(String fieldName) {
         return (String) document.getFieldValue(fieldName);
     }

--- a/store/src/java/com/zimbra/cs/index/query/Query.java
+++ b/store/src/java/com/zimbra/cs/index/query/Query.java
@@ -141,6 +141,8 @@ public abstract class Query {
             }
             buf.append('"');
             return buf.toString();
+        } else if (luceneField.startsWith("header_")) {
+            return String.format("#%s:%s", luceneField.substring("header_".length()), term);
         } else {
             return field + term;
         }

--- a/store/src/java/com/zimbra/cs/index/solr/SolrUtils.java
+++ b/store/src/java/com/zimbra/cs/index/solr/SolrUtils.java
@@ -409,4 +409,8 @@ public class SolrUtils {
         }
         return indexName;
     }
+
+    public static String getNumericHeaderFieldName(String header) {
+        return "header_" + header;
+    }
 }

--- a/store/src/java/com/zimbra/cs/mime/ParsedContact.java
+++ b/store/src/java/com/zimbra/cs/mime/ParsedContact.java
@@ -39,6 +39,7 @@ import org.apache.solr.common.SolrInputDocument;
 import org.json.JSONException;
 
 import com.google.common.base.Strings;
+import com.google.common.primitives.Ints;
 import com.zimbra.common.localconfig.DebugConfig;
 import com.zimbra.common.mailbox.ContactConstants;
 import com.zimbra.common.mime.ContentDisposition;
@@ -729,8 +730,12 @@ public final class ParsedContact {
                     ContactConstants.A_groupMember.equals(fieldName)) {
                 continue;
             }
-
-            doc.addField(String.format("%s:%s", fieldName, entry.getValue()));
+            String val = entry.getValue();
+            doc.addField(String.format("%s:%s", fieldName, val));
+            Integer intVal = Ints.tryParse(val);
+            if (intVal != null) {
+                doc.addIntHeader(fieldName.toLowerCase(), intVal);
+            }
         }
 
         // fetch all the 'email' addresses for this contact into a single concatenated string

--- a/store/src/java/com/zimbra/cs/mime/ParsedMessage.java
+++ b/store/src/java/com/zimbra/cs/mime/ParsedMessage.java
@@ -51,6 +51,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import com.google.common.primitives.Ints;
 import com.zimbra.common.account.ZAttrProvisioning;
 import com.zimbra.common.calendar.ZCalendar.ICalTok;
 import com.zimbra.common.calendar.ZCalendar.ZCalendarBuilder;
@@ -1004,6 +1005,11 @@ public final class ParsedMessage {
                     	val = value;
                     }
                     doc.addField(String.format("%s:%s", key, val));
+                    Integer intVal = Ints.tryParse(val);
+                    if (intVal != null) {
+                        //numeric values get indexed in a separate field
+                        doc.addIntHeader(key.toLowerCase(), intVal);
+                    }
                 }
             }
         }

--- a/store/src/java/com/zimbra/qa/unittest/TestSolrHeaderSearch.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestSolrHeaderSearch.java
@@ -1,0 +1,111 @@
+package com.zimbra.qa.unittest;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+
+import javax.mail.internet.MimeMessage;
+
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.io.Closeables;
+import com.zimbra.common.httpclient.ZimbraHttpClientManager;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.index.SortBy;
+import com.zimbra.cs.index.ZimbraQueryResults;
+import com.zimbra.cs.index.solr.SolrUtils;
+import com.zimbra.cs.mailbox.MailItem.Type;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.OperationContext;
+import com.zimbra.cs.mime.Mime;
+import com.zimbra.cs.mime.ParsedMessage;
+import com.zimbra.cs.util.JMSession;
+
+public class TestSolrHeaderSearch {
+    private static final String USER_NAME = TestSolrHeaderSearch.class.getSimpleName();
+    private Account acct;
+    private Mailbox mbox;
+    private static final String INDEX_NAME = USER_NAME + "_index";
+
+    @Before
+    public void setUp() throws Exception {
+        cleanUp();
+        acct = TestUtil.createAccount(USER_NAME);
+        acct.setMailboxIndexName(INDEX_NAME);
+        mbox = TestUtil.getMailbox(USER_NAME);
+        TestUtil.addMessage(mbox, generateMessage()).getId();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        cleanUp();
+    }
+
+    private void cleanUp() throws Exception {
+        TestUtil.deleteAccountIfExists(USER_NAME);
+        try {
+            String indexUrl = Provisioning.getInstance().getConfig().getIndexURL();
+            if (indexUrl.startsWith("solrcloud")) {
+                String zkHost = indexUrl.substring("solrcloud:".length());
+                CloudSolrClient client = SolrUtils.getCloudSolrClient(zkHost);
+                SolrUtils.deleteCloudIndex(client, INDEX_NAME);
+            } else if (indexUrl.startsWith("solr")){
+                String solrBaseUrl = indexUrl.substring("solr:".length());
+                CloseableHttpClient httpClient = ZimbraHttpClientManager.getInstance().getInternalHttpClient();
+                SolrClient client = SolrUtils.getSolrClient(httpClient, solrBaseUrl, INDEX_NAME);
+                SolrUtils.deleteStandaloneIndex(client, solrBaseUrl, INDEX_NAME);
+            }
+        } catch (Exception e) {
+        }
+    }
+
+    private void search(String query, boolean shouldReturn) throws Exception {
+        ZimbraQueryResults results = mbox.index.search(new OperationContext(mbox), query, Collections.singleton(Type.MESSAGE), SortBy.DATE_DESC, 100);
+        if (shouldReturn) {
+            assertTrue("should see result for " + query, results.hasNext());
+        } else {
+            assertFalse("should not see result for " + query, results.hasNext());
+        }
+        Closeables.closeQuietly(results);
+    }
+
+    private ParsedMessage generateMessage() throws Exception {
+        MimeMessage mm = new Mime.FixedMimeMessage(JMSession.getSession());
+        mm.setHeader("From", "test@zimbra.com");
+        mm.setHeader("To", acct.getName());
+        mm.setHeader("X-TestHeader", "100");
+        mm.setHeader("Subject", "test");
+        mm.setText("test");
+        return new ParsedMessage(mm, false);
+    }
+
+    @Test
+    public void testSearchHeader() throws Exception {
+        search("#X-TestHeader:100", true);
+        search("#X-TestHeader:101", false);
+        search("#X-OtherHeader:100", false);
+
+        //wildcards
+        search("#X-TestHeader:*", true);
+        search("#X-TestHeader:1*", true);
+        search("#X-TestHeader:10*", true);
+        search("#X-TestHeader:100*", true);
+        search("#X-TestHeader:2*", false);
+
+        //range queries
+        search("#X-TestHeader:<=100", true);
+        search("#X-TestHeader:<200", true);
+        search("#X-TestHeader:<100", false);
+        search("#X-TestHeader:>50", true);
+        search("#X-TestHeader:>=100", true);
+        search("#X-TestHeader:>100", false);
+
+    }
+}

--- a/store/src/java/com/zimbra/qa/unittest/ZimbraSuite.java
+++ b/store/src/java/com/zimbra/qa/unittest/ZimbraSuite.java
@@ -167,6 +167,7 @@ public class ZimbraSuite  {
         sClasses.add(TestRelatedContacts.class);
         sClasses.add(TestSearchSortByRelevance.class);
         sClasses.add(TestSmartFolders.class);
+        sClasses.add(TestSolrHeaderSearch.class);
     }
 
     /**


### PR DESCRIPTION
For numeric email headers like `HeaderName: 100`, the Zimbra query language supports both wildcard searches like `#HeaderName:1*` and range queries `#HeaderName:>90`. This was done with a custom tokenizer that, when encountering a numeric header value, generated two tokens:
- A token with the value `headername:100`, to allow for wildcard queries
- A token with the value `headername:#{code}`, where {code} is the integer value _prefix-coded_ using the `NumericUtils` class.
The prefix-coded tokens provided a sort order that could be used for range queries on the underlying numbers, instead of on their string representations.

With Lucene 6, the version used for our original Solr backend, prefix-coding functions were moved to the `LegacyNumericUtils` class. Lucene 7 (and therefore Solr 7) removes this mechanism entirely.  The recommended approach in the Lucene documentation is to use the new `PointField` feature, which indexes numbers in a totally different data structure under the hood, allowing for more efficient numeric queries.  The problem this poses is that indexed values have to now be purely numeric, as opposed to being prefixed by `headername:#` as before. 

The upshot is that numeric headers can no longer be indexed in the `l.field` Solr field - instead, each header is now indexed in its own Solr field of the type `pints` (multivalued integer points). To capture arbitrary headers, a new dynamic field definition has been added to the schema to capture fields of the form `header_*`.

The following changes have been made to support this:
- `IndexDocument` has a new method `addIntHeader` that takes a header name and integer value
- `FieldQuery` creates Lucene integer range queries using the `IntPoint.newRangeQuery` method, instead of relying on term ranges. These queries target the appropriate field prefixed by `header_`, instead of the `l.field` field used for non-numeric header values.
- `ParsedMessage` and `ParsedContact` classes determine when the header value is numeric, and if so, call `IndexDocument::addIntHeader`
- The `FieldTokenizer` class in the `zm-solr` repo no longer generates specialized tokens for range searches. See the https://github.com/Zimbra/zm-solr/pull/6 for more details.

A test class `TestSolrHeaderSearch` has been added to verify both wildcard and range query functionality for numeric headers. Note that when an `EmbeddedSolrIndex` is implemented, these tests can be converted to unit tests.