### PR TITLE
ZCS-5202,ZCS-5112 JSON XmlElementWrapper support broken

### DIFF
--- a/soap/src/java-test/com/zimbra/soap/JaxbToJsonTest.java
+++ b/soap/src/java-test/com/zimbra/soap/JaxbToJsonTest.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.Charset;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -98,6 +99,7 @@ import com.zimbra.soap.json.jackson.annotate.ZimbraJsonAttribute;
 import com.zimbra.soap.json.jackson.annotate.ZimbraKeyValuePairs;
 import com.zimbra.soap.mail.message.DiffDocumentResponse;
 import com.zimbra.soap.mail.message.GetFilterRulesResponse;
+import com.zimbra.soap.mail.message.GetSystemRetentionPolicyResponse;
 import com.zimbra.soap.mail.message.NoOpResponse;
 import com.zimbra.soap.mail.type.AppointmentData;
 import com.zimbra.soap.mail.type.CalendaringDataInterface;
@@ -107,6 +109,8 @@ import com.zimbra.soap.mail.type.FilterRule;
 import com.zimbra.soap.mail.type.FilterTest;
 import com.zimbra.soap.mail.type.FilterTests;
 import com.zimbra.soap.mail.type.InstanceDataInfo;
+import com.zimbra.soap.mail.type.Policy;
+import com.zimbra.soap.mail.type.RetentionPolicy;
 import com.zimbra.soap.type.GranteeType;
 import com.zimbra.soap.type.KeyValuePair;
 
@@ -1953,6 +1957,60 @@ header="X-Spam-Score"/>
         Assert.assertEquals("JSONElement xml-elem-json-attr as attribute", str1, jsonElem.getAttribute("xml-elem-json-attr"));
         // Note difference from XMLElement - for JSON this is Always an attribute but for XML it can be treated as an element
         Assert.assertEquals("JSONElement num xml-elem-json-attr elements", 0, jsonElem.listElements("xml-elem-json-attr").size());
