### PR TITLE
ZCS-4802 : Reset Password API and it's implementation

### DIFF
--- a/common/src/java/com/zimbra/common/service/ServiceException.java
+++ b/common/src/java/com/zimbra/common/service/ServiceException.java
@@ -350,6 +350,10 @@ public class ServiceException extends Exception {
         return new ServiceException("no valid authtoken present", AUTH_REQUIRED, SENDERS_FAULT);
     }
 
+    public static ServiceException AUTH_REQUIRED(String email) {
+        return new ServiceException("no valid authtoken present for " + email, AUTH_REQUIRED, SENDERS_FAULT);
+    }
+
     public static ServiceException CANNOT_DISABLE_TWO_FACTOR_AUTH() {
         return new ServiceException("cannot disable two-factor authentication", CANNOT_DISABLE_TWO_FACTOR_AUTH, SENDERS_FAULT);
     }

--- a/common/src/java/com/zimbra/common/soap/AccountConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AccountConstants.java
@@ -568,4 +568,9 @@ public class AccountConstants {
     public static final String P_LINK_EXPIRY = "exp";
     public static final String P_EMAIL = "email";
     public static final String P_ADDRESS_VERIFICATION = "address-verification";
+
+    // Password reset feature
+    public static final String E_RESET_PASSWORD_REQUEST = "ResetPasswordRequest";
+    public static final String E_RESET_PASSWORD_RESPONSE = "ResetPasswordResponse";
+    public static final QName RESET_PASSWORD_REQUEST = QName.get(E_RESET_PASSWORD_REQUEST, NAMESPACE);
 }

