### PR TITLE
ZCS-5187: Add accountInfo flag

### DIFF
--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9640,16 +9640,16 @@ TODO: delete them permanently from here
   <globalConfigValue>1518163473</globalConfigValue>
 </attr>
 
-<attr id="3024" name="zimbraFeatureResetPasswordEnabled" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="8.8.9">
+<attr id="3024" name="zimbraFeatureResetPasswordEnabled" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited,accountInfo" since="8.8.9">
   <defaultCOSValue>FALSE</defaultCOSValue>
   <desc>whether or not password reset feature is enabled</desc>
 </attr>
 
-<attr id="3025" name="zimbraPrefPasswordRecoveryAddress" type="cs_emailp" cardinality="single" optionalIn="account" since="8.8.9">
+<attr id="3025" name="zimbraPrefPasswordRecoveryAddress" type="cs_emailp" cardinality="single" optionalIn="account" flags="accountInfo" since="8.8.9">
   <desc>RFC822 recovery email address for an account</desc>
 </attr>
 
-<attr id="3026" name="zimbraPrefPasswordRecoveryAddressStatus" type="enum" value="verified,pending" cardinality="single" optionalIn="account" since="8.8.9">
+<attr id="3026" name="zimbraPrefPasswordRecoveryAddressStatus" type="enum" value="verified,pending" cardinality="single" optionalIn="account" flags="accountInfo" since="8.8.9">
   <desc>End-user recovery email address verification status</desc>
 </attr>
 


### PR DESCRIPTION
**Problem:** zimbraFeatureResetPasswordEnabled, zimbraPrefPasswordRecoveryAddress and zimbraPrefPasswordRecoveryAddressStatus are not accessible on UI

**Fix:** add "accountInfo" flag to these attributes, so that they can be received on UI in GetInfoResponse.

**Testing Done:** Manually tested all 3 attributes using "zmprov desc -a". Flag is set to all 3 now.
```
zmprov desc -a zimbraFeatureResetPasswordEnabled
zimbraFeatureResetPasswordEnabled
    whether or not password reset feature is enabled
               type : boolean
              value : 
           callback : 
          immutable : false
        cardinality : single
         requiredIn : 
         optionalIn : domain,cos,account
              flags : accountInfo,accountCosDomainInherited
           defaults : FALSE
                min : 
                max : 
                 id : 3024
    requiresRestart : 
              since : 8.8.9
    deprecatedSince : 

zmprov desc -a zimbraPrefPasswordRecoveryAddress
zimbraPrefPasswordRecoveryAddress
    RFC822 recovery email address for an account
               type : cs_emailp
              value : 
           callback : 
          immutable : false
        cardinality : single
         requiredIn : 
         optionalIn : account
              flags : accountInfo
           defaults : 
                min : 
                max : 
                 id : 3025
    requiresRestart : 
              since : 8.8.9
    deprecatedSince : 

zmprov desc -a zimbraPrefPasswordRecoveryAddressStatus
zimbraPrefPasswordRecoveryAddressStatus
    End-user recovery email address verification status
               type : enum
              value : verified,pending
           callback : 
          immutable : false
        cardinality : single
         requiredIn : 
         optionalIn : account
              flags : accountInfo
           defaults : 
                min : 
                max : 
                 id : 3026
    requiresRestart : 
              since : 8.8.9
    deprecatedSince : 
```
**Testing to be done by QA:** Check whether all 3 attributes are received in GetInfoResponse or not.