### PR TITLE
ZCS-4755: ID synchronization via Redis

### DIFF
--- a/store/src/java-test/com/zimbra/cs/mailbox/InMemoryIdProvider.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/InMemoryIdProvider.java
@@ -1,0 +1,43 @@
+package com.zimbra.cs.mailbox;
+
+public class InMemoryIdProvider extends IdProvider {
+
+    public InMemoryIdProvider(Mailbox mbox) {
+        super(mbox);
+    }
+
+    @Override
+    protected SynchronizedId initId(IdType idType) {
+        return new InMemoryId();
+    }
+
+    private static class InMemoryId implements IdProvider.SynchronizedId {
+
+        private int value;
+
+        @Override
+        public int value() {
+            return value;
+        }
+
+        @Override
+        public void increment(int delta) {
+            value += delta;
+
+        }
+
+        @Override
+        public int setIfNotExists(int value) {
+            this.value = value;
+            return value;
+        }
+    }
+
+    public static class Factory implements IdProvider.Factory {
+
+        @Override
+        public IdProvider getIdProvider(Mailbox mbox) {
+            return new InMemoryIdProvider(mbox);
+        }
+    }
+}

--- a/store/src/java-test/com/zimbra/cs/mailbox/MailboxTestUtil.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/MailboxTestUtil.java
@@ -163,7 +163,7 @@ public final class MailboxTestUtil {
 
         MailboxManager.setInstance(null);
         IndexStore.setFactory(LC.zimbra_class_index_store_factory.value());
-
+        IdProvider.setFactory(new InMemoryIdProvider.Factory());
         LC.zimbra_class_store.setDefault(storeManagerClass.getName());
         StoreManager.getInstance().startup();
     }
