### PR TITLE
Bugfix/zcs 4691 failed mailbox unlocks

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -173,6 +173,12 @@ public final class LC {
     @Reloadable
     public static final KnownKey zimbra_mailbox_lock_timeout = KnownKey.newKey(60); // seconds
 
+    @Reloadable
+    public static final KnownKey zimbra_mailbox_lock_read_lease_seconds = KnownKey.newKey(300); /* 5 min */
+
+    @Reloadable
+    public static final KnownKey zimbra_mailbox_lock_write_lease_seconds = KnownKey.newKey(120); /* 2 min */
+
     public static final KnownKey zimbra_mailbox_lock_readwrite = KnownKey.newKey(true);
 
     @Supported

--- a/store/src/java/com/zimbra/cs/mailbox/DistributedMailboxLockFactory.java
+++ b/store/src/java/com/zimbra/cs/mailbox/DistributedMailboxLockFactory.java
@@ -3,6 +3,7 @@ package com.zimbra.cs.mailbox;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.redisson.api.RLock;
 import org.redisson.api.RReadWriteLock;
@@ -18,6 +19,7 @@ import com.zimbra.common.mailbox.MailboxLockFactory;
 import com.zimbra.common.util.ZimbraLog;
 
 public class DistributedMailboxLockFactory implements MailboxLockFactory {
+    private static AtomicInteger lockIdBase = new AtomicInteger();
     private final Mailbox mailbox;
     private final RedissonClient redisson;
     private RReadWriteLock readWriteLock;
@@ -92,20 +94,26 @@ public class DistributedMailboxLockFactory implements MailboxLockFactory {
      */
     public class DistributedMailboxLock implements MailboxLock {
         private final RReadWriteLock rwLock;
+        private final int id;
+        private final long start;
         private boolean write;
         private RLock lock;
         private final int initialReadHoldCount;
         private final int initialWriteHoldCount;
+        private final String where = ZimbraLog.getStackTrace(10);
 
         private DistributedMailboxLock(final RReadWriteLock readWriteLock, final boolean write) {
             this.rwLock = readWriteLock;
             this.write = write;
             this.lock = this.write ? readWriteLock.writeLock() : readWriteLock.readLock();
+            id = lockIdBase.incrementAndGet();
+            if (id >= 0xffff) {
+                lockIdBase.set(1);  // restricting to +ve integers keeps hex short
+            }
+            start = System.currentTimeMillis();
             initialReadHoldCount = readWriteLock.readLock().getHoldCount();
             initialWriteHoldCount = readWriteLock.writeLock().getHoldCount();
-            if (ZimbraLog.mailboxlock.isTraceEnabled()) {
-                ZimbraLog.mailboxlock.trace("constructor %s\n%s", this, ZimbraLog.getStackTrace(10));
-            }
+            ZimbraLog.mailboxlock.info("constructor %s", this);
         }
 
         public DistributedMailboxLock createAndAcquireWriteLock(final RReadWriteLock rReadWriteLock) {
@@ -166,22 +174,26 @@ public class DistributedMailboxLockFactory implements MailboxLockFactory {
             }
         }
 
+        private long leaseSeconds() {
+            return write ? LC.zimbra_mailbox_lock_write_lease_seconds.longValue() :
+                LC.zimbra_mailbox_lock_read_lease_seconds.longValue();
+        }
+
         private boolean tryLock() throws InterruptedException {
-            long start = System.currentTimeMillis();
-            boolean result = this.lock.tryLock(0, TimeUnit.SECONDS);
+            boolean result = this.lock.tryLock(0, leaseSeconds(), TimeUnit.SECONDS);
             if (ZimbraLog.mailboxlock.isTraceEnabled()) {
-                ZimbraLog.mailboxlock.trace("tryLock result=%s %s %s\n%s", result, this,
-                        ZimbraLog.elapsedSince(start), ZimbraLog.getStackTrace(16));
+                ZimbraLog.mailboxlock.trace("tryLock result=%s %s\n%s", result, this,
+                        ZimbraLog.getStackTrace(16));
             }
             return result;
         }
 
         private boolean tryLockWithTimeout() throws InterruptedException {
-            long start = System.currentTimeMillis();
-            boolean result = this.lock.tryLock(LC.zimbra_mailbox_lock_timeout.intValue(), TimeUnit.SECONDS);
+            boolean result = this.lock.tryLock(LC.zimbra_mailbox_lock_timeout.intValue(), leaseSeconds(),
+                    TimeUnit.SECONDS);
             if (ZimbraLog.mailboxlock.isTraceEnabled()) {
-                ZimbraLog.mailboxlock.trace("tryLockWithTimeout result=%s %s %s\n%s", result,
-                        this, ZimbraLog.elapsedSince(start), ZimbraLog.getStackTrace(16));
+                ZimbraLog.mailboxlock.trace("tryLockWithTimeout result=%s %s\n%s", result, this,
+                        ZimbraLog.getStackTrace(16));
             }
             return result;
         }
@@ -199,7 +211,8 @@ public class DistributedMailboxLockFactory implements MailboxLockFactory {
                     iters--;
                 }
             } catch (IllegalMonitorStateException imse) {
-                ZimbraLog.mailboxlock.info("closing writelocks problem (ignoring)", imse);
+                /* most likely cause is that the lease on the lock has run out */
+                ZimbraLog.mailboxlock.info("closing writelocks problem (ignoring) %s", this, imse);
             }
             iters = rwLock.readLock().getHoldCount() - initialReadHoldCount;
             try {
@@ -208,7 +221,8 @@ public class DistributedMailboxLockFactory implements MailboxLockFactory {
                     iters--;
                 }
             } catch (IllegalMonitorStateException imse) {
-                ZimbraLog.mailboxlock.info("closing readlocks problem (ignoring)", imse);
+                /* most likely cause is that the lease on the lock has run out */
+                ZimbraLog.mailboxlock.info("closing readlocks problem (ignoring) %s", this, imse);
             }
             /* If we upgraded to a write lock, we may need to reinstate a read lock, that we released */
             iters = initialReadHoldCount - rwLock.readLock().getHoldCount();
@@ -222,8 +236,11 @@ public class DistributedMailboxLockFactory implements MailboxLockFactory {
                 }
                 iters--;
             }
-            if (ZimbraLog.mailboxlock.isTraceEnabled()) {
-                ZimbraLog.mailboxlock.trace("close[END] %s", this);
+            if ((System.currentTimeMillis() - start) > (15 * 1000)) {
+                /* Took a long time.  Log where got constructed. */
+                ZimbraLog.mailboxlock.info("close() LONG-LOCK %s\n%s", this, where);
+            } else {
+                ZimbraLog.mailboxlock.info("close() %s", this);
             }
         }
 
@@ -301,26 +318,47 @@ public class DistributedMailboxLockFactory implements MailboxLockFactory {
             }
         }
 
+        private String toString(RLock lck) {
+            ToStringHelper helper = Objects.toStringHelper(lck);
+            if (lck.isLocked()) {
+                helper.add("locked", lck.isLocked());
+            }
+            if (lck.getHoldCount() != 0) {
+                helper.add("holds", lck.getHoldCount());
+            }
+            if (!lck.isExists()) {
+                helper.add("exists", lck.isExists());
+            }
+            if (lck.remainTimeToLive() == -1) {
+                helper.add("ttl", "forever");
+            } else if (lck.remainTimeToLive() != -2 /* -2 means key does not exist */) {
+                helper.add("ttl", lck.remainTimeToLive());
+            }
+            return helper.toString();
+        }
+
+        private String toString(RReadWriteLock lck) {
+            ToStringHelper helper = Objects.toStringHelper(lck)
+                .add("name", lck.getName());
+            if (lck.remainTimeToLive() == -1) {
+                helper.add("ttl", "forever");
+            } else if (lck.remainTimeToLive() != -2 /* -2 means key does not exist */) {
+                helper.add("ttl", lck.remainTimeToLive());
+            }
+            helper.add("read", toString(lck.readLock()));
+            helper.add("write", toString(lck.writeLock()));
+            return helper.toString();
+        }
+
         @Override
         public String toString() {
             ToStringHelper helper = Objects.toStringHelper(this)
+                .add("id", Integer.toHexString(id))
                 .add("write", write)
-                .add("rwLock", rwLock)
-                .add("lock", String.format("(%s class=%s)", lock.getName(), lock.getClass().getName()));
-            boolean isLocked;
-            int hCount;
-            isLocked = rwLock.readLock().isLocked();
-            hCount = rwLock.readLock().getHoldCount();
-            if (isLocked || hCount != 0) {
-                helper.add("readLock", String.format("(locked=%s holds=%d)", isLocked, hCount));
-            }
-            isLocked = rwLock.writeLock().isLocked();
-            hCount = rwLock.writeLock().getHoldCount();
-            if (isLocked || hCount != 0) {
-                helper.add("writeLock", String.format("(locked=%s holds=%d)", isLocked, hCount));
-            }
+                .add("rwLock", toString(rwLock));
             addIfNot(helper, "initialReadHoldCount", 0, initialReadHoldCount);
             addIfNot(helper, "initialWriteHoldCount", 0, initialWriteHoldCount);
+            helper.addValue(ZimbraLog.elapsedSince(start));
             return helper.toString();
         }
     }

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -1105,42 +1105,47 @@ public class Mailbox implements MailboxStore {
             return;
         }
         assert(session.getSessionId() != null);
