### PR TITLE
ZCS-5698 Add ldap attributes required for HAB

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -2902,6 +2902,15 @@ public class ZAttrProvisioning {
     public static final String A_zimbraAccountExtraObjectClass = "zimbraAccountExtraObjectClass";
 
     /**
+     * seniority index of the account which will determine the sorting order
+     * in the hierarchical address book
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=3030)
+    public static final String A_zimbraAccountSeniorityIndex = "zimbraAccountSeniorityIndex";
+
+    /**
      * account status. active - active lockout - no login until lockout
      * duration is over, mail delivery OK. locked - no login, mail delivery
      * OK. maintenance - no login, no delivery(lmtp server returns 4.x.x
@@ -7791,6 +7800,14 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=353)
     public static final String A_zimbraHideInGal = "zimbraHideInGal";
+
+    /**
+     * domain level root of hierarchical address book
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=3031)
+    public static final String A_zimbraHierarchicalAddressBookRoot = "zimbraHierarchicalAddressBookRoot";
 
     /**
      * Deprecated since: 6.0.0_BETA2. deprecated in favor for

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9726,5 +9726,13 @@ TODO: delete them permanently from here
   <desc>seniority index of the group which will determine the sorting order in the hierarchical address book</desc>
 </attr>
 
+<attr id="3030" name="zimbraAccountSeniorityIndex" type="integer" cardinality="single" optionalIn="account" since="8.8.10">
+  <desc>seniority index of the account which will determine the sorting order in the hierarchical address book</desc>
+</attr>
+
+<attr id="3031" name="zimbraHierarchicalAddressBookRoot" type="string" cardinality="multi" optionalIn="domain" flags="domainInfo" since="8.8.10">
+  <desc>domain level root of hierarchical address book</desc>
+</attr>
+
 </attrs>
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -2786,6 +2786,83 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * seniority index of the account which will determine the sorting order
+     * in the hierarchical address book
+     *
+     * @return zimbraAccountSeniorityIndex, or -1 if unset
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=3030)
+    public int getAccountSeniorityIndex() {
+        return getIntAttr(Provisioning.A_zimbraAccountSeniorityIndex, -1, true);
+    }
+
+    /**
+     * seniority index of the account which will determine the sorting order
+     * in the hierarchical address book
+     *
+     * @param zimbraAccountSeniorityIndex new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=3030)
+    public void setAccountSeniorityIndex(int zimbraAccountSeniorityIndex) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAccountSeniorityIndex, Integer.toString(zimbraAccountSeniorityIndex));
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * seniority index of the account which will determine the sorting order
+     * in the hierarchical address book
+     *
+     * @param zimbraAccountSeniorityIndex new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=3030)
+    public Map<String,Object> setAccountSeniorityIndex(int zimbraAccountSeniorityIndex, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAccountSeniorityIndex, Integer.toString(zimbraAccountSeniorityIndex));
+        return attrs;
+    }
+
+    /**
+     * seniority index of the account which will determine the sorting order
+     * in the hierarchical address book
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=3030)
+    public void unsetAccountSeniorityIndex() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAccountSeniorityIndex, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * seniority index of the account which will determine the sorting order
+     * in the hierarchical address book
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=3030)
+    public Map<String,Object> unsetAccountSeniorityIndex(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAccountSeniorityIndex, "");
+        return attrs;
+    }
+
+    /**
      * account status. active - active lockout - no login until lockout
      * duration is over, mail delivery OK. locked - no login, mail delivery
      * OK. maintenance - no login, no delivery(lmtp server returns 4.x.x

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -14402,6 +14402,140 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
+     * domain level root of hierarchical address book
+     *
+     * @return zimbraHierarchicalAddressBookRoot, or empty array if unset
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=3031)
+    public String[] getHierarchicalAddressBookRoot() {
+        return getMultiAttr(Provisioning.A_zimbraHierarchicalAddressBookRoot, true, true);
+    }
+
+    /**
+     * domain level root of hierarchical address book
+     *
+     * @param zimbraHierarchicalAddressBookRoot new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=3031)
+    public void setHierarchicalAddressBookRoot(String[] zimbraHierarchicalAddressBookRoot) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHierarchicalAddressBookRoot, zimbraHierarchicalAddressBookRoot);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * domain level root of hierarchical address book
+     *
+     * @param zimbraHierarchicalAddressBookRoot new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=3031)
+    public Map<String,Object> setHierarchicalAddressBookRoot(String[] zimbraHierarchicalAddressBookRoot, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHierarchicalAddressBookRoot, zimbraHierarchicalAddressBookRoot);
+        return attrs;
+    }
+
+    /**
+     * domain level root of hierarchical address book
+     *
+     * @param zimbraHierarchicalAddressBookRoot new to add to existing values
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=3031)
+    public void addHierarchicalAddressBookRoot(String zimbraHierarchicalAddressBookRoot) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraHierarchicalAddressBookRoot, zimbraHierarchicalAddressBookRoot);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * domain level root of hierarchical address book
+     *
+     * @param zimbraHierarchicalAddressBookRoot new to add to existing values
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=3031)
+    public Map<String,Object> addHierarchicalAddressBookRoot(String zimbraHierarchicalAddressBookRoot, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraHierarchicalAddressBookRoot, zimbraHierarchicalAddressBookRoot);
+        return attrs;
+    }
+
+    /**
+     * domain level root of hierarchical address book
+     *
+     * @param zimbraHierarchicalAddressBookRoot existing value to remove
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=3031)
+    public void removeHierarchicalAddressBookRoot(String zimbraHierarchicalAddressBookRoot) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraHierarchicalAddressBookRoot, zimbraHierarchicalAddressBookRoot);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * domain level root of hierarchical address book
+     *
+     * @param zimbraHierarchicalAddressBookRoot existing value to remove
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=3031)
+    public Map<String,Object> removeHierarchicalAddressBookRoot(String zimbraHierarchicalAddressBookRoot, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraHierarchicalAddressBookRoot, zimbraHierarchicalAddressBookRoot);
+        return attrs;
+    }
+
+    /**
+     * domain level root of hierarchical address book
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=3031)
+    public void unsetHierarchicalAddressBookRoot() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHierarchicalAddressBookRoot, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * domain level root of hierarchical address book
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=3031)
+    public Map<String,Object> unsetHierarchicalAddressBookRoot(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHierarchicalAddressBookRoot, "");
+        return attrs;
+    }
+
+    /**
      * Zimbra Systems Unique ID
      *
      * @return zimbraId, or null if unset


### PR DESCRIPTION
**Problem:** Create zimbraAccountSeniorityIndex and zimbraHierarchicalAddressBookRoot ldap attributes with given details on the jira ticket ZCS-5698.

**Fix:**  Created zimbraAccountSeniorityIndex and zimbraHierarchicalAddressBookRoot ldap attributes.

**Testing done:** Tested attributes manually using zmprov command.
```
zmprov desc -a zimbraAccountSeniorityIndex
zimbraAccountSeniorityIndex
    seniority index of the account which will determine the sorting order
    in the hierarchical address book

               type : integer
              value : 
           callback : 
          immutable : false
        cardinality : single
         requiredIn : 
         optionalIn : account
              flags : 
           defaults : 
                min : 
                max : 
                 id : 3030
    requiresRestart : 
              since : 8.8.10
    deprecatedSince : 


zmprov desc -a zimbraHierarchicalAddressBookRoot
zimbraHierarchicalAddressBookRoot
    domain level root of hierarchical address book

               type : string
              value : 
           callback : 
          immutable : false
        cardinality : multi
         requiredIn : 
         optionalIn : domain
              flags : domainInfo
           defaults : 
                min : 
                max : 
                 id : 3031
    requiresRestart : 
              since : 8.8.10
    deprecatedSince : 

```

**Testing needs to be done by QA:** Check wheather the ldap attributes are created with given details(in jara ticket) or not.