--- a/soap/src/java/com/zimbra/soap/JaxbUtil.java
+++ b/soap/src/java/com/zimbra/soap/JaxbUtil.java
@@ -178,6 +178,8 @@ public final class JaxbUtil {
             com.zimbra.soap.account.message.RegisterMobileGatewayAppResponse.class,
             com.zimbra.soap.account.message.RenewMobileGatewayAppTokenRequest.class,
             com.zimbra.soap.account.message.RenewMobileGatewayAppTokenResponse.class,
+            com.zimbra.soap.account.message.ResetPasswordRequest.class,
+            com.zimbra.soap.account.message.ResetPasswordResponse.class,
             com.zimbra.soap.account.message.RevokeAppSpecificPasswordRequest.class,
             com.zimbra.soap.account.message.RevokeAppSpecificPasswordResponse.class,
             com.zimbra.soap.account.message.RevokeOAuthConsumerRequest.class,

--- a/soap/src/java/com/zimbra/soap/account/message/ResetPasswordRequest.java
+++ b/soap/src/java/com/zimbra/soap/account/message/ResetPasswordRequest.java
@@ -1,0 +1,71 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.account.message;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.AccountConstants;
+import com.zimbra.common.util.StringUtil;
+
+/**
+ <ResetPasswordRequest>
+   <password>...</password>
+ </ResetPasswordRequest>
+ * @zm-api-command-auth-required true - This request should be sent after authentication.
+ * @zm-api-command-admin-auth-required false
+ * @zm-api-command-description Reset Password
+*/
+@XmlRootElement(name=AccountConstants.E_RESET_PASSWORD_REQUEST /* ResetPasswordRequest */)
+@XmlType(propOrder = {})
+public class ResetPasswordRequest {
+    /**
+     * @zm-api-field-description New Password to assign
+     */
+    @XmlElement(name=AccountConstants.E_PASSWORD /* password */, required=true)
+    private String password;
+
+    public ResetPasswordRequest() {
+    }
+
+    public ResetPasswordRequest(String newPassword) {
+        this.password = newPassword;
+    }
+
+    /**
+     * @return the password
+     */
+    public String getPassword() {
+        return password;
+    }
+
+    /**
+     * @param password the password to set
+     */
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public void validateResetPasswordRequest() throws ServiceException {
+        if (StringUtil.isNullOrEmpty(this.password)) {
+            throw ServiceException.INVALID_REQUEST("Invalid or missing password", null);
+        }
+    }
+}

--- a/soap/src/java/com/zimbra/soap/account/message/ResetPasswordResponse.java
+++ b/soap/src/java/com/zimbra/soap/account/message/ResetPasswordResponse.java
@@ -1,0 +1,30 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.account.message;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.AccountConstants;
+/**
+<ResetPasswordResponse>
+</ResetPasswordResponse>
+*/
+@XmlRootElement(name=AccountConstants.E_RESET_PASSWORD_RESPONSE /*ResetPasswordResponse*/)
+public class ResetPasswordResponse {
+
+}

--- a/store/docs/soap.txt
+++ b/store/docs/soap.txt
@@ -4796,3 +4796,13 @@ user_email = email address of the user who forgot the password.
 
 <RecoverAccountResponse recoveryEmail="{recory_email_address}" />
 recory_email_address = verified recovery email address for getRecoveryEmail operation
+
+-----------------------------
+API to reset password of authenticated account under zimbraAccount namespace.
+<ResetPasswordRequest>
+    <password>...</password>
+</ResetPasswordRequest>
+ HERE,
+ password = new password to set for account
+
+<ResetPasswordResponse />

--- a/store/src/java-test/com/zimbra/cs/service/ResetPasswordTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/ResetPasswordTest.java
@@ -1,0 +1,207 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.service;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.mail.Address;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.MethodRule;
+import org.junit.rules.TestName;
+import org.junit.rules.TestWatchman;
+import org.junit.runners.model.FrameworkMethod;
+
+import com.google.common.collect.Maps;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.util.L10nUtil;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.DeliveryOptions;
+import com.zimbra.cs.mailbox.Flag;
+import com.zimbra.cs.mailbox.MailSender;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.Mailbox.MailboxData;
+import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.mime.ParsedMessage;
+import com.zimbra.cs.service.account.ResetPassword;
+import com.zimbra.cs.service.mail.ServiceTestUtil;
+import com.zimbra.soap.JaxbUtil;
+import com.zimbra.soap.account.message.ResetPasswordRequest;
+
+import junit.framework.Assert;
+
+public class ResetPasswordTest {
+
+    final static String USER_NAME = "test4802@zimbra.com";
+    final static String PASSWORD = "old_secret";
+    final static String NEW_PASSWORD = "new_secret";
+
+    @Rule
+    public TestName testName = new TestName();
+    @Rule
+    public MethodRule watchman = new TestWatchman() {
+
+        @Override
+        public void failed(Throwable e, FrameworkMethod method) {
+            System.out.println(method.getName() + " " + e.getClass().getSimpleName());
+        }
+    };
+
+    @BeforeClass
+    public static void init() throws Exception {
+        MailboxTestUtil.initServer();
+        Provisioning prov = Provisioning.getInstance();
+
+        Map<String, Object> attrs = Maps.newHashMap();
+
+        prov.createDomain("zimbra.com", attrs);
+
+        attrs = Maps.newHashMap();
+        attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        attrs.put(Provisioning.A_mail, USER_NAME);
+        prov.createAccount(USER_NAME, PASSWORD, attrs);
+
+        MailboxManager.setInstance(new DirectInsertionMailboxManager());
+
+        L10nUtil.setMsgClassLoader("../store-conf/conf/msgs");
+    }
+
+    public static class DirectInsertionMailboxManager extends MailboxManager {
+
+        public DirectInsertionMailboxManager() throws ServiceException {
+            super();
+        }
+
+        @Override
+        protected Mailbox instantiateMailbox(MailboxData data) {
+            return new Mailbox(data) {
+
+                @Override
+                public MailSender getMailSender() {
+                    return new MailSender() {
+
+                        @Override
+                        protected Collection<Address> sendMessage(Mailbox mbox, MimeMessage mm,
+                            Collection<RollbackData> rollbacks) {
+                            List<Address> successes = new ArrayList<Address>();
+                            Address[] addresses;
+                            try {
+                                addresses = getRecipients(mm);
+                            } catch (Exception e) {
+                                addresses = new Address[0];
+                            }
+                            DeliveryOptions dopt = new DeliveryOptions()
+                                .setFolderId(Mailbox.ID_FOLDER_INBOX).setFlags(Flag.BITMASK_UNREAD);
+                            for (Address addr : addresses) {
+                                try {
+                                    Account acct = Provisioning.getInstance()
+                                        .getAccountByName(((InternetAddress) addr).getAddress());
+                                    if (acct != null) {
+                                        Mailbox target = MailboxManager.getInstance()
+                                            .getMailboxByAccount(acct);
+                                        target.addMessage(null, new ParsedMessage(mm, false), dopt,
+                                            null);
+                                        successes.add(addr);
+                                    }
+                                } catch (Exception e) {
+                                    e.printStackTrace(System.out);
+                                }
+                            }
+                            if (successes.isEmpty() && !isSendPartial()) {
+                                for (RollbackData rdata : rollbacks) {
+                                    if (rdata != null) {
+                                        rdata.rollback();
+                                    }
+                                }
+                            }
+                            return successes;
+                        }
+                    };
+                }
+            };
+        }
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        System.out.println(testName.getMethodName());
+        MailboxTestUtil.clearData();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        MailboxTestUtil.clearData();
+    }
+
+    @Test
+    public void testResetPassword() throws Exception {
+        Provisioning prov = Provisioning.getInstance();
+        Account acct1 = prov.getAccount(USER_NAME);
+        acct1.setFeatureResetPasswordEnabled(true);
+        ResetPassword resetPassword = new TestResetPassword();
+        Map<String, Object> ctxt = ServiceTestUtil.getRequestContext(acct1);
+
+        ResetPasswordRequest resetReq = new ResetPasswordRequest();
+        resetReq.setPassword(NEW_PASSWORD);
+        Element request = JaxbUtil.jaxbToElement(resetReq);
+        try {
+            resetPassword.handle(request, ctxt);
+        } catch (ServiceException se) {
+            Assert.fail("This should not happen");
+        }
+    }
+
+    @Test
+    public void testResetPassword_FeatureDisabled() throws Exception {
+        Provisioning prov = Provisioning.getInstance();
+        Account acct1 = prov.getAccount(USER_NAME);
+        acct1.setFeatureResetPasswordEnabled(false);
+        ResetPassword resetPassword = new TestResetPassword();
+        Map<String, Object> ctxt = ServiceTestUtil.getRequestContext(acct1);
+
+        ResetPasswordRequest resetReq = new ResetPasswordRequest();
+        resetReq.setPassword(NEW_PASSWORD);
+        Element request = JaxbUtil.jaxbToElement(resetReq);
+        try {
+            resetPassword.handle(request, ctxt);
+        } catch (ServiceException se) {
+            Assert.assertEquals("permission denied: Reset password feature is disabled", se.getMessage());
+        }
+    }
+}
+
+class TestResetPassword extends ResetPassword {
+    @Override
+    protected void setPasswordAndPurgeAuthTokens(Provisioning prov, Account acct, String newPassword)
+            throws ServiceException {
+        // do nothing
+    }
+}

--- a/store/src/java/com/zimbra/cs/service/account/AccountService.java
+++ b/store/src/java/com/zimbra/cs/service/account/AccountService.java
@@ -116,6 +116,9 @@ public class AccountService implements DocumentService {
 
         // misc
         dispatcher.registerHandler(AccountConstants.GET_VERSION_INFO_REQUEST, new GetVersionInfo());
+
+        // reset password
+        dispatcher.registerHandler(AccountConstants.RESET_PASSWORD_REQUEST, new ResetPassword());
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/service/account/ResetPassword.java
+++ b/store/src/java/com/zimbra/cs/service/account/ResetPassword.java
@@ -1,0 +1,86 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.service.account;
+
+import java.util.Map;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.AccountConstants;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.AuthToken;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.service.AuthProvider;
+import com.zimbra.soap.JaxbUtil;
+import com.zimbra.soap.ZimbraSoapContext;
+import com.zimbra.soap.account.message.ResetPasswordRequest;
+
+public class ResetPassword extends AccountDocumentHandler {
+
+    public Element handle(Element request, Map<String, Object> context) throws ServiceException {
+        if (!checkPasswordSecurity(context)) {
+            throw ServiceException.INVALID_REQUEST("clear text password is not allowed", null);
+        }
+        Provisioning prov = Provisioning.getInstance();
+        ZimbraSoapContext zsc = getZimbraSoapContext(context);
+        ResetPasswordRequest req = JaxbUtil.elementToJaxb(request);
+        req.validateResetPasswordRequest();
+
+        AuthToken at = zsc.getAuthToken();
+        AuthProvider.validateAuthToken(prov, at, false);
+
+        Account acct = at.getAccount();
+        if (!acct.isFeatureResetPasswordEnabled()) {
+            throw ServiceException.PERM_DENIED("Reset password feature is disabled");
+        }
+        String newPassword = req.getPassword();
+
+        // proxy if required
+        if (!Provisioning.onLocalServer(acct)) {
+            try {
+                return proxyRequest(request, context, acct.getId());
+            } catch (ServiceException e) {
+                // if something went wrong proxying the request, just execute it locally
+                if (ServiceException.PROXY_ERROR.equals(e.getCode())) {
+                    ZimbraLog.account.warn("encountered proxy error", e);
+                } else {
+                    // but if it's a real error, it's a real error
+                    throw e;
+                }
+            }
+        }
+
+        setPasswordAndPurgeAuthTokens(prov, acct, newPassword);
+
+        Element response = zsc.createElement(AccountConstants.E_RESET_PASSWORD_RESPONSE);
+        return response;
+    }
+
+    protected void setPasswordAndPurgeAuthTokens(Provisioning prov, Account acct, String newPassword) throws ServiceException {
+        // set new password
+        prov.setPassword(acct, newPassword);
+        // purge old auth tokens to invalidate existing sessions
+        acct.purgeAuthTokens();
+    }
+
+    @Override
+    public boolean needsAuth(Map<String, Object> context) {
+        return true;
+    }
+}

--- a/store/src/java/com/zimbra/cs/service/mail/RecoverAccount.java
+++ b/store/src/java/com/zimbra/cs/service/mail/RecoverAccount.java
@@ -73,6 +73,9 @@ public final class RecoverAccount extends MailDocumentHandler {
             ZimbraLog.account.debug("%s Account not found for %s", LOG_OPERATION, email);
             throw ServiceException.FAILURE("Something went wrong. Please contact your administrator.", null);
         }
+        if (!user.isFeatureResetPasswordEnabled()) {
+            throw ServiceException.PERM_DENIED("Reset password feature is disabled");
+        }
         if (user.getPrefPasswordRecoveryAddressStatus() == null
                 || !user.getPrefPasswordRecoveryAddressStatus().isVerified()) {
             ZimbraLog.account.debug("%s Verified recovery email is not found for %s", LOG_OPERATION, email);


### PR DESCRIPTION
**Problem:** Write reset password API and it's implementation

**Fix:** 
1. Created API ResetPasswordRequest and its response
```
<ResetPasswordRequest>
  <password>...</password>
</ResetPasswordRequest>
<ResetPasswordResponse />
```
2. Implemented required code for password reset. Password will be changed for account in auth token.
3. Updated soap.txt
4. Added feature check in the same api and recover account api


**Testing Done:**
1. Manually tested API
2. Manually tested different scenarios with valid/invalid input.
3. Manually tested all the scenarios of logout on password change. Tested with ZWC, IMAP and ActiveSync clients. All clients ask to login again once the password is reset.
4. Added unit tests.

**Testing to be done by QA:**
1. Manually test api and different scenarios with valid/invalid inputs.
2. Automate 1.
3. Verification of logout after password reset on different clients.
4. Extensively test functionality of password reset.