### PR TITLE
ZCS-4147: Explicitly indexing 'none' and 'any' attachment types

### DIFF
--- a/store/src/java/com/zimbra/cs/mime/ParsedMessage.java
+++ b/store/src/java/com/zimbra/cs/mime/ParsedMessage.java
@@ -1020,8 +1020,14 @@ public final class ParsedMessage {
 
 
         // Get the list of attachment content types from this message and any TNEF attachments
-        for (String attachment: Mime.getAttachmentTypeList(messageParts)) {
-        	doc.addAttachments(attachment);
+        Set<String> attachmentTypes = Mime.getAttachmentTypeList(messageParts);
+        if (attachmentTypes.isEmpty()) {
+            doc.addAttachments(LuceneFields.L_ATTACHMENT_NONE);
+        } else {
+            for (String attachment: attachmentTypes) {
+                doc.addAttachments(attachment);
+                doc.addAttachments(LuceneFields.L_ATTACHMENT_ANY);
+            }
         }
         return doc;
     }


### PR DESCRIPTION
Attachment queries like `has:attachement` have been broken with Solr due to how we now index attachment types. The fix on the mailbox side is to explicitly add "any" or "none" tokens to each index document, instead of relying on the tokenizer to do this.

See https://github.com/Zimbra/zm-solr/pull/9 for the zm-solr side of this fix, and for a more in-depth explanation of the issue.