### PR TITLE
ZCS-5396: fix getDynamicGroup call to not use cache

### DIFF
--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -9912,12 +9912,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
             /*
              * all is well, get the group by id
              */
-            DynamicGroup group = null;
-            if (isHabGroup) {
-                group = getDynamicGroup(DistributionListBy.id, zimbraId, zlc, Boolean.FALSE);
-            } else {
-                group = getDynamicGroupBasic(DistributionListBy.id, zimbraId, zlc);
-            }
+            DynamicGroup group = getDynamicGroupBasic(DistributionListBy.id, zimbraId, zlc);
 
             if (group != null) {
                 AttributeManager.getInstance().postModify(groupAttrs, group, callbackContext);
@@ -10211,7 +10206,10 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     private DynamicGroup getDynamicGroup(Key.DistributionListBy keyType, String key,
             ZLdapContext zlc, boolean basicAttrsOnly) throws ServiceException {
-        DynamicGroup dynGroup = getDynamicGroupFromCache(keyType, key);
+        DynamicGroup dynGroup = null;
+        if (basicAttrsOnly) {
+            dynGroup = getDynamicGroupFromCache(keyType, key);
+        }
         if (dynGroup != null) {
             return dynGroup;
         }


### PR DESCRIPTION
when checking members of dynamic group, we should not used cached data as result of member query of dynamic group might have changed. Hence, added the check to get data from cache only when basic attributes are being queried. and when members need to be queried, do not get cached data.