+    }
+
+    private static String jsonEmptyGetSystemRetentionPolicyResponse =
+            "{\n" +
+            "  \"retentionPolicy\": [{\n" +
+            "      \"keep\": [{}],\n" +
+            "      \"purge\": [{}]\n" +
+            "    }],\n" +
+            "  \"_jsns\": \"urn:zimbraMail\"\n" +
+            "}";
+
+    private static String jsonGetSystemRetentionPolicyResponse =
+            "{\n" +
+            "  \"retentionPolicy\": [{\n" +
+            "      \"keep\": [{\n" +
+            "          \"policy\": [{\n" +
+            "              \"type\": \"user\",\n" +
+            "              \"lifetime\": \"200\"\n" +
+            "            }]\n" +
+            "        }],\n" +
+            "      \"purge\": [{\n" +
+            "          \"policy\": [{\n" +
+            "              \"type\": \"user\",\n" +
+            "              \"lifetime\": \"400\"\n" +
+            "            }]\n" +
+            "        }]\n" +
+            "    }],\n" +
+            "  \"_jsns\": \"urn:zimbraMail\"\n" +
+            "}";
+
+    @Test
+    public void systemRetentionPolicyResponse() throws Exception {
+        RetentionPolicy rp = new RetentionPolicy((Iterable<Policy>) null, (Iterable<Policy>) null);
+        GetSystemRetentionPolicyResponse jaxb = new GetSystemRetentionPolicyResponse(rp);
+        Element jsonJaxbElem = JacksonUtil.jaxbToJSONElement(jaxb);
+        logDebug("JSONElement from JAXB ---> prettyPrint\n%1$s", jsonJaxbElem.prettyPrint());
+        Assert.assertEquals("json string from jaxb", jsonEmptyGetSystemRetentionPolicyResponse,
+                jsonJaxbElem.prettyPrint());
+        GetSystemRetentionPolicyResponse roundtripped =
+                JaxbUtil.elementToJaxb(jsonJaxbElem, GetSystemRetentionPolicyResponse.class);
+        Assert.assertEquals("roundtripped retention policy",
+                jaxb.getRetentionPolicy().toString(), roundtripped.getRetentionPolicy().toString());
+
+        rp = new RetentionPolicy(
+                Collections.singleton(Policy.newUserPolicy("200")),
+                Collections.singleton(Policy.newUserPolicy("400")));
+        jaxb = new GetSystemRetentionPolicyResponse(rp);
+        jsonJaxbElem = JacksonUtil.jaxbToJSONElement(jaxb);
+        logDebug("JSONElement from JAXB ---> prettyPrint\n%1$s", jsonJaxbElem.prettyPrint());
+        Assert.assertEquals("json string from jaxb", jsonGetSystemRetentionPolicyResponse,
+                jsonJaxbElem.prettyPrint());
+        roundtripped = JaxbUtil.elementToJaxb(jsonJaxbElem, GetSystemRetentionPolicyResponse.class);
+        Assert.assertEquals("roundtripped retention policy",
+                jaxb.getRetentionPolicy().toString(), roundtripped.getRetentionPolicy().toString());
     }
 
     public String getZimbraJsonJaxbString(Object obj) {

--- a/soap/src/java-test/com/zimbra/soap/JaxbToJsonTest.java
+++ b/soap/src/java-test/com/zimbra/soap/JaxbToJsonTest.java
@@ -40,7 +40,6 @@ import org.apache.log4j.BasicConfigurator;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.dom4j.QName;
-import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -121,6 +120,34 @@ public class JaxbToJsonTest {
 
     private static final Logger LOG = Logger.getLogger(JaxbToJsonTest.class);
 
+    private static String jsonEmptyGetSystemRetentionPolicyResponse =
+            "{\n" +
+            "  \"retentionPolicy\": [{\n" +
+            "      \"keep\": [{}],\n" +
+            "      \"purge\": [{}]\n" +
+            "    }],\n" +
+            "  \"_jsns\": \"urn:zimbraMail\"\n" +
+            "}";
+
+    private static String jsonGetSystemRetentionPolicyResponse =
+            "{\n" +
+            "  \"retentionPolicy\": [{\n" +
+            "      \"keep\": [{\n" +
+            "          \"policy\": [{\n" +
+            "              \"type\": \"user\",\n" +
+            "              \"lifetime\": \"200\"\n" +
+            "            }]\n" +
+            "        }],\n" +
+            "      \"purge\": [{\n" +
+            "          \"policy\": [{\n" +
+            "              \"type\": \"user\",\n" +
+            "              \"lifetime\": \"400\"\n" +
+            "            }]\n" +
+            "        }]\n" +
+            "    }],\n" +
+            "  \"_jsns\": \"urn:zimbraMail\"\n" +
+            "}";
+
     static {
         BasicConfigurator.configure();
         Logger.getRootLogger().setLevel(Level.INFO);
@@ -150,10 +177,6 @@ public class JaxbToJsonTest {
         }
     }
 
-    @BeforeClass
-    public static void init() throws Exception {
-    }
-
     /**
      * the element referenced MailConstants.E_FRAG is treated in XML as an element with content but no attributes.
      * However in JSON, it is just treated like an ordinary attribute.
@@ -165,7 +188,7 @@ public class JaxbToJsonTest {
      *         }],
      */
     @Test
-    public void bug61264_AttributeDispositionCONTENThandling() throws Exception {
+    public void bug61264AttributeDispositionCONTENThandling() throws Exception {
         StringBuilder sb;
         final String uid = "uidString";
         final String frag = "Fragment text";
@@ -186,7 +209,7 @@ public class JaxbToJsonTest {
         Element jsoncalItemElem = JSONElement.mFactory.createElement(MailConstants.E_APPOINTMENT);
         jsoncalItemElem.addAttribute(MailConstants.A_UID, uid);
         jsoncalItemElem.addAttribute("x_uid", uid);
-        Element instElt = jsoncalItemElem.addElement(MailConstants.E_INSTANCE);
+        Element instElt = jsoncalItemElem.addNonUniqueElement(MailConstants.E_INSTANCE);
         instElt.addAttribute(MailConstants.E_FRAG, frag, Element.Disposition.CONTENT);
         instElt.addAttribute(MailConstants.A_CAL_IS_EXCEPTION, true);
         instElt.addAttribute(MailConstants.A_NAME, name);
@@ -194,7 +217,7 @@ public class JaxbToJsonTest {
         Element xmlcalItemElem = XMLElement.mFactory.createElement(MailConstants.E_APPOINTMENT);
         xmlcalItemElem.addAttribute(MailConstants.A_UID, uid);
         xmlcalItemElem.addAttribute("x_uid", uid);
-        Element xmlinstElt = xmlcalItemElem.addElement(MailConstants.E_INSTANCE);
+        Element xmlinstElt = xmlcalItemElem.addNonUniqueElement(MailConstants.E_INSTANCE);
         xmlinstElt.addAttribute(MailConstants.E_FRAG, frag, Element.Disposition.CONTENT);
         xmlinstElt.addAttribute(MailConstants.A_CAL_IS_EXCEPTION, true);
         xmlinstElt.addAttribute(MailConstants.A_NAME, name);
@@ -224,8 +247,8 @@ public class JaxbToJsonTest {
 
         Element parent4legacyJson = JSONElement.mFactory.createElement(new QName("legacy-json", MailConstants.NAMESPACE));
         Element parent4jackson = JSONElement.mFactory.createElement(new QName("jacksonjson", MailConstants.NAMESPACE));
-        parent4legacyJson.addElement(jsoncalItemElem);
-        parent4jackson.addElement(jacksonJaxbElem);
+        parent4legacyJson.addNonUniqueElement(jsoncalItemElem);
+        parent4jackson.addNonUniqueElement(jacksonJaxbElem);
 
         sb = new StringBuilder();
         xmlcalItemElem.output(sb);
@@ -262,32 +285,6 @@ public class JaxbToJsonTest {
         Assert.assertEquals("name", name, instE.getAttribute(MailConstants.A_NAME));
     }
 
-    private void jacksonSerializeCheck(ObjectMapper mapper, String tag, Object obj)
-    throws ServiceException {
-        String json = JacksonUtil.jaxbToJsonString(mapper, obj);
-        StringBuilder fullTag = new StringBuilder("JacksonPlay ")
-            .append(obj.getClass().getName()).append(" ").append(tag).append(" ");
-        logDebug(fullTag.toString() +
-                "JAXB --> Jackson --> String\n" + json);
-        try {
-            Element jsonElemFromJackson = JacksonUtil.jacksonJsonToElement(json, obj);
-            logDebug(fullTag.toString() +
-                    "JAXB --> Jackson --> String ---> Element ---> prettyPrint\n" +
-                    jsonElemFromJackson.prettyPrint());
-        } catch (ServiceException e) {
-            LOG.error(fullTag.toString() + "\nProblem with Element.parseJSON", e);
-        }
-        try {
-            Element jsonE = JaxbUtil.jaxbToElement(obj, JSONElement.mFactory);
-            logDebug(fullTag.toString() +
-                    "JAXB --> jaxbToElement --> Element ---> prettyPrint\n" +
-                    jsonE.prettyPrint());
-        } catch (ServiceException e) {
-            LOG.error(fullTag.toString() + "\nProblem with jaxbToElement", e);
-        }
-        logDebug("===============================================");
-    }
-
     /**
      *  {
      *    "status": [{
@@ -300,12 +297,12 @@ public class JaxbToJsonTest {
      *  }
      */
     @Test
-    public void ZmBooleanAntStringXmlElements() throws Exception {
+    public void zmBooleanAntStringXmlElements() throws Exception {
         final String msg = "ver ndx message";
         // ---------------------------------  For Comparison - Element handling
         Element legacyElem = JSONElement.mFactory.createElement(AdminConstants.VERIFY_INDEX_RESPONSE);
-        legacyElem.addElement(AdminConstants.E_STATUS).addText(String.valueOf(true));
-        legacyElem.addElement(AdminConstants.E_MESSAGE).addText(msg);
+        legacyElem.addNonUniqueElement(AdminConstants.E_STATUS).addText(String.valueOf(true));
+        legacyElem.addNonUniqueElement(AdminConstants.E_MESSAGE).addText(msg);
         logDebug("VerifyIndexResponse JSONElement ---> prettyPrint\n%1$s", legacyElem.prettyPrint());
 
         VerifyIndexResponse viResp = new VerifyIndexResponse(true, msg);
@@ -326,15 +323,15 @@ public class JaxbToJsonTest {
      *               { "disp": "disPosition 2", "_content": "text 2" }],
      */
     @Test
-    public void XmlValueAnnotation() throws Exception {
+    public void xmlValueAnnotation() throws Exception {
         String dispos1 = "disposition 1";
         String text1 = "text 1\nIn the sun";
         String dispos2 = "disPosition 2";
         String text2 = "text 2";
         // ---------------------------------  For Comparison - Element handling where the JAXB has an @XmlValue
         Element legacyElem = JSONElement.mFactory.createElement(MailConstants.DIFF_DOCUMENT_RESPONSE);
-        legacyElem.addElement(MailConstants.E_CHUNK).addAttribute(MailConstants.A_DISP, dispos1).setText(text1);
-        legacyElem.addElement(MailConstants.E_CHUNK).addAttribute(MailConstants.A_DISP, dispos2).setText(text2);
+        legacyElem.addNonUniqueElement(MailConstants.E_CHUNK).addAttribute(MailConstants.A_DISP, dispos1).setText(text1);
+        legacyElem.addNonUniqueElement(MailConstants.E_CHUNK).addAttribute(MailConstants.A_DISP, dispos2).setText(text2);
         logDebug("DiffDocumentResponse JSONElement ---> prettyPrint\n%1$s", legacyElem.prettyPrint());
         // --------------------------------- @XmlValue handling test - need @JsonProperty("_content") annotation
         DiffDocumentResponse ddResp = new DiffDocumentResponse();
@@ -387,7 +384,7 @@ public class JaxbToJsonTest {
         KVPairs roundtripped = JaxbUtil.elementToJaxb(jsonJaxbElem, KVPairs.class);
         logDebug("JSONElement (for comparison) ---> prettyPrint\n%1$s", jsonElem.prettyPrint());
         logDebug("JSONElement from JAXB ---> prettyPrint\n%1$s", jsonJaxbElem.prettyPrint());
-        List<com.zimbra.common.soap.Element.KeyValuePair> elemKVPs = jsonJaxbElem.listKeyValuePairs();
+        List<Element.KeyValuePair> elemKVPs = jsonJaxbElem.listKeyValuePairs();
         Assert.assertEquals("elemKVP num", 3, elemKVPs.size());
         List<KeyValuePair> kvps = roundtripped.getKeyValuePairs();
         Assert.assertEquals("roundtripped kvps num", 3, kvps.size());
@@ -434,7 +431,7 @@ public class JaxbToJsonTest {
         logDebug("JSONElement (for comparison) ---> prettyPrint\n%1$s", jsonElem.prettyPrint());
         logDebug("JSONElement from JAXB ---> prettyPrint\n%1$s", jsonJaxbElem.prettyPrint());
         KeyValuePairsTester roundtripped = JaxbUtil.elementToJaxb(jsonJaxbElem, KeyValuePairsTester.class);
-        List<com.zimbra.common.soap.Element.KeyValuePair> elemKVPs = jsonJaxbElem.listKeyValuePairs();
+        List<Element.KeyValuePair> elemKVPs = jsonJaxbElem.listKeyValuePairs();
         Assert.assertEquals("elemKVP num", 3, elemKVPs.size());
         Assert.assertEquals("prettyPrint", jsonElem.prettyPrint(), jsonJaxbElem.prettyPrint());
         List<KeyValuePair> kvps = roundtripped.getAttrList();
@@ -482,7 +479,7 @@ public class JaxbToJsonTest {
         String origJson = jsonJaxbElem.prettyPrint();
         logDebug("JSONElement from JAXB ---> prettyPrint\n%1$s", origJson);
         OddKeyValuePairsTester roundtripped = JaxbUtil.elementToJaxb(jsonJaxbElem, OddKeyValuePairsTester.class);
-        List<com.zimbra.common.soap.Element.KeyValuePair> elemKVPs = jsonJaxbElem.listKeyValuePairs();
+        List<Element.KeyValuePair> elemKVPs = jsonJaxbElem.listKeyValuePairs();
         Assert.assertEquals("elemKVP num", 3, elemKVPs.size());
         Assert.assertEquals("prettyPrint", jsonElem.prettyPrint(), jsonJaxbElem.prettyPrint());
         List<Attr> kvps = roundtripped.getAttrList();
@@ -522,7 +519,7 @@ public class JaxbToJsonTest {
         logDebug("JSONElement from JAXB ---> prettyPrint\n%1$s", jsonJaxbElem.prettyPrint());
         Assert.assertEquals("prettyPrint", jsonElem.prettyPrint(), jsonJaxbElem.prettyPrint());
         WrappedKeyValuePairsTester roundtripped = JaxbUtil.elementToJaxb(jsonJaxbElem, WrappedKeyValuePairsTester.class);
-        List<com.zimbra.common.soap.Element.KeyValuePair> elemKVPs = jsonJaxbElem.getElement("wrapper").listKeyValuePairs();
+        List<Element.KeyValuePair> elemKVPs = jsonJaxbElem.getElement("wrapper").listKeyValuePairs();
         Assert.assertEquals("elemKVP num", 2, elemKVPs.size());
         List<KeyValuePair> kvps = roundtripped.getAttrList();
         Assert.assertEquals("roundtripped kvps num", 2, kvps.size());
@@ -584,7 +581,7 @@ Extract from mailbox.log for creation of this DL by ZWC - demonstrating the diff
      * Desired JSON
      */
     // Re-enable when Bug 74371 is fixed? @Test
-    public void kvpForCreateDLResp_bug74371() throws Exception {
+    public void kvpForCreateDLRespBug74371() throws Exception {
         Element jsonElem = JSONElement.mFactory.createElement(
                 QName.get(AccountConstants.E_CREATE_DISTRIBUTION_LIST_RESPONSE, AccountConstants.NAMESPACE_STR));
         populateCreateDlResp(jsonElem);
@@ -606,7 +603,7 @@ Extract from mailbox.log for creation of this DL by ZWC - demonstrating the diff
         Element eDL = jsonJaxbElem.getElement(AdminConstants.E_DL);
         List<? extends KeyValuePair> kvps = roundtripped.getAttrList();
         Assert.assertEquals("roundtripped kvps num", 2, kvps.size());
-        List<com.zimbra.common.soap.Element.KeyValuePair> elemKVPs = eDL.getElement("a").listKeyValuePairs();
+        List<Element.KeyValuePair> elemKVPs = eDL.getElement("a").listKeyValuePairs();
         Assert.assertEquals("elemKVP num", 2, elemKVPs.size());
         Assert.assertEquals("prettyPrint", jsonElem.prettyPrint(), jsonJaxbElem.prettyPrint());
     }
@@ -726,16 +723,16 @@ Extract from mailbox.log for creation of this DL by ZWC - demonstrating the diff
         jaxb.addKeyValuePair(new KeyValuePair("notificationMessage", notifMsg));
         Element elem = JacksonUtil.jaxbToJSONElement(jaxb, XMbxSearchConstants.CREATE_XMBX_SEARCH_REQUEST);
         logDebug("CreateXmbxSearchRequest JSONElement from JAXB ---> prettyPrint\n%1$s", elem.prettyPrint());
-        List<com.zimbra.common.soap.Element.KeyValuePair> kvps = elem.listKeyValuePairs();
+        List<Element.KeyValuePair> kvps = elem.listKeyValuePairs();
         Assert.assertEquals("Number of keyValuePairs ", 4, kvps.size());
-        com.zimbra.common.soap.Element.KeyValuePair kvp4 = kvps.get(3);
+        Element.KeyValuePair kvp4 = kvps.get(3);
         Assert.assertEquals("KeyValuePair notificationMessage key", "notificationMessage", kvp4.getKey());
         Assert.assertEquals("KeyValuePair notificationMessage value", notifMsg, kvp4.getValue());
     }
 
     // Cut down version of com.zimbra.cs.service.admin.ToXML.encodeAttr
     private void encodeAttr(Element parent, String key, String value, String eltname, String attrname) {
-        Element e = parent.addElement(eltname);
+        Element e = parent.addNonUniqueElement(eltname);
         e.addAttribute(attrname, key);
         e.setText(value);
     }
@@ -760,7 +757,7 @@ Extract from mailbox.log for creation of this DL by ZWC - demonstrating the diff
     }
 
     private void populateCreateDlResp(Element elem) {
-        Element eDL = elem.addElement(AdminConstants.E_DL);
+        Element eDL = elem.addNonUniqueElement(AdminConstants.E_DL);
         eDL.addAttribute(AdminConstants.A_NAME, "my name");
         eDL.addAttribute(AdminConstants.A_ID, "myId");
         eDL.addAttribute(AdminConstants.A_DYNAMIC, true);
@@ -772,7 +769,7 @@ Extract from mailbox.log for creation of this DL by ZWC - demonstrating the diff
     }
 
     private void populateGetDlResp(Element elem) {
-        Element eDL = elem.addElement(AdminConstants.E_DL);
+        Element eDL = elem.addNonUniqueElement(AdminConstants.E_DL);
         eDL.addAttribute(AdminConstants.A_NAME, "my name");
         eDL.addAttribute(AdminConstants.A_ID, "myId");
         eDL.addKeyValuePair("mail", "fun@example.test", AccountConstants.E_A, AccountConstants.A_N);
@@ -804,9 +801,9 @@ Extract from mailbox.log for creation of this DL by ZWC - demonstrating the diff
         Element legacyElem = JSONElement.mFactory.createElement(AccountConstants.GET_DISTRIBUTION_LIST_MEMBERS_RESPONSE);
         legacyElem.addAttribute(AccountConstants.A_MORE, false);
         legacyElem.addAttribute(AccountConstants.A_TOTAL, 23);
-        legacyElem.addElement(AccountConstants.E_DLM).setText("dlmember1@no.where");
-        legacyElem.addElement(AccountConstants.E_DLM).setText("dlmember2@no.where");
-        legacyElem.addElement(AccountConstants.E_DLM).setText("dlmember3@no.where");
+        legacyElem.addNonUniqueElement(AccountConstants.E_DLM).setText("dlmember1@no.where");
+        legacyElem.addNonUniqueElement(AccountConstants.E_DLM).setText("dlmember2@no.where");
+        legacyElem.addNonUniqueElement(AccountConstants.E_DLM).setText("dlmember3@no.where");
         logDebug("GetDistributionListMembersResponse JSONElement ---> prettyPrint\n%1$s", legacyElem.prettyPrint());
         // GetDistributionListMembersResponse has:
         //      @XmlElement(name=AccountConstants.E_DLM, required=false)
@@ -901,23 +898,23 @@ header="X-Spam-Score"/>
      */
     private Element mkFilterRulesResponse(Element.ElementFactory factory) {
         Element legacyElem = factory.createElement(MailConstants.GET_FILTER_RULES_RESPONSE);
-        Element filterRulesE = legacyElem.addElement(MailConstants.E_FILTER_RULES);
-        Element filterRuleE = filterRulesE.addElement(MailConstants.E_FILTER_RULE);
+        Element filterRulesE = legacyElem.addNonUniqueElement(MailConstants.E_FILTER_RULES);
+        Element filterRuleE = filterRulesE.addNonUniqueElement(MailConstants.E_FILTER_RULE);
         filterRuleE.addAttribute(MailConstants.A_NAME, "filter.bug65572");
         filterRuleE.addAttribute(MailConstants.A_ACTIVE, false);
-        Element filterTestsE = filterRuleE.addElement(MailConstants.E_FILTER_TESTS);
+        Element filterTestsE = filterRuleE.addNonUniqueElement(MailConstants.E_FILTER_TESTS);
         filterTestsE.addAttribute(MailConstants.A_CONDITION, "anyof");
-        Element hdrTestE = filterTestsE.addElement(MailConstants.E_HEADER_TEST);
+        Element hdrTestE = filterTestsE.addNonUniqueElement(MailConstants.E_HEADER_TEST);
         hdrTestE.addAttribute(MailConstants.A_INDEX, 0);
         hdrTestE.addAttribute(MailConstants.A_HEADER, "X-Spam-Score");
         hdrTestE.addAttribute(MailConstants.A_CASE_SENSITIVE, false);  /* not actually in above test */
         hdrTestE.addAttribute(MailConstants.A_STRING_COMPARISON, "contains");
         hdrTestE.addAttribute(MailConstants.A_VALUE, "0");
-        Element filterActionsE = filterRuleE.addElement(MailConstants.E_FILTER_ACTIONS);
-        Element actionFlagE = filterActionsE.addElement(MailConstants.E_ACTION_FLAG);
+        Element filterActionsE = filterRuleE.addNonUniqueElement(MailConstants.E_FILTER_ACTIONS);
+        Element actionFlagE = filterActionsE.addNonUniqueElement(MailConstants.E_ACTION_FLAG);
         actionFlagE.addAttribute(MailConstants.A_FLAG_NAME, "flagged");
         actionFlagE.addAttribute(MailConstants.A_INDEX, 0);
-        Element actionStopE = filterActionsE.addElement(MailConstants.E_ACTION_STOP);
+        Element actionStopE = filterActionsE.addNonUniqueElement(MailConstants.E_ACTION_STOP);
         actionStopE.addAttribute(MailConstants.A_INDEX, 1);
         return legacyElem;
     }
@@ -959,7 +956,7 @@ header="X-Spam-Score"/>
      * @throws Exception
      */
     @Test
-    public void bug65572_BooleanAndXmlElements() throws Exception {
+    public void bug65572BooleanAndXmlElements() throws Exception {
         Element legacyXmlElem = mkFilterRulesResponse(XMLElement.mFactory);
         Element legacyJsonElem = mkFilterRulesResponse(JSONElement.mFactory);
 
@@ -1036,7 +1033,7 @@ header="X-Spam-Score"/>
      * use for Zimbra JSON now handles lists of strings this way by default.  GetFilterRules uses JAXB rather than
      * Element already.
      * Similar situation using Element based code for GetDistributionListMembers response used multiple calls to:
-     *     parent.addElement(AccountConstants.E_DLM).setText(member);
+     *     parent.addNonUniqueElement(AccountConstants.E_DLM).setText(member);
      * Desired JSON :
       {
         "condition": "anyof",
@@ -1091,7 +1088,7 @@ header="X-Spam-Score"/>
     public void xmlEnumValuesInAttrAndElem() throws Exception {
         Element jsonElem = JSONElement.mFactory.createElement(QName.get("enum-tester", "urn:zimbraTest"));
         jsonElem.addAttribute("fold1", ViewEnum.VIRTUAL_CONVERSATION.toString());
-        jsonElem.addElement("fold2").addText(ViewEnum.UNKNOWN.toString());
+        jsonElem.addNonUniqueElement("fold2").addText(ViewEnum.UNKNOWN.toString());
         EnumAttribEnumElem tstr = new EnumAttribEnumElem();
         tstr.setFold1(ViewEnum.VIRTUAL_CONVERSATION);
         tstr.setFold2(ViewEnum.UNKNOWN);
@@ -1156,7 +1153,7 @@ header="X-Spam-Score"/>
         final String elem1Val = "My element ONE";
         Element jsonElem = JSONElement.mFactory.createElement(QName.get("string-tester", "urn:zimbraTest2"));
         jsonElem.addAttribute("attribute-1", attr1Val);
-        jsonElem.addElement(QName.get("element1", "urn:zimbraTest3")).addText(elem1Val);
+        jsonElem.addNonUniqueElement(QName.get("element1", "urn:zimbraTest3")).addText(elem1Val);
         StringAttrStringElem tstr = new StringAttrStringElem();
         tstr.setAttr1(attr1Val);
         tstr.setElem1(elem1Val);
@@ -1194,9 +1191,9 @@ header="X-Spam-Score"/>
         final String attr1Val = "My attribute ONE";
         final String elem1Val = "My element ONE";
         Element jsonElem = JSONElement.mFactory.createElement(QName.get("ns-delta", "urn:ZimbraTest4"));
-        Element saseElem = jsonElem.addElement(QName.get("strAttrStrElem", "urn:ZimbraTest5"));
+        Element saseElem = jsonElem.addNonUniqueElement(QName.get("strAttrStrElem", "urn:ZimbraTest5"));
         saseElem.addAttribute("attribute-1", attr1Val);
-        saseElem.addElement(QName.get("element1", "urn:ZimbraTest3")).addText(elem1Val);
+        saseElem.addNonUniqueElement(QName.get("element1", "urn:ZimbraTest3")).addText(elem1Val);
         logDebug("JSONElement (for comparison) ---> prettyPrint\n%1$s", jsonElem.prettyPrint());
         NamespaceDeltaElem tstr = new NamespaceDeltaElem();
         StringAttrStringElem tstrSase = new StringAttrStringElem();
@@ -1276,8 +1273,8 @@ header="X-Spam-Score"/>
     }
 
     /**
-     * A JSON element added via {@code addElement} is always serialized as an array, because there could be
-     * further {@code addElement} calls with the same element name.  On the other hand, a JSON element added via
+     * A JSON element added via {@code addNonUniqueElement} is always serialized as an array, because there could be
+     * further {@code addNonUniqueElement} calls with the same element name.  On the other hand, a JSON element added via
      * {@code addUniqueElement} won't be serialized as an array as their is an implicit assumption that there will
      * be only one element with that name.
      * Desired JSON :
@@ -1305,7 +1302,7 @@ header="X-Spam-Score"/>
         final String valueStr = new Integer(value).toString();
         Element jsonElem = JSONElement.mFactory.createElement(QName.get("unique-tester", "urn:zimbraTest"));
         jsonElem.addUniqueElement(QName.get("unique-str-elem", "urn:zimbraTest1")).setText(elem1);
-        jsonElem.addElement(QName.get("non-unique-elem", "urn:zimbraTest1")).setText(elem1);
+        jsonElem.addNonUniqueElement(QName.get("non-unique-elem", "urn:zimbraTest1")).setText(elem1);
         jsonElem.addUniqueElement("unique-complex-elem").addAttribute("attr1", attrib1).setText(valueStr);
         logDebug("JSONElement (for comparison) ---> prettyPrint\n%1$s", jsonElem.prettyPrint());
         UniqueTester tstr = new UniqueTester();
@@ -1344,9 +1341,9 @@ header="X-Spam-Score"/>
     @Test
     public void enumElemList() throws Exception {
         Element jsonElem = JSONElement.mFactory.createElement(QName.get("enum-elem-list", "urn:zimbraTest"));
-        jsonElem.addElement("enum-entry").addText(ViewEnum.APPOINTMENT.toString());
-        jsonElem.addElement("enum-entry").addText(ViewEnum.UNKNOWN.toString());
-        jsonElem.addElement("enum-entry").addText(ViewEnum.DOCUMENT.toString());
+        jsonElem.addNonUniqueElement("enum-entry").addText(ViewEnum.APPOINTMENT.toString());
+        jsonElem.addNonUniqueElement("enum-entry").addText(ViewEnum.UNKNOWN.toString());
+        jsonElem.addNonUniqueElement("enum-entry").addText(ViewEnum.DOCUMENT.toString());
         logDebug("JSONElement (for comparison) ---> prettyPrint\n%1$s", jsonElem.prettyPrint());
         EnumElemList tstr = new EnumElemList();
         tstr.addEntry(ViewEnum.APPOINTMENT);
@@ -1404,9 +1401,9 @@ header="X-Spam-Score"/>
     @Test
     public void wrappedEnumElemList() throws Exception {
         Element jsonElem = JSONElement.mFactory.createElement(QName.get("wrapped-enum-elem-list", "urn:zimbraTest"));
-        Element wrapElem = jsonElem.addElement("wrapper");
-        wrapElem.addElement("enum-entry").addText(ViewEnum.APPOINTMENT.toString());
-        wrapElem.addElement("enum-entry").addText(ViewEnum.DOCUMENT.toString());
+        Element wrapElem = jsonElem.addNonUniqueElement("wrapper");
+        wrapElem.addNonUniqueElement("enum-entry").addText(ViewEnum.APPOINTMENT.toString());
+        wrapElem.addNonUniqueElement("enum-entry").addText(ViewEnum.DOCUMENT.toString());
         logDebug("JSONElement (for comparison) ---> prettyPrint\n%1$s", jsonElem.prettyPrint());
         WrappedEnumElemList tstr = new WrappedEnumElemList();
         tstr.addEntry(ViewEnum.APPOINTMENT);
@@ -1942,9 +1939,9 @@ header="X-Spam-Score"/>
         Element jsonElem = JSONElement.mFactory.createElement(QName.get("XmlElemJsonAttr", "urn:zimbraTest"));
         Element xmlElem = XMLElement.mFactory.createElement(QName.get("XmlElemJsonAttr", "urn:zimbraTest"));
         jsonElem.addAttribute("xml-elem-json-attr", str1, Element.Disposition.CONTENT);
-        jsonElem.addElement("classic-elem").setText(str2);
+        jsonElem.addNonUniqueElement("classic-elem").setText(str2);
         xmlElem.addAttribute("xml-elem-json-attr", str1, Element.Disposition.CONTENT);
-        xmlElem.addElement("classic-elem").setText(str2);
+        xmlElem.addNonUniqueElement("classic-elem").setText(str2);
         logDebug("XMLElement ---> prettyPrint\n%1$s", xmlElem.prettyPrint());
         logDebug("JSONElement ---> prettyPrint\n%1$s", jsonElem.prettyPrint());
         XmlElemJsonAttr jaxb = new XmlElemJsonAttr(str1, str2);
@@ -1958,34 +1955,6 @@ header="X-Spam-Score"/>
         // Note difference from XMLElement - for JSON this is Always an attribute but for XML it can be treated as an element
         Assert.assertEquals("JSONElement num xml-elem-json-attr elements", 0, jsonElem.listElements("xml-elem-json-attr").size());
     }
-
-    private static String jsonEmptyGetSystemRetentionPolicyResponse =
-            "{\n" +
-            "  \"retentionPolicy\": [{\n" +
-            "      \"keep\": [{}],\n" +
-            "      \"purge\": [{}]\n" +
-            "    }],\n" +
-            "  \"_jsns\": \"urn:zimbraMail\"\n" +
-            "}";
-
-    private static String jsonGetSystemRetentionPolicyResponse =
-            "{\n" +
-            "  \"retentionPolicy\": [{\n" +
-            "      \"keep\": [{\n" +
-            "          \"policy\": [{\n" +
-            "              \"type\": \"user\",\n" +
-            "              \"lifetime\": \"200\"\n" +
-            "            }]\n" +
-            "        }],\n" +
-            "      \"purge\": [{\n" +
-            "          \"policy\": [{\n" +
-            "              \"type\": \"user\",\n" +
-            "              \"lifetime\": \"400\"\n" +
-            "            }]\n" +
-            "        }]\n" +
-            "    }],\n" +
-            "  \"_jsns\": \"urn:zimbraMail\"\n" +
-            "}";
 
     @Test
     public void systemRetentionPolicyResponse() throws Exception {

--- a/soap/src/java/com/zimbra/soap/json/JacksonUtil.java
+++ b/soap/src/java/com/zimbra/soap/json/JacksonUtil.java
@@ -23,6 +23,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlSchema;
 
 import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.base.Strings;
@@ -169,6 +170,7 @@ public final class JacksonUtil {
         ObjectMapper mapper = new ObjectMapper();
         mapper.setAnnotationIntrospector(getZimbraIntrospector());
         mapper.enable(SerializationFeature.INDENT_OUTPUT);
+        mapper.enable(MapperFeature.USE_WRAPPER_NAME_AS_PROPERTY_NAME);
         ZimbraJsonModule zimbraModule = new ZimbraJsonModule();
         // Doesn't appear to work. ZimbraBeanPropertyWriter uses this directly instead.
         // zimbraModule.addSerializer(org.w3c.dom.Element.class, new ZmDomElementJsonSerializer());

--- a/soap/src/java/com/zimbra/soap/json/jackson/ZimbraJaxbAnnotationIntrospector.java
+++ b/soap/src/java/com/zimbra/soap/json/jackson/ZimbraJaxbAnnotationIntrospector.java
@@ -26,6 +26,11 @@ import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 
+/**
+ * This class exists because of:
+ *     https://github.com/FasterXML/jackson-modules-base/issues/47
+ * Perhaps when that is fixed, this can go away.
+ */
 public class ZimbraJaxbAnnotationIntrospector extends JaxbAnnotationIntrospector {
     private static final long serialVersionUID = 3903948048784286612L;
 

--- a/soap/src/java/com/zimbra/soap/json/jackson/ZimbraJaxbAnnotationIntrospector.java
+++ b/soap/src/java/com/zimbra/soap/json/jackson/ZimbraJaxbAnnotationIntrospector.java
@@ -1,0 +1,74 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.soap.json.jackson;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+
+import com.fasterxml.jackson.databind.PropertyName;
+import com.fasterxml.jackson.databind.introspect.Annotated;
+import com.fasterxml.jackson.databind.introspect.AnnotatedField;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
+
+public class ZimbraJaxbAnnotationIntrospector extends JaxbAnnotationIntrospector {
+    private static final long serialVersionUID = 3903948048784286612L;
+
+    public ZimbraJaxbAnnotationIntrospector(TypeFactory typeFactory) {
+        super(typeFactory);
+    }
+
+    @Override
+    public PropertyName findNameForSerialization(Annotated a)
+    {
+        PropertyName propertyName = super.findNameForSerialization(a);
+        if (propertyName == null) {
+            return propertyName;
+        }
+        PropertyName pn = null;
+        if (a instanceof AnnotatedMethod) {
+            AnnotatedMethod am = (AnnotatedMethod) a;
+            pn = xmlElementWrapperName(am);
+        }
+        if (a instanceof AnnotatedField) {
+            AnnotatedField af = (AnnotatedField) a;
+            pn = xmlElementWrapperName(af);
+        }
+        return pn != null ? pn : propertyName;
+    }
+
+    private PropertyName xmlElementWrapperName(Annotated ae) {
+        XmlElement element = ae.getAnnotation(XmlElement.class);
+        if (element == null) {
+            return null;
+        }
+        XmlElementWrapper wrapper = ae.getAnnotation(XmlElementWrapper.class);
+        return (wrapper == null) ? null : combineNames(wrapper.name(), wrapper.namespace());
+    }
+
+    private static PropertyName combineNames(String localName, String namespace)
+    {
+        if (MARKER_FOR_DEFAULT.equals(localName)) {
+            return null;
+        }
+        if (MARKER_FOR_DEFAULT.equals(namespace)) {
+            return new PropertyName(localName);
+        }
+        return new PropertyName(localName, namespace);
+    }
+}

--- a/soap/src/java/com/zimbra/soap/json/jackson/ZmPairAnnotationIntrospector.java
+++ b/soap/src/java/com/zimbra/soap/json/jackson/ZmPairAnnotationIntrospector.java
@@ -28,30 +28,25 @@ import com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.databind.util.ClassUtil;
-import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 import com.zimbra.common.soap.Element;
-
 
     /**
      * Zimbra specific annotation introspector.  Mostly based on a pair of annotation introspectors
-     * (JacksonAnnotationIntrospector/JaxbAnnotationIntrospector)
-     * 
+     * (JacksonAnnotationIntrospector/ZimbraJaxbAnnotationIntrospector)
+     * ZimbraJaxbAnnotationIntrospector is a hopefully temporary wrapper round JaxbAnnotationIntrospector
+     * to get around a bug.
+     *
      * @XmlValue handling - Zimbra uses the property name "_content" (JaxbAnnotationIntrospector uses "value")
-     * 
+     *
      * Enum value handling - Use JaxbAnnotationIntrospector's handling in preference to JacksonAnnotationIntrospector's
      */
 public final class ZmPairAnnotationIntrospector extends AnnotationIntrospectorPair {
-    /**
-         * 
-         */
         private static final long serialVersionUID = -3110570221665228877L;
 
     public ZmPairAnnotationIntrospector() {
-
-        super(new JacksonAnnotationIntrospector(), new
-            JaxbAnnotationIntrospector(TypeFactory.defaultInstance()));
+        super(new JacksonAnnotationIntrospector(),
+            new ZimbraJaxbAnnotationIntrospector(TypeFactory.defaultInstance()));
     }
-
 
     @Override // since 2.7
     public String[] findEnumValues(Class<?> enumType, Enum<?>[] enumValues, String[] names) {
@@ -84,9 +79,6 @@ public final class ZmPairAnnotationIntrospector extends AnnotationIntrospectorPa
         return names;
     }
 
-
-
-    
     @Override
     public PropertyName findNameForSerialization(Annotated am) {
         String name = findJaxbValueName(am);
@@ -94,7 +86,6 @@ public final class ZmPairAnnotationIntrospector extends AnnotationIntrospectorPa
         propName = (!propName.isEmpty()) ? propName : super.findNameForSerialization(am);
         return propName;
     }
-     
 
     @Override
     public PropertyName findNameForDeserialization(Annotated af) {
@@ -103,7 +94,6 @@ public final class ZmPairAnnotationIntrospector extends AnnotationIntrospectorPa
         return (!propName.isEmpty()) ? propName : super.findNameForDeserialization(af);
     }
 
-    
     /**
      * @return "_content" if the XmlValue annotation is found, otherwise null
      */
@@ -116,7 +106,5 @@ public final class ZmPairAnnotationIntrospector extends AnnotationIntrospectorPa
     public String findPropertyDefaultValue(Annotated ann) {
         String name = findJaxbValueName(ann);
       return (name != null) ? name : super.findPropertyDefaultValue(ann);
-
     }
-
 }


### PR DESCRIPTION
This is a workaround for a presumed bug in Jackson (see https://github.com/FasterXML/jackson-modules-base/issues/47) where it doesn't work with our way of mapping `@XmlElementWrapper` / `@XmlElement` annotated properties to JSON - we use the name in `@XmlElementWrapper` rather than the usual Jackson preference for the name in `@XmlElement`.
In theory, there is a feature which should switch things to work the way we want them to work but that doesn't work, at least in specific scenarios we use where we have the same name at the `@XmlElement` level for objects of the same class for 2 different fields.
After that change, can now select "edit properties" of the inbox in ZWC and also configure message retention.