### PR TITLE
ZCS-3055:Bad ZWC allday reply treated old way

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/CalendarItem.java
+++ b/store/src/java/com/zimbra/cs/mailbox/CalendarItem.java
@@ -3498,7 +3498,8 @@ public abstract class CalendarItem extends MailItem {
                          * expected time for an instance forward or backward relative to UTC
                          */
                         ParsedDateTime seriesStartTime = cur.getStartTime();
-                        if (seriesStartTime != null) {
+                        /* Don't do this for allday events as they shouldn't really have timezones */
+                        if ((seriesStartTime != null) && (seriesStartTime.hasTime())) {
                             ICalTimeZone seriesTz = seriesStartTime.getTimeZone();
                             if (seriesTz != null) {
                                 pdt.toTimeZone(seriesTz);


### PR DESCRIPTION
There is an existing ZWC bug that responses to allday appointments
contain a DATE-TIME for the value of the RECURRENCE-ID instead of
a DATE.  The previous ZCS-3055 changes introduced a change in
behavior when handling this, which is even more buggy than
the previous handling.  In particular, you end up with:

    RECURRENCE-ID;TZID="UTC":20180427T230000

instead of the more correct (but still wrong):

    RECURRENCE-ID:20180427T230000Z

This change re-instates the old behavior.

Note that this does NOT address display problems resulting from
the way the bad response is currently handled - See ticket ZCS-4932