### PR TITLE
ZCS-5413 Add domainInfo flag in zimbraFeatureResetPasswordStatus

### DIFF
--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9462,7 +9462,7 @@ TODO: delete them permanently from here
   <desc>list of invalid jwt</desc>
 </attr>
 
-<attr id="2134" name="zimbraFeatureResetPasswordStatus" type="enum" value="enabled,suspended,disabled" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited,accountInfo" callback="RecoveryEmailCallback" since="8.8.9">
+<attr id="2134" name="zimbraFeatureResetPasswordStatus" type="enum" value="enabled,suspended,disabled" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited,accountInfo,domainInfo" callback="RecoveryEmailCallback" since="8.8.9">
   <defaultCOSValue>disabled</defaultCOSValue>
   <desc>status of password reset feature</desc>
 </attr>

--- a/store/src/java/com/zimbra/cs/service/admin/GetDomainInfo.java
+++ b/store/src/java/com/zimbra/cs/service/admin/GetDomainInfo.java
@@ -54,7 +54,8 @@ public class GetDomainInfo extends AdminDocumentHandler {
             ZAttrProvisioning.A_zimbraSkinForegroundColor,
             ZAttrProvisioning.A_zimbraSkinSecondaryColor,
             ZAttrProvisioning.A_zimbraSkinSelectionColor,
-            ZAttrProvisioning.A_zimbraSkinFavicon);
+            ZAttrProvisioning.A_zimbraSkinFavicon,
+            ZAttrProvisioning.A_zimbraFeatureResetPasswordStatus);
 
     @Override
     public Element handle(Element request, Map<String, Object> context) throws ServiceException {


### PR DESCRIPTION
Problem: Add domainInfo flag in zimbraFeatureResetPasswordStatus

Fix:
1. Added domainInfo flag.
2. Added the same attribute in bootstrapInfoAttrs

Testing done:
Verified getDomainInfoResponse manually. Please see below soap log.

```
2018-06-29 11:51:27,485 TRACE [qtp1132967838-108:https:https://localhost:7071/service/admin/soap/GetDomainInfoRequest] [ua=ZCS/8.7.6_GA;soapId=938c569;] soap - C:
<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
  <soap:Header>
    <context xmlns="urn:zimbra">
      <nosession/>
      <userAgent name="ZCS" version="8.7.6_GA"/>
      <authTokenControl voidOnExpired="0"/>
    </context>
  </soap:Header>
  <soap:Body>
    <GetDomainInfoRequest xmlns="urn:zimbraAdmin">
      <domain by="virtualHostname">cpathak.zdev.local</domain>
    </GetDomainInfoRequest>
  </soap:Body>
</soap:Envelope>
2018-06-29 11:51:27,486 INFO  [qtp1132967838-108:https:https://localhost:7071/service/admin/soap/GetDomainInfoRequest] [ua=ZCS/8.7.6_GA;soapId=938c569;] soap - GetDomainInfoRequest elapsed=1
2018-06-29 11:51:27,487 TRACE [qtp1132967838-108:https:https://localhost:7071/service/admin/soap/GetDomainInfoRequest] [ua=ZCS/8.7.6_GA;soapId=938c569;] soap - S:
<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
  <soap:Header>
    <context xmlns="urn:zimbra"/>
  </soap:Header>
  <soap:Body>
    <GetDomainInfoResponse xmlns="urn:zimbraAdmin">
      <domain name="VALUE-BLOCKED" id="VALUE-BLOCKED">
        <a n="zimbraWebClientMaxInputBufferLength">1024</a>
        <a n="zimbraWebClientStaySignedInDisabled">FALSE</a>
        <a n="zimbraFeatureResetPasswordStatus">disabled</a>
      </domain>
    </GetDomainInfoResponse>
  </soap:Body>
</soap:Envelope>
```