### PR TITLE
ZCS-2691 Create DataSource implementation for LinkedIn contacts via oAuth

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1296,7 +1296,7 @@ public final class LC {
     public static final KnownKey zm_oauth_classes_handlers_yahoo = KnownKey.newKey("com.zimbra.oauth.handlers.impl.YahooOAuth2Handler");
     public static final KnownKey zm_oauth_classes_handlers_google = KnownKey.newKey("com.zimbra.oauth.handlers.impl.GoogleOAuth2Handler");
     public static final KnownKey zm_oauth_classes_handlers_facebook = KnownKey.newKey("com.zimbra.oauth.handlers.impl.FacebookOAuth2Handler");
-    
+    public static final KnownKey zm_oauth_classes_handlers_linkedin = KnownKey.newKey("com.zimbra.oauth.handlers.impl.LinkedinOAuth2Handler");
     
     static {
         // Automatically set the key name with the variable name.


### PR DESCRIPTION
Problem/Task: create datasource implementation for Linkedin contacts sync using oAuth2

Fix:
1. Authorize and authenticate using oAuth2 rest api provided by Linkedin
2. Folder created is with name as <username>-contact-linkedin, as profile call for linkedin needs "r_fullprofile" permission and this permission in given by linkedin on request. Request with linkedin support is raised. 

Testing done:
1. Contact folder and datasource is created in user account.
2. Tested functionality manually.
```
zmprov gds cp1
# name cp1@cpathak.zdev.local-contact-linkedin
# type oauth2contact
objectClass: zimbraDataSource
zimbraCreateTimestamp: 20180724133602.672Z
zimbraDataSourceConnectionType: cleartext
zimbraDataSourceEnabled: TRUE
zimbraDataSourceFolderId: 60020
zimbraDataSourceHost: www.linkedin.com
zimbraDataSourceId: 54e84c2e-50e5-405f-aa60-9c008d41aac0
zimbraDataSourceImportClassName: com.zimbra.oauth.handlers.impl.LinkedinContactsImport
zimbraDataSourceImportOnly: FALSE
zimbraDataSourceName: cp1@cpathak.zdev.local-contact-linkedin
zimbraDataSourceOAuthRefreshToken: VALUE-BLOCKED
zimbraDataSourcePollingInterval: 1d
zimbraDataSourceType: oauth2contact
```

Testing needs to be done by QA:
1. go to https://www.linkedin.com/developer/apps
2. create app from - my apps -> create app
3. select default app permissions "r_basicprofile" and "r_emailaddress"
4. add "https://<your_host_name>/service/extension/oauth2/authenticate/linkedin" OAuth 2.0 authorized redirect url 
5. set zimbraOAuthConsumerRedirectUri: https://cpathak.zdev.local/service/extension/oauth2/authenticate/linkedin:linkedin
6. set zimbraOAuthConsumerCredentials: <app_client_id>:<app_client_secret>:linkedin
7. Make sure, Authorization and Authentication is done using oAuth2
8. Make sure, contacts folder and datasource is created as mentioned above

Linked PR:
https://github.com/Zimbra/zm-oauth-social/pull/44