### PR TITLE
ZCS-4142 Fixing error found for deploy zimlet

### DIFF
--- a/store/src/java/com/zimbra/cs/zimlet/ZimletUtil.java
+++ b/store/src/java/com/zimbra/cs/zimlet/ZimletUtil.java
@@ -512,7 +512,9 @@ public class ZimletUtil {
         attrs.put(Provisioning.A_zimbraZimletKeyword,         zd.getServerExtensionKeyword());
         attrs.put(Provisioning.A_zimbraZimletVersion,         zd.getVersion().toString());
         attrs.put(Provisioning.A_zimbraZimletDescription,     zd.getDescription());
-        attrs.put(Provisioning.A_zimbraXZimletCompatibleSemVer,zd.getZimbraXCompatibleSemVer());
+        if (!StringUtil.isNullOrEmpty(zd.getZimbraXCompatibleSemVer())) {
+            attrs.put(Provisioning.A_zimbraXZimletCompatibleSemVer,zd.getZimbraXCompatibleSemVer());
+        }
         attrs.put(Provisioning.A_zimbraZimletHandlerClass,    zd.getServerExtensionClass());
         attrs.put(Provisioning.A_zimbraZimletServerIndexRegex, zd.getRegexString());
         return attrs;


### PR DESCRIPTION
Fixed an error found while deploying classic zimlets
Old zimlets do not have an attribute Semver. Which was causing and LDAPException while updating attributes.

Verified that zimlet deployment works after this fix.