### PR TITLE
ZCS-5351 Implement API for user account info

### DIFF
--- a/common/src/java/com/zimbra/common/gql/GqlConstants.java
+++ b/common/src/java/com/zimbra/common/gql/GqlConstants.java
@@ -35,4 +35,21 @@ public class GqlConstants {
 
     // search folder constants
     public static final String SEARCH_FOLDER = "SearchFolder";
+
+    // account info constants
+    public static final String ACCOUNT_INFO = "AccountInfo";
+    public static final String ATTRS = "attrs";
+    public static final String SOAP_URL = "soapURL";
+    public static final String PUBLIC_URL = "publicURL";
+    public static final String CHANGE_PASSWORD_URL = "changePasswordURL";
+    public static final String COMMUNITY_URL = "communityURL";
+    public static final String ADMIN_URL = "adminURL";
+    public static final String BOSH_URL = "boshURL";
+
+    // named value constants
+    public static final String NAMED_VALUE = "NamedValue";
+    public static final String VALUE = "value";
+
+    // end session constants
+    public static final String CLEAR_COOKIES= "clearCookies";
 }

--- a/soap/src/java/com/zimbra/soap/account/message/GetAccountInfoResponse.java
+++ b/soap/src/java/com/zimbra/soap/account/message/GetAccountInfoResponse.java
@@ -147,6 +147,7 @@ public class GetAccountInfoResponse {
     public void setChangePasswordURL(String changePasswordURL) { this.changePasswordURL = changePasswordURL; }
     public void setCommunityURL(String communityURL) { this.communityURL = communityURL; }
     public void setAdminURL(String adminURL) { this.adminURL = adminURL; }
+    public void setBoshURL(String boshURL) { this.boshURL = boshURL; }
     public String getName() { return name; }
     public List<NamedValue> getAttrs() {
         return attrs;
@@ -156,6 +157,7 @@ public class GetAccountInfoResponse {
     public String getChangePasswordURL() { return changePasswordURL; }
     public String getCommunityURL() { return communityURL; }
     public String getAdminURL() { return adminURL; }
+    public String getBoshURL() { return boshURL; }
 
     public MoreObjects.ToStringHelper addToStringInfo(MoreObjects.ToStringHelper helper) {
         return helper

--- a/soap/src/java/com/zimbra/soap/type/NamedValue.java
+++ b/soap/src/java/com/zimbra/soap/type/NamedValue.java
@@ -22,9 +22,15 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlValue;
 
+import com.zimbra.common.gql.GqlConstants;
 import com.zimbra.common.soap.AdminConstants;
 
+import io.leangen.graphql.annotations.GraphQLNonNull;
+import io.leangen.graphql.annotations.GraphQLQuery;
+import io.leangen.graphql.annotations.types.GraphQLType;
+
 @XmlAccessorType(XmlAccessType.NONE)
+@GraphQLType(name=GqlConstants.NAMED_VALUE, description="attribute names and values")
 public class NamedValue {
 
     /**
@@ -32,6 +38,8 @@ public class NamedValue {
      * @zm-api-field-description Name
      */
     @XmlAttribute(name=AdminConstants.A_NAME, required=true)
+    @GraphQLNonNull
+    @GraphQLQuery(name=GqlConstants.NAME, description="name of the attribute")
     private final String name;
 
     /**
@@ -39,6 +47,7 @@ public class NamedValue {
      * @zm-api-field-description Value
      */
     @XmlValue
+    @GraphQLQuery(name=GqlConstants.VALUE, description="value of the attribute")
     private final String value;
 
     /**


### PR DESCRIPTION
**Problem:** Write graphql api for GetAccountInfo and EndSession soap apis

**Fix:**
- Created both apis

**Testing done:**
- Tested both apis maually
```
query{
  accountInfoGet{
    name
    attrs {
      name
      value
    }
    soapURL
    publicURL
    communityURL
    changePasswordURL
    adminURL
    boshURL
  }
}
```
```
mutation{
  accountEndSession(clearCookies: true)
}
```

**Testing needed by QA:**
- test both the apis
- write automation for the same

**Linked PR:**
https://github.com/Zimbra/zm-gql/pull/23