### PR TITLE
ZCS-5107 : xml type in common should be in soap type directory

### DIFF
--- a/soap/src/java/com/zimbra/soap/admin/message/ContactBackupResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/ContactBackupResponse.java
@@ -28,7 +28,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 import com.google.common.base.Objects;
 import com.zimbra.common.soap.AdminConstants;
-import com.zimbra.common.soap.ContactBackupServer;
+import com.zimbra.soap.admin.type.ContactBackupServer;
 import com.zimbra.soap.json.jackson.annotate.ZimbraJsonArrayForWrapper;
 
 /**

--- a/soap/src/java/com/zimbra/soap/admin/type/ContactBackupServer.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/ContactBackupServer.java
@@ -15,7 +15,7 @@
  * ***** END LICENSE BLOCK *****
  */
 
-package com.zimbra.common.soap;
+package com.zimbra.soap.admin.type;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -24,17 +24,18 @@ import javax.xml.bind.annotation.XmlEnum;
 
 import com.google.common.base.Objects;
 import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.AdminConstants;
 
 @XmlAccessorType(XmlAccessType.NONE)
 public class ContactBackupServer {
     @XmlEnum
-    public enum Status {
+    public enum ContactBackupStatus {
         // case must match protocol
         started, error, stopped;
 
-        public static Status fromString(String s) throws ServiceException {
+        public static ContactBackupStatus fromString(String s) throws ServiceException {
             try {
-                return Status.valueOf(s);
+                return ContactBackupStatus.valueOf(s);
             } catch (IllegalArgumentException e) {
                 throw ServiceException.INVALID_REQUEST("unknown key: "+s, e);
             }
@@ -44,7 +45,7 @@ public class ContactBackupServer {
     @XmlAttribute(name=AdminConstants.A_NAME /* name */, required=true)
     private String name;
     @XmlAttribute(name=AdminConstants.A_STATUS /* status */, required=true)
-    private Status status;
+    private ContactBackupStatus contactBackupStatus;
 
     @SuppressWarnings("unused")
     private ContactBackupServer() {
@@ -52,11 +53,11 @@ public class ContactBackupServer {
     }
     /**
      * @param name
-     * @param status
+     * @param contactBackupStatus
      */
-    public ContactBackupServer(String name, Status status) {
+    public ContactBackupServer(String name, ContactBackupStatus contactBackupStatus) {
         this.name = name;
-        this.status = status;
+        this.contactBackupStatus = contactBackupStatus;
     }
     /**
      * @return the name
@@ -73,22 +74,22 @@ public class ContactBackupServer {
     /**
      * @return the status
      */
-    public Status getStatus() {
-        return status;
+    public ContactBackupStatus getStatus() {
+        return contactBackupStatus;
     }
     /**
-     * @param status the status to set
+     * @param contactBackupStatus the status to set
      */
-    public void setStatus(Status status) {
-        this.status = status;
+    public void setStatus(ContactBackupStatus contactBackupStatus) {
+        this.contactBackupStatus = contactBackupStatus;
     }
 
     public Objects.ToStringHelper addToStringInfo(Objects.ToStringHelper helper) {
         if (this.name != null && !this.name.isEmpty()) {
             helper.add("name", this.name);
         }
-        if (this.status != null) {
-            helper.add("status", this.status);
+        if (this.contactBackupStatus != null) {
+            helper.add("status", this.contactBackupStatus);
         }
         return helper;
     }

--- a/store/src/java-test/com/zimbra/cs/service/admin/ContactBackupApiTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/admin/ContactBackupApiTest.java
@@ -11,8 +11,6 @@ import org.junit.Test;
 
 import com.google.common.collect.Maps;
 import com.zimbra.common.service.ServiceException;
-import com.zimbra.common.soap.ContactBackupServer;
-import com.zimbra.common.soap.ContactBackupServer.Status;
 import com.zimbra.common.soap.Element;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.Provisioning;
@@ -24,6 +22,8 @@ import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.admin.message.ContactBackupRequest;
 import com.zimbra.soap.admin.message.ContactBackupRequest.Operation;
 import com.zimbra.soap.admin.message.ContactBackupResponse;
+import com.zimbra.soap.admin.type.ContactBackupServer;
+import com.zimbra.soap.admin.type.ContactBackupServer.ContactBackupStatus;
 import com.zimbra.soap.admin.type.ServerSelector;
 import com.zimbra.soap.admin.type.ServerSelector.ServerBy;
 
@@ -76,7 +76,7 @@ public class ContactBackupApiTest {
         Assert.assertNotNull(cbResp.getServers());
         List<ContactBackupServer> servers = cbResp.getServers();
         for (ContactBackupServer server : servers) {
-            Assert.assertEquals(server.getStatus(), Status.started);
+            Assert.assertEquals(server.getStatus(), ContactBackupStatus.started);
         }
     }
 
@@ -102,7 +102,7 @@ public class ContactBackupApiTest {
         Assert.assertNotNull(cbResp.getServers());
         List<ContactBackupServer> servers = cbResp.getServers();
         for (ContactBackupServer server : servers) {
-            Assert.assertEquals(server.getStatus(), Status.stopped);
+            Assert.assertEquals(server.getStatus(), ContactBackupStatus.stopped);
         }
     }
 
@@ -111,7 +111,7 @@ public class ContactBackupApiTest {
         protected List<ContactBackupServer> startContactBackup(List<ServerSelector> selectors, Map<String, Object> context, ZimbraSoapContext zsc) throws ServiceException {
             List<ContactBackupServer> servers = new ArrayList<ContactBackupServer>();
             for (ServerSelector serverSelector : selectors) {
-                servers.add(new ContactBackupServer(serverSelector.getKey(), Status.started));
+                servers.add(new ContactBackupServer(serverSelector.getKey(), ContactBackupStatus.started));
             }
             return servers;
         }
@@ -120,7 +120,7 @@ public class ContactBackupApiTest {
         protected List<ContactBackupServer> stopContactBackup(List<ServerSelector> selectors, Map<String, Object> context, ZimbraSoapContext zsc) throws ServiceException {
             List<ContactBackupServer> servers = new ArrayList<ContactBackupServer>();
             for (ServerSelector serverSelector : selectors) {
-                servers.add(new ContactBackupServer(serverSelector.getKey(), Status.stopped));
+                servers.add(new ContactBackupServer(serverSelector.getKey(), ContactBackupStatus.stopped));
             }
             return servers;
         }

--- a/store/src/java/com/zimbra/cs/service/admin/ContactBackup.java
+++ b/store/src/java/com/zimbra/cs/service/admin/ContactBackup.java
@@ -22,8 +22,6 @@ import java.util.List;
 import java.util.Map;
 
 import com.zimbra.common.service.ServiceException;
-import com.zimbra.common.soap.ContactBackupServer;
-import com.zimbra.common.soap.ContactBackupServer.Status;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Provisioning;
@@ -35,6 +33,8 @@ import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.admin.message.ContactBackupRequest;
 import com.zimbra.soap.admin.message.ContactBackupRequest.Operation;
 import com.zimbra.soap.admin.message.ContactBackupResponse;
+import com.zimbra.soap.admin.type.ContactBackupServer;
+import com.zimbra.soap.admin.type.ContactBackupServer.ContactBackupStatus;
 import com.zimbra.soap.admin.type.ServerSelector;
 import com.zimbra.soap.admin.type.ServerSelector.ServerBy;
 
@@ -81,17 +81,17 @@ public class ContactBackup extends AdminDocumentHandler {
                 server = verifyServerPerms(serverSelector, zsc);
             } catch (ServiceException se) {
                 ZimbraLog.contactbackup.debug("Could not find server or no permission on %s", serverSelector.getKey());
-                servers.add(new ContactBackupServer(serverSelector.getKey(), Status.error));
+                servers.add(new ContactBackupServer(serverSelector.getKey(), ContactBackupStatus.error));
                 continue;
             }
             boolean local = CallbackUtil.isLocalServer(server);
             if (local) {
                 if (!ContactBackupThread.isRunning()) {
                     ZimbraLog.contactbackup.debug("ContactBackup is not running on %s", server.getServiceHostname());
-                    servers.add(new ContactBackupServer(server.getName(), Status.error));
+                    servers.add(new ContactBackupServer(server.getName(), ContactBackupStatus.error));
                 } else {
                     ContactBackupThread.shutdown();
-                    servers.add(new ContactBackupServer(server.getName(), Status.stopped));
+                    servers.add(new ContactBackupServer(server.getName(), ContactBackupStatus.stopped));
                 }
             } else {
                 List<ServerSelector> list = new ArrayList<ServerSelector>();
@@ -115,16 +115,16 @@ public class ContactBackup extends AdminDocumentHandler {
                 server = verifyServerPerms(serverSelector, zsc);
             } catch (ServiceException se) {
                 ZimbraLog.contactbackup.debug("Could not find server or no permission on %s", serverSelector.getKey());
-                servers.add(new ContactBackupServer(serverSelector.getKey(), Status.error));
+                servers.add(new ContactBackupServer(serverSelector.getKey(), ContactBackupStatus.error));
                 continue;
             }
             boolean local = CallbackUtil.isLocalServer(server);
             if (local) {
                 if (!ContactBackupThread.isRunning()) {
                     ContactBackupThread.startup();
-                    servers.add(new ContactBackupServer(server.getName(), Status.started));
+                    servers.add(new ContactBackupServer(server.getName(), ContactBackupStatus.started));
                 } else {
-                    servers.add(new ContactBackupServer(server.getName(), Status.error));
+                    servers.add(new ContactBackupServer(server.getName(), ContactBackupStatus.error));
                 }
             } else {
                 List<ServerSelector> list = new ArrayList<ServerSelector>();


### PR DESCRIPTION
Moved ContactBackupServer
**common/src/java/com/zimbra/common/soap/ContactBackupServer.java → soap/src/java/com/zimbra/soap/admin/type/ContactBackupServer.java**

Renamed **Status** to **ContactBackupStatus** as two classes should not have the same XML type name.