### PR TITLE
ZCS-5577 Receiving Invalid request exception for CreateCosRequest.

### DIFF
--- a/store/src/java/com/zimbra/cs/account/callback/DefaultCalendarIdCallback.java
+++ b/store/src/java/com/zimbra/cs/account/callback/DefaultCalendarIdCallback.java
@@ -100,7 +100,7 @@ public class DefaultCalendarIdCallback extends AttributeCallback {
            }
        } else if (entry instanceof Cos) {
            throw ServiceException.INVALID_REQUEST("Changing value for " + attrName + " on COS is not allowed.", null);
-       } else {
+       } else if (entry != null) {
            throw ServiceException.INVALID_REQUEST("Invalid entry received.", null);
        }
    }


### PR DESCRIPTION
**Problem:** CreateCosRequest fails with invalid request exception.

**Fix:**
- Invalid request exception was thrown because the entry object is null while creating cos.
- This was not found on local as the new attribute was introduced as part ZCS-90 and It is not initialized to default value on dev environment.
- Added null check for entry object in the callback class from where the exception was being thrown.

**Testing done:**
- Tested on zdev-vm004.eng.zimbra.com by replacing store jar.
- Tested by creating cos from command line using zmprov command.
- Tested by creating cos from admin console.

**Testing to be done by QA:**
- Cos creation should not fail because of this attribute.
- Account creation should not fail because of this attribute.
