### PR TITLE
ZCS-5266: Errors shown on UI should be language independent

### DIFF
--- a/store/src/java-test/com/zimbra/cs/service/RecoverAccountTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/RecoverAccountTest.java
@@ -209,7 +209,7 @@ public class RecoverAccountTest {
         try {
             new RecoverAccount().handle(req, ServiceTestUtil.getRequestContext(acct1));
         } catch(ServiceException se) {
-            Assert.assertEquals(se.getMessage(), "system failure: Something went wrong. Please contact your administrator.");
+            Assert.assertEquals("service exception: Something went wrong. Please contact your administrator.", se.getMessage());
         }
     }
 
@@ -265,14 +265,14 @@ public class RecoverAccountTest {
             new RecoverAccount().handle(req, ServiceTestUtil.getRequestContext(acct1));// resend count = 4, and it should fail
             Assert.fail("ServiceException should be thrown.");
         } catch(ServiceException se) {
-            Assert.assertEquals("invalid request: Max resend attempts reached, feature is suspended", se.getMessage());
+            Assert.assertEquals("service exception: Max re-send attempts reached, feature is suspended.", se.getMessage());
         }
 
         try {
             ResetPasswordUtil.validateFeatureResetPasswordStatus(acct1);
             Assert.fail("ServiceException should be thrown.");
         } catch (ServiceException e) {
-            Assert.assertEquals("permission denied: password reset feature is suspended.", e.getMessage());
+            Assert.assertEquals("service exception: Password reset feature is suspended.", e.getMessage());
         }
 
         Thread.sleep(10000);
@@ -291,7 +291,7 @@ public class RecoverAccountTest {
             ResetPasswordUtil.validateFeatureResetPasswordStatus(acct1);
             Assert.fail("ServiceException should be thrown.");
         } catch (ServiceException e) {
-            Assert.assertEquals("permission denied: password reset feature is not enabled.", e.getMessage());
+            Assert.assertEquals("service exception: Password reset feature is disabled.", e.getMessage());
         }
     }
 

--- a/store/src/java-test/com/zimbra/cs/service/SetRecoveryAccountTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/SetRecoveryAccountTest.java
@@ -219,7 +219,7 @@ public class SetRecoveryAccountTest {
             Assert.fail("Exception should have been thrown");
         } catch (ServiceException e) {
             Assert.assertEquals(
-                "invalid request: Verification code already sent to this recovery email.",
+                "service exception: Verification code already sent to this recovery email.",
                 e.getMessage());
         }
     }
@@ -238,7 +238,7 @@ public class SetRecoveryAccountTest {
             Assert.fail("Exception should have been thrown");
         } catch (ServiceException e) {
             Assert.assertEquals(
-                "system failure: Recovery address should not be same as primary/alias email address.",
+                "service exception: Recovery address should not be same as primary/alias email address.",
                 e.getMessage());
         }
     }

