### PR TITLE
ZCS-3055 Different date shown for Recurring Appointment Instance

### DIFF
--- a/soap/src/java/com/zimbra/soap/mail/message/CreateAppointmentExceptionRequest.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/CreateAppointmentExceptionRequest.java
@@ -17,14 +17,15 @@
 
 package com.zimbra.soap.mail.message;
 
-import com.google.common.base.Objects;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import com.google.common.base.Objects;
 import com.zimbra.common.soap.MailConstants;
 import com.zimbra.soap.mail.type.CalItemRequestBase;
+import com.zimbra.soap.mail.type.Msg;
 
 /**
  * @zm-api-command-auth-required true
@@ -66,6 +67,17 @@ public class CreateAppointmentExceptionRequest extends CalItemRequestBase {
     public CreateAppointmentExceptionRequest() {
     }
 
+    public static CreateAppointmentExceptionRequest createForModseqRevIdCompMsg(
+            Integer modSeq, Integer rev, String theId, Integer numComp, Msg msg) {
+        CreateAppointmentExceptionRequest caer = new CreateAppointmentExceptionRequest();
+        caer.setModifiedSequence(modSeq);
+        caer.setRevision(rev);
+        caer.setId(theId);
+        caer.setNumComponents(numComp);
+        caer.setMsg(msg);
+        return caer;
+    }
+
     public void setId(String id) { this.id = id; }
     public void setNumComponents(Integer numComponents) {
         this.numComponents = numComponents;
@@ -79,6 +91,7 @@ public class CreateAppointmentExceptionRequest extends CalItemRequestBase {
     public Integer getModifiedSequence() { return modifiedSequence; }
     public Integer getRevision() { return revision; }
 
+    @Override
     public Objects.ToStringHelper addToStringInfo(Objects.ToStringHelper helper) {
         helper = super.addToStringInfo(helper);
         return helper

--- a/store/src/java/com/zimbra/cs/mailbox/CalendarItem.java
+++ b/store/src/java/com/zimbra/cs/mailbox/CalendarItem.java
@@ -677,7 +677,11 @@ public abstract class CalendarItem extends MailItem {
      * Diagnostic code to flag when odd RECURRENCE-ID is used
      */
     private void checkRecurIdIsSensible(RecurId recurId) throws ServiceException {
-        Collection<Instance> instancesNear = instancesNear(recurId);
+        checkRecurIdIsSensible(recurId, instancesNear(recurId));
+    }
+
+    private void checkRecurIdIsSensible(RecurId recurId, Collection<Instance> instancesNear)
+            throws ServiceException {
         if (instancesNear.isEmpty()) {
             ZimbraLog.calendar.warn(
                     "WARNING:RECURRENCE-ID %s, does not match any pre-existing instances.",
@@ -3485,8 +3489,21 @@ public abstract class CalendarItem extends MailItem {
             for (int i = 0; i < numInvites(); i++) {
                 Invite cur = getInvite(i);
                 if (cur.getRecurId() == null) {
+                    checkRecurIdIsSensible(reply.getRecurId(), instancesNear);
                     try {
                         ParsedDateTime pdt = ParsedDateTime.parseUtcOnly(reply.getRecurId().getDtZ());
+                        /* Best practice is to use RECURRENCE-IDs with the same TZID as the DTSTART
+                         * for the main series.  Try to make that so here.  This is so that exceptions
+                         * don't become invalid when the rules for a timezone change, moving the
+                         * expected time for an instance forward or backward relative to UTC
+                         */
+                        ParsedDateTime seriesStartTime = cur.getStartTime();
+                        if (seriesStartTime != null) {
+                            ICalTimeZone seriesTz = seriesStartTime.getTimeZone();
+                            if (seriesTz != null) {
+                                pdt.toTimeZone(seriesTz);
+                            }
+                        }
                         Invite localException = cur.makeInstanceInvite(pdt);
                         localException.setDtStamp(System.currentTimeMillis());
                         localException.updateMatchingAttendeesFromReply(reply);

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -1295,6 +1295,23 @@ public class Mailbox implements MailboxStore {
         return nextId;
     }
 
+    public interface ItemIdGetter {
+        public int get();
+    }
+
+    /** Wrapper for getNextItemId method - should only be used within a transaction */
+    private class NextItemIdGetter implements ItemIdGetter {
+        @Override
+        public int get() {
+            if (!currentChange().isActive()) {
+                ZimbraLog.mailbox.info("NextItemIdGetter used when not in transaction! %s",
+                        ZimbraLog.getStackTrace(10));
+                return 0;
+            }
+            return getNextItemId(ID_AUTO_INCREMENT);
+        }
+    }
+
     TargetConstraint getOperationTargetConstraint() {
         return currentChange().tcon;
     }
@@ -5374,7 +5391,9 @@ public class Mailbox implements MailboxStore {
                     }
 
                     calItem.setTags(flags, ntags);
-                    calItem.processNewInvite(scid.message, scid.invite, folderId, nextAlarm, false, true);
+                    calItem.processNewInvite(scid.message, scid.invite, folderId, nextAlarm,
+                            false /* preserveAlarms */, true /* replaceExistingInvites */,
+                            false /* updatePrevFolders */);
                 }
                 redoRecorder.setCalendarItemAttrs(calItem.getId(), calItem.getFolderId());
             }
@@ -5844,7 +5863,8 @@ public class Mailbox implements MailboxStore {
                 return;
             }
             calItem.snapshotRevision();
-            calItem.processNewInviteReply(inv, sender);
+            calItem.processNewInviteReply(inv, sender, false /* don't update prev folders */,
+                    new NextItemIdGetter());
             success = true;
         } finally {
             endTransaction(success);

--- a/store/src/java/com/zimbra/cs/mailbox/Message.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Message.java
@@ -1250,7 +1250,10 @@ public class Message extends MailItem {
                                 invChanges = new InviteChanges(prev, cur);
                         }
 
-                        modifiedCalItem = status.calItem.processNewInvite(pm, cur, calFolderId, discardExistingInvites);
+                        modifiedCalItem = status.calItem.processNewInvite(
+                                pm, cur, calFolderId, CalendarItem.NEXT_ALARM_KEEP_CURRENT,
+                                true /* preserveAlarms */, discardExistingInvites,
+                                false /* updatePrevFolders */);
                         status.calItemFolderId = calFolderId;
                         status.calItem.getFolder().updateHighestMODSEQ();
                     }

--- a/store/src/java/com/zimbra/qa/unittest/TestJaxb.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestJaxb.java
@@ -20,9 +20,15 @@ package com.zimbra.qa.unittest;
 import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.TimeZone;
 
 import javax.xml.bind.Marshaller;
@@ -40,12 +46,14 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 
+import com.zimbra.client.ZAppointmentHit;
 import com.zimbra.client.ZDateTime;
 import com.zimbra.client.ZFolder;
 import com.zimbra.client.ZInvite;
 import com.zimbra.client.ZMailbox;
 import com.zimbra.client.ZMessage;
 import com.zimbra.client.ZSearchParams;
+import com.zimbra.common.calendar.ParsedDateTime;
 import com.zimbra.common.httpclient.HttpClientUtil;
 import com.zimbra.common.mime.MimeConstants;
 import com.zimbra.common.service.ServiceException;
@@ -81,6 +89,7 @@ import com.zimbra.soap.mail.type.BrowseData;
 import com.zimbra.soap.mail.type.CalOrganizer;
 import com.zimbra.soap.mail.type.CalendarAttendee;
 import com.zimbra.soap.mail.type.CalendarAttendeeWithGroupInfo;
+import com.zimbra.soap.mail.type.DateTimeStringAttr;
 import com.zimbra.soap.mail.type.DtTimeInfo;
 import com.zimbra.soap.mail.type.EmailAddrInfo;
 import com.zimbra.soap.mail.type.InstanceDataInfo;
@@ -136,6 +145,126 @@ public class TestJaxb {
     }
 
     /**
+     * @param attendeeZMbox - null if no attendee needed
+     */
+    public static InviteComponent createInviteComponentSkeleton(String subject, String location,
+            ZMailbox organizerZMbox, ZMailbox... attendeeZMboxes) throws ServiceException {
+        InviteComponent inviteComp = new InviteComponent();
+        if (attendeeZMboxes != null) {
+            for (ZMailbox attendeeZMbox : attendeeZMboxes) {
+                inviteComp.addAttendee(
+                        CalendarAttendee.createForAddressDisplaynameRolePartstatRsvp(
+                                attendeeZMbox.getName(), getCN(attendeeZMbox), "REQ",
+                                ZAppointmentHit.PSTATUS_NEEDS_ACTION, true));
+            }
+        }
+        inviteComp.setStatus("CONF");
+        inviteComp.setFreeBusy("B");
+        inviteComp.setCalClass("PUB");
+        inviteComp.setTransparency("O");
+        inviteComp.setIsDraft(false);
+        inviteComp.setIsAllDay(false);
+        inviteComp.setName(subject);
+        inviteComp.setLocation(location);
+        inviteComp.setOrganizer(CalOrganizer.createForAddress(organizerZMbox.getName()));
+        return inviteComp;
+    }
+
+    public static MimePartInfo makeTextAndHtmlAlternatives(String text) {
+        MimePartInfo mimePart = MimePartInfo.createForContentType("multipart/alternative");
+        mimePart.addMimePart(MimePartInfo.createForContentTypeAndContent("text/plain", text));
+        mimePart.addMimePart(MimePartInfo.createForContentTypeAndContent(
+                "text/html", String.format("<html><body><p><b>%s</b></p></body></html>", text)));
+        return mimePart;
+    }
+
+    public static Msg createMsgForAppointmentRequest(String subject, InviteComponent inviteComp,
+            ZMailbox...  attendeeZMboxes) throws ServiceException {
+        Msg msg = new Msg();
+        msg.setFolderId("10");
+        msg.setInvite(InvitationInfo.create(inviteComp));
+        if (attendeeZMboxes != null) {
+            for (ZMailbox attendeeZMbox : attendeeZMboxes) {
+                msg.addEmailAddress(EmailAddrInfo.createForAddressPersonalAndAddressType(
+                        attendeeZMbox.getName(), getCN(attendeeZMbox), "t"));
+            }
+        }
+        msg.setSubject(subject);
+        msg.setMimePart(makeTextAndHtmlAlternatives("invite body"));
+        return msg;
+    }
+
+    public static CreateAppointmentResponse sendMeetingRequest(ZMailbox zmbox, Msg msg)
+            throws ServiceException {
+        CreateAppointmentResponse caResp = zmbox.invokeJaxb(CreateAppointmentRequest.create(msg));
+        Assert.assertNotNull("JAXB CreateAppointmentResponse object", caResp);
+        Assert.assertNotNull("JAXB CreateAppointmentResponse calItemId", caResp.getCalItemId());
+        Assert.assertNotNull("JAXB CreateAppointmentResponse invId", caResp.getCalInvId());
+        Assert.assertNotNull("JAXB CreateAppointmentResponse modified sequence ms",
+                caResp.getModifiedSequence());
+        Assert.assertNotNull("JAXB CreateAppointmentResponse rev", caResp.getRevision());
+        return caResp;
+    }
+
+    public static ZMessage waitForInvite(ZMailbox zmbox, String subject) throws Exception {
+        ZMessage msg = TestUtil.waitForMessage(zmbox, String.format("subject:\"%s\"", subject));
+        Assert.assertNotNull(String.format("ZMessage from waitForInvite(mbox=%s, subject='%s')",
+                zmbox.getName(), subject), msg);
+        ZInvite invite = msg.getInvite();
+        Assert.assertNotNull(String.format("ZInvite from waitForInvite(mbox=%s, subject='%s')",
+                zmbox.getName(), subject), invite);
+        return msg;
+    }
+
+    public static String dateTime(Calendar cal) {
+        return String.format("%04d%02d%02dT%02d%02d00",
+                cal.get(Calendar.YEAR),
+                cal.get(Calendar.MONTH) + 1 /* is zero based in Calendar */,
+                cal.get(Calendar.DAY_OF_MONTH),
+                cal.get(Calendar.HOUR_OF_DAY),
+                cal.get(Calendar.MINUTE));
+    }
+
+    public static String prettyIshDateTime(Calendar cal) {
+        return String.format("%04d-%02d-%02d %02d:%02",
+                cal.get(Calendar.YEAR),
+                cal.get(Calendar.MONTH) + 1 /* is zero based in Calendar */,
+                cal.get(Calendar.DAY_OF_MONTH),
+                cal.get(Calendar.HOUR_OF_DAY),
+                cal.get(Calendar.MINUTE));
+    }
+
+    public static RecurrenceInfo recurrence(String frequency, int interval, String until) {
+        SimpleRepeatingRule repeatingRule = SimpleRepeatingRule.createFromFrequencyAndInterval(
+                frequency, IntervalRule.create(interval));
+        if (until != null) {
+            repeatingRule.setUntil(new DateTimeStringAttr(until));
+        }
+        return RecurrenceInfo.create(AddRecurrenceInfo.create(repeatingRule));
+    }
+
+    public static void setStartAndEnd(InviteComponent inviteComp, String tzName,
+            GregorianCalendar start, GregorianCalendar end) {
+        inviteComp.setDtStart(DtTimeInfo.createForDatetimeAndZone(dateTime(start), tzName));
+        inviteComp.setDtEnd(DtTimeInfo.createForDatetimeAndZone(dateTime(end), tzName));
+    }
+
+    public static GregorianCalendar startTime(
+            String tzName, int year, int monthZeroBased, int day, int hour, int minute) {
+        TimeZone tz = TimeZone.getTimeZone(tzName);
+        GregorianCalendar start = new GregorianCalendar(tz);
+        start.clear() /* otherwise milliseconds left at some random value! */;
+        start.set(year, monthZeroBased, day, hour, minute, 0);
+        return start;
+    }
+
+    public static GregorianCalendar plus(GregorianCalendar start, int field, int amount) {
+        GregorianCalendar end = (GregorianCalendar) start.clone();
+        end.add(field, amount);
+        return end;
+    }
+
+    /**
      * Bug 96748:
      * 1. user1 sends meeting invite to user2
      * 2. user2 proposes new time
@@ -144,65 +273,31 @@ public class TestJaxb {
      * At step 4, no acceptance message was being generated
      */
     @Test
-    public void testProposeNewTimeWorkflow()
-    throws Exception
-    {
+    public void proposeNewTimeWorkflow() throws Exception {
         TestUtil.createAccount(ORGANIZER);
         TestUtil.createAccount(ATTENDEE1);
         String subject = NAME_PREFIX + " attendee will cause time to change";
         ZMailbox organizerBox = TestUtil.getZMailbox(ORGANIZER);
         ZMailbox attendeeBox = TestUtil.getZMailbox(ATTENDEE1);
-        String organizerEmail = organizerBox.getName();
 
         // Create and send the meeting request
-        InviteComponent inviteComp = new InviteComponent();
-        inviteComp.addAttendee(
-                CalendarAttendee.createForAddressDisplaynameRolePartstatRsvp(
-                        attendeeBox.getName(), getCN(attendeeBox), "REQ", "NE", true));
-        inviteComp.setStatus("CONF");
-        inviteComp.setFreeBusy("B");
-        inviteComp.setCalClass("PUB");
-        inviteComp.setTransparency("O");
-        inviteComp.setIsDraft(false);
-        inviteComp.setIsAllDay(false);
-        Date startDate = new Date(System.currentTimeMillis() + Constants.MILLIS_PER_DAY);
+        InviteComponent inviteComp = createInviteComponentSkeleton(subject, "room 101",
+                organizerBox, attendeeBox);
+        long soon = ((System.currentTimeMillis() / 1000) + 10) * 1000;  /* to nearest second + 10 */
+        Date startDate = new Date(soon + Constants.MILLIS_PER_DAY);
         ZDateTime start = new ZDateTime(startDate.getTime(), false, organizerBox.getPrefs().getTimeZone());
         Date endDate = new Date(startDate.getTime() + Constants.MILLIS_PER_HOUR);
         ZDateTime end = new ZDateTime(endDate.getTime(), false, organizerBox.getPrefs().getTimeZone());
-        Date newStartDate = new Date(System.currentTimeMillis() + 2 * Constants.MILLIS_PER_DAY);
+        Date newStartDate = new Date(soon + 2 * Constants.MILLIS_PER_DAY);
         ZDateTime newStart = new ZDateTime(newStartDate.getTime(), false, organizerBox.getPrefs().getTimeZone());
         Date newEndDate = new Date(newStartDate.getTime() + Constants.MILLIS_PER_HOUR);
         ZDateTime newEnd = new ZDateTime(newEndDate.getTime(), false, organizerBox.getPrefs().getTimeZone());
         inviteComp.setDtStart(DtTimeInfo.createForDatetimeAndZone(start.getDateTime(), start.getTimeZoneId()));
         inviteComp.setDtEnd(DtTimeInfo.createForDatetimeAndZone(end.getDateTime(), end.getTimeZoneId()));
-        inviteComp.setName(subject);
-        inviteComp.setLocation("room 101");
-        inviteComp.setOrganizer(CalOrganizer.createForAddress(organizerEmail));
-        InvitationInfo invite = new InvitationInfo();
-        invite.setInviteComponent(inviteComp);
-        EmailAddrInfo attendeeAddr = EmailAddrInfo.createForAddressPersonalAndAddressType(
-                attendeeBox.getName(), getCN(attendeeBox), "t");
-        MimePartInfo mimePart = MimePartInfo.createForContentType("multipart/alternative");
-        mimePart.addMimePart(MimePartInfo.createForContentTypeAndContent("text/plain", "invite body"));
-        mimePart.addMimePart(MimePartInfo.createForContentTypeAndContent(
-                "text/html", "<html><body><p><b>invite</b> body</p></body></html>"));
-        Msg msg = new Msg();
-        msg.setFolderId("10");
-        msg.setInvite(invite);
-        msg.addEmailAddress(attendeeAddr);
-        msg.setSubject(subject);
-        msg.setMimePart(mimePart);
-        CreateAppointmentRequest createApptReq = CreateAppointmentRequest.create(msg);
-        CreateAppointmentResponse caResp = organizerBox.invokeJaxb(createApptReq);
-        Assert.assertNotNull("JAXB CreateAppointmentResponse object", caResp);
-        Assert.assertNotNull("JAXB CreateAppointmentResponse calItemId", caResp.getCalItemId());
-        Assert.assertNotNull("JAXB CreateAppointmentResponse invId", caResp.getCalInvId());
-        Assert.assertNotNull("JAXB CreateAppointmentResponse modified sequence ms", caResp.getModifiedSequence());
-        Assert.assertNotNull("JAXB CreateAppointmentResponse rev", caResp.getRevision());
-        ZMessage seriesInviteMsg = TestUtil.waitForMessage(attendeeBox, subject);
-        Assert.assertNotNull("ZMessage for series invite", seriesInviteMsg);
-        ZInvite seriesInvite = seriesInviteMsg.getInvite();
-        Assert.assertNotNull("ZInvite for series invite", seriesInvite);
+        sendMeetingRequest(organizerBox,
+                        createMsgForAppointmentRequest(subject, inviteComp, attendeeBox));
+
+        waitForInvite(attendeeBox, subject);
         AppointmentHitInfo hit = findMatchingAppointment(attendeeBox, startDate, endDate, subject);
         // User 1 proposes new time for meeting
         ZMessage propNewTimeMsg = attendeeProposeNewTimeForMeeting(attendeeBox, organizerBox,
@@ -218,35 +313,48 @@ public class TestJaxb {
         acceptInvite(attendeeBox, organizerBox, attendee2ndInvite, subject);
     }
 
-    private ZMessage acceptInvite(ZMailbox attendeeBox, ZMailbox organizerBox, ZMessage inviteMsg, String subject)
+    private static ZMessage sendInviteReplyAndWaitForIt(ZMailbox attendeeBox, ZMailbox organizerBox,
+            String inviteMsgId, String subjectSuffix, String verb, DtTimeInfo exceptionId)
     throws Exception {
-        SendInviteReplyRequest sirReq = new SendInviteReplyRequest(inviteMsg.getId(), 0 /* componentNum */, "ACCEPT");
+        SendInviteReplyRequest sirReq = new SendInviteReplyRequest(inviteMsgId, 0 /* componentNum */, verb);
         sirReq.setIdentityId(attendeeBox.getAccountInfo(false).getId());
         // ZWC 8.6 and earlier used to set this to false.  Now sets it to true.
         sirReq.setUpdateOrganizer(true);
-        MimePartInfo mimePart = MimePartInfo.createForContentType("multipart/alternative");
-        mimePart.addMimePart(MimePartInfo.createForContentTypeAndContent("text/plain", "Accepting"));
-        mimePart.addMimePart(MimePartInfo.createForContentTypeAndContent(
-                "text/html", "<html><body><p><b>Accepting</b></p></body></html>"));
+        EmailAddrInfo attendeeAddr = EmailAddrInfo.createForAddressPersonalAndAddressType(
+                attendeeBox.getName(), getCN(attendeeBox), "f");
+        EmailAddrInfo orgAddr = EmailAddrInfo.createForAddressPersonalAndAddressType(
+                organizerBox.getName(), organizerBox.getName(), "t");
+        String plainText;
+        String subject;
+        if ("ACCEPT".equals(verb)) {
+            plainText = "Yes, I will attend.";
+            subject = "Accept: " + subjectSuffix;
+        } else if ("DECLINE".equals(verb)) {
+            plainText = "No, I won't attend.";
+            subject = "Decline: " + subjectSuffix;
+        } else {
+            plainText = "Maybe, I will attend.";
+            subject = "Tentative: " + subjectSuffix;
+        }
         Msg msg = new Msg();
         msg.setReplyType("r");
         msg.setIdentityId(attendeeBox.getAccountInfo(false).getId());
-        EmailAddrInfo orgAddr = EmailAddrInfo.createForAddressPersonalAndAddressType(
-                organizerBox.getName(), organizerBox.getName(), "t");
-        EmailAddrInfo attendeeAddr = EmailAddrInfo.createForAddressPersonalAndAddressType(
-                attendeeBox.getName(), getCN(attendeeBox), "f");
         msg.addEmailAddress(orgAddr);
         msg.addEmailAddress(attendeeAddr);
-        String acceptSubject = "Accept: " + subject;
-        msg.setSubject(acceptSubject);
-        msg.setMimePart(mimePart);
+        msg.setSubject(subject);
+        msg.setMimePart(makeTextAndHtmlAlternatives(plainText));
+        if (exceptionId != null) {
+            sirReq.setExceptionId(exceptionId);
+        }
         sirReq.setMsg(msg);
         SendInviteReplyResponse sirResp = attendeeBox.invokeJaxb(sirReq);
         Assert.assertNotNull("JAXB SendInviteReplyResponse object", sirResp);
-        ZMessage inboxMsg = TestUtil.waitForMessage(
-                organizerBox, String.format("subject:\"%s\"", acceptSubject));
-        Assert.assertNotNull("ZMessage for accept", inboxMsg);
-        return inboxMsg;
+        return waitForInvite(organizerBox, subject);
+    }
+
+    private static ZMessage acceptInvite(ZMailbox attendeeBox, ZMailbox organizerBox, ZMessage inviteMsg,
+            String subject) throws Exception {
+        return sendInviteReplyAndWaitForIt(attendeeBox, organizerBox, inviteMsg.getId(), subject, "ACCEPT", null);
     }
 
     /**
@@ -257,29 +365,15 @@ public class TestJaxb {
             ZDateTime newStart, ZDateTime newEnd, AppointmentHitInfo hit, String subject)
     throws Exception
     {
-        String organizerEmail = organizerBox.getName();
-        InviteComponent inviteComp = new InviteComponent();
-        inviteComp.addAttendee(
-                CalendarAttendee.createForAddressDisplaynameRolePartstatRsvp(attendeeBox.getName(), getCN(attendeeBox),
-                        "REQ", "NE", true));   /* Note Tentative, not Needs action */
-        inviteComp.setStatus("CONF");
-        inviteComp.setFreeBusy("B");
-        inviteComp.setCalClass("PUB");
-        inviteComp.setTransparency("O");
-        inviteComp.setIsDraft(false);
-        inviteComp.setIsAllDay(false);
-        inviteComp.setDtStart(DtTimeInfo.createForDatetimeAndZone(newStart.getDateTime(), newStart.getTimeZoneId()));
-        inviteComp.setDtEnd(DtTimeInfo.createForDatetimeAndZone(newEnd.getDateTime(), newEnd.getTimeZoneId()));
-        inviteComp.setName(subject);
-        inviteComp.setLocation("room 101");
-        inviteComp.setOrganizer(CalOrganizer.createForAddress(organizerEmail));
+        InviteComponent inviteComp = createInviteComponentSkeleton(subject, "room 101",
+                organizerBox, attendeeBox);
+        inviteComp.setDtStart(DtTimeInfo.createForDatetimeAndZone(newStart.getDateTime(),
+                newStart.getTimeZoneId()));
+        inviteComp.setDtEnd(DtTimeInfo.createForDatetimeAndZone(newEnd.getDateTime(),
+                newEnd.getTimeZoneId()));
         InvitationInfo invite = new InvitationInfo();
         invite.setUid(hit.getUid());
         invite.setInviteComponent(inviteComp);
-        MimePartInfo mimePart = MimePartInfo.createForContentType("multipart/alternative");
-        String bodyText =
-                String.format("The following meeting has been modified:\n\n%s",subject);
-        mimePart.addMimePart(MimePartInfo.createForContentTypeAndContent("text/plain", bodyText));
         Msg msg = new Msg();
         msg.setFolderId(hit.getFolderId());
         msg.setInvite(invite);
@@ -287,31 +381,47 @@ public class TestJaxb {
                 attendeeBox.getName(), getCN(attendeeBox), "t");
         msg.addEmailAddress(attendeeAddr);
         msg.setSubject(subject);
-        msg.setMimePart(mimePart);
+        msg.setMimePart(makeTextAndHtmlAlternatives(
+                String.format("The following meeting has been modified:\n\n%s",subject)));
         ModifyAppointmentRequest maReq = ModifyAppointmentRequest.createForIdModseqRevCompnumMsg(
                 hit.getInvId(), hit.getModifiedSequence(), hit.getRevision(), hit.getComponentNum(), msg);
         ModifyAppointmentResponse maResp = organizerBox.invokeJaxb(maReq);
         Assert.assertNotNull("JAXB ModifyAppointmentResponse", maResp);
-        return TestUtil.waitForMessage(attendeeBox, String.format("subject:\"%s\"", subject));
+        return waitForInvite(attendeeBox, subject);
     }
 
-    private AppointmentHitInfo findMatchingAppointment(ZMailbox mbox,
-        Date startDate, Date endDate, String subject) throws ServiceException {
+    private List<AppointmentHitInfo> findMatchingExpandedAppointments(ZMailbox mbox,
+        Date startDate, Date endDate, String search, int expected) throws ServiceException {
         SearchRequest searchRequest = new SearchRequest();
         searchRequest.setSortBy("none");
         searchRequest.setLimit(500);
         searchRequest.setLocale("en_US");
-        searchRequest.setCalItemExpandStart(startDate.getTime() - 1000);
-        searchRequest.setCalItemExpandEnd(endDate.getTime() + 1000);
+        searchRequest.setCalItemExpandStart(startDate.getTime() - 2 * 60 * 60 * 1000);
+        searchRequest.setCalItemExpandEnd(endDate.getTime() + 2 * 60 * 60 * 1000);
         searchRequest.setSearchTypes("appointment");
         searchRequest.setOffset(0);
-        searchRequest.setQuery(subject);
+        searchRequest.setQuery(search);
         SearchResponse searchResp = mbox.invokeJaxb(searchRequest);
         Assert.assertNotNull("JAXB SearchResponse object", searchResp);
         List<SearchHit> hits = searchResp.getSearchHits();
         Assert.assertNotNull("JAXB SearchResponse hits", hits);
-        Assert.assertEquals("JAXB SearchResponse hits", 1, hits.size());
-        return (AppointmentHitInfo) hits.get(0);
+        Assert.assertEquals("JAXB SearchResponse hits", expected, hits.size());
+        List<AppointmentHitInfo> apptHits = new ArrayList<>(hits.size());
+        for (SearchHit hit : hits) {
+            AppointmentHitInfo apptHit = (AppointmentHitInfo) hit;
+            apptHits.add(apptHit);
+        }
+        return apptHits;
+    }
+
+    private AppointmentHitInfo findMatchingAppointment(ZMailbox mbox,
+        Date startDate, Date endDate, String subject) throws ServiceException {
+        List<AppointmentHitInfo> hits = findMatchingExpandedAppointments(mbox,
+            startDate, endDate, subject, 1);
+        AppointmentHitInfo hit = hits.get(0);
+        Assert.assertEquals("Matching first instance start time",
+                startDate.getTime(), hit.getInstances().get(0).getStartTime().longValue());
+        return hits.get(0);
     }
 
     /**
@@ -323,12 +433,7 @@ public class TestJaxb {
     throws Exception {
         EmailAddrInfo orgAddr = EmailAddrInfo.createForAddressPersonalAndAddressType(
                 organizerBox.getName(), organizerBox.getName(), "t");
-        MimePartInfo mimePart = MimePartInfo.createForContentType("multipart/alternative");
-        String plainText = "New Time Proposed.";
         String subject = "New Time Proposed: " + subjectSuffix;
-        String htmlText = String.format("<html><body><p><b>%s</b></p></body></html>", plainText);
-        mimePart.addMimePart(MimePartInfo.createForContentTypeAndContent("text/plain", plainText));
-        mimePart.addMimePart(MimePartInfo.createForContentTypeAndContent("text/html", htmlText));
         Msg msg = new Msg();
         InviteComponent compo = new InviteComponent();
         compo.setName(subjectSuffix);
@@ -340,193 +445,149 @@ public class TestJaxb {
         InvitationInfo invite = InvitationInfo.create(compo);
         msg.addEmailAddress(orgAddr);  /* replying to the organizer */
         msg.setSubject(subject);
-        msg.setMimePart(mimePart);
+        msg.setMimePart(makeTextAndHtmlAlternatives("New Time Proposed."));
         msg.setInvite(invite);
         CounterAppointmentResponse sirResp = attendeeBox.invokeJaxb(
              CounterAppointmentRequest.createForMsgModseqRevIdCompnum(
                  msg, hit.getModifiedSequence(), hit.getRevision(), hit.getInvId(), hit.getComponentNum()));
         Assert.assertNotNull("JAXB CounterAppointmentResponse object", sirResp);
-        return TestUtil.waitForMessage(organizerBox, String.format("subject:\"%s\"", subject));
+        return waitForInvite(organizerBox, subject);
     }
 
-    /**
-     * Bug 94018.  Accepting series, then declining single instance leads to inconsistent display of attendee
-     * status for organizer copy for the declined instance.
-     * Test steps:
-     * 1.  Invite 2 users to a daily meeting.
-     * 2.  User 1 replies, accepting the daily meeting.
-     * 3.  User 1 replies again, declining one of the instances in the daily meeting.
-     * 4.  User 2 replies tentatively accepting the daily meeting.
-     *
-     * At the end of this, check that an exception has been created.  Check that that exception registers
-     * the decline from user 1 AND the tentative acceptance from user2 that arrived later.
-     */
-    @Test
-    public void testAcceptSeriesDeclineInstance()
-    throws Exception {
-        TestUtil.createAccount(ORGANIZER);
-        TestUtil.createAccount(ATTENDEE1);
-        TestUtil.createAccount(ATTENDEE2);
-        String subject = NAME_PREFIX + " Daily";
-        ZMailbox organizerBox = TestUtil.getZMailbox(ORGANIZER);
-        ZMailbox attendeeBox = TestUtil.getZMailbox(ATTENDEE1);
-        ZMailbox attendee2Box = TestUtil.getZMailbox(ATTENDEE2);
-        String organizerEmail = organizerBox.getName();
-
-        // Create and send the daily meeting
-        InviteComponent inviteComp = new InviteComponent();
-        inviteComp.addAttendee(
-                CalendarAttendee.createForAddressDisplaynameRolePartstatRsvp(
-                        attendeeBox.getName(), getCN(attendeeBox), "REQ", "NE", true));
-        inviteComp.addAttendee(
-                CalendarAttendee.createForAddressDisplaynameRolePartstatRsvp(
-                        attendee2Box.getName(), getCN(attendee2Box), "REQ", "NE", true));
-        inviteComp.setStatus("CONF");
-        inviteComp.setFreeBusy("B");
-        inviteComp.setCalClass("PUB");
-        inviteComp.setTransparency("O");
-        inviteComp.setIsDraft(false);
-        inviteComp.setIsAllDay(false);
-        inviteComp.setDtStart(DtTimeInfo.createForDatetimeAndZone("20161008T130000", "Europe/London"));
-        inviteComp.setDtEnd(DtTimeInfo.createForDatetimeAndZone("20161008T140000", "Europe/London"));
-        inviteComp.setName(subject);
-        inviteComp.setLocation("room 101");
-        inviteComp.setOrganizer(CalOrganizer.createForAddress(organizerEmail));
-        inviteComp.setRecurrence(RecurrenceInfo.create(
-                AddRecurrenceInfo.create(
-                        SimpleRepeatingRule.createFromFrequencyAndInterval("DAI", IntervalRule.create(1)))));
-        InvitationInfo invite = new InvitationInfo();
-        invite.setInviteComponent(inviteComp);
-        EmailAddrInfo attendeeAddr = EmailAddrInfo.createForAddressPersonalAndAddressType(
-                attendeeBox.getName(), getCN(attendeeBox), "t");
-        EmailAddrInfo attendeeAddr2 = EmailAddrInfo.createForAddressPersonalAndAddressType(
-                attendee2Box.getName(), getCN(attendee2Box), "t");
-        MimePartInfo mimePart = MimePartInfo.createForContentType("multipart/alternative");
-        mimePart.addMimePart(MimePartInfo.createForContentTypeAndContent("text/plain", "invite body"));
-        mimePart.addMimePart(MimePartInfo.createForContentTypeAndContent(
-                "text/html", "<html><body><p><b>invite</b> body</p></body></html>"));
-        Msg msg = new Msg();
-        msg.setFolderId("10");
-        msg.setInvite(invite);
-        msg.addEmailAddress(attendeeAddr);
-        msg.addEmailAddress(attendeeAddr2);
-        msg.setSubject(subject);
-        msg.setMimePart(mimePart);
-        CreateAppointmentRequest createSeriesRequest = CreateAppointmentRequest.create(msg);
-        CreateAppointmentResponse caResp = organizerBox.invokeJaxb(createSeriesRequest);
-        Assert.assertNotNull("JAXB CreateAppointmentResponse object", caResp);
-        Assert.assertNotNull("JAXB CreateAppointmentResponse calItemId", caResp.getCalItemId());
-        Assert.assertNotNull("JAXB CreateAppointmentResponse invId", caResp.getCalInvId());
-        Assert.assertNotNull("JAXB CreateAppointmentResponse modified sequence ms", caResp.getModifiedSequence());
-        Assert.assertNotNull("JAXB CreateAppointmentResponse rev", caResp.getRevision());
-        ZMessage seriesInviteMsg = TestUtil.waitForMessage(attendeeBox, subject);
-        Assert.assertNotNull("ZMessage for series invite", seriesInviteMsg);
-        ZInvite seriesInvite = seriesInviteMsg.getInvite();
-        Assert.assertNotNull("ZInvite for series invite", seriesInvite);
-
-        // User 1 accepts the daily meeting
-        ZMessage seriesAcceptMsg = sendInviteReplyToSeries(attendeeBox, organizerBox,
-                seriesInviteMsg.getId(), subject, "ACCEPT");
-        Assert.assertNotNull("ZMessage for series accept", seriesAcceptMsg);
-
-        // User 1 declines one instance of the daily meeting
-        SendInviteReplyRequest sirReq = new SendInviteReplyRequest( seriesInviteMsg.getId(),
-                0 /* componentNum */, "DECLINE");
-        sirReq.setIdentityId(attendeeBox.getAccountInfo(false).getId());
-        sirReq.setExceptionId(DtTimeInfo.createForDatetimeAndZone("20161011T130000", "Europe/London"));
-        sirReq.setUpdateOrganizer(true);
-        attendeeAddr.setAddressType("f");
-        mimePart = MimePartInfo.createForContentType("multipart/alternative");
-        mimePart.addMimePart(MimePartInfo.createForContentTypeAndContent(
-                "text/plain", "I won't attend on Tuesday, October 11, 2016."));
-        mimePart.addMimePart(MimePartInfo.createForContentTypeAndContent(
-                "text/html", "<html><body><p><b>I won't attend  on Tuesday, October 11, 2016</b></p></body></html>"));
-        msg = new Msg();
-        msg.setReplyType("r");
-        msg.setIdentityId(attendeeBox.getAccountInfo(false).getId());
-        EmailAddrInfo orgAddr = EmailAddrInfo.createForAddressPersonalAndAddressType(
-                organizerBox.getName(), organizerBox.getName(), "t");
-        msg.addEmailAddress(orgAddr);
-        msg.addEmailAddress(attendeeAddr);
-        String declineSubject = "Decline: " + subject;
-        msg.setSubject(declineSubject);
-        msg.setMimePart(mimePart);
-        sirReq.setMsg(msg);
-        SendInviteReplyResponse sirResp = attendeeBox.invokeJaxb(sirReq);
-        Assert.assertNotNull("JAXB SendInviteReplyResponse object", sirResp);
-        ZMessage instanceDeclineMsg = TestUtil.waitForMessage(
-                organizerBox, String.format("subject:\"%s\"", declineSubject));
-        Assert.assertNotNull("ZMessage for series accept", instanceDeclineMsg);
-        seriesInviteMsg = TestUtil.waitForMessage(attendee2Box, subject);
-        Assert.assertNotNull("ZMessage for series invite", seriesInviteMsg);
-        seriesInvite = seriesInviteMsg.getInvite();
-        Assert.assertNotNull("ZInvite for series invite", seriesInvite);
-
-        // User 2 tentatively accepts the daily meeting
-        ZMessage seriesTentativeMsg = sendInviteReplyToSeries(attendee2Box, organizerBox,
-                seriesInviteMsg.getId(), subject, "TENTATIVE");
-        Assert.assertNotNull("ZMessage for series tentative", seriesTentativeMsg);
-
-        // Search for the organizer's calendar entry
-        SearchRequest sReq = new SearchRequest();
-        sReq.setSearchTypes(ZSearchParams.TYPE_APPOINTMENT);
-        sReq.setCalItemExpandStart(ymdStringToDate("2016-10-09"));
-        sReq.setCalItemExpandEnd(ymdStringToDate("2016-10-14"));
-        sReq.setQuery((String.format("in:Calendar and subject:%s", subject)));
-        SearchResponse sResp = organizerBox.invokeJaxb(sReq);
-        List<SearchHit> hits = sResp.getSearchHits();
-        Assert.assertNotNull("Organizer calendar Search hits at end", hits);
-        Assert.assertEquals("Num Organizer calendar hits at end", 1, hits.size());
-        SearchHit orgCalHit = hits.get(0);
-        Assert.assertTrue(orgCalHit instanceof AppointmentHitInfo);
-        AppointmentHitInfo orgApptHit = (AppointmentHitInfo) orgCalHit;
-        String seriesInviteId = orgApptHit.getInvId();
-        Assert.assertNotNull("Organizer Calendar at end - series invite id", seriesInviteId);
-        List<InstanceDataInfo> instances = orgApptHit.getInstances();
-        Assert.assertNotNull("Organizer Calendar at end - instances in expansion", instances);
-        Assert.assertEquals("Organizer Calendar at end - number of instances in expansion", 5, instances.size());
-        // The third entry in the list should be for the exception
-        String exceptionInviteId = instances.get(2).getInvId();
-        Assert.assertNotNull("Organizer Calendar at end - exception invite id", exceptionInviteId);
-        String exceptionRidZ = instances.get(2).getRecurIdZ();
-        Assert.assertNotNull("Organizer Calendar at end - exception invite RecurIdZ", exceptionRidZ);
+    private void validateException(ZMailbox zmbox, InstanceDataInfo instance,
+            Map<ZMailbox, String> partstats, GregorianCalendar recurIdTime) throws ServiceException {
+        String exceptionInviteId = instance.getInvId();
+        Assert.assertNotNull("exception invite id", exceptionInviteId);
+        String exceptionRidZ = instance.getRecurIdZ();
+        Assert.assertNotNull("exception invite RecurIdZ", exceptionRidZ);
+        Assert.assertEquals("RecurIdZ",
+                ParsedDateTime.fromUTCTime(recurIdTime.getTimeInMillis()).getDateTimePartString(false),
+                exceptionRidZ);
 
         // Do a GetMsg for the exception in the Organizer's calendar
         MsgSpec gmeMsgSpec = new MsgSpec(exceptionInviteId);
         gmeMsgSpec.setRecurIdZ(exceptionRidZ);
         GetMsgRequest gmeReq = new GetMsgRequest(gmeMsgSpec);
-        GetMsgResponse gmeResp = organizerBox.invokeJaxb(gmeReq);
+        GetMsgResponse gmeResp = zmbox.invokeJaxb(gmeReq);
         List<InviteComponentWithGroupInfo> eInviteComps = gmeResp.getMsg().getInvite().getInviteComponents();
-        Assert.assertEquals("Organizer Calendar at end - number of components in exception", 1, eInviteComps.size());
+        Assert.assertEquals("number of components in exception", 1, eInviteComps.size());
         List<CalendarAttendeeWithGroupInfo> eAttendees = eInviteComps.get(0).getAttendees();
-        Assert.assertEquals("Organizer Calendar at end - number of attendees in exception", 2, eAttendees.size());
+        Assert.assertEquals("number of attendees in exception", 2, eAttendees.size());
         for (CalendarAttendeeWithGroupInfo eAttendee : eAttendees) {
             String addr = eAttendee.getAddress();
             String ptst = eAttendee.getPartStat();
-            if (addr.equals(attendeeBox.getName())) {
-                Assert.assertEquals("exception attendee1 partstat", "DE", ptst);
-            } else if (addr.equals(attendee2Box.getName())) {
-                Assert.assertEquals("exception attendee2 partstat", "TE", ptst);
-            } else {
-                Assert.fail(String.format("Unexpected attendee in exception [%s]", addr));
+            boolean found = false;
+            for (Entry<ZMailbox, String> entry : partstats.entrySet()) {
+                if (addr.equals(entry.getKey().getName())) {
+                    Assert.assertEquals(String.format("Exception partstat for %s", entry.getKey()),
+                            entry.getValue(), ptst);
+                    found = true;
+                }
             }
+            Assert.assertTrue(String.format("Unexpected attendee in exception [%s]", addr), found);
         }
+    }
+
+    /**
+     * Bug 94018.  Accepting series, then declining single instance leads to inconsistent display of attendee
+     * status for organizer copy for the declined instance.
+     *
+     * Pseudo exceptions should be created for each reply to an individual instance of the series.
+     *
+     * At the end of this, check that exceptions have been created.  Check that the exceptions register
+     * the correct statuses for the users.
+     */
+    @Test
+    public void acceptAndTentativeSeriesDeclineInstanceAcceptInstance()
+    throws Exception {
+        TestUtil.createAccount(ORGANIZER);
+        TestUtil.createAccount(ATTENDEE1);
+        TestUtil.createAccount(ATTENDEE2);
+        String subject = NAME_PREFIX + " every 2 days";
+        ZMailbox organizerZMbox = TestUtil.getZMailbox(ORGANIZER);
+        ZMailbox attendee1ZMbox = TestUtil.getZMailbox(ATTENDEE1);
+        ZMailbox attendee2ZMbox = TestUtil.getZMailbox(ATTENDEE2);
+
+        String londonTZ = "Europe/London";
+        int year = Calendar.getInstance().get(Calendar.YEAR) + 1;
+
+        // Create and send meeting that occurs every 2 days
+        InviteComponent inviteComp = createInviteComponentSkeleton(subject, "room 101",
+            organizerZMbox, attendee1ZMbox, attendee2ZMbox);
+        GregorianCalendar start = startTime(londonTZ, year, 1 /* February */, 2 /* day */, 14 /* hour */, 0);
+        GregorianCalendar end = plus(start, Calendar.MINUTE, 30);
+        setStartAndEnd(inviteComp, londonTZ, start, end);
+        inviteComp.setRecurrence(
+                recurrence("DAI", 2 /* every 2 days */, String.format("%d0529", year) /* until */));
+        sendMeetingRequest(organizerZMbox,
+            createMsgForAppointmentRequest(subject, inviteComp, attendee1ZMbox, attendee2ZMbox));
+
+        // attendee 1 wait for original invite
+        ZMessage seriesMsg = waitForInvite(attendee1ZMbox, subject);
+        // attendee 1 accepts the original invite to the whole series
+        sendInviteReplyAndWaitForIt(
+                attendee1ZMbox, organizerZMbox, seriesMsg.getId(), subject, "ACCEPT", null);
+
+        // attendee 1 declines one instance of the daily meeting - 2 + 4 --> 6th Feb
+        GregorianCalendar exceptionTime = plus(start, Calendar.DAY_OF_MONTH, 4);
+        sendInviteReplyAndWaitForIt(
+                attendee1ZMbox, organizerZMbox, seriesMsg.getId(), subject, "DECLINE",
+                DtTimeInfo.createForDatetimeAndZone(dateTime(exceptionTime), londonTZ));
+
+        // attendee 2 wait for original invite
+        seriesMsg = waitForInvite(attendee2ZMbox, subject);
+        // attendee 2 tentatively accepts the original invite to the whole series
+        sendInviteReplyAndWaitForIt(
+                attendee2ZMbox, organizerZMbox, seriesMsg.getId(), subject, "TENTATIVE", null);
+
+        // attendee 2 declines one instance of the daily meeting 2 + 8 --> 10th Feb
+        GregorianCalendar exceptionTime2 = plus(start, Calendar.DAY_OF_MONTH, 8);
+        sendInviteReplyAndWaitForIt(
+                attendee2ZMbox, organizerZMbox, seriesMsg.getId(), subject + " " + ATTENDEE2, "DECLINE",
+                DtTimeInfo.createForDatetimeAndZone(dateTime(exceptionTime2), londonTZ));
+
+        // Search for a range of instances of the organizer's calendar entry
+        SearchRequest sReq = new SearchRequest();
+        sReq.setSearchTypes(ZSearchParams.TYPE_APPOINTMENT);
+        /* 2nd Feb + 1 --> 3rd, 2nd Feb + 13 --> 15th.  So should match instances on:
+         *     4th, 6th, 8th, 10th, 12th, 14th. */
+        List<AppointmentHitInfo> apptHits = findMatchingExpandedAppointments(organizerZMbox,
+                plus(start, Calendar.DAY_OF_MONTH, 1).getTime(),
+                plus(start, Calendar.DAY_OF_MONTH, 13).getTime(),
+                String.format("in:Calendar and subject:%s", subject), 1);
+        AppointmentHitInfo orgApptHit = apptHits.get(0);
+        Assert.assertNotNull("Organizer Calendar at end - series invite id", orgApptHit.getInvId());
+        List<InstanceDataInfo> instances = orgApptHit.getInstances();
+        Assert.assertNotNull("Organizer Calendar at end - instances in expansion", instances);
+        Assert.assertEquals("Organizer Calendar at end - number of instances in expansion",
+                6, instances.size());
+
+        // The 2nd entry in the list should be for an exception
+        Map<ZMailbox,String> partstatMap = new HashMap<>(2);
+        partstatMap.put(attendee1ZMbox, ZAppointmentHit.PSTATUS_DECLINED);   /* for this instance */
+        partstatMap.put(attendee2ZMbox, ZAppointmentHit.PSTATUS_TENTATIVE);  /* for the series */
+        validateException(organizerZMbox, instances.get(1), partstatMap, exceptionTime);
+
+        // The 4th entry in the list should also be for an exception
+        partstatMap.put(attendee1ZMbox, ZAppointmentHit.PSTATUS_ACCEPT);    /* for the series */
+        partstatMap.put(attendee2ZMbox, ZAppointmentHit.PSTATUS_DECLINED);  /* for the instance */
+        validateException(organizerZMbox, instances.get(3), partstatMap, exceptionTime2);
 
         // Do a GetMsg for the series in the Organizer's calendar
-        MsgSpec gmsMsgSpec = new MsgSpec(seriesInviteId);
+        MsgSpec gmsMsgSpec = new MsgSpec(orgApptHit.getInvId());
         GetMsgRequest gmsReq = new GetMsgRequest(gmsMsgSpec);
-        GetMsgResponse gmsResp = organizerBox.invokeJaxb(gmsReq);
+        GetMsgResponse gmsResp = organizerZMbox.invokeJaxb(gmsReq);
         List<InviteComponentWithGroupInfo> sInviteComps = gmsResp.getMsg().getInvite().getInviteComponents();
-        Assert.assertEquals("Organizer Calendar at end - number of components in series", 1, sInviteComps.size());
+        Assert.assertEquals("number of components in series", 1, sInviteComps.size());
         List<CalendarAttendeeWithGroupInfo> sAttendees = sInviteComps.get(0).getAttendees();
-        Assert.assertEquals("Organizer Calendar at end - number of attendees in exception", 2, sAttendees.size());
+        Assert.assertEquals("number of attendees in exception", 2, sAttendees.size());
         for (CalendarAttendeeWithGroupInfo sAttendee : sAttendees) {
             String addr = sAttendee.getAddress();
             String ptst = sAttendee.getPartStat();
-            if (addr.equals(attendeeBox.getName())) {
-                Assert.assertEquals("exception attendee1 partstat", "AC", ptst);
-            } else if (addr.equals(attendee2Box.getName())) {
-                Assert.assertEquals("exception attendee2 partstat", "TE", ptst);
+            if (addr.equals(attendee1ZMbox.getName())) {
+                Assert.assertEquals("exception attendee1 partstat", ZAppointmentHit.PSTATUS_ACCEPT, ptst);
+            } else if (addr.equals(attendee2ZMbox.getName())) {
+                Assert.assertEquals("exception attendee2 partstat", ZAppointmentHit.PSTATUS_TENTATIVE, ptst);
             } else {
                 Assert.fail(String.format("Unexpected attendee in exception [%s]", addr));
             }
@@ -544,48 +605,10 @@ public class TestJaxb {
             date = formatter.parse(ymdString);
             return date.getTime();
         } catch (ParseException e) {
-            Assert.fail(String.format("Failed to convert string %s to long - exception %s",  ymdString, e.getMessage()));
+            Assert.fail(String.format("Failed to convert string %s to long - exception %s",
+                    ymdString, e.getMessage()));
         }
         return 0;
-    }
-
-    private ZMessage sendInviteReplyToSeries(
-            ZMailbox attendeeBox, ZMailbox organizerBox, String inviteMsgId, String subjectSuffix, String verb)
-    throws Exception {
-        SendInviteReplyRequest sirReq = new SendInviteReplyRequest(inviteMsgId, 0 /* componentNum */, verb);
-        sirReq.setIdentityId(attendeeBox.getAccountInfo(false).getId());
-        sirReq.setUpdateOrganizer(true);
-        EmailAddrInfo attendeeAddr = EmailAddrInfo.createForAddressPersonalAndAddressType(
-                attendeeBox.getName(), getCN(attendeeBox), "f");
-        EmailAddrInfo orgAddr = EmailAddrInfo.createForAddressPersonalAndAddressType(
-                organizerBox.getName(), organizerBox.getName(), "t");
-        MimePartInfo mimePart = MimePartInfo.createForContentType("multipart/alternative");
-        String plainText;
-        String subject;
-        if ("ACCEPT".equals(verb)) {
-            plainText = "Yes, I will attend.";
-            subject = "Accept: " + subjectSuffix;
-        } else if ("DECLINE".equals(verb)) {
-            plainText = "No, I won't attend.";
-            subject = "Decline: " + subjectSuffix;
-        } else {
-            plainText = "Maybe, I will attend.";
-            subject = "Tentative: " + subjectSuffix;
-        }
-        String htmlText = String.format("<html><body><p><b>%s</b></p></body></html>", plainText);
-        mimePart.addMimePart(MimePartInfo.createForContentTypeAndContent("text/plain", plainText));
-        mimePart.addMimePart(MimePartInfo.createForContentTypeAndContent("text/html", htmlText));
-        Msg msg = new Msg();
-        msg.setReplyType("r");
-        msg.setIdentityId(attendeeBox.getAccountInfo(false).getId());
-        msg.addEmailAddress(orgAddr);
-        msg.addEmailAddress(attendeeAddr);
-        msg.setSubject(subject);
-        msg.setMimePart(mimePart);
-        sirReq.setMsg(msg);
-        SendInviteReplyResponse sirResp = attendeeBox.invokeJaxb(sirReq);
-        Assert.assertNotNull("JAXB SendInviteReplyResponse object", sirResp);
-        return TestUtil.waitForMessage(organizerBox, String.format("subject:\"%s\"", subject));
     }
 
     private String envelope(String authToken, String requestBody) {

--- a/store/src/java/com/zimbra/qa/unittest/TestUtil.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestUtil.java
@@ -684,7 +684,9 @@ public class TestUtil extends Assert {
     }
 
     public static ZMessage waitForMessage(ZMailbox mbox, String query) throws Exception {
-        List<ZMessage> msgs = waitForMessages(mbox, query, 1, 10000);
+        // Used to wait up to 10 secs but due to the way postfix sometimes works, can get longer delays
+        // so increased the max wait time.
+        List<ZMessage> msgs = waitForMessages(mbox, query, 1, 31000);
         return msgs.get(0);
     }
 


### PR DESCRIPTION
    ZWC expects each exception in a message to have a unique item ID
    associated with it.  If this doesn't happen, the details of the first
    exception are used.

    Pseudo exceptions created when a reply is received specifying a
    particular PARTSTAT to single instance of the main series
    were not obeying this rule.  Instead 0 was used for both the item ID
    and the component number.  I had hoped that using the item ID of the
    calendar entry and a different component number would fix the issue,
    as intuitively, this is what I expected those values to mean but
    that doesn't match reality or what happens when exceptions are created
    in the calendar as a result of ZWC actions (or CalDAV actions)

    * public `Mailbox.ItemIdGetter` interface and private
      `Mailbox.NextItemIdGetter` implementation added as a preferred
      workaround to making `getNextItemId` protected
    * Eliminated a few wrapper `processNewInvite` and `processNewInviteReply`
      methods