### PR TITLE
ZCS-90 introduce default calendar preference attribute

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -12856,6 +12856,17 @@ public class ZAttrProvisioning {
     public static final String A_zimbraPrefDedupeMessagesSentToSelf = "zimbraPrefDedupeMessagesSentToSelf";
 
     /**
+     * Default calendar folder id. Current default calendar id is 10, as
+     * calendar folder with id 10, is created for all users. Cos level change
+     * is blocked. So admin can not change value of this attribute on cos
+     * level.
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=2994)
+    public static final String A_zimbraPrefDefaultCalendarId = "zimbraPrefDefaultCalendarId";
+
+    /**
      * default font size
      *
      * @since ZCS 6.0.8

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9503,6 +9503,13 @@ TODO: delete them permanently from here
   <desc>time for which reset password feature is suspended</desc>
 </attr>
 
+<attr id="2994" name="zimbraPrefDefaultCalendarId" type="integer" cardinality="single" optionalIn="account,cos" flags="accountInherited" callback="DefaultCalendarIdCallback" since="8.8.10">
+  <defaultCOSValue>10</defaultCOSValue>
+  <desc>Default calendar folder id. Current default calendar id is 10, as calendar folder with id 10, is created for all users.
+    Cos level change is blocked. So admin can not change value of this attribute on cos level.
+  </desc>
+</attr>
+
 <attr id="2995" name="zimbraEphemeralBackendURL" type="string" cardinality="single" optionalIn="globalConfig" callback="EphemeralBackendCheck" since="8.7.6">
   <desc>URL of ephemeral storage backend</desc>
   <globalConfigValue>ldap://default</globalConfigValue>

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -42438,6 +42438,93 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * Default calendar folder id. Current default calendar id is 10, as
+     * calendar folder with id 10, is created for all users. Cos level change
+     * is blocked. So admin can not change value of this attribute on cos
+     * level.
+     *
+     * @return zimbraPrefDefaultCalendarId, or 10 if unset
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=2994)
+    public int getPrefDefaultCalendarId() {
+        return getIntAttr(Provisioning.A_zimbraPrefDefaultCalendarId, 10, true);
+    }
+
+    /**
+     * Default calendar folder id. Current default calendar id is 10, as
+     * calendar folder with id 10, is created for all users. Cos level change
+     * is blocked. So admin can not change value of this attribute on cos
+     * level.
+     *
+     * @param zimbraPrefDefaultCalendarId new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=2994)
+    public void setPrefDefaultCalendarId(int zimbraPrefDefaultCalendarId) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefDefaultCalendarId, Integer.toString(zimbraPrefDefaultCalendarId));
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Default calendar folder id. Current default calendar id is 10, as
+     * calendar folder with id 10, is created for all users. Cos level change
+     * is blocked. So admin can not change value of this attribute on cos
+     * level.
+     *
+     * @param zimbraPrefDefaultCalendarId new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=2994)
+    public Map<String,Object> setPrefDefaultCalendarId(int zimbraPrefDefaultCalendarId, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefDefaultCalendarId, Integer.toString(zimbraPrefDefaultCalendarId));
+        return attrs;
+    }
+
+    /**
+     * Default calendar folder id. Current default calendar id is 10, as
+     * calendar folder with id 10, is created for all users. Cos level change
+     * is blocked. So admin can not change value of this attribute on cos
+     * level.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=2994)
+    public void unsetPrefDefaultCalendarId() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefDefaultCalendarId, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Default calendar folder id. Current default calendar id is 10, as
+     * calendar folder with id 10, is created for all users. Cos level change
+     * is blocked. So admin can not change value of this attribute on cos
+     * level.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=2994)
+    public Map<String,Object> unsetPrefDefaultCalendarId(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefDefaultCalendarId, "");
+        return attrs;
+    }
+
+    /**
      * default font size
      *
      * @return zimbraPrefDefaultPrintFontSize, or "12pt" if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -33045,6 +33045,93 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * Default calendar folder id. Current default calendar id is 10, as
+     * calendar folder with id 10, is created for all users. Cos level change
+     * is blocked. So admin can not change value of this attribute on cos
+     * level.
+     *
+     * @return zimbraPrefDefaultCalendarId, or 10 if unset
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=2994)
+    public int getPrefDefaultCalendarId() {
+        return getIntAttr(Provisioning.A_zimbraPrefDefaultCalendarId, 10, true);
+    }
+
+    /**
+     * Default calendar folder id. Current default calendar id is 10, as
+     * calendar folder with id 10, is created for all users. Cos level change
+     * is blocked. So admin can not change value of this attribute on cos
+     * level.
+     *
+     * @param zimbraPrefDefaultCalendarId new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=2994)
+    public void setPrefDefaultCalendarId(int zimbraPrefDefaultCalendarId) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefDefaultCalendarId, Integer.toString(zimbraPrefDefaultCalendarId));
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Default calendar folder id. Current default calendar id is 10, as
+     * calendar folder with id 10, is created for all users. Cos level change
+     * is blocked. So admin can not change value of this attribute on cos
+     * level.
+     *
+     * @param zimbraPrefDefaultCalendarId new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=2994)
+    public Map<String,Object> setPrefDefaultCalendarId(int zimbraPrefDefaultCalendarId, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefDefaultCalendarId, Integer.toString(zimbraPrefDefaultCalendarId));
+        return attrs;
+    }
+
+    /**
+     * Default calendar folder id. Current default calendar id is 10, as
+     * calendar folder with id 10, is created for all users. Cos level change
+     * is blocked. So admin can not change value of this attribute on cos
+     * level.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=2994)
+    public void unsetPrefDefaultCalendarId() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefDefaultCalendarId, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Default calendar folder id. Current default calendar id is 10, as
+     * calendar folder with id 10, is created for all users. Cos level change
+     * is blocked. So admin can not change value of this attribute on cos
+     * level.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=2994)
+    public Map<String,Object> unsetPrefDefaultCalendarId(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefDefaultCalendarId, "");
+        return attrs;
+    }
+
+    /**
      * default font size
      *
      * @return zimbraPrefDefaultPrintFontSize, or "12pt" if unset

--- a/store/src/java/com/zimbra/cs/account/callback/DefaultCalendarIdCallback.java
+++ b/store/src/java/com/zimbra/cs/account/callback/DefaultCalendarIdCallback.java
@@ -1,0 +1,112 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ *
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.account.callback;
+
+import java.util.Map;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.StringUtil;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.AttributeCallback;
+import com.zimbra.cs.account.Cos;
+import com.zimbra.cs.account.Entry;
+import com.zimbra.cs.mailbox.ACL;
+import com.zimbra.cs.mailbox.Folder;
+import com.zimbra.cs.mailbox.MailItem;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailbox.Mountpoint;
+import com.zimbra.cs.mailbox.OperationContext;
+import com.zimbra.cs.mailbox.acl.FolderACL;
+
+public class DefaultCalendarIdCallback extends AttributeCallback {
+
+   @SuppressWarnings("rawtypes")
+   @Override
+   public void preModify(CallbackContext context, String attrName, Object attrValue, Map attrsToModify, Entry entry)
+           throws ServiceException {
+       // validate new value 1st
+       if (attrValue == null) {
+           throw ServiceException.INVALID_REQUEST("Invalid value received for " + attrName, null);
+       }
+       Integer value = 0;
+       try {
+           if (attrValue instanceof String[]) {
+               String[] arr = (String[]) attrValue;
+               if (arr.length < 1) {
+                   throw ServiceException.INVALID_REQUEST("Invalid value received for " + attrName, null);
+               }
+               String temp = arr[0];
+               if (StringUtil.isNullOrEmpty(temp)) {
+                   throw ServiceException.INVALID_REQUEST("Invalid value received for " + attrName, null);
+               }
+               value = Integer.valueOf(temp);
+           } else if (attrValue instanceof String) {
+               String temp = (String) attrValue;
+               if (StringUtil.isNullOrEmpty(temp)) {
+                   throw ServiceException.INVALID_REQUEST("Invalid value received for " + attrName, null);
+               }
+               value = Integer.valueOf(temp);
+           } else {
+               throw ServiceException.INVALID_REQUEST("Invalid value received for " + attrName, null);
+           }
+       } catch (NumberFormatException nfe) {
+           throw ServiceException.INVALID_REQUEST("Value for " + attrName + " must be valid integer", null);
+       }
+       if (value  == 0) {
+           throw ServiceException.INVALID_REQUEST("Invalid value received for " + attrName, null);
+       }
+
+       if (entry instanceof Account) {
+           Account account = (Account) entry;
+           Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
+           OperationContext octxt = new OperationContext(mbox);
+           Folder folder = mbox.getFolderById(octxt, value);
+           // validate if the folder exist or not
+           if (folder == null) {
+               throw ServiceException.NOT_FOUND("Folder not found for id " + value + ". Please provide valid folder id.", null);
+           }
+           // check if folder is calendar or not
+           if (folder.getDefaultView() != MailItem.Type.APPOINTMENT) {
+               throw ServiceException.INVALID_REQUEST("Folder must be a calendar folder.", null);
+           }
+           // check for permissions if it's shared calendar
+           if (folder.getType() == MailItem.Type.MOUNTPOINT) {
+              Mountpoint mp = mbox.getMountpointById(octxt, folder.getId());
+              String ownerId = mp.getOwnerId();
+              int ownerItemId = mp.getRemoteId();
+              FolderACL facl = new FolderACL(octxt, ownerId, ownerItemId);
+              boolean writeAccess = facl.canAccess(ACL.RIGHT_WRITE);
+              if (!writeAccess) {
+                  throw ServiceException.PERM_DENIED(account.getMail() + " do not have enough permissions on " + folder.getName() + " to set default.");
+              }
+           }
+       } else if (entry instanceof Cos) {
+           throw ServiceException.INVALID_REQUEST("Changing value for " + attrName + " on COS is not allowed.", null);
+       } else {
+           throw ServiceException.INVALID_REQUEST("Invalid entry received.", null);
+       }
+   }
+
+   @Override
+   public void postModify(CallbackContext context, String attrName, Entry entry) {
+       // do nothing
+   }
+}

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -10513,4 +10513,10 @@ public class Mailbox implements MailboxStore {
         // do nothing
     }
 
+    /*
+     * This method resets defalult calendar id to ID_FOLDER_CALENDAR in pref
+     */
+    public void resetDefaultCalendarId() throws ServiceException {
+        getAccount().setPrefDefaultCalendarId(ID_FOLDER_CALENDAR);
+    }
 }

