### PR TITLE
ZBUG-446 NPE avoidance

### DIFF
--- a/store/src/java/com/zimbra/cs/imap/ImapFolder.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapFolder.java
@@ -313,7 +313,7 @@ public final class ImapFolder implements ImapListener.ImapFolderData, java.io.Se
 
     @Override
     public String toString() {
-        return path.toString();
+        return (path == null) ? "NULLPATH" : path.toString();
     }
 
     /** Returns the UID Validity Value for the {@link FolderStore}.  This is the
@@ -1104,7 +1104,8 @@ public final class ImapFolder implements ImapListener.ImapFolderData, java.io.Se
         return removed;
     }
 
-    protected void restore(ImapListener sess, SessionData sdata) throws ImapSessionClosedException, ServiceException {
+    protected synchronized void restore(ImapListener sess, SessionData sdata)
+            throws ImapSessionClosedException, ServiceException {
         session = sess;
         MailboxStore sessMbox = session.getMailbox();
         if (sessMbox == null) {
@@ -1112,9 +1113,20 @@ public final class ImapFolder implements ImapListener.ImapFolderData, java.io.Se
             throw new ImapSessionClosedException();
         }
         mailboxStore = ImapMailboxStore.get(sessMbox, sessMbox.getAccountId());
+        if (mailboxStore == null) {
+            ZimbraLog.imap.warn("Unable to get mailboxStore corresponding to mailbox=%s sessionPath=%s",
+                    sessMbox, session.getPath());
+            throw new ImapSessionClosedException();
+        }
         path = session.getPath();
         // FIXME: NOT RESTORING sequence.msg.sflags PROPERLY -- need to serialize it!!!
         sessionData = sdata;
+        if (folderIdentifier == null) {
+            ZimbraLog.imap.warn("Restored ImapFolder has null folderIdentifier mailbox=%s sessionPath=%s",
+                    sessMbox, session.getPath());
+            /* We're going to have big problems with this anyway, if this is true */
+            throw new ImapSessionClosedException();
+        }
     }
 
     @Override
@@ -1169,6 +1181,14 @@ public final class ImapFolder implements ImapListener.ImapFolderData, java.io.Se
 
     @Override
     public void handleItemUpdate(int changeId, Change chg, ImapSession.AddedItems added) {
+        ImapMailboxStore mboxStore = mailboxStore;
+        if (mboxStore == null) {
+            if (ZimbraLog.imap.isDebugEnabled()) {
+                ZimbraLog.imap.debug("handleItemUpdate called when mailboxStore=null. ImapFolder=%s\n%s",
+                        this.path, ZimbraLog.getStackTrace(20));
+            }
+            return;  // restore set mailboxStore to null
+        }
         BaseItemInfo item = (BaseItemInfo) chg.what;
         int itemId;
         int fId;
@@ -1179,9 +1199,9 @@ public final class ImapFolder implements ImapListener.ImapFolderData, java.io.Se
             ZimbraLog.imap.warn("unable to get item or folder ID during handling item update", e);
             return;
         }
-        if ((folderIdentifier.accountId != null) && !folderIdentifier.accountId.equals(mailboxStore.getAccountId())) {
+        if ((folderIdentifier.accountId != null) && !folderIdentifier.accountId.equals(mboxStore.getAccountId())) {
             ZimbraLog.imap.debug("handleItemUpdate unexpectedly called with folder=%s when local mailbox is %s",
-                    folderIdentifier, mailboxStore);
+                    folderIdentifier, mboxStore);
             return;
         }
         boolean inFolder = isVirtual() || fId == folderIdentifier.id;
@@ -1214,11 +1234,19 @@ public final class ImapFolder implements ImapListener.ImapFolderData, java.io.Se
 
     @Override
     public void handleAddedMessages(int changeId, ImapSession.AddedItems added) {
+        ImapMailboxStore mboxStore = mailboxStore;
+        if (mboxStore == null) {
+            if (ZimbraLog.imap.isDebugEnabled()) {
+                ZimbraLog.imap.debug("handleAddedMessages called when mailboxStore=null. ImapFolder=%s\n%s",
+                        this.path, ZimbraLog.getStackTrace(20));
+            }
+            return;  // restore set mailboxStore to null
+        }
         boolean debug = ZimbraLog.imap.isDebugEnabled();
 
         added.sort();
         boolean recent = true;
-        for (ImapListener i4session : mailboxStore.getListeners(folderIdentifier)) {
+        for (ImapListener i4session : mboxStore.getListeners(folderIdentifier)) {
             // added messages are only \Recent if we're the first IMAP session notified about them
             if (i4session == session) {
                 break;
@@ -1261,7 +1289,7 @@ public final class ImapFolder implements ImapListener.ImapFolderData, java.io.Se
             try {
                 ZimbraLog.imap.debug("  ** moved; changing imap uid (ntfn): %s", renumber);
                 // notification will take care of adding to mailbox
-                mailboxStore.resetImapUid(renumber);
+                mboxStore.resetImapUid(renumber);
             } catch (ServiceException e) {
                 if (debug) {
                     ZimbraLog.imap.debug("  ** moved; imap uid change failed; msg hidden (ntfn): %s", renumber);

--- a/store/src/java/com/zimbra/cs/imap/LocalImapMailboxStore.java
+++ b/store/src/java/com/zimbra/cs/imap/LocalImapMailboxStore.java
@@ -101,11 +101,15 @@ public class LocalImapMailboxStore extends ImapMailboxStore {
     @Override
     public List<ImapListener> getListeners(ItemIdentifier ident) {
         List<ImapListener> listeners = new ArrayList<ImapListener>();
+        if (ident == null) {
+            ZimbraLog.imap.warnQuietlyFmt("Attempted to getListeners for null item ID on mailbox %s", this);
+            return listeners;
+        }
         for (Session listener : mailbox.getListeners(Session.Type.IMAP)) {
             if (listener instanceof ImapSession) {
                 ImapSession iListener = (ImapSession)listener;
                 if (iListener.getFolderId() == ident.id) {
-                    listeners.add((ImapListener)iListener);
+                    listeners.add(iListener);
                 }
             }
         }


### PR DESCRIPTION
This is largely safety code.  We don't appear to have been able to reproduce the NPEs reported internally and I haven't been able to either but this code should address one theory:
* thread 1 enters `restore`.
* thread 2 enters `restore` and gets all the way through.
* thread 1's associated session is being decommissioned, so it sets mailboxStore = null and throws
  an ImapSessionClosedException
* later, thread 2 accesses mailboxStore and goes boom.

I largely think of `restore` as being part of a get from cache, that get shouldn't really be fully successful until the returned object is valid and complete.  However, I have observed multiple gets from ehcache returning the same object, and then go on to call `restore` to tidy it up.  I've made `restore` synchronized so that at least you shouldn't get 2 threads doing this tidyup at the same time.
The other main safety code is to take safe copies of mailboxStore at the start of methods and if there are any problems with the fields which should be set, bail out.