### PR TITLE
ZCS-4242: Upgrade to Solr 7

### DIFF
--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -40,9 +40,9 @@
   <dependency org="com.ibm.icu" name="icu4j" rev="4.8.1.1"/>
   <dependency org="oauth" name="oauth" rev="1.4"/>
   <dependency org="zimbra" name="zm-ews-stub" rev="2.0"/>
-  <dependency org="org.apache.lucene" name="lucene-core" rev="6.6.0"/>
-  <dependency org="org.apache.lucene" name="lucene-analyzers-common" rev="6.6.0" />
-  <dependency org="org.apache.lucene" name="lucene-analyzers-kuromoji" rev="6.6.0"/>
+  <dependency org="org.apache.lucene" name="lucene-core" rev="7.2.1"/>
+  <dependency org="org.apache.lucene" name="lucene-analyzers-common" rev="7.2.1" />
+  <dependency org="org.apache.lucene" name="lucene-analyzers-kuromoji" rev="7.2.1"/>
   <dependency org="org.apache.zookeeper" name="zookeeper" rev="3.4.5"/>
   <dependency org="ews_2010" name="ews_2010" rev="1.0"/>
   <dependency org="xerces" name="xercesImpl" rev="2.9.1-patch-01"/>
@@ -79,8 +79,8 @@
   <dependency org="org.apache.curator" name="curator-client" rev="2.0.1-incubating" />
   <dependency org="org.apache.curator" name="curator-x-discovery" rev="2.0.1-incubating" />
   <dependency org="org.apache.curator" name="curator-framework" rev="2.0.1-incubating" />
-  <dependency org="org.apache.solr" name="solr-solrj" rev="6.6.0" />
-  <dependency org="org.apache.solr" name="solr-core" rev="6.6.0" />
+  <dependency org="org.apache.solr" name="solr-solrj" rev="7.2.1" />
+  <dependency org="org.apache.solr" name="solr-core" rev="7.2.1" />
   <dependency org="org.apache.zookeeper" name="zookeeper" rev="3.4.5"/>
   <dependency org="org.apache.james" name="apache-jsieve-core" rev="0.5"/>
   <dependency org="org.noggit" name="noggit" rev="0.7"/>

--- a/store/src/java/com/zimbra/cs/index/TermInfo.java
+++ b/store/src/java/com/zimbra/cs/index/TermInfo.java
@@ -27,7 +27,7 @@ import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
 import org.apache.lucene.document.Field;
-import org.apache.lucene.document.FieldType;
+import org.apache.lucene.index.IndexableFieldType;
 import org.codehaus.jackson.annotate.JsonProperty;
 
 import com.google.common.base.Objects;
@@ -70,7 +70,7 @@ public final class TermInfo {
     public static int updateMapWithDetailsForField(Analyzer analyzer, Field field,
             Map<String, TermInfo> term2info, int pos)
     throws IOException {
-        FieldType fieldType = field.fieldType();
+        IndexableFieldType fieldType = field.fieldType();
         if (fieldType.indexOptions() == null) {
             return pos;
         }

--- a/store/src/java/com/zimbra/cs/index/ZimbraTopDocs.java
+++ b/store/src/java/com/zimbra/cs/index/ZimbraTopDocs.java
@@ -65,7 +65,7 @@ public class ZimbraTopDocs {
      * Create equivalent ZimbraTopDocs object to a Lucene TopDocs object
      */
     public static ZimbraTopDocs create(TopDocs luceneTopDocs) {
-        return new ZimbraTopDocs(luceneTopDocs.totalHits,
+        return new ZimbraTopDocs((int) luceneTopDocs.totalHits,
                 ZimbraScoreDoc.listFromLuceneScoreDocs(luceneTopDocs.scoreDocs), luceneTopDocs.getMaxScore());
     }
 

--- a/store/src/java/com/zimbra/cs/index/ZimbraTopFieldDocs.java
+++ b/store/src/java/com/zimbra/cs/index/ZimbraTopFieldDocs.java
@@ -53,7 +53,7 @@ public class ZimbraTopFieldDocs extends ZimbraTopDocs {
      * Create equivalent ZimbraTopFieldDocs object to a Lucene TopFieldDocs object
      */
     public static ZimbraTopFieldDocs create(TopFieldDocs luceneTopFieldDocs) {
-        return new ZimbraTopFieldDocs(luceneTopFieldDocs.totalHits, 
+        return new ZimbraTopFieldDocs((int) luceneTopFieldDocs.totalHits,
                 ZimbraScoreDoc.listFromLuceneScoreDocs(luceneTopFieldDocs.scoreDocs),
                 luceneTopFieldDocs.getMaxScore(), Arrays.asList(luceneTopFieldDocs.fields));
     }


### PR DESCRIPTION
This PR bumps the `Solr/Lucene` ivy dependencies to `7.2.1` and resolves a few issues caused by API changes that comes with the version upgrade.

Relevant Lucene 7 API changes:
- `TopDocs.totalHits` is now a `long` instead of an `int`. For our use case, it's safe to just cast it to an integer
- `Field.fieldType()` now returns `IndexableFieldType`. This affects the `TermInfo` class, though I'm not sure if this class is even used anymore.