### PR TITLE
NICPS-167: Add new ldap attribute to store captcha api url

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -4332,6 +4332,15 @@ public class ZAttrProvisioning {
     public static final String A_zimbraCalResType = "zimbraCalResType";
 
     /**
+     * This attribute stores the captcha service API url to display and
+     * validate captcha
+     *
+     * @since ZCS 8.8.8
+     */
+    @ZAttr(id=5012)
+    public static final String A_zimbraCaptchaApiUrl = "zimbraCaptchaApiUrl";
+
+    /**
      * This attribute is used to enable/disable CAPTCHA functionality on
      * login page
      *

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9687,8 +9687,13 @@ TODO: delete them permanently from here
 <attr id="5010" name="zimbraCustomTemplateID" type="string" cardinality="multi" optionalIn="account" flags="accountInfo" since="8.8.8">
 	<desc>This attribute contains user templateID to be used with custom templates</desc>
 </attr>
+
 <attr id="5011" name="zimbraAuthDomainCheckEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="8.8.8">
 	<globalConfigValue>FALSE</globalConfigValue>
 	<desc>This attribute is used to enable/disable virtualdomain/host check on webmail login page</desc>
+</attr>
+
+<attr id="5012" name="zimbraCaptchaApiUrl" type="string" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="8.8.8">
+	<desc>This attribute stores the captcha service API url to display and validate captcha</desc>
 </attr>
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -8961,6 +8961,83 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * This attribute stores the captcha service API url to display and
+     * validate captcha
+     *
+     * @return zimbraCaptchaApiUrl, or null if unset
+     *
+     * @since ZCS 8.8.8
+     */
+    @ZAttr(id=5012)
+    public String getCaptchaApiUrl() {
+        return getAttr(Provisioning.A_zimbraCaptchaApiUrl, null, true);
+    }
+
+    /**
+     * This attribute stores the captcha service API url to display and
+     * validate captcha
+     *
+     * @param zimbraCaptchaApiUrl new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.8
+     */
+    @ZAttr(id=5012)
+    public void setCaptchaApiUrl(String zimbraCaptchaApiUrl) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraCaptchaApiUrl, zimbraCaptchaApiUrl);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * This attribute stores the captcha service API url to display and
+     * validate captcha
+     *
+     * @param zimbraCaptchaApiUrl new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.8
+     */
+    @ZAttr(id=5012)
+    public Map<String,Object> setCaptchaApiUrl(String zimbraCaptchaApiUrl, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraCaptchaApiUrl, zimbraCaptchaApiUrl);
+        return attrs;
+    }
+
+    /**
+     * This attribute stores the captcha service API url to display and
+     * validate captcha
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.8
+     */
+    @ZAttr(id=5012)
+    public void unsetCaptchaApiUrl() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraCaptchaApiUrl, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * This attribute stores the captcha service API url to display and
+     * validate captcha
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.8
+     */
+    @ZAttr(id=5012)
+    public Map<String,Object> unsetCaptchaApiUrl(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraCaptchaApiUrl, "");
+        return attrs;
+    }
+
+    /**
      * When creating self-signed SSL certs during an install, we also create
      * a local Certificate Authority (CA) to sign these SSL certs. This local
      * CA-s own cert is then added to different applications &quot;trusted

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -6013,6 +6013,83 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
+     * This attribute stores the captcha service API url to display and
+     * validate captcha
+     *
+     * @return zimbraCaptchaApiUrl, or null if unset
+     *
+     * @since ZCS 8.8.8
+     */
+    @ZAttr(id=5012)
+    public String getCaptchaApiUrl() {
+        return getAttr(Provisioning.A_zimbraCaptchaApiUrl, null, true);
+    }
+
+    /**
+     * This attribute stores the captcha service API url to display and
+     * validate captcha
+     *
+     * @param zimbraCaptchaApiUrl new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.8
+     */
+    @ZAttr(id=5012)
+    public void setCaptchaApiUrl(String zimbraCaptchaApiUrl) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraCaptchaApiUrl, zimbraCaptchaApiUrl);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * This attribute stores the captcha service API url to display and
+     * validate captcha
+     *
+     * @param zimbraCaptchaApiUrl new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.8
+     */
+    @ZAttr(id=5012)
+    public Map<String,Object> setCaptchaApiUrl(String zimbraCaptchaApiUrl, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraCaptchaApiUrl, zimbraCaptchaApiUrl);
+        return attrs;
+    }
+
+    /**
+     * This attribute stores the captcha service API url to display and
+     * validate captcha
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.8
+     */
+    @ZAttr(id=5012)
+    public void unsetCaptchaApiUrl() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraCaptchaApiUrl, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * This attribute stores the captcha service API url to display and
+     * validate captcha
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.8
+     */
+    @ZAttr(id=5012)
+    public Map<String,Object> unsetCaptchaApiUrl(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraCaptchaApiUrl, "");
+        return attrs;
+    }
+
+    /**
      * allow unencrypted password login via XMPP
      *
      * @return zimbraChatAllowUnencryptedPassword, or false if unset


### PR DESCRIPTION
This is a new ldap attribute added to store the captcha API url, which is access on webmail login page to dispaly and validate captcha.

Related PRs: https://github.com/Zimbra/zm-taglib/pull/12/
https://github.com/Zimbra/zm-web-client/pull/267