### PR TITLE
ZCS-4362, ZCS-4363, ZCS-4364: Distributed Sessions via Pub/Sub

### DIFF
--- a/store/src/java-test/com/zimbra/cs/mailbox/MailboxTestUtil.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/MailboxTestUtil.java
@@ -18,7 +18,6 @@
 package com.zimbra.cs.mailbox;
 
 import java.io.File;
-import java.io.FileFilter;
 import java.io.FileNotFoundException;
 import java.io.FilenameFilter;
 import java.io.IOException;
@@ -62,6 +61,8 @@ import com.zimbra.cs.mailbox.cache.LocalItemCache;
 import com.zimbra.cs.mailbox.calendar.Invite;
 import com.zimbra.cs.mime.Mime;
 import com.zimbra.cs.mime.ParsedMessage;
+import com.zimbra.cs.session.LocalSessionDataProvider;
+import com.zimbra.cs.session.SessionDataProvider;
 import com.zimbra.cs.store.MockStoreManager;
 import com.zimbra.cs.store.StoreManager;
 import com.zimbra.cs.store.http.HttpStoreManagerTest.MockHttpStoreManager;
@@ -164,6 +165,8 @@ public final class MailboxTestUtil {
         IndexStore.setFactory(EmbeddedSolrIndex.Factory.class.getName());
         MailboxState.setFactory(new LocalMailboxState.Factory());
         ItemCache.setFactory(new LocalItemCache.Factory());
+        SessionDataProvider.setFactory(new LocalSessionDataProvider.Factory());
+        NotificationPubSub.setFactory(new LocalPubSub.Factory());
         MailboxManager.setInstance(null);
         IndexStore.setFactory(LC.zimbra_class_index_store_factory.value());
         LC.zimbra_class_store.setDefault(storeManagerClass.getName());
@@ -187,7 +190,8 @@ public final class MailboxTestUtil {
         IndexStore.setFactory(EmbeddedSolrIndex.Factory.class.getName());
         MailboxState.setFactory(new LocalMailboxState.Factory());
         ItemCache.setFactory(new LocalItemCache.Factory());
-
+        SessionDataProvider.setFactory(new LocalSessionDataProvider.Factory());
+        NotificationPubSub.setFactory(new LocalPubSub.Factory());
         MailboxManager.setInstance(null);
 
         LC.zimbra_class_store.setDefault(storeManagerClass.getName());

--- a/store/src/java/com/zimbra/cs/imap/ImapListener.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapListener.java
@@ -631,7 +631,7 @@ public abstract class ImapListener extends Session {
 
     @SuppressWarnings("rawtypes")
     @Override
-    public void notifyPendingChanges(PendingModifications pnsIn, int changeId, Session source) {
+    public void notifyPendingChanges(PendingModifications pnsIn, int changeId, SourceSessionInfo source) {
         if (!pnsIn.hasNotifications()) {
             return;
         }

--- a/store/src/java/com/zimbra/cs/imap/LocalImapMailboxStore.java
+++ b/store/src/java/com/zimbra/cs/imap/LocalImapMailboxStore.java
@@ -102,7 +102,7 @@ public class LocalImapMailboxStore extends ImapMailboxStore {
     @Override
     public List<ImapListener> getListeners(ItemIdentifier ident) {
         List<ImapListener> listeners = new ArrayList<ImapListener>();
-        for (Session listener : mailbox.getListeners(Session.Type.IMAP)) {
+        for (Session listener : mailbox.getNotificationPubSub().getSubscriber().getListeners(Session.Type.IMAP)) {
             if (listener instanceof ImapSession) {
                 ImapSession iListener = (ImapSession)listener;
                 if (iListener.getFolderId() == ident.id) {

--- a/store/src/java/com/zimbra/cs/mailbox/Folder.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Folder.java
@@ -306,7 +306,7 @@ public class Folder extends MailItem implements FolderStore {
     }
 
     private boolean writableImapSessionActive() {
-        for (Session s : mMailbox.getListeners(Session.Type.IMAP)) {
+        for (Session s : mMailbox.getNotificationPubSub().getSubscriber().getListeners(Session.Type.IMAP)) {
             ImapSession i4session = (ImapSession) s;
             if (i4session.getFolderItemIdentifier().id == mId && i4session.isWritable()) {
                 return true;

--- a/store/src/java/com/zimbra/cs/mailbox/LocalPubSub.java
+++ b/store/src/java/com/zimbra/cs/mailbox/LocalPubSub.java
@@ -1,0 +1,39 @@
+package com.zimbra.cs.mailbox;
+
+import com.zimbra.cs.session.Session.Type;
+
+public class LocalPubSub extends NotificationPubSub {
+
+    public LocalPubSub(Mailbox mbox) {
+        super(mbox);
+    }
+
+    public class LocalPublisher extends Publisher {
+
+        @Override
+        public int getNumListeners(Type type) {
+            return LocalPubSub.this.getSubscriber().getListeners(type).size();
+        }
+    }
+
+    public class LocalSubscriber extends Subscriber {}
+
+    @Override
+    protected Publisher initPubisher() {
+        return new LocalPublisher();
+    }
+
+    @Override
+    protected Subscriber initSubscriber() {
+        return new LocalSubscriber();
+    }
+
+    public static class Factory extends NotificationPubSub.Factory {
+
+        @Override
+        protected NotificationPubSub initPubSub(Mailbox mbox) {
+            return new LocalPubSub(mbox);
+        }
+
+    }
+}

--- a/store/src/java/com/zimbra/cs/mailbox/MailItem.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailItem.java
@@ -467,7 +467,7 @@ public abstract class MailItem implements Comparable<MailItem>, ScheduledTaskRes
         private static final String FN_MOD_CONTENT  = "modc";
         private static final String FN_DATE_CHANGED = "dc";
 
-        Metadata serialize() {
+        public Metadata serialize() {
             Metadata meta = new Metadata();
             meta.put(FN_ID, id);
             meta.put(FN_TYPE, type);

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -40,7 +40,6 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Pattern;
@@ -120,7 +119,6 @@ import com.zimbra.cs.db.DbMailItem.QueryParams;
 import com.zimbra.cs.db.DbMailbox;
 import com.zimbra.cs.db.DbPool;
 import com.zimbra.cs.db.DbPool.DbConnection;
-import com.zimbra.cs.db.DbSession;
 import com.zimbra.cs.db.DbTag;
 import com.zimbra.cs.db.DbVolumeBlobs;
 import com.zimbra.cs.event.Event;
@@ -146,7 +144,6 @@ import com.zimbra.cs.ldap.LdapConstants;
 import com.zimbra.cs.mailbox.CalendarItem.AlarmData;
 import com.zimbra.cs.mailbox.CalendarItem.Callback;
 import com.zimbra.cs.mailbox.CalendarItem.ReplyInfo;
-import com.zimbra.cs.mailbox.FoldersTagsCache.FoldersTags;
 import com.zimbra.cs.mailbox.MailItem.CustomMetadata;
 import com.zimbra.cs.mailbox.MailItem.PendingDelete;
 import com.zimbra.cs.mailbox.MailItem.TargetConstraint;
@@ -266,7 +263,8 @@ import com.zimbra.cs.session.PendingLocalModifications;
 import com.zimbra.cs.session.PendingModifications;
 import com.zimbra.cs.session.PendingModifications.Change;
 import com.zimbra.cs.session.Session;
-import com.zimbra.cs.session.SessionCache;
+import com.zimbra.cs.session.Session.SourceSessionInfo;
+import com.zimbra.cs.session.Session.Type;
 import com.zimbra.cs.session.SoapSession;
 import com.zimbra.cs.stats.ZimbraPerf;
 import com.zimbra.cs.store.Blob;
@@ -687,7 +685,6 @@ public class Mailbox implements MailboxStore {
     private final int mId;
     private final MailboxData mData;
     private final ThreadLocal<MailboxChange> threadChange = new ThreadLocal<MailboxChange>();
-    private final List<Session> mListeners = new CopyOnWriteArrayList<Session>();
 
     private FolderCache mFolderCache;
     private Map<Object, Tag> mTagCache;
@@ -702,6 +699,7 @@ public class Mailbox implements MailboxStore {
     private boolean galSyncMailbox = false;
     private volatile boolean requiresWriteLock = true;
     private MailboxState state;
+    private NotificationPubSub.Publisher publisher;
 
     protected Mailbox(MailboxData data) {
         mId = data.id;
@@ -713,8 +711,10 @@ public class Mailbox implements MailboxStore {
         callbacks = new HashMap<>();
         callbacks.put(MessageCallback.Type.sent, new SentMessageCallback());
         callbacks.put(MessageCallback.Type.received, new ReceivedMessageCallback());
+
         state = MailboxState.getFactory().getMailboxState(mData);
         state.setLastChangeDate(System.currentTimeMillis());
+        publisher = getNotificationPubSub().getPublisher();
     }
 
     public void setGalSyncMailbox(boolean galSyncMailbox) {
@@ -964,150 +964,8 @@ public class Mailbox implements MailboxStore {
         return sender;
     }
 
-
-    /** Returns the list of all <code>Mailbox</code> listeners of a given type.
-     *  Returns all listeners when the passed-in type is <tt>null</tt>. */
-    public List<Session> getListeners(Session.Type stype) {
-        if (mListeners.isEmpty()) {
-            return Collections.emptyList();
-        } else if (stype == null) {
-            return new ArrayList<Session>(mListeners);
-        }
-
-        List<Session> sessions = new ArrayList<Session>(mListeners.size());
-        for (Session s : mListeners) {
-            if (s.getType() == stype) {
-                sessions.add(s);
-            }
-        }
-        return sessions;
-    }
-
-    boolean hasListeners(Session.Type stype) {
-        if (mListeners.isEmpty()) {
-            return false;
-        } else if (stype == null) {
-            return true;
-        }
-
-        for (Session s : mListeners) {
-            if (s.getType() == stype) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /** Loookup a {@link Session} in the set of listeners on this mailbox. */
-    public Session getListener(String sessionId) {
-        if (sessionId != null) {
-            for (Session session : mListeners) {
-                if (sessionId.equals(session.getSessionId())) {
-                    return session;
-                }
-            }
-        }
-        return null;
-    }
-
-    /** Adds a {@link Session} to the set of listeners notified on Mailbox
-     *  changes.
-     *
-     * @param session  The Session registering for notifications.
-     * @throws ServiceException  If the mailbox is in maintenance mode. */
-    public void addListener(Session session) throws ServiceException {
-        if (session == null) {
-            return;
-        }
-        assert(session.getSessionId() != null);
-        if (maintenance != null) {
-            throw MailServiceException.MAINTENANCE(mId);
-        }
-        ZimbraLog.mailbox.debug("adding listener: %s", session);
-        if (!mListeners.contains(session)) {
-            mListeners.add(session);
-        }
-        /* check whether beginMaintenance happened whilst adding a listener.  If it did then
-         * undo it.  This avoids getting a write lock */
-        if (maintenance != null) {
-            purgeListeners();
-            throw MailServiceException.MAINTENANCE(mId);
-        }
-        if (!Zimbra.isAlwaysOn()) {
-            return;
-        }
-        // Rest done only if AlwaysOn
-        try (final MailboxLock l = getWriteLockAndLockIt()) {
-            if (mListeners.size() == 1) {
-                // insert session into DB
-                DbConnection conn = DbPool.getConnection();
-                try {
-                    MailboxStore sessMbox = session.getMailbox();
-                    if (sessMbox instanceof Mailbox) {
-                        DbSession.create(conn, ((Mailbox)sessMbox).getId(), Provisioning.getInstance()
-                                .getLocalServer().getId());
-                    } else {
-                        throw new UnsupportedOperationException(String.format(
-                                "Operation not supported for non-Mailbox MailboxStore",
-                                sessMbox == null ? "null" : sessMbox.getClass().getName()));
-                    }
-                    conn.commit();
-                } catch (ServiceException e) {
-                    ZimbraLog.session.info("exception while inserting session into DB", e);
-                } finally {
-                    if (conn != null) {
-                        conn.closeQuietly();
-                    }
-                }
-            }
-        }
-    }
-
-    /** Removes a {@link Session} from the set of listeners notified on
-     *  Mailbox changes.
-     *
-     * @param session  The listener to deregister for notifications. */
-    public void removeListener(Session session) {
-        if (ZimbraLog.mailbox.isDebugEnabled()) {
-            ZimbraLog.mailbox.debug("clearing listener: %s", session);
-        }
-        mListeners.remove(session);
-        if (!Zimbra.isAlwaysOn()) {
-            return;
-        }
-        // Rest done only if AlwaysOn
-        try (final MailboxLock l = getWriteLockAndLockIt()) {
-            if (mListeners.size() == 0) {
-                // DbSessions Cleanup
-                DbConnection conn = null;
-                try {
-                    conn = DbPool.getConnection();
-                    DbSession.delete(conn, getId(), Provisioning.getInstance().getLocalServer().getId());
-                    conn.commit();
-                } catch (ServiceException e) {
-                    ZimbraLog.mailbox.error("Deleting database session: ", e);
-                } finally {
-                    if (conn != null) {
-                        conn.closeQuietly();
-                    }
-                }
-            }
-        }
-    }
-
-    /** Cleans up and disconnects all {@link Session}s listening for
-     *  notifications on this Mailbox.
-     *
-     * @see SessionCache#clearSession(Session) */
-    private void purgeListeners() {
-        ZimbraLog.mailbox.debug("purging listeners");
-
-        for (Session session : mListeners) {
-            SessionCache.clearSession(session);
-        }
-        // this may be redundant, as Session.doCleanup should dequeue
-        //   the listener, but empty the list here just to be sure
-        mListeners.clear();
+    boolean hasListeners(Type type) {
+        return publisher.getNumListeners(type) > 0;
     }
 
     /** Returns whether the server is keeping track of message deletes
@@ -1434,11 +1292,12 @@ public class Mailbox implements MailboxStore {
         try (final MailboxLock l = getReadLockAndLockIt()) {
             long lastAccess = (currentChange().accessed == MailboxChange.NO_CHANGE ? state.getLastWriteDate()
                             : currentChange().accessed) * 1000L;
-            for (Session s : mListeners) {
-                if (s instanceof SoapSession) {
-                    lastAccess = Math.max(lastAccess, ((SoapSession) s).getLastWriteAccessTime());
-                }
-            }
+            //TODO: no way to get Soap access time on remote mailboxes
+//            for (Session s : mListeners) {
+//                if (s instanceof SoapSession) {
+//                    lastAccess = Math.max(lastAccess, ((SoapSession) s).getLastWriteAccessTime());
+//                }
+//            }
             return lastAccess;
         }
     }
@@ -1654,8 +1513,6 @@ public class Mailbox implements MailboxStore {
                 return maintenance;
             }
             ZimbraLog.mailbox.info("Putting mailbox %d under maintenance.", getId());
-
-            purgeListeners();
             index.evict();
 
             maintenance = new MailboxMaintenance(mData.accountId, mId, this);
@@ -9117,13 +8974,8 @@ public class Mailbox implements MailboxStore {
         }
 
         if (notification != null) {
-            for (Session session : mListeners) {
-                try {
-                    session.notifyPendingChanges(notification.mods, notification.lastChangeId, source);
-                } catch (RuntimeException e) {
-                    ZimbraLog.mailbox.error("ignoring error during notification", e);
-                }
-            }
+            SourceSessionInfo sourceInfo = source != null ? source.toSessionInfo() : null;
+            publisher.publish(notification.mods, notification.lastChangeId, sourceInfo, this.hashCode());
             MailboxListener.notifyListeners(notification);
         }
     }
@@ -9175,7 +9027,7 @@ public class Mailbox implements MailboxStore {
 
     private void trimItemCache() {
         try {
-            int sizeTarget = mListeners.isEmpty() ? MAX_ITEM_CACHE_WITHOUT_LISTENERS : MAX_ITEM_CACHE_WITH_LISTENERS;
+            int sizeTarget = !hasListeners(null) ? MAX_ITEM_CACHE_WITHOUT_LISTENERS : MAX_ITEM_CACHE_WITH_LISTENERS;
             if (galSyncMailbox) {
                 sizeTarget = MAX_ITEM_CACHE_FOR_GALSYNC_MAILBOX;
             }
@@ -10120,5 +9972,9 @@ public class Mailbox implements MailboxStore {
                 .omitNullValues()
                 .toString();
         }
+    }
+
+    public NotificationPubSub getNotificationPubSub() {
+        return NotificationPubSub.getFactory().getNotificationPubSub(this);
     }
 }

--- a/store/src/java/com/zimbra/cs/mailbox/NotificationPubSub.java
+++ b/store/src/java/com/zimbra/cs/mailbox/NotificationPubSub.java
@@ -1,0 +1,206 @@
+package com.zimbra.cs.mailbox;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import com.zimbra.common.mailbox.MailboxStore;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.session.PendingLocalModifications;
+import com.zimbra.cs.session.PendingModifications;
+import com.zimbra.cs.session.Session;
+import com.zimbra.cs.session.Session.SourceSessionInfo;
+import com.zimbra.cs.session.Session.Type;
+import com.zimbra.cs.session.SessionCache;
+
+public abstract class NotificationPubSub {
+
+    private static Factory factory;
+    private Publisher publisher = null;
+    private Subscriber subscriber = null;
+    protected Mailbox mbox;
+
+    public NotificationPubSub(Mailbox mbox) {
+        this.mbox = mbox;
+    }
+
+    public static void setFactory(Factory factory) {
+        NotificationPubSub.factory = factory;
+    }
+
+    public static Factory getFactory() {
+        return factory;
+    }
+
+    public synchronized Publisher getPublisher() {
+        if (publisher == null) {
+            publisher = initPubisher();
+        }
+        return publisher;
+    }
+
+    public synchronized Subscriber getSubscriber() {
+        if (subscriber == null) {
+            subscriber = initSubscriber();
+        }
+        return subscriber;
+    }
+
+    protected abstract Publisher initPubisher();
+
+    protected abstract Subscriber initSubscriber();
+
+    public abstract class Publisher {
+
+        /**
+         * Publish notifications to listeners. By default, only notifies local listeners.
+         */
+        public void publish(PendingLocalModifications pns, int changeId, SourceSessionInfo source, int sourceMailboxHash) {
+            notifyLocal(pns, changeId, source, sourceMailboxHash);
+        }
+
+        /**
+         * Returns the number of listeners that are listening on this publisher
+         */
+        public abstract int getNumListeners(Type type);
+
+        public void notifyLocal(PendingLocalModifications pns, int changeId, SourceSessionInfo source, int sourceMailboxHash) {
+            Subscriber subscriber = NotificationPubSub.this.getSubscriber();
+            subscriber.notifyListeners(pns, changeId, source, sourceMailboxHash, false);
+        }
+    }
+
+    public abstract class Subscriber {
+
+        private final List<Session> listeners = new CopyOnWriteArrayList<Session>();
+
+        /** Returns the list of all <code>Mailbox</code> listeners of a given type.
+         *  Returns all listeners when the passed-in type is <tt>null</tt>. */
+        public List<Session> getListeners(Session.Type stype) {
+            if (listeners.isEmpty()) {
+                return Collections.emptyList();
+            } else if (stype == null) {
+                return new ArrayList<Session>(listeners);
+            }
+
+            List<Session> sessions = new ArrayList<Session>(listeners.size());
+            for (Session s : listeners) {
+                if (s.getType() == stype) {
+                    sessions.add(s);
+                }
+            }
+            return sessions;
+        }
+
+        boolean hasListeners(Session.Type stype) {
+            if (listeners.isEmpty()) {
+                return false;
+            } else if (stype == null) {
+                return true;
+            }
+
+            for (Session s : listeners) {
+                if (s.getType() == stype) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /** Loookup a {@link Session} in the set of listeners on this mailbox. */
+        public Session getListener(String sessionId) {
+            if (sessionId != null) {
+                for (Session session : listeners) {
+                    if (sessionId.equals(session.getSessionId())) {
+                        return session;
+                    }
+                }
+            }
+            return null;
+        }
+
+        /** Adds a {@link Session} to the set of listeners notified on Mailbox
+         *  changes.
+         *
+         * @param session  The Session registering for notifications.
+         * @throws ServiceException  If the mailbox is in maintenance mode. */
+        public void addListener(Session session) throws ServiceException {
+            if (session == null) {
+                return;
+            }
+            assert(session.getSessionId() != null);
+            if (mbox.getMaintenance() != null) {
+                throw MailServiceException.MAINTENANCE(mbox.getId());
+            }
+            ZimbraLog.mailbox.debug("adding listener: %s", session);
+            if (!listeners.contains(session)) {
+                listeners.add(session);
+            }
+            /* check whether beginMaintenance happened whilst adding a listener.  If it did then
+             * undo it.  This avoids getting a write lock */
+            if (mbox.getMaintenance() != null) {
+                purgeListeners();
+                throw MailServiceException.MAINTENANCE(mbox.getId());
+            }
+        }
+
+        /** Removes a {@link Session} from the set of listeners notified on
+         *  Mailbox changes.
+         *
+         * @param session  The listener to deregister for notifications. */
+        public void removeListener(Session session) {
+            if (ZimbraLog.mailbox.isDebugEnabled()) {
+                ZimbraLog.mailbox.debug("clearing listener: %s", session);
+            }
+            listeners.remove(session);
+        }
+
+        /** Cleans up and disconnects all {@link Session}s listening for
+         *  notifications on this Mailbox.
+         *
+         * @see SessionCache#clearSession(Session) */
+        public void purgeListeners() {
+            ZimbraLog.mailbox.debug("purging listeners");
+
+            for (Session session : listeners) {
+                SessionCache.clearSession(session);
+            }
+            listeners.clear();
+        }
+
+        protected void notifyListeners(PendingModifications pns, int changeId, SourceSessionInfo source, int sourceMailboxHash, boolean skipLocal) {
+            for (Session session : listeners) {
+                MailboxStore mbox = session.getMailbox();
+                if (skipLocal && mbox != null && sourceMailboxHash == mbox.hashCode()) {
+                    //ignore all notifications received via pub/sub from the same mailbox node - sessions were notified locally
+                    continue;
+                }
+                if (skipLocal && source != null && source.equals(session)) {
+                    //ignore notifications received via pub/sub from the the same session on a different node
+                    continue;
+                }
+                session.notifyPendingChanges(pns, changeId, source);
+            }
+        }
+    }
+
+    public static abstract class Factory {
+
+        private Map<String, NotificationPubSub> cache = new HashMap<>();
+
+        protected abstract NotificationPubSub initPubSub(Mailbox mbox);
+
+        public synchronized NotificationPubSub getNotificationPubSub(Mailbox mbox) {
+            NotificationPubSub pubsub = cache.get(mbox.getAccountId());
+            if (pubsub == null) {
+                pubsub = initPubSub(mbox);
+                cache.put(mbox.getAccountId(), pubsub);
+            }
+            return pubsub;
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/mailbox/RedisPubSub.java
+++ b/store/src/java/com/zimbra/cs/mailbox/RedisPubSub.java
@@ -1,0 +1,112 @@
+package com.zimbra.cs.mailbox;
+
+import java.io.IOException;
+
+import org.redisson.api.RTopic;
+import org.redisson.api.RedissonClient;
+import org.redisson.api.listener.MessageListener;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.session.PendingLocalModifications;
+import com.zimbra.cs.session.PendingLocalModifications.PendingModificationSnapshot;
+import com.zimbra.cs.session.Session.SourceSessionInfo;
+import com.zimbra.cs.session.Session.Type;
+
+public class RedisPubSub extends NotificationPubSub {
+
+    private RedissonClient client;
+    private RTopic<NotificationMsg> channel;
+
+    public RedisPubSub(Mailbox mbox, RedissonClient client) {
+        super(mbox);
+        this.client = client;
+        this.channel = client.getTopic(getChannelName());
+    }
+
+    private String getChannelName() {
+        return mbox.getAccountId();
+    }
+    @Override
+    protected Publisher initPubisher() {
+        return new RedisPublisher();
+    }
+
+    @Override
+    protected Subscriber initSubscriber() {
+        return new RedisSubscriber();
+    }
+
+    public class RedisPublisher extends Publisher {
+
+        @Override
+        public void publish(PendingLocalModifications pns, int changeId, SourceSessionInfo source, int sourceMailboxHash) {
+            super.publish(pns, changeId, source, sourceMailboxHash); //notify local first
+            try {
+                //don't publish mods with no changes remotely to minimize chatter
+                if (!pns.hasNotifications()) {
+                    return;
+                }
+                PendingModificationSnapshot snapshot = pns.toSnapshot();
+                long received = channel.publish(new NotificationMsg(snapshot, changeId, source, sourceMailboxHash));
+                ZimbraLog.mailbox.info("published notifications for changeId=%d, received by %d", changeId, received);
+            } catch (IOException | ServiceException e) {
+                ZimbraLog.ml.error("unable to serialize notifications for changeId=%d, accountId=%s", changeId, mbox.getAccountId(), e);
+            }
+        }
+
+        @Override
+        public int getNumListeners(Type type) {
+            //TODO: this only returns the number of local listeners!
+            return RedisPubSub.this.getSubscriber().getListeners(type).size();
+        }
+    }
+
+    public class RedisSubscriber extends Subscriber implements MessageListener<NotificationMsg> {
+
+        private int listenerId;
+
+        public RedisSubscriber() {
+            listenerId = channel.addListener(this);
+            ZimbraLog.mailbox.info("began listening on Redis channel %s", channel.getChannelNames().get(0));
+        }
+
+        @Override
+        public void onMessage(String channelName, NotificationMsg msg) {
+            ZimbraLog.mailbox.info("got notification for changeId=%d from channel %s", msg.changeId, channelName);
+            PendingLocalModifications mods;
+            try {
+                mods = PendingLocalModifications.fromSnapshot(mbox, msg.modification);
+                notifyListeners(mods, msg.changeId, msg.source, msg.sourceMailboxHash, true);
+            } catch (ServiceException e) {
+                ZimbraLog.ml.error("unable to deserialize notifications for changeId=%d, accountId=%s", msg.changeId, mbox.getAccountId(), e);
+            }
+        }
+    }
+
+    private static class NotificationMsg {
+        private PendingModificationSnapshot modification;
+        private int changeId;
+        private SourceSessionInfo source;
+        private int sourceMailboxHash;
+
+        public NotificationMsg() {}
+
+        public NotificationMsg(PendingModificationSnapshot modification, int changeId,
+                SourceSessionInfo source, int sourceMailboxHash) throws IOException, ServiceException {
+            this.modification = modification;
+            this.changeId = changeId;
+            this.source = source;
+            this.sourceMailboxHash = sourceMailboxHash;
+        }
+    }
+
+    public static class Factory extends NotificationPubSub.Factory {
+
+        @Override
+        protected NotificationPubSub initPubSub(Mailbox mbox) {
+            RedissonClient client = RedissonClientHolder.getInstance().getRedissonClient();
+            return new RedisPubSub(mbox, client);
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/session/AdminSession.java
+++ b/store/src/java/com/zimbra/cs/session/AdminSession.java
@@ -36,7 +36,7 @@ import java.util.List;
 public class AdminSession extends Session {
 
     private static final long ADMIN_SESSION_TIMEOUT_MSEC = 10 * Constants.MILLIS_PER_MINUTE;
-  
+
     private DirectorySearchParams mSearchParams;
     private HashMap<String,Object> mData = new HashMap<String,Object>();
 
@@ -58,21 +58,21 @@ public class AdminSession extends Session {
     protected long getSessionIdleLifetime() {
         return ADMIN_SESSION_TIMEOUT_MSEC;
     }
-    
+
     public Object getData(String key) { return mData.get(key); }
     public void setData(String key, Object data) { mData.put(key, data); }
     public void clearData(String key) { mData.remove(key); }
 
-    @Override public void notifyPendingChanges(PendingModifications pns, int changeId, Session source) { }
+    @Override public void notifyPendingChanges(PendingModifications pns, int changeId, SourceSessionInfo source) { }
 
     @Override protected void cleanup() { }
 
     public List<NamedEntry> searchDirectory(SearchDirectoryOptions searchOpts,
-            int offset, NamedEntry.CheckRight rightChecker) 
+            int offset, NamedEntry.CheckRight rightChecker)
     throws ServiceException {
-        
+
         DirectorySearchParams params = new DirectorySearchParams(searchOpts, rightChecker);
-        
+
         boolean needToSearch =  (offset == 0) || (mSearchParams == null) || !mSearchParams.equals(params);
         //ZimbraLog.account.info("this="+this+" mSearchParams="+mSearchParams+" equal="+!params.equals(mSearchParams));
         if (needToSearch) {

--- a/store/src/java/com/zimbra/cs/session/LocalSessionDataProvider.java
+++ b/store/src/java/com/zimbra/cs/session/LocalSessionDataProvider.java
@@ -1,0 +1,100 @@
+package com.zimbra.cs.session;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import com.zimbra.cs.session.SoapSession.QueuedNotifications;
+
+public class LocalSessionDataProvider extends SessionDataProvider {
+
+    private long idSequence = 0;
+    private Map<String, Integer> soapSequenceMap;
+    private Map<String, NotificationQueue> notificationMap;
+
+    public LocalSessionDataProvider() {
+        soapSequenceMap = new HashMap<>();
+        notificationMap = new HashMap<>();
+    }
+
+    @Override
+    public long getNextIdSequence() {
+        return idSequence++;
+    }
+
+    @Override
+    public int getNextSoapSessionSequence(String soapSessionId) {
+        return soapSequenceMap.merge(soapSessionId, 1, Integer::sum);
+    }
+
+    @Override
+    public void cleanup(String sessionId) {
+        soapSequenceMap.remove(sessionId);
+    }
+
+    @Override
+    public boolean soapSessionExists(String sessionId) {
+        return soapSequenceMap.containsKey(sessionId);
+    }
+
+    @Override
+    public NotificationQueue getSoapNotifications(SoapSession session) {
+        String id = session.getSessionId();
+        NotificationQueue queue = notificationMap.get(id);
+        if (queue == null) {
+            queue = new LocalNotificationQueue();
+            notificationMap.put(id, queue);
+        }
+        return queue;
+    }
+
+    @Override
+    public int getCurrentSoapSessionSequence(String soapSessionId) {
+        Integer curId = soapSequenceMap.get(soapSessionId);
+        return curId == null ? 0 : curId;
+    }
+
+    public static class LocalNotificationQueue extends SessionDataProvider.NotificationQueue {
+
+
+        private List<QueuedNotifications> list;
+
+        public LocalNotificationQueue() {
+            list = new ArrayList<>();
+        }
+
+        @Override
+        public List<QueuedNotifications> getNotifications() {
+            return list;
+        }
+
+        @Override
+        public void add(QueuedNotifications notifications) {
+            list.add(notifications);
+        }
+
+        @Override
+        public void purge(int sequence) {
+            synchronized(list){
+                for (Iterator<QueuedNotifications> it = list.iterator(); it.hasNext(); ) {
+                    if (it.next().getSequence() <= sequence) {
+                        it.remove();
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+
+    }
+
+    public static class Factory implements SessionDataProvider.Factory {
+
+        @Override
+        public SessionDataProvider getIdProvider() {
+            return new LocalSessionDataProvider();
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/session/PendingLocalModifications.java
+++ b/store/src/java/com/zimbra/cs/session/PendingLocalModifications.java
@@ -20,6 +20,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -197,16 +198,17 @@ public final class PendingLocalModifications extends PendingModifications<MailIt
     }
 
     private static Map<PendingModifications.ModificationKey, PendingModifications.Change> getOriginal(Mailbox mbox,
-            Map<ModificationKeyMeta, ChangeMeta> map) throws ServiceException {
+            Map<String, ChangeMeta> map) throws ServiceException {
         if (map == null) {
             return null;
         }
         Map<PendingModifications.ModificationKey, PendingModifications.Change> ret = new LinkedHashMap<PendingModifications.ModificationKey, PendingModifications.Change>();
-        Iterator<Entry<ModificationKeyMeta, ChangeMeta>> iter = map.entrySet().iterator();
+        Iterator<Entry<String, ChangeMeta>> iter = map.entrySet().iterator();
         while (iter.hasNext()) {
-            Entry<ModificationKeyMeta, ChangeMeta> entry = iter.next();
+            Entry<String, ChangeMeta> entry = iter.next();
+            ModificationKeyMeta keyMeta = ModificationKeyMeta.fromString(entry.getKey());
             PendingModifications.ModificationKey key = new PendingModifications.ModificationKey(
-                    entry.getKey().accountId, entry.getKey().itemId);
+                    keyMeta.accountId, keyMeta.itemId);
             ChangeMeta changeMeta = entry.getValue();
             Object what = null;
             Object preModifyObj = null;
@@ -240,16 +242,119 @@ public final class PendingLocalModifications extends PendingModifications<MailIt
                 }
             } else if (changeMeta.preModifyObjType == ChangeMeta.ObjectType.MAILITEMTYPE) {
                 preModifyObj = MailItem.Type.of(changeMeta.metaPreModifyObj);
-            } else if (changeMeta.whatType == ChangeMeta.ObjectType.MAILBOX) {
+            } else if (changeMeta.preModifyObjType == ChangeMeta.ObjectType.MAILBOX) {
                 what = mbox;
-            } else {
-                ZimbraLog.session.warn("Unexpected mailbox change type received: %s", changeMeta.whatType);
+            } else if (changeMeta.preModifyObjType != null ){
+                ZimbraLog.session.warn("Unexpected mailbox change type received: %s", changeMeta.preModifyObjType);
                 continue;
             }
             PendingModifications.Change change = new Change(what, changeMeta.metaWhy, preModifyObj);
             ret.put(key, change);
         }
         return ret;
+    }
+
+    private Map<String, String> encodeCreatedMap() throws ServiceException {
+        if (created == null) {
+            return null;
+        } else {
+            Map<String, String> createdMeta = new LinkedHashMap<>();
+            for (Map.Entry<ModificationKey, BaseItemInfo> entry: created.entrySet()) {
+                ModificationKey key = entry.getKey();
+                BaseItemInfo itemInfo = entry.getValue();
+                if (itemInfo instanceof MailItem) {
+                    MailItem item = (MailItem) itemInfo;
+                    Metadata md = item.getUnderlyingData().serialize();
+                    createdMeta.put(new ModificationKeyMeta(key.getAccountId(), key.getItemId()).toString(), md.toString());
+                }
+            }
+            return createdMeta;
+        }
+    }
+
+    private static Map<String, ChangeMeta> encodeMap(Map<ModificationKey, Change> map) throws ServiceException {
+        if (map == null) {
+            return null;
+        }
+        Map<String, ChangeMeta> metaMap = new LinkedHashMap<>();
+        for (Map.Entry<ModificationKey, Change> entry: map.entrySet()) {
+            ModificationKey key = entry.getKey();
+            Change change = entry.getValue();
+            ChangeMeta.ObjectType type = null;
+            ChangeMeta.ObjectType preModType = null;
+            String str = null;
+            String preModStr = null;
+            if (change.what instanceof Mailbox) {
+                type = ChangeMeta.ObjectType.MAILBOX;
+            } else if (change.what instanceof MailItem) {
+                type = ChangeMeta.ObjectType.MAILITEM;
+                str = ((MailItem) change.what).getUnderlyingData().serialize().toString();
+                if (change.preModifyObj != null) {
+                    preModStr = ((MailItem) change.preModifyObj).getUnderlyingData().serialize().toString();
+                }
+            } else if (change.what instanceof MailItem.Type) {
+                type = ChangeMeta.ObjectType.MAILITEMTYPE;
+                str = ((MailItem.Type) change.what).toString();
+                if (change.preModifyObj instanceof MailItem.Type) {
+                    preModStr = ((MailItem.Type) change.preModifyObj).toString();
+                }
+            }
+            ChangeMeta changeMeta = new ChangeMeta(type, str, change.why, preModType, preModStr);
+            metaMap.put(new ModificationKeyMeta(key.getAccountId(), key.getItemId()).toString(), changeMeta);
+        }
+        return metaMap;
+    }
+
+    public static class PendingModificationSnapshot {
+        private Set<Type> changedTypes;
+        private Set<Integer> changedFolders;
+        private Set<Integer> changedParentFolders;
+        private Map<String, String> created;
+        private Map<String, ChangeMeta> modified;
+        private Map<String, ChangeMeta> deleted;
+    }
+
+    public PendingModificationSnapshot toSnapshot() throws ServiceException {
+        PendingModificationSnapshot snapshot = new PendingModificationSnapshot();
+        snapshot.changedTypes = new HashSet<>(changedTypes);
+        snapshot.changedFolders = new HashSet<>(getChangedFolders());
+        snapshot.changedParentFolders = new HashSet<>(getChangedParentFolders());
+        snapshot.modified = encodeMap(modified);
+        snapshot.deleted = encodeMap(deleted);
+        snapshot.created = encodeCreatedMap();
+        return snapshot;
+    }
+
+    public static PendingLocalModifications fromSnapshot(Mailbox mbox, PendingModificationSnapshot snapshot) throws ServiceException {
+        PendingLocalModifications pms = new PendingLocalModifications();
+        pms.changedTypes = snapshot.changedTypes;
+        pms.addChangedParentFolderIds(snapshot.changedParentFolders);
+        for (Integer id: snapshot.changedFolders) {
+            pms.addChangedFolderId(id);
+        }
+        if (snapshot.created != null) {
+            pms.created = new LinkedHashMap<PendingModifications.ModificationKey, BaseItemInfo>();
+            Iterator<Entry<String, String>> iter = snapshot.created.entrySet().iterator();
+            while (iter.hasNext()) {
+                Entry<String, String> entry = iter.next();
+                Metadata meta = new Metadata(entry.getValue());
+                MailItem.UnderlyingData ud = new MailItem.UnderlyingData();
+                ud.deserialize(meta);
+                MailItem item = MailItem.constructItem(mbox, ud, true);
+                if (item instanceof Folder) {
+                    Folder folder = ((Folder) item);
+                    folder.setParent(mbox.getFolderById(null, folder.getFolderId()));
+
+                }
+                ModificationKeyMeta keyMeta = ModificationKeyMeta.fromString(entry.getKey());
+                PendingModifications.ModificationKey key = new PendingModifications.ModificationKey(
+                        keyMeta.accountId, keyMeta.itemId);
+                pms.created.put(key, item);
+            }
+        }
+        pms.modified = getOriginal(mbox, snapshot.modified);
+        pms.deleted = getOriginal(mbox, snapshot.deleted);
+        return pms;
     }
 
     @SuppressWarnings("unchecked")
@@ -284,10 +389,18 @@ public final class PendingLocalModifications extends PendingModifications<MailIt
             }
 
             Map<ModificationKeyMeta, ChangeMeta> metaModified = (Map<ModificationKeyMeta, ChangeMeta>) ois.readObject();
-            pms.modified = getOriginal(mbox, metaModified);
+            Map<String, ChangeMeta> metaModifiedStringKeys = new HashMap<>();
+            for (Map.Entry<ModificationKeyMeta, ChangeMeta> entry: metaModified.entrySet()) {
+                metaModifiedStringKeys.put(entry.getKey().toString(), entry.getValue());
+            }
+            pms.modified = getOriginal(mbox, metaModifiedStringKeys);
 
             Map<ModificationKeyMeta, ChangeMeta> metaDeleted = (Map<ModificationKeyMeta, ChangeMeta>) ois.readObject();
-            pms.deleted = getOriginal(mbox, metaDeleted);
+            Map<String, ChangeMeta> metaDeletedStringKeys = new HashMap<>();
+            for (Map.Entry<ModificationKeyMeta, ChangeMeta> entry: metaDeleted.entrySet()) {
+                metaDeletedStringKeys.put(entry.getKey().toString(), entry.getValue());
+            }
+            pms.deleted = getOriginal(mbox, metaDeletedStringKeys);
         }
         return pms;
     }

--- a/store/src/java/com/zimbra/cs/session/PendingModifications.java
+++ b/store/src/java/com/zimbra/cs/session/PendingModifications.java
@@ -403,9 +403,21 @@ public abstract class PendingModifications<T extends ZimbraMailItem> {
         String accountId;
         Integer itemId;
 
+        public ModificationKeyMeta() {}
+
         public ModificationKeyMeta(String accountId, int itemId) {
             this.accountId = accountId;
             this.itemId = itemId;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("%s|%d", accountId, itemId);
+        }
+
+        public static ModificationKeyMeta fromString(String encoded) {
+            String[] parts = encoded.split("\\|");
+            return new ModificationKeyMeta(parts[0], Integer.parseInt(parts[1]));
         }
 
     }
@@ -422,6 +434,8 @@ public abstract class PendingModifications<T extends ZimbraMailItem> {
         public int    metaWhy;
         public ObjectType preModifyObjType;
         public String metaPreModifyObj;
+
+        public ChangeMeta(){}
 
         public ChangeMeta(ObjectType type, String thing, int reason, ObjectType preModifyObjType, String preModifyObj) {
             whatType = type;

--- a/store/src/java/com/zimbra/cs/session/RedisSessionDataProvider.java
+++ b/store/src/java/com/zimbra/cs/session/RedisSessionDataProvider.java
@@ -1,0 +1,172 @@
+package com.zimbra.cs.session;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.redisson.api.RAtomicLong;
+import org.redisson.api.RList;
+import org.redisson.api.RMap;
+import org.redisson.api.RedissonClient;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.RedissonClientHolder;
+import com.zimbra.cs.session.PendingLocalModifications.PendingModificationSnapshot;
+import com.zimbra.cs.session.SoapSession.QueuedNotifications;
+
+public class RedisSessionDataProvider extends SessionDataProvider {
+
+    private static final String SOAP_SESSION_SEQ_MAP_NAME = "SOAP_SESSION_SEQUENCES";
+    private static final String SESSION_ID_SEQ_NAME = "SESSION_ID_SEQUENCE";
+    private RMap<String, Integer> soapSequenceMap;
+    private RAtomicLong idCounter;
+    private Map<String, RedisNotificationQueue> notificationMap;
+
+    public RedisSessionDataProvider() {
+        RedissonClient client = RedissonClientHolder.getInstance().getRedissonClient();
+        soapSequenceMap = client.getMap(SOAP_SESSION_SEQ_MAP_NAME);
+        idCounter = client.getAtomicLong(SESSION_ID_SEQ_NAME);
+        notificationMap = new HashMap<>();
+    }
+
+    @Override
+    protected long getNextIdSequence() {
+        return idCounter.addAndGet(1);
+    }
+
+    @Override
+    public int getNextSoapSessionSequence(String soapSessionId) {
+        return soapSequenceMap.addAndGet(soapSessionId, 1);
+    }
+
+
+    @Override
+    public int getCurrentSoapSessionSequence(String soapSessionId) {
+        Integer val = soapSequenceMap.putIfAbsent(soapSessionId, 1);
+        return val == null ? 1 : val;
+    }
+
+    @Override
+    public void cleanup(String sessionId) {
+        soapSequenceMap.remove(sessionId);
+        if (notificationMap.containsKey(sessionId)) {
+            notificationMap.get(sessionId).clear();
+        }
+    }
+
+    @Override
+    public boolean soapSessionExists(String sessionId) {
+        return soapSequenceMap.containsKey(sessionId);
+    }
+
+    @Override
+    public NotificationQueue getSoapNotifications(SoapSession session) {
+        RedisNotificationQueue queue = notificationMap.get(session.getSessionId());
+        if (queue == null) {
+            queue = new RedisNotificationQueue(session);
+            notificationMap.put(session.getSessionId(), queue);
+        }
+        return queue;
+    }
+
+    public static class RedisNotificationQueue extends SessionDataProvider.NotificationQueue {
+
+        private RList<SerializableNotification> list;
+        private Mailbox mbox;
+        private String authAcctId;
+
+        public RedisNotificationQueue(SoapSession session) {
+            RedissonClient client = RedissonClientHolder.getInstance().getRedissonClient();
+            list = client.getList("session_" + session.getSessionId());
+            mbox = session.getMailboxOrNull();
+            authAcctId = session.getAuthenticatedAccountId();
+        }
+
+        @Override
+        public List<QueuedNotifications> getNotifications() {
+            List<QueuedNotifications> l = new ArrayList<>();
+            for (SerializableNotification s: list.readAll()){
+                try {
+                    l.add(s.toNotifications(mbox));
+                } catch (ServiceException e) {
+                    ZimbraLog.session.warn("unable to deserialize notification from redis");
+                }
+            }
+            return l;
+        }
+
+        private static class SerializableNotification {
+            private String authAcctId;
+            private PendingModificationSnapshot snapshot;
+            private int sequence;
+
+            public SerializableNotification() {}
+
+            public SerializableNotification(String acctId, PendingModificationSnapshot snapshot, int sequence) {
+                this.authAcctId = acctId;
+                this.snapshot = snapshot;
+                this.sequence = sequence;
+            }
+
+            private QueuedNotifications toNotifications(Mailbox mbox) throws ServiceException {
+                QueuedNotifications q = new QueuedNotifications(authAcctId, sequence);
+                q.addNotification(PendingLocalModifications.fromSnapshot(mbox, snapshot));
+                return q;
+            }
+        }
+
+        @Override
+        public void add(QueuedNotifications notifications) {
+            try {
+                PendingModificationSnapshot snapshot = notifications.mMailboxChanges.toSnapshot();
+                int seq = notifications.getSequence();
+                list.add(new SerializableNotification(authAcctId, snapshot, seq));
+            } catch (ServiceException e) {
+                ZimbraLog.session.error("unable to push QueuedNotifications to redis", e);
+            }
+        }
+
+        /**
+         * overrides to act directly on the underlying RList, to avoid unnecessary deserializing
+         */
+        @Override
+        public boolean isEmpty() {
+            return list.isEmpty();
+        }
+
+        @Override
+        public void clear() {
+            list.clear();
+        }
+
+        @Override
+        public int size() {
+            return list.size();
+        }
+
+        @Override
+        public void purge(int sequence) {
+            //TODO: should this be made fully atomic with a Lua script?
+            int idx = 0;
+            for (QueuedNotifications qn : getNotifications()) {
+                if (qn.getSequence() <= sequence) {
+                    idx++;
+                } else {
+                    break;
+                }
+            }
+            list.trim(idx, -1);
+        }
+    }
+
+    public static class Factory implements SessionDataProvider.Factory {
+
+        @Override
+        public SessionDataProvider getIdProvider() {
+            return new RedisSessionDataProvider();
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/session/RemoteSoapSession.java
+++ b/store/src/java/com/zimbra/cs/session/RemoteSoapSession.java
@@ -37,12 +37,16 @@ public class RemoteSoapSession extends SoapSession {
     /** Creates a <tt>SoapSession</tt> owned by the given account homed on
      *  a different server.  It thus cannot listen on its own {@link Mailbox}.
      * @see Session#register() */
-    public RemoteSoapSession(ZimbraSoapContext zsc) {
-        super(zsc);
+    public RemoteSoapSession(ZimbraSoapContext zsc, String sessionId) {
+        super(zsc, sessionId);
         try {
             authUserCtxt = new ZimbraSoapContext(zsc);
         } catch (ServiceException e) {
         }
+    }
+
+    public RemoteSoapSession(ZimbraSoapContext zsc) {
+        this(zsc, null);
     }
 
     @Override
@@ -76,13 +80,11 @@ public class RemoteSoapSession extends SoapSession {
             return null;
         }
         QueuedNotifications ntfn;
-        synchronized (sentChanges) {
-            if (!changes.hasNotifications()) {
-                return null;
-            }
-            ntfn = changes;
-            changes = new QueuedNotifications(ntfn.getSequence() + 1);
+        if (!changes.hasNotifications()) {
+            return null;
         }
+        ntfn = changes;
+        changes = new QueuedNotifications(mAuthenticatedAccountId, SessionCache.getNextSoapSequence(getSessionId()));
 
         putQueuedNotifications(null, ntfn, ctxt, zsc);
         return ctxt;

--- a/store/src/java/com/zimbra/cs/session/Session.java
+++ b/store/src/java/com/zimbra/cs/session/Session.java
@@ -112,12 +112,16 @@ public abstract class Session {
      *                  {@code Session} is attached to
      * @param type      The type of {@code Session} being created */
     public Session(String authId, String targetId, Type type) {
+        this(null, authId, targetId, type);
+    }
+
+    public Session(String sessionId, String authId, String targetId, Type type) {
         mAuthenticatedAccountId = authId;
         mTargetAccountId = targetId == null ? authId : targetId;
         mSessionType = type;
         mCreationTime = System.currentTimeMillis();
         mLastAccessed = mCreationTime;
-        mSessionId = SessionCache.getNextSessionId(mSessionType);
+        mSessionId = sessionId == null ? SessionCache.getNextSessionId(mSessionType) : sessionId;
     }
 
     public Type getType() {
@@ -141,7 +145,7 @@ public abstract class Session {
             // once addListener is called, you may NOT lock the mailbox (b/c of deadlock possibilities)
             if (mbox != null) {
                 if (mbox instanceof Mailbox) {
-                    ((Mailbox)mbox).addListener(this);
+                    ((Mailbox) mbox).getNotificationPubSub().getSubscriber().addListener(this);
                 } else {
                     throw new UnsupportedOperationException(String.format(
                             "Session register only supports Mailbox currently can't handle %s",
@@ -168,7 +172,7 @@ public abstract class Session {
 
         if (isMailboxListener()) {
             mailbox = mbox;
-            mbox.addListener(this);
+            mbox.getNotificationPubSub().getSubscriber().addListener(this);
         }
 
         // registering the session automatically sets mSessionId
@@ -195,7 +199,7 @@ public abstract class Session {
                 Mailbox mbox = (Mailbox)mboxStore;
                 //assert(l.isWriteLockedByCurrentThread() || !Thread.holdsLock(this));
                 if (isMailboxListener()) {
-                    mbox.removeListener(this);
+                    mbox.getNotificationPubSub().getSubscriber().removeListener(this);
                     mailbox = null;
                 }
             } else if (isMailboxListener()) {
@@ -308,11 +312,11 @@ public abstract class Session {
      *  on the Mailbox.
      *  <p>
      *  *All* changes are currently cached, regardless of the client's state/views.
-     * @param pns       A set of new change notifications from our Mailbox.
-     * @param changeId  The change ID of the change.
-     * @param source    The {@code Session} originating these changes, or
+     * @param pns                  A set of new change notifications from our Mailbox.
+     * @param changeId             The change ID of the change.
+     * @param sourceSessionInfo    Info about the {@code Session} originating these changes, or
      *                  <tt>null</tt> if none was specified. */
-    public abstract void notifyPendingChanges(PendingModifications pns, int changeId, Session source);
+    public abstract void notifyPendingChanges(PendingModifications pns, int changeId, SourceSessionInfo sourceSessionInfo);
 
     /** Notify this session that an external event has occured. */
     public void notifyExternalEvent(ExternalEventNotification extra) {
@@ -407,5 +411,42 @@ public abstract class Session {
     @Override
     public String toString() {
         return addToStringInfo(Objects.toStringHelper(this)).toString();
+    }
+
+    public SourceSessionInfo toSessionInfo() {
+        return new SourceSessionInfo(this);
+    }
+
+    public static class SourceSessionInfo {
+        private String sessionId;
+        private String wsId = null;
+
+        public SourceSessionInfo() {}
+
+        public SourceSessionInfo(Session sourceSession) {
+            this.sessionId = sourceSession.getSessionId();
+            if (sourceSession instanceof SoapSession) {
+                wsId = ((SoapSession) sourceSession).getCurWaitSetID();
+            }
+        }
+
+        public String getSessionId() {
+            return sessionId;
+        }
+
+        public String getWaitSetId() {
+            return wsId;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (other instanceof Session) {
+                return sessionId.equals(((Session) other).getSessionId());
+            } else if (other instanceof SourceSessionInfo) {
+                return sessionId.equals(((SourceSessionInfo) other).getSessionId());
+            } else {
+                return false;
+            }
+        }
     }
 }

--- a/store/src/java/com/zimbra/cs/session/SessionDataProvider.java
+++ b/store/src/java/com/zimbra/cs/session/SessionDataProvider.java
@@ -1,0 +1,60 @@
+package com.zimbra.cs.session;
+
+import java.util.List;
+
+import com.zimbra.cs.session.SoapSession.QueuedNotifications;
+
+
+public abstract class SessionDataProvider {
+
+    private static Factory factory;
+
+    public static Factory getFactory() {
+        return factory;
+    }
+
+    public static void setFactory(Factory factory) {
+        SessionDataProvider.factory = factory;
+    }
+
+    public String getNextSessionIdSequence(Session.Type type) {
+        return Integer.toString(type.getIndex()) + Long.toString(getNextIdSequence());
+    }
+
+    protected abstract long getNextIdSequence();
+
+    public abstract int getNextSoapSessionSequence(String soapSessionId);
+
+    public abstract int getCurrentSoapSessionSequence(String soapSessionId);
+
+    public abstract void cleanup(String sessionId);
+
+    public abstract boolean soapSessionExists(String sessionId);
+
+    public abstract NotificationQueue getSoapNotifications(SoapSession session);
+
+    public static abstract class NotificationQueue {
+
+        public abstract List<QueuedNotifications> getNotifications();
+
+        public abstract void add(QueuedNotifications notifications);
+
+        public boolean isEmpty() {
+            return getNotifications().isEmpty();
+        }
+
+        public void clear() {
+            getNotifications().clear();
+        }
+
+        public int size() {
+            return getNotifications().size();
+        }
+
+        public abstract void purge(int lastSequence);
+    }
+
+    public static interface Factory {
+        public SessionDataProvider getIdProvider();
+    }
+}

--- a/store/src/java/com/zimbra/cs/session/SoapSession.java
+++ b/store/src/java/com/zimbra/cs/session/SoapSession.java
@@ -72,6 +72,7 @@ import com.zimbra.cs.service.util.ItemId;
 import com.zimbra.cs.service.util.ItemIdFormatter;
 import com.zimbra.cs.session.PendingModifications.Change;
 import com.zimbra.cs.session.PendingModifications.ModificationKey;
+import com.zimbra.cs.session.SessionDataProvider.NotificationQueue;
 import com.zimbra.cs.util.BuildInfo;
 import com.zimbra.cs.util.Zimbra;
 import com.zimbra.soap.DocumentHandler;
@@ -130,13 +131,15 @@ public class SoapSession extends Session {
         @Override public void cleanup()  { }
 
         @SuppressWarnings("rawtypes")
-        @Override public void notifyPendingChanges(PendingModifications pmsIn, int changeId, Session source) {
+        @Override public void notifyPendingChanges(PendingModifications pmsIn, int changeId, SourceSessionInfo source) {
             PendingLocalModifications pms = (PendingLocalModifications) pmsIn;
             try {
                 if (calculateVisibleFolders(false))
                     pms = filterNotifications(pms);
-                if (pms != null && pms.hasNotifications())
-                    handleNotifications(pms, source == this || source == SoapSession.this);
+                if (pms != null && pms.hasNotifications()) {
+                    boolean fromThisSession = source == null ? false : source.equals(this) || source.equals(SoapSession.this);
+                    handleNotifications(pms, fromThisSession);
+                }
             } catch (ServiceException e) {
                 ZimbraLog.session.warn("exception during delegated notifyPendingChanges", e);
             }
@@ -389,19 +392,22 @@ public class SoapSession extends Session {
         }
     }
 
-    class QueuedNotifications {
+    static class QueuedNotifications {
         /** ExternalEventNotifications are kept sequentially */
         List<ExternalEventNotification> mExternalNotifications;
         PendingLocalModifications mMailboxChanges;
         RemoteNotifications mRemoteChanges;
         boolean mHasLocalChanges;
+        private String authenticatedAccountId;
 
         /** used by the Session object to ensure that notifications are reliably
          *  received by the listener */
         private final int mSequence;
         int getSequence()  { return mSequence; }
 
-        QueuedNotifications(int seqno)  { mSequence = seqno; }
+        QueuedNotifications(String authenticatedAccountId, int seqno)  {
+            this.authenticatedAccountId = authenticatedAccountId;
+            mSequence = seqno; }
 
         boolean hasNotifications() {
             return hasNotifications(false);
@@ -435,7 +441,7 @@ public class SoapSession extends Session {
                 mMailboxChanges = new PendingLocalModifications();
             mMailboxChanges.add(pms);
             if (!mHasLocalChanges)
-                mHasLocalChanges |= pms.overlapsWithAccount(mAuthenticatedAccountId);
+                mHasLocalChanges |= pms.overlapsWithAccount(authenticatedAccountId);
         }
 
         void addNotification(RemoteNotifications rns) {
@@ -466,10 +472,8 @@ public class SoapSession extends Session {
     private long previousAccess = -1;
     private long lastWrite      = -1;
 
-    // read/write access to all these members requires synchronizing on "mSentChanges"
     protected int forceRefresh;
-    protected LinkedList<QueuedNotifications> sentChanges = new LinkedList<QueuedNotifications>();
-    protected QueuedNotifications changes = new QueuedNotifications(1);
+    protected QueuedNotifications changes;
     private PushChannel pushChannel;
     private boolean unregistered;
     private final Map<String, DelegateSession> delegateSessions = new HashMap<String, DelegateSession>(3);
@@ -483,10 +487,23 @@ public class SoapSession extends Session {
      *  listening on its {@link Mailbox}.
      * @see Session#register() */
     public SoapSession(ZimbraSoapContext zsc) {
-        super(zsc.getAuthtokenAccountId(), zsc.getAuthtokenAccountId(), Session.Type.SOAP);
+        this(zsc, null);
+    }
+
+    public SoapSession(ZimbraSoapContext zsc, String sessionId) {
+        super(sessionId, zsc.getAuthtokenAccountId(), zsc.getAuthtokenAccountId(), Session.Type.SOAP);
         this.asAdmin = zsc.isUsingAdminPrivileges();
         responseProtocol = zsc.getResponseProtocol();
         curWaitSetID = zsc.getCurWaitSetID();
+        changes = new QueuedNotifications(mAuthenticatedAccountId, getCurSequenceId());
+    }
+
+    private int getCurSequenceId() {
+        return SessionCache.getCurrentSoapSequence(getSessionId());
+    }
+
+    private int getNextSequenceId() {
+        return SessionCache.getNextSoapSequence(getSessionId());
     }
 
     @Override
@@ -604,11 +621,9 @@ public class SoapSession extends Session {
                 return;
             }
         }
-        synchronized (sentChanges) {
-            int force = changes.getSequence();
-            ZimbraLog.session.debug("removeDelegateSession: changing mForceRefresh: %d -> %d", forceRefresh, force);
-            forceRefresh = force;
-        }
+        int force = changes.getSequence();
+        ZimbraLog.session.debug("removeDelegateSession: changing mForceRefresh: %d -> %d", forceRefresh, force);
+        forceRefresh = force;
     }
 
 
@@ -673,10 +688,8 @@ public class SoapSession extends Session {
         Element eNotify = context.getOptionalElement(ZimbraNamespace.E_NOTIFY);
         if (eNotify != null) {
             RemoteNotifications rns = new RemoteNotifications(eNotify);
-            synchronized (sentChanges) {
-                if (!skipNotifications(rns.getScaledNotificationCount(), !isPing)) {
-                    addRemoteNotifications(rns);
-                }
+            if (!skipNotifications(rns.getScaledNotificationCount(), !isPing)) {
+                addRemoteNotifications(rns);
             }
         }
     }
@@ -801,15 +814,14 @@ public class SoapSession extends Session {
         }
 
         boolean dataReady;
-        synchronized (sentChanges) {
-            // are there any notifications already pending given the passed-in seqno?
-            int lastSeqNo = sc.getLastKnownSequence();
-            dataReady = changes.hasNotifications(sc.localChangesOnly());
-            if (!dataReady && changes.getSequence() > lastSeqNo + 1 && !sentChanges.isEmpty()) {
-                for (QueuedNotifications ntfn : sentChanges) {
-                    if (ntfn.getSequence() > lastSeqNo && ntfn.hasNotifications(sc.localChangesOnly())) {
-                        dataReady = true;  break;
-                    }
+        // are there any notifications already pending given the passed-in seqno?
+        int lastSeqNo = sc.getLastKnownSequence();
+        dataReady = changes.hasNotifications(sc.localChangesOnly());
+        NotificationQueue queue = SessionCache.getSoapNotificationQueue(this);
+        if (!dataReady && changes.getSequence() > lastSeqNo + 1 && !queue.isEmpty()) {
+            for (QueuedNotifications ntfn : queue.getNotifications()) {
+                if (ntfn.getSequence() > lastSeqNo && ntfn.hasNotifications(sc.localChangesOnly())) {
+                    dataReady = true;  break;
                 }
             }
         }
@@ -828,9 +840,7 @@ public class SoapSession extends Session {
         if (extra == null) {
             return;
         }
-        synchronized (sentChanges) {
-            changes.addNotification(extra);
-        }
+        changes.addNotification(extra);
         try {
             // if we're in a hanging no-op, alert the client that there are changes
             notifyPushChannel(null);
@@ -864,13 +874,14 @@ public class SoapSession extends Session {
      * @param changeId  The change ID of the change.
      * @param source    The (optional) Session which initiated these changes. */
     @Override
-    public void notifyPendingChanges(PendingModifications pmsIn, int changeId, Session source) {
+    public void notifyPendingChanges(PendingModifications pmsIn, int changeId, SourceSessionInfo source) {
         PendingLocalModifications pms = (PendingLocalModifications) pmsIn;
         Mailbox mbox = this.getMailboxOrNull();
         if (pms == null || mbox == null || !pms.hasNotifications()) {
             return;
         }
-        if (source == this) {
+        boolean fromThisSession = source != null && source.equals(this);
+        if (fromThisSession) {
             updateLastWrite(mbox);
         } else {
             // keep track of "recent" message count: all present before the session started, plus all received during the session
@@ -894,8 +905,20 @@ public class SoapSession extends Session {
                 }
             }
         }
+        discardChangesIfNecessary();
+        handleNotifications(pms, fromThisSession);
+    }
 
-        handleNotifications(pms, source == this);
+    private boolean discardChangesIfNecessary() {
+      //if another mailbox worker has advanced the sequence, discard the current changes, since the client
+        //has already received them
+        int curSequence = getCurSequenceId();
+        if (changes.getSequence() < curSequence) {
+            ZimbraLog.session.info("stale change sequence %d < %d for session %s, discarding queued notifications", changes.getSequence(), curSequence, getSessionId());
+            changes = new QueuedNotifications(mAuthenticatedAccountId, curSequence);
+            return true;
+        }
+        return false;
     }
 
     boolean hasSerializableChanges(PendingLocalModifications pms) {
@@ -935,13 +958,11 @@ public class SoapSession extends Session {
     private void cacheNotifications(PendingLocalModifications pms, boolean fromThisSession) {
         // XXX: should constrain to folders, tags, and stuff relevant to the current query?
 
-        synchronized (sentChanges) {
-            if (!skipNotifications(pms.getScaledNotificationCount(), fromThisSession)) {
-                // if we're here, these changes either
-                //   a) do not cause the session's notification cache to overflow, or
-                //   b) originate from this session and hence must be notified back to the session
-                changes.addNotification(pms);
-            }
+        if (!skipNotifications(pms.getScaledNotificationCount(), fromThisSession)) {
+            // if we're here, these changes either
+            //   a) do not cause the session's notification cache to overflow, or
+            //   b) originate from this session and hence must be notified back to the session
+            changes.addNotification(pms);
         }
     }
 
@@ -963,7 +984,7 @@ public class SoapSession extends Session {
                 forceRefresh = force;
             }
 
-            for (QueuedNotifications ntfn : sentChanges) {
+            for (QueuedNotifications ntfn : getQueuedNotifications()) {
                 count += ntfn.getScaledNotificationCount();
                 if (count > MAX_QUEUED_NOTIFICATIONS) {
                     ntfn.clearMailboxChanges();
@@ -1009,18 +1030,16 @@ public class SoapSession extends Session {
 
 
     public boolean requiresRefresh(final int lastSequence) {
-        synchronized (sentChanges) {
-            boolean required = false;
-            int currentSeq = getCurrentNotificationSequence();
-            if (lastSequence <= 0) {
-                required = forceRefresh == currentSeq;
-            } else {
-                required = forceRefresh > Math.min(lastSequence, currentSeq);
-            }
-            ZimbraLog.session.debug("refresh required: forceRefresh=%d,lastSequence=%d,currentSequence=%d",
-                    forceRefresh, lastSequence, currentSeq);
-            return required;
+        boolean required = false;
+        int currentSeq = getCurrentNotificationSequence();
+        if (lastSequence <= 0) {
+            required = forceRefresh == currentSeq;
+        } else {
+            required = forceRefresh > Math.min(lastSequence, currentSeq);
         }
+        ZimbraLog.session.debug("refresh required: forceRefresh=%d,lastSequence=%d,currentSequence=%d",
+                forceRefresh, lastSequence, currentSeq);
+        return required;
     }
 
     /** Serializes basic folder/tag structure to a SOAP response header.
@@ -1039,10 +1058,8 @@ public class SoapSession extends Session {
         if (mbox == null) {
             return;
         }
-        synchronized (sentChanges) {
-            for (QueuedNotifications ntfn : sentChanges) {
-                ntfn.clearMailboxChanges();
-            }
+        for (QueuedNotifications ntfn : getQueuedNotifications()) {
+            ntfn.clearMailboxChanges();
         }
 
         Element eRefresh = ctxt.addUniqueElement(ZimbraNamespace.E_REFRESH);
@@ -1285,39 +1302,28 @@ public class SoapSession extends Session {
 
 
     public int getCurrentNotificationSequence() {
-        synchronized (sentChanges) {
-            return changes.getSequence();
-        }
+        return changes.getSequence();
     }
 
     public void acknowledgeNotifications(int sequence) {
-        synchronized (sentChanges) {
-            if (sentChanges == null || sentChanges.isEmpty()) {
-                return;
-            }
-            if (sequence <= 0) {
-                // if the client didn't send a valid "last sequence number", *don't* keep old changes around
-                sentChanges.clear();
-            } else {
-                // clear any notifications we now know the client has received
-                for (Iterator<QueuedNotifications> it = sentChanges.iterator(); it.hasNext(); ) {
-                    if (it.next().getSequence() <= sequence) {
-                        it.remove();
-                    } else {
-                        break;
-                    }
-                }
-            }
+        NotificationQueue queue = SessionCache.getSoapNotificationQueue(this);
+        if (queue.isEmpty()) {
+            return;
+        }
+        if (sequence <= 0) {
+            // if the client didn't send a valid "last sequence number", *don't* keep old changes around
+            queue.clear();
+        } else {
+            // clear any notifications we now know the client has received
+            queue.purge(sequence);
         }
     }
 
     public Collection<PendingLocalModifications> getNotifications() {
         List<PendingLocalModifications> ret = new ArrayList<PendingLocalModifications>();
-        synchronized (sentChanges) {
-            for (QueuedNotifications notification : sentChanges) {
-                if (notification.hasNotifications()) {
-                    ret.add(notification.mMailboxChanges);
-                }
+        for (QueuedNotifications notification : getQueuedNotifications()) {
+            if (notification.hasNotifications()) {
+                ret.add(notification.mMailboxChanges);
             }
         }
         return ret;
@@ -1372,35 +1378,34 @@ public class SoapSession extends Session {
 
         // because ToXML functions can now call back into the Mailbox, don't hold any locks when calling putQueuedNotifications
         LinkedList<QueuedNotifications> notifications;
-        synchronized (sentChanges) {
             // send the "change" block:  <change token="555"/>
-            ctxt.addUniqueElement(HeaderConstants.E_CHANGE).addAttribute(HeaderConstants.A_CHANGE_ID, mbox.getLastChangeID());
+        ctxt.addUniqueElement(HeaderConstants.E_CHANGE).addAttribute(HeaderConstants.A_CHANGE_ID, mbox.getLastChangeID());
 
-            // clear any notifications we now know the client has received
-            acknowledgeNotifications(lastSequence);
+        // clear any notifications we now know the client has received
+        acknowledgeNotifications(lastSequence);
 
-            // cover ourselves in case a client is doing something really stupid...
-            if (sentChanges.size() > 20) {
-                ZimbraLog.session.warn("clearing abnormally long notification change list due to misbehaving client");
-                sentChanges.clear();
-            }
-
-            if (changes.hasNotifications() || requiresRefresh(lastSequence)) {
-                assert(changes.getSequence() >= 1);
-                int newSequence = changes.getSequence() + 1;
-                sentChanges.add(changes);
-                changes = new QueuedNotifications(newSequence);
-            }
-
-            // mChanges must be empty at this point (everything moved into the mSentChanges list)
-            assert(!changes.hasNotifications());
-
-            // drop out if notify is off or if there is nothing to send
-            if (sentChanges.isEmpty()) {
-                return ctxt;
-            }
-            notifications = new LinkedList<QueuedNotifications>(sentChanges);
+        // cover ourselves in case a client is doing something really stupid...
+        NotificationQueue queue = SessionCache.getSoapNotificationQueue(this);
+        if (queue.size() > 20) {
+            ZimbraLog.session.warn("clearing abnormally long notification change list due to misbehaving client");
+            queue.clear();
         }
+
+        if (changes.hasNotifications() || requiresRefresh(lastSequence)) {
+            if (!discardChangesIfNecessary()) {
+                queue.add(changes);
+                changes = new QueuedNotifications(mAuthenticatedAccountId,getNextSequenceId());
+            }
+        }
+
+        // mChanges must be empty at this point (everything moved into the mSentChanges list)
+        assert(!changes.hasNotifications());
+
+        // drop out if notify is off or if there is nothing to send
+        if (queue.isEmpty()) {
+            return ctxt;
+        }
+        notifications = new LinkedList<QueuedNotifications>(queue.getNotifications());
 
         // send all the old changes
         QueuedNotifications last = notifications.getLast();
@@ -1669,5 +1674,9 @@ public class SoapSession extends Session {
 
     public String getCurWaitSetID() {
         return curWaitSetID;
+    }
+
+    private List<QueuedNotifications> getQueuedNotifications() {
+        return SessionCache.getSoapNotificationQueue(this).getNotifications();
     }
 }

--- a/store/src/java/com/zimbra/cs/session/WaitSetAccount.java
+++ b/store/src/java/com/zimbra/cs/session/WaitSetAccount.java
@@ -47,7 +47,7 @@ public class WaitSetAccount {
             try {
                 Mailbox mbox = getMailboxIfLoaded();
                 if (mbox != null)
-                    return (WaitSetSession)mbox.getListener(sessionId);
+                    return (WaitSetSession)mbox.getNotificationPubSub().getSubscriber().getListener(sessionId);
             } catch (ServiceException e) {
                 ZimbraLog.session.info("Caught exception fetching mailbox in WaitSetAccount.getSession()", e);
             }

--- a/store/src/java/com/zimbra/cs/session/WaitSetSession.java
+++ b/store/src/java/com/zimbra/cs/session/WaitSetSession.java
@@ -94,7 +94,7 @@ public class WaitSetSession extends Session {
     protected long getSessionIdleLifetime() { return 0; }
 
     @Override
-    public void notifyPendingChanges(PendingModifications pns, int changeId, Session source) {
+    public void notifyPendingChanges(PendingModifications pns, int changeId, SourceSessionInfo source) {
         boolean trace = ZimbraLog.session.isTraceEnabled();
         if (trace) {
             ZimbraLog.session.trace("Notifying WaitSetSession %s: change id=%s changedFolders=%s changesTypes='%s'",
@@ -127,8 +127,8 @@ public class WaitSetSession extends Session {
             }
             return;
         }
-        if (source != null && source instanceof SoapSession) {
-            String curWaitSetID = ((SoapSession) source).getCurWaitSetID();
+        if (source != null && source.getWaitSetId() != null) {
+            String curWaitSetID = source.getWaitSetId();
             if (curWaitSetID != null && curWaitSetID.equals(mWs.getWaitSetId())) {
                 if (trace) {
                     ZimbraLog.session.trace("Not signaling waitset; changes will be returned in SOAP headers");

--- a/store/src/java/com/zimbra/cs/util/Zimbra.java
+++ b/store/src/java/com/zimbra/cs/util/Zimbra.java
@@ -64,15 +64,19 @@ import com.zimbra.cs.index.solr.SolrIndex;
 import com.zimbra.cs.iochannel.MessageChannel;
 import com.zimbra.cs.mailbox.MailboxManager;
 import com.zimbra.cs.mailbox.MailboxState;
+import com.zimbra.cs.mailbox.NotificationPubSub;
 import com.zimbra.cs.mailbox.PurgeThread;
 import com.zimbra.cs.mailbox.RedisMailboxState;
+import com.zimbra.cs.mailbox.RedisPubSub;
 import com.zimbra.cs.mailbox.ScheduledTaskManager;
 import com.zimbra.cs.mailbox.acl.AclPushTask;
 import com.zimbra.cs.memcached.MemcachedConnector;
 import com.zimbra.cs.redolog.RedoLogProvider;
 import com.zimbra.cs.server.ServerManager;
 import com.zimbra.cs.servlet.FirstServlet;
+import com.zimbra.cs.session.RedisSessionDataProvider;
 import com.zimbra.cs.session.SessionCache;
+import com.zimbra.cs.session.SessionDataProvider;
 import com.zimbra.cs.session.WaitSetMgr;
 import com.zimbra.cs.stats.ZimbraPerf;
 import com.zimbra.cs.store.StoreManager;
@@ -322,6 +326,8 @@ public final class Zimbra {
 
         MailboxManager.getInstance().startup();
 
+        SessionDataProvider.setFactory(new RedisSessionDataProvider.Factory());
+        NotificationPubSub.setFactory(new RedisPubSub.Factory());
         MailboxState.setFactory(new RedisMailboxState.Factory());
 
         app.initialize(sIsMailboxd);

--- a/store/src/java/com/zimbra/qa/unittest/TestImapServerListener.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestImapServerListener.java
@@ -825,7 +825,7 @@ public class TestImapServerListener {
         }
 
         @Override
-        public void notifyPendingChanges(PendingModifications pnsIn, int changeId, Session source) {
+        public void notifyPendingChanges(PendingModifications pnsIn, int changeId, SourceSessionInfo source) {
             triggered = true;
             doneSignal.countDown();
         }

--- a/store/src/java/com/zimbra/soap/SoapSessionFactory.java
+++ b/store/src/java/com/zimbra/soap/SoapSessionFactory.java
@@ -49,11 +49,16 @@ public class SoapSessionFactory {
         return sSessionFactory;
     }
 
+
     public SoapSession getSoapSession(ZimbraSoapContext zsc) throws ServiceException {
+        return getSoapSession(zsc,null);
+    }
+
+    public SoapSession getSoapSession(ZimbraSoapContext zsc, String sessionId) throws ServiceException {
         if (zsc.isAuthUserOnLocalhost()) {
-            return new SoapSession(zsc);
+            return new SoapSession(zsc, sessionId);
         } else {
-            return new RemoteSoapSession(zsc);
+            return new RemoteSoapSession(zsc, sessionId);
         }
     }
 }


### PR DESCRIPTION
This PR enables soap session functionality in an multi-node environment, restoring mailbox notifications via response headers. This is done through several enhancements:
1. A new pub/sub mechanism that allows sessions to receive notifications from anywhere in the cluster
2. Migration of several instances of session state to Redis
3. An update the session modification sequence logic that (hopefully) ensures that the client does not receive duplicate notifications from multiple nodes

#### The problem
To understand this PR, it's first important to understand how soap sessions handled mailbox notifications prior to HA and how the new architecture breaks it. 
The two relevant components of a SoapSession are:
* `SoapSession.changes`, which is a `QueuedNotifications` object that contains an increasing sequence number
* `SoapSession.sentChanges`, which is a list of past `QueuedNotifications` whose members are evicted when the client sends confirmation that the changes have been successfully applied

Over time, the session is notified by the mailbox of `PendingModifications`, which it accumulates in the current `QueuedNotifications` object. When it comes time to package these notifications to send back to the client, this `QueuedNotifications` object is appended to the `sentChanges` list and the _entire_ list is encoded in the response header (though usually this list only has one element). A new `QueuedNotifications` instance is then created, with an incremented modification sequence, ready to accept further notifications.

With stateless distributed mailbox workers, this mechanism break down in the following ways:
* The modification sequence is no longer monotonically increasing from the client's perspective, since mailbox worker A is not aware of the sequence number on worker B. This is bad since the client will not apply changes with a sequence number lower than its known watermark.
* A session registered on one mailbox server will not be notified of changes made by a request processed on a different server, leading to missing notifications.
* If a client sends a request to a newly-started mailbox worker, the worker will not have the referenced session in its `SessionCache`, resulting in a new session being created instead.
* Since the `sentChanges` array is stored in-memory, the client is not guaranteed to receive previous notifications in the event that something went wrong, since a subsequent request is likely to go to a different server unaware of the change history.
* IDs for sessions generated on different servers may conflict, since session IDs are generated in an increasing sequence.

#### SessionDataProvider
The `SessionDataProvider` abstraction is a key component in resolving some of the issues described above, providing a way to share certain session information across the cluster. It currently provides access the following:
* The latest session ID by session type. This ensures that there are no session ID conflicts.
* The latest soap session modification sequence, by session ID
* A check for whether a soap session with a given ID exists on the cluster
* The list of sent notifications by session, replacing the  in-memory `sentChanges` list.

#### NotificationPubSub
A major change in this PR is that sessions are no longer registered directly on the `Mailbox` object. Instead, a `NotificationPubSub` abstract class is used to notify sessions of these changes. This is done with the `Publisher` and `Subscriber` helper classes: the mailbox pushes changes to the `Publisher`, which are received by sessions listening on the associated `Subscriber.` For simplicity, much of the code in `NotificationPubSub` base class was lifted directly from the corresponding `Mailbox` methods.

The primary implementation is `RedisPubSub`, which publishes `PendingLocalModifications` to a Redis channel named after the mailbox's account ID. The `RedisSubscriber` listens on this channel, reconstructs the modifications object, and notifies the sessions registered on its server. As an optimization, and to avoid introducing a race condition, sessions that are registered on the same node as the publisher are notified _directly_ using the `NotificationPubSub::notifyLocal` method.

There are two cases in which sessions registered on a subscriber are _not_ notified of changes received through the Redis channel:
* The changes originated on the same mailbox node as the listener. Since these sessions were already notified using `notifyLocal`, processing the change would result in duplicate notifications. This is done by checking the object hash of the `Mailbox` that originated the change to the hash of the Session's mailbox.
* The changes originated on a different mailbox node, but by an instance of the same session. Processing these would also result in duplicate notifications.

#### SoapSession Changes
Putting this all together, soap session logic has been changed in the following ways:
* If a client request is handled by a server on which the referenced soap session has not been cached, `DocumentHandler` will first check to see if the session is registered _globally_ - that is, if a modification sequence exists for that session ID in Redis. If so, a `SoapSession` will be instantiated with the passed-in ID, and cached in the local `SessionCache` as usual. If not, an entirely new session will be created (as was the original behavior).
* The notification sequence for each `QueuedNotifications` object is kept consistent for a given session across the cluster; this ensures that the client receives notifications in a monotonically increasing order regardless of which server the response comes from.
* The list of sent notifications previously kept in-memory is now stored in Redis. This means that any server can trim this list upon acknowledgement from the client or re-send notifications if necessary.
* Since an instance of a session will be notified of a change on _each server_ where it is cached, but only one of these servers will actually send that change back to the client, we need a way to invalidate changes on the _other_ servers after this happens. This is done by comparing the modification sequence on the `QueuedNotifications` object to the _latest_ sequence number in Redis; if at any point the sequence on the server falls behind the Redis value, it means that another server has already sent these changes to the client and the local copy can be discarded. This check happens in two places: prior to updating `QueuedNotifications` with a new change, and prior to encoding the existing changes into the response headers.

#### Open Issues
A limitation of the Redis pub/sub mechanism is we no longer have access to session-specific metadata, or the count of how many listeners there are, by type, across all workers. This can be implemented as a separate registry that gets updated with metadata upon session registration. Methods such as `Mailbox::getListeners` and `Mailbox::getNumListeners` are now on the `Publisher` class, but currently only return the locally-registered sessions. That said, this limitation should not affect `SoapSession` operation.

Another limitation has to do with mailbox maintenance. Previously, putting a mailbox into maintenance mode would unregister all listeners; this is no longer the case, since unregistering listeners on other nodes would require passing a signal along the notification channel. While this is not difficult, it is somewhat outside the scope of this ticket. This can be changed once mailbox maintenance is more clearly defined.

Lastly, it is entirely possible that there are still gaps or race conditions in this distributed session mechanism that I overlooked. Such bugs may result in the client either receiving duplicate notifications, or not receiving them at all. These issues (should they come up) will of course be addressed, but it should be mentioned that a refresh of the UI should bring the client back in sync with the server.
