### PR TITLE
ZBUG-201:Case 00696446:Cannot manage users in Admin Console

### DIFF
--- a/store/src/java-test/com/zimbra/cs/service/admin/GetDomainEncodingTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/admin/GetDomainEncodingTest.java
@@ -1,0 +1,87 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.service.admin;
+
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.MethodRule;
+import org.junit.rules.TestName;
+
+import com.google.common.collect.Maps;
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.common.soap.Element;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Domain;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.service.mail.ServiceTestUtil;
+import com.zimbra.cs.util.ZTestWatchman;
+import com.zimbra.soap.SoapEngine;
+import com.zimbra.soap.ZimbraSoapContext;
+
+import junit.framework.Assert;
+
+public class GetDomainEncodingTest {
+
+    @Rule
+    public TestName testName = new TestName();
+    @Rule
+    public MethodRule watchman = new ZTestWatchman();
+
+    @Before
+    public void setUp() throws Exception {
+        System.out.println(testName.getMethodName());
+        MailboxTestUtil.initServer();
+        MailboxTestUtil.clearData();
+        Provisioning prov = Provisioning.getInstance();
+        Map<String, Object> attrs = Maps.newHashMap();
+        String[] values = new String[2];
+        values[0] = "ldap://ldap1.com";
+        values[1] = "ldap://ldap2.com";
+        attrs.put("zimbraAuthLdapURL", values);
+        prov.createDomain("zimbra.com", attrs);
+        attrs = Maps.newHashMap();
+        attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        prov.createAccount("test201@zimbra.com", "secret", attrs);
+    }
+
+    @Test
+    public void testZBUG201() throws Exception {
+        Account acct = Provisioning.getInstance().getAccountByName("test201@zimbra.com");
+        Domain domain = Provisioning.getInstance().getDomain(acct);
+        Map<String, Object> context = ServiceTestUtil.getRequestContext(acct);
+        ZimbraSoapContext zsc = (ZimbraSoapContext) context.get(SoapEngine.ZIMBRA_CONTEXT);
+        Element response = zsc.createElement(AdminConstants.GET_DOMAIN_RESPONSE);
+        GetDomain.encodeDomain(response, domain, true, null, null);
+        // check that the response contains single space separated value for zimbraAuthLdapURL
+        Assert.assertEquals(true, response.prettyPrint().contains("<a n=\"zimbraAuthLdapURL\">ldap://ldap1.com ldap://ldap2.com</a>"));
+    }
+
+    @After
+    public void tearDown() {
+        try {
+            MailboxTestUtil.clearData();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/service/admin/GetDomain.java
+++ b/store/src/java/com/zimbra/cs/service/admin/GetDomain.java
@@ -89,7 +89,12 @@ public class GetDomain extends AdminDocumentHandler {
         domain.addAttribute(AdminConstants.A_NAME,d.getUnicodeName());
         domain.addAttribute(AdminConstants.A_ID,d.getId());
         Map attrs = d.getUnicodeAttrs(applyConfig);
-        
+        Object value = attrs.get(Provisioning.A_zimbraAuthLdapURL);
+		if (value != null && value instanceof String[]) {
+			String sv[] = (String[]) value;
+			String joinedValue = String.join(" ", sv);
+			attrs.put(Provisioning.A_zimbraAuthLdapURL, joinedValue);
+		}
         ToXML.encodeAttrs(domain, attrs, reqAttrs, attrRightChecker);
     }
     


### PR DESCRIPTION
encodeDomain is changed to encode 'zimbraAuthLdapURL' as single value containing multiple values separated by space instead of encoding it as multiple attributes.

Added Junit test
ant test-all passed