### PR TITLE
ZCS-4797:Add recovery email address for password reset

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -1996,9 +1996,7 @@ public class ZAttrProvisioning {
 
     public static enum PrefPasswordRecoveryAddressStatus {
         verified("verified"),
-        pending("pending"),
-        failed("failed"),
-        expired("expired");
+        pending("pending");
         private String mValue;
         private PrefPasswordRecoveryAddressStatus(String value) { mValue = value; }
         public String toString() { return mValue; }
@@ -2010,8 +2008,6 @@ public class ZAttrProvisioning {
         }
         public boolean isVerified() { return this == verified;}
         public boolean isPending() { return this == pending;}
-        public boolean isFailed() { return this == failed;}
-        public boolean isExpired() { return this == expired;}
     }
 
     public static enum PrefPop3DeleteOption {
@@ -6329,11 +6325,12 @@ public class ZAttrProvisioning {
     public static final String A_zimbraFeatureContactBackupEnabled = "zimbraFeatureContactBackupEnabled";
 
     /**
-     * Sleep time between subsequent contact backups. 0 means that contact
-     * backup is disabled. . Must be in valid duration format:
-     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
-     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
-     * specified, the default is s(seconds).
+     * Deprecated since: 8.8.6. No longer used by ContactBackupRequest SOAP
+     * handler. Orig desc: Sleep time between subsequent contact backups. 0
+     * means that contact backup is disabled. . Must be in valid duration
+     * format: {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h -
+     * hours, m - minutes, s - seconds, d - days, ms - milliseconds. If time
+     * unit is not specified, the default is s(seconds).
      *
      * @since ZCS 8.8.5
      */
@@ -12080,6 +12077,14 @@ public class ZAttrProvisioning {
     public static final String A_zimbraPasswordMustChange = "zimbraPasswordMustChange";
 
     /**
+     * Maximum attempts for password recovery resend
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=3031)
+    public static final String A_zimbraPasswordRecoveryMaxAttempts = "zimbraPasswordRecoveryMaxAttempts";
+
+    /**
      * phonetic company name
      *
      * @since ZCS 7.0.0
@@ -14149,6 +14154,26 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=483)
     public static final String A_zimbraQuotaWarnPercent = "zimbraQuotaWarnPercent";
+
+    /**
+     * Expiry time for recovery email code verification. Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=3030)
+    public static final String A_zimbraRecoveryEmailCodeValidity = "zimbraRecoveryEmailCodeValidity";
+
+    /**
+     * Recovery email verification data
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=3029)
+    public static final String A_zimbraRecoveryEmailVerificationData = "zimbraRecoveryEmailVerificationData";
 
     /**
      * redolog rollover destination

--- a/common/src/java/com/zimbra/common/soap/MailConstants.java
+++ b/common/src/java/com/zimbra/common/soap/MailConstants.java
@@ -1367,4 +1367,13 @@ public final class MailConstants {
     public static final String E_MODIFY_PROFILE_IMAGE_RESPONSE = "ModifyProfileImageResponse";
     public static final QName MODIFY_PROFILE_IMAGE_REQUEST = QName.get(E_MODIFY_PROFILE_IMAGE_REQUEST, NAMESPACE);
     public static final QName MODIFY_PROFILE_IMAGE_RESPONSE = QName.get(E_MODIFY_PROFILE_IMAGE_RESPONSE, NAMESPACE);
+    
+    // Password reset API
+    public static final String E_SET_RECOVERY_EMAIL_REQUEST = "SetRecoveryEmailRequest";
+    public static final String E_SET_RECOVERY_EMAIL_RESPONSE = "SetRecoveryEmailResponse";
+    public static final QName SET_RECOVERY_EMAIL_REQUEST = QName.get(E_SET_RECOVERY_EMAIL_REQUEST, NAMESPACE);
+    public static final QName SET_RECOVERY_EMAIL_RESPONSE = QName.get(E_SET_RECOVERY_EMAIL_RESPONSE, NAMESPACE);
+    public static final String A_RECOVERY_EMAIL_ADDRESS = "recoveryEmailAddress";
+    public static final String A_RECOVERY_EMAIL_ADDRESS_VERIFICATION_CODE = "recoveryEmailAddressVerificationCode";
+    
 }

--- a/common/src/java/com/zimbra/common/util/L10nUtil.java
+++ b/common/src/java/com/zimbra/common/util/L10nUtil.java
@@ -279,7 +279,13 @@ public class L10nUtil {
         //forwarding email address verification
         verifyEmailSubject,
         verifyEmailBodyText,
-        verifyEmailBodyHtml
+        verifyEmailBodyHtml,
+
+        // recovery email address verification
+        verifyRecoveryEmailSubject,
+        verifyRecoveryEmailBodyText,
+        verifyRecoveryEmailBodyHtml
+
         // add other messages in the future...
     }
 

--- a/soap/src/java/com/zimbra/soap/JaxbUtil.java
+++ b/soap/src/java/com/zimbra/soap/JaxbUtil.java
@@ -1016,6 +1016,8 @@ public final class JaxbUtil {
             com.zimbra.soap.mail.message.SetCustomMetadataResponse.class,
             com.zimbra.soap.mail.message.SetMailboxMetadataRequest.class,
             com.zimbra.soap.mail.message.SetMailboxMetadataResponse.class,
+            com.zimbra.soap.mail.message.SetRecoveryEmailRequest.class,
+            com.zimbra.soap.mail.message.SetRecoveryEmailResponse.class,
             com.zimbra.soap.mail.message.SetTaskRequest.class,
             com.zimbra.soap.mail.message.SetTaskResponse.class,
             com.zimbra.soap.mail.message.SnoozeCalendarItemAlarmRequest.class,

--- a/soap/src/java/com/zimbra/soap/mail/message/SetRecoveryEmailRequest.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/SetRecoveryEmailRequest.java
@@ -1,0 +1,102 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.mail.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.google.common.base.Objects;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.MailConstants;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name = MailConstants.E_SET_RECOVERY_EMAIL_REQUEST)
+public class SetRecoveryEmailRequest {
+
+    @XmlEnum
+    public static enum Op {
+        sendCode, validateCode, resendCode, reset;
+
+        public static Op fromString(String s) throws ServiceException {
+            try {
+                return Op.valueOf(s);
+            } catch (IllegalArgumentException e) {
+                throw ServiceException.INVALID_REQUEST("unknown key: " + s, e);
+            }
+        }
+    }
+
+    /**
+     * @zm-api-field-tag op
+     * @zm-api-field-description op can be sendCode, validateCode, resendCode or reset.
+     */
+    @XmlAttribute(name = MailConstants.A_OPERATION /* op */, required = true)
+    private Op op;
+
+    /**
+     * @zm-api-field-tag recoveryEmailAddress
+     * @zm-api-field-description recovery email address
+     */
+    @XmlAttribute(name = MailConstants.A_RECOVERY_EMAIL_ADDRESS /* recoveryEmailAddress */, required = false)
+    private String recoveryEmailAddress;
+
+    /**
+     * @zm-api-field-tag recoveryEmailAddressVerificationCode
+     * @zm-api-field-description recovery email address verification code
+     */
+    @XmlAttribute(name = MailConstants.A_RECOVERY_EMAIL_ADDRESS_VERIFICATION_CODE /* recoveryEmailAddressVerificationCode */, required = false)
+    private String recoveryEmailAddressVerificationCode;
+
+    public Op getOp() {
+        return op;
+    }
+
+    public void setOp(Op op) {
+        this.op = op;
+    }
+
+    public String getRecoveryEmailAddress() {
+        return recoveryEmailAddress;
+    }
+
+    public void setRecoveryEmailAddress(String recoveryEmailAddress) {
+        this.recoveryEmailAddress = recoveryEmailAddress;
+    }
+
+    public String getRecoveryEmailAddressVerificationCode() {
+        return recoveryEmailAddressVerificationCode;
+    }
+
+    public void
+        setRecoveryEmailAddressVerificationCode(String recoveryEmailAddressVerificationCode) {
+        this.recoveryEmailAddressVerificationCode = recoveryEmailAddressVerificationCode;
+    }
+
+    public Objects.ToStringHelper addToStringInfo(Objects.ToStringHelper helper) {
+        return helper.add("op", op).add("recoveryEmailAddress", recoveryEmailAddress)
+            .add("recoveryEmailAddressVerificationCode", recoveryEmailAddressVerificationCode);
+    }
+
+    @Override
+    public String toString() {
+        return addToStringInfo(Objects.toStringHelper(this)).toString();
+    }
+}

--- a/soap/src/java/com/zimbra/soap/mail/message/SetRecoveryEmailResponse.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/SetRecoveryEmailResponse.java
@@ -1,0 +1,30 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.mail.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.MailConstants;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name = MailConstants.E_SET_RECOVERY_EMAIL_RESPONSE)
+public class SetRecoveryEmailResponse {
+
+}

--- a/store-conf/conf/msgs/ZsMsg.properties
+++ b/store-conf/conf/msgs/ZsMsg.properties
@@ -922,3 +922,19 @@ verifyEmailBodyHtml =\
   Click on this <a href="{1}">link</a> to verify your email address</br>\
   The link expires by {2}\
   </div>
+
+# recovery email address verification
+verifyRecoveryEmailSubject = Request for recovery email address verification by {0}
+verifyRecoveryEmailBodyText =\
+  Verification of your recovery email address\n\
+  \n\
+  Recovery email verification code: {0}\n\
+  The code expires by: {1}\n\
+  *~*~*~*~*~*~*~*~*~*\n
+verifyRecoveryEmailBodyHtml =\
+  <div style="font-family:sans-serif;">\
+  <h1 style="font-size:1.3em;">Verification of your recovery email address</h1>\
+  <hr>\
+  Recovery email verification code: {0}</br>\
+  The code expires by {1}\
+  </div>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9649,7 +9649,7 @@ TODO: delete them permanently from here
   <desc>RFC822 recovery email address for an account</desc>
 </attr>
 
-<attr id="3026" name="zimbraPrefPasswordRecoveryAddressStatus" type="enum" value="verified,pending,failed,expired" cardinality="single" optionalIn="account" since="8.8.9">
+<attr id="3026" name="zimbraPrefPasswordRecoveryAddressStatus" type="enum" value="verified,pending" cardinality="single" optionalIn="account" since="8.8.9">
   <desc>End-user recovery email address verification status</desc>
 </attr>
 
@@ -9660,6 +9660,20 @@ TODO: delete them permanently from here
 <attr id="3028" name="zimbraResetPasswordRecoveryCodeExpiry" type="duration" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited" since="8.8.9">
   <defaultCOSValue>10m</defaultCOSValue>
   <desc>Expiry time for password reset recovery code</desc>
+</attr>
+
+<attr id="3029" name="zimbraRecoveryEmailVerificationData" type="string" cardinality="single" optionalIn="account" since="8.8.9">
+  <desc>Recovery email verification data</desc>
+</attr>
+
+<attr id="3030" name="zimbraRecoveryEmailCodeValidity" type="duration" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited" since="8.8.9">
+  <defaultCOSValue>1d</defaultCOSValue>
+  <desc>Expiry time for recovery email code verification</desc>
+</attr>
+
+<attr id="3031" name="zimbraPasswordRecoveryMaxAttempts" type="integer" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited" since="8.8.9">
+  <defaultCOSValue>3</defaultCOSValue>
+  <desc>Maximum attempts for password recovery resend</desc>
 </attr>
 
 </attrs>

--- a/store/docs/soap.txt
+++ b/store/docs/soap.txt
@@ -4766,3 +4766,15 @@ Note: The item id returned in response can be used to download the profile image
 Server Debug config parameters:
 1. profile_image_max_size = maximum image size allowed for account profile
 2. profile_thumbnail_image_dimension = profile ldap thumbnail image dimesion
+
+-----------------------------
+API to set recovery email address
+<SetRecoveryEmailRequest op="{op}" recoveryEmailAddress="{recoveryEmailAddress}" recoveryEmailAddressVerificationCode="{recoveryEmailAddressVerificationCode}">
+</SetRecoveryEmailRequest>
+
+{op} = op can be sendCode, validateCode, resendCode or reset. 'reset' will clear all ldap attributes related to recovery email.
+{recoveryEmailAddress} = Recovery email address to be set
+{recoveryEmailAddressVerificationCode} = Recovery email address verification code to validate the address
+
+<SetRecoveryEmailResponse>
+</SetRecoveryEmailResponse>

--- a/store/src/java-test/com/zimbra/cs/service/SetRecoveryEmailTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/SetRecoveryEmailTest.java
@@ -1,0 +1,195 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.service;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.mail.Address;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.MethodRule;
+import org.junit.rules.TestName;
+import org.junit.rules.TestWatchman;
+import org.junit.runners.model.FrameworkMethod;
+
+import com.google.common.collect.Maps;
+import com.zimbra.common.account.Key;
+import com.zimbra.common.account.ZAttrProvisioning.PrefPasswordRecoveryAddressStatus;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.util.L10nUtil;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.DeliveryOptions;
+import com.zimbra.cs.mailbox.Flag;
+import com.zimbra.cs.mailbox.MailItem;
+import com.zimbra.cs.mailbox.MailSender;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.Mailbox.MailboxData;
+import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.mailbox.Message;
+import com.zimbra.cs.mime.ParsedMessage;
+import com.zimbra.cs.service.mail.ServiceTestUtil;
+import com.zimbra.cs.service.mail.SetRecoveryEmail;
+import com.zimbra.soap.JaxbUtil;
+import com.zimbra.soap.mail.message.SetRecoveryEmailRequest;
+
+import junit.framework.Assert;
+
+public class SetRecoveryEmailTest {
+
+    public static String zimbraServerDir = "";
+
+    @Rule
+    public TestName testName = new TestName();
+    @Rule
+    public MethodRule watchman = new TestWatchman() {
+
+        @Override
+        public void failed(Throwable e, FrameworkMethod method) {
+            System.out.println(method.getName() + " " + e.getClass().getSimpleName());
+        }
+    };
+
+    @BeforeClass
+    public static void init() throws Exception {
+        MailboxTestUtil.initServer();
+        Provisioning prov = Provisioning.getInstance();
+
+        Map<String, Object> attrs = Maps.newHashMap();
+
+        prov.createDomain("zimbra.com", attrs);
+
+        attrs = Maps.newHashMap();
+        attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        attrs.put(Provisioning.A_zimbraFeatureResetPasswordEnabled, true);
+        prov.createAccount("test4797@zimbra.com", "secret", attrs);
+
+        attrs = Maps.newHashMap();
+        attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        prov.createAccount("testRecovery@zimbra.com", "secret", attrs);
+
+        MailboxManager.setInstance(new DirectInsertionMailboxManager());
+
+        L10nUtil.setMsgClassLoader("../store-conf/conf/msgs");
+    }
+
+    public static class DirectInsertionMailboxManager extends MailboxManager {
+
+        public DirectInsertionMailboxManager() throws ServiceException {
+            super();
+        }
+
+        @Override
+        protected Mailbox instantiateMailbox(MailboxData data) {
+            return new Mailbox(data) {
+
+                @Override
+                public MailSender getMailSender() {
+                    return new MailSender() {
+
+                        @Override
+                        protected Collection<Address> sendMessage(Mailbox mbox, MimeMessage mm,
+                            Collection<RollbackData> rollbacks) {
+                            List<Address> successes = new ArrayList<Address>();
+                            Address[] addresses;
+                            try {
+                                addresses = getRecipients(mm);
+                            } catch (Exception e) {
+                                addresses = new Address[0];
+                            }
+                            DeliveryOptions dopt = new DeliveryOptions()
+                                .setFolderId(Mailbox.ID_FOLDER_INBOX).setFlags(Flag.BITMASK_UNREAD);
+                            for (Address addr : addresses) {
+                                try {
+                                    Account acct = Provisioning.getInstance()
+                                        .getAccountByName(((InternetAddress) addr).getAddress());
+                                    if (acct != null) {
+                                        Mailbox target = MailboxManager.getInstance()
+                                            .getMailboxByAccount(acct);
+                                        target.addMessage(null, new ParsedMessage(mm, false), dopt,
+                                            null);
+                                        successes.add(addr);
+                                    }
+                                } catch (Exception e) {
+                                    e.printStackTrace(System.out);
+                                }
+                            }
+                            if (successes.isEmpty() && !isSendPartial()) {
+                                for (RollbackData rdata : rollbacks) {
+                                    if (rdata != null) {
+                                        rdata.rollback();
+                                    }
+                                }
+                            }
+                            return successes;
+                        }
+                    };
+                }
+            };
+        }
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        System.out.println(testName.getMethodName());
+        MailboxTestUtil.clearData();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        MailboxTestUtil.clearData();
+    }
+
+    @Test
+    public void test4797() throws Exception {
+        Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test4797@zimbra.com");
+        Account recoveryAcct = Provisioning.getInstance().get(Key.AccountBy.name,
+            "testRecovery@zimbra.com");
+        Mailbox recoveryMailbox = MailboxManager.getInstance().getMailboxByAccount(recoveryAcct);
+        acct1.setFeatureResetPasswordEnabled(true);
+        Assert.assertNull(acct1.getPrefPasswordRecoveryAddress());
+        Assert.assertNull(acct1.getPrefPasswordRecoveryAddressStatus());
+        SetRecoveryEmailRequest request = new SetRecoveryEmailRequest();
+        request.setOp(SetRecoveryEmailRequest.Op.sendCode);
+        request.setRecoveryEmailAddress("testRecovery@zimbra.com");
+        Element req = JaxbUtil.jaxbToElement(request);
+        new SetRecoveryEmail().handle(req, ServiceTestUtil.getRequestContext(acct1));
+        // Verify that the recovery email address is updated into ldap and
+        // status is set to pending
+        Assert.assertEquals("testRecovery@zimbra.com", acct1.getPrefPasswordRecoveryAddress());
+        Assert.assertEquals(PrefPasswordRecoveryAddressStatus.pending,
+            acct1.getAttrs().get(Provisioning.A_zimbraPrefPasswordRecoveryAddressStatus));
+        // Verify that recovery email address recieved the verification email
+        Message msg = (Message) recoveryMailbox.getItemList(null, MailItem.Type.MESSAGE).get(0);
+        Assert.assertEquals(
+            "Request for recovery email address verification by test4797@zimbra.com",
+            msg.getSubject());
+    }
+}

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -35997,6 +35997,78 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * Maximum attempts for password recovery resend
+     *
+     * @return zimbraPasswordRecoveryMaxAttempts, or 3 if unset
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=3031)
+    public int getPasswordRecoveryMaxAttempts() {
+        return getIntAttr(Provisioning.A_zimbraPasswordRecoveryMaxAttempts, 3, true);
+    }
+
+    /**
+     * Maximum attempts for password recovery resend
+     *
+     * @param zimbraPasswordRecoveryMaxAttempts new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=3031)
+    public void setPasswordRecoveryMaxAttempts(int zimbraPasswordRecoveryMaxAttempts) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPasswordRecoveryMaxAttempts, Integer.toString(zimbraPasswordRecoveryMaxAttempts));
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Maximum attempts for password recovery resend
+     *
+     * @param zimbraPasswordRecoveryMaxAttempts new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=3031)
+    public Map<String,Object> setPasswordRecoveryMaxAttempts(int zimbraPasswordRecoveryMaxAttempts, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPasswordRecoveryMaxAttempts, Integer.toString(zimbraPasswordRecoveryMaxAttempts));
+        return attrs;
+    }
+
+    /**
+     * Maximum attempts for password recovery resend
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=3031)
+    public void unsetPasswordRecoveryMaxAttempts() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPasswordRecoveryMaxAttempts, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Maximum attempts for password recovery resend
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=3031)
+    public Map<String,Object> unsetPasswordRecoveryMaxAttempts(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPasswordRecoveryMaxAttempts, "");
+        return attrs;
+    }
+
+    /**
      * phonetic company name
      *
      * @return zimbraPhoneticCompany, or null if unset
@@ -50626,7 +50698,7 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * End-user recovery email address verification status
      *
-     * <p>Valid values: [verified, pending, failed, expired]
+     * <p>Valid values: [verified, pending]
      *
      * @return zimbraPrefPasswordRecoveryAddressStatus, or null if unset and/or has invalid value
      *
@@ -50640,7 +50712,7 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * End-user recovery email address verification status
      *
-     * <p>Valid values: [verified, pending, failed, expired]
+     * <p>Valid values: [verified, pending]
      *
      * @return zimbraPrefPasswordRecoveryAddressStatus, or null if unset
      *
@@ -50654,7 +50726,7 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * End-user recovery email address verification status
      *
-     * <p>Valid values: [verified, pending, failed, expired]
+     * <p>Valid values: [verified, pending]
      *
      * @param zimbraPrefPasswordRecoveryAddressStatus new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -50671,7 +50743,7 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * End-user recovery email address verification status
      *
-     * <p>Valid values: [verified, pending, failed, expired]
+     * <p>Valid values: [verified, pending]
      *
      * @param zimbraPrefPasswordRecoveryAddressStatus new value
      * @param attrs existing map to populate, or null to create a new map
@@ -50689,7 +50761,7 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * End-user recovery email address verification status
      *
-     * <p>Valid values: [verified, pending, failed, expired]
+     * <p>Valid values: [verified, pending]
      *
      * @param zimbraPrefPasswordRecoveryAddressStatus new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -50706,7 +50778,7 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * End-user recovery email address verification status
      *
-     * <p>Valid values: [verified, pending, failed, expired]
+     * <p>Valid values: [verified, pending]
      *
      * @param zimbraPrefPasswordRecoveryAddressStatus new value
      * @param attrs existing map to populate, or null to create a new map
@@ -50724,7 +50796,7 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * End-user recovery email address verification status
      *
-     * <p>Valid values: [verified, pending, failed, expired]
+     * <p>Valid values: [verified, pending]
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -50740,7 +50812,7 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * End-user recovery email address verification status
      *
-     * <p>Valid values: [verified, pending, failed, expired]
+     * <p>Valid values: [verified, pending]
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
@@ -56005,6 +56077,190 @@ public abstract class ZAttrAccount  extends MailTarget {
     public Map<String,Object> unsetQuotaWarnPercent(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraQuotaWarnPercent, "");
+        return attrs;
+    }
+
+    /**
+     * Expiry time for recovery email code verification. Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * <p>Use getRecoveryEmailCodeValidityAsString to access value as a string.
+     *
+     * @see #getRecoveryEmailCodeValidityAsString()
+     *
+     * @return zimbraRecoveryEmailCodeValidity in millseconds, or 86400000 (1d)  if unset
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=3030)
+    public long getRecoveryEmailCodeValidity() {
+        return getTimeInterval(Provisioning.A_zimbraRecoveryEmailCodeValidity, 86400000L, true);
+    }
+
+    /**
+     * Expiry time for recovery email code verification. Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @return zimbraRecoveryEmailCodeValidity, or "1d" if unset
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=3030)
+    public String getRecoveryEmailCodeValidityAsString() {
+        return getAttr(Provisioning.A_zimbraRecoveryEmailCodeValidity, "1d", true);
+    }
+
+    /**
+     * Expiry time for recovery email code verification. Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @param zimbraRecoveryEmailCodeValidity new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=3030)
+    public void setRecoveryEmailCodeValidity(String zimbraRecoveryEmailCodeValidity) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRecoveryEmailCodeValidity, zimbraRecoveryEmailCodeValidity);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Expiry time for recovery email code verification. Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @param zimbraRecoveryEmailCodeValidity new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=3030)
+    public Map<String,Object> setRecoveryEmailCodeValidity(String zimbraRecoveryEmailCodeValidity, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRecoveryEmailCodeValidity, zimbraRecoveryEmailCodeValidity);
+        return attrs;
+    }
+
+    /**
+     * Expiry time for recovery email code verification. Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=3030)
+    public void unsetRecoveryEmailCodeValidity() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRecoveryEmailCodeValidity, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Expiry time for recovery email code verification. Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=3030)
+    public Map<String,Object> unsetRecoveryEmailCodeValidity(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRecoveryEmailCodeValidity, "");
+        return attrs;
+    }
+
+    /**
+     * Recovery email verification data
+     *
+     * @return zimbraRecoveryEmailVerificationData, or null if unset
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=3029)
+    public String getRecoveryEmailVerificationData() {
+        return getAttr(Provisioning.A_zimbraRecoveryEmailVerificationData, null, true);
+    }
+
+    /**
+     * Recovery email verification data
+     *
+     * @param zimbraRecoveryEmailVerificationData new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=3029)
+    public void setRecoveryEmailVerificationData(String zimbraRecoveryEmailVerificationData) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRecoveryEmailVerificationData, zimbraRecoveryEmailVerificationData);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Recovery email verification data
+     *
+     * @param zimbraRecoveryEmailVerificationData new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=3029)
+    public Map<String,Object> setRecoveryEmailVerificationData(String zimbraRecoveryEmailVerificationData, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRecoveryEmailVerificationData, zimbraRecoveryEmailVerificationData);
+        return attrs;
+    }
+
+    /**
+     * Recovery email verification data
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=3029)
+    public void unsetRecoveryEmailVerificationData() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRecoveryEmailVerificationData, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Recovery email verification data
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=3029)
+    public Map<String,Object> unsetRecoveryEmailVerificationData(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRecoveryEmailVerificationData, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -15790,11 +15790,12 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Sleep time between subsequent contact backups. 0 means that contact
-     * backup is disabled. . Must be in valid duration format:
-     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
-     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
-     * specified, the default is s(seconds).
+     * Deprecated since: 8.8.6. No longer used by ContactBackupRequest SOAP
+     * handler. Orig desc: Sleep time between subsequent contact backups. 0
+     * means that contact backup is disabled. . Must be in valid duration
+     * format: {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h -
+     * hours, m - minutes, s - seconds, d - days, ms - milliseconds. If time
+     * unit is not specified, the default is s(seconds).
      *
      * <p>Use getFeatureContactBackupFrequencyAsString to access value as a string.
      *
@@ -15810,11 +15811,12 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Sleep time between subsequent contact backups. 0 means that contact
-     * backup is disabled. . Must be in valid duration format:
-     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
-     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
-     * specified, the default is s(seconds).
+     * Deprecated since: 8.8.6. No longer used by ContactBackupRequest SOAP
+     * handler. Orig desc: Sleep time between subsequent contact backups. 0
+     * means that contact backup is disabled. . Must be in valid duration
+     * format: {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h -
+     * hours, m - minutes, s - seconds, d - days, ms - milliseconds. If time
+     * unit is not specified, the default is s(seconds).
      *
      * @return zimbraFeatureContactBackupFrequency, or "0" if unset
      *
@@ -15826,11 +15828,12 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Sleep time between subsequent contact backups. 0 means that contact
-     * backup is disabled. . Must be in valid duration format:
-     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
-     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
-     * specified, the default is s(seconds).
+     * Deprecated since: 8.8.6. No longer used by ContactBackupRequest SOAP
+     * handler. Orig desc: Sleep time between subsequent contact backups. 0
+     * means that contact backup is disabled. . Must be in valid duration
+     * format: {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h -
+     * hours, m - minutes, s - seconds, d - days, ms - milliseconds. If time
+     * unit is not specified, the default is s(seconds).
      *
      * @param zimbraFeatureContactBackupFrequency new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -15845,11 +15848,12 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Sleep time between subsequent contact backups. 0 means that contact
-     * backup is disabled. . Must be in valid duration format:
-     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
-     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
-     * specified, the default is s(seconds).
+     * Deprecated since: 8.8.6. No longer used by ContactBackupRequest SOAP
+     * handler. Orig desc: Sleep time between subsequent contact backups. 0
+     * means that contact backup is disabled. . Must be in valid duration
+     * format: {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h -
+     * hours, m - minutes, s - seconds, d - days, ms - milliseconds. If time
+     * unit is not specified, the default is s(seconds).
      *
      * @param zimbraFeatureContactBackupFrequency new value
      * @param attrs existing map to populate, or null to create a new map
@@ -15865,11 +15869,12 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Sleep time between subsequent contact backups. 0 means that contact
-     * backup is disabled. . Must be in valid duration format:
-     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
-     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
-     * specified, the default is s(seconds).
+     * Deprecated since: 8.8.6. No longer used by ContactBackupRequest SOAP
+     * handler. Orig desc: Sleep time between subsequent contact backups. 0
+     * means that contact backup is disabled. . Must be in valid duration
+     * format: {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h -
+     * hours, m - minutes, s - seconds, d - days, ms - milliseconds. If time
+     * unit is not specified, the default is s(seconds).
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -15883,11 +15888,12 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Sleep time between subsequent contact backups. 0 means that contact
-     * backup is disabled. . Must be in valid duration format:
-     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
-     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
-     * specified, the default is s(seconds).
+     * Deprecated since: 8.8.6. No longer used by ContactBackupRequest SOAP
+     * handler. Orig desc: Sleep time between subsequent contact backups. 0
+     * means that contact backup is disabled. . Must be in valid duration
+     * format: {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h -
+     * hours, m - minutes, s - seconds, d - days, ms - milliseconds. If time
+     * unit is not specified, the default is s(seconds).
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -28044,6 +28044,78 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * Maximum attempts for password recovery resend
+     *
+     * @return zimbraPasswordRecoveryMaxAttempts, or 3 if unset
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=3031)
+    public int getPasswordRecoveryMaxAttempts() {
+        return getIntAttr(Provisioning.A_zimbraPasswordRecoveryMaxAttempts, 3, true);
+    }
+
+    /**
+     * Maximum attempts for password recovery resend
+     *
+     * @param zimbraPasswordRecoveryMaxAttempts new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=3031)
+    public void setPasswordRecoveryMaxAttempts(int zimbraPasswordRecoveryMaxAttempts) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPasswordRecoveryMaxAttempts, Integer.toString(zimbraPasswordRecoveryMaxAttempts));
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Maximum attempts for password recovery resend
+     *
+     * @param zimbraPasswordRecoveryMaxAttempts new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=3031)
+    public Map<String,Object> setPasswordRecoveryMaxAttempts(int zimbraPasswordRecoveryMaxAttempts, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPasswordRecoveryMaxAttempts, Integer.toString(zimbraPasswordRecoveryMaxAttempts));
+        return attrs;
+    }
+
+    /**
+     * Maximum attempts for password recovery resend
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=3031)
+    public void unsetPasswordRecoveryMaxAttempts() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPasswordRecoveryMaxAttempts, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Maximum attempts for password recovery resend
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=3031)
+    public Map<String,Object> unsetPasswordRecoveryMaxAttempts(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPasswordRecoveryMaxAttempts, "");
+        return attrs;
+    }
+
+    /**
      * whether POP3 is enabled for an account
      *
      * @return zimbraPop3Enabled, or true if unset
@@ -43271,6 +43343,118 @@ public abstract class ZAttrCos extends NamedEntry {
     public Map<String,Object> unsetQuotaWarnPercent(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraQuotaWarnPercent, "");
+        return attrs;
+    }
+
+    /**
+     * Expiry time for recovery email code verification. Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * <p>Use getRecoveryEmailCodeValidityAsString to access value as a string.
+     *
+     * @see #getRecoveryEmailCodeValidityAsString()
+     *
+     * @return zimbraRecoveryEmailCodeValidity in millseconds, or 86400000 (1d)  if unset
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=3030)
+    public long getRecoveryEmailCodeValidity() {
+        return getTimeInterval(Provisioning.A_zimbraRecoveryEmailCodeValidity, 86400000L, true);
+    }
+
+    /**
+     * Expiry time for recovery email code verification. Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @return zimbraRecoveryEmailCodeValidity, or "1d" if unset
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=3030)
+    public String getRecoveryEmailCodeValidityAsString() {
+        return getAttr(Provisioning.A_zimbraRecoveryEmailCodeValidity, "1d", true);
+    }
+
+    /**
+     * Expiry time for recovery email code verification. Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @param zimbraRecoveryEmailCodeValidity new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=3030)
+    public void setRecoveryEmailCodeValidity(String zimbraRecoveryEmailCodeValidity) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRecoveryEmailCodeValidity, zimbraRecoveryEmailCodeValidity);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Expiry time for recovery email code verification. Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @param zimbraRecoveryEmailCodeValidity new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=3030)
+    public Map<String,Object> setRecoveryEmailCodeValidity(String zimbraRecoveryEmailCodeValidity, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRecoveryEmailCodeValidity, zimbraRecoveryEmailCodeValidity);
+        return attrs;
+    }
+
+    /**
+     * Expiry time for recovery email code verification. Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=3030)
+    public void unsetRecoveryEmailCodeValidity() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRecoveryEmailCodeValidity, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Expiry time for recovery email code verification. Must be in valid
+     * duration format: {digits}{time-unit}. digits: 0-9, time-unit:
+     * [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days, ms -
+     * milliseconds. If time unit is not specified, the default is
+     * s(seconds).
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=3030)
+    public Map<String,Object> unsetRecoveryEmailCodeValidity(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraRecoveryEmailCodeValidity, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -8772,11 +8772,12 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Sleep time between subsequent contact backups. 0 means that contact
-     * backup is disabled. . Must be in valid duration format:
-     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
-     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
-     * specified, the default is s(seconds).
+     * Deprecated since: 8.8.6. No longer used by ContactBackupRequest SOAP
+     * handler. Orig desc: Sleep time between subsequent contact backups. 0
+     * means that contact backup is disabled. . Must be in valid duration
+     * format: {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h -
+     * hours, m - minutes, s - seconds, d - days, ms - milliseconds. If time
+     * unit is not specified, the default is s(seconds).
      *
      * <p>Use getFeatureContactBackupFrequencyAsString to access value as a string.
      *
@@ -8792,11 +8793,12 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Sleep time between subsequent contact backups. 0 means that contact
-     * backup is disabled. . Must be in valid duration format:
-     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
-     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
-     * specified, the default is s(seconds).
+     * Deprecated since: 8.8.6. No longer used by ContactBackupRequest SOAP
+     * handler. Orig desc: Sleep time between subsequent contact backups. 0
+     * means that contact backup is disabled. . Must be in valid duration
+     * format: {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h -
+     * hours, m - minutes, s - seconds, d - days, ms - milliseconds. If time
+     * unit is not specified, the default is s(seconds).
      *
      * @return zimbraFeatureContactBackupFrequency, or "0" if unset
      *
@@ -8808,11 +8810,12 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Sleep time between subsequent contact backups. 0 means that contact
-     * backup is disabled. . Must be in valid duration format:
-     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
-     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
-     * specified, the default is s(seconds).
+     * Deprecated since: 8.8.6. No longer used by ContactBackupRequest SOAP
+     * handler. Orig desc: Sleep time between subsequent contact backups. 0
+     * means that contact backup is disabled. . Must be in valid duration
+     * format: {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h -
+     * hours, m - minutes, s - seconds, d - days, ms - milliseconds. If time
+     * unit is not specified, the default is s(seconds).
      *
      * @param zimbraFeatureContactBackupFrequency new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -8827,11 +8830,12 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Sleep time between subsequent contact backups. 0 means that contact
-     * backup is disabled. . Must be in valid duration format:
-     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
-     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
-     * specified, the default is s(seconds).
+     * Deprecated since: 8.8.6. No longer used by ContactBackupRequest SOAP
+     * handler. Orig desc: Sleep time between subsequent contact backups. 0
+     * means that contact backup is disabled. . Must be in valid duration
+     * format: {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h -
+     * hours, m - minutes, s - seconds, d - days, ms - milliseconds. If time
+     * unit is not specified, the default is s(seconds).
      *
      * @param zimbraFeatureContactBackupFrequency new value
      * @param attrs existing map to populate, or null to create a new map
@@ -8847,11 +8851,12 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Sleep time between subsequent contact backups. 0 means that contact
-     * backup is disabled. . Must be in valid duration format:
-     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
-     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
-     * specified, the default is s(seconds).
+     * Deprecated since: 8.8.6. No longer used by ContactBackupRequest SOAP
+     * handler. Orig desc: Sleep time between subsequent contact backups. 0
+     * means that contact backup is disabled. . Must be in valid duration
+     * format: {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h -
+     * hours, m - minutes, s - seconds, d - days, ms - milliseconds. If time
+     * unit is not specified, the default is s(seconds).
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -8865,11 +8870,12 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Sleep time between subsequent contact backups. 0 means that contact
-     * backup is disabled. . Must be in valid duration format:
-     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
-     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
-     * specified, the default is s(seconds).
+     * Deprecated since: 8.8.6. No longer used by ContactBackupRequest SOAP
+     * handler. Orig desc: Sleep time between subsequent contact backups. 0
+     * means that contact backup is disabled. . Must be in valid duration
+     * format: {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h -
+     * hours, m - minutes, s - seconds, d - days, ms - milliseconds. If time
+     * unit is not specified, the default is s(seconds).
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/service/mail/MailService.java
+++ b/store/src/java/com/zimbra/cs/service/mail/MailService.java
@@ -239,5 +239,9 @@ public final class MailService implements DocumentService {
 
         // Profile Image API
         dispatcher.registerHandler(MailConstants.MODIFY_PROFILE_IMAGE_REQUEST, new ModifyProfileImage());
+        
+        // Password reset API
+        dispatcher.registerHandler(MailConstants.SET_RECOVERY_EMAIL_REQUEST, new SetRecoveryEmail());
+        
     }
 }

--- a/store/src/java/com/zimbra/cs/service/mail/SetRecoveryEmail.java
+++ b/store/src/java/com/zimbra/cs/service/mail/SetRecoveryEmail.java
@@ -1,0 +1,240 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.service.mail;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TimeZone;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
+
+import org.apache.commons.lang.RandomStringUtils;
+
+import com.zimbra.common.account.ZAttrProvisioning.PrefPasswordRecoveryAddressStatus;
+import com.zimbra.common.mime.MimeConstants;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.util.L10nUtil;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.common.util.L10nUtil.MsgKey;
+import com.zimbra.common.util.StringUtil;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.OperationContext;
+import com.zimbra.cs.util.AccountUtil;
+import com.zimbra.soap.DocumentHandler;
+import com.zimbra.soap.ZimbraSoapContext;
+import com.zimbra.soap.mail.message.SetRecoveryEmailRequest;
+import com.zimbra.soap.mail.message.SetRecoveryEmailRequest.Op;
+import com.zimbra.soap.mail.message.SetRecoveryEmailResponse;
+
+public class SetRecoveryEmail extends DocumentHandler {
+
+    @Override
+    public Element handle(Element request, Map<String, Object> context) throws ServiceException {
+        ZimbraSoapContext zsc = getZimbraSoapContext(context);
+        Account account = getRequestedAccount(zsc);
+        Mailbox mbox = getRequestedMailbox(zsc);
+        OperationContext octxt = getOperationContext(zsc, context);
+        SetRecoveryEmailRequest req = zsc.elementToJaxb(request);
+        if (!mbox.getAccount().getBooleanAttr(Provisioning.A_zimbraFeatureResetPasswordEnabled,
+            false)) {
+            throw ServiceException.PERM_DENIED("password reset feature not enabled.");
+        }
+        Op op = req.getOp();
+        if (op == null) {
+            throw ServiceException.INVALID_REQUEST("Invalid operation received.", null);
+        }
+        switch (op) {
+        case sendCode:
+            String recoveryEmailAddr = req.getRecoveryEmailAddress();
+            if (StringUtil.isNullOrEmpty(recoveryEmailAddr)) {
+                throw ServiceException.INVALID_REQUEST("Recovery email address not provided.",
+                    null);
+            }
+            validateEmail(recoveryEmailAddr, account);
+            sendCode(recoveryEmailAddr, 1, account, mbox, zsc, octxt);
+            break;
+        case validateCode:
+            String recoveryEmailAddrVerificationCode = req
+                .getRecoveryEmailAddressVerificationCode();
+            if (StringUtil.isNullOrEmpty(recoveryEmailAddrVerificationCode)) {
+                throw ServiceException.INVALID_REQUEST(
+                    "Recovery email address verification code not provided.", null);
+            }
+            validateCode(recoveryEmailAddrVerificationCode, account, mbox, zsc, octxt);
+            break;
+        case resendCode:
+            resendCode(account, mbox, zsc, octxt);
+            break;
+        case reset:
+            reset(mbox, zsc);
+            break;
+        default:
+            throw ServiceException.INVALID_REQUEST("Invalid operation received.", null);
+        }
+        SetRecoveryEmailResponse resp = new SetRecoveryEmailResponse();
+        return zsc.jaxbToElement(resp);
+    }
+
+    protected void sendCode(String email, int resendCount, Account account, Mailbox mbox,
+        ZimbraSoapContext zsc, OperationContext octxt) throws ServiceException {
+        String code = RandomStringUtils.random(8, true, true);
+        Account authAccount = getAuthenticatedAccount(zsc);
+        long expiry = account.getRecoveryEmailCodeValidity();
+        Date now = new Date();
+        long expiryTime = now.getTime() + expiry;
+        sendRecoveryEmailVerificationCode(authAccount, account, email, code, expiryTime, octxt,
+            mbox);
+        HashMap<String, Object> prefs = new HashMap<String, Object>();
+        prefs.put(Provisioning.A_zimbraPrefPasswordRecoveryAddress, email);
+        prefs.put(Provisioning.A_zimbraPrefPasswordRecoveryAddressStatus,
+            PrefPasswordRecoveryAddressStatus.pending);
+        prefs.put(Provisioning.A_zimbraRecoveryEmailVerificationData,
+            email + ":" + code + ":" + expiryTime + ":" + resendCount);
+        Provisioning.getInstance().modifyAttrs(mbox.getAccount(), prefs, true, zsc.getAuthToken());
+
+    }
+
+    protected void sendRecoveryEmailVerificationCode(Account authAccount, Account ownerAccount,
+        String emailIdToVerify, String code, long expiryTime, OperationContext octxt, Mailbox mbox)
+        throws ServiceException {
+        Locale locale = authAccount.getLocale();
+        String ownerAcctDisplayName = ownerAccount.getDisplayName();
+        if (ownerAcctDisplayName == null) {
+            ownerAcctDisplayName = ownerAccount.getName();
+        }
+        String subject = L10nUtil.getMessage(MsgKey.verifyRecoveryEmailSubject, locale,
+            ownerAcctDisplayName);
+        String charset = authAccount.getAttr(Provisioning.A_zimbraPrefMailDefaultCharset,
+            MimeConstants.P_CHARSET_UTF8);
+        try {
+
+            DateFormat format = new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss z");
+            format.setTimeZone(TimeZone.getTimeZone("GMT"));
+            String gmtDate = format.format(expiryTime);
+            if (ZimbraLog.account.isDebugEnabled()) {
+                ZimbraLog.account.debug(
+                    "Expiry of Forwarding address verification code sent to %s is %s",
+                    emailIdToVerify, gmtDate);
+                ZimbraLog.account.debug("Forwarding address verification code sent to %s is %s",
+                    emailIdToVerify, code);
+            }
+            String mimePartText = L10nUtil.getMessage(MsgKey.verifyRecoveryEmailBodyText, locale, code,
+                gmtDate);
+            String mimePartHtml = L10nUtil.getMessage(MsgKey.verifyRecoveryEmailBodyHtml, locale, code,
+                gmtDate);
+            MimeMultipart mmp = AccountUtil.generateMimeMultipart(mimePartText, mimePartHtml, null);
+            MimeMessage mm = AccountUtil.generateMimeMessage(authAccount, ownerAccount, subject,
+                charset, null, null, emailIdToVerify, mmp);
+            mbox.getMailSender().sendMimeMessage(octxt, mbox, false, mm, null, null, null, null,
+                false);
+        } catch (MessagingException e) {
+            ZimbraLog.account
+                .warn("Failed to send verification code to email ID: '" + emailIdToVerify + "'", e);
+            throw ServiceException
+                .FAILURE("Failed to send verification code to email ID: " + emailIdToVerify, e);
+        }
+    }
+
+    protected void validateCode(String recoveryEmailAddrVerificationCode, Account account,
+        Mailbox mbox, ZimbraSoapContext zsc, OperationContext octxt) throws ServiceException {
+        String verificationData = account.getRecoveryEmailVerificationData();
+        String[] data = verificationData.split(":");
+        String code = data[1];
+        long expiryTime = Long.parseLong(data[2]);
+        Date now = new Date();
+        if (expiryTime < now.getTime()) {
+            throw ServiceException
+                .FAILURE("The recovery email address verification code is expired.", null);
+
+        }
+        if (code.equals(recoveryEmailAddrVerificationCode)) {
+            HashMap<String, Object> prefs = new HashMap<String, Object>();
+            prefs.put(Provisioning.A_zimbraPrefPasswordRecoveryAddressStatus,
+                PrefPasswordRecoveryAddressStatus.verified);
+            prefs.put(Provisioning.A_zimbraRecoveryEmailVerificationData, null);
+            Provisioning.getInstance().modifyAttrs(mbox.getAccount(), prefs, true,
+                zsc.getAuthToken());
+
+        } else {
+            throw ServiceException
+                .FAILURE("Verification of recovery email address verification code failed.", null);
+        }
+    }
+
+    protected void resendCode(Account account, Mailbox mbox, ZimbraSoapContext zsc,
+        OperationContext octxt) throws ServiceException {
+        String verificationData = account.getRecoveryEmailVerificationData();
+        String[] data = verificationData.split(":");
+        String email = data[0];
+        String code = data[1];
+        long expiryTime = Long.parseLong(data[2]);
+        int resendCount = Integer.parseInt(data[3]);
+        if (resendCount < account.getPasswordRecoveryMaxAttempts()) {
+            // check if code is expired
+            Date now = new Date();
+            if (expiryTime < now.getTime()) {
+                // generate new code and send
+                sendCode(email, resendCount + 1, account, mbox, zsc, octxt);
+
+            } else {
+                // send existing code
+                long expiry = account.getRecoveryEmailCodeValidity();
+                long newExpiryTime = now.getTime() + expiry;
+                Account authAccount = getAuthenticatedAccount(zsc);
+                // update resend count
+                resendCount = resendCount + 1;
+                HashMap<String, Object> prefs = new HashMap<String, Object>();
+                prefs.put(Provisioning.A_zimbraRecoveryEmailVerificationData,
+                    email + ":" + code + ":" + newExpiryTime + ":" + resendCount);
+                Provisioning.getInstance().modifyAttrs(mbox.getAccount(), prefs, true,
+                    zsc.getAuthToken());
+                sendRecoveryEmailVerificationCode(authAccount, account, email, code, newExpiryTime,
+                    octxt, mbox);
+            }
+        } else {
+            throw ServiceException.FAILURE("Resend code request has reached maximum limit.", null);
+        }
+    }
+
+    protected void reset(Mailbox mbox, ZimbraSoapContext zsc) throws ServiceException {
+        HashMap<String, Object> prefs = new HashMap<String, Object>();
+        prefs.put(Provisioning.A_zimbraPrefPasswordRecoveryAddress, null);
+        prefs.put(Provisioning.A_zimbraPrefPasswordRecoveryAddressStatus, null);
+        prefs.put(Provisioning.A_zimbraRecoveryEmailVerificationData, null);
+        Provisioning.getInstance().modifyAttrs(mbox.getAccount(), prefs, true, zsc.getAuthToken());
+
+    }
+
+    private static void validateEmail(String email, Account account) throws ServiceException {
+        String[] addresses = account.getMailAddress();
+        if (Arrays.asList(addresses).contains(email)) {
+            throw ServiceException
+                .FAILURE("Recovery address should not be same as primary email address.", null);
+        }
+    }
+}


### PR DESCRIPTION
The user will add a recovery email address  in preferences page.
A verification email is sent to user with verification code and expiry time.
Once validation is complete, the status is set to verified and can then be used for password reset.

API Added:
SetRecoveryEmail with following operations:
sendCode, validateCode, resendCode, reset
sendCode: send verification code into an email to recovery email address
validateCode: validate recovery email address with provided verification code
resendCode: resend the code to recovery email address. If the code is not yet expired, send the same code. If it is expired, generate new one and send
reset: clear all ldap attributes related to recovery email address

Updated Soap doc
Added Junit test