### PR TITLE
Deny edit/delete custom volumes -> Zimbra 8.8.10

### DIFF
--- a/store/src/java-test/com/zimbra/cs/store/MockStoreManager.java
+++ b/store/src/java-test/com/zimbra/cs/store/MockStoreManager.java
@@ -65,6 +65,11 @@ public final class MockStoreManager extends StoreManager {
     }
 
     @Override
+    public boolean supports(StoreFeature feature, String locator) {
+         return supports(feature);
+    }
+
+    @Override
     public boolean supports(StoreFeature feature) {
         switch (feature) {
             case BULK_DELETE:

--- a/store/src/java/com/zimbra/cs/service/admin/DeleteVolume.java
+++ b/store/src/java/com/zimbra/cs/service/admin/DeleteVolume.java
@@ -26,7 +26,6 @@ import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.accesscontrol.AdminRight;
 import com.zimbra.cs.account.accesscontrol.Rights.Admin;
 import com.zimbra.cs.store.StoreManager;
-import com.zimbra.cs.volume.Volume;
 import com.zimbra.cs.volume.VolumeManager;
 import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.ZimbraSoapContext;

--- a/store/src/java/com/zimbra/cs/service/admin/DeleteVolume.java
+++ b/store/src/java/com/zimbra/cs/service/admin/DeleteVolume.java
@@ -25,6 +25,8 @@ import com.zimbra.common.soap.Element;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.accesscontrol.AdminRight;
 import com.zimbra.cs.account.accesscontrol.Rights.Admin;
+import com.zimbra.cs.store.StoreManager;
+import com.zimbra.cs.volume.Volume;
 import com.zimbra.cs.volume.VolumeManager;
 import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.ZimbraSoapContext;
@@ -45,6 +47,10 @@ public final class DeleteVolume extends AdminDocumentHandler {
 
         VolumeManager mgr = VolumeManager.getInstance();
         mgr.getVolume(req.getId()); // make sure the volume exists before doing anything heavyweight...
+        StoreManager storeManager = StoreManager.getInstance();
+        if (storeManager.supports(StoreManager.StoreFeature.CUSTOM_STORE_API, String.valueOf(req.getId()))) {
+          throw ServiceException.INVALID_REQUEST("Operation unsupported, use zxsuite to delete this volume", null);
+        }
         mgr.delete(req.getId());
         return new DeleteVolumeResponse();
     }

--- a/store/src/java/com/zimbra/cs/service/admin/ModifyVolume.java
+++ b/store/src/java/com/zimbra/cs/service/admin/ModifyVolume.java
@@ -25,6 +25,7 @@ import com.zimbra.common.soap.Element;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.accesscontrol.AdminRight;
 import com.zimbra.cs.account.accesscontrol.Rights.Admin;
+import com.zimbra.cs.store.StoreManager;
 import com.zimbra.cs.volume.Volume;
 import com.zimbra.cs.volume.VolumeManager;
 import com.zimbra.soap.JaxbUtil;
@@ -50,6 +51,10 @@ public final class ModifyVolume extends AdminDocumentHandler {
         VolumeInfo vol = req.getVolume();
         if (vol == null) {
             throw ServiceException.INVALID_REQUEST("must specify a volume Element", null);
+        }
+        StoreManager storeManager = StoreManager.getInstance();
+        if (storeManager.supports(StoreManager.StoreFeature.CUSTOM_STORE_API, String.valueOf(vol.getId()))) {
+            throw ServiceException.INVALID_REQUEST("Operation unsupported, use zxsuite to edit this volume", null);
         }
         if (vol.getType() > 0) {
             builder.setType(vol.getType());

--- a/store/src/java/com/zimbra/cs/store/StoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/StoreManager.java
@@ -117,13 +117,19 @@ public abstract class StoreManager {
          * The remote store must track reference count internally
          * and delete the actual file only when ref-count reaches 0
          */
-        SINGLE_INSTANCE_SERVER_CREATE
+        SINGLE_INSTANCE_SERVER_CREATE,
+        /**
+         * The store is a custom store that does not support standard Zimbra actions.
+         * It requires to be handled using zxsuite command
+         */
+        CUSTOM_STORE_API,
     };
 
     /**
      * Returns whether the store supports a given {@link StoreFeature}.
      */
     public abstract boolean supports(StoreFeature feature);
+    public abstract boolean supports(StoreFeature feature, String locator);
 
     /**
      * Returns a 'BlobBuilder' which can be used to store a blob in incoming

--- a/store/src/java/com/zimbra/cs/store/external/ExternalStoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/external/ExternalStoreManager.java
@@ -312,6 +312,11 @@ public abstract class ExternalStoreManager extends StoreManager implements Exter
     }
 
     @Override
+    public boolean supports(StoreFeature feature, String locator) {
+      return supports(feature);
+    }
+
+    @Override
     public boolean supports(StoreFeature feature) {
         switch (feature) {
             case BULK_DELETE:                   return false;

--- a/store/src/java/com/zimbra/cs/store/file/FileBlobStore.java
+++ b/store/src/java/com/zimbra/cs/store/file/FileBlobStore.java
@@ -66,6 +66,11 @@ public final class FileBlobStore extends StoreManager {
     }
 
     @Override
+    public boolean supports(StoreFeature feature, String locator) {
+        return supports(feature);
+    }
+
+    @Override
     public boolean supports(StoreFeature feature) {
         switch (feature) {
             case BULK_DELETE:  return true;


### PR DESCRIPTION
Hello,
  we want to deny zmvolume command and Zimbra admin web-ui to edit/delete volumes
handled by a custom StoreManager.
We can accomplish this by adding a new StoreFeature.CUSTOM_STORE_API.
ZeXtras StoreManager also allows to create volumes on different store types,
each supporting different features, so we added a new method to StoreManager to
check features of a single volume:
StoreManager.supports(StoreFeature feature, String locator)

Thanks