@@ -183,6 +183,7 @@ public final class MailboxTestUtil {
         //use EmbeddedSolrIndex for indexing, because Solr webapp is nor running
         Provisioning.getInstance().getLocalServer().setIndexURL("embeddedsolr:local");
         IndexStore.setFactory(EmbeddedSolrIndex.Factory.class.getName());
+        IdProvider.setFactory(new InMemoryIdProvider.Factory());
 
         MailboxManager.setInstance(null);
 

--- a/store/src/java/com/zimbra/cs/mailbox/IdProvider.java
+++ b/store/src/java/com/zimbra/cs/mailbox/IdProvider.java
@@ -1,0 +1,82 @@
+package com.zimbra.cs.mailbox;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * Abstract class used for ensuring monotonically increasing IDs in a distributed environment
+ * @author iraykin
+ */
+public abstract class IdProvider {
+
+    private static Factory factory;
+    private Map<IdType, SynchronizedId> idMap = new HashMap<>();
+
+    protected static enum IdType {
+        ITEM_ID, SEARCH_ID, CHANGE_ID;
+    }
+
+    protected static interface SynchronizedId {
+
+        /**
+         * Get the current value of the ID
+         */
+        int value();
+
+        /**
+         * Increment the value of the ID by the given delta
+         */
+        void increment(int delta);
+
+        /**
+         * If the ID is unset, set it to the given value.
+         * @return the ID value
+         */
+        int setIfNotExists(int value);
+    }
+
+    protected Mailbox mbox;
+
+    public IdProvider(Mailbox mbox) {
+        this.mbox = mbox;
+        init();
+    }
+
+    protected void init() {
+        for (IdType idType: IdType.values()) {
+            idMap.put(idType, initId(idType));
+        }
+    }
+
+    public static void setFactory(Factory factory) {
+        IdProvider.factory = factory;
+    }
+
+    public static Factory getFactory() {
+        return factory;
+    }
+
+    protected abstract SynchronizedId initId(IdType idType);
+
+    private SynchronizedId getId(IdType idType) {
+        return idMap.get(idType);
+    }
+
+    public IdProvider.SynchronizedId getItemId() {
+        return getId(IdType.ITEM_ID);
+    }
+
+    public IdProvider.SynchronizedId getSearchId() {
+        return getId(IdType.SEARCH_ID);
+    }
+
+    public IdProvider.SynchronizedId getChangeId() {
+        return getId(IdType.CHANGE_ID);
+    }
+
+    public static interface Factory {
+
+        public IdProvider getIdProvider(Mailbox mbox);
+    }
+}

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -420,6 +420,8 @@ public class Mailbox implements MailboxStore {
         final List<Object> otherDirtyStuff = new LinkedList<Object>();
         PendingDelete deletes = null;
         private boolean writeChange;
+        private int itemIdDelta = 0;
+        private int searchIdDelta = 0;
 
         MailboxChange() {
         }
@@ -539,6 +541,8 @@ public class Mailbox implements MailboxStore {
             this.dirty.clear();
             this.otherDirtyStuff.clear();
             threadChange.remove();
+            this.itemIdDelta = 0;
+            this.searchIdDelta = 0;
 
             ZimbraLog.mailbox.debug("clearing change");
         }
@@ -772,7 +776,7 @@ public class Mailbox implements MailboxStore {
     private static final int MAX_MSGID_CACHE = 10;
 
     private final int mId;
-    private MailboxData mData;
+    MailboxData mData;
     private final ThreadLocal<MailboxChange> threadChange = new ThreadLocal<MailboxChange>();
     private final List<Session> mListeners = new CopyOnWriteArrayList<Session>();
 
@@ -788,6 +792,7 @@ public class Mailbox implements MailboxStore {
     private volatile boolean open = false;
     private boolean galSyncMailbox = false;
     private volatile boolean requiresWriteLock = true;
+    private IdProvider idProvider;
 
     protected Mailbox(MailboxData data) {
         mId = data.id;
@@ -800,6 +805,11 @@ public class Mailbox implements MailboxStore {
         callbacks = new HashMap<>();
         callbacks.put(MessageCallback.Type.sent, new SentMessageCallback());
         callbacks.put(MessageCallback.Type.received, new ReceivedMessageCallback());
+
+        idProvider = IdProvider.getFactory().getIdProvider(this);
+        mData.lastItemId   = idProvider.getItemId().setIfNotExists(mData.lastItemId);
+        mData.lastSearchId = idProvider.getSearchId().setIfNotExists(mData.lastSearchId);
+        mData.lastChangeId = idProvider.getChangeId().setIfNotExists(mData.lastChangeId);
     }
 
     public void setGalSyncMailbox(boolean galSyncMailbox) {
@@ -1247,7 +1257,7 @@ public class Mailbox implements MailboxStore {
     }
 
     public int getLastSearchId() {
-        return currentChange().searchId == MailboxChange.NO_CHANGE ? mData.lastSearchId: currentChange().searchId;
+        return currentChange().searchId == MailboxChange.NO_CHANGE ? idProvider.getSearchId().value(): currentChange().searchId;
     }
 
     /**
@@ -1257,7 +1267,7 @@ public class Mailbox implements MailboxStore {
      * @see #getOperationChangeID */
     @Override
     public int getLastChangeID() {
-        return currentChange().changeId == MailboxChange.NO_CHANGE ? mData.lastChangeId : Math.max(mData.lastChangeId,
+        return currentChange().changeId == MailboxChange.NO_CHANGE ? idProvider.getChangeId().value(): Math.max(mData.lastChangeId,
                         currentChange().changeId);
     }
 
@@ -1322,7 +1332,7 @@ public class Mailbox implements MailboxStore {
      * @see MailItem#getId()
      * @see DbMailbox#ITEM_CHECKPOINT_INCREMENT */
     public int getLastItemId() {
-        return currentChange().itemId == MailboxChange.NO_CHANGE ? mData.lastItemId : currentChange().itemId;
+        return currentChange().itemId == MailboxChange.NO_CHANGE ? idProvider.getItemId().value() : currentChange().itemId;
     }
 
     // Don't make this method package-visible.  Keep it private.
@@ -1332,7 +1342,9 @@ public class Mailbox implements MailboxStore {
         int nextId = idFromRedo == ID_AUTO_INCREMENT ? lastId + 1 : idFromRedo;
 
         if (nextId > lastId) {
-            currentChange().itemId = nextId;
+            MailboxChange change = currentChange();
+            change.itemId = nextId;
+            change.itemIdDelta++;
         }
         return nextId;
     }
@@ -1342,7 +1354,9 @@ public class Mailbox implements MailboxStore {
         int nextId = idFromRedo == ID_AUTO_INCREMENT ? lastId + 1 : idFromRedo;
 
         if (nextId > lastId) {
-            currentChange().searchId = nextId;
+            MailboxChange change = currentChange();
+            change.searchId = nextId;
+            change.searchIdDelta++;
         }
         return nextId;
     }
@@ -10258,9 +10272,14 @@ public class Mailbox implements MailboxStore {
                     }
                 }
 
-                boolean changeMade = currentChange().changeId != MailboxChange.NO_CHANGE;
+                MailboxChange change = currentChange();
+                boolean changeMade = change.changeId != MailboxChange.NO_CHANGE;
                 deletes = currentChange().deletes; // keep a reference for cleanup
                                                    // deletes outside the lock
+
+                //increment the item/search ID watermark
+                incrementIds(change);
+
                 // We are finally done with database and redo commits. Cache update
                 // comes last.
                 commitCache(currentChange(), lock);
@@ -10291,6 +10310,18 @@ public class Mailbox implements MailboxStore {
                     }
                 }
             }
+        }
+    }
+
+    private void incrementIds(MailboxChange change) {
+        if (change.itemIdDelta > 0) {
+            idProvider.getItemId().increment(change.itemIdDelta);
+        }
+        if (change.searchIdDelta > 0) {
+            idProvider.getSearchId().increment(change.searchIdDelta);
+        }
+        if (change.changeId != MailboxChange.NO_CHANGE) {
+            idProvider.getChangeId().increment(1);
         }
     }
 }

--- a/store/src/java/com/zimbra/cs/mailbox/RedisIdProvider.java
+++ b/store/src/java/com/zimbra/cs/mailbox/RedisIdProvider.java
@@ -1,0 +1,96 @@
+package com.zimbra.cs.mailbox;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.redisson.api.RAtomicLong;
+import org.redisson.api.RScript;
+import org.redisson.api.RScript.Mode;
+import org.redisson.api.RScript.ReturnType;
+import org.redisson.api.RedissonClient;
+
+import com.zimbra.common.util.ZimbraLog;
+
+public class RedisIdProvider extends IdProvider {
+
+    private static final String ITEM_ID_LABEL = "itemId";
+    private static final String SEARCH_ID_LABEL = "searchId";
+    private static final String CHANGE_ID_LABEL = "changeId";
+
+    private RedissonClient client;
+
+    public RedisIdProvider(Mailbox mailbox) {
+        super(mailbox);
+    }
+
+    @Override
+    protected void init() {
+        client = RedissonClientHolder.getInstance().getRedissonClient();
+        super.init();
+    }
+
+    @Override
+    protected SynchronizedId initId(IdType idType) {
+        switch(idType) {
+        case ITEM_ID:
+            return new RedisId(client, ITEM_ID_LABEL);
+        case SEARCH_ID:
+            return new RedisId(client, SEARCH_ID_LABEL);
+        case CHANGE_ID:
+            return new RedisId(client, CHANGE_ID_LABEL);
+        default:
+            return null;
+        }
+    }
+
+    private class RedisId implements IdProvider.SynchronizedId {
+        private RAtomicLong value;
+        private String label;
+        private String key;
+
+        private RedisId(RedissonClient client, String label) {
+            this.label = label;
+            this.key = String.format("%s_%s", mbox.getAccountId(), label);
+            this.value = client.getAtomicLong(key);
+        }
+
+        @Override
+        public int value() {
+            int idValue = (int) value.get();
+            ZimbraLog.mailbox.debug("got last %s=%d from redis for mailbox %s", label, idValue, mbox.getAccountId());
+            return idValue;
+        }
+
+        @Override
+        public void increment(int delta) {
+            if (delta > 0) {
+                int newValue = (int) value.addAndGet(delta);
+                ZimbraLog.mailbox.debug("incremented %s for mailbox %s by %d, new value is %s", label, mbox.getAccountId(), delta, newValue);
+            }
+        }
+
+        @Override
+        public int setIfNotExists(int value) {
+            String luaScript =
+                    "redis.call('setnx', KEYS[1], ARGV[1]); "
+                    + "return redis.call('get', KEYS[1]); ";
+            List<Object> keys = Collections.<Object>singletonList(key);
+            RScript script = client.getScript();
+            int retVal = (int) script.eval(Mode.READ_WRITE, luaScript, ReturnType.INTEGER, keys, value);
+            if (retVal == value) {
+                ZimbraLog.mailbox.debug("set %s for account %s to %s", label, mbox.getAccountId(), retVal);
+            } else {
+                ZimbraLog.mailbox.debug("%s for account %s already has value %s", label, mbox.getAccountId(), retVal);
+            }
+            return retVal;
+        }
+    }
+
+    public static class Factory implements IdProvider.Factory {
+
+        @Override
+        public IdProvider getIdProvider(Mailbox mbox) {
+            return new RedisIdProvider(mbox);
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/util/Zimbra.java
+++ b/store/src/java/com/zimbra/cs/util/Zimbra.java
@@ -63,8 +63,10 @@ import com.zimbra.cs.index.queue.IndexingService;
 import com.zimbra.cs.index.solr.SolrIndex;
 import com.zimbra.cs.iochannel.MessageChannel;
 import com.zimbra.cs.mailbox.ContactBackupThread;
+import com.zimbra.cs.mailbox.IdProvider;
 import com.zimbra.cs.mailbox.MailboxManager;
 import com.zimbra.cs.mailbox.PurgeThread;
+import com.zimbra.cs.mailbox.RedisIdProvider;
 import com.zimbra.cs.mailbox.ScheduledTaskManager;
 import com.zimbra.cs.mailbox.acl.AclPushTask;
 import com.zimbra.cs.memcached.MemcachedConnector;
@@ -401,6 +403,8 @@ public final class Zimbra {
                 ZimbraPerf.initialize(ZimbraPerf.ServerID.ZIMBRA);
             }
         }
+
+        IdProvider.setFactory(new RedisIdProvider.Factory());
 
         ExtensionUtil.postInitAll();
 


### PR DESCRIPTION
This PR introduces an `IdProvider` that ensures that IDs in a multi-server environment remain monotonically increasing. This externalizes the state of three values previously read from the in-memory `MailboxData` instance: `itemId`, `searchId`, and `changeId`.

#### New Classes
`SynchronizedId` represents a value that can be safely read and incremented in a distributed environment. It has three methods:
- `value()` returns the cluster-wide current value of the ID
- `increment()` atomically increments the value by the given delta
- `setIfNotExists()` atomically sets the value if it is currently unset, and returns the value regardless of whether it was modified or not.

`IdProvider` is an abstract class with methods `getItemId`, `getSearchId`, and `getChangeId` that return implementations of `SynchronizedId`.

#### RedisIdProvider
`RedisIdProvider` is the primary `IdProvider` implementation, and uses the existing `Redisson` dependency. `RedisId` implements `SynchronizedId` by wrapping an `RAtomicLong`. To implement `setIfnotExists`, a simple Lua script is passed to the Redis `eval` function to ensure that the operation is atomic.

#### Mailbox changes
* An `idProvider` field is set in the Mailbox constructor; the `IdProvider` instance is created with a factory.
* The methods `getLastItemId`, `getLastSearchId`, and `getLastChangeID` fetch the respective values from the appropriate `SynchronizedId` object instead of simply looking at the `MailboxData` fields.
* `MailboxChange` now tracks how many times the item ID and search ID has been incremented over the course of the transaction.
* At the end of a successful transaction, the `SynchronizedId` values are incremented appropriately in the new `Mailbox::incrementIds` method. If a transaction fails, no such update happens.
* The mailbox constructor now overwrites the `MailboxData.last*Id` fields  with values returned by `SynchronizedId::setIfNotExists` calls. This is done to avoid ID checkpointing logic from unnecessarily bumping up the ID values when a mailbox worker joins the cluster. In other words, the first time a Mailbox is instantiated cluster-wide, then the MailboxData value represents the truth and the Redis value is set to match it; otherwise, the Redis value must be current and the MailboxData value is adjusted to match.

#### InMemoryIdProvider
In order to avoid introducing a Redis dependency to unit tests, a simple `InMemoryIdProvider` has been implemented as well. It is set in the `MailboxTestUtil::initServer` methods.