--- a/store/src/java/com/zimbra/cs/account/EmailChannel.java
+++ b/store/src/java/com/zimbra/cs/account/EmailChannel.java
@@ -102,7 +102,7 @@ public class EmailChannel extends ChannelProvider {
             ZimbraSoapContext zsc) throws ServiceException {
         Map<String, String> recoveryDataMap = getSetRecoveryAccountCodeMap(account);
         if (recoveryDataMap == null || recoveryDataMap.isEmpty()) {
-            throw ServiceException.FAILURE("Verification of code for recovery account failed.", null);
+            throw ForgetPasswordException.CODE_NOT_FOUND("Verification code for recovery email address not found on server.");
         }
         String code = recoveryDataMap.get(CodeConstants.CODE.toString());
         long expiryTime = Long.parseLong(recoveryDataMap.get(CodeConstants.EXPIRY_TIME.toString()));
@@ -115,7 +115,7 @@ public class EmailChannel extends ChannelProvider {
         }
         Date now = new Date();
         if (expiryTime < now.getTime()) {
-            throw ServiceException.FAILURE("The recovery email address verification code is expired.", null);
+            throw ForgetPasswordException.CODE_EXPIRED("The recovery email address verification code is expired.");
         }
         if (code.equals(recoveryAccountVerificationCode)) {
             HashMap<String, Object> prefs = new HashMap<String, Object>();
@@ -124,7 +124,7 @@ public class EmailChannel extends ChannelProvider {
             prefs.put(Provisioning.A_zimbraRecoveryAccountVerificationData, null);
             Provisioning.getInstance().modifyAttrs(mbox.getAccount(), prefs, true, zsc.getAuthToken());
         } else {
-            throw ServiceException.FAILURE("Verification of recovery email address verification code failed.", null);
+            throw ForgetPasswordException.CODE_MISMATCH("Verification of recovery email address verification code failed.");
         }
     }
 

--- a/store/src/java/com/zimbra/cs/account/ForgetPasswordException.java
+++ b/store/src/java/com/zimbra/cs/account/ForgetPasswordException.java
@@ -1,0 +1,94 @@
+/*
+ * ***** BEGIN LICENSE BLOCK ***** Zimbra Collaboration Suite Server Copyright
+ * (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>. *****
+ * END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.account;
+
+import com.zimbra.common.service.ServiceException;
+
+// to be used for reset password feature exceptions
+@SuppressWarnings("serial")
+public class ForgetPasswordException extends AccountServiceException {
+    private static enum Codes{
+        RECOVERY_EMAIL_SAME_AS_PRIMARY_OR_ALIAS("service.RECOVERY_EMAIL_SAME_AS_PRIMARY_OR_ALIAS"),
+        CODE_ALREADY_SENT("service.CODE_ALREADY_SENT"),
+        MAX_ATTEMPTS_REACHED("service.MAX_ATTEMPTS_REACHED"),
+        MAX_ATTEMPTS_REACHED_SUSPEND_FEATURE("service.MAX_ATTEMPTS_REACHED_SUSPEND_FEATURE"),
+        CODE_NOT_FOUND("service.CODE_NOT_FOUND"),
+        CODE_MISMATCH("service.CODE_MISMATCH"),
+        CODE_EXPIRED("service.CODE_EXPIRED"),
+        CONTACT_ADMIN("service.CONTACT_ADMIN"),
+        FEATURE_RESET_PASSWORD_SUSPENDED("service.FEATURE_RESET_PASSWORD_SUSPENDED"),
+        FEATURE_RESET_PASSWORD_DISABLED("service.FEATURE_RESET_PASSWORD_DISABLED");
+
+        private String code;
+        private Codes(String code) {
+            this.code = code;
+        }
+
+        @Override
+        public String toString() {
+            return code;
+        }
+    }
+
+    protected ForgetPasswordException(String message, String code, boolean isReceiversFault) {
+        this(message, code, isReceiversFault, null);
+    }
+
+    protected ForgetPasswordException(String message, String code, boolean isReceiversFault, Throwable cause) {
+        super(message, code, isReceiversFault, cause);
+    }
+
+    public static ServiceException RECOVERY_EMAIL_SAME_AS_PRIMARY_OR_ALIAS(String message) {
+        return new ForgetPasswordException("service exception: " + message, Codes.RECOVERY_EMAIL_SAME_AS_PRIMARY_OR_ALIAS.toString(), SENDERS_FAULT);
+    }
+
+    public static ServiceException CODE_ALREADY_SENT(String message) {
+        return new ForgetPasswordException("service exception: " + message, Codes.CODE_ALREADY_SENT.toString(), SENDERS_FAULT);
+    }
+
+    public static ServiceException MAX_ATTEMPTS_REACHED(String message) {
+        return new ForgetPasswordException("service exception: " + message, Codes.MAX_ATTEMPTS_REACHED.toString(), SENDERS_FAULT);
+    }
+
+    public static ServiceException MAX_ATTEMPTS_REACHED_SUSPEND_FEATURE(String message) {
+        return new ForgetPasswordException("service exception: " + message, Codes.MAX_ATTEMPTS_REACHED_SUSPEND_FEATURE.toString(), SENDERS_FAULT);
+    }
+
+    public static ServiceException CODE_NOT_FOUND(String message) {
+        return new ForgetPasswordException("service exception: " + message, Codes.CODE_NOT_FOUND.toString(), SENDERS_FAULT);
+    }
+
+    public static ServiceException CODE_MISMATCH(String message) {
+        return new ForgetPasswordException("service exception: " + message, Codes.CODE_MISMATCH.toString(), SENDERS_FAULT);
+    }
+
+    public static ServiceException CODE_EXPIRED(String message) {
+        return new ForgetPasswordException("service exception: " + message, Codes.CODE_EXPIRED.toString(), SENDERS_FAULT);
+    }
+
+    public static ServiceException CONTACT_ADMIN(String message) {
+        return new ForgetPasswordException("service exception: " + message, Codes.CONTACT_ADMIN.toString(), SENDERS_FAULT);
+    }
+
+    public static ServiceException FEATURE_RESET_PASSWORD_SUSPENDED(String message) {
+        return new ForgetPasswordException("service exception: " + message, Codes.FEATURE_RESET_PASSWORD_SUSPENDED.toString(), SENDERS_FAULT);
+    }
+
+    public static ServiceException FEATURE_RESET_PASSWORD_DISABLED(String message) {
+        return new ForgetPasswordException("service exception: " + message, Codes.FEATURE_RESET_PASSWORD_DISABLED.toString(), SENDERS_FAULT);
+    }
+}

--- a/store/src/java/com/zimbra/cs/service/mail/SetRecoveryAccount.java
+++ b/store/src/java/com/zimbra/cs/service/mail/SetRecoveryAccount.java
@@ -34,6 +34,7 @@ import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.ChannelProvider;
+import com.zimbra.cs.account.ForgetPasswordException;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.OperationContext;
@@ -103,7 +104,7 @@ public class SetRecoveryAccount extends DocumentHandler {
                 ZimbraLog.passwordreset.debug("sendCode: existing recovery email: %s", recoveryEmail);
             }
             if (resendCount == 0 && recoveryEmail.equals(email)) {
-                throw ServiceException.INVALID_REQUEST("Verification code already sent to this recovery email.", null);
+                throw ForgetPasswordException.CODE_ALREADY_SENT("Verification code already sent to this recovery email.");
             }
         }
         String code = RandomStringUtils.random(8, true, true);
@@ -127,7 +128,7 @@ public class SetRecoveryAccount extends DocumentHandler {
             ChannelProvider provider) throws ServiceException {
         Map<String, String> dataMap = provider.getSetRecoveryAccountCodeMap(account);
         if (dataMap == null || dataMap.isEmpty()) {
-            throw ServiceException.FAILURE("The recovery email address verification data is missing.", null);
+            throw ForgetPasswordException.CODE_NOT_FOUND("Verification code for recovery email address not found on server.");
         }
         String email = dataMap.get(CodeConstants.EMAIL.toString());
         String code = dataMap.get(CodeConstants.CODE.toString());
@@ -157,7 +158,7 @@ public class SetRecoveryAccount extends DocumentHandler {
                 provider.sendAndStoreSetRecoveryAccountCode(authAccount, mbox, dataMap, zsc, octxt, null);
             }
         } else {
-            throw ServiceException.FAILURE("Resend code request has reached maximum limit.", null);
+            throw ForgetPasswordException.MAX_ATTEMPTS_REACHED("Re-send code request has reached maximum limit.");
         }
     }
 
@@ -177,7 +178,7 @@ public class SetRecoveryAccount extends DocumentHandler {
             ZimbraLog.passwordreset.debug("validateEmail: Primary account aliases: %s", aliases);
         }
         if (aliases.contains(email) || accountName.equals(email)) {
-            throw ServiceException.FAILURE("Recovery address should not be same as primary/alias email address.", null);
+            throw ForgetPasswordException.RECOVERY_EMAIL_SAME_AS_PRIMARY_OR_ALIAS("Recovery address should not be same as primary/alias email address.");
         }
     }
 }

--- a/store/src/java/com/zimbra/cs/service/util/ResetPasswordUtil.java
+++ b/store/src/java/com/zimbra/cs/service/util/ResetPasswordUtil.java
@@ -25,6 +25,7 @@ import com.zimbra.common.account.ForgetPasswordEnums.CodeConstants;
 import com.zimbra.common.account.ZAttrProvisioning.FeatureResetPasswordStatus;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.ForgetPasswordException;
 
 public class ResetPasswordUtil {
 
@@ -44,15 +45,15 @@ public class ResetPasswordUtil {
                     account.setFeatureResetPasswordStatus(FeatureResetPasswordStatus.enabled);
                     account.unsetResetPasswordRecoveryCode();
                 } else {
-                    throw ServiceException.PERM_DENIED("password reset feature is suspended.");
+                    throw ForgetPasswordException.FEATURE_RESET_PASSWORD_SUSPENDED("Password reset feature is suspended.");
                 }
             } else {
                 account.setFeatureResetPasswordStatus(FeatureResetPasswordStatus.enabled);
             }
             break;
         case disabled:
-            throw ServiceException.PERM_DENIED("password reset feature is not enabled.");
-        default: throw ServiceException.PERM_DENIED("password reset feature is not enabled.");
+        default:
+            throw ForgetPasswordException.FEATURE_RESET_PASSWORD_DISABLED("Password reset feature is disabled.");
         }
     }
 }


### PR DESCRIPTION
**Problem:** Errors shown on UI should be language independent

**Fix:** Create error codes and pass them instead of passing plain string message for error condition.

**Testing Done:**
1. Corrected and ran unit tests for SetRecoverAccountTest and RecoverAccountTest.
2. Manually tested responses on SOAPUI.

**Testing to be done by QA:**
1. Correct required automation.
2. Test and verify errors received in responses.

**Linked PR:**
https://github.com/Zimbra/zm-web-client/pull/279