### PR TITLE
ZCS-4893 Ability to configure redis

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1239,6 +1239,9 @@ public final class LC {
     @Supported
     public static final KnownKey external_store_delete_max_ioexceptions = KnownKey.newKey(25);
 
+    @Supported
+    public static final KnownKey redis_service_uri = KnownKey.newKey("redis://zmc-redis:6379");
+
     public enum PUBLIC_SHARE_VISIBILITY { samePrimaryDomain, all, none };
 
     /**

--- a/store/src/java/com/zimbra/cs/mailbox/RedissonClientHolder.java
+++ b/store/src/java/com/zimbra/cs/mailbox/RedissonClientHolder.java
@@ -1,3 +1,19 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
 package com.zimbra.cs.mailbox;
 
 import org.redisson.Redisson;
@@ -6,25 +22,25 @@ import org.redisson.config.Config;
 
 public final class RedissonClientHolder {
 
-	private final RedissonClient redisson;
-	private final static String HOST = "redis";
-	private final static String PORT = "6379";
+    private final RedissonClient redisson;
+    private final static String HOST = "redis";
+    private final static String PORT = "6379";
 
-	private static class InstanceHolder {
+    private static class InstanceHolder {
         public static RedissonClientHolder instance = new RedissonClientHolder();
     }
 
-	private RedissonClientHolder() {
-		Config config = new Config();
-		config.useSingleServer().setAddress("redis://" + HOST + ":" + PORT);
-		this.redisson = Redisson.create(config);
-	}
+    private RedissonClientHolder() {
+        Config config = new Config();
+        config.useSingleServer().setAddress("redis://" + HOST + ":" + PORT);
+        this.redisson = Redisson.create(config);
+    }
 
-	public static RedissonClientHolder getInstance() {
-		return  InstanceHolder.instance;
-	}
+    public static RedissonClientHolder getInstance() {
+        return  InstanceHolder.instance;
+    }
 
-	public RedissonClient getRedissonClient() {
-		return redisson;
-	}
+    public RedissonClient getRedissonClient() {
+        return redisson;
+    }
 }

--- a/store/src/java/com/zimbra/cs/mailbox/RedissonClientHolder.java
+++ b/store/src/java/com/zimbra/cs/mailbox/RedissonClientHolder.java
@@ -20,20 +20,28 @@ import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
 
+import com.zimbra.common.localconfig.LC;
+import com.zimbra.common.util.ZimbraLog;
+
 public final class RedissonClientHolder {
 
     private final RedissonClient redisson;
-    private final static String HOST = "redis";
-    private final static String PORT = "6379";
-
     private static class InstanceHolder {
         public static RedissonClientHolder instance = new RedissonClientHolder();
     }
 
     private RedissonClientHolder() {
-        Config config = new Config();
-        config.useSingleServer().setAddress("redis://" + HOST + ":" + PORT);
-        this.redisson = Redisson.create(config);
+        String uri = null;
+        try {
+            uri = LC.redis_service_uri.value();
+            Config config = new Config();
+            config.useSingleServer().setAddress(uri);
+            this.redisson = Redisson.create(config);
+            ZimbraLog.system.info("Setup RedissonClient to %s", uri);
+        } catch (Exception ex) {
+            ZimbraLog.system.fatal("Cannot setup RedissonClient to connect to %s", uri, ex);
+            throw ex;
+        }
     }
 
     public static RedissonClientHolder getInstance() {


### PR DESCRIPTION
The latest zm-docker expects to access redis using the service name "zmc-redis" instead of "redis".
Fixed zm-mailbox to match, making it configurable via LC keys at the same time.