### PR TITLE
ZCS-5359:Create an api in admin namespace to change primary email address

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -11908,6 +11908,15 @@ public class ZAttrProvisioning {
     public static final String A_zimbraObjectType = "zimbraObjectType";
 
     /**
+     * temporary RFC822 email address of this recipient for accepting mail
+     * during account rename
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=2143)
+    public static final String A_zimbraOldMailAddress = "zimbraOldMailAddress";
+
+    /**
      * allowed OpenID Provider Endpoint URLs for authentication
      *
      * @since ZCS 7.1.0
@@ -14120,6 +14129,14 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=3018)
     public static final String A_zimbraPreviousEphemeralBackendURL = "zimbraPreviousEphemeralBackendURL";
+
+    /**
+     * timestamp of account rename and previous name of the account
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=2144)
+    public static final String A_zimbraPrimaryEmailChangeHistory = "zimbraPrimaryEmailChangeHistory";
 
     /**
      * whether this instance of Zimbra is running ZCS or some other

--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -74,6 +74,8 @@ public final class AdminConstants {
     public static final String E_SEARCH_ACCOUNTS_RESPONSE = "SearchAccountsResponse";
     public static final String E_RENAME_ACCOUNT_REQUEST = "RenameAccountRequest";
     public static final String E_RENAME_ACCOUNT_RESPONSE = "RenameAccountResponse";
+    public static final String E_CHANGE_PRIMARY_EMAIL_REQUEST = "ChangePrimaryEmailRequest";
+    public static final String E_CHANGE_PRIMARY_EMAIL_RESPONSE = "ChangePrimaryEmailResponse";
 
     public static final String E_CREATE_DOMAIN_REQUEST = "CreateDomainRequest";
     public static final String E_CREATE_DOMAIN_RESPONSE = "CreateDomainResponse";
@@ -573,6 +575,8 @@ public final class AdminConstants {
     public static final QName SEARCH_ACCOUNTS_RESPONSE = QName.get(E_SEARCH_ACCOUNTS_RESPONSE, NAMESPACE);
     public static final QName RENAME_ACCOUNT_REQUEST = QName.get(E_RENAME_ACCOUNT_REQUEST, NAMESPACE);
     public static final QName RENAME_ACCOUNT_RESPONSE = QName.get(E_RENAME_ACCOUNT_RESPONSE, NAMESPACE);
+    public static final QName CHANGE_PRIMARY_EMAIL_REQUEST = QName.get(E_CHANGE_PRIMARY_EMAIL_REQUEST, NAMESPACE);
+    public static final QName CHANGE_PRIMARY_EMAIL_RESPONSE = QName.get(E_CHANGE_PRIMARY_EMAIL_RESPONSE, NAMESPACE);
 
     public static final QName CREATE_DOMAIN_REQUEST = QName.get(E_CREATE_DOMAIN_REQUEST, NAMESPACE);
     public static final QName CREATE_DOMAIN_RESPONSE = QName.get(E_CREATE_DOMAIN_RESPONSE, NAMESPACE);

--- a/soap/src/java/com/zimbra/soap/JaxbUtil.java
+++ b/soap/src/java/com/zimbra/soap/JaxbUtil.java
@@ -658,6 +658,8 @@ public final class JaxbUtil {
             com.zimbra.soap.admin.message.RemoveStaleDeviceMetadataResponse.class,
             com.zimbra.soap.admin.message.RenameAccountRequest.class,
             com.zimbra.soap.admin.message.RenameAccountResponse.class,
+            com.zimbra.soap.admin.message.ChangePrimaryEmailRequest.class,
+            com.zimbra.soap.admin.message.ChangePrimaryEmailResponse.class,
             com.zimbra.soap.admin.message.RenameCalendarResourceRequest.class,
             com.zimbra.soap.admin.message.RenameCalendarResourceResponse.class,
             com.zimbra.soap.admin.message.RenameCosRequest.class,

--- a/soap/src/java/com/zimbra/soap/admin/message/ChangePrimaryEmailRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/ChangePrimaryEmailRequest.java
@@ -1,0 +1,67 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.soap.type.AccountSelector;
+
+/**
+ * @zm-api-command-auth-required true
+ * @zm-api-command-admin-auth-required true
+ * @zm-api-command-description Change Account
+ */
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name=AdminConstants.E_CHANGE_PRIMARY_EMAIL_REQUEST)
+@XmlType(propOrder = {})
+public class ChangePrimaryEmailRequest {
+
+    /**
+     * @zm-api-field-description Specifies the account to be changed
+     */
+    @XmlElement(name=AdminConstants.E_ACCOUNT, required=true)
+    private AccountSelector account;
+
+    /**
+     * @zm-api-field-tag new-account-name
+     * @zm-api-field-description New account name
+     */
+    @XmlElement(name=AdminConstants.E_NEW_NAME, required=true)
+    private final String newName;
+
+    /**
+     * no-argument constructor wanted by JAXB
+     */
+    @SuppressWarnings("unused")
+    private ChangePrimaryEmailRequest() {
+        this(null, null);
+    }
+
+    public ChangePrimaryEmailRequest(AccountSelector account, String newName) {
+        this.account = account;
+        this.newName = newName;
+    }
+
+    public AccountSelector getAccount() { return account; }
+    public String getNewName() { return newName; }
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/ChangePrimaryEmailResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/ChangePrimaryEmailResponse.java
@@ -1,0 +1,44 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.soap.admin.type.AccountInfo;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name=AdminConstants.E_CHANGE_PRIMARY_EMAIL_RESPONSE)
+@XmlType(propOrder = {})
+public class ChangePrimaryEmailResponse {
+    /**
+     * @zm-api-field-description Information about account after rename
+     */
+    @XmlElement(name=AdminConstants.E_ACCOUNT)
+    private AccountInfo account;
+
+    public void setAccount(AccountInfo account) {
+        this.account = account;
+    }
+
+    public AccountInfo getAccount() { return account; }
+}

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9503,6 +9503,14 @@ TODO: delete them permanently from here
   <desc>time for which reset password feature is suspended</desc>
 </attr>
 
