### PR TITLE
ZCS-4607: fixed bug when removing all tags from MailItem

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/MailItem.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailItem.java
@@ -384,6 +384,9 @@ public abstract class MailItem implements Comparable<MailItem>, ScheduledTaskRes
             if (ntags != null) {
                 this.tags = Arrays.stream(ntags.getTags()).filter(t -> !t.startsWith(Tag.SMARTFOLDER_NAME_PREFIX)).toArray(String[]::new);
                 this.smartFolders = Arrays.stream(ntags.getTags()).filter(t -> t.startsWith(Tag.SMARTFOLDER_NAME_PREFIX)).toArray(String[]::new);
+            } else {
+                this.tags = NO_TAGS;
+                this.smartFolders = NO_TAGS;
             }
             return this;
         }
@@ -2527,6 +2530,7 @@ public abstract class MailItem implements Comparable<MailItem>, ScheduledTaskRes
         } else {
             Set<String> tags = Sets.newLinkedHashSet();
             Collections.addAll(tags, mData.getTags());
+            Collections.addAll(tags, mData.getSmartFolders());
             if (add) {
                 tags.add(tag.getName());
             } else {


### PR DESCRIPTION
This bug was introduced with the recent addition of SmartFolders. The UnderlyingData::setTags method was updated to handle both tags and SmartFolders, and in the process, null handling was broken. When all tags are removed from a MailItem, the value passed to setTags is a null, which tells the system to set the tags field to NO_TAGS. This bugfix restores this logic.