### PR TITLE
ZCS-5396:Admin API to add member to hab group

### DIFF
--- a/store/src/java/com/zimbra/cs/account/Group.java
+++ b/store/src/java/com/zimbra/cs/account/Group.java
@@ -40,6 +40,8 @@ import com.zimbra.cs.account.accesscontrol.ZimbraACE;
  */
 public abstract class Group extends MailTarget implements AliasedEntry {
 
+    private boolean isHABGroup = Boolean.FALSE;
+
     public static final DistributionListSubscriptionPolicy
             DEFAULT_SUBSCRIPTION_POLICY = DistributionListSubscriptionPolicy.REJECT;
 
@@ -128,6 +130,13 @@ public abstract class Group extends MailTarget implements AliasedEntry {
         return Collections.unmodifiableSet(addrs);
     }
 
+    public boolean isHABGroup() {
+        return isHABGroup;
+    }
+
+    public void setHABGroup(boolean isHabGroup) {
+        this.isHABGroup = isHabGroup;
+    }
 
     public static class GroupOwner {
         /*

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -7298,8 +7298,15 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
                 throw ServiceException.INVALID_REQUEST("Cannot add self as a member: " + memberName, null);
 
             // cannot add a dynamic group as member
-            if (getDynamicGroupBasic(Key.DistributionListBy.name, memberName, null) != null) {
-                throw ServiceException.INVALID_REQUEST("Cannot add dynamic group as a member: " + memberName, null);
+            DynamicGroup dynMember = getDynamicGroup(Key.DistributionListBy.name, memberName, null, Boolean.FALSE);
+            if (dynMember != null) {
+                if (dl.isHABGroup()) {
+                    if (dlIsInDynamicHABGroup(dynMember, addrsOfDL.getAll())) {
+                        throw ServiceException.INVALID_REQUEST("Cannot add dynamic group as a member, since it contains the parent: " + memberName, null);
+                    }
+                } else {
+                    throw ServiceException.INVALID_REQUEST("Cannot add dynamic group as a member: " + memberName, null);
+                }
             }
 
             if (!existing.contains(memberName)) {
@@ -9667,11 +9674,16 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
                 List<String> objectclass =
                     attrs.getMultiAttrStringAsList(Provisioning.A_objectClass, CheckBinary.NOCHECK);
 
+                Group grp = null;
                 if (objectclass.contains(AttributeClass.OC_zimbraDistributionList)) {
-                    return makeDistributionList(sr.getDN(), attrs, basicAttrsOnly);
+                    grp = makeDistributionList(sr.getDN(), attrs, basicAttrsOnly);
                 } else if (objectclass.contains(AttributeClass.OC_zimbraGroup)) {
-                    return makeDynamicGroup(initZlc, sr.getDN(), attrs);
+                    grp = makeDynamicGroup(initZlc, sr.getDN(), attrs);
                 }
+                if (grp != null && objectclass.contains(AttributeClass.OC_zimbraHabGroup)) {
+                    grp.setHABGroup(Boolean.TRUE);
+                }
+                return grp;
             }
         } catch (LdapMultipleEntriesMatchedException e) {
             throw AccountServiceException.MULTIPLE_ENTRIES_MATCHED("getGroupByQuery", e);
@@ -10189,6 +10201,11 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     private DynamicGroup getDynamicGroupBasic(Key.DistributionListBy keyType, String key,
             ZLdapContext zlc) throws ServiceException {
+        return getDynamicGroup(keyType, key, zlc, Boolean.TRUE);
+    }
+
+    private DynamicGroup getDynamicGroup(Key.DistributionListBy keyType, String key,
+            ZLdapContext zlc, boolean basicAttrsOnly) throws ServiceException {
         DynamicGroup dynGroup = getDynamicGroupFromCache(keyType, key);
         if (dynGroup != null) {
             return dynGroup;
@@ -10196,10 +10213,10 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
         switch(keyType) {
         case id:
-            dynGroup = getDynamicGroupById(key, zlc, true);
+            dynGroup = getDynamicGroupById(key, zlc, basicAttrsOnly);
             break;
         case name:
-            dynGroup = getDynamicGroupByName(key, zlc, true);
+            dynGroup = getDynamicGroupByName(key, zlc, basicAttrsOnly);
             break;
         }
 
@@ -10632,6 +10649,31 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
         }
 
         return members.toArray(new String[members.size()]);
+    }
+
+    public boolean dlIsInDynamicHABGroup(DynamicGroup group, List<String> dlsToCheck) {
+        ZLdapContext zlc = null;
+        try {
+            zlc = LdapClient.getContext(LdapServerType.REPLICA, LdapUsage.GET_GROUP_MEMBER);
+            String[] memberDNs = group.getMultiAttr(Provisioning.A_member);
+            final String[] attrsToGet = new String[] { Provisioning.A_mail, Provisioning.A_zimbraMailAlias };
+            for (String memberDN : memberDNs) {
+                ZAttributes memberAttrs = zlc.getAttributes(memberDN, attrsToGet);
+                if (memberAttrs != null && dlsToCheck != null) {
+                    for (String dlToCheck : dlsToCheck) {
+                        if (memberAttrs.hasAttributeValue(Provisioning.A_mail, dlToCheck)
+                                || memberAttrs.hasAttributeValue(Provisioning.A_zimbraMailAlias, dlToCheck)) {
+                            return Boolean.TRUE;
+                        }
+                    }
+                }
+            }
+        } catch (ServiceException e) {
+            ZimbraLog.account.warn("unable to get dynamic group members", e);
+        } finally {
+            LdapClient.closeContext(zlc);
+        }
+        return Boolean.FALSE;
     }
 
     public String[] getDynamicGroupMembers(DynamicGroup group) throws ServiceException {


### PR DESCRIPTION
Re-used AddDistributionListMemberRequest to add member to hab group.
Modified the AddDistributionListMember implementation to add dynamic group as member in HAB distribution list without changing behaviour for non-hab dl in which dynamic group can not be added.
Also, added check for loop detection, dynamic group result should not include the parent DL, otherwise it won't be added as member.