+        if (maintenance != null) {
+            throw MailServiceException.MAINTENANCE(mId);
+        }
+        ZimbraLog.mailbox.debug("adding listener: %s", session);
+        if (!mListeners.contains(session)) {
+            mListeners.add(session);
+        }
+        /* check whether beginMaintenance happened whilst adding a listener.  If it did then
+         * undo it.  This avoids getting a write lock */
+        if (maintenance != null) {
+            purgeListeners();
+            throw MailServiceException.MAINTENANCE(mId);
+        }
+        if (!Zimbra.isAlwaysOn()) {
+            return;
+        }
+        // Rest done only if AlwaysOn
         try (final MailboxLock l = getWriteLockAndLockIt()) {
-            if (maintenance != null) {
-                throw MailServiceException.MAINTENANCE(mId);
-            }
-            if (!mListeners.contains(session)) {
-                mListeners.add(session);
-            }
-
-            if (Zimbra.isAlwaysOn()) {
-                if (mListeners.size() == 1) {
-                    // insert session into DB
-                    DbConnection conn = DbPool.getConnection();
-                    try {
-                        MailboxStore sessMbox = session.getMailbox();
-                        if (sessMbox instanceof Mailbox) {
-                            DbSession.create(conn, ((Mailbox)sessMbox).getId(), Provisioning.getInstance()
-                                            .getLocalServer().getId());
-                        } else {
-                            throw new UnsupportedOperationException(String.format(
-                                    "Operation not supported for non-Mailbox MailboxStore",
-                                    sessMbox == null ? "null" : sessMbox.getClass().getName()));
-                        }
-                        conn.commit();
-                    } catch (ServiceException e) {
-                        ZimbraLog.session.info("exception while inserting session into DB", e);
-                    } finally {
-                        if (conn != null) {
-                            conn.closeQuietly();
-                        }
+            if (mListeners.size() == 1) {
+                // insert session into DB
+                DbConnection conn = DbPool.getConnection();
+                try {
+                    MailboxStore sessMbox = session.getMailbox();
+                    if (sessMbox instanceof Mailbox) {
+                        DbSession.create(conn, ((Mailbox)sessMbox).getId(), Provisioning.getInstance()
+                                .getLocalServer().getId());
+                    } else {
+                        throw new UnsupportedOperationException(String.format(
+                                "Operation not supported for non-Mailbox MailboxStore",
+                                sessMbox == null ? "null" : sessMbox.getClass().getName()));
                     }
-                    //
+                    conn.commit();
+                } catch (ServiceException e) {
+                    ZimbraLog.session.info("exception while inserting session into DB", e);
+                } finally {
+                    if (conn != null) {
+                        conn.closeQuietly();
+                    }
                 }
             }
         }
-
-        ZimbraLog.mailbox.debug("adding listener: %s", session);
     }
 
     /** Removes a {@link Session} from the set of listeners notified on
@@ -1148,30 +1153,30 @@ public class Mailbox implements MailboxStore {
      *
      * @param session  The listener to deregister for notifications. */
     public void removeListener(Session session) {
+        if (ZimbraLog.mailbox.isDebugEnabled()) {
+            ZimbraLog.mailbox.debug("clearing listener: %s", session);
+        }
+        mListeners.remove(session);
+        if (!Zimbra.isAlwaysOn()) {
+            return;
+        }
+        // Rest done only if AlwaysOn
         try (final MailboxLock l = getWriteLockAndLockIt()) {
-            mListeners.remove(session);
-
-            if (Zimbra.isAlwaysOn()) {
-                if (mListeners.size() == 0) {
-                    // DbSessions Cleanup
-                    DbConnection conn = null;
-                    try {
-                        conn = DbPool.getConnection();
-                        DbSession.delete(conn, getId(), Provisioning.getInstance().getLocalServer().getId());
-                        conn.commit();
-                    } catch (ServiceException e) {
-                        ZimbraLog.mailbox.error("Deleting database session: ", e);
-                    } finally {
-                        if (conn != null) {
-                            conn.closeQuietly();
-                        }
+            if (mListeners.size() == 0) {
+                // DbSessions Cleanup
+                DbConnection conn = null;
+                try {
+                    conn = DbPool.getConnection();
+                    DbSession.delete(conn, getId(), Provisioning.getInstance().getLocalServer().getId());
+                    conn.commit();
+                } catch (ServiceException e) {
+                    ZimbraLog.mailbox.error("Deleting database session: ", e);
+                } finally {
+                    if (conn != null) {
+                        conn.closeQuietly();
                     }
                 }
             }
-        }
-
-        if (ZimbraLog.mailbox.isDebugEnabled()) {
-            ZimbraLog.mailbox.debug("clearing listener: " + session);
         }
     }
 


### PR DESCRIPTION
Discovered that if you don't set a lease time for locks (we don't currently) then the default is 30 seconds.  Made changes to use longer lease times.  Also added diagnostics so that we can get a feel for how long we actually do locks.  Lock objects get an id so that can track their behavior.  At least temporarily, logging some stuff at info level.  Still need robustness against failed unlocks in case we go past the lease times.
The other listener related change is slightly speculative and needs a good review to make sure logic is OK for competing threads entering/leaving maintenance and adding/removing listeners.