### PR TITLE
ZCS-5598: Bug 109012 - Account Enumeration [CWE-203]

### DIFF
--- a/store/src/java/com/zimbra/cs/service/UserServlet.java
+++ b/store/src/java/com/zimbra/cs/service/UserServlet.java
@@ -276,7 +276,6 @@ public class UserServlet extends ZimbraServlet {
             return;
         }
         if (ctxt != null &&!ctxt.cookieAuthHappened && ctxt.basicAuthAllowed() && !ctxt.basicAuthHappened) {
-            resp.addHeader(AuthUtil.WWW_AUTHENTICATE_HEADER, getRealmHeader(req, null));
             resp.sendError(HttpServletResponse.SC_UNAUTHORIZED, L10nUtil.getMessage(MsgKey.errMustAuthenticate, req));
         } else if (ctxt != null && ctxt.cookieAuthHappened && !ctxt.isCsrfAuthSucceeded()
             && (req.getMethod().equalsIgnoreCase("POST") || req.getMethod().equalsIgnoreCase("PUT"))) {


### PR DESCRIPTION
This change removes the "WWW-Authenticate: BASIC realm="Zimbra"  from the response header for existing users in the test curl calls, 401 responses.

Test calls:
curl -k -i -u 'admin:password' 'https://[zimbra.hostname]/service/home/~'
curl -k -i -u 'doesnotexistrandom737:password' 'https://[zimbra.hostname]/service/home/~'

For the following calls both 401 headers should not have the following row, 
"WWW-Authenticate: BASIC realm="Zimbra"