### PR TITLE
Task/zcs 4381 - generate an ldap schema file + add zimbraLDAPSchemaVersion attribute

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -4,6 +4,7 @@
       <exec dir="./native" executable="make"          failonerror="true"/>
       <ant dir="./store"  target="war"                inheritAll="true"/>
       <ant dir="./store"  target="create-version-sql" inheritAll="true"/>
+      <ant dir="./store"  target="create-version-ldap" inheritAll="true"/>
     </target>
 
    <target name="publish-local-all">

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -8427,6 +8427,14 @@ public class ZAttrProvisioning {
     public static final String A_zimbraLdapGentimeFractionalSecondsEnabled = "zimbraLdapGentimeFractionalSecondsEnabled";
 
     /**
+     * LDAP schema version for the system.
+     *
+     * @since ZCS 8.8.8
+     */
+    @ZAttr(id=3023)
+    public static final String A_zimbraLDAPSchemaVersion = "zimbraLDAPSchemaVersion";
+
+    /**
      * name to use in greeting and sign-off; if empty, uses hostname
      */
     @ZAttr(id=23)

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -350,6 +350,7 @@ sub stage_zimbra_common_mbox_conf_attrs()
    cpy_file( "store/conf/attrs/amavisd-new-attrs.xml", "$stage_base_dir/opt/zimbra/conf/attrs/amavisd-new-attrs.xml" );
    cpy_file( "store/conf/attrs/zimbra-attrs.xml",      "$stage_base_dir/opt/zimbra/conf/attrs/zimbra-attrs.xml" );
    cpy_file( "store/conf/attrs/zimbra-ocs.xml",        "$stage_base_dir/opt/zimbra/conf/attrs/zimbra-ocs.xml" );
+   cpy_file( "store/build/dist/conf/attrs/zimbra-attrs-schema",   "$stage_base_dir/opt/zimbra/conf/zimbra-attrs-schema" );
 
    return ["store/conf/attrs"];
 }

--- a/store/build.xml
+++ b/store/build.xml
@@ -86,6 +86,7 @@
     <mkdir dir="${base.dir}/${slapd.conf.dir}"/>
     <mkdir dir="${base.dir}/${slapd.etc.dir}/schema"/>
     <mkdir dir="${base.dir}/bin"/>
+    <mkdir dir="${base.dir}/conf/attrs"/>
     <mkdir dir="${base.dir}/conf/msgs"/>
     <mkdir dir="${base.dir}/db"/>
     <mkdir dir="${base.dir}/lib/ext"/>
@@ -392,6 +393,14 @@
       </classpath>
        <arg line="-o ${dist.dir}"/>
     </java>
+  </target>
+  <target name="create-version-ldap" depends="build-init" description="Creates ldap schema version: zimbra-attrs-schema">
+    <exec executable="git" failonerror="false" output="${dist.dir}/conf/attrs/zimbra-attrs-schema">
+      <arg value="log"/>
+      <arg value="-1"/>
+      <arg value="--pretty=format:%at"/>
+      <arg value="conf/attrs/zimbra-attrs.xml"/>
+    </exec>
   </target>
   <target name="setup-for-soap-tests" description="Does necessary setup for RunUnitTestsRequests">
     <exec executable="sudo" failonerror="false">

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9633,4 +9633,10 @@ TODO: delete them permanently from here
   <defaultCOSValue>FALSE</defaultCOSValue>
   <desc>Display received/sent time in mail list</desc>
 </attr>
+
+<attr id="3023" name="zimbraLDAPSchemaVersion" type="string" cardinality="single" requiredIn="globalConfig" since="8.8.8">
+  <desc>LDAP schema version for the system.</desc>
+  <globalConfigValue>1518163473</globalConfigValue>
+</attr>
+
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -24085,6 +24085,78 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * LDAP schema version for the system.
+     *
+     * @return zimbraLDAPSchemaVersion, or "1518163473" if unset
+     *
+     * @since ZCS 8.8.8
+     */
+    @ZAttr(id=3023)
+    public String getLDAPSchemaVersion() {
+        return getAttr(Provisioning.A_zimbraLDAPSchemaVersion, "1518163473", true);
+    }
+
+    /**
+     * LDAP schema version for the system.
+     *
+     * @param zimbraLDAPSchemaVersion new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.8
+     */
+    @ZAttr(id=3023)
+    public void setLDAPSchemaVersion(String zimbraLDAPSchemaVersion) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraLDAPSchemaVersion, zimbraLDAPSchemaVersion);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * LDAP schema version for the system.
+     *
+     * @param zimbraLDAPSchemaVersion new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.8
+     */
+    @ZAttr(id=3023)
+    public Map<String,Object> setLDAPSchemaVersion(String zimbraLDAPSchemaVersion, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraLDAPSchemaVersion, zimbraLDAPSchemaVersion);
+        return attrs;
+    }
+
+    /**
+     * LDAP schema version for the system.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.8
+     */
+    @ZAttr(id=3023)
+    public void unsetLDAPSchemaVersion() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraLDAPSchemaVersion, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * LDAP schema version for the system.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.8
+     */
+    @ZAttr(id=3023)
+    public Map<String,Object> unsetLDAPSchemaVersion(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraLDAPSchemaVersion, "");
+        return attrs;
+    }
+
+    /**
      * how often the zimbraLastLogonTimestamp is updated. if set to 0,
      * updating zimbraLastLogonTimestamp is completely disabled . Must be in
      * valid duration format: {digits}{time-unit}. digits: 0-9, time-unit:


### PR DESCRIPTION
A mechanism was needed to be added such that a given `zimbra-store` package could know which version of the LDAP schema it was built against.

This PR adds a new ant target `create-version-ldap` which generates a file which is utilized by scripts in the `zm-build` repository.