--- a/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
@@ -264,6 +264,14 @@ public class ItemAction extends MailDocumentHandler {
             proxyRequest(zsc.createElement(MailConstants.NO_OP_REQUEST), context, remoteNotify.getId());
         }
 
+        // check if default calendar is deleted, if yes, reset default calendar id
+        Integer defaultCalId = mbox.getAccount().getPrefDefaultCalendarId();
+        if (defaultCalId != null
+                && (opStr.equals(MailConstants.OP_TRASH) || opStr.equals(MailConstants.OP_HARD_DELETE))
+                && result.mSuccessIds.contains(defaultCalId.toString())) {
+            ZimbraLog.mailbox.info("Default calendar deleted, so setting default calendar back to \"Calendar\"");
+            mbox.resetDefaultCalendarId();
+        }
         return result;
     }
 


### PR DESCRIPTION
Enhancement: Introduce default calendar preference attribute

Approach & Fix:
- Added new ldap attribute zimbraPrefDefaultCalendarId on account and cos level
- Added callback on the same to do verification before changing the value of it.
- Changing value on cos level is blocked
- Verified folder presence, type, and permissions in case of shared calendar.
- In case of shared calendar, can only be used as default calendar when WRITE access is available.

Testing done:
- Tested scenarios manually. (http://testrail01.buf.synacor.com/testrail/index.php?/cases/view/1272290)

Testing needs to be done by QA:
- Tests scenarios manually (http://testrail01.buf.synacor.com/testrail/index.php?/cases/view/1272290)
- Automate the same
- Test on multi-node for shared calendar case.