### PR TITLE
Bug 95459: Improve warning "unknown GAL op"

### DIFF
--- a/store/src/java/com/zimbra/cs/ldap/LdapUsage.java
+++ b/store/src/java/com/zimbra/cs/ldap/LdapUsage.java
@@ -156,8 +156,11 @@ public enum LdapUsage {
 
     public static LdapUsage fromGalOp(GalOp galOp) {
         if (galOp == null) {
-            ZimbraLog.ldap.warn("unknown GAL op");
-            return LdapUsage.GAL;  // really an error
+            ZimbraLog.ldap.warn("unknown GAL op: null");
+            if (ZimbraLog.ldap.isDebugEnabled()) {
+                ZimbraLog.ldap.debug("unknown GAL op: null", new Exception("null GAL op, exception provided for stack detail"));
+            }
+            return GAL;  // really an error
         }
         switch (galOp) {
             case autocomplete:
@@ -167,15 +170,18 @@ public enum LdapUsage {
             case sync:
                 return GAL_SYNC;
             default:
-                ZimbraLog.ldap.warn("unknown GAL op");
+                ZimbraLog.ldap.warn("unknown GAL op: %s", galOp.toString());
                 return GAL;
         }
     }
 
     public static LdapUsage fromGalOpLegacy(GalOp galOp) {
         if (galOp == null) {
-            ZimbraLog.ldap.warn("unknown GAL op");
-            return LdapUsage.GAL_LEGACY;  // really an error
+            ZimbraLog.ldap.warn("unknown GAL op: null (legacy)");
+            if (ZimbraLog.ldap.isDebugEnabled()) {
+                ZimbraLog.ldap.debug("unknown GAL op: null (legacy)", new Exception("null GAL op, exception provided for stack detail"));
+            }
+            return GAL_LEGACY;  // really an error
         }
         switch (galOp) {
             case autocomplete:
@@ -185,7 +191,7 @@ public enum LdapUsage {
             case sync:
                 return GAL_LEGACY_SYNC;
             default:
-                ZimbraLog.ldap.warn("unknown GAL op");
+                ZimbraLog.ldap.warn("unknown GAL op: %s (legacy)", galOp.toString());
                 return GAL_LEGACY;
         }
     }


### PR DESCRIPTION
This was already included in commit a9600c27a05a986711ca5488408853b5386041b8 but got accidentally dropped by the import/merge of commit 57546f768286a6a267d8adb7c148435d0f20b0a2. See my musings on [bug 95459](https://bugzilla.zimbra.com/show_bug.cgi?id=95459#c8).

This change improves the logging for unknown GAL ops.

