### PR TITLE
ZCS-4716: Solr request compilation fix

### DIFF
--- a/store/src/java/com/zimbra/cs/index/solr/SolrIndex.java
+++ b/store/src/java/com/zimbra/cs/index/solr/SolrIndex.java
@@ -235,7 +235,7 @@ public class SolrIndex extends IndexStore {
         //after term queries on this level have been gathered group them by field
         for (String field: dismaxTermsByField.keySet()) {
             List<String> terms = dismaxTermsByField.get(field);
-            String allTerms = Joiner.on(" ").join(terms);
+            String allTerms = Joiner.on(" OR ").join(terms);
             TermQuery combined = new TermQuery(new Term(field, allTerms));
             //a tricky issue here is deciding which Occur value to use.
             //if we moved MUST or MUST_NOT values inside, we should use a MUST,


### PR DESCRIPTION
While most of the test failures listed in ZCS-4716 pass due to various fixes introduced recently, MailClient/Contacts/Bugs/bug10230.xml still fails. The failure stems from the solr query building code incorrectly joining multiple terms - specifically, searching for messages _and_ contacts requires the `l.partname` field to match the values "top" OR "CONTACT". The query was being built without an explicit "OR", which made it act like an AND query instead, leading to no results.