### PR TITLE
ZCS-4928:fix ambiguous Log.[warn|error]Quietly

### DIFF
--- a/common/src/java/com/zimbra/common/util/Log.java
+++ b/common/src/java/com/zimbra/common/util/Log.java
@@ -337,7 +337,7 @@ public class Log {
     }
 
     /** Like warn but provides stack trace info if debug is enabled */
-    public void warnQuietly(String format, Object o) {
+    public void warnQuietlyFmt(String format, Object o) {
         if (!isWarnEnabled()) {
             return;
         }
@@ -417,7 +417,7 @@ public class Log {
     }
 
     /** Like error but provides stack trace info if debug is enabled */
-    public void errorQuietly(String format, Object o) {
+    public void errorQuietlyFmt(String format, Object o) {
         if (!isErrorEnabled()) {
             return;
         }

--- a/store/src/java/com/zimbra/cs/ldap/LdapUsage.java
+++ b/store/src/java/com/zimbra/cs/ldap/LdapUsage.java
@@ -156,7 +156,7 @@ public enum LdapUsage {
 
     public static LdapUsage fromGalOp(GalOp galOp) {
         if (galOp == null) {
-            ZimbraLog.ldap.warnQuietly("unknown GAL op: null - treating as %s", GAL);
+            ZimbraLog.ldap.warnQuietlyFmt("unknown GAL op: null - treating as %s", GAL);
             return GAL;  // really an error
         }
         switch (galOp) {
@@ -174,7 +174,7 @@ public enum LdapUsage {
 
     public static LdapUsage fromGalOpLegacy(GalOp galOp) {
         if (galOp == null) {
-            ZimbraLog.ldap.warnQuietly("unknown legacy GAL op: null - treating as %s", GAL_LEGACY);
+            ZimbraLog.ldap.warnQuietlyFmt("unknown legacy GAL op: null - treating as %s", GAL_LEGACY);
             return GAL_LEGACY;  // really an error
         }
         switch (galOp) {


### PR DESCRIPTION
Fix compilation issue:
    [javac]                 ZimbraLog.ews.errorQuietly("Error generating the salt", e);
    [javac]                              ^
    [javac]   both method errorQuietly(Object,Throwable) in Log and method errorQuietly(String,Object) in Log match