### PR TITLE
ZBUG-536 Fixed email subject rendering

### DIFF
--- a/common/src/java-test/com/zimbra/common/zmime/ZInternetHeaderTest.java
+++ b/common/src/java-test/com/zimbra/common/zmime/ZInternetHeaderTest.java
@@ -38,6 +38,8 @@ public class ZInternetHeaderTest {
     private static String RAW_HEADER_COMBINED = "=?utf-8?B?V1NVUzog5pu05paw44OX44Ot44Kw44Op44Og44Gu54q25oWL" +
             "44Gu5qaC6KaB44KSIEJXU1VTVk1TViDjgYvjgonlj5fkv6HjgZfjgb7j" +
             "gZfjgZ8=?=";
+    private static String ZBUG536 = "=?iso-8859-1?B?QVBBRCAtIFN0YXRzIEFQQUQgLSBE6WJ1dCBldCBmaW4gZOljaXNpb24gZW50cmUgcG91ciBsZSBt\n" + 
+        "  b2lzIGRlIEp1aW4gMjAxOA==?=";
     private static String DECODED_HEADER = "WSUS: 更新プログラムの状態の概要を BWSUSVMSV から受信しました";
     private static String RAW_HEADER_FRENCH1 = "[FSU] Fwd: XXXXXX] =?UTF-8?Q?r=C3=A9ponse_=C3=A0?= la lettre du =?UTF-8?Q?pr=C3=A9sident=2E?=";
     private static String DECODED_FRENCH1 = "[FSU] Fwd: XXXXXX] réponse à la lettre du président.";
@@ -160,5 +162,11 @@ public class ZInternetHeaderTest {
         String decodedHeader;
         decodedHeader = ZInternetHeader.decode("=?us-ascii?Q?a b c?=");
         Assert.assertEquals("a b c", decodedHeader);
+    }
+    
+    @Test
+    public void testMultilineZBUG536Subject() {
+        String decodedHeader = ZInternetHeader.decode(ZBUG536);
+        Assert.assertEquals("APAD - Stats APAD - Début et fin décision entre pour le mois de Juin 2018", decodedHeader);
     }
 }

--- a/common/src/java/com/zimbra/common/zmime/ZInternetHeader.java
+++ b/common/src/java/com/zimbra/common/zmime/ZInternetHeader.java
@@ -535,7 +535,7 @@ public class ZInternetHeader {
                     currElement.appendBody(content[pos]);
                 }
             } else if (currStat == SequenceType.EW) {
-                if ((content[pos] == ' ' || content[pos] == '\t') && !"us-ascii".equalsIgnoreCase(currElement.getCharset())) {
+                if ((content[pos] == ' ' || content[pos] == '\t') && !allowInvalidEncoding(currElement.getCharset())) {
                     return null;
                 } else if (encodeStat == EncodeSequenceState.TEXT && (pos < (end - 1)) && content[pos] == '?' && content[pos + 1] == '=' ) {
                     pos++;
@@ -581,6 +581,15 @@ public class ZInternetHeader {
         }
         fields.add(currElement);
         return fields.getAll();
+    }
+    
+    static boolean allowInvalidEncoding(String charset) {
+        
+        if ("iso-8859-1".equalsIgnoreCase(charset) || "us-ascii".equalsIgnoreCase(charset)) {
+            return true;
+        } else {
+            return false;
+        }
     }
 
     static String unfold(final String folded) {

--- a/common/src/java/com/zimbra/common/zmime/ZInternetHeader.java
+++ b/common/src/java/com/zimbra/common/zmime/ZInternetHeader.java
@@ -583,13 +583,9 @@ public class ZInternetHeader {
         return fields.getAll();
     }
     
-    static boolean allowInvalidEncoding(String charset) {
+    public static boolean allowInvalidEncoding(String charset) {
         
-        if ("iso-8859-1".equalsIgnoreCase(charset) || "us-ascii".equalsIgnoreCase(charset)) {
-            return true;
-        } else {
-            return false;
-        }
+        return ("iso-8859-1".equalsIgnoreCase(charset) || "us-ascii".equalsIgnoreCase(charset)) ;
     }
 
     static String unfold(final String folded) {


### PR DESCRIPTION
Added code to ignore if encoded header has space which is not encoded and char set is ISO-8859-1
Added unit test.

Tests | Failures | Errors | Skipped | Success rate | Time
1327 | 0 | 0 | 10 | 100.00% | 359.591

