### PR TITLE
ZCS-5101: create interface for email and sms in forget password functionality

### DIFF
--- a/common/src/java/com/zimbra/common/soap/MailConstants.java
+++ b/common/src/java/com/zimbra/common/soap/MailConstants.java
@@ -1373,11 +1373,11 @@ public final class MailConstants {
     public static final String E_SET_RECOVERY_EMAIL_RESPONSE = "SetRecoveryEmailResponse";
     public static final QName SET_RECOVERY_EMAIL_REQUEST = QName.get(E_SET_RECOVERY_EMAIL_REQUEST, NAMESPACE);
     public static final QName SET_RECOVERY_EMAIL_RESPONSE = QName.get(E_SET_RECOVERY_EMAIL_RESPONSE, NAMESPACE);
-    public static final String A_RECOVERY_EMAIL_ADDRESS = "recoveryEmailAddress";
-    public static final String A_RECOVERY_EMAIL_ADDRESS_VERIFICATION_CODE = "recoveryEmailAddressVerificationCode";
+    public static final String A_RECOVERY_ACCOUNT_VERIFICATION_CODE = "recoveryAccountVerificationCode";
     public static final String E_RECOVER_ACCOUNT_REQUEST = "RecoverAccountRequest";
     public static final String E_RECOVER_ACCOUNT_RESPONSE = "RecoverAccountResponse";
     public static final QName RECOVER_ACCOUNT_REQUEST = QName.get(E_RECOVER_ACCOUNT_REQUEST, NAMESPACE);
     public static final QName RECOVER_ACCOUNT_RESPONSE = QName.get(E_RECOVER_ACCOUNT_RESPONSE, NAMESPACE);
-    public static final String A_RECOVERY_EMAIL = "RecoveryEmail";
+    public static final String A_RECOVERY_ACCOUNT = "recoveryAccount";
+    public static final String A_CHANNEL = "channel";
 }

--- a/soap/src/java/com/zimbra/soap/mail/message/RecoverAccountRequest.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/RecoverAccountRequest.java
@@ -22,8 +22,12 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import com.google.common.base.Objects;
+import com.google.common.base.Strings;
+import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.MailConstants;
+import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.soap.mail.type.PasswordResetOperation;
+import com.zimbra.soap.type.Channel;
 
 /**
  * @zm-api-command-auth-required true
@@ -46,12 +50,19 @@ public final class RecoverAccountRequest {
     @XmlAttribute(name = MailConstants.A_EMAIL /* email */, required = true)
     private String email;
 
+    /**
+     * @zm-api-field-description email
+     */
+    @XmlAttribute(name = MailConstants.A_CHANNEL /* channel */, required = true)
+    private Channel channel;
+
     public RecoverAccountRequest() {
     }
 
-    public RecoverAccountRequest(PasswordResetOperation op, String email) {
+    public RecoverAccountRequest(PasswordResetOperation op, String email, Channel channel) {
         this.op = op;
         this.email = email;
+        this.channel = channel;
     }
 
     /**
@@ -84,12 +95,41 @@ public final class RecoverAccountRequest {
         this.email = email;
     }
 
+    /**
+     * @return the channel
+     */
+    public Channel getChannel() {
+        return channel;
+    }
+
+    /**
+     * @param channel the channel to set
+     */
+    public void setChannel(Channel channel) {
+        this.channel = channel;
+    }
+
     public Objects.ToStringHelper addToStringInfo(Objects.ToStringHelper helper) {
-        return helper.add("op", op.toString()).add("email", email);
+        return helper.add("op", op.toString()).add("email", email).add("channel", channel);
     }
 
     @Override
     public String toString() {
         return addToStringInfo(Objects.toStringHelper(this)).toString();
+    }
+
+    public void validateRecoverAccountRequest() throws ServiceException {
+        if (op == null) {
+            ZimbraLog.account.debug("%s Invalid op received", "RecoverAccount");
+            throw ServiceException.INVALID_REQUEST("Invalid op received", null);
+        }
+        if (Strings.isNullOrEmpty(email)) {
+            ZimbraLog.account.debug("%s Invalid email received", "RecoverAccount");
+            throw ServiceException.INVALID_REQUEST("\"email\" not received in request.", null);
+        }
+        if (channel == null) {
+            ZimbraLog.account.debug("%s Invalid channel received", "RecoverAccount");
+            throw ServiceException.INVALID_REQUEST("Invalid channel received", null);
+        }
     }
 }

