### PR TITLE
ZCS-4590: Various Solr Bug Fixes

### DIFF
--- a/store/src/java/com/zimbra/cs/index/LuceneQueryOperation.java
+++ b/store/src/java/com/zimbra/cs/index/LuceneQueryOperation.java
@@ -131,19 +131,16 @@ public final class LuceneQueryOperation extends QueryOperation {
     private void updateBoolQuery(BooleanClause newClause) {
         BooleanQuery.Builder newQuery = new BooleanQuery.Builder();
         newQuery.add(newClause);
-        if (luceneQuery == null) {
-            luceneQuery = newQuery.build();
-        }
-        if (luceneQuery instanceof BooleanQuery) {
+        if (luceneQuery != null && luceneQuery instanceof BooleanQuery) {
             for (BooleanClause clause: ((BooleanQuery) luceneQuery).clauses()) {
                 newQuery.add(clause);
             }
-            luceneQuery = newQuery.build();
-        } else {
+        } else if (luceneQuery != null) {
             newQuery.add(luceneQuery, Occur.MUST);
-            luceneQuery = newQuery.build();
         }
+        luceneQuery = newQuery.build();
     }
+
     /**
      * Adds the specified text clause ANDED with the existing query.
      * <p>

--- a/store/src/java/com/zimbra/cs/index/LuceneQueryOperation.java
+++ b/store/src/java/com/zimbra/cs/index/LuceneQueryOperation.java
@@ -21,16 +21,12 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Set;
 
-import org.apache.lucene.document.Document;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.BooleanQuery.Builder;
-import org.apache.lucene.search.MultiPhraseQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
@@ -40,12 +36,10 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Sets;
 import com.google.common.io.Closeables;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
-import com.zimbra.cs.index.ZimbraIndexReader.TermFieldEnumeration;
 import com.zimbra.cs.mailbox.Folder;
 import com.zimbra.cs.mailbox.MailItem;
 import com.zimbra.cs.mailbox.Mailbox;
@@ -362,16 +356,23 @@ public final class LuceneQueryOperation extends QueryOperation {
             }
         }
         if (hasMustNotClause) {
-            builder.add(new TermQuery(new Term(LuceneFields.L_PARTNAME, LuceneFields.L_PARTNAME_TOP)),
-                    BooleanClause.Occur.SHOULD);
+            List<Query> topLevelClauses = new ArrayList<>();
+            topLevelClauses.add(new TermQuery(new Term(LuceneFields.L_PARTNAME, LuceneFields.L_PARTNAME_TOP)));
             Set<MailItem.Type> types = context.getParams().getTypes();
             if (types.contains(MailItem.Type.CONTACT)) {
-                builder.add(new TermQuery(new Term(LuceneFields.L_PARTNAME, LuceneFields.L_PARTNAME_CONTACT)),
-                        BooleanClause.Occur.SHOULD);
+                topLevelClauses.add(new TermQuery(new Term(LuceneFields.L_PARTNAME, LuceneFields.L_PARTNAME_CONTACT)));
             }
             if (types.contains(MailItem.Type.NOTE)) {
-                builder.add(new TermQuery(new Term(LuceneFields.L_PARTNAME, LuceneFields.L_PARTNAME_NOTE)),
-                        BooleanClause.Occur.SHOULD);
+                topLevelClauses.add(new TermQuery(new Term(LuceneFields.L_PARTNAME, LuceneFields.L_PARTNAME_NOTE)));
+            }
+            if (topLevelClauses.size() == 1) {
+                builder.add(topLevelClauses.get(0), Occur.MUST);
+            } else {
+                BooleanQuery.Builder topLevelClauseBuilder = new BooleanQuery.Builder();
+                for (Query topLevelClauseQuery: topLevelClauses) {
+                    topLevelClauseBuilder.add(topLevelClauseQuery, Occur.SHOULD);
+                }
+                builder.add(topLevelClauseBuilder.build(), Occur.MUST);
             }
         }
         return builder.build();

--- a/store/src/java/com/zimbra/cs/index/ProxiedQueryResults.java
+++ b/store/src/java/com/zimbra/cs/index/ProxiedQueryResults.java
@@ -246,6 +246,7 @@ public final class ProxiedQueryResults extends ZimbraQueryResultsImpl {
 
         searchParams.setOffset(bufferStartOffset);
         searchParams.setLimit(chunkSizeToUse);
+        searchParams.setLogSearch(false);
         searchParams.encodeParams(searchElt);
         if (singleShotRemoteRequest && (searchParams.getCursor() != null)) {
             Element cursorElt = searchElt.addElement(MailConstants.E_CURSOR);

--- a/store/src/java/com/zimbra/cs/index/SearchParams.java
+++ b/store/src/java/com/zimbra/cs/index/SearchParams.java
@@ -122,6 +122,7 @@ public final class SearchParams implements Cloneable, ZimbraSearchParams {
     private boolean prefetch = true;
     private Fetch fetch = Fetch.NORMAL;
     private boolean quick = false; // whether or not to skip the catch-up index prior to search
+    private boolean logSearch = true; // whether or not to log the search in search history
 
     public boolean isQuick() {
         return quick;
@@ -461,6 +462,10 @@ public final class SearchParams implements Cloneable, ZimbraSearchParams {
         this.wantContent = wantContent;
     }
 
+    public void setLogSearch(boolean logSearch) {
+        this.logSearch = logSearch;
+    }
+
     /**
      * Encode the necessary parameters into a {@code <SearchRequest>} (or similar element) in cases where we have to
      * proxy a search request over to a remote server.
@@ -527,6 +532,7 @@ public final class SearchParams implements Cloneable, ZimbraSearchParams {
         if (getWantContent() != null) {
             el.addAttribute(MailConstants.A_WANT_CONTENT, getWantContent().toString());
         }
+        el.addAttribute(MailConstants.A_LOG_SEARCH, logSearch);
 
         // skip cursor data
     }

--- a/store/src/java/com/zimbra/cs/index/query/Query.java
+++ b/store/src/java/com/zimbra/cs/index/query/Query.java
@@ -73,6 +73,20 @@ public abstract class Query {
             }
         throw new IllegalArgumentException(string + " is not a valid comparison");
         }
+
+        public static Comparison fromPrefix(String text) {
+            if (text.startsWith(Comparison.LE.symbol)) {
+                return Comparison.LE;
+            } else if (text.startsWith(Comparison.LT.symbol)) {
+                return Comparison.LT;
+            } else if (text.startsWith(Comparison.GE.symbol)) {
+                return Comparison.GE;
+            } else if (text.startsWith(Comparison.GT.symbol)) {
+                return Comparison.GT;
+            } else {
+                return null;
+            }
+        }
     }
 
     private static final Map<String, String> LUCENE2QUERY =
@@ -212,5 +226,4 @@ public abstract class Query {
      * Returns true if this query has at least one text query, false if it's entirely DB query.
      */
     public abstract boolean hasTextOperation();
-
 }

--- a/store/src/java/com/zimbra/cs/index/query/SenderQuery.java
+++ b/store/src/java/com/zimbra/cs/index/query/SenderQuery.java
@@ -36,17 +36,7 @@ public final class SenderQuery extends Query {
      * {@link TextQuery}.
      */
     private SenderQuery(String text) {
-        if (text.startsWith(Comparison.LE.toString())) {
-            comparison = Comparison.LE;
-        } else if (text.startsWith(Comparison.LT.toString())) {
-            comparison = Comparison.LT;
-        } else if (text.startsWith(Comparison.GE.toString())) {
-            comparison = Comparison.GE;
-        } else if (text.startsWith(Comparison.GT.toString())) {
-            comparison = Comparison.GT;
-        } else {
-            throw new IllegalArgumentException(text);
-        }
+        comparison = Comparison.fromPrefix(text);
         sender = text.substring(comparison.toString().length());
     }
 

--- a/store/src/java/com/zimbra/cs/index/solr/SolrIndex.java
+++ b/store/src/java/com/zimbra/cs/index/solr/SolrIndex.java
@@ -183,7 +183,7 @@ public class SolrIndex extends IndexStore {
                     if (SolrUtils.containsWhitespace(term)) {
                         return new TermQuery(new Term(field, SolrUtils.quoteText(term)));
                     } else {
-                        return new TermQuery(new Term(field,"+"+term));
+                        return new TermQuery(new Term(field, term));
                     }
                 } else {
                     if (SolrUtils.containsWhitespace(term)) {
@@ -210,9 +210,7 @@ public class SolrIndex extends IndexStore {
             Query clauseQuery = clause.getQuery();
             String op = "";
             occur = clause.getOccur();
-            if (occur == Occur.MUST) {
-                op = "+";
-            } else if (occur == Occur.MUST_NOT) {
+            if (occur == Occur.MUST_NOT) {
                 op = "-";
             }
             if (clauseQuery instanceof TermQuery) {
@@ -310,7 +308,8 @@ public class SolrIndex extends IndexStore {
           include the reversed tokens in the facet results */
         if (origField.equals(LuceneFields.L_H_FROM) ||
                 origField.equals(LuceneFields.L_H_TO) ||
-                origField.equals(LuceneFields.L_H_CC)) {
+                origField.equals(LuceneFields.L_H_CC) ||
+                origField.equals(LuceneFields.L_FILENAME)) {
             return origField + "_search";
         }
         else {

--- a/store/src/java/com/zimbra/cs/mailbox/MailboxIndex.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailboxIndex.java
@@ -193,6 +193,9 @@ public final class MailboxIndex {
      * @throws ServiceException
      */
     public boolean existsInContacts(Collection<InternetAddress> addrs) throws IOException, ServiceException {
+        if (addrs.isEmpty()) {
+            return false;
+        }
         ZimbraIndexSearcher searcher = indexStore.openSearcher();
         try {
             BooleanQuery.Builder builder = new BooleanQuery.Builder();


### PR DESCRIPTION
This PR encompasses several small bugfixes for issues found while investigating Solr-related test failures described in https://jira.corp.synacor.com/browse/ZCS-4590.

#### ZCS-4596: Subject Range Queries
The `SubjectQuery` class that was pulled in from the original Solr repo was unfinished. Specifically, handling of range queries like `subject:<foo` no longer worked as the `SubjectQuery::create` static method never always received a `null` for the `Query.Comparison` parameter. While it is unclear why this was changed, the fix is straightforward: parse the proper `Comparison` enum from the search string and handle it appropriately.
This resolves the `MailClient/Search/Basic/search_subject_string_comparison.xml` soap test.

#### ZCS-4606: Negative Queries
Negative queries like `not foo` trigger an NPE in the search code due to the query returning search history items from the index. When a query has a negation clause, it is rewritten with the `LuceneQueryOperation::fixMustNotOnly` method to include a "catch-all" clause that matches all MIME documents of the appropriate type, so that the negated query can be subtracted from it. The issue was that this clauses was added with a SHOULD condition, which makes it possible for search history documents to matches as well. The solution was to update this method to add the top-level cause with a MUST condition instead.
I also noticed that search clauses were being doubled-up somewhere along the query compilation step. While this didn't seem to introduce any apparent problems, I tracked this down to a small bug in the `LuceneQueryOperation::updateBoolQuery` method.
This fix resolves the `MailClient/Search/Negate/Folder/Mountpoints/negate_content.xml` soap test.

#### ZCS-4603: Solr syntax error
This bug was caused by the `MailboxIndex::existsInContacts` method sending an empty query `()` to Solr. This method was recently rewritten to use facets instead of term enumerations, but was missing logic to handle an empty list. Short-circuiting the method if the passed-in list is empty resolves the`MailClient/Filters/Bugs/bug37018.xml` soap test.

#### ZCS-4604: Search History for Proxied Searches
The error reported in this ticket was caused by a search on a remote mailbox attempting to log a search history entry for a search string that had not been registered. This actually pointed to a serious but easily resolvable flaw with the search history mechanism - if _user1_ shares a folder with _user2_, _user2_'s search history would include _user1_'s searches (if this error wasn't thrown). Luckily, there already exists a mechanism for a client to explicitly disallow a search request from logging in search history via the `logSearch` boolean parameter; this bug is resolved setting this to `false` when querying a remote mailbox through the `ProxiedQueryResults` class.
With this fix, the soap tests in `MailClient/Folders/Sharing/Bugs/bugs.xml` no longer result in errors, although `Bug_23590` still fails. I am unable to reproduce this bug locally, which suggests that the failure is now caused by the timing issue described in https://jira.corp.synacor.com/browse/ZCS-4628.

#### ZCS-4597: Queries with stopwords return no results
The name of this ticket is "Search query with long data in it fails", which is actually misleading - the difference between successful and unsuccessful searches is that the failed ones contain stopwords. It tracked this down to a problem in how we are rewriting a simple text query into a query that targets multiple fields (`l.content`, `subject`, `to_search`, `from_search`, `cc_search`, `filename`) using the `edismax` query parser.  There were two issues:
- It turns out there is a known issue when an `edismax` query targets fields with inconsistent stopword handling (https://issues.apache.org/jira/browse/SOLR-3085). Indeed, the `l.content` field drop stopwords while the `*_search` fields don't. The fix involves adding a stopword filter to those fields in the solr schema (see https://github.com/Zimbra/zm-solr/pull/8)
- When composing the edismax query, a "+" was being appended to each of the terms that must be included. This was unnecessary, since the `mm` (must match) parameter is set to 100%, ensuring this is the case. The presence of these plus signs may have been affecting how the query was parsed.

Note: to test these fixes against the original test cases, I rebased this branch on top of `feature/ha-combined` and deployed a `zm-docker` container with an updated build config that points to the rebased copy of this branch.