### PR TITLE
NICPS-232: Restrict user to login on virtual domain - Part 2

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -3442,6 +3442,15 @@ public class ZAttrProvisioning {
     public static final String A_zimbraAttributeMigrationInfo = "zimbraAttributeMigrationInfo";
 
     /**
+     * This attribute is used to enable/disable virtualdomain/host check on
+     * webmail login page
+     *
+     * @since ZCS 8.8.8
+     */
+    @ZAttr(id=5011)
+    public static final String A_zimbraAuthDomainCheckEnabled = "zimbraAuthDomainCheckEnabled";
+
+    /**
      * fallback to local auth if external mech fails
      */
     @ZAttr(id=257)

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9687,4 +9687,8 @@ TODO: delete them permanently from here
 <attr id="5010" name="zimbraCustomTemplateID" type="string" cardinality="multi" optionalIn="account" flags="accountInfo" since="8.8.8">
 	<desc>This attribute contains user templateID to be used with custom templates</desc>
 </attr>
+<attr id="5011" name="zimbraAuthDomainCheckEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="8.8.8">
+	<globalConfigValue>FALSE</globalConfigValue>
+	<desc>This attribute is used to enable/disable virtualdomain/host check on webmail login page</desc>
+</attr>
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -3985,6 +3985,83 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * This attribute is used to enable/disable virtualdomain/host check on
+     * webmail login page
+     *
+     * @return zimbraAuthDomainCheckEnabled, or false if unset
+     *
+     * @since ZCS 8.8.8
+     */
+    @ZAttr(id=5011)
+    public boolean isAuthDomainCheckEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraAuthDomainCheckEnabled, false, true);
+    }
+
+    /**
+     * This attribute is used to enable/disable virtualdomain/host check on
+     * webmail login page
+     *
+     * @param zimbraAuthDomainCheckEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.8
+     */
+    @ZAttr(id=5011)
+    public void setAuthDomainCheckEnabled(boolean zimbraAuthDomainCheckEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAuthDomainCheckEnabled, zimbraAuthDomainCheckEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * This attribute is used to enable/disable virtualdomain/host check on
+     * webmail login page
+     *
+     * @param zimbraAuthDomainCheckEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.8
+     */
+    @ZAttr(id=5011)
+    public Map<String,Object> setAuthDomainCheckEnabled(boolean zimbraAuthDomainCheckEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAuthDomainCheckEnabled, zimbraAuthDomainCheckEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * This attribute is used to enable/disable virtualdomain/host check on
+     * webmail login page
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.8
+     */
+    @ZAttr(id=5011)
+    public void unsetAuthDomainCheckEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAuthDomainCheckEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * This attribute is used to enable/disable virtualdomain/host check on
+     * webmail login page
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.8
+     */
+    @ZAttr(id=5011)
+    public Map<String,Object> unsetAuthDomainCheckEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAuthDomainCheckEnabled, "");
+        return attrs;
+    }
+
+    /**
      * auth token secret key
      *
      * @return zimbraAuthTokenKey, or empty array if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -2301,6 +2301,83 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
+     * This attribute is used to enable/disable virtualdomain/host check on
+     * webmail login page
+     *
+     * @return zimbraAuthDomainCheckEnabled, or false if unset
+     *
+     * @since ZCS 8.8.8
+     */
+    @ZAttr(id=5011)
+    public boolean isAuthDomainCheckEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraAuthDomainCheckEnabled, false, true);
+    }
+
+    /**
+     * This attribute is used to enable/disable virtualdomain/host check on
+     * webmail login page
+     *
+     * @param zimbraAuthDomainCheckEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.8
+     */
+    @ZAttr(id=5011)
+    public void setAuthDomainCheckEnabled(boolean zimbraAuthDomainCheckEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAuthDomainCheckEnabled, zimbraAuthDomainCheckEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * This attribute is used to enable/disable virtualdomain/host check on
+     * webmail login page
+     *
+     * @param zimbraAuthDomainCheckEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.8
+     */
+    @ZAttr(id=5011)
+    public Map<String,Object> setAuthDomainCheckEnabled(boolean zimbraAuthDomainCheckEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAuthDomainCheckEnabled, zimbraAuthDomainCheckEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * This attribute is used to enable/disable virtualdomain/host check on
+     * webmail login page
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.8
+     */
+    @ZAttr(id=5011)
+    public void unsetAuthDomainCheckEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAuthDomainCheckEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * This attribute is used to enable/disable virtualdomain/host check on
+     * webmail login page
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.8
+     */
+    @ZAttr(id=5011)
+    public Map<String,Object> unsetAuthDomainCheckEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAuthDomainCheckEnabled, "");
+        return attrs;
+    }
+
+    /**
      * This attribute is used to configure the interval with which servers
      * will send a list of invalidated tokens to each other. When an account
      * logs out of a server, the account&#039;s authtoken is added to a queue


### PR DESCRIPTION
This is for ticket https://jira.corp.synacor.com/browse/NICPS-232, 
Run 
#zmprov desc -a zimbraAuthDomainCheckEnabled 
to Verify if new LDAP attribute is available 

Run zmprov mcf zimbraAuthDomainCheckEnabled TRUE

to update the attribute value to TRUE 
Verify domain/virtualhost check is enaabled.

Run zmprov mcf zimbraAuthDomainCheckEnabled FALSE
to update the attribute value to FALSE 
Verify domain/virtualhost check is disabled.

Related PRs: https://github.com/Zimbra/zm-taglib/pull/9,
https://github.com/Zimbra/zm-taglib/pull/10