--- a/soap/src/java/com/zimbra/soap/mail/message/RecoverAccountRequest.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/RecoverAccountRequest.java
@@ -51,7 +51,7 @@ public final class RecoverAccountRequest {
     private String email;
 
     /**
-     * @zm-api-field-description email
+     * @zm-api-field-description channel
      */
     @XmlAttribute(name = MailConstants.A_CHANNEL /* channel */, required = true)
     private Channel channel;

--- a/soap/src/java/com/zimbra/soap/mail/message/RecoverAccountResponse.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/RecoverAccountResponse.java
@@ -35,32 +35,32 @@ public final class RecoverAccountResponse {
     /**
      * @zm-api-field-description RecoveryEmail
      */
-    @XmlAttribute(name = MailConstants.A_RECOVERY_EMAIL /* RecoveryEmail */, required = false)
-    private String recoveryEmail;
+    @XmlAttribute(name = MailConstants.A_RECOVERY_ACCOUNT /* recoveryAccount */, required = false)
+    private String recoveryAccount;
 
     public RecoverAccountResponse() {
     }
 
-    public RecoverAccountResponse(String recoveryEmail) {
-        this.recoveryEmail = recoveryEmail;
+    public RecoverAccountResponse(String recoveryAccount) {
+        this.recoveryAccount = recoveryAccount;
     }
 
     /**
      * @return the recovery recoveryEmail
      */
-    public String getRecoveryEmail() {
-        return recoveryEmail;
+    public String getRecoveryAccount() {
+        return recoveryAccount;
     }
 
     /**
-     * @param email the recovery recoveryEmail
+     * @param recoveryAccount the recovery recoveryEmail
      */
-    public void setRecoveryEmail(String email) {
-        this.recoveryEmail = email;
+    public void setRecoveryAccount(String recoveryAccount) {
+        this.recoveryAccount = recoveryAccount;
     }
 
     public Objects.ToStringHelper addToStringInfo(Objects.ToStringHelper helper) {
-        return helper.add("recoveryEmail", recoveryEmail);
+        return helper.add("recoveryAccount", recoveryAccount);
     }
 
     @Override

--- a/soap/src/java/com/zimbra/soap/mail/message/RecoverAccountResponse.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/RecoverAccountResponse.java
@@ -33,7 +33,7 @@ import com.zimbra.common.soap.MailConstants;
 @XmlRootElement(name = MailConstants.E_RECOVER_ACCOUNT_RESPONSE)
 public final class RecoverAccountResponse {
     /**
-     * @zm-api-field-description RecoveryEmail
+     * @zm-api-field-description recoveryAccount
      */
     @XmlAttribute(name = MailConstants.A_RECOVERY_ACCOUNT /* recoveryAccount */, required = false)
     private String recoveryAccount;
@@ -46,14 +46,14 @@ public final class RecoverAccountResponse {
     }
 
     /**
-     * @return the recovery recoveryEmail
+     * @return the recovery recoveryAccount
      */
     public String getRecoveryAccount() {
         return recoveryAccount;
     }
 
     /**
-     * @param recoveryAccount the recovery recoveryEmail
+     * @param recoveryAccount the recovery account
      */
     public void setRecoveryAccount(String recoveryAccount) {
         this.recoveryAccount = recoveryAccount;

--- a/soap/src/java/com/zimbra/soap/mail/message/SetRecoveryEmailRequest.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/SetRecoveryEmailRequest.java
@@ -26,6 +26,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import com.google.common.base.Objects;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.MailConstants;
+import com.zimbra.soap.type.Channel;
 
 @XmlAccessorType(XmlAccessType.NONE)
 @XmlRootElement(name = MailConstants.E_SET_RECOVERY_EMAIL_REQUEST)
@@ -55,15 +56,22 @@ public class SetRecoveryEmailRequest {
      * @zm-api-field-tag recoveryEmailAddress
      * @zm-api-field-description recovery email address
      */
-    @XmlAttribute(name = MailConstants.A_RECOVERY_EMAIL_ADDRESS /* recoveryEmailAddress */, required = false)
-    private String recoveryEmailAddress;
+    @XmlAttribute(name = MailConstants.A_RECOVERY_ACCOUNT /* recoveryAccount */, required = false)
+    private String recoveryAccount;
 
     /**
      * @zm-api-field-tag recoveryEmailAddressVerificationCode
      * @zm-api-field-description recovery email address verification code
      */
-    @XmlAttribute(name = MailConstants.A_RECOVERY_EMAIL_ADDRESS_VERIFICATION_CODE /* recoveryEmailAddressVerificationCode */, required = false)
-    private String recoveryEmailAddressVerificationCode;
+    @XmlAttribute(name = MailConstants.A_RECOVERY_ACCOUNT_VERIFICATION_CODE /* recoveryAccountVerificationCode */, required = false)
+    private String recoveryAccountVerificationCode;
+
+    /**
+     * @zm-api-field-tag channel
+     * @zm-api-field-description recovery channel
+     */
+    @XmlAttribute(name = MailConstants.A_CHANNEL /* channel */, required = true)
+    private Channel channel;
 
     public Op getOp() {
         return op;
@@ -73,26 +81,41 @@ public class SetRecoveryEmailRequest {
         this.op = op;
     }
 
-    public String getRecoveryEmailAddress() {
-        return recoveryEmailAddress;
+    public String getRecoveryAccount() {
+        return recoveryAccount;
     }
 
-    public void setRecoveryEmailAddress(String recoveryEmailAddress) {
-        this.recoveryEmailAddress = recoveryEmailAddress;
+    public void setRecoveryAccount(String recoveryAccount) {
+        this.recoveryAccount = recoveryAccount;
     }
 
-    public String getRecoveryEmailAddressVerificationCode() {
-        return recoveryEmailAddressVerificationCode;
+    public String getRecoveryAccountVerificationCode() {
+        return recoveryAccountVerificationCode;
     }
 
     public void
-        setRecoveryEmailAddressVerificationCode(String recoveryEmailAddressVerificationCode) {
-        this.recoveryEmailAddressVerificationCode = recoveryEmailAddressVerificationCode;
+        setRecoveryAccountVerificationCode(String recoveryAccountVerificationCode) {
+        this.recoveryAccountVerificationCode = recoveryAccountVerificationCode;
+    }
+
+    /**
+     * @return the channel
+     */
+    public Channel getChannel() {
+        return channel;
+    }
+
+    /**
+     * @param channel the channel to set
+     */
+    public void setChannel(Channel channel) {
+        this.channel = channel;
     }
 
     public Objects.ToStringHelper addToStringInfo(Objects.ToStringHelper helper) {
-        return helper.add("op", op).add("recoveryEmailAddress", recoveryEmailAddress)
-            .add("recoveryEmailAddressVerificationCode", recoveryEmailAddressVerificationCode);
+        return helper.add("op", op).add("recoveryAccount", recoveryAccount)
+            .add("recoveryAccountVerificationCode", recoveryAccountVerificationCode)
+            .add("channel", channel);
     }
 
     @Override

--- a/soap/src/java/com/zimbra/soap/mail/message/SetRecoveryEmailRequest.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/SetRecoveryEmailRequest.java
@@ -53,15 +53,15 @@ public class SetRecoveryEmailRequest {
     private Op op;
 
     /**
-     * @zm-api-field-tag recoveryEmailAddress
-     * @zm-api-field-description recovery email address
+     * @zm-api-field-tag recoveryAccount
+     * @zm-api-field-description recovery account
      */
     @XmlAttribute(name = MailConstants.A_RECOVERY_ACCOUNT /* recoveryAccount */, required = false)
     private String recoveryAccount;
 
     /**
-     * @zm-api-field-tag recoveryEmailAddressVerificationCode
-     * @zm-api-field-description recovery email address verification code
+     * @zm-api-field-tag recoveryAccountVerificationCode
+     * @zm-api-field-description recovery account verification code
      */
     @XmlAttribute(name = MailConstants.A_RECOVERY_ACCOUNT_VERIFICATION_CODE /* recoveryAccountVerificationCode */, required = false)
     private String recoveryAccountVerificationCode;

--- a/soap/src/java/com/zimbra/soap/mail/type/PasswordResetOperation.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/PasswordResetOperation.java
@@ -10,9 +10,8 @@ import com.google.common.collect.Maps;
 
 @XmlEnum
 public enum PasswordResetOperation {
-    @XmlEnumValue("getRecoveryEmail")
-    GET_RECOVERY_EMAIL("getRecoveryEmail"), @XmlEnumValue("sendRecoveryCode")
-    SEND_RECOVERY_CODE("sendRecoveryCode");
+    @XmlEnumValue("getRecoveryAccount") GET_RECOVERY_ACCOUNT("getRecoveryAccount"),
+    @XmlEnumValue("sendRecoveryCode") SEND_RECOVERY_CODE("sendRecoveryCode");
 
     private static Map<String, PasswordResetOperation> nameToPasswordRestOperations = Maps.newHashMap();
     static {

--- a/soap/src/java/com/zimbra/soap/type/Channel.java
+++ b/soap/src/java/com/zimbra/soap/type/Channel.java
@@ -1,0 +1,52 @@
+/*
+ * ***** BEGIN LICENSE BLOCK ***** Zimbra Collaboration Suite Server Copyright
+ * (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>. *****
+ * END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.type;
+
+import java.util.Map;
+
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
+
+@XmlEnum
+public enum Channel {
+    @XmlEnumValue("email") EMAIL("email");
+
+    private static Map<String, Channel> nameToChannel = Maps.newHashMap();
+    static {
+        for (Channel v : Channel.values()) {
+            nameToChannel.put(v.toString(), v);
+        }
+    }
+
+    private String name;
+
+    private Channel(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+
+    public static Channel fromString(String name) {
+        return nameToChannel.get(Strings.nullToEmpty(name));
+    }
+}

--- a/store/docs/soap.txt
+++ b/store/docs/soap.txt
@@ -4796,8 +4796,8 @@ sendRecoveryCode = send recovery code to recovery email only if it's verified.
 user_email = email address of the user who forgot the password.
 channel = Mandatory attribute. Currently only email is supported.
 
-<RecoverAccountResponse recoveryAccount="{recory_email_address}" />
-recory_email_address = verified recovery email address for getRecoveryAccount operation
+<RecoverAccountResponse recoveryAccount="{recovery_email_address}" />
+recovery_email_address = verified recovery email address for getRecoveryAccount operation
 
 -----------------------------
 API to reset password of authenticated account under zimbraAccount namespace.

--- a/store/docs/soap.txt
+++ b/store/docs/soap.txt
@@ -4771,12 +4771,13 @@ Server Debug config parameters:
 
 -----------------------------
 API to set recovery email address
-<SetRecoveryEmailRequest op="{op}" recoveryEmailAddress="{recoveryEmailAddress}" recoveryEmailAddressVerificationCode="{recoveryEmailAddressVerificationCode}">
+<SetRecoveryEmailRequest op="{op}" recoveryAccount="{recoveryEmailAddress}" recoveryAccountVerificationCode="{recoveryAccountVerificationCode}" channel="email">
 </SetRecoveryEmailRequest>
 
 {op} = op can be sendCode, validateCode, resendCode or reset.
 {recoveryEmailAddress} = Recovery email address to be set
-{recoveryEmailAddressVerificationCode} = Recovery email address verification code to validate the address
+{recoveryAccountVerificationCode} = Recovery email address verification code to validate the address
+channel = Mandatory attribute. Currently only email is supported.
 
 sendCode: reads input parameter {recoveryEmailAddress}. If the code is not already sent to this email, generates new code and sends to the recovery address. Sets the recovery address status to pending.
 validateCode: reads input parameter {recoveryEmailAddressVerificationCode}. If the code is not expired and verified successfully, sets the recovery address status to verified.
@@ -4788,14 +4789,15 @@ reset: reads no input parameter. 'reset' will clear all ldap attributes related 
 
 -----------------------------
 API to get recovery email address and send recovery code to reset forgotten password.
-<RecoverAccountRequest op="{getRecoveryEmail|sendRecoveryCode}" email="{user_email}" xmlns="urn:zimbraMail" />
+<RecoverAccountRequest op="{getRecoveryAccount|sendRecoveryCode}" email="{user_email}" channel="email" xmlns="urn:zimbraMail" />
 
-getRecoveryEmail = get recovery email only if it's verified.
+getRecoveryAccount = get recovery email only if it's verified.
 sendRecoveryCode = send recovery code to recovery email only if it's verified.
 user_email = email address of the user who forgot the password.
+channel = Mandatory attribute. Currently only email is supported.
 
-<RecoverAccountResponse recoveryEmail="{recory_email_address}" />
-recory_email_address = verified recovery email address for getRecoveryEmail operation
+<RecoverAccountResponse recoveryAccount="{recory_email_address}" />
+recory_email_address = verified recovery email address for getRecoveryAccount operation
 
 -----------------------------
 API to reset password of authenticated account under zimbraAccount namespace.

--- a/store/src/java-test/com/zimbra/cs/service/SetRecoveryEmailTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/SetRecoveryEmailTest.java
@@ -59,6 +59,7 @@ import com.zimbra.cs.service.mail.ServiceTestUtil;
 import com.zimbra.cs.service.mail.SetRecoveryEmail;
 import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.mail.message.SetRecoveryEmailRequest;
+import com.zimbra.soap.type.Channel;
 
 import junit.framework.Assert;
 
@@ -183,7 +184,8 @@ public class SetRecoveryEmailTest {
         Assert.assertNull(acct1.getPrefPasswordRecoveryAddressStatus());
         SetRecoveryEmailRequest request = new SetRecoveryEmailRequest();
         request.setOp(SetRecoveryEmailRequest.Op.sendCode);
-        request.setRecoveryEmailAddress("testRecovery@zimbra.com");
+        request.setRecoveryAccount("testRecovery@zimbra.com");
+        request.setChannel(Channel.EMAIL);
         Element req = JaxbUtil.jaxbToElement(request);
         new SetRecoveryEmail().handle(req, ServiceTestUtil.getRequestContext(acct1));
         // Verify that the recovery email address is updated into ldap and
@@ -212,7 +214,8 @@ public class SetRecoveryEmailTest {
         acct1.setFeatureResetPasswordEnabled(true);
         SetRecoveryEmailRequest request = new SetRecoveryEmailRequest();
         request.setOp(SetRecoveryEmailRequest.Op.sendCode);
-        request.setRecoveryEmailAddress("test5035@zimbra.com");
+        request.setRecoveryAccount("test5035@zimbra.com");
+        request.setChannel(Channel.EMAIL);
         Element req = JaxbUtil.jaxbToElement(request);
         try {
             new SetRecoveryEmail().handle(req, ServiceTestUtil.getRequestContext(acct1));
@@ -221,6 +224,22 @@ public class SetRecoveryEmailTest {
             Assert.assertEquals(
                 "system failure: Recovery address should not be same as primary/alias email address.",
                 e.getMessage());
+        }
+    }
+
+    @Test
+    public void testMissingChannel() throws Exception {
+        Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test5035@zimbra.com");
+        acct1.setFeatureResetPasswordEnabled(true);
+        SetRecoveryEmailRequest request = new SetRecoveryEmailRequest();
+        request.setOp(SetRecoveryEmailRequest.Op.sendCode);
+        request.setRecoveryAccount("test5035@zimbra.com");
+        Element req = JaxbUtil.jaxbToElement(request);
+        try {
+            new SetRecoveryEmail().handle(req, ServiceTestUtil.getRequestContext(acct1));
+            Assert.fail("Exception should have been thrown");
+        } catch (ServiceException e) {
+            Assert.assertEquals("invalid request: Invalid channel received.", e.getMessage());
         }
     }
 }

--- a/store/src/java-test/com/zimbra/cs/service/SetRecoveryEmailTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/SetRecoveryEmailTest.java
@@ -176,6 +176,7 @@ public class SetRecoveryEmailTest {
     @Test
     public void test4797() throws Exception {
         Account acct1 = Provisioning.getInstance().get(Key.AccountBy.name, "test4797@zimbra.com");
+        acct1.setMail("test4797@zimbra.com");
         Account recoveryAcct = Provisioning.getInstance().get(Key.AccountBy.name,
             "testRecovery@zimbra.com");
         Mailbox recoveryMailbox = MailboxManager.getInstance().getMailboxByAccount(recoveryAcct);

--- a/store/src/java/com/zimbra/cs/account/EmailRecoveryCode.java
+++ b/store/src/java/com/zimbra/cs/account/EmailRecoveryCode.java
@@ -22,7 +22,11 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
@@ -31,38 +35,126 @@ import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
 
+import org.apache.commons.lang.RandomStringUtils;
+
 import com.zimbra.common.account.ForgetPasswordEnums.CodeConstants;
+import com.zimbra.common.account.ZAttrProvisioning.PrefPasswordRecoveryAddressStatus;
 import com.zimbra.common.mime.MimeConstants;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.L10nUtil;
+import com.zimbra.common.util.L10nUtil.MsgKey;
 import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
-import com.zimbra.common.util.L10nUtil.MsgKey;
 import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxManager;
 import com.zimbra.cs.mailbox.OperationContext;
+import com.zimbra.cs.service.util.JWEUtil;
 import com.zimbra.cs.util.AccountUtil;
+import com.zimbra.soap.ZimbraSoapContext;
+import com.zimbra.soap.mail.message.RecoverAccountRequest;
+import com.zimbra.soap.mail.message.RecoverAccountResponse;
+import com.zimbra.soap.mail.message.SetRecoveryEmailRequest;
+import com.zimbra.soap.mail.message.SetRecoveryEmailRequest.Op;
+import com.zimbra.soap.mail.message.SetRecoveryEmailResponse;
+import com.zimbra.soap.mail.type.PasswordResetOperation;
 
 public class EmailRecoveryCode implements SendRecoveryCode {
     public static final String LOG_OPERATION = "RecoverAccount:";
+    private static final int CODE_LENGTH = 8;
     private Map<String, String> recoveryCodeMap;
-    private Mailbox mbox;
     private Account account;
+    private Mailbox mbox;
 
-    @SuppressWarnings("unused")
-    private EmailRecoveryCode() {
-        // private default constructor
+    public EmailRecoveryCode() {
+        recoveryCodeMap = new HashMap<String, String>();
     }
-    /**
-     * @param recoveryCodeMap
-     */
+
     public EmailRecoveryCode(Map<String, String> recoveryCodeMap, Mailbox mbox, Account account) {
+        if (recoveryCodeMap ==  null) {
+            recoveryCodeMap = new HashMap<String, String>();
+        }
         this.recoveryCodeMap = recoveryCodeMap;
         this.mbox = mbox;
         this.account = account;
     }
 
     @Override
-    public void sendForgetPasswordCode() throws ServiceException {
+    public RecoverAccountResponse handleRecoverAccountRequest(RecoverAccountRequest request, Account account)
+            throws ServiceException {
+        RecoverAccountResponse resp = new RecoverAccountResponse();
+        this.account = account;
+        mbox = MailboxManager.getInstance().getMailboxByAccount(account);
+        PasswordResetOperation op = request.getOp();
+        String email = request.getEmail();
+        String recoveryEmail = account.getPrefPasswordRecoveryAddress();
+        if (StringUtil.isNullOrEmpty(recoveryEmail)) {
+            ZimbraLog.account.debug("%s Recovery email missing or unverified for %s", LOG_OPERATION, email);
+            throw ServiceException.FAILURE("Something went wrong. Please contact your administrator.", null);
+        }
+        switch (op) {
+            case GET_RECOVERY_ACCOUNT:
+                recoveryEmail = StringUtil.maskEmail(recoveryEmail);
+                ZimbraLog.account.debug("%s Recovery email: %s", LOG_OPERATION, recoveryEmail);
+                resp.setRecoveryAccount(recoveryEmail);
+                break;
+            case SEND_RECOVERY_CODE:
+                String storedCodeString = account.getResetPasswordRecoveryCode();
+                ZonedDateTime currentDate = ZonedDateTime.now(ZoneId.systemDefault());
+                if (!StringUtil.isNullOrEmpty(storedCodeString)) {
+                    ZimbraLog.account.debug("%s Recovery code found for %s", LOG_OPERATION, email);
+                    recoveryCodeMap = JWEUtil.getDecodedJWE(storedCodeString);
+                    ZonedDateTime storedDate = Instant
+                            .ofEpochMilli(Long.valueOf(recoveryCodeMap.get(CodeConstants.EXPIRY_TIME.toString())))
+                            .atZone(ZoneId.systemDefault());
+                    if (ChronoUnit.MILLIS.between(currentDate, storedDate) <= 0L) {
+                        ZimbraLog.account.debug(
+                                "%s Recovery code expired, so generating new one and reseting resend count.",
+                                LOG_OPERATION);
+                        recoveryCodeMap.put(CodeConstants.CODE.toString(), RandomStringUtils.random(CODE_LENGTH, true, true));
+                        // add expiry duration in current time.
+                        currentDate = currentDate.plus(account.getResetPasswordRecoveryCodeExpiry(), ChronoUnit.MILLIS);
+                        Long val = currentDate.toInstant().toEpochMilli();
+                        recoveryCodeMap.put(CodeConstants.EXPIRY_TIME.toString(), String.valueOf(val));
+                        recoveryCodeMap.put(CodeConstants.RESEND_COUNT.toString(), String.valueOf(0));
+                    } else {
+                        ZimbraLog.account.debug("%s Recovery code not expired yet, so using the same code.",
+                                LOG_OPERATION);
+                        int resendCount = Integer.valueOf(recoveryCodeMap.get(CodeConstants.RESEND_COUNT.toString()));
+                        resendCount++;
+                        if (account.getPasswordRecoveryMaxAttempts() < resendCount) {
+                            throw ServiceException.INVALID_REQUEST("Max resend attempts reached", null);
+                        } else {
+                            recoveryCodeMap.put(CodeConstants.RESEND_COUNT.toString(), String.valueOf(resendCount));
+                        }
+                    }
+                } else {
+                    ZimbraLog.account.debug("%s Recovery code not found for %s, creating new one", LOG_OPERATION,
+                            email);
+                    recoveryCodeMap.put(CodeConstants.EMAIL.toString(), recoveryEmail);
+                    recoveryCodeMap.put(CodeConstants.CODE.toString(), RandomStringUtils.random(CODE_LENGTH, true, true));
+                    // add expiry duration in current time.
+                    currentDate = currentDate.plus(account.getResetPasswordRecoveryCodeExpiry(), ChronoUnit.MILLIS);
+                    Long val = currentDate.toInstant().toEpochMilli();
+                    recoveryCodeMap.put(CodeConstants.EXPIRY_TIME.toString(), String.valueOf(val));
+                    recoveryCodeMap.put(CodeConstants.RESEND_COUNT.toString(), String.valueOf(0));
+                }
+                sendResetPasswordRecoveryCode();
+                saveResetPasswordRecoveryCode(null, null);
+                break;
+            default:
+                throw ServiceException.INVALID_REQUEST("Invalid op received", null);
+        }
+        return resp;
+    }
+
+    @Override
+    public void sendResetPasswordRecoveryCode() throws ServiceException {
+        if (recoveryCodeMap.isEmpty() || account == null) {
+            throw ServiceException.INVALID_REQUEST("Invalid request received in sendForgetPasswordCode()", null);
+        }
+        if (mbox == null) {
+            mbox = MailboxManager.getInstance().getMailboxByAccount(account);
+        }
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("EEE, d MMM yyyy HH:mm:ss z")
                 .withZone(ZoneId.of("GMT"));
         Locale locale = account.getLocale();
@@ -94,17 +186,69 @@ public class EmailRecoveryCode implements SendRecoveryCode {
     }
 
     @Override
-    public void sendRecoveryAccountValidationCode(Account ownerAccount, OperationContext octxt) throws ServiceException {
+    public void saveResetPasswordRecoveryCode(AuthToken authToken, HashMap<String, Object> prefs) throws ServiceException {
+        if (recoveryCodeMap.isEmpty() || account == null) {
+            throw ServiceException.INVALID_REQUEST("Invalid request received in saveRecoveryCode()", null);
+        }
+
+        if (prefs == null) {
+            prefs = new HashMap<String, Object>();
+        }
+        prefs.put(Provisioning.A_zimbraResetPasswordRecoveryCode, JWEUtil.getJWE(recoveryCodeMap));
+        Provisioning.getInstance().modifyAttrs(account, prefs, true, authToken);
+    }
+
+    @Override
+    public SetRecoveryEmailResponse handleSetRecoveryEmailRequest(SetRecoveryEmailRequest request,
+            ZimbraSoapContext zsc, OperationContext octxt) throws ServiceException {
+        SetRecoveryEmailResponse resp = new SetRecoveryEmailResponse();
+        Op op = request.getOp();
+        if (op == null) {
+            throw ServiceException.INVALID_REQUEST("Invalid operation received.", null);
+        }
+        switch (op) {
+            case sendCode:
+                String recoveryEmailAddr = request.getRecoveryAccount();
+                if (StringUtil.isNullOrEmpty(recoveryEmailAddr)) {
+                    throw ServiceException.INVALID_REQUEST("Recovery email address not provided.",
+                        null);
+                }
+                validateEmail(recoveryEmailAddr);
+                sendCode(recoveryEmailAddr, 0, zsc, octxt);
+                break;
+            case validateCode:
+                String recoveryAccountVerificationCode = request
+                    .getRecoveryAccountVerificationCode();
+                if (StringUtil.isNullOrEmpty(recoveryAccountVerificationCode)) {
+                    throw ServiceException.INVALID_REQUEST(
+                        "Recovery email address verification code not provided.", null);
+                }
+                validateSetRecoveryEmailCode(recoveryAccountVerificationCode, zsc, octxt);
+                break;
+            case resendCode:
+                resendCode(zsc, octxt);
+                break;
+            case reset:
+                resetSetRecoveryEmailCode(zsc);
+                break;
+            default:
+                throw ServiceException.INVALID_REQUEST("Invalid operation received.", null);
+            }
+        return resp;
+    }
+
+    @Override
+    public void sendSetRecoveryAccountValidationCode(OperationContext octxt) throws ServiceException {
         String emailIdToVerify = recoveryCodeMap.get(CodeConstants.EMAIL.toString());
         String code = recoveryCodeMap.get(CodeConstants.CODE.toString());
         String expiryTime = recoveryCodeMap.get(CodeConstants.EXPIRY_TIME.toString());
         Locale locale = account.getLocale();
-        String ownerAcctDisplayName = ownerAccount.getDisplayName();
-        if (ownerAcctDisplayName == null) {
-            ownerAcctDisplayName = ownerAccount.getName();
+        String acctDisplayName = account.getDisplayName();
+        if (StringUtil.isNullOrEmpty(acctDisplayName)) {
+            acctDisplayName = account.getMail();
         }
         String subject = L10nUtil.getMessage(MsgKey.verifyRecoveryEmailSubject, locale,
-            ownerAcctDisplayName);
+            acctDisplayName);
         String charset = account.getAttr(Provisioning.A_zimbraPrefMailDefaultCharset,
             MimeConstants.P_CHARSET_UTF8);
         try {
@@ -125,7 +269,7 @@ public class EmailRecoveryCode implements SendRecoveryCode {
             String mimePartHtml = L10nUtil.getMessage(MsgKey.verifyRecoveryEmailBodyHtml, locale, code,
                 gmtDate);
             MimeMultipart mmp = AccountUtil.generateMimeMultipart(mimePartText, mimePartHtml, null);
-            MimeMessage mm = AccountUtil.generateMimeMessage(account, ownerAccount, subject,
+            MimeMessage mm = AccountUtil.generateMimeMessage(account, account, subject,
                 charset, null, null, emailIdToVerify, mmp);
             mbox.getMailSender().sendMimeMessage(octxt, mbox, false, mm, null, null, null, null,
                 false);
@@ -137,4 +281,145 @@ public class EmailRecoveryCode implements SendRecoveryCode {
         }
     }
 
+    private void sendCode(String email, int resendCount, ZimbraSoapContext zsc, OperationContext octxt) throws ServiceException {
+        String verificationData = account.getRecoveryEmailVerificationData();
+        if (verificationData != null) {
+            Map<String, String> recoveryDataMap = JWEUtil.getDecodedJWE(verificationData);
+            String recoveryEmail = recoveryDataMap.get(CodeConstants.EMAIL.toString());
+            if (ZimbraLog.passwordreset.isDebugEnabled()) {
+                ZimbraLog.passwordreset.debug("sendCode: existing recovery email: %s", recoveryEmail);
+            }
+            if (resendCount == 0 && recoveryEmail.equals(email)) {
+                throw ServiceException.INVALID_REQUEST(
+                    "Verification code already sent to this recovery email.", null);
+            }
+        }
+        String code = RandomStringUtils.random(8, true, true);
+        long expiry = account.getRecoveryEmailCodeValidity();
+        Date now = new Date();
+        long expiryTime = now.getTime() + expiry;
+        recoveryCodeMap.put(CodeConstants.EMAIL.toString(), email);
+        recoveryCodeMap.put(CodeConstants.CODE.toString(), code);
+        recoveryCodeMap.put(CodeConstants.EXPIRY_TIME.toString(), String.valueOf(expiryTime));
+        recoveryCodeMap.put(CodeConstants.RESEND_COUNT.toString(), String.valueOf(resendCount));
+        sendSetRecoveryAccountValidationCode(octxt);
+
+        HashMap<String, Object> prefs = new HashMap<String, Object>();
+        prefs.put(Provisioning.A_zimbraPrefPasswordRecoveryAddress, email);
+        prefs.put(Provisioning.A_zimbraPrefPasswordRecoveryAddressStatus,
+            PrefPasswordRecoveryAddressStatus.pending);
+        saveSetRecoveryAccountValidationCode(zsc.getAuthToken(), prefs);
+    }
+
+    private void resendCode(ZimbraSoapContext zsc, OperationContext octxt) throws ServiceException {
+        String verificationData = account.getRecoveryEmailVerificationData();
+        if (verificationData == null) {
+            throw ServiceException
+            .FAILURE("The recovery email address verification data is missing.", null);
+        }
+        Map<String, String> dataMap = JWEUtil.getDecodedJWE(verificationData);
+        String email = dataMap.get(CodeConstants.EMAIL.toString());
+        String code = dataMap.get(CodeConstants.CODE.toString());
+        long expiryTime = Long.parseLong(dataMap.get(CodeConstants.EXPIRY_TIME.toString()));
+        int resendCount = Integer.parseInt(dataMap.get(CodeConstants.RESEND_COUNT.toString()));
+        if (ZimbraLog.passwordreset.isDebugEnabled()) {
+            DateFormat format = new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss z");
+            format.setTimeZone(TimeZone.getTimeZone("GMT"));
+            String gmtDate = format.format(expiryTime);
+            ZimbraLog.passwordreset.debug("resendCode: Current resend count: %d", resendCount);
+            ZimbraLog.passwordreset.debug("resendCode: Resending code to: %s", email);
+            ZimbraLog.passwordreset.debug("resendCode: Code expiry time: %s", gmtDate);
+            ZimbraLog.passwordreset.debug("resendCode: Last 3 characters of resent code: %s",
+                code.substring(5));
+        }
+        if (resendCount < account.getPasswordRecoveryMaxAttempts()) {
+            // check if code is expired
+            Date now = new Date();
+            if (expiryTime < now.getTime()) {
+                // generate new code and send
+                sendCode(email, resendCount + 1, zsc, octxt);
+            } else {
+                // send existing code
+                // update resend count
+                resendCount = resendCount + 1;
+                HashMap<String, Object> prefs = new HashMap<String, Object>();
+                dataMap.put(CodeConstants.RESEND_COUNT.toString(), String.valueOf(resendCount));
+                prefs.put(Provisioning.A_zimbraRecoveryEmailVerificationData, JWEUtil.getJWE(dataMap));
+                Provisioning.getInstance().modifyAttrs(mbox.getAccount(), prefs, true, zsc.getAuthToken());
+                sendSetRecoveryAccountValidationCode(octxt);
+            }
+        } else {
+            throw ServiceException.FAILURE("Resend code request has reached maximum limit.", null);
+        }
+    }
+
+    @Override
+    public void saveSetRecoveryAccountValidationCode(AuthToken authToken, HashMap<String, Object> prefs) throws ServiceException {
+        if (recoveryCodeMap.isEmpty() || account == null) {
+            throw ServiceException.INVALID_REQUEST("Invalid request received in saveRecoveryCode()", null);
+        }
+        if (prefs == null) {
+            prefs = new HashMap<String, Object>();
+        }
+        String verificationDataStr = JWEUtil.getJWE(recoveryCodeMap);
+        prefs.put(Provisioning.A_zimbraRecoveryEmailVerificationData, verificationDataStr);
+        Provisioning.getInstance().modifyAttrs(account, prefs, true, authToken);
+    }
+
+    @Override
+    public void validateSetRecoveryEmailCode(String recoveryAccountVerificationCode, ZimbraSoapContext zsc, OperationContext octxt) throws ServiceException {
+            String verificationData = account.getRecoveryEmailVerificationData();
+            if (verificationData == null) {
+                throw ServiceException
+                .FAILURE("The recovery email address verification data is missing.", null);
+            }
+            Map<String, String> recoveryDataMap = JWEUtil.getDecodedJWE(verificationData);
+            String code = recoveryDataMap.get(CodeConstants.CODE.toString());
+            long expiryTime = Long.parseLong(recoveryDataMap.get(CodeConstants.EXPIRY_TIME.toString()));
+            if (ZimbraLog.passwordreset.isDebugEnabled()) {
+                DateFormat format = new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss z");
+                format.setTimeZone(TimeZone.getTimeZone("GMT"));
+                String gmtDate = format.format(expiryTime);
+                ZimbraLog.passwordreset.debug("validateCode: expiryTime for code: %s", gmtDate);
+                ZimbraLog.passwordreset.debug("ValidateCode: last 3 characters of recovery code: %s",
+                    code.substring(5));
+            }
+            Date now = new Date();
+            if (expiryTime < now.getTime()) {
+                throw ServiceException
+                    .FAILURE("The recovery email address verification code is expired.", null);
+            }
+            if (code.equals(recoveryAccountVerificationCode)) {
+                HashMap<String, Object> prefs = new HashMap<String, Object>();
+                prefs.put(Provisioning.A_zimbraPrefPasswordRecoveryAddressStatus,
+                    PrefPasswordRecoveryAddressStatus.verified);
+                prefs.put(Provisioning.A_zimbraRecoveryEmailVerificationData, null);
+                Provisioning.getInstance().modifyAttrs(mbox.getAccount(), prefs, true,
+                    zsc.getAuthToken());
+            } else {
+                throw ServiceException
+                    .FAILURE("Verification of recovery email address verification code failed.", null);
+            }
+        }
+
+    protected void resetSetRecoveryEmailCode(ZimbraSoapContext zsc) throws ServiceException {
+        HashMap<String, Object> prefs = new HashMap<String, Object>();
+        prefs.put(Provisioning.A_zimbraPrefPasswordRecoveryAddress, null);
+        prefs.put(Provisioning.A_zimbraPrefPasswordRecoveryAddressStatus, null);
+        prefs.put(Provisioning.A_zimbraRecoveryEmailVerificationData, null);
+        Provisioning.getInstance().modifyAttrs(mbox.getAccount(), prefs, true, zsc.getAuthToken());
+    }
+
+    private void validateEmail(String email) throws ServiceException {
+        String accountName = account.getName();
+        List<String> aliases = Arrays.asList(account.getAliases());
+        if (ZimbraLog.passwordreset.isDebugEnabled()) {
+            ZimbraLog.passwordreset.debug("validateEmail: Primary account name: %s", accountName);
+            ZimbraLog.passwordreset.debug("validateEmail: Primary account aliases: %s", aliases);
+        }
+        if (aliases.contains(email) || accountName.equals(email)) {
+            throw ServiceException
+                .FAILURE("Recovery address should not be same as primary/alias email address.", null);
+        }
+    }
 }

--- a/store/src/java/com/zimbra/cs/account/EmailRecoveryCode.java
+++ b/store/src/java/com/zimbra/cs/account/EmailRecoveryCode.java
@@ -1,0 +1,140 @@
+/*
+ * ***** BEGIN LICENSE BLOCK ***** Zimbra Collaboration Suite Server Copyright
+ * (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>. *****
+ * END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.account;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TimeZone;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
+
+import com.zimbra.common.account.ForgetPasswordEnums.CodeConstants;
+import com.zimbra.common.mime.MimeConstants;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.L10nUtil;
+import com.zimbra.common.util.StringUtil;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.common.util.L10nUtil.MsgKey;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.OperationContext;
+import com.zimbra.cs.util.AccountUtil;
+
+public class EmailRecoveryCode implements SendRecoveryCode {
+    public static final String LOG_OPERATION = "RecoverAccount:";
+    private Map<String, String> recoveryCodeMap;
+    private Mailbox mbox;
+    private Account account;
+
+    @SuppressWarnings("unused")
+    private EmailRecoveryCode() {
+        // private default constructor
+    }
+    /**
+     * @param recoveryCodeMap
+     */
+    public EmailRecoveryCode(Map<String, String> recoveryCodeMap, Mailbox mbox, Account account) {
+        this.recoveryCodeMap = recoveryCodeMap;
+        this.mbox = mbox;
+        this.account = account;
+    }
+
+    @Override
+    public void sendForgetPasswordCode() throws ServiceException {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("EEE, d MMM yyyy HH:mm:ss z")
+                .withZone(ZoneId.of("GMT"));
+        Locale locale = account.getLocale();
+        String displayName = account.getDisplayName();
+        if (displayName == null) {
+            displayName = account.getName();
+        }
+        Long expiryLong = Long.valueOf(recoveryCodeMap.get(CodeConstants.EXPIRY_TIME.toString()));
+        ZonedDateTime mailDate = Instant.ofEpochMilli(expiryLong).atZone(ZoneId.of("GMT"));
+        String subject = L10nUtil.getMessage(MsgKey.sendPasswordRecoveryEmailSubject, locale, account.getDomainName());
+        String charset = account.getAttr(Provisioning.A_zimbraPrefMailDefaultCharset, MimeConstants.P_CHARSET_UTF8);
+        String mimePartText = L10nUtil.getMessage(MsgKey.sendPasswordRecoveryEmailBodyText, locale, displayName,
+                recoveryCodeMap.get(CodeConstants.CODE.toString()), mailDate.format(formatter));
+        String mimePartHtml = L10nUtil.getMessage(MsgKey.sendPasswordRecoveryEmailBodyHtml, locale, displayName,
+                recoveryCodeMap.get(CodeConstants.CODE.toString()), mailDate.format(formatter));
+        try {
+            MimeMultipart mmp = AccountUtil.generateMimeMultipart(mimePartText, mimePartHtml, null);
+            MimeMessage mm = AccountUtil.generateMimeMessage(account, account, subject, charset, null, null,
+                    recoveryCodeMap.get(CodeConstants.EMAIL.toString()), mmp);
+            mbox.getMailSender().sendMimeMessage(null, mbox, false, mm, null, null, null, null, false);
+        } catch (MessagingException me) {
+            ZimbraLog.account.debug("%s Error occured while sending recovery code in email to ", LOG_OPERATION,
+                    recoveryCodeMap.get(CodeConstants.EMAIL.toString()));
+            throw ServiceException.FAILURE("Error occured while sending recovery code in email to "
+                    + recoveryCodeMap.get(CodeConstants.EMAIL.toString()), me);
+        }
+        ZimbraLog.account.debug("%s Recovery code sent in email to %s", LOG_OPERATION,
+                StringUtil.maskEmail(recoveryCodeMap.get(CodeConstants.EMAIL.toString())));
+    }
+
+    @Override
+    public void sendRecoveryAccountValidationCode(Account ownerAccount, OperationContext octxt) throws ServiceException {
+        String emailIdToVerify = recoveryCodeMap.get(CodeConstants.EMAIL.toString());
+        String code = recoveryCodeMap.get(CodeConstants.CODE.toString());
+        String expiryTime = recoveryCodeMap.get(CodeConstants.EXPIRY_TIME.toString());
+        Locale locale = account.getLocale();
+        String ownerAcctDisplayName = ownerAccount.getDisplayName();
+        if (ownerAcctDisplayName == null) {
+            ownerAcctDisplayName = ownerAccount.getName();
+        }
+        String subject = L10nUtil.getMessage(MsgKey.verifyRecoveryEmailSubject, locale,
+            ownerAcctDisplayName);
+        String charset = account.getAttr(Provisioning.A_zimbraPrefMailDefaultCharset,
+            MimeConstants.P_CHARSET_UTF8);
+        try {
+            DateFormat format = new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss z");
+            format.setTimeZone(TimeZone.getTimeZone("GMT"));
+            Date expiryDate = new Date(Long.valueOf(expiryTime));
+            String gmtDate = format.format(expiryDate);
+            if (ZimbraLog.passwordreset.isDebugEnabled()) {
+                ZimbraLog.passwordreset.debug(
+                    "sendRecoveryEmailVerificationCode: Expiry of recovery address verification code sent to %s: %s",
+                    emailIdToVerify, gmtDate);
+                ZimbraLog.passwordreset.debug(
+                    "sendRecoveryEmailVerificationCode: Last 3 characters of recovery code sent to %s: %s",
+                    emailIdToVerify, code.substring(5));
+            }
+            String mimePartText = L10nUtil.getMessage(MsgKey.verifyRecoveryEmailBodyText, locale, code,
+                gmtDate);
+            String mimePartHtml = L10nUtil.getMessage(MsgKey.verifyRecoveryEmailBodyHtml, locale, code,
+                gmtDate);
+            MimeMultipart mmp = AccountUtil.generateMimeMultipart(mimePartText, mimePartHtml, null);
+            MimeMessage mm = AccountUtil.generateMimeMessage(account, ownerAccount, subject,
+                charset, null, null, emailIdToVerify, mmp);
+            mbox.getMailSender().sendMimeMessage(octxt, mbox, false, mm, null, null, null, null,
+                false);
+        } catch (MessagingException e) {
+            ZimbraLog.account
+                .warn("Failed to send verification code to email ID: '" + emailIdToVerify + "'", e);
+            throw ServiceException
+                .FAILURE("Failed to send verification code to email ID: " + emailIdToVerify, e);
+        }
+    }
+
+}

--- a/store/src/java/com/zimbra/cs/account/SendRecoveryCode.java
+++ b/store/src/java/com/zimbra/cs/account/SendRecoveryCode.java
@@ -1,0 +1,25 @@
+/*
+ * ***** BEGIN LICENSE BLOCK ***** Zimbra Collaboration Suite Server Copyright
+ * (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>. *****
+ * END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.account;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.mailbox.OperationContext;
+
+public interface SendRecoveryCode {
+    public void sendForgetPasswordCode() throws ServiceException;
+    public void sendRecoveryAccountValidationCode(Account ownerAccount, OperationContext octxt) throws ServiceException;
+}

--- a/store/src/java/com/zimbra/cs/account/SendRecoveryCode.java
+++ b/store/src/java/com/zimbra/cs/account/SendRecoveryCode.java
@@ -16,10 +16,22 @@
 
 package com.zimbra.cs.account;
 
+import java.util.HashMap;
+
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.mailbox.OperationContext;
+import com.zimbra.soap.ZimbraSoapContext;
+import com.zimbra.soap.mail.message.RecoverAccountRequest;
+import com.zimbra.soap.mail.message.RecoverAccountResponse;
+import com.zimbra.soap.mail.message.SetRecoveryEmailRequest;
+import com.zimbra.soap.mail.message.SetRecoveryEmailResponse;
 
 public interface SendRecoveryCode {
-    public void sendForgetPasswordCode() throws ServiceException;
-    public void sendRecoveryAccountValidationCode(Account ownerAccount, OperationContext octxt) throws ServiceException;
+    public RecoverAccountResponse handleRecoverAccountRequest(RecoverAccountRequest request, Account account) throws ServiceException;
+    public void sendResetPasswordRecoveryCode() throws ServiceException;
+    public void saveResetPasswordRecoveryCode(AuthToken authToken, HashMap<String, Object> prefs) throws ServiceException;
+    public SetRecoveryEmailResponse handleSetRecoveryEmailRequest(SetRecoveryEmailRequest request, ZimbraSoapContext zsc, OperationContext octxt) throws ServiceException;
+    public void sendSetRecoveryAccountValidationCode(OperationContext octxt) throws ServiceException;
+    public void validateSetRecoveryEmailCode(String recoveryAccountVerificationCode, ZimbraSoapContext zsc, OperationContext octxt) throws ServiceException;
+    public void saveSetRecoveryAccountValidationCode(AuthToken authToken, HashMap<String, Object> prefs) throws ServiceException;
 }

--- a/store/src/java/com/zimbra/cs/service/mail/RecoverAccount.java
+++ b/store/src/java/com/zimbra/cs/service/mail/RecoverAccount.java
@@ -19,37 +19,29 @@ package com.zimbra.cs.service.mail;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
-
-import javax.mail.MessagingException;
-import javax.mail.internet.MimeMessage;
-import javax.mail.internet.MimeMultipart;
 
 import org.apache.commons.lang.RandomStringUtils;
 
-import com.google.common.base.Strings;
 import com.zimbra.common.account.ForgetPasswordEnums.CodeConstants;
-import com.zimbra.common.mime.MimeConstants;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
-import com.zimbra.common.util.L10nUtil;
-import com.zimbra.common.util.L10nUtil.MsgKey;
 import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.EmailRecoveryCode;
 import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.SendRecoveryCode;
 import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.MailboxManager;
 import com.zimbra.cs.service.util.JWEUtil;
-import com.zimbra.cs.util.AccountUtil;
 import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.mail.message.RecoverAccountRequest;
 import com.zimbra.soap.mail.message.RecoverAccountResponse;
 import com.zimbra.soap.mail.type.PasswordResetOperation;
+import com.zimbra.soap.type.Channel;
 
 public final class RecoverAccount extends MailDocumentHandler {
     public static final String LOG_OPERATION = "RecoverAccount:";
@@ -59,16 +51,11 @@ public final class RecoverAccount extends MailDocumentHandler {
         ZimbraSoapContext zsc = getZimbraSoapContext(context);
 
         RecoverAccountRequest req = zsc.elementToJaxb(request);
+        req.validateRecoverAccountRequest();
         PasswordResetOperation op = req.getOp();
-        if (op == null) {
-            ZimbraLog.account.debug("%s Invalid op received", LOG_OPERATION);
-            throw ServiceException.INVALID_REQUEST("Invalid op received", null);
-        }
         String email = req.getEmail();
-        if (Strings.isNullOrEmpty(email)) {
-            throw ServiceException.INVALID_REQUEST("\"email\" not received in request.", null);
-        }
         Account user = Provisioning.getInstance().getAccountByName(email);
+        Channel channel = req.getChannel();
         if (user == null) {
             ZimbraLog.account.debug("%s Account not found for %s", LOG_OPERATION, email);
             throw ServiceException.FAILURE("Something went wrong. Please contact your administrator.", null);
@@ -81,104 +68,90 @@ public final class RecoverAccount extends MailDocumentHandler {
             ZimbraLog.account.debug("%s Verified recovery email is not found for %s", LOG_OPERATION, email);
             throw ServiceException.FAILURE("Something went wrong. Please contact your administrator.", null);
         }
-        String recoveryEmail = user.getPrefPasswordRecoveryAddress();
-        if (StringUtil.isNullOrEmpty(recoveryEmail)) {
-            ZimbraLog.account.debug("%s Recovery email missing or unverified for %s", LOG_OPERATION, email);
-            throw ServiceException.FAILURE("Something went wrong. Please contact your administrator.", null);
-        }
 
         RecoverAccountResponse resp = new RecoverAccountResponse();
-        switch (op) {
-            case GET_RECOVERY_EMAIL:
-                recoveryEmail = StringUtil.maskEmail(recoveryEmail);
-                ZimbraLog.account.debug("%s Recovery email: %s", LOG_OPERATION, recoveryEmail);
-                resp.setRecoveryEmail(recoveryEmail);
-                break;
-            case SEND_RECOVERY_CODE:
-                String storedCodeString = user.getResetPasswordRecoveryCode();
-                ZonedDateTime currentDate = ZonedDateTime.now(ZoneId.systemDefault());
-                Map<String, String> recoveryCodeMap = new HashMap<String, String>();
-                if (!StringUtil.isNullOrEmpty(storedCodeString)) {
-                    ZimbraLog.account.debug("%s Recovery code found for %s", LOG_OPERATION, email);
-                    recoveryCodeMap = JWEUtil.getDecodedJWE(storedCodeString);
-                    ZonedDateTime storedDate = Instant
-                            .ofEpochMilli(Long.valueOf(recoveryCodeMap.get(CodeConstants.EXPIRY_TIME.toString())))
-                            .atZone(ZoneId.systemDefault());
-                    if (ChronoUnit.MILLIS.between(currentDate, storedDate) <= 0L) {
-                        ZimbraLog.account.debug(
-                                "%s Recovery code expired, so generating new one and reseting resend count.",
-                                LOG_OPERATION);
-                        recoveryCodeMap.put(CodeConstants.CODE.toString(), RandomStringUtils.random(8, true, true));
-                        // add expiry duration in current time.
-                        currentDate = currentDate.plus(user.getResetPasswordRecoveryCodeExpiry(), ChronoUnit.MILLIS);
-                        Long val = currentDate.toInstant().toEpochMilli();
-                        recoveryCodeMap.put(CodeConstants.EXPIRY_TIME.toString(), String.valueOf(val));
-                        recoveryCodeMap.put(CodeConstants.RESEND_COUNT.toString(), String.valueOf(0));
-                    } else {
-                        ZimbraLog.account.debug("%s Recovery code not expired yet, so using the same code.",
-                                LOG_OPERATION);
-                        int resendCount = Integer.valueOf(recoveryCodeMap.get(CodeConstants.RESEND_COUNT.toString()));
-                        resendCount++;
-                        if (user.getPasswordRecoveryMaxAttempts() < resendCount) {
-                            throw ServiceException.INVALID_REQUEST("Max resend attempts reached", null);
-                        } else {
-                            recoveryCodeMap.put(CodeConstants.RESEND_COUNT.toString(), String.valueOf(resendCount));
-                        }
-                    }
-                } else {
-                    ZimbraLog.account.debug("%s Recovery code not found for %s, creating new one", LOG_OPERATION,
-                            email);
-                    recoveryCodeMap.put(CodeConstants.EMAIL.toString(), recoveryEmail);
-                    recoveryCodeMap.put(CodeConstants.CODE.toString(), RandomStringUtils.random(8, true, true));
-                    // add expiry duration in current time.
-                    currentDate = currentDate.plus(user.getResetPasswordRecoveryCodeExpiry(), ChronoUnit.MILLIS);
-                    Long val = currentDate.toInstant().toEpochMilli();
-                    recoveryCodeMap.put(CodeConstants.EXPIRY_TIME.toString(), String.valueOf(val));
-                    recoveryCodeMap.put(CodeConstants.RESEND_COUNT.toString(), String.valueOf(0));
+        switch (channel) {
+            case EMAIL:
+                String recoveryEmail = user.getPrefPasswordRecoveryAddress();
+                if (StringUtil.isNullOrEmpty(recoveryEmail)) {
+                    ZimbraLog.account.debug("%s Recovery email missing or unverified for %s", LOG_OPERATION, email);
+                    throw ServiceException.FAILURE("Something went wrong. Please contact your administrator.", null);
                 }
-                sendAndStoreForgetPasswordCode(zsc, user, recoveryCodeMap);
+                switch (op) {
+                    case GET_RECOVERY_ACCOUNT:
+                        recoveryEmail = StringUtil.maskEmail(recoveryEmail);
+                        ZimbraLog.account.debug("%s Recovery email: %s", LOG_OPERATION, recoveryEmail);
+                        resp.setRecoveryAccount(recoveryEmail);
+                        break;
+                    case SEND_RECOVERY_CODE:
+                        String storedCodeString = user.getResetPasswordRecoveryCode();
+                        ZonedDateTime currentDate = ZonedDateTime.now(ZoneId.systemDefault());
+                        Map<String, String> recoveryCodeMap = new HashMap<String, String>();
+                        if (!StringUtil.isNullOrEmpty(storedCodeString)) {
+                            ZimbraLog.account.debug("%s Recovery code found for %s", LOG_OPERATION, email);
+                            recoveryCodeMap = JWEUtil.getDecodedJWE(storedCodeString);
+                            ZonedDateTime storedDate = Instant
+                                    .ofEpochMilli(Long.valueOf(recoveryCodeMap.get(CodeConstants.EXPIRY_TIME.toString())))
+                                    .atZone(ZoneId.systemDefault());
+                            if (ChronoUnit.MILLIS.between(currentDate, storedDate) <= 0L) {
+                                ZimbraLog.account.debug(
+                                        "%s Recovery code expired, so generating new one and reseting resend count.",
+                                        LOG_OPERATION);
+                                recoveryCodeMap.put(CodeConstants.CODE.toString(), RandomStringUtils.random(8, true, true));
+                                // add expiry duration in current time.
+                                currentDate = currentDate.plus(user.getResetPasswordRecoveryCodeExpiry(), ChronoUnit.MILLIS);
+                                Long val = currentDate.toInstant().toEpochMilli();
+                                recoveryCodeMap.put(CodeConstants.EXPIRY_TIME.toString(), String.valueOf(val));
+                                recoveryCodeMap.put(CodeConstants.RESEND_COUNT.toString(), String.valueOf(0));
+                            } else {
+                                ZimbraLog.account.debug("%s Recovery code not expired yet, so using the same code.",
+                                        LOG_OPERATION);
+                                int resendCount = Integer.valueOf(recoveryCodeMap.get(CodeConstants.RESEND_COUNT.toString()));
+                                resendCount++;
+                                if (user.getPasswordRecoveryMaxAttempts() < resendCount) {
+                                    throw ServiceException.INVALID_REQUEST("Max resend attempts reached", null);
+                                } else {
+                                    recoveryCodeMap.put(CodeConstants.RESEND_COUNT.toString(), String.valueOf(resendCount));
+                                }
+                            }
+                        } else {
+                            ZimbraLog.account.debug("%s Recovery code not found for %s, creating new one", LOG_OPERATION,
+                                    email);
+                            recoveryCodeMap.put(CodeConstants.EMAIL.toString(), recoveryEmail);
+                            recoveryCodeMap.put(CodeConstants.CODE.toString(), RandomStringUtils.random(8, true, true));
+                            // add expiry duration in current time.
+                            currentDate = currentDate.plus(user.getResetPasswordRecoveryCodeExpiry(), ChronoUnit.MILLIS);
+                            Long val = currentDate.toInstant().toEpochMilli();
+                            recoveryCodeMap.put(CodeConstants.EXPIRY_TIME.toString(), String.valueOf(val));
+                            recoveryCodeMap.put(CodeConstants.RESEND_COUNT.toString(), String.valueOf(0));
+                        }
+                        sendAndStoreRecoveryCode(user, recoveryCodeMap, channel);
+                        break;
+                    default:
+                        throw ServiceException.INVALID_REQUEST("Invalid op received", null);
+                }
                 break;
             default:
-                throw ServiceException.INVALID_REQUEST("Invalid op received", null);
+                throw ServiceException.INVALID_REQUEST("Invalid channel received", null);
         }
         return zsc.jaxbToElement(resp);
     }
 
-    private void sendAndStoreForgetPasswordCode(ZimbraSoapContext zsc, Account user,
-            Map<String, String> recoveryCodeMap) throws ServiceException {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("EEE, d MMM yyyy HH:mm:ss z")
-                .withZone(ZoneId.of("GMT"));
+    private void sendAndStoreRecoveryCode(Account user, Map<String, String> recoveryCodeMap, Channel channel) throws ServiceException {
         Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(user);
-        Locale locale = user.getLocale();
-        String displayName = user.getDisplayName();
-        if (displayName == null) {
-            displayName = user.getName();
+        SendRecoveryCode sendRecoveryCode = null;
+        switch (channel) {
+            case EMAIL:
+                sendRecoveryCode = new EmailRecoveryCode(recoveryCodeMap, mbox, user);
+                break;
+            default:
+                throw ServiceException.INVALID_REQUEST("Invalid channel received", null);
         }
-        Long expiryLong = Long.valueOf(recoveryCodeMap.get(CodeConstants.EXPIRY_TIME.toString()));
-        ZonedDateTime mailDate = Instant.ofEpochMilli(expiryLong).atZone(ZoneId.of("GMT"));
-        String subject = L10nUtil.getMessage(MsgKey.sendPasswordRecoveryEmailSubject, locale, user.getDomainName());
-        String charset = user.getAttr(Provisioning.A_zimbraPrefMailDefaultCharset, MimeConstants.P_CHARSET_UTF8);
-        String mimePartText = L10nUtil.getMessage(MsgKey.sendPasswordRecoveryEmailBodyText, locale, displayName,
-                recoveryCodeMap.get(CodeConstants.CODE.toString()), mailDate.format(formatter));
-        String mimePartHtml = L10nUtil.getMessage(MsgKey.sendPasswordRecoveryEmailBodyHtml, locale, displayName,
-                recoveryCodeMap.get(CodeConstants.CODE.toString()), mailDate.format(formatter));
-        try {
-            MimeMultipart mmp = AccountUtil.generateMimeMultipart(mimePartText, mimePartHtml, null);
-            MimeMessage mm = AccountUtil.generateMimeMessage(user, user, subject, charset, null, null,
-                    recoveryCodeMap.get(CodeConstants.EMAIL.toString()), mmp);
-            mbox.getMailSender().sendMimeMessage(null, mbox, false, mm, null, null, null, null, false);
-        } catch (MessagingException me) {
-            ZimbraLog.account.debug("%s Error occured while sending recovery code in email to ", LOG_OPERATION,
-                    recoveryCodeMap.get(CodeConstants.EMAIL.toString()));
-            throw ServiceException.FAILURE("Error occured while sending recovery code in email to "
-                    + recoveryCodeMap.get(CodeConstants.EMAIL.toString()), me);
-        }
-        ZimbraLog.account.debug("%s Recovery code sent in email to %s", LOG_OPERATION,
-                StringUtil.maskEmail(recoveryCodeMap.get(CodeConstants.EMAIL.toString())));
+        sendRecoveryCode.sendForgetPasswordCode();
         // store the same in ldap attribute for user
         HashMap<String, Object> prefs = new HashMap<String, Object>();
         prefs.put(Provisioning.A_zimbraResetPasswordRecoveryCode, JWEUtil.getJWE(recoveryCodeMap));
-        Provisioning.getInstance().modifyAttrs(mbox.getAccount(), prefs, true, zsc.getAuthToken());
+        Provisioning.getInstance().modifyAttrs(user, prefs, true, null);
     }
 
     // no auth required for this request, so return false for both needsAuth and needsAdminAuth

--- a/store/src/java/com/zimbra/cs/service/mail/SetRecoveryEmail.java
+++ b/store/src/java/com/zimbra/cs/service/mail/SetRecoveryEmail.java
@@ -17,29 +17,16 @@
 
 package com.zimbra.cs.service.mail;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.TimeZone;
 
-import org.apache.commons.lang.RandomStringUtils;
-
-import com.zimbra.common.account.ForgetPasswordEnums.CodeConstants;
-import com.zimbra.common.account.ZAttrProvisioning.PrefPasswordRecoveryAddressStatus;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
-import com.zimbra.common.util.StringUtil;
-import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.EmailRecoveryCode;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.SendRecoveryCode;
 import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.OperationContext;
-import com.zimbra.cs.service.util.JWEUtil;
 import com.zimbra.soap.DocumentHandler;
 import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.mail.message.SetRecoveryEmailRequest;
@@ -67,195 +54,16 @@ public class SetRecoveryEmail extends DocumentHandler {
         if (op == null) {
             throw ServiceException.INVALID_REQUEST("Invalid operation received.", null);
         }
-        switch (channel) {
-            case EMAIL:
-                switch (op) {
-                    case sendCode:
-                        String recoveryEmailAddr = req.getRecoveryAccount();
-                        if (StringUtil.isNullOrEmpty(recoveryEmailAddr)) {
-                            throw ServiceException.INVALID_REQUEST("Recovery email address not provided.",
-                                null);
-                        }
-                        validateEmail(recoveryEmailAddr, account);
-                        sendCode(recoveryEmailAddr, 0, account, mbox, zsc, octxt, channel);
-                        break;
-                    case validateCode:
-                        String recoveryAccountVerificationCode = req
-                            .getRecoveryAccountVerificationCode();
-                        if (StringUtil.isNullOrEmpty(recoveryAccountVerificationCode)) {
-                            throw ServiceException.INVALID_REQUEST(
-                                "Recovery email address verification code not provided.", null);
-                        }
-                        validateCode(recoveryAccountVerificationCode, account, mbox, zsc, octxt);
-                        break;
-                    case resendCode:
-                        resendCode(account, mbox, zsc, octxt, channel);
-                        break;
-                    case reset:
-                        reset(mbox, zsc);
-                        break;
-                    default:
-                        throw ServiceException.INVALID_REQUEST("Invalid operation received.", null);
-                    }
-                break;
-            default:
-                throw ServiceException.INVALID_REQUEST("Invalid channel received.", null);
-        }
-        SetRecoveryEmailResponse resp = new SetRecoveryEmailResponse();
-        return zsc.jaxbToElement(resp);
-    }
-
-    protected void sendCode(String email, int resendCount, Account account, Mailbox mbox,
-        ZimbraSoapContext zsc, OperationContext octxt, Channel channel) throws ServiceException {
-        String verificationData = account.getRecoveryEmailVerificationData();
-        if (verificationData != null) {
-            Map<String, String> recoveryDataMap = JWEUtil.getDecodedJWE(verificationData);
-            String recoveryEmail = recoveryDataMap.get(CodeConstants.EMAIL.toString());
-            if (ZimbraLog.passwordreset.isDebugEnabled()) {
-                ZimbraLog.passwordreset.debug("sendCode: existing recovery email: %s", recoveryEmail);
-            }
-            if (resendCount == 0 && recoveryEmail.equals(email)) {
-                throw ServiceException.INVALID_REQUEST(
-                    "Verification code already sent to this recovery email.", null);
-            }
-        }
-        String code = RandomStringUtils.random(8, true, true);
-        Account authAccount = getAuthenticatedAccount(zsc);
-        long expiry = account.getRecoveryEmailCodeValidity();
-        Date now = new Date();
-        long expiryTime = now.getTime() + expiry;
-        Map<String, String> dataMap = new HashMap<>();
-        dataMap.put(CodeConstants.EMAIL.toString(), email);
-        dataMap.put(CodeConstants.CODE.toString(), code);
-        dataMap.put(CodeConstants.EXPIRY_TIME.toString(), String.valueOf(expiryTime));
-        dataMap.put(CodeConstants.RESEND_COUNT.toString(), String.valueOf(resendCount));
+        SetRecoveryEmailResponse resp = null;
         SendRecoveryCode sendRecoveryCode = null;
         switch (channel) {
             case EMAIL:
-                sendRecoveryCode = new EmailRecoveryCode(dataMap, mbox, authAccount);
+                sendRecoveryCode = new EmailRecoveryCode(null, mbox, account);
                 break;
             default:
                 throw ServiceException.INVALID_REQUEST("Invalid channel received.", null);
         }
-        sendRecoveryCode.sendRecoveryAccountValidationCode(account, octxt);
-        HashMap<String, Object> prefs = new HashMap<String, Object>();
-        prefs.put(Provisioning.A_zimbraPrefPasswordRecoveryAddress, email);
-        prefs.put(Provisioning.A_zimbraPrefPasswordRecoveryAddressStatus,
-            PrefPasswordRecoveryAddressStatus.pending);
-        String verificationDataStr = JWEUtil.getJWE(dataMap);
-        prefs.put(Provisioning.A_zimbraRecoveryEmailVerificationData, verificationDataStr);
-        Provisioning.getInstance().modifyAttrs(mbox.getAccount(), prefs, true, zsc.getAuthToken());
-    }
-
-    protected void validateCode(String recoveryAccountVerificationCode, Account account,
-        Mailbox mbox, ZimbraSoapContext zsc, OperationContext octxt) throws ServiceException {
-        String verificationData = account.getRecoveryEmailVerificationData();
-        if (verificationData == null) {
-            throw ServiceException
-            .FAILURE("The recovery email address verification data is missing.", null);
-        }
-        Map<String, String> recoveryDataMap = JWEUtil.getDecodedJWE(verificationData);
-        String code = recoveryDataMap.get(CodeConstants.CODE.toString());
-        long expiryTime = Long.parseLong(recoveryDataMap.get(CodeConstants.EXPIRY_TIME.toString()));
-        if (ZimbraLog.passwordreset.isDebugEnabled()) {
-            DateFormat format = new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss z");
-            format.setTimeZone(TimeZone.getTimeZone("GMT"));
-            String gmtDate = format.format(expiryTime);
-            ZimbraLog.passwordreset.debug("validateCode: expiryTime for code: %s", gmtDate);
-            ZimbraLog.passwordreset.debug("ValidateCode: last 3 characters of recovery code: %s",
-                code.substring(5));
-        }
-        Date now = new Date();
-        if (expiryTime < now.getTime()) {
-            throw ServiceException
-                .FAILURE("The recovery email address verification code is expired.", null);
-
-        }
-        if (code.equals(recoveryAccountVerificationCode)) {
-            HashMap<String, Object> prefs = new HashMap<String, Object>();
-            prefs.put(Provisioning.A_zimbraPrefPasswordRecoveryAddressStatus,
-                PrefPasswordRecoveryAddressStatus.verified);
-            prefs.put(Provisioning.A_zimbraRecoveryEmailVerificationData, null);
-            Provisioning.getInstance().modifyAttrs(mbox.getAccount(), prefs, true,
-                zsc.getAuthToken());
-
-        } else {
-            throw ServiceException
-                .FAILURE("Verification of recovery email address verification code failed.", null);
-        }
-    }
-
-    protected void resendCode(Account account, Mailbox mbox, ZimbraSoapContext zsc,
-        OperationContext octxt, Channel channel) throws ServiceException {
-        String verificationData = account.getRecoveryEmailVerificationData();
-        if (verificationData == null) {
-            throw ServiceException
-            .FAILURE("The recovery email address verification data is missing.", null);
-        }
-        Map<String, String> dataMap = JWEUtil.getDecodedJWE(verificationData);
-        String email = dataMap.get(CodeConstants.EMAIL.toString());
-        String code = dataMap.get(CodeConstants.CODE.toString());
-        long expiryTime = Long.parseLong(dataMap.get(CodeConstants.EXPIRY_TIME.toString()));
-        int resendCount = Integer.parseInt(dataMap.get(CodeConstants.RESEND_COUNT.toString()));
-        if (ZimbraLog.passwordreset.isDebugEnabled()) {
-            DateFormat format = new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss z");
-            format.setTimeZone(TimeZone.getTimeZone("GMT"));
-            String gmtDate = format.format(expiryTime);
-            ZimbraLog.passwordreset.debug("resendCode: Current resend count: %d", resendCount);
-            ZimbraLog.passwordreset.debug("resendCode: Resending code to: %s", email);
-            ZimbraLog.passwordreset.debug("resendCode: Code expiry time: %s", gmtDate);
-            ZimbraLog.passwordreset.debug("resendCode: Last 3 characters of resent code: %s",
-                code.substring(5));
-        }
-        if (resendCount < account.getPasswordRecoveryMaxAttempts()) {
-            // check if code is expired
-            Date now = new Date();
-            if (expiryTime < now.getTime()) {
-                // generate new code and send
-                sendCode(email, resendCount + 1, account, mbox, zsc, octxt, channel);
-            } else {
-                // send existing code
-                Account authAccount = getAuthenticatedAccount(zsc);
-                // update resend count
-                resendCount = resendCount + 1;
-                HashMap<String, Object> prefs = new HashMap<String, Object>();
-                dataMap.put(CodeConstants.RESEND_COUNT.toString(), String.valueOf(resendCount));
-                prefs.put(Provisioning.A_zimbraRecoveryEmailVerificationData, JWEUtil.getJWE(dataMap));
-                Provisioning.getInstance().modifyAttrs(mbox.getAccount(), prefs, true, zsc.getAuthToken());
-                SendRecoveryCode sendRecoveryCode = null;
-                switch (channel) {
-                    case EMAIL:
-                        sendRecoveryCode = new EmailRecoveryCode(dataMap, mbox, authAccount);
-                        break;
-                    default:
-                        throw ServiceException.INVALID_REQUEST("Invalid channel received.", null);
-                }
-                sendRecoveryCode.sendRecoveryAccountValidationCode(account, octxt);
-            }
-        } else {
-            throw ServiceException.FAILURE("Resend code request has reached maximum limit.", null);
-        }
-    }
-
-    protected void reset(Mailbox mbox, ZimbraSoapContext zsc) throws ServiceException {
-        HashMap<String, Object> prefs = new HashMap<String, Object>();
-        prefs.put(Provisioning.A_zimbraPrefPasswordRecoveryAddress, null);
-        prefs.put(Provisioning.A_zimbraPrefPasswordRecoveryAddressStatus, null);
-        prefs.put(Provisioning.A_zimbraRecoveryEmailVerificationData, null);
-        Provisioning.getInstance().modifyAttrs(mbox.getAccount(), prefs, true, zsc.getAuthToken());
-
-    }
-
-    private static void validateEmail(String email, Account account) throws ServiceException {
-        String accountName = account.getName();
-        java.util.List<String> aliases = Arrays.asList(account.getAliases());
-        if (ZimbraLog.passwordreset.isDebugEnabled()) {
-            ZimbraLog.passwordreset.debug("validateEmail: Primary account name: %s", accountName);
-            ZimbraLog.passwordreset.debug("validateEmail: Primary account aliases: %s", aliases);
-        }
-        if (aliases.contains(email) || accountName.equals(email)) {
-            throw ServiceException
-                .FAILURE("Recovery address should not be same as primary/alias email address.", null);
-        }
+        resp = sendRecoveryCode.handleSetRecoveryEmailRequest(req, zsc, octxt);
+        return zsc.jaxbToElement(resp);
     }
 }


### PR DESCRIPTION
**Problem:** make code compatible, to easily add sms channel in future for account recovery.

**Fix:**
- create enum for Channel
- - email
- create interface for SendRecoveryCode
- - Implement EmailRecoveryCode(actual implementation to send emails)
- add param to RecoverAccountRequest
- - channel=“email” (this should be channel enum)
- - for other channels, invalid input
- change SetRecoveryEmailRequest -> SetRecoveryAccountRequest
- - add param channel=“email” (this should be channel enum)
- - rename recoveryEmailAddress -> recoveryAccount
- - rename recoveryEmailAddressVerificationCode -> recoveryAccountVerificationCode
- - this should send email using EmailRecoveryCode class

**Testing Done:**
- Added unit tests in RecoverAccountTest and SetRecoveryEmailTest.
- Corrected all other unit tests in the same.

**Testing to be done by QA:**
- Make changes in the existing automation to accommodate API changes.
- Test password reset functionality overall as per current implementation.
