### PR TITLE
ZBUG-451:Password Expiration Notification message has odd looking subject

### DIFF
--- a/common/src/java-test/com/zimbra/common/zmime/ZInternetHeaderTest.java
+++ b/common/src/java-test/com/zimbra/common/zmime/ZInternetHeaderTest.java
@@ -154,4 +154,11 @@ public class ZInternetHeaderTest {
         decodedHeader = ZInternetHeader.decode(RAW_INVALID3);
         Assert.assertEquals(EXP_INVALID3, decodedHeader);
     }
+
+    @Test
+    public void testAscii() {
+        String decodedHeader;
+        decodedHeader = ZInternetHeader.decode("=?us-ascii?Q?a b c?=");
+        Assert.assertEquals("a b c", decodedHeader);
+    }
 }

--- a/common/src/java/com/zimbra/common/zmime/ZInternetHeader.java
+++ b/common/src/java/com/zimbra/common/zmime/ZInternetHeader.java
@@ -535,7 +535,7 @@ public class ZInternetHeader {
                     currElement.appendBody(content[pos]);
                 }
             } else if (currStat == SequenceType.EW) {
-                if (content[pos] == ' ' || content[pos] == '\t') {
+                if ((content[pos] == ' ' || content[pos] == '\t') && !"us-ascii".equalsIgnoreCase(currElement.getCharset())) {
                     return null;
                 } else if (encodeStat == EncodeSequenceState.TEXT && (pos < (end - 1)) && content[pos] == '?' && content[pos + 1] == '=' ) {
                     pos++;


### PR DESCRIPTION
Password Expiration mail subject was not properly decoded as it had spaces in the encoded word.As per RFC 2047, spaces should not be there in encoded word, but we are bypassing this check for us-ascii charset for user convenience.