### PR TITLE
NICPS-18 Modify optionalIn of some OAuth ldap attributes

### DIFF
--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -8461,7 +8461,7 @@ TODO: delete them permanently from here
   <desc>whether or not an account represents a Mobile Gateway app</desc>
 </attr>
 
-<attr id="1761" name="zimbraDataSourceOAuthToken" type="string" cardinality="single" optionalIn="imapDataSource" since="8.7.0">
+<attr id="1761" name="zimbraDataSourceOAuthToken" type="string" cardinality="single" optionalIn="dataSource,imapDataSource" flags="ephemeral" since="8.7.0">
   <desc>OAuth token for authentication using OAuth</desc>
 </attr>
 
@@ -8946,11 +8946,11 @@ TODO: delete them permanently from here
   <desc>Subject prefix for the spam training messages used to sent to the zimbraSpamIsSpamAccount/zimbraSpamIsNotSpamAccount account.</desc>
 </attr>
 
-<attr id="2021" name="zimbraDataSourceOAuthClientId" type="string" cardinality="single" optionalIn="dataSource,imapDataSource" since="8.7.0,9.0.0">
+<attr id="2021" name="zimbraDataSourceOAuthClientId" type="string" cardinality="single" optionalIn="globalConfig,domain,dataSource,imapDataSource" since="8.7.0,9.0.0">
   <desc>Client Id for OAuth token</desc>
 </attr>
 
-<attr id="2022" name="zimbraDataSourceOAuthClientSecret" type="string" cardinality="single" optionalIn="dataSource,imapDataSource" since="8.7.0,9.0.0">
+<attr id="2022" name="zimbraDataSourceOAuthClientSecret" type="string" cardinality="single" optionalIn="globalConfig,domain,dataSource,imapDataSource" since="8.7.0,9.0.0">
   <desc>Client Secret for OAuth token</desc>
 </attr>
 
@@ -8958,7 +8958,7 @@ TODO: delete them permanently from here
   <desc>Refresh token for authentication using OAuth</desc>
 </attr>
 
