### PR TITLE
ZCS-3055,ZCS-4932 Declining single instance of all-day series handled strangely

### DIFF
--- a/common/src/java/com/zimbra/common/calendar/ParsedDateTime.java
+++ b/common/src/java/com/zimbra/common/calendar/ParsedDateTime.java
@@ -282,7 +282,7 @@ public final class ParsedDateTime {
     }
 
     @Override
-    public Object clone() {
+    public ParsedDateTime clone() {
         GregorianCalendar cal = (GregorianCalendar) mCal.clone();
         return new ParsedDateTime(cal, mICalTimeZone, mHasTime);
     }
@@ -359,7 +359,7 @@ public final class ParsedDateTime {
     public ParsedDuration difference(ParsedDateTime other) {
         // Force the other ParsedDateTime to the same time zone.  Necessary to resolve DST ambiguity.
         if (!sameTimeZone(other)) {
-            other = ((ParsedDateTime) other.clone());
+            other = (other.clone());
             other.toTimeZone(mICalTimeZone);
         }
 
@@ -572,7 +572,7 @@ public final class ParsedDateTime {
         if (isUTC())
             return getDateTimePartString(false);
         else {
-            ParsedDateTime dtZ = (ParsedDateTime) clone();
+            ParsedDateTime dtZ = clone();
             dtZ.toUTC();
             return dtZ.getDateTimePartString(false);
         }


### PR DESCRIPTION
Hold off reviewing.  Not working in Harare time.
ZWC generates faulty responses to single instances of all-day series.  Specifying a timezone and DATE-TIME (with zeroes in the time part) in the RECURRENCE-ID.
The previous fix to ZCS-3055 handled this in a similar but slightly different way to previous code which may have introduced problems.
With this change, processing responses in order to update the calendar should handle more of
these faulty responses in a way which reflects what was intended and for those it doesn't fix, behaviour should be the same as prior to the original ZCS-3055 fix