### PR TITLE
ZCS-5021:Implementing a JWE token to store data for recovery email setup

### DIFF
--- a/store/src/java-test/com/zimbra/cs/service/util/JWEUtilTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/util/JWEUtilTest.java
@@ -1,0 +1,52 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.service.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+
+import junit.framework.Assert;
+public class JWEUtilTest {
+
+    @BeforeClass
+    public static void init() throws Exception {
+        MailboxTestUtil.initServer();
+    }
+
+    @Test
+    public void testJWE() {
+        Map<String, String> map = new HashMap<>();
+        String val1 = "jwt";
+        String val2 = "encryption";
+        map.put("key1", val1);
+        map.put("key2", val2);
+        try {
+            String jwe = JWEUtil.getJWE(map);
+            Map<String, String> result = JWEUtil.getDecodedJWE(jwe);
+            Assert.assertEquals(val1, result.get("key1"));
+            Assert.assertEquals(val2, result.get("key2"));
+        } catch (ServiceException se) {
+            Assert.fail("testJWE failed");
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/service/util/JWEUtil.java
+++ b/store/src/java/com/zimbra/cs/service/util/JWEUtil.java
@@ -1,0 +1,57 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.service.util;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.BlobMetaData;
+import com.zimbra.common.util.BlobMetaDataEncodingException;
+import com.zimbra.cs.account.AuthTokenKey;
+import com.zimbra.cs.account.DataSource;
+
+public class JWEUtil {
+
+    public static String getJWE(Map <String, String> map) throws ServiceException {
+        String encryptedData = null;
+        AuthTokenKey key = AuthTokenKey.getCurrentKey();
+        StringBuilder encodedBuff = new StringBuilder(64);
+        map.entrySet().forEach(e -> BlobMetaData.encodeMetaData(e.getKey(), e.getValue(), encodedBuff));
+        encryptedData = key.getVersion() + "_" + DataSource.encryptData(new String(key.getKey()), encodedBuff.toString());
+        return encryptedData;
+    }
+
+    public static Map <String, String> getDecodedJWE(String jwe) throws ServiceException {
+        Map<String, String> result = null;
+        String[] jweArr = jwe.split("_");
+        if (jweArr.length != 2) {
+            throw ServiceException.PARSE_ERROR("invalid jwe format", null);
+        }
+        AuthTokenKey key = AuthTokenKey.getVersion(jweArr[0]);
+        String data = DataSource.decryptData(new String(key.getKey()), jweArr[1]);
+        try {
+            Map <?,?> map = BlobMetaData.decode(data);
+            result = map.entrySet().stream()
+                    .collect(Collectors.toMap( e -> (String) e.getKey(), e -> (String)e.getValue()));
+        } catch (BlobMetaDataEncodingException e) {
+            throw ServiceException.FAILURE("failed to get decoded jwe", e);
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
added utility methods to store the data related to recovery email setup(email, code, expiryTime and resend code) in a single encrypted string and decode the values back from that string.
fixed three issues:
1. When code is sent for first time, resendCount should be zero.
2. When existing code is re-sent again, it's expiry time should not be updated.
3. when resend op is called, it was behaving as send and giving exception that code has already been sent to this recovery email address.