+<attr id="2143" name="zimbraOldMailAddress" type="email" max="256" immutable="1" cardinality="single" optionalIn="mailRecipient" flags="accountInfo" since="8.8.10">
+  <desc>temporary RFC822 email address of this recipient for accepting mail during account rename</desc>
+</attr>
+
+<attr id="2144" name="zimbraPrimaryEmailChangeHistory" type="string" cardinality="multi" optionalIn="account" flags="accountInfo" since="8.8.10">
+  <desc>timestamp of account rename and previous name of the account</desc>
+</attr>
+
 <attr id="2994" name="zimbraPrefDefaultCalendarId" type="integer" cardinality="single" optionalIn="account,cos" flags="accountInherited" callback="DefaultCalendarIdCallback" since="8.8.10">
   <defaultCOSValue>10</defaultCOSValue>
   <desc>Default calendar folder id. Current default calendar id is 10, as calendar folder with id 10, is created for all users.

--- a/store/docs/soap-admin.txt
+++ b/store/docs/soap-admin.txt
@@ -225,6 +225,21 @@ Access: domain admin sufficient
    note: this request is by default proxied to the account's home server
 
 -----------------------------
+<ChangePrimaryEmailRequest>
+  <account by="id|name|foreignPrincipal">{account-to-be-renamed}</account>
+  <newName>{new-account-name}</newName>
+</ChangePrimaryEmailRequest>
+
+<ChangePrimaryEmailResponse>
+  <account name="{name}" id="{id}">
+    <a n="...">...</a>+
+  </account>
+</ChangePrimaryEmailResponse>
+
+Access: domain admin sufficient
+This api renames an account and adds old account name as an alias to the account.
+note: this request is by default proxied to the account's home server
+-----------------------------
 
 <SetPasswordRequest>
   <id>{value-of-zimbraId}</id>

