### PR TITLE
Bugfix/zbug 481

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/DebugConfig.java
+++ b/common/src/java/com/zimbra/common/localconfig/DebugConfig.java
@@ -234,7 +234,7 @@ public final class DebugConfig {
         "a,abbr,acronym,blockquote,div,font,h1,h2,h3,h4,h5,h6,img,li,ol,p,span,table,td,th,tr,ul");
 
     public static final String xhtmlWhitelistedAttributes = value("defang_xhtml_whitelisted_attributes",
-        "abbr,align,alt,border,cellpadding,cellspacing,cite,class,color,colspan,height,href,id,,name,rel,rev,rowspan,size,src,style,title,target,valign,width");
+        "abbr,align,alt,border,cellpadding,cellspacing,cite,class,color,colspan,height,href,id,name,rel,rev,rowspan,size,src,style,title,target,valign,width");
 
     public static boolean defang_block_form_same_host_post_req = value("defang_block_form_same_host_post_req", true);
 

--- a/common/src/java/com/zimbra/common/localconfig/DebugConfig.java
+++ b/common/src/java/com/zimbra/common/localconfig/DebugConfig.java
@@ -230,6 +230,12 @@ public final class DebugConfig {
             "defang_style_unwanted_import",
             "@import(\\s)*((\'|\")?(\\s)*(http://|https://)?([^\\s;]*)(\\s)*(\'|\")?(\\s)*;?)");
 
+    public static final String xhtmlWhitelistedTags = value("defang_xhtml_whitelisted_tags",
+        "a,abbr,acronym,blockquote,div,font,h1,h2,h3,h4,h5,h6,img,li,ol,p,span,table,td,th,tr,ul");
+
+    public static final String xhtmlWhitelistedAttributes = value("defang_xhtml_whitelisted_attributes",
+        "abbr,align,alt,border,cellpadding,cellspacing,cite,class,color,colspan,height,href,id,,name,rel,rev,rowspan,size,src,style,title,target,valign,width");
+
     public static boolean defang_block_form_same_host_post_req = value("defang_block_form_same_host_post_req", true);
 
 

--- a/store/src/java-test/com/zimbra/cs/html/XHtmlDefangTest.java
+++ b/store/src/java-test/com/zimbra/cs/html/XHtmlDefangTest.java
@@ -1,5 +1,26 @@
 package com.zimbra.cs.html;
 
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2017, 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.io.StringReader;
+
 import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParserFactory;
@@ -22,6 +43,22 @@ public class XHtmlDefangTest {
         Assert.assertFalse(sf.getFeature(Constants.EXTERNAL_GENERAL_ENTITIES));
         Assert.assertFalse(sf.getFeature(Constants.EXTERNAL_PARAMETER_ENTITIES));
         Assert.assertFalse(sf.getFeature(Constants.LOAD_EXTERNAL_DTD));
+    }
+
+    @Test
+    public void testDefang() {
+        XHtmlDefang defang = new XHtmlDefang();
+        String text = "<?xml version='1.0'\n" +
+            "encoding='UTF-8'?><svg xmlns=\"http://www.w3.org/2000/svg\"\n" +
+            "onload=\"alert('XSS in the attacchment')\"></svg>";
+        StringReader reader = new StringReader(text);
+
+        try {
+            String sanitizedText = defang.defang(reader, true);
+            Assert.assertTrue("Does not contain onload attribute.", sanitizedText.indexOf("onload") == -1);
+        } catch (IOException e) {
+            fail("No Exception should be thrown");
+        }
     }
 
 }

--- a/store/src/java/com/zimbra/cs/html/XHtmlDocumentHandler.java
+++ b/store/src/java/com/zimbra/cs/html/XHtmlDocumentHandler.java
@@ -18,6 +18,7 @@ package com.zimbra.cs.html;
 
 import java.io.IOException;
 import java.io.Writer;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.Stack;

--- a/store/src/java/com/zimbra/cs/html/XHtmlDocumentHandler.java
+++ b/store/src/java/com/zimbra/cs/html/XHtmlDocumentHandler.java
@@ -26,8 +26,10 @@ import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
+import com.zimbra.common.localconfig.DebugConfig;
+
 /**
- * A basic xhtml handler that deletes unfriendly tags and attributes.
+ * A basic xhtml handler that deletes unfriendly tags and attributes which are not whitelisted.
  * 
  * The functionality is based mostly off the DefangFilter that's used for html.
  * 
@@ -40,38 +42,15 @@ import org.xml.sax.helpers.DefaultHandler;
  */
 public class XHtmlDocumentHandler extends DefaultHandler {
     /**
-     * The list of tags that should always be removed
+     * The list of tags that should always be allowed
      */
-    private static Set<String> removeTags = new HashSet<String>();
-    
-    private static Set<String> removeAttributes = new HashSet<String>(); 
-    // fills in the static sets
-    static {
-        removeTags.add("applet");
-        removeTags.add("frame");
-        removeTags.add("frameset");
-        removeTags.add("iframe");
-        removeTags.add("object");
-        removeTags.add("script");
-        removeTags.add("style");
-        removeTags.add("animate");
-        removeTags.add("foreignobject");
-        removeTags.add("embed");
-        removeTags.add("use");
-
-        removeAttributes.add("onclick");
-        removeAttributes.add("ondblclick");
-        removeAttributes.add("onmousedown");
-        removeAttributes.add("onmouseup");
-        removeAttributes.add("onmouseover");
-        removeAttributes.add("onmousemove");
-        removeAttributes.add("onmouseout");
-        removeAttributes.add("onkeypress");
-        removeAttributes.add("onkeydown");
-        removeAttributes.add("onkeyup");
-
-    }
-
+    private static Set<String> allowTags = new HashSet<String>(
+        Arrays.asList(DebugConfig.xhtmlWhitelistedTags.split(",")));
+    /**
+     * The list of attributes that should always be allowed
+     */
+    private static Set<String> allowAttributes = new HashSet<String>(
+        Arrays.asList(DebugConfig.xhtmlWhitelistedAttributes.split(",")));
 
     /*
      * The writer that we'll write the sanitzed output to
@@ -145,7 +124,7 @@ public class XHtmlDocumentHandler extends DefaultHandler {
         String eName = "".equals(sName)? qName: sName; // element name
 
         // check to see if we're removing this tag
-        if(removeTags.contains(eName.toLowerCase())) {
+        if(!allowTags.contains(eName.toLowerCase())) {
             removedElements.push(eName.toLowerCase());
             return;
         }
@@ -161,7 +140,7 @@ public class XHtmlDocumentHandler extends DefaultHandler {
             if (attrs != null) {
               for (int i = 0; i < attrs.getLength(); i++) {
                 String aName = "".equals(attrs.getLocalName(i))? attrs.getQName(i) : attrs.getLocalName(i); // Attr name
-                if(removeAttributes.contains(aName.toLowerCase())) {
+                if(!allowAttributes.contains(aName.toLowerCase())) {
                     // just skip this attribute
                     continue;
                 }


### PR DESCRIPTION
Added white list of tags and attributes in XHtmlhandler for sanitizing mime.
Added unit test

Verified with the .svg files provided in the bug that an email is not sent and we do not get a popup.
Verified that email with pdf and html attachment and content are correctly rendered.