### PR TITLE
ZCS-4798 : RecoverAccount API and it's implementation

### DIFF
--- a/store/src/java-test/com/zimbra/cs/service/RecoverAccountTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/RecoverAccountTest.java
@@ -260,7 +260,7 @@ public class RecoverAccountTest {
         try {
             new RecoverAccount().handle(req, ServiceTestUtil.getRequestContext(acct1));// resend count = 4, and it should fail
         } catch(ServiceException se) {
-            Assert.assertEquals("Max resend attempts reached", se.getMessage());
+            Assert.assertEquals("invalid request: Max resend attempts reached", se.getMessage());
         }
     }
 }


### PR DESCRIPTION
Fixed failures related to auth, resend count and input validation.
1. Authentication is not required for RecoverAccountRequest
2. email input verification.
3. resend count increased before comparison. 

Testing done :
tested all 3 fixes manually.