### PR TITLE
ZCS-5359:fix proxy logic in ChangePrimaryEmail handler

### DIFF
--- a/store/src/java/com/zimbra/cs/service/admin/ChangePrimaryEmail.java
+++ b/store/src/java/com/zimbra/cs/service/admin/ChangePrimaryEmail.java
@@ -43,7 +43,7 @@ public class ChangePrimaryEmail extends AdminDocumentHandler {
     private static final String[] TARGET_ACCOUNT_PATH = new String[] { AdminConstants.E_ACCOUNT };
 
     @Override
-    protected String[] getProxiedAccountPath() {
+    protected String[] getProxiedAccountElementPath() {
         return TARGET_ACCOUNT_PATH;
     }
 


### PR DESCRIPTION
since ChangePrimaryEmail request uses Account element with Account.by selector, overridden relevant method in the handler to make the proxy work.