--- a/store/src/java-test/com/zimbra/cs/account/MockProvisioning.java
+++ b/store/src/java-test/com/zimbra/cs/account/MockProvisioning.java
@@ -331,7 +331,7 @@ public final class MockProvisioning extends Provisioning {
 
     @Override
     public void renameAccount(String zimbraId, String newName) {
-        throw new UnsupportedOperationException();
+        //do nothing
     }
 
     @Override

--- a/store/src/java-test/com/zimbra/cs/service/admin/ChangePrimaryEmailTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/admin/ChangePrimaryEmailTest.java
@@ -1,0 +1,106 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.service.admin;
+
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.MethodRule;
+import org.junit.rules.TestName;
+import org.junit.rules.TestWatchman;
+import org.junit.runners.model.FrameworkMethod;
+
+import com.google.common.collect.Maps;
+import com.zimbra.common.account.Key;
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.common.soap.Element;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.accesscontrol.RightManager;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.service.mail.ServiceTestUtil;
+import com.zimbra.soap.JaxbUtil;
+import com.zimbra.soap.admin.message.ChangePrimaryEmailRequest;
+import com.zimbra.soap.type.AccountSelector;
+
+import junit.framework.Assert;
+
+public class ChangePrimaryEmailTest {
+    public static String zimbraServerDir = "";
+
+    @Rule
+    public TestName testName = new TestName();
+    @Rule
+    public MethodRule watchman = new TestWatchman() {
+
+        @Override
+        public void failed(Throwable e, FrameworkMethod method) {
+            System.out.println(method.getName() + " " + e.getClass().getSimpleName());
+        }
+    };
+
+    @BeforeClass
+    public static void init() throws Exception {
+        MailboxTestUtil.initServer();
+        Provisioning prov = Provisioning.getInstance();
+
+        Map<String, Object> attrs = Maps.newHashMap();
+
+        prov.createDomain("zimbra.com", attrs);
+        attrs = Maps.newHashMap();
+        attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        prov.createAccount("old@zimbra.com", "secret", attrs);
+        attrs = Maps.newHashMap();
+        attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        attrs.put(Provisioning.A_zimbraIsAdminAccount, true);
+        prov.createAccount("admin@zimbra.com", "secret", attrs);
+        RightManager.getInstance().getAllAdminRights();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        System.out.println(testName.getMethodName());
+        MailboxTestUtil.clearData();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        MailboxTestUtil.clearData();
+    }
+
+    @Test
+    public void testChangePrimaryEmail() throws Exception {
+        Account admin = Provisioning.getInstance().get(Key.AccountBy.name, "admin@zimbra.com");
+        admin.setIsAdminAccount(true);
+        ChangePrimaryEmailRequest request = new ChangePrimaryEmailRequest(AccountSelector.fromName("old@zimbra.com"), "new@zimbra.com");
+        Element req = JaxbUtil.jaxbToElement(request);
+        ChangePrimaryEmail handler = new ChangePrimaryEmail();
+        handler.setResponseQName(AdminConstants.CHANGE_PRIMARY_EMAIL_REQUEST);
+        handler.handle(req, ServiceTestUtil.getRequestContext(admin));
+        //getting new account with old name as mock provisioning doesn't rename account
+        Account newAcc = Provisioning.getInstance().get(Key.AccountBy.name, "old@zimbra.com");
+        String change = newAcc.getPrimaryEmailChangeHistory()[0];
+        Assert.assertEquals("old@zimbra.com", change.substring(0, change.indexOf("|")));
+        Assert.assertEquals("old@zimbra.com", newAcc.getAliases()[0]);
+    }
+
+}

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -34199,6 +34199,83 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * temporary RFC822 email address of this recipient for accepting mail
+     * during account rename
+     *
+     * @return zimbraOldMailAddress, or null if unset
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=2143)
+    public String getOldMailAddress() {
+        return getAttr(Provisioning.A_zimbraOldMailAddress, null, true);
+    }
+
+    /**
+     * temporary RFC822 email address of this recipient for accepting mail
+     * during account rename
+     *
+     * @param zimbraOldMailAddress new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=2143)
+    public void setOldMailAddress(String zimbraOldMailAddress) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraOldMailAddress, zimbraOldMailAddress);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * temporary RFC822 email address of this recipient for accepting mail
+     * during account rename
+     *
+     * @param zimbraOldMailAddress new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=2143)
+    public Map<String,Object> setOldMailAddress(String zimbraOldMailAddress, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraOldMailAddress, zimbraOldMailAddress);
+        return attrs;
+    }
+
+    /**
+     * temporary RFC822 email address of this recipient for accepting mail
+     * during account rename
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=2143)
+    public void unsetOldMailAddress() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraOldMailAddress, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * temporary RFC822 email address of this recipient for accepting mail
+     * during account rename
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=2143)
+    public Map<String,Object> unsetOldMailAddress(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraOldMailAddress, "");
+        return attrs;
+    }
+
+    /**
      * regex of allowed characters in password
      *
      * @return zimbraPasswordAllowedChars, or null if unset
@@ -55776,6 +55853,140 @@ public abstract class ZAttrAccount  extends MailTarget {
     public Map<String,Object> unsetPrefZmgPushNotificationEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraPrefZmgPushNotificationEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * timestamp of account rename and previous name of the account
+     *
+     * @return zimbraPrimaryEmailChangeHistory, or empty array if unset
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=2144)
+    public String[] getPrimaryEmailChangeHistory() {
+        return getMultiAttr(Provisioning.A_zimbraPrimaryEmailChangeHistory, true, true);
+    }
+
+    /**
+     * timestamp of account rename and previous name of the account
+     *
+     * @param zimbraPrimaryEmailChangeHistory new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=2144)
+    public void setPrimaryEmailChangeHistory(String[] zimbraPrimaryEmailChangeHistory) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrimaryEmailChangeHistory, zimbraPrimaryEmailChangeHistory);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * timestamp of account rename and previous name of the account
+     *
+     * @param zimbraPrimaryEmailChangeHistory new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=2144)
+    public Map<String,Object> setPrimaryEmailChangeHistory(String[] zimbraPrimaryEmailChangeHistory, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrimaryEmailChangeHistory, zimbraPrimaryEmailChangeHistory);
+        return attrs;
+    }
+
+    /**
+     * timestamp of account rename and previous name of the account
+     *
+     * @param zimbraPrimaryEmailChangeHistory new to add to existing values
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=2144)
+    public void addPrimaryEmailChangeHistory(String zimbraPrimaryEmailChangeHistory) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraPrimaryEmailChangeHistory, zimbraPrimaryEmailChangeHistory);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * timestamp of account rename and previous name of the account
+     *
+     * @param zimbraPrimaryEmailChangeHistory new to add to existing values
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=2144)
+    public Map<String,Object> addPrimaryEmailChangeHistory(String zimbraPrimaryEmailChangeHistory, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraPrimaryEmailChangeHistory, zimbraPrimaryEmailChangeHistory);
+        return attrs;
+    }
+
+    /**
+     * timestamp of account rename and previous name of the account
+     *
+     * @param zimbraPrimaryEmailChangeHistory existing value to remove
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=2144)
+    public void removePrimaryEmailChangeHistory(String zimbraPrimaryEmailChangeHistory) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraPrimaryEmailChangeHistory, zimbraPrimaryEmailChangeHistory);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * timestamp of account rename and previous name of the account
+     *
+     * @param zimbraPrimaryEmailChangeHistory existing value to remove
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=2144)
+    public Map<String,Object> removePrimaryEmailChangeHistory(String zimbraPrimaryEmailChangeHistory, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraPrimaryEmailChangeHistory, zimbraPrimaryEmailChangeHistory);
+        return attrs;
+    }
+
+    /**
+     * timestamp of account rename and previous name of the account
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=2144)
+    public void unsetPrimaryEmailChangeHistory() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrimaryEmailChangeHistory, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * timestamp of account rename and previous name of the account
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=2144)
+    public Map<String,Object> unsetPrimaryEmailChangeHistory(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrimaryEmailChangeHistory, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/service/admin/AdminService.java
+++ b/store/src/java/com/zimbra/cs/service/admin/AdminService.java
@@ -58,6 +58,7 @@ public class AdminService implements DocumentService {
         dispatcher.registerHandler(AdminConstants.REMOVE_ACCOUNT_ALIAS_REQUEST, new RemoveAccountAlias());
         dispatcher.registerHandler(AdminConstants.SEARCH_ACCOUNTS_REQUEST, new SearchAccounts());
         dispatcher.registerHandler(AdminConstants.RENAME_ACCOUNT_REQUEST, new RenameAccount());
+        dispatcher.registerHandler(AdminConstants.CHANGE_PRIMARY_EMAIL_REQUEST, new ChangePrimaryEmail());
 
         dispatcher.registerHandler(AdminConstants.SEARCH_DIRECTORY_REQUEST, new SearchDirectory());
         dispatcher.registerHandler(AdminConstants.GET_ACCOUNT_MEMBERSHIP_REQUEST, new GetAccountMembership());

--- a/store/src/java/com/zimbra/cs/service/admin/ChangePrimaryEmail.java
+++ b/store/src/java/com/zimbra/cs/service/admin/ChangePrimaryEmail.java
@@ -1,0 +1,138 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.service.admin;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang.StringUtils;
+
+import com.zimbra.common.account.Key.AccountBy;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.accesscontrol.AdminRight;
+import com.zimbra.cs.account.accesscontrol.Rights.Admin;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.soap.JaxbUtil;
+import com.zimbra.soap.ZimbraSoapContext;
+import com.zimbra.soap.admin.message.ChangePrimaryEmailRequest;
+import com.zimbra.soap.type.AccountSelector;
+
+public class ChangePrimaryEmail extends AdminDocumentHandler {
+
+    private static final String[] TARGET_ACCOUNT_PATH = new String[] { AdminConstants.E_ACCOUNT };
+
+    @Override
+    protected String[] getProxiedAccountPath() {
+        return TARGET_ACCOUNT_PATH;
+    }
+
+    /**
+     * must be careful and only allow renames from/to domains a domain admin can
+     * see
+     */
+    @Override
+    public boolean domainAuthSufficient(Map<String, Object> context) {
+        return true;
+    }
+
+    /**
+     * @return true - which means accept responsibility for measures to prevent
+     *         account harvesting by delegate admins
+     */
+    @Override
+    public boolean defendsAgainstDelegateAdminAccountHarvesting() {
+        return true;
+    }
+
+    @Override
+    public Element handle(Element request, Map<String, Object> context) throws ServiceException {
+
+        ZimbraSoapContext zsc = getZimbraSoapContext(context);
+        Provisioning prov = Provisioning.getInstance();
+
+        ChangePrimaryEmailRequest req = JaxbUtil.elementToJaxb(request);
+        String newName = req.getNewName();
+        if (StringUtils.isEmpty(newName)) {
+            throw ServiceException.INVALID_REQUEST(String.format("missing <%s>", AdminConstants.E_NEW_NAME), null);
+        }
+        AccountSelector acctSel = req.getAccount();
+        if (acctSel == null) {
+            throw ServiceException.INVALID_REQUEST(String.format("missing <%s>", AdminConstants.E_ACCOUNT), null);
+        }
+
+        String accountSelectorKey = acctSel.getKey();
+        AccountBy by = acctSel.getBy().toKeyAccountBy();
+        Account account = prov.get(by, accountSelectorKey, zsc.getAuthToken());
+
+        defendAgainstAccountHarvesting(account, by, accountSelectorKey, zsc, Admin.R_renameAccount);
+        defendAgainstAccountOrCalendarResourceHarvesting(account, by, accountSelectorKey, zsc, Admin.R_addAccountAlias,
+                Admin.R_addCalendarResourceAlias);
+
+        String oldName = account.getName();
+        String accountId = account.getId();
+
+        checkAccountRight(zsc, account, Admin.R_renameAccount);
+        checkDomainRightByEmail(zsc, newName, Admin.R_createAccount);
+        checkDomainRightByEmail(zsc, oldName, Admin.R_createAlias);
+
+        account.setOldMailAddress(oldName);
+        ZimbraLog.security.debug("old mail address set to %s for account %s", oldName, accountId);
+
+        Mailbox mbox = Provisioning.onLocalServer(account) ? MailboxManager.getInstance().getMailboxByAccount(account) : null;
+        if (mbox == null) {
+            throw ServiceException.FAILURE("unable to get mailbox for rename: " + accountId, null);
+        }
+        prov.renameAccount(accountId, newName);
+        mbox.renameMailbox(oldName, newName);
+        ZimbraLog.security.info(ZimbraLog
+                .encodeAttrs(new String[] { "cmd", "ChangePrimaryEmail", "name", oldName, "newName", newName }));
+
+        // get account again after rename
+        account = prov.get(AccountBy.id, accountId, true, zsc.getAuthToken());
+        if (account == null) {
+            throw ServiceException.FAILURE("unable to get account after rename: " + accountId, null);
+        }
+
+        prov.addAlias(account, oldName);
+        ZimbraLog.security.info(ZimbraLog.encodeAttrs(new String[] { "cmd", "ChangePrimaryEmail added alias",
+                "name", account.getName(), "alias", oldName }));
+
+        Date renameTime = new Date();
+        account.addPrimaryEmailChangeHistory(String.format("%s|%d", oldName, renameTime.getTime()));
+        account.unsetOldMailAddress();
+
+        Element response = zsc.createElement(AdminConstants.CHANGE_PRIMARY_EMAIL_RESPONSE);
+        ToXML.encodeAccount(response, account);
+        return response;
+    }
+
+    @Override
+    public void docRights(List<AdminRight> relatedRights, List<String> notes) {
+        relatedRights.add(Admin.R_renameAccount);
+        relatedRights.add(Admin.R_createAccount);
+        relatedRights.add(Admin.R_createAlias);
+        relatedRights.add(Admin.R_addCalendarResourceAlias);
+        relatedRights.add(Admin.R_addAccountAlias);
+    }
+}


### PR DESCRIPTION
1. Added zimbraOldMailAddress attribute to the account.
2. renameAccount
3. added alias with old name to renamed account.
4. removed zimbraOldMailAddress from renamed account
5. added zimbraPrimaryEmailChangeHistory to the renamed account.

new request:
\<ChangePrimaryEmailRequest\>
      \<account by="id|name|foreignPrincipal"\>{account-to-be-renamed}\</account\>
      \<newName\>{new-account-name}\</newName\>
\</ChangePrimaryEmailRequest\>


Tests | Failures | Errors | Skipped | Success rate | Time
-- | -- | -- | -- | -- | --
1327 | 0 | 0 | 10 | 100.00% | 2541.945

