### PR TITLE
ZCS-5122: add recovery attempts remain in response

### DIFF
--- a/common/src/java/com/zimbra/common/soap/MailConstants.java
+++ b/common/src/java/com/zimbra/common/soap/MailConstants.java
@@ -1374,6 +1374,7 @@ public final class MailConstants {
     public static final QName SET_RECOVERY_EMAIL_REQUEST = QName.get(E_SET_RECOVERY_EMAIL_REQUEST, NAMESPACE);
     public static final QName SET_RECOVERY_EMAIL_RESPONSE = QName.get(E_SET_RECOVERY_EMAIL_RESPONSE, NAMESPACE);
     public static final String A_RECOVERY_EMAIL_ADDRESS = "recoveryEmailAddress";
+    public static final String A_RECOVERY_ATTEMPTS_LEFT = "recoveryAttemptsLeft";
     public static final String A_RECOVERY_EMAIL_ADDRESS_VERIFICATION_CODE = "recoveryEmailAddressVerificationCode";
     public static final String E_RECOVER_ACCOUNT_REQUEST = "RecoverAccountRequest";
     public static final String E_RECOVER_ACCOUNT_RESPONSE = "RecoverAccountResponse";

--- a/soap/src/java/com/zimbra/soap/mail/message/RecoverAccountResponse.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/RecoverAccountResponse.java
@@ -38,6 +38,12 @@ public final class RecoverAccountResponse {
     @XmlAttribute(name = MailConstants.A_RECOVERY_EMAIL /* RecoveryEmail */, required = false)
     private String recoveryEmail;
 
+    /**
+     * @zm-api-field-description attempts remaining before feature suspension
+     */
+    @XmlAttribute(name = MailConstants.A_RECOVERY_ATTEMPTS_LEFT /* RecoveryAttemptsLeft */, required = false)
+    private Integer recoveryAttemptsLeft;
+
     public RecoverAccountResponse() {
     }
 
@@ -59,8 +65,17 @@ public final class RecoverAccountResponse {
         this.recoveryEmail = email;
     }
 
+    public Integer getRecoveryAttemptsLeft() {
+        return recoveryAttemptsLeft;
+    }
+
+    public void setRecoveryAttemptsLeft(Integer recoveryAttemptsLeft) {
+        this.recoveryAttemptsLeft = recoveryAttemptsLeft;
+    }
+
     public Objects.ToStringHelper addToStringInfo(Objects.ToStringHelper helper) {
-        return helper.add("recoveryEmail", recoveryEmail);
+        return helper.add("recoveryEmail", recoveryEmail)
+                    .add("recoveryAttemptsRemain", recoveryAttemptsLeft);
     }
 
     @Override

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9462,11 +9462,11 @@ TODO: delete them permanently from here
   <desc>status of password reset feature</desc>
 </attr>
 
-<attr id="2135" name="zimbraPrefPasswordRecoveryAddress" type="cs_emailp" cardinality="single" optionalIn="account" flags="accountInfo"  callback="RecoveryEmailCallback" since="8.8.9">
+<attr id="2135" name="zimbraPrefPasswordRecoveryAddress" type="cs_emailp" cardinality="single" optionalIn="account" flags="accountInfo" callback="RecoveryEmailCallback" since="8.8.9">
   <desc>RFC822 recovery email address for an account</desc>
 </attr>
 
-<attr id="2136" name="zimbraPrefPasswordRecoveryAddressStatus" type="enum" value="verified,pending" cardinality="single" optionalIn="account" flags="accountInfo" since="8.8.9">
+<attr id="2136" name="zimbraPrefPasswordRecoveryAddressStatus" type="enum" value="verified,pending" cardinality="single" optionalIn="account" flags="accountInfo" callback="RecoveryEmailCallback" since="8.8.9">
   <desc>End-user recovery email address verification status</desc>
 </attr>
 

--- a/store/docs/soap.txt
+++ b/store/docs/soap.txt
@@ -4794,8 +4794,9 @@ getRecoveryEmail = get recovery email only if it's verified.
 sendRecoveryCode = send recovery code to recovery email only if it's verified.
 user_email = email address of the user who forgot the password.
 
-<RecoverAccountResponse recoveryEmail="{recory_email_address}" />
+<RecoverAccountResponse recoveryEmail="{recory_email_address}" recoveryAttemptsLeft="{recovery_attempts_left}"/>
 recory_email_address = verified recovery email address for getRecoveryEmail operation
+recovery_attempts_left = attempts remaining before feature suspension
 
 -----------------------------
 API to reset password of authenticated account under zimbraAccount namespace.

--- a/store/src/java/com/zimbra/cs/service/util/ResetPasswordUtil.java
+++ b/store/src/java/com/zimbra/cs/service/util/ResetPasswordUtil.java
@@ -42,6 +42,7 @@ public class ResetPasswordUtil {
                 Date now = new Date();
                 if (suspensionTime < now.getTime()) {
                     account.setFeatureResetPasswordStatus(FeatureResetPasswordStatus.enabled);
+                    account.unsetResetPasswordRecoveryCode();
                 } else {
                     throw ServiceException.PERM_DENIED("password reset feature is suspended.");
                 }


### PR DESCRIPTION
1. return recovery attempts remaining before feature suspension in recoverAccount response.
2. clear the recovery code data when feature status is changed.ex: suspended to enabled.
