### PR TITLE
ZCS-4398: fixed NPE when failing to create solr collection

### DIFF
--- a/store/src/java/com/zimbra/cs/index/solr/SolrUtils.java
+++ b/store/src/java/com/zimbra/cs/index/solr/SolrUtils.java
@@ -254,7 +254,7 @@ public class SolrUtils {
         OnFailureAction onFailure = new RetryUtil.RequestWithRetry.OnFailureAction() {
 
             @Override
-            protected void run() throws ServiceException {
+            public void run() throws ServiceException {
                 HttpSolrClient solrClient = (HttpSolrClient) client;
                 String origBaseUrl = solrClient.getBaseURL();
                 try {
@@ -289,7 +289,7 @@ public class SolrUtils {
         OnFailureAction onFailure = new RetryUtil.RequestWithRetry.OnFailureAction() {
 
             @Override
-            protected void run() throws ServiceException {
+            public void run() throws ServiceException {
                 createCloudIndex(client, collectionName, getConfigSetName(indexType), getInitialNumShards(accountId, indexType));
             }
         };


### PR DESCRIPTION
The RetryUtil class had bug that resulted in a null being returned if the `OnFailureAction.run()` invocation returned false. This resulted in an NPE thrown from `SolrIndex` class if the Solr collection was not able to be created for whatever reason, masking the real underlying problem.
This fix changes the `RetryUtil` logic to propagate any errors encountered in the `OnFailureAction.run()` method, making it impossible for a null to be returned.