### PR TITLE
ZCS-5361:Primary Email address Changes in postfix and Mailbox code

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/DebugConfig.java
+++ b/common/src/java/com/zimbra/common/localconfig/DebugConfig.java
@@ -340,6 +340,11 @@ public final class DebugConfig {
      */
     public static final String restrictedServerLDAPAttributes = value ("restricted_server_ldap_attributes", "zimbraSSLPrivateKey");
 
+    /**
+     * sleep time between account rename and alias creation for testing mail delivery during change of primary email
+     */
+    public static final int sleepTimeForTestingChangePrimaryEmail = value ("change_primary_email_sleep_time", 0);
+
     private static boolean value(String key, boolean defaultValue) {
         String value = LC.get(key);
         return value.isEmpty() ? defaultValue : Boolean.parseBoolean(value);

--- a/store/src/java/com/zimbra/cs/ldap/unboundid/UBIDLdapFilterFactory.java
+++ b/store/src/java/com/zimbra/cs/ldap/unboundid/UBIDLdapFilterFactory.java
@@ -457,7 +457,8 @@ public class UBIDLdapFilterFactory extends ZLdapFilterFactory {
                 Filter.createANDFilter(
                         Filter.createORFilter(
                                 Filter.createEqualityFilter(Provisioning.A_zimbraMailDeliveryAddress, name),
-                                Filter.createEqualityFilter(Provisioning.A_zimbraMailAlias, name)),
+                                Filter.createEqualityFilter(Provisioning.A_zimbraMailAlias, name),
+                                Filter.createEqualityFilter(Provisioning.A_zimbraOldMailAddress, name)),
                         FILTER_ALL_ACCOUNTS));
     }
 


### PR DESCRIPTION
1. added new cache object for the zimbraOldMailAddress in AccountCache.
2. modified the LDAP filter string to search the value of zimbraOldMailAddress as well.
3. added debug config parameter for sleep between account rename and alias creation to enable QA to test mail delivery to old address during the change primary email process.