-<attr id="2024" name="zimbraDataSourceOAuthRefreshTokenUrl" type="string" cardinality="single" optionalIn="dataSource,imapDataSource" since="8.7.0,9.0.0">
+<attr id="2024" name="zimbraDataSourceOAuthRefreshTokenUrl" type="string" cardinality="single" optionalIn="globalConfig,domain,dataSource,imapDataSource" since="8.7.0,9.0.0">
   <desc>Url for refreshing OAuth Token</desc>
 </attr>
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -13274,6 +13274,222 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Client Id for OAuth token
+     *
+     * @return zimbraDataSourceOAuthClientId, or null if unset
+     *
+     * @since ZCS 8.7.0,9.0.0
+     */
+    @ZAttr(id=2021)
+    public String getDataSourceOAuthClientId() {
+        return getAttr(Provisioning.A_zimbraDataSourceOAuthClientId, null, true);
+    }
+
+    /**
+     * Client Id for OAuth token
+     *
+     * @param zimbraDataSourceOAuthClientId new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.0,9.0.0
+     */
+    @ZAttr(id=2021)
+    public void setDataSourceOAuthClientId(String zimbraDataSourceOAuthClientId) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDataSourceOAuthClientId, zimbraDataSourceOAuthClientId);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Client Id for OAuth token
+     *
+     * @param zimbraDataSourceOAuthClientId new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.0,9.0.0
+     */
+    @ZAttr(id=2021)
+    public Map<String,Object> setDataSourceOAuthClientId(String zimbraDataSourceOAuthClientId, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDataSourceOAuthClientId, zimbraDataSourceOAuthClientId);
+        return attrs;
+    }
+
+    /**
+     * Client Id for OAuth token
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.0,9.0.0
+     */
+    @ZAttr(id=2021)
+    public void unsetDataSourceOAuthClientId() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDataSourceOAuthClientId, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Client Id for OAuth token
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.0,9.0.0
+     */
+    @ZAttr(id=2021)
+    public Map<String,Object> unsetDataSourceOAuthClientId(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDataSourceOAuthClientId, "");
+        return attrs;
+    }
+
+    /**
+     * Client Secret for OAuth token
+     *
+     * @return zimbraDataSourceOAuthClientSecret, or null if unset
+     *
+     * @since ZCS 8.7.0,9.0.0
+     */
+    @ZAttr(id=2022)
+    public String getDataSourceOAuthClientSecret() {
+        return getAttr(Provisioning.A_zimbraDataSourceOAuthClientSecret, null, true);
+    }
+
+    /**
+     * Client Secret for OAuth token
+     *
+     * @param zimbraDataSourceOAuthClientSecret new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.0,9.0.0
+     */
+    @ZAttr(id=2022)
+    public void setDataSourceOAuthClientSecret(String zimbraDataSourceOAuthClientSecret) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDataSourceOAuthClientSecret, zimbraDataSourceOAuthClientSecret);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Client Secret for OAuth token
+     *
+     * @param zimbraDataSourceOAuthClientSecret new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.0,9.0.0
+     */
+    @ZAttr(id=2022)
+    public Map<String,Object> setDataSourceOAuthClientSecret(String zimbraDataSourceOAuthClientSecret, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDataSourceOAuthClientSecret, zimbraDataSourceOAuthClientSecret);
+        return attrs;
+    }
+
+    /**
+     * Client Secret for OAuth token
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.0,9.0.0
+     */
+    @ZAttr(id=2022)
+    public void unsetDataSourceOAuthClientSecret() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDataSourceOAuthClientSecret, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Client Secret for OAuth token
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.0,9.0.0
+     */
+    @ZAttr(id=2022)
+    public Map<String,Object> unsetDataSourceOAuthClientSecret(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDataSourceOAuthClientSecret, "");
+        return attrs;
+    }
+
+    /**
+     * Url for refreshing OAuth Token
+     *
+     * @return zimbraDataSourceOAuthRefreshTokenUrl, or null if unset
+     *
+     * @since ZCS 8.7.0,9.0.0
+     */
+    @ZAttr(id=2024)
+    public String getDataSourceOAuthRefreshTokenUrl() {
+        return getAttr(Provisioning.A_zimbraDataSourceOAuthRefreshTokenUrl, null, true);
+    }
+
+    /**
+     * Url for refreshing OAuth Token
+     *
+     * @param zimbraDataSourceOAuthRefreshTokenUrl new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.0,9.0.0
+     */
+    @ZAttr(id=2024)
+    public void setDataSourceOAuthRefreshTokenUrl(String zimbraDataSourceOAuthRefreshTokenUrl) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDataSourceOAuthRefreshTokenUrl, zimbraDataSourceOAuthRefreshTokenUrl);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Url for refreshing OAuth Token
+     *
+     * @param zimbraDataSourceOAuthRefreshTokenUrl new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.0,9.0.0
+     */
+    @ZAttr(id=2024)
+    public Map<String,Object> setDataSourceOAuthRefreshTokenUrl(String zimbraDataSourceOAuthRefreshTokenUrl, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDataSourceOAuthRefreshTokenUrl, zimbraDataSourceOAuthRefreshTokenUrl);
+        return attrs;
+    }
+
+    /**
+     * Url for refreshing OAuth Token
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.0,9.0.0
+     */
+    @ZAttr(id=2024)
+    public void unsetDataSourceOAuthRefreshTokenUrl() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDataSourceOAuthRefreshTokenUrl, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Url for refreshing OAuth Token
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.0,9.0.0
+     */
+    @ZAttr(id=2024)
+    public Map<String,Object> unsetDataSourceOAuthRefreshTokenUrl(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDataSourceOAuthRefreshTokenUrl, "");
+        return attrs;
+    }
+
+    /**
      * Read timeout in seconds
      *
      * @return zimbraDataSourceReadTimeout, or 60 if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -5450,6 +5450,222 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
+     * Client Id for OAuth token
+     *
+     * @return zimbraDataSourceOAuthClientId, or null if unset
+     *
+     * @since ZCS 8.7.0,9.0.0
+     */
+    @ZAttr(id=2021)
+    public String getDataSourceOAuthClientId() {
+        return getAttr(Provisioning.A_zimbraDataSourceOAuthClientId, null, true);
+    }
+
+    /**
+     * Client Id for OAuth token
+     *
+     * @param zimbraDataSourceOAuthClientId new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.0,9.0.0
+     */
+    @ZAttr(id=2021)
+    public void setDataSourceOAuthClientId(String zimbraDataSourceOAuthClientId) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDataSourceOAuthClientId, zimbraDataSourceOAuthClientId);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Client Id for OAuth token
+     *
+     * @param zimbraDataSourceOAuthClientId new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.0,9.0.0
+     */
+    @ZAttr(id=2021)
+    public Map<String,Object> setDataSourceOAuthClientId(String zimbraDataSourceOAuthClientId, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDataSourceOAuthClientId, zimbraDataSourceOAuthClientId);
+        return attrs;
+    }
+
+    /**
+     * Client Id for OAuth token
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.0,9.0.0
+     */
+    @ZAttr(id=2021)
+    public void unsetDataSourceOAuthClientId() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDataSourceOAuthClientId, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Client Id for OAuth token
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.0,9.0.0
+     */
+    @ZAttr(id=2021)
+    public Map<String,Object> unsetDataSourceOAuthClientId(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDataSourceOAuthClientId, "");
+        return attrs;
+    }
+
+    /**
+     * Client Secret for OAuth token
+     *
+     * @return zimbraDataSourceOAuthClientSecret, or null if unset
+     *
+     * @since ZCS 8.7.0,9.0.0
+     */
+    @ZAttr(id=2022)
+    public String getDataSourceOAuthClientSecret() {
+        return getAttr(Provisioning.A_zimbraDataSourceOAuthClientSecret, null, true);
+    }
+
+    /**
+     * Client Secret for OAuth token
+     *
+     * @param zimbraDataSourceOAuthClientSecret new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.0,9.0.0
+     */
+    @ZAttr(id=2022)
+    public void setDataSourceOAuthClientSecret(String zimbraDataSourceOAuthClientSecret) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDataSourceOAuthClientSecret, zimbraDataSourceOAuthClientSecret);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Client Secret for OAuth token
+     *
+     * @param zimbraDataSourceOAuthClientSecret new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.0,9.0.0
+     */
+    @ZAttr(id=2022)
+    public Map<String,Object> setDataSourceOAuthClientSecret(String zimbraDataSourceOAuthClientSecret, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDataSourceOAuthClientSecret, zimbraDataSourceOAuthClientSecret);
+        return attrs;
+    }
+
+    /**
+     * Client Secret for OAuth token
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.0,9.0.0
+     */
+    @ZAttr(id=2022)
+    public void unsetDataSourceOAuthClientSecret() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDataSourceOAuthClientSecret, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Client Secret for OAuth token
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.0,9.0.0
+     */
+    @ZAttr(id=2022)
+    public Map<String,Object> unsetDataSourceOAuthClientSecret(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDataSourceOAuthClientSecret, "");
+        return attrs;
+    }
+
+    /**
+     * Url for refreshing OAuth Token
+     *
+     * @return zimbraDataSourceOAuthRefreshTokenUrl, or null if unset
+     *
+     * @since ZCS 8.7.0,9.0.0
+     */
+    @ZAttr(id=2024)
+    public String getDataSourceOAuthRefreshTokenUrl() {
+        return getAttr(Provisioning.A_zimbraDataSourceOAuthRefreshTokenUrl, null, true);
+    }
+
+    /**
+     * Url for refreshing OAuth Token
+     *
+     * @param zimbraDataSourceOAuthRefreshTokenUrl new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.0,9.0.0
+     */
+    @ZAttr(id=2024)
+    public void setDataSourceOAuthRefreshTokenUrl(String zimbraDataSourceOAuthRefreshTokenUrl) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDataSourceOAuthRefreshTokenUrl, zimbraDataSourceOAuthRefreshTokenUrl);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Url for refreshing OAuth Token
+     *
+     * @param zimbraDataSourceOAuthRefreshTokenUrl new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.0,9.0.0
+     */
+    @ZAttr(id=2024)
+    public Map<String,Object> setDataSourceOAuthRefreshTokenUrl(String zimbraDataSourceOAuthRefreshTokenUrl, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDataSourceOAuthRefreshTokenUrl, zimbraDataSourceOAuthRefreshTokenUrl);
+        return attrs;
+    }
+
+    /**
+     * Url for refreshing OAuth Token
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.7.0,9.0.0
+     */
+    @ZAttr(id=2024)
+    public void unsetDataSourceOAuthRefreshTokenUrl() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDataSourceOAuthRefreshTokenUrl, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Url for refreshing OAuth Token
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.7.0,9.0.0
+     */
+    @ZAttr(id=2024)
+    public Map<String,Object> unsetDataSourceOAuthRefreshTokenUrl(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDataSourceOAuthRefreshTokenUrl, "");
+        return attrs;
+    }
+
+    /**
      * maximum aggregate quota for the domain in bytes
      *
      * @return zimbraDomainAggregateQuota, or 0 if unset


### PR DESCRIPTION
Requirement
---
We want to sync Zimbra calendar app to Google Calendar.

Fix
---
We will add OAuth2 authorization mechanism to CalDav Datasource.
In this PR, I'd like to modify the definition of existing ldap attributes.
We already have OAuth2 related ldap attributes since 8.7.0, but the scope are not appropriate.

1. zimbraDataSourceOAuthClientId - client_id is the id for each OAuth client application. This value should be stored in global config or domain level, rather than in each DataSource object.

1. zimbraDataSourceOAuthClientSecret - client_secret is a string used with client_id to identify the OAuth client application. This value should be stored in global config or domain level, rather than in the each DataSource object.

1. zimbraDataSourceOAuthRefreshTokenUrl - refresh token Url is the OAuth service endpoint which accept "refresh token" request. This value should be stored in global config or domain level, rather than in the each DataSource object.

1. zimbraDataSourceOAuthToken - This is for access_token, which is a token string to authorize the access to the hosted resources. This value should be stored for each user, so we should store it in DataSource object. access_token for Google services expires in 3600s. In large scale deployment, we should better to store it in the ephemeral storage.

1. zimbraDataSourceOAuthRefreshToken - Refresh token is a token string used to refresh access_token. This value should be stored for each user, and won't be updated often. We should store it in DataSource object. In this PR, I don't modify the definition of this attribute.

Testing done
---
Testing done by developer

Testing to be done by QA
---
Testing needed to be done by QA

Linked PR
---
NA