### PR TITLE
ZCS-4167: GraphQL annotations for search resource and resolver classes (conversations, messages)

### DIFF
--- a/soap/src/java/com/zimbra/soap/mail/type/CalTZInfo.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/CalTZInfo.java
@@ -32,7 +32,11 @@ import com.zimbra.common.soap.MailConstants;
 import com.zimbra.soap.base.CalTZInfoInterface;
 import com.zimbra.soap.type.TzOnsetInfo;
 
+import io.leangen.graphql.annotations.GraphQLQuery;
+import io.leangen.graphql.annotations.types.GraphQLType;
+
 @XmlAccessorType(XmlAccessType.NONE)
+@GraphQLType(name="CalTZInfo", description="Timezone specification")
 public class CalTZInfo implements CalTZInfoInterface {
 
     /**
@@ -42,6 +46,7 @@ public class CalTZInfo implements CalTZInfoInterface {
      * Otherwise, it must be present, although it will be ignored by the server
      */
     @XmlAttribute(name=MailConstants.A_ID /* id */, required=true)
+    @GraphQLQuery(name="id", description="Timezone ID.")
     private final String id;
 
     /**
@@ -49,6 +54,7 @@ public class CalTZInfo implements CalTZInfoInterface {
      * @zm-api-field-description Standard Time's offset in minutes from UTC; local = UTC + offset
      */
     @XmlAttribute(name=MailConstants.A_CAL_TZ_STDOFFSET /* stdoff */, required=true)
+    @GraphQLQuery(name="tzStdOffset", description="Standard Time's offset in minutes from UTC; local = UTC + offset")
     private final Integer tzStdOffset;
 
     /**
@@ -56,6 +62,7 @@ public class CalTZInfo implements CalTZInfoInterface {
      * @zm-api-field-description Daylight Saving Time's offset in minutes from UTC; present only if DST is used
      */
     @XmlAttribute(name=MailConstants.A_CAL_TZ_DAYOFFSET /* dayoff */, required=true)
+    @GraphQLQuery(name="tzDayOffset", description="Daylight Saving Time's offset in minutes from UTC; present only if DST is used")
     private final Integer tzDayOffset;
 
     /**
@@ -63,24 +70,28 @@ public class CalTZInfo implements CalTZInfoInterface {
      * Either specify week/wkday combo, or mday.
      */
     @XmlElement(name=MailConstants.E_CAL_TZ_STANDARD /* standard */, required=false)
+    @GraphQLQuery(name="standardTzOnset", description="Time/rule for transitioning from daylight time to standard time. Either specify week/wkday combo, or mday.")
     private TzOnsetInfo standardTzOnset;
 
     /**
      * @zm-api-field-description Time/rule for transitioning from standard time to daylight time
      */
     @XmlElement(name=MailConstants.E_CAL_TZ_DAYLIGHT /* daylight */, required=false)
+    @GraphQLQuery(name="daylightTzOnset", description="Time/rule for transitioning from standard time to daylight time. See `standardTzOnset` for more details.")
     private TzOnsetInfo daylightTzOnset;
 
     /**
      * @zm-api-field-description Standard Time component's timezone name
      */
     @XmlAttribute(name=MailConstants.A_CAL_TZ_STDNAME /* stdname */, required=false)
+    @GraphQLQuery(name="standardTZName", description="Standard Time component's timezone name")
     private String standardTZName;
 
     /**
      * @zm-api-field-description Daylight Saving Time component's timezone name
      */
     @XmlAttribute(name=MailConstants.A_CAL_TZ_DAYNAME /* dayname */, required=false)
+    @GraphQLQuery(name="daylightTZName", description="Daylight Saving Time component's timezone name")
     private String daylightTZName;
 
     /**
@@ -124,6 +135,7 @@ public class CalTZInfo implements CalTZInfoInterface {
     }
 
     @Override
+    @GraphQLQuery(name="id", description="Timezone ID.")
     public String getId() { return id; }
     @Override
     public Integer getTzStdOffset() { return tzStdOffset; }

--- a/soap/src/java/com/zimbra/soap/mail/type/ConversationHitInfo.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ConversationHitInfo.java
@@ -29,10 +29,15 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 
+import com.zimbra.common.gql.GqlConstants;
 import com.zimbra.common.soap.MailConstants;
 import com.zimbra.soap.type.SearchHit;
 
+import io.leangen.graphql.annotations.GraphQLQuery;
+import io.leangen.graphql.annotations.types.GraphQLType;
+
 @XmlAccessorType(XmlAccessType.NONE)
+@GraphQLType(name="ConversationHitInfo", description="Conversation search result information")
 public class ConversationHitInfo
 extends ConversationSummary
 implements SearchHit {
@@ -71,7 +76,10 @@ implements SearchHit {
         return this;
     }
 
+    @GraphQLQuery(name="sortField", description="The sort field")
     public String getSortField() { return sortField; }
+
+    @GraphQLQuery(name="messageHits", description="List of messages in the conversation")
     public List<ConversationMsgHitInfo> getMessageHits() {
         return Collections.unmodifiableList(messageHits);
     }

--- a/soap/src/java/com/zimbra/soap/mail/type/ConversationMsgHitInfo.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ConversationMsgHitInfo.java
@@ -25,7 +25,12 @@ import com.google.common.base.MoreObjects;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.MailConstants;
 
+import io.leangen.graphql.annotations.GraphQLQuery;
+import io.leangen.graphql.annotations.types.GraphQLType;
+import io.leangen.graphql.annotations.GraphQLNonNull;
+
 @XmlAccessorType(XmlAccessType.NONE)
+@GraphQLType(name="ConversationMsgHitInfo", description="Conversation search result information containing messages")
 public class ConversationMsgHitInfo {
 
     /**
@@ -96,11 +101,18 @@ public class ConversationMsgHitInfo {
         this.autoSendTime = autoSendTime;
     }
     public void setDate(Long date) { this.date = date; }
+    @GraphQLNonNull
+    @GraphQLQuery(name="id", description="The message ID")
     public String getId() { return id; }
+    @GraphQLQuery(name="size", description="The message size")
     public Long getSize() { return size; }
+    @GraphQLQuery(name="folderId", description="The folder ID")
     public String getFolderId() { return folderId; }
+    @GraphQLQuery(name="flags", description="Flags Example: Flags. (u)nread, (f)lagged, has (a)ttachment, (r)eplied, (s)ent by me, for(w)arded, calendar in(v)ite, (d)raft, IMAP-\\Deleted (x), (n)otification sent, urgent (!), low-priority (?), priority (+)")
     public String getFlags() { return flags; }
+    @GraphQLQuery(name="autoSendTime", description="The time at which the draft should be automatically sent by the server")
     public Long getAutoSendTime() { return autoSendTime; }
+    @GraphQLQuery(name="date", description="Date Seconds since the epoch, from the date header in the message")
     public Long getDate() { return date; }
 
     /** Done like this rather than using JAXB for performance reasons */

--- a/soap/src/java/com/zimbra/soap/mail/type/ConversationSummary.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ConversationSummary.java
@@ -34,8 +34,12 @@ import com.zimbra.common.soap.MailConstants;
 import com.zimbra.soap.type.ZmBoolean;
 import com.zimbra.soap.json.jackson.annotate.ZimbraJsonAttribute;
 
+import io.leangen.graphql.annotations.GraphQLQuery;
+import io.leangen.graphql.annotations.types.GraphQLType;
+
 @XmlAccessorType(XmlAccessType.NONE)
 @XmlType(propOrder = {"metadatas", "subject", "fragment", "emails"})
+@GraphQLType(name="ConversationSummary", description="Conversation search result information")
 public class ConversationSummary {
 
     /**
@@ -194,22 +198,37 @@ public class ConversationSummary {
         this.emails.add(email);
     }
 
+    @GraphQLQuery(name="id", description="Conversation ID")
     public String getId() { return id; }
+    @GraphQLQuery(name="num", description="Number of messages in conversation without IMAP \\Deleted flag set")
     public Integer getNum() { return num; }
+    @GraphQLQuery(name="numUnread", description="Number of unread messages in conversation")
     public Integer getNumUnread() { return numUnread; }
+    @GraphQLQuery(name="totalSize", description="Total number of messages in conversation including those with the IMAP \\Deleted flag")
     public Integer getTotalSize() { return totalSize; }
+    @GraphQLQuery(name="flags", description="Flags set on the conversation. (u)nread, (f)lagged, has (a)ttachment, (r)eplied, (s)ent by me, for(w)arded, calendar in(v)ite, (d)raft, IMAP-\\Deleted (x), (n)otification sent, urgent (!), low-priority (?), priority (+)")
     public String getFlags() { return flags; }
+    @GraphQLQuery(name="tags", description="Tags - Comma separated list of integers.  DEPRECATED - use \"tagNames\" instead")
     public String getTags() { return tags; }
+    @GraphQLQuery(name="tagNames", description="Comma-separated list of tag names")
     public String getTagNames() { return tagNames; }
+    @GraphQLQuery(name="date", description="Date (secs since epoch) of most recent message in the converstation")
     public Long getDate() { return date; }
+    @GraphQLQuery(name="elided", description="If elided is set, some participants are missing before the first returned")
     public Boolean getElided() { return ZmBoolean.toBool(elided); }
+    @GraphQLQuery(name="changeDate", description="Date metadata changed")
     public Long getChangeDate() { return changeDate; }
+    @GraphQLQuery(name="modifiedSequence", description="Modified sequence")
     public Integer getModifiedSequence() { return modifiedSequence; }
+    @GraphQLQuery(name="metadatas", description="Custom metadata information")
     public List<MailCustomMetadata> getMetadatas() {
         return Collections.unmodifiableList(metadatas);
     }
+    @GraphQLQuery(name="subject", description="Subject of conversation")
     public String getSubject() { return subject; }
+    @GraphQLQuery(name="fragment", description="First few bytes of the message (probably between 40 and 100 bytes)")
     public String getFragment() { return fragment; }
+    @GraphQLQuery(name="emails", description="Email information for conversation participants, if available")
     public List<EmailInfo> getEmails() {
         return Collections.unmodifiableList(emails);
     }

--- a/soap/src/java/com/zimbra/soap/mail/type/EmailInfo.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/EmailInfo.java
@@ -31,7 +31,11 @@ import com.zimbra.common.soap.MailConstants;
 import com.zimbra.soap.base.EmailInfoInterface;
 import com.zimbra.soap.type.ZmBoolean;
 
+import io.leangen.graphql.annotations.GraphQLQuery;
+import io.leangen.graphql.annotations.types.GraphQLType;
+
 @XmlAccessorType(XmlAccessType.NONE)
+@GraphQLType(name="EmailInfo", description="Email information")
 public class EmailInfo
 implements EmailInfoInterface {
 
@@ -124,16 +128,22 @@ implements EmailInfoInterface {
     }
 
     @Override
+    @GraphQLQuery(name="address", description="The email address")
     public String getAddress() { return address; }
     @Override
+    @GraphQLQuery(name="display", description="The email addresses display name. Example: \"Jane Doe\" <local@domain.com>")
     public String getDisplay() { return display; }
     @Override
+    @GraphQLQuery(name="personal", description="The comment/name part of an address")
     public String getPersonal() { return personal; }
     @Override
+    @GraphQLQuery(name="addressType", description="Address type. Example: (f)rom, (t)o, (c)c, (b)cc, (r)eply-to, (s)ender, read-receipt (n)otification, (rf) resent-from")
     public String getAddressType() { return addressType; }
     @Override
+    @GraphQLQuery(name="group", description="Set if the email address is a group")
     public Boolean getGroup() { return ZmBoolean.toBool(group); }
     @Override
+    @GraphQLQuery(name="canExpandGroupMembers", description="Denotes that the group can be expanded showing its members")
     public Boolean getCanExpandGroupMembers() { return ZmBoolean.toBool(canExpandGroupMembers); }
 
     public static Iterable <EmailInfo> fromInterfaces(Iterable <EmailInfoInterface> ifs) {

--- a/soap/src/java/com/zimbra/soap/mail/type/MailCustomMetadata.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/MailCustomMetadata.java
@@ -51,7 +51,6 @@ implements CustomMetadataInterface {
      * report on.
      */
     @XmlAttribute(name=MailConstants.A_SECTION /* section */, required=false)
-    @GraphQLQuery(name="section", description="Section")
     private String section;
 
     public MailCustomMetadata() {
@@ -60,6 +59,7 @@ implements CustomMetadataInterface {
     @Override
     public void setSection(String section) { this.section = section; }
     @Override
+    @GraphQLQuery(name="section", description="Section. If absent this indicates that CustomMetadata info is present but there are no sections to report on.")
     public String getSection() { return section; }
 
     public static List <MailCustomMetadata> fromInterfaces(Iterable <CustomMetadataInterface> params) {

--- a/soap/src/java/com/zimbra/soap/mail/type/MessageCommon.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/MessageCommon.java
@@ -34,6 +34,10 @@ import com.zimbra.common.soap.MailConstants;
 import com.zimbra.soap.base.CustomMetadataInterface;
 import com.zimbra.soap.base.MessageCommonInterface;
 
+import io.leangen.graphql.annotations.GraphQLQuery;
+import io.leangen.graphql.annotations.types.GraphQLType;
+import io.leangen.graphql.annotations.GraphQLNonNull;
+
 @XmlAccessorType(XmlAccessType.NONE)
 @XmlType(propOrder = {"metadatas"})
 public class MessageCommon
@@ -158,25 +162,37 @@ implements MessageCommonInterface {
     }
 
     @Override
+    @GraphQLQuery(name="size", description="Size in bytes")
     public Long getSize() { return size; }
     @Override
+    @GraphQLQuery(name="date", description="Date Seconds since the epoch, from the date header in the message")
     public Long getDate() { return date; }
     @Override
+    @GraphQLQuery(name="folder", description="Folder ID")
     public String getFolder() { return folder; }
     @Override
+    @GraphQLQuery(name="conversationId", description="Converstation ID")
     public String getConversationId() { return conversationId; }
     @Override
+    @GraphQLQuery(name="flags", description="Flags set on the conversation. (u)nread, (f)lagged, has (a)ttachment, (r)eplied, (s)ent by me, for(w)arded, calendar in(v)ite, (d)raft, IMAP-Deleted (x), (n)otification sent, urgent (!), low-priority (?), priority (+)")
     public String getFlags() { return flags; }
     @Override
+    @GraphQLQuery(name="tags", description="Tags - Comma separated list of integers. DEPRECATED - use \"tagNames\" instead")
     public String getTags() { return tags; }
     @Override
+    @GraphQLQuery(name="tagNames", description="Comma-separated list of tag names")
     public String getTagNames() { return tagNames; }
     @Override
+    @GraphQLQuery(name="revision", description="Revision increment")
     public Integer getRevision() { return revision; }
     @Override
+    @GraphQLQuery(name="changeDate", description="Date metadata changed")
     public Long getChangeDate() { return changeDate; }
     @Override
+    @GraphQLQuery(name="modifiedSequence", description="Change sequence")
     public Integer getModifiedSequence() { return modifiedSequence; }
+
+    @GraphQLQuery(name="metadatas", description="Custom metadata information")
     public List<MailCustomMetadata> getMetadatas() {
         return Collections.unmodifiableList(metadatas);
     }

--- a/soap/src/java/com/zimbra/soap/mail/type/MessageHitInfo.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/MessageHitInfo.java
@@ -33,7 +33,12 @@ import com.zimbra.common.soap.MailConstants;
 import com.zimbra.soap.type.SearchHit;
 import com.zimbra.soap.type.ZmBoolean;
 
+import io.leangen.graphql.annotations.GraphQLQuery;
+import io.leangen.graphql.annotations.types.GraphQLType;
+import io.leangen.graphql.annotations.GraphQLNonNull;
+
 @XmlAccessorType(XmlAccessType.NONE)
+@GraphQLType(name="MessageHitInfo", description="Message search result information containing a list of messages")
 public class MessageHitInfo
 extends MessageInfo
 implements SearchHit {
@@ -83,8 +88,11 @@ implements SearchHit {
         return this;
     }
 
+    @GraphQLQuery(name="sortField", description="The sort field value")
     public String getSortField() { return sortField; }
+    @GraphQLQuery(name="contentMatched", description="If the message matched the specified query string")
     public Boolean getContentMatched() { return ZmBoolean.toBool(contentMatched); }
+    @GraphQLQuery(name="messagePartHits", description="Hit Parts, indicators that the named parts matched the search string")
     public List<Part> getMessagePartHits() {
         return Collections.unmodifiableList(messagePartHits);
     }

--- a/soap/src/java/com/zimbra/soap/mail/type/MessageInfo.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/MessageInfo.java
@@ -37,9 +37,16 @@ import com.zimbra.soap.base.MessageInfoInterface;
 import com.zimbra.soap.json.jackson.annotate.ZimbraJsonAttribute;
 import com.zimbra.soap.type.KeyValuePair;
 
+import io.leangen.graphql.annotations.GraphQLQuery;
+import io.leangen.graphql.annotations.types.GraphQLType;
+import io.leangen.graphql.annotations.GraphQLNonNull;
+import io.leangen.graphql.annotations.GraphQLIgnore;
+
 @XmlAccessorType(XmlAccessType.NONE)
 @XmlType(propOrder = { "fragment", "emails", "subject",
     "messageIdHeader", "inReplyTo", "invite", "headers", "contentElems" })
+
+@GraphQLType(name="MessageInfo", description="Message information")
 public class MessageInfo
 extends MessageCommon
 implements MessageInfoInterface {
@@ -199,6 +206,7 @@ implements MessageInfoInterface {
     public void setId(String id) { this.id = id; }
 
     public void setImapUid(Integer imapUid) { this.imapUid = imapUid; }
+    @GraphQLQuery(name="imapUid", description="The imap UID")
     public Integer getImapUid() { return imapUid; }
 
     @Override
@@ -286,42 +294,60 @@ implements MessageInfoInterface {
     }
 
     @Override
+    @GraphQLQuery(name="id", description="The message ID")
     public String getId() { return id; }
     @Override
+    @GraphQLQuery(name="calendarIntendedFor", description="X-Zimbra-Calendar-Intended-For header")
     public String getCalendarIntendedFor() { return calendarIntendedFor; }
     @Override
+    @GraphQLQuery(name="origId", description="Message id of the message being replied to/forwarded (outbound messages only)")
     public String getOrigId() { return origId; }
     @Override
+    @GraphQLQuery(name="draftReplyType", description="Reply type - r|w")
     public String getDraftReplyType() { return draftReplyType; }
     @Override
+    @GraphQLQuery(name="identityId", description="Specifies the identity being used to compose the message")
     public String getIdentityId() { return identityId; }
     @Override
+    @GraphQLQuery(name="draftAccountId", description="Draft account ID")
     public String getDraftAccountId() { return draftAccountId; }
     @Override
+    @GraphQLQuery(name="draftAutoSendTime", description="Specifies the time at which the draft should be automatically sent by the server")
     public Long getDraftAutoSendTime() { return draftAutoSendTime; }
     @Override
+    @GraphQLQuery(name="sentDate", description="The sent date in the header")
     public Long getSentDate() { return sentDate; }
     @Override
+    @GraphQLQuery(name="resentDate", description="The re-sent date in the header")
     public Long getResentDate() { return resentDate; }
     @Override
+    @GraphQLQuery(name="part", description="Part")
     public String getPart() { return part; }
     @Override
+    @GraphQLQuery(name="fragment", description="First few bytes of the message (probably between 40 and 100 bytes)")
     public String getFragment() { return fragment; }
+    @GraphQLQuery(name="emails", description="Email information")
     public List<EmailInfo> getEmails() {
         return Collections.unmodifiableList(emails);
     }
     @Override
+    @GraphQLQuery(name="subject", description="The email subject")
     public String getSubject() { return subject; }
     @Override
+    @GraphQLQuery(name="messageIdHeader", description="The message ID")
     public String getMessageIdHeader() { return messageIdHeader; }
     @Override
+    @GraphQLQuery(name="inReplyTo", description="Message-ID header for message being replied to")
     public String getInReplyTo() { return inReplyTo; }
+    @GraphQLQuery(name="invite", description="Parsed out iCalendar invite")
     public InviteInfo getInvite() { return invite; }
     @Override
+    @GraphQLQuery(name="headers", description="List of headers")
     public List<KeyValuePair> getHeaders() {
         return Collections.unmodifiableList(headers);
     }
     @Override
+    @GraphQLQuery(name="contentElems", description="List of content elements")
     public List<Object> getContentElems() {
         return Collections.unmodifiableList(contentElems);
     }
@@ -371,11 +397,13 @@ implements MessageInfoInterface {
     }
 
     @Override
+    @GraphQLIgnore
     public List<EmailInfoInterface> getEmailInterfaces() {
         return EmailInfo.toInterfaces(emails);
     }
 
     @Override
+    @GraphQLIgnore
     public InviteInfoInterface getInvitInterfacee() {
         return invite;
     }

--- a/soap/src/java/com/zimbra/soap/type/CursorInfo.java
+++ b/soap/src/java/com/zimbra/soap/type/CursorInfo.java
@@ -25,7 +25,11 @@ import javax.xml.bind.annotation.XmlAttribute;
 import com.zimbra.common.soap.MailConstants;
 import com.zimbra.soap.type.ZmBoolean;
 
+import io.leangen.graphql.annotations.GraphQLQuery;
+import io.leangen.graphql.annotations.types.GraphQLType;
+
 @XmlAccessorType(XmlAccessType.NONE)
+@GraphQLType(name="CursorInfo", description="Cursor specification")
 public final class CursorInfo {
 
     /**
@@ -86,9 +90,13 @@ public final class CursorInfo {
 
     public void setIncludeOffset(Boolean includeOffset) { this.includeOffset = ZmBoolean.fromBool(includeOffset); }
 
+    @GraphQLQuery(name="id", description="Previous ID. cursor-prev-id and cursor-sort-value and correspond to the last hit on the current page (assuming you're going forward, if you're backing up then they should be the first hit on the current page) or the selected item before changing the sort order. cursor-sort-value should be set to the value of the 'sf' (SortField) attribute. If you are changing the sort field, don't specify sortVal because 'sf' is sort field dependent. (In this case, the server supplements sortVal using the specified item ID. If the item no longer exist, the cursor gets cleared.) The server uses those attributes to find the spot in the new results that corresponds to your old position: even if some entries have been removed or added to the search results (e.g. if you are searching is:unread and you read some).")
     public String getId() { return id; }
+    @GraphQLQuery(name="sortVal", description="Should be set to the value of the `sortField` (SortField) attribute.")
     public String getSortVal() { return sortVal; }
+    @GraphQLQuery(name="endSortVal", description="Used for ranges to tell the cursor where to stop (non-inclusive) returning values")
     public String getEndSortVal() { return endSortVal; }
+    @GraphQLQuery(name="includeOffset", description="f true, the response will include the cursor position (starting from 0) in the entire hits. This can't be used with text queries. Don't abuse this option because this operation is relatively expensive")
     public Boolean getIncludeOffset() { return ZmBoolean.toBool(includeOffset); }
 
     public MoreObjects.ToStringHelper addToStringInfo(

--- a/soap/src/java/com/zimbra/soap/type/TzOnsetInfo.java
+++ b/soap/src/java/com/zimbra/soap/type/TzOnsetInfo.java
@@ -23,7 +23,11 @@ import javax.xml.bind.annotation.XmlAttribute;
 
 import com.zimbra.common.soap.MailConstants;
 
+import io.leangen.graphql.annotations.GraphQLQuery;
+import io.leangen.graphql.annotations.types.GraphQLType;
+
 @XmlAccessorType(XmlAccessType.NONE)
+@GraphQLType(name="TzOnsetInfo", description="Time/rule for transitioning from daylight time to standard time. Either specify week/wkday combo, or mday.")
 public class TzOnsetInfo {
 
     /**
@@ -31,6 +35,7 @@ public class TzOnsetInfo {
      * @zm-api-field-description Week number; 1=first, 2=second, 3=third, 4=fourth, -1=last
      */
     @XmlAttribute(name=MailConstants.A_CAL_TZ_WEEK /* week */, required=false)
+    @GraphQLQuery(name="week", description="Week number; 1=first, 2=second, 3=third, 4=fourth, -1=last")
     private Integer week;
 
     /**
@@ -38,6 +43,7 @@ public class TzOnsetInfo {
      * @zm-api-field-description Day of week; 1=Sunday, 2=Monday, etc.
      */
     @XmlAttribute(name=MailConstants.A_CAL_TZ_DAYOFWEEK /* wkday */, required=false)
+    @GraphQLQuery(name="dayOfWeek", description="Day of week; 1=Sunday, 2=Monday, etc.")
     private Integer dayOfWeek;
 
     /**
@@ -45,6 +51,7 @@ public class TzOnsetInfo {
      * @zm-api-field-description Month; 1=January, 2=February, etc.
      */
     @XmlAttribute(name=MailConstants.A_CAL_TZ_MONTH /* mon */, required=true)
+    @GraphQLQuery(name="month", description="Month; 1=January, 2=February, etc.")
     private Integer month;
 
     /**
@@ -52,6 +59,7 @@ public class TzOnsetInfo {
      * @zm-api-field-description Day of month (1..31)
      */
     @XmlAttribute(name=MailConstants.A_CAL_TZ_DAYOFMONTH /* mday */, required=false)
+    @GraphQLQuery(name="dayOfMonth", description="Day of month (1..31)")
     private Integer dayOfMonth;
 
     /**
@@ -59,6 +67,7 @@ public class TzOnsetInfo {
      * @zm-api-field-description Transition hour (0..23)
      */
     @XmlAttribute(name=MailConstants.A_CAL_TZ_HOUR /* hour */, required=true)
+    @GraphQLQuery(name="hour", description="Transition hour (0..23)")
     private Integer hour;
 
     /**
@@ -66,6 +75,7 @@ public class TzOnsetInfo {
      * @zm-api-field-description Transition minute (0..59)
      */
     @XmlAttribute(name=MailConstants.A_CAL_TZ_MINUTE /* min */, required=true)
+    @GraphQLQuery(name="minute", description="Transition minute (0..59)")
     private Integer minute;
 
     /**
@@ -73,6 +83,7 @@ public class TzOnsetInfo {
      * @zm-api-field-description Transition second; 0..59, usually 0
      */
     @XmlAttribute(name=MailConstants.A_CAL_TZ_SECOND /* sec */, required=true)
+    @GraphQLQuery(name="second", description="Transition second; 0..59, usually 0")
     private Integer second;
 
     public TzOnsetInfo() {


### PR DESCRIPTION
Implement searchMessages & searchConversations api in Zimbra GraphQL project

Summary:

Added SearchResolver & ZXMLSearchRepository which handle search related methods.
Created searchConversations & searchMessages as GraphiQL queries that are used to search their respective types of searches.
Added required annotations.
Created generic search class in ZXMLSearchRepository to handle different types of searches.
Docs:

Can be viewed with GraphiQL Document explorer
Testing:

Tested searching with the queries in the ticket.
Testing to be done by QA:

Test both queries with the sample query data on the ticket.
https://jira.corp.synacor.com/browse/ZCS-4167

Linked PR:
- https://github.com/Zimbra/zm-gql/pull/19