### PR TITLE
ZCS-4963: Redis Subscribe Timeout Fix

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1242,6 +1242,9 @@ public final class LC {
     @Supported
     public static final KnownKey redis_service_uri = KnownKey.newKey("redis://zmc-redis:6379");
 
+    @Supported
+    public static final KnownKey redis_num_pubsub_channels = KnownKey.newKey(250);
+
     public enum PUBLIC_SHARE_VISIBILITY { samePrimaryDomain, all, none };
 
     /**

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -9025,7 +9025,7 @@ public class Mailbox implements MailboxStore {
 
     private void trimItemCache() {
         try {
-            int sizeTarget = !hasListeners(null) ? MAX_ITEM_CACHE_WITHOUT_LISTENERS : MAX_ITEM_CACHE_WITH_LISTENERS;
+            int sizeTarget = MAX_ITEM_CACHE_WITH_LISTENERS;
             if (galSyncMailbox) {
                 sizeTarget = MAX_ITEM_CACHE_FOR_GALSYNC_MAILBOX;
             }

--- a/store/src/java/com/zimbra/cs/mailbox/NotificationPubSub.java
+++ b/store/src/java/com/zimbra/cs/mailbox/NotificationPubSub.java
@@ -186,6 +186,11 @@ public abstract class NotificationPubSub {
                 session.notifyPendingChanges(pns, changeId, source);
             }
         }
+
+
+        public Mailbox getMailbox() {
+            return NotificationPubSub.this.mbox;
+        }
     }
 
     public static abstract class Factory {

--- a/store/src/java/com/zimbra/cs/mailbox/RedisPubSub.java
+++ b/store/src/java/com/zimbra/cs/mailbox/RedisPubSub.java
@@ -1,32 +1,42 @@
 package com.zimbra.cs.mailbox;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.redisson.api.RTopic;
 import org.redisson.api.RedissonClient;
 import org.redisson.api.listener.MessageListener;
 
+import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.session.PendingLocalModifications;
+import com.zimbra.cs.session.Session;
 import com.zimbra.cs.session.PendingLocalModifications.PendingModificationSnapshot;
 import com.zimbra.cs.session.Session.SourceSessionInfo;
 import com.zimbra.cs.session.Session.Type;
 
 public class RedisPubSub extends NotificationPubSub {
 
+    private String accountId;
     private RedissonClient client;
-    private RTopic<NotificationMsg> channel;
+    private final int numChannels;
+
+    private static Map<String, NotificationChannel> channelMap = new HashMap<>();
 
     public RedisPubSub(Mailbox mbox, RedissonClient client) {
         super(mbox);
+        this.accountId = mbox.getAccountId();
         this.client = client;
-        this.channel = client.getTopic(getChannelName());
+        this.numChannels = LC.redis_num_pubsub_channels.intValue();
     }
 
     private String getChannelName() {
-        return mbox.getAccountId();
+        int channelNum = mbox.getId() % numChannels;
+        return String.format("NOTIFICATION-CHANNEL-%d", channelNum);
     }
+
     @Override
     protected Publisher initPubisher() {
         return new RedisPublisher();
@@ -35,6 +45,16 @@ public class RedisPubSub extends NotificationPubSub {
     @Override
     protected Subscriber initSubscriber() {
         return new RedisSubscriber();
+    }
+
+    private synchronized NotificationChannel getChannel() {
+        String channelName = getChannelName();
+        NotificationChannel channel = channelMap.get(channelName);
+        if (channel == null) {
+            channel = new NotificationChannel(client, channelName);
+            channelMap.put(channelName, channel);
+        }
+        return channel;
     }
 
     public class RedisPublisher extends Publisher {
@@ -48,10 +68,10 @@ public class RedisPubSub extends NotificationPubSub {
                     return;
                 }
                 PendingModificationSnapshot snapshot = pns.toSnapshot();
-                long received = channel.publish(new NotificationMsg(snapshot, changeId, source, sourceMailboxHash));
+                long received = getChannel().publish(new NotificationMsg(accountId, snapshot, changeId, source, sourceMailboxHash));
                 ZimbraLog.mailbox.info("published notifications for changeId=%d, received by %d", changeId, received);
             } catch (IOException | ServiceException e) {
-                ZimbraLog.ml.error("unable to serialize notifications for changeId=%d, accountId=%s", changeId, mbox.getAccountId(), e);
+                ZimbraLog.mailbox.error("unable to serialize notifications for changeId=%d, accountId=%s", changeId, mbox.getAccountId(), e);
             }
         }
 
@@ -62,29 +82,94 @@ public class RedisPubSub extends NotificationPubSub {
         }
     }
 
-    public class RedisSubscriber extends Subscriber implements MessageListener<NotificationMsg> {
-
-        private int listenerId;
+    public class RedisSubscriber extends Subscriber {
 
         public RedisSubscriber() {
-            listenerId = channel.addListener(this);
-            ZimbraLog.mailbox.info("began listening on Redis channel %s", channel.getChannelNames().get(0));
+            getChannel().addSubscriber(this);
         }
 
         @Override
-        public void onMessage(String channelName, NotificationMsg msg) {
-            ZimbraLog.mailbox.info("got notification for changeId=%d from channel %s", msg.changeId, channelName);
+        public void purgeListeners() {
+            super.purgeListeners();
+            getChannel().removeSubscriber(accountId);
+        }
+    }
+
+    /**
+     * Helper class acting as both the listener and publisher to a Redis notification pubsub channel.
+     * This channel handles notifications for multiple accounts to avoid having a separate connection for each
+     * mailbox; incoming notifications are routed to the appropriate Subscriber instance.
+     */
+    public static class NotificationChannel implements MessageListener<NotificationMsg> {
+
+        private int listenerId;
+        private RTopic<NotificationMsg> channel;
+        private Map<String, Subscriber> subscriberMap;
+        private String name;
+        boolean active = false;
+
+        public NotificationChannel(RedissonClient client, String channelName) {
+            this.name = channelName;
+            this.subscriberMap = new HashMap<>();
+            this.channel = client.getTopic(channelName);
+            beginListening();
+        }
+
+        public void beginListening() {
+            if (active) {
+                return;
+            }
+            this.listenerId = channel.addListener(this);
+            ZimbraLog.mailbox.info("beginning listening on Redis notifification channel %s", name);
+            active = true;
+        }
+
+        public void addSubscriber(RedisSubscriber subscriber) {
+            beginListening();
+            String acctId = subscriber.getMailbox().getAccountId();
+            subscriberMap.put(acctId, subscriber);
+            ZimbraLog.mailbox.info("added account %s to Redis notifification channel %s", acctId, name);
+        }
+
+        public void removeSubscriber(String accountId) {
+            subscriberMap.remove(accountId);
+            if (subscriberMap.isEmpty()) {
+                ZimbraLog.mailbox.info("%s has no subscribers, removing listener", name);
+                channel.removeListener(listenerId);
+                active = false;
+            }
+        }
+
+        public long publish(NotificationMsg msg) {
+            return channel.publish(msg);
+        }
+
+        @Override
+        public void onMessage(String channel, NotificationMsg msg) {
+            String notificationAcctId = msg.accountId;
+            ZimbraLog.mailbox.info("got notification for account %s, changeId=%d from channel %s", msg.accountId, msg.changeId, channel);
+            Subscriber subscriber = subscriberMap.get(notificationAcctId);
+            if (subscriber == null) {
+                ZimbraLog.mailbox.warn("%s received notification for unassociated account %s", name, notificationAcctId);
+                return;
+            }
             PendingLocalModifications mods;
             try {
-                mods = PendingLocalModifications.fromSnapshot(mbox, msg.modification);
-                notifyListeners(mods, msg.changeId, msg.source, msg.sourceMailboxHash, true);
+                mods = PendingLocalModifications.fromSnapshot(subscriber.getMailbox(), msg.modification);
+                subscriber.notifyListeners(mods, msg.changeId, msg.source, msg.sourceMailboxHash, true);
             } catch (ServiceException e) {
-                ZimbraLog.ml.error("unable to deserialize notifications for changeId=%d, accountId=%s", msg.changeId, mbox.getAccountId(), e);
+                ZimbraLog.mailbox.error("unable to deserialize notifications for changeId=%d, accountId=%s", msg.changeId, notificationAcctId, e);
             }
+        }
+
+        @Override
+        public String toString() {
+            return String.format("[Channel %s (%s mailboxes)]", name, subscriberMap.size());
         }
     }
 
     private static class NotificationMsg {
+        private String accountId;
         private PendingModificationSnapshot modification;
         private int changeId;
         private SourceSessionInfo source;
@@ -92,8 +177,9 @@ public class RedisPubSub extends NotificationPubSub {
 
         public NotificationMsg() {}
 
-        public NotificationMsg(PendingModificationSnapshot modification, int changeId,
+        public NotificationMsg(String accountId, PendingModificationSnapshot modification, int changeId,
                 SourceSessionInfo source, int sourceMailboxHash) throws IOException, ServiceException {
+            this.accountId = accountId;
             this.modification = modification;
             this.changeId = changeId;
             this.source = source;

--- a/store/src/java/com/zimbra/cs/mailbox/cache/MapItemCache.java
+++ b/store/src/java/com/zimbra/cs/mailbox/cache/MapItemCache.java
@@ -9,8 +9,8 @@ import com.zimbra.cs.mailbox.MailItem;
 import com.zimbra.cs.mailbox.Mailbox;
 
 public abstract class MapItemCache<T> extends ItemCache {
-    private final Map<Integer /* id */, T> mapById;
-    private final Map<String /* uuid */, Integer /* id */> uuid2id;
+    protected final Map<Integer /* id */, T> mapById;
+    protected final Map<String /* uuid */, Integer /* id */> uuid2id;
 
     public MapItemCache(Mailbox mbox, Map<Integer, T> itemMap, Map<String, Integer> uuidMap) {
         super(mbox);
@@ -65,9 +65,13 @@ public abstract class MapItemCache<T> extends ItemCache {
         return mapById.containsKey(item.getId());
     }
 
+    protected Collection<T> getAllValues() {
+        return mapById.values();
+    }
+
     @Override
     public Collection<MailItem> values() {
-        return mapById.values().stream().map(v -> fromCacheValue(v)).filter(mi -> Objects.nonNull(mi)).collect(Collectors.toList());
+        return getAllValues().stream().map(v -> fromCacheValue(v)).filter(mi -> Objects.nonNull(mi)).collect(Collectors.toList());
     }
 
     @Override

--- a/store/src/java/com/zimbra/cs/mailbox/cache/RedisItemCache.java
+++ b/store/src/java/com/zimbra/cs/mailbox/cache/RedisItemCache.java
@@ -1,5 +1,6 @@
 package com.zimbra.cs.mailbox.cache;
 
+import java.util.Collection;
 import java.util.Map;
 
 import org.redisson.api.RBucket;
@@ -44,6 +45,12 @@ public class RedisItemCache extends MapItemCache<String> {
             ZimbraLog.cache.error("unable to get MailItem from Redis cache for account %s", mbox.getAccountId());
             return null;
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected Collection<String> getAllValues() {
+        return ((RMap<Integer, String>) mapById).readAllValues();
     }
 
     @Override

--- a/store/src/java/com/zimbra/cs/mailbox/cache/RedisItemCache.java
+++ b/store/src/java/com/zimbra/cs/mailbox/cache/RedisItemCache.java
@@ -26,7 +26,7 @@ public class RedisItemCache extends MapItemCache<String> {
 
     private void initFolderTagBucket() {
         RedissonClient client = RedissonClientHolder.getInstance().getRedissonClient();
-        folderTagBucket = client.getBucket(String.format("%s:FOLDERS_TAGS", mbox.getAccountId()));
+        folderTagBucket = client.getBucket(String.format("FOLDERS_TAGS:%s", mbox.getAccountId()));
     }
 
     @Override
@@ -70,8 +70,8 @@ public class RedisItemCache extends MapItemCache<String> {
         @Override
         public ItemCache getItemCache(Mailbox mbox) {
             RedissonClient client = RedissonClientHolder.getInstance().getRedissonClient();
-            String itemMapName = String.format("%s:id", mbox.getAccountId());
-            String uuidMapName = String.format("%s:uuid", mbox.getAccountId());
+            String itemMapName = String.format("ITEMS_BY_ID:%s", mbox.getAccountId());
+            String uuidMapName = String.format("ITEMS_BY_UUID:%s", mbox.getAccountId());
             RMap<Integer, String> itemMap = client.getMap(itemMapName);
             RMap<String, Integer> uuidMap = client.getMap(uuidMapName);
             return new RedisItemCache(mbox, itemMap, uuidMap);

--- a/store/src/java/com/zimbra/cs/session/SoapSession.java
+++ b/store/src/java/com/zimbra/cs/session/SoapSession.java
@@ -914,7 +914,7 @@ public class SoapSession extends Session {
         //has already received them
         int curSequence = getCurSequenceId();
         if (changes.getSequence() < curSequence) {
-            ZimbraLog.session.info("stale change sequence %d < %d for session %s, discarding queued notifications", changes.getSequence(), curSequence, getSessionId());
+            ZimbraLog.session.debug("stale change sequence %d < %d for session %s, discarding queued notifications", changes.getSequence(), curSequence, getSessionId());
             changes = new QueuedNotifications(mAuthenticatedAccountId, curSequence);
             return true;
         }


### PR DESCRIPTION
The original Redis pub/sub system for notifications created a dedicated subscription channel for each mailbox. It actually turns out that the number of subscriptions is limited by two factors, defined in the Redisson client config:
- `subscriptionConnectionPoolSize`, which defaults to 50
- `subscriptionsPerConnection`, which defaults to 5
It's no surprise then that Redission refused new subscription connections when the number of created accounts surpassed 250, leading to timeouts.
While it is possible to raise these values, it seems unwise to assume that we can safely increase the number of connections without limit. 
A workaround introduced in this PR is to have _shared_ subscription channels. We map mailboxes to one of _n_ channels in a deterministic way (_n_ being configurable in LC), and attach the account ID to the message being published. On the receiving end, the listener can route the incoming notification messages appropriately.

This is done using the new `NotificationChannel` static inner class. `RedisPubSub` has a map of these keyed by their channel names, now called `NOTIFICATION-CHANNEL-{N}`, and each instance maintains a map of account IDs mapped to their `RedisSubscriber` objects. When a `NotificationChannel` receives a message, it looks up the appropriate subscriber in this map and calls `notifyListeners` on it.

This PR also contains a few other small semi-related changes:
 - The `Mailbox.trimItemCache()` method no longer calls hasListeners() to determine the cache size, as this is no longer a meaningful check
- The `RedisItemCache.values()` method reads all hash values in a single operation instead of relying on the built-in `RMap` values() iterator, which actually fetches the values one-by-one
- The logging call in `SoapSession` notifying of a stale notification is now logged at a `debug` level, as it happens very often