### PR TITLE
ZCS-4455: DbLogWriter Connection Handling

### DIFF
--- a/store/src/java-test/com/zimbra/cs/redolog/logger/DbLogWriterTest.java
+++ b/store/src/java-test/com/zimbra/cs/redolog/logger/DbLogWriterTest.java
@@ -43,7 +43,6 @@ public class DbLogWriterTest {
     @Test
     public void openCloseLog() throws Exception {
         logWriter.open();
-        assertTrue("Connection is open successfully", logWriter.isOpen());
         assertTrue("Table has to have header in place when open the redolog first time",
                 (logWriter.getSize() == LogHeader.HEADER_LEN));
 
@@ -57,7 +56,6 @@ public class DbLogWriterTest {
         assertEquals("file size incorrect.", LogHeader.HEADER_LEN + 10, logWriter.getSize());
 
         logWriter.close();
-        assertFalse("Connection was closed successfully", logWriter.isOpen());
 
         // store some fields from the current writer.
         final long createTime = logWriter.getCreateTime();
@@ -177,7 +175,7 @@ public class DbLogWriterTest {
         InputStream headerData = DbDistibutedRedolog.getHeaderOp(conn);
         byte header[] = new byte[LogHeader.HEADER_LEN];
         headerData.read(header, 0, LogHeader.HEADER_LEN);
-        header[versionLocation] = (byte) ((short)header[versionLocation] + 1);
+        header[versionLocation] = (byte) (header[versionLocation] + 1);
         DbDistibutedRedolog.clearRedolog(conn);
         DbDistibutedRedolog.logOp(conn, OpType.HEADER, new ByteArrayInputStream(header));
         conn.commit();

--- a/store/src/java/com/zimbra/cs/redolog/logger/LogWriter.java
+++ b/store/src/java/com/zimbra/cs/redolog/logger/LogWriter.java
@@ -63,7 +63,7 @@ public interface LogWriter {
 	 * @throws IOException
 	 */
 	public void log(RedoableOp op, InputStream data, boolean synchronous) throws IOException;
-    
+
     /**
      * Make sure all writes are committed to disk, or whatever the log
      * destination medium is.  This is mainly useful only when we need to
@@ -78,7 +78,7 @@ public interface LogWriter {
 	 * Returns the current size of the log.  Used for rollover tracking.
 	 * @return
 	 */
-	public long getSize();
+	public long getSize() throws IOException;
 
 	/**
 	 * Returns the time of the log creation.
@@ -123,7 +123,7 @@ public interface LogWriter {
 	 * if open.
 	 * @return true if and only if the deletion succeeded; false otherwise
 	 */
-	public boolean delete();
+	public boolean delete() throws IOException;
 
     /**
      * Performs log rollover.


### PR DESCRIPTION
This PR addresses a problem with The `DbLogWriter` class, hopefully resolving the `com.zimbra.cs.redolog.logger.DbLogWriter com.zimbra.cs.redolog.logger.DbLogWriter failed` error.

Prior to this change, `DbLogWriter` maintained a single `DbConnection` instance in the `conn` variable. This connection was created at `RedoLogManager` startup and only closed in the `stop` method, which is only called during system shutdown. This connection was responsible for handling all DB calls for the duration of the `DbLogWriter` lifetime; it is entirely possible that the intermittent error is due to it timing out or being otherwise corrupted.

This change makes it so that every database call in this class uses a new `DbConnection` instance (for reference, this is how all other DB-bound classes function). For convenience, this is done via a new inner class `DbLogWriterConn`, which implements `Closeable` so that the methods can use a try-with-resources block. 

A side effect of the previous design was that the `DbLogWriter::log` and `getSize` methods had to be synchronized. With this update, this is no longer the case. Lastly, several instances of `RuntimeException` being thrown has been removed, replaced by an `IOException` declared at the interface level.