### PR TITLE
zcs-4842: folder/tag cache rollback

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -1958,10 +1958,8 @@ public class Mailbox implements MailboxStore {
     private void loadFoldersAndTags() throws ServiceException {
         // if the persisted mailbox sizes aren't available, we *must* recalculate
         boolean initial = state.getNumContacts() < 0 || state.getSize() < 0;
-        if (lockFactory.getHoldCount() > 1) {
-            if (mFolderCache != null && mTagCache != null && !initial) {
-                return;
-            }
+        if (mFolderCache != null && mTagCache != null && !initial) {
+            return;
         }
         if (ZimbraLog.cache.isDebugEnabled()) {
             ZimbraLog.cache.debug("loading due to initial? %s folders? %s tags? %s writeChange? %s", initial, mFolderCache == null, mTagCache == null, currentChange().writeChange);


### PR DESCRIPTION
This fix rolls back behavior behavior introduced with the migration to redis for folder/tag caches. I had erroneously thought that these caches are built at every transaction, which was a result if my misunderstanding the condition that short-circuits the `loadFoldersAndTags` method. While this method is called at every transaction, it is meant to exit if the caches are already in place. 
My recent changes made it so that this did not happen, causing the folder/tag snapshots to be rebuilt every time. This resulted in a performance hit, as well as introduced bugs caused by multiple objects representing the same folder existing at the same time.

The downside of this rollback is that folders and tags are no longer synchronized between mailbox workers. Finding a new approach to resolve this will be addressed in another ticket.