### PR TITLE
ZCS-4165 Annotations for Contact resolver.

### DIFF
--- a/common/src/java/com/zimbra/common/gql/GqlConstants.java
+++ b/common/src/java/com/zimbra/common/gql/GqlConstants.java
@@ -167,6 +167,9 @@ public class GqlConstants {
     public static final String CLASS_INCLUDE_RECIPS_SETTING = "IncludeRecipsSettings";
 
     // contacts constants
+    public static final String CLASS_CONTACT_GROUP_MEMBER = "ContactGroupMember";
+    public static final String CLASS_CONTACT_ATTRIBUTE = "ContactAttribute";
+    public static final String CLASS_CONTACT_INFO = "ContactInfo";
     public static final String CLASS_ACTION_RESULT = "ActionResult";
     public static final String CLASS_NEW_CONTACT_GROUP_MEMBER = "NewContactGroupMember";
     public static final String CLASS_VCARD_INFO = "VCardInfo";
@@ -191,5 +194,17 @@ public class GqlConstants {
     public static final String DO_VERBOSE = "doVerbose";
     public static final String CONSTRAINT = "constraint";
     public static final String INPUT = "input";
+    public static final String DO_REPLACE = "doReplace";
+    public static final String IS_EXPANDABLE = "isExpandable";
+    public static final String LAST_MODIFIED = "lastModified";
+    public static final String FILE_AS = "fileAs";
+    public static final String EMAIL = "email";
+    public static final String EMAIL2 = "email2";
+    public static final String EMAIL3 = "email3";
+    public static final String DLIST = "dlist";
+    public static final String REFERENCE = "reference";
+    public static final String IS_TOO_MANY_MEMBERS = "isTooManyMembers";
+    public static final String CONTENT_TYPE = "contentType";
+    public static final String CONTENT_FILENAME = "contentFilename";
 
 }

--- a/common/src/java/com/zimbra/common/gql/GqlConstants.java
+++ b/common/src/java/com/zimbra/common/gql/GqlConstants.java
@@ -38,7 +38,7 @@ public class GqlConstants {
 
     // account info constants
     public static final String CLASS_ACCOUNT_INFO = "AccountInfo";
-    public static final String ATTRS = "attrs";
+    public static final String ATTRIBUTES = "attributes";
     public static final String SOAP_URL = "soapURL";
     public static final String PUBLIC_URL = "publicURL";
     public static final String CHANGE_PASSWORD_URL = "changePasswordURL";
@@ -68,10 +68,10 @@ public class GqlConstants {
     public static final String FULL_CONVERSATION = "fullConversation";
     public static final String RESULT_MODE = "resultMode";
     public static final String PREFETCH = "prefetch";
-    public static final String WANT_RECEPIENTS = "wantRecipients";
+    public static final String INCLUDE_RECEPIENTS = "includeRecipients";
     public static final String NEUTER_IMAGES = "neuterImages";
-    public static final String NEED_CAN_EXPAND = "needCanExpand";
-    public static final String WANT_HTML = "wantHtml";
+    public static final String INCLUDE_IS_EXPANDABLE = "includeIsExpandable";
+    public static final String INCLUDE_HTML = "includeHtml";
     public static final String MAX_INLINED_LENGTH = "maxInlinedLength";
     public static final String MARK_READ = "markRead";
     public static final String FETCH = "fetch";
@@ -93,6 +93,7 @@ public class GqlConstants {
     public static final String QUERY_OFFSET = "queryOffset";
     public static final String CLASS_CALENDAR_TIME_ZONE_INFO = "CalTZInfo";
     public static final String ID = "id";
+    public static final String IDS = "ids";
     public static final String TIME_ZONE_STANDARD_OFFSET = "tzStdOffset";
     public static final String TIME_ZONE_DAY_OFFSET = "tzDayOffset";
     public static final String STANDARD_TIME_ZONE_ONSET = "standardTzOnset";
@@ -114,18 +115,18 @@ public class GqlConstants {
     public static final String TAG_NAMES = "tagNames";
     public static final String ELIDED = "elided";
     public static final String CHANGE_DATE = "changeDate";
-    public static final String MODIFIED_FIELD_SEQUENCE = "modifiedSequence";
     public static final String METADATAS = "metadatas";
     public static final String SUBJECT = "subject";
     public static final String FRAGMENT = "fragment";
     public static final String EMAILS = "emails";
     public static final String CLASS_EMAIL_INFO = "EmailInfo";
+    public static final String MODIFIED_FIELD_SEQUENCE = "modifiedSequence";
     public static final String ADDRESS = "address";
     public static final String DISPLAY = "display";
     public static final String PERSONAL = "personal";
     public static final String ADDRESS_TYPE = "addressType";
     public static final String GROUP = "group";
-    public static final String CAN_EXPAND_GROUP_MEMBERS = "canExpandGroupMembers";
+    public static final String IS_GROUP_MEMBERS_EXPANDABLE = "isGroupMembersExpandable";
     public static final String CLASS_MAIL_CUSTOM_METADATA = "MailCustomMetadata";
     public static final String SECTION = "section";
     public static final String FOLDER = "folder";
@@ -147,6 +148,7 @@ public class GqlConstants {
     public static final String RESENT_DATE = "resentDate";
     public static final String PART = "part";
     public static final String MESSAGE_ID_HEADER = "messageIdHeader";
+    public static final String MESSAGE_ID = "messageId";
     public static final String IN_REPLY_TO = "inReplyTo";
     public static final String INVITE = "invite";
     public static final String CONTENT_ELEMS = "contentElems";
@@ -162,6 +164,32 @@ public class GqlConstants {
     public static final String HOUR = "hour";
     public static final String MINUTE = "minute";
     public static final String SECOND = "second";
+    public static final String CLASS_INCLUDE_RECIPS_SETTING = "IncludeRecipsSettings";
 
+    // contacts constants
+    public static final String CLASS_ACTION_RESULT = "ActionResult";
+    public static final String CLASS_NEW_CONTACT_GROUP_MEMBER = "NewContactGroupMember";
+    public static final String CLASS_VCARD_INFO = "VCardInfo";
+    public static final String CLASS_CONTACT_SPEC = "ContactSpec";
+    public static final String CLASS_NEW_CONTACT_ATTRIBUTE = "NewContactAttribute";
+    public static final String CLASS_GET_CONTACTS_REQUEST = "GetContactsRequest";
+    public static final String MEMBER_ATTRIBUTES = "memberAttributes";
+    public static final String CONTACT = "contact";
+    public static final String CONTACTS = "contacts";
+    public static final String CONTACT_GROUP_MEMBERS = "contactGroupMembers";
+    public static final String DO_SYNC = "doSync";
+    public static final String DO_DEREF_GROUP_MEMBER = "doDerefGroupMember";
+    public static final String INCLUDE_HIDDEN_ATTRS = "includeHiddenAttrs";
+    public static final String INCLUDE_CERT_INFO = "includeCertInfo";
+    public static final String INCLUDE_IMAP_UID = "includeImapUid";
+    public static final String INCLUDE_MODIFIED_SEQUENCE = "includeModifiedSequence";
+    public static final String MAX_MEMBERS = "maxMembers";
+    public static final String VCARD = "vcard";
+    public static final String ATTACHMENT_ID = "attachmentId";
+    public static final String TYPE = "type";
+    public static final String NON_EXISTENT_IDS = "nonExistentIds";
+    public static final String DO_VERBOSE = "doVerbose";
+    public static final String CONSTRAINT = "constraint";
+    public static final String INPUT = "input";
 
 }

--- a/common/src/java/com/zimbra/common/gql/GqlConstants.java
+++ b/common/src/java/com/zimbra/common/gql/GqlConstants.java
@@ -167,6 +167,9 @@ public class GqlConstants {
     public static final String CLASS_INCLUDE_RECIPS_SETTING = "IncludeRecipsSettings";
 
     // contacts constants
+    public static final String CLASS_MODIFY_CONTACT_GROUP_MEMBER = "ModifyContactGroupMember";
+    public static final String CLASS_MODIFY_CONTACT_ATTRIBUTE = "ModifyContactAttribute";
+    public static final String CLASS_MODIFY_CONTACT_SPEC = "ModifyContactSpec";
     public static final String CLASS_CONTACT_GROUP_MEMBER = "ContactGroupMember";
     public static final String CLASS_CONTACT_ATTRIBUTE = "ContactAttribute";
     public static final String CLASS_CONTACT_INFO = "ContactInfo";
@@ -206,5 +209,6 @@ public class GqlConstants {
     public static final String IS_TOO_MANY_MEMBERS = "isTooManyMembers";
     public static final String CONTENT_TYPE = "contentType";
     public static final String CONTENT_FILENAME = "contentFilename";
+    public static final String OPERATION = "operation";
 
 }

--- a/common/src/java/com/zimbra/common/gql/GqlConstants.java
+++ b/common/src/java/com/zimbra/common/gql/GqlConstants.java
@@ -19,14 +19,14 @@ package com.zimbra.common.gql;
 
 public class GqlConstants {
     // modify search folder spec constants
-    public static final String MODIFY_SEARCH_FOLDER_SPEC = "ModifySearchFolderSpec";
+    public static final String CLASS_MODIFY_SEARCH_FOLDER_SPEC = "ModifySearchFolderSpec";
     public static final String SEARCH_FOLDER_ID = "searchFolderId";
     public static final String QUERY = "query";
     public static final String SEARCH_TYPES = "searchTypes";
     public static final String SORT_BY = "sortBy";
 
     // new search folder spec constants
-    public static final String NEW_SEARCH_FOLDER_SPEC = "NewSearchFolderSpec";
+    public static final String CLASS_NEW_SEARCH_FOLDER_SPEC = "NewSearchFolderSpec";
     public static final String NAME = "name";
     public static final String FLAGS = "flags";
     public static final String COLOR = "color";
@@ -34,10 +34,10 @@ public class GqlConstants {
     public static final String RGB = "rgb";
 
     // search folder constants
-    public static final String SEARCH_FOLDER = "SearchFolder";
+    public static final String CLASS_SEARCH_FOLDER = "SearchFolder";
 
     // account info constants
-    public static final String ACCOUNT_INFO = "AccountInfo";
+    public static final String CLASS_ACCOUNT_INFO = "AccountInfo";
     public static final String ATTRS = "attrs";
     public static final String SOAP_URL = "soapURL";
     public static final String PUBLIC_URL = "publicURL";
@@ -47,15 +47,15 @@ public class GqlConstants {
     public static final String BOSH_URL = "boshURL";
 
     // named value constants
-    public static final String NAMED_VALUE = "NamedValue";
+    public static final String CLASS_NAMED_VALUE = "NamedValue";
     public static final String VALUE = "value";
 
     // end session constants
     public static final String CLEAR_COOKIES= "clearCookies";
 
     // search constants
+    public static final String CLASS_SEARCH_REQUEST = "SearchRequest";
     public static final String SEARCH_PARAMS = "params";
-    public static final String SEARCH_REQUEST = "SearchRequest";
     public static final String HEADERS = "headers";
     public static final String INCLUDE_MEMBER_OF = "includeMemberOf";
     public static final String MSG_CONTENT = "msgContent";
@@ -83,15 +83,15 @@ public class GqlConstants {
     public static final String ALLOWABLE_TASK_STATUS = "allowableTaskStatus";
     public static final String INCLUDE_TAG_MUTED = "includeTagMuted";
     public static final String INCLUDE_TAG_DELETED = "includeTagDeleted";
-    public static final String CONVERSATION_SEARCH_RESPONSE = "ConversationSearchResponse";
-    public static final String MESSAGE_SEARCH_RESPONSE = "MessageSearchResponse";
+    public static final String CLASS_CONVERSATION_SEARCH_RESPONSE = "ConversationSearchResponse";
+    public static final String CLASS_MESSAGE_SEARCH_RESPONSE = "MessageSearchResponse";
     public static final String SEARCH_HITS = "searchHits";
-    public static final String SEARCH_RESPONSE = "SearchResponse";
+    public static final String CLASS_SEARCH_RESPONSE = "SearchResponse";
     public static final String QUERY_INFOS = "queryInfos";
     public static final String TOTAL_SIZE = "totalSize";
     public static final String QUERY_MORE = "queryMore";
     public static final String QUERY_OFFSET = "queryOffset";
-    public static final String CALENDAR_TIME_ZONE_INFO = "CalTZInfo";
+    public static final String CLASS_CALENDAR_TIME_ZONE_INFO = "CalTZInfo";
     public static final String ID = "id";
     public static final String TIME_ZONE_STANDARD_OFFSET = "tzStdOffset";
     public static final String TIME_ZONE_DAY_OFFSET = "tzDayOffset";
@@ -102,12 +102,12 @@ public class GqlConstants {
     public static final String CONVERSATION_HIT_INFO = "ConversationHitInfo";
     public static final String SORT_FIELD = "sortField";
     public static final String MESSAGE_HITS = "messageHits";
-    public static final String CONVERSATION_MESSAGE_HIT_INFO = "ConversationMsgHitInfo";
+    public static final String CLASS_CONVERSATION_MESSAGE_HIT_INFO = "ConversationMsgHitInfo";
     public static final String SIZE = "size";
     public static final String FOLDER_ID = "folderId";
     public static final String AUTO_SEND_TIME = "autoSendTime";
     public static final String DATE = "date";
-    public static final String CONVERSATION_SUMMARY = "ConversationSummary";
+    public static final String CLASS_CONVERSATION_SUMMARY = "ConversationSummary";
     public static final String NUM = "num";
     public static final String NUM_UNREAD = "numUnread";
     public static final String TAGS = "tags";
@@ -119,23 +119,23 @@ public class GqlConstants {
     public static final String SUBJECT = "subject";
     public static final String FRAGMENT = "fragment";
     public static final String EMAILS = "emails";
-    public static final String EMAIL_INFO = "EmailInfo";
+    public static final String CLASS_EMAIL_INFO = "EmailInfo";
     public static final String ADDRESS = "address";
     public static final String DISPLAY = "display";
     public static final String PERSONAL = "personal";
     public static final String ADDRESS_TYPE = "addressType";
     public static final String GROUP = "group";
     public static final String CAN_EXPAND_GROUP_MEMBERS = "canExpandGroupMembers";
-    public static final String MAIL_CUSTOM_METADATA = "MailCustomMetadata";
+    public static final String CLASS_MAIL_CUSTOM_METADATA = "MailCustomMetadata";
     public static final String SECTION = "section";
     public static final String FOLDER = "folder";
     public static final String CONVERSATION_ID = "conversationId";
     public static final String REVISION = "revision";
     public static final String MODIFIED_SEQUENCE = "modifiedSequence";
-    public static final String MESSAGE_HIT_INFO = "MessageHitInfo";
+    public static final String CLASS_MESSAGE_HIT_INFO = "MessageHitInfo";
     public static final String CONTENT_MATCHED = "contentMatched";
     public static final String MESSAGE_PART_HITS = "messagePartHits";
-    public static final String MESSAGE_INFO = "MessageInfo";
+    public static final String CLASS_MESSAGE_INFO = "MessageInfo";
     public static final String IMAP_UID = "imapUid";
     public static final String CALENDAR_INTENDED_FOR = "calendarIntendedFor";
     public static final String ORIG_ID = "origId";
@@ -150,11 +150,11 @@ public class GqlConstants {
     public static final String IN_REPLY_TO = "inReplyTo";
     public static final String INVITE = "invite";
     public static final String CONTENT_ELEMS = "contentElems";
-    public static final String CURSOR_INFO = "CursorInfo";
+    public static final String CLASS_CURSOR_INFO = "CursorInfo";
     public static final String SORT_VAL = "sortVal";
     public static final String END_SORT_VAL = "endSortVal";
     public static final String INCLUDE_OFFSET = "includeOffset";
-    public static final String TZ_ONSET_INFO = "TzOnsetInfo";
+    public static final String CLASS_TZ_ONSET_INFO = "TzOnsetInfo";
     public static final String WEEK = "week";
     public static final String DAY_OF_WEEK = "dayOfWeek";
     public static final String MONTH = "month";

--- a/soap/src/java/com/zimbra/soap/mail/type/ActionResult.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ActionResult.java
@@ -26,6 +26,7 @@ import javax.xml.bind.annotation.XmlTransient;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Splitter;
+import com.zimbra.common.gql.GqlConstants;
 import com.zimbra.common.soap.MailConstants;
 
 import io.leangen.graphql.annotations.GraphQLIgnore;
@@ -34,7 +35,7 @@ import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.types.GraphQLType;
 
 @XmlAccessorType(XmlAccessType.NONE)
-@GraphQLType(name="ActionResult", description="Action response")
+@GraphQLType(name=GqlConstants.CLASS_ACTION_RESULT, description="Action response")
 public class ActionResult {
 
     private final static Splitter COMMA_SPLITTER = Splitter.on(",");
@@ -45,7 +46,7 @@ public class ActionResult {
      */
     @XmlAttribute(name=MailConstants.A_ID /* id */, required=true)
     @GraphQLNonNull
-    @GraphQLQuery(name="ids", description="Comma-separated list of ids which have been successfully processed")
+    @GraphQLQuery(name=GqlConstants.IDS, description="Comma-separated list of ids which have been successfully processed")
     private final String id;
 
     /**
@@ -61,7 +62,7 @@ public class ActionResult {
      * @zm-api-field-description Comma-separated list of non-existent ids (if requested)
      */
     @XmlAttribute(name=MailConstants.A_NON_EXISTENT_IDS /* nei */, required=false)
-    @GraphQLQuery(name="nonExistentIds", description="Comma-separated list of non-existent ids (if requested)")
+    @GraphQLQuery(name=GqlConstants.NON_EXISTENT_IDS, description="Comma-separated list of non-existent ids (if requested)")
     protected String nonExistentIds;
 
     /**
@@ -85,13 +86,13 @@ public class ActionResult {
     }
 
     @GraphQLNonNull
-    @GraphQLQuery(name="ids", description="Comma-separated list of ids which have been successfully processed")
+    @GraphQLQuery(name=GqlConstants.IDS, description="Comma-separated list of ids which have been successfully processed")
     public String getId() { return id; }
     @GraphQLIgnore
     public String getOperation() { return operation; }
 
     public void setNonExistentIds(String ids) { this.nonExistentIds = ids; };
-    @GraphQLQuery(name="nonExistentIds", description="Comma-separated list of non-existent ids (if requested)")
+    @GraphQLQuery(name=GqlConstants.NON_EXISTENT_IDS, description="Comma-separated list of non-existent ids (if requested)")
     public String getNonExistentIds() { return nonExistentIds; };
     public void setNewlyCreatedIds(String newlyCreatedIds) { this.newlyCreatedIds = newlyCreatedIds; }
     @XmlTransient

--- a/soap/src/java/com/zimbra/soap/mail/type/ActionResult.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ActionResult.java
@@ -53,8 +53,7 @@ public class ActionResult {
      * @zm-api-field-description Operation
      */
     @XmlAttribute(name=MailConstants.A_OPERATION /* op */, required=true)
-    @GraphQLNonNull
-    @GraphQLQuery(name="operation", description="Operation")
+    @GraphQLIgnore
     private final String operation;
 
     /**
@@ -88,8 +87,7 @@ public class ActionResult {
     @GraphQLNonNull
     @GraphQLQuery(name="ids", description="Comma-separated list of ids which have been successfully processed")
     public String getId() { return id; }
-    @GraphQLNonNull
-    @GraphQLQuery(name="operation", description="Operation")
+    @GraphQLIgnore
     public String getOperation() { return operation; }
 
     public void setNonExistentIds(String ids) { this.nonExistentIds = ids; };

--- a/soap/src/java/com/zimbra/soap/mail/type/CalTZInfo.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/CalTZInfo.java
@@ -37,7 +37,7 @@ import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.types.GraphQLType;
 
 @XmlAccessorType(XmlAccessType.NONE)
-@GraphQLType(name=GqlConstants.CALENDAR_TIME_ZONE_INFO, description="Timezone specification")
+@GraphQLType(name=GqlConstants.CLASS_CALENDAR_TIME_ZONE_INFO, description="Timezone specification")
 public class CalTZInfo implements CalTZInfoInterface {
 
     /**

--- a/soap/src/java/com/zimbra/soap/mail/type/ContactActionSelector.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ContactActionSelector.java
@@ -17,10 +17,6 @@
 
 package com.zimbra.soap.mail.type;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-
 import java.util.Collections;
 import java.util.List;
 
@@ -28,20 +24,30 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.zimbra.common.soap.MailConstants;
 
+import io.leangen.graphql.annotations.GraphQLIgnore;
+import io.leangen.graphql.annotations.GraphQLInputField;
+import io.leangen.graphql.annotations.types.GraphQLType;
+
 @XmlAccessorType(XmlAccessType.NONE)
+@GraphQLType(name="ContactActionSelector", description="Input for contact actions")
 public class ContactActionSelector extends ActionSelector {
 
     /**
      * @zm-api-field-description New Contact attributes
      */
     @XmlElement(name=MailConstants.E_ATTRIBUTE, required=false)
-    private List<NewContactAttr> attrs = Lists.newArrayList();
+    @GraphQLInputField(name="attrs", description="Contact attributes")
+    private final List<NewContactAttr> attrs = Lists.newArrayList();
 
     public ContactActionSelector() {
     }
 
+    @GraphQLInputField(name="attrs", description="Contact attributes")
     public void setAttrs(Iterable <NewContactAttr> attrs) {
         this.attrs.clear();
         if (attrs != null) {
@@ -49,6 +55,7 @@ public class ContactActionSelector extends ActionSelector {
         }
     }
 
+    @GraphQLIgnore
     public ContactActionSelector addAttr(NewContactAttr attr) {
         this.attrs.add(attr);
         return this;

--- a/soap/src/java/com/zimbra/soap/mail/type/ContactActionSelector.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ContactActionSelector.java
@@ -47,6 +47,10 @@ public class ContactActionSelector extends ActionSelector {
     public ContactActionSelector() {
     }
 
+    public ContactActionSelector(String ids, String operation) {
+        super(ids, operation);
+    }
+
     @GraphQLInputField(name="attrs", description="Contact attributes")
     public void setAttrs(Iterable <NewContactAttr> attrs) {
         this.attrs.clear();

--- a/soap/src/java/com/zimbra/soap/mail/type/ContactActionSelector.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ContactActionSelector.java
@@ -29,19 +29,13 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.zimbra.common.soap.MailConstants;
 
-import io.leangen.graphql.annotations.GraphQLIgnore;
-import io.leangen.graphql.annotations.GraphQLInputField;
-import io.leangen.graphql.annotations.types.GraphQLType;
-
 @XmlAccessorType(XmlAccessType.NONE)
-@GraphQLType(name="ContactActionSelector", description="Input for contact actions")
 public class ContactActionSelector extends ActionSelector {
 
     /**
      * @zm-api-field-description New Contact attributes
      */
     @XmlElement(name=MailConstants.E_ATTRIBUTE, required=false)
-    @GraphQLInputField(name="attrs", description="Contact attributes")
     private final List<NewContactAttr> attrs = Lists.newArrayList();
 
     public ContactActionSelector() {
@@ -51,7 +45,6 @@ public class ContactActionSelector extends ActionSelector {
         super(ids, operation);
     }
 
-    @GraphQLInputField(name="attrs", description="Contact attributes")
     public void setAttrs(Iterable <NewContactAttr> attrs) {
         this.attrs.clear();
         if (attrs != null) {
@@ -59,7 +52,6 @@ public class ContactActionSelector extends ActionSelector {
         }
     }
 
-    @GraphQLIgnore
     public ContactActionSelector addAttr(NewContactAttr attr) {
         this.attrs.add(attr);
         return this;

--- a/soap/src/java/com/zimbra/soap/mail/type/ContactGroupMember.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ContactGroupMember.java
@@ -27,6 +27,7 @@ import javax.xml.bind.annotation.XmlElement;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.zimbra.common.gql.GqlConstants;
 import com.zimbra.common.soap.MailConstants;
 import com.zimbra.soap.base.ContactGroupMemberInterface;
 import com.zimbra.soap.base.ContactInterface;
@@ -36,7 +37,7 @@ import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.types.GraphQLType;
 
 @XmlAccessorType(XmlAccessType.NONE)
-@GraphQLType(name="ContactGroupMember", description="Contact group member")
+@GraphQLType(name=GqlConstants.CLASS_CONTACT_GROUP_MEMBER, description="Contact group member")
 public class ContactGroupMember
 implements ContactGroupMemberInterface {
 
@@ -94,14 +95,14 @@ implements ContactGroupMemberInterface {
     public void setContact(ContactInfo contact) { this.contact = contact; }
     @Override
     @GraphQLNonNull
-    @GraphQLQuery(name="type", description="Member type. C|G|I")
+    @GraphQLQuery(name=GqlConstants.TYPE, description="Member type. C|G|I")
     public String getType() { return type; }
     @Override
     @GraphQLNonNull
-    @GraphQLQuery(name="value", description="Member value")
+    @GraphQLQuery(name=GqlConstants.VALUE, description="Member value")
     public String getValue() { return value; }
     @Override
-    @GraphQLQuery(name="contact", description="Contact information for dereferenced member")
+    @GraphQLQuery(name=GqlConstants.CONTACT, description="Contact information for dereferenced member")
     public ContactInfo getContact() { return contact; }
 
     @Override

--- a/soap/src/java/com/zimbra/soap/mail/type/ContactGroupMember.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ContactGroupMember.java
@@ -19,20 +19,24 @@ package com.zimbra.soap.mail.type;
 
 import java.util.List;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.zimbra.common.soap.MailConstants;
 import com.zimbra.soap.base.ContactGroupMemberInterface;
 import com.zimbra.soap.base.ContactInterface;
 
+import io.leangen.graphql.annotations.GraphQLNonNull;
+import io.leangen.graphql.annotations.GraphQLQuery;
+import io.leangen.graphql.annotations.types.GraphQLType;
+
 @XmlAccessorType(XmlAccessType.NONE)
+@GraphQLType(name="ContactGroupMember", description="Contact group member")
 public class ContactGroupMember
 implements ContactGroupMemberInterface {
 
@@ -53,7 +57,7 @@ implements ContactGroupMemberInterface {
      * @zm-api-field-tag member-value
      * @zm-api-field-description Member value
      * <table>
-     * <tr> <td> <b>type="C"</b> </td> 
+     * <tr> <td> <b>type="C"</b> </td>
      *      <td> Item ID of another contact.  If the referenced contact is in a shared folder, the item ID must be
      *           qualified by zimbraId of the owner.  e.g. {zimbraId}:{itemId} </td> </tr>
      * <tr> <td> <b>type="G"</b> </td> <td> GAL entry reference (returned in SearchGalResponse) </td> </tr>
@@ -89,10 +93,15 @@ implements ContactGroupMemberInterface {
     public void setValue(String value) { this.value = value; }
     public void setContact(ContactInfo contact) { this.contact = contact; }
     @Override
+    @GraphQLNonNull
+    @GraphQLQuery(name="type", description="Member type. C|G|I")
     public String getType() { return type; }
     @Override
+    @GraphQLNonNull
+    @GraphQLQuery(name="value", description="Member value")
     public String getValue() { return value; }
     @Override
+    @GraphQLQuery(name="contact", description="Contact information for dereferenced member")
     public ContactInfo getContact() { return contact; }
 
     @Override
@@ -103,8 +112,8 @@ implements ContactGroupMemberInterface {
     public static Iterable <ContactGroupMember> fromInterfaces(Iterable <ContactGroupMemberInterface> params) {
         if (params == null)
             return null;
-        List <ContactGroupMember> newList = Lists.newArrayList();
-        for (ContactGroupMemberInterface param : params) {
+        final List <ContactGroupMember> newList = Lists.newArrayList();
+        for (final ContactGroupMemberInterface param : params) {
             newList.add((ContactGroupMember) param);
         }
         return newList;
@@ -113,7 +122,7 @@ implements ContactGroupMemberInterface {
     public static List <ContactGroupMemberInterface> toInterfaces(Iterable <ContactGroupMember> params) {
         if (params == null)
             return null;
-        List <ContactGroupMemberInterface> newList = Lists.newArrayList();
+        final List <ContactGroupMemberInterface> newList = Lists.newArrayList();
         Iterables.addAll(newList, params);
         return newList;
     }

--- a/soap/src/java/com/zimbra/soap/mail/type/ContactInfo.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ContactInfo.java
@@ -42,10 +42,15 @@ import com.zimbra.soap.type.ContactAttr;
 import com.zimbra.soap.type.SearchHit;
 import com.zimbra.soap.type.ZmBoolean;
 
+import io.leangen.graphql.annotations.GraphQLIgnore;
+import io.leangen.graphql.annotations.GraphQLQuery;
+import io.leangen.graphql.annotations.types.GraphQLType;
+
 /**
  * {@link SearchHit} is used in {@link SearchResponse} as the element type for a List
  */
 @XmlAccessorType(XmlAccessType.NONE)
+@GraphQLType(name="ContactInfo", description="Contact information")
 public class ContactInfo
 implements ContactInterface, SearchHit {
 
@@ -331,57 +336,80 @@ implements ContactInterface, SearchHit {
         this.memberOf = groups;
     }
 
+    @GraphQLQuery(name="memberOf", description="Comma separated list of IDs of contact groups this contact is a member of")
     public Collection<String> getMemberOf() {
         return Lists.newArrayList(COMMA_SPLITTER.split(Strings.nullToEmpty(memberOf)));
     }
 
     @Override
+    @GraphQLQuery(name="sortField", description="Sort field value")
     public String getSortField() { return sortField; }
     @Override
+    @GraphQLQuery(name="isExpandable", description="Denotes whether user can expand group members")
     public Boolean getCanExpand() { return ZmBoolean.toBool(canExpand); }
     @Override
+    @GraphQLQuery(name="id", description="Unique contact ID")
     public String getId() { return id; }
     @Override
+    @GraphQLQuery(name="folder", description="The containing Folder ID")
     public String getFolder() { return folder; }
     @Override
+    @GraphQLQuery(name="flags", description="(f)lagged, has (a)ttachment")
     public String getFlags() { return flags; }
     @Override
+    @GraphQLIgnore
     public String getTags() { return tags; }
     @Override
+    @GraphQLQuery(name="tagNames", description="Comma-separated list of tag names")
     public String getTagNames() { return tagNames; }
     @Override
+    @GraphQLQuery(name="lastModified", description="Modified date in seconds")
     public Long getChangeDate() { return changeDate; }
     @Override
+    @GraphQLQuery(name="modifiedSequenceId", description="Modified sequence")
     public Integer getModifiedSequenceId() { return modifiedSequenceId; }
     @Override
+    @GraphQLQuery(name="date", description="Date in milliseconds")
     public Long getDate() { return date; }
     @Override
+    @GraphQLQuery(name="revisionId", description="Saved sequence number")
     public Integer getRevisionId() { return revisionId; }
     @Override
+    @GraphQLQuery(name="fileAs", description="Current fileAs string for display/sorting purposes")
     public String getFileAs() { return fileAs; }
     @Override
+    @GraphQLQuery(name="email", description="Contact email address")
     public String getEmail() { return email; }
     @Override
+    @GraphQLQuery(name="email2", description="Contact email address 2")
     public String getEmail2() { return email2; }
     @Override
+    @GraphQLQuery(name="email3", description="Contact email address 3")
     public String getEmail3() { return email3; }
     @Override
+    @GraphQLQuery(name="type", description="Contact type")
     public String getType() { return type; }
     @Override
+    @GraphQLQuery(name="dlist", description="Contact dlist")
     public String getDlist() { return dlist; }
     @Override
+    @GraphQLQuery(name="reference", description="Global Address List entry reference")
     public String getReference() { return reference; }
     @Override
+    @GraphQLQuery(name="isTooManyMembers", description="Denotes whether the number of entries on a GAL group exceeds the specified max")
     public Boolean getTooManyMembers() { return ZmBoolean.toBool(tooManyMembers); }
 
+    @GraphQLQuery(name="metadatas", description="Custom metadata information")
     public List<MailCustomMetadata> getMetadatas() {
         return metadatas;
     }
     @Override
+    @GraphQLQuery(name="attrs", description="Attributes")
     public List<ContactAttr> getAttrs() {
         return attrs;
     }
 
+    @GraphQLQuery(name="contactGroupMembers", description="Contact group members")
     public List<ContactGroupMember> getContactGroupMembers() {
         return Collections.unmodifiableList(contactGroupMembers);
     }
@@ -401,6 +429,7 @@ implements ContactInterface, SearchHit {
 
     // non-JAXB method
     @Override
+    @GraphQLIgnore
     public List<CustomMetadataInterface> getMetadataInterfaces() {
         return MailCustomMetadata.toInterfaces(metadatas);
     }
@@ -408,8 +437,8 @@ implements ContactInterface, SearchHit {
     public static Iterable <ContactInfo> fromInterfaces(Iterable <ContactInterface> params) {
         if (params == null)
             return null;
-        List <ContactInfo> newList = Lists.newArrayList();
-        for (ContactInterface param : params) {
+        final List <ContactInfo> newList = Lists.newArrayList();
+        for (final ContactInterface param : params) {
             newList.add((ContactInfo) param);
         }
         return newList;
@@ -418,12 +447,13 @@ implements ContactInterface, SearchHit {
     public static List <ContactInterface> toInterfaces(Iterable <ContactInfo> params) {
         if (params == null)
             return null;
-        List <ContactInterface> newList = Lists.newArrayList();
+        final List <ContactInterface> newList = Lists.newArrayList();
         Iterables.addAll(newList, params);
         return newList;
     }
 
     public void setImapUid(Integer imapUid) { this.imapUid = imapUid; }
+    @GraphQLQuery(name="imapUid", description="Imap UID")
     public Integer getImapUid() { return imapUid; }
 
     public MoreObjects.ToStringHelper addToStringInfo(MoreObjects.ToStringHelper helper) {
@@ -468,6 +498,7 @@ implements ContactInterface, SearchHit {
     }
 
     @Override
+    @GraphQLIgnore
     public List<ContactGroupMemberInterface> getContactGroupMemberInterfaces() {
         return ContactGroupMember.toInterfaces(contactGroupMembers);
     }

--- a/soap/src/java/com/zimbra/soap/mail/type/ContactInfo.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ContactInfo.java
@@ -31,6 +31,7 @@ import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.zimbra.common.gql.GqlConstants;
 import com.zimbra.common.soap.AccountConstants;
 import com.zimbra.common.soap.MailConstants;
 import com.zimbra.soap.base.ContactGroupMemberInterface;
@@ -50,7 +51,7 @@ import io.leangen.graphql.annotations.types.GraphQLType;
  * {@link SearchHit} is used in {@link SearchResponse} as the element type for a List
  */
 @XmlAccessorType(XmlAccessType.NONE)
-@GraphQLType(name="ContactInfo", description="Contact information")
+@GraphQLType(name=GqlConstants.CLASS_CONTACT_INFO, description="Contact information")
 public class ContactInfo
 implements ContactInterface, SearchHit {
 
@@ -342,74 +343,74 @@ implements ContactInterface, SearchHit {
     }
 
     @Override
-    @GraphQLQuery(name="sortField", description="Sort field value")
+    @GraphQLQuery(name=GqlConstants.SORT_FIELD, description="Sort field value")
     public String getSortField() { return sortField; }
     @Override
-    @GraphQLQuery(name="isExpandable", description="Denotes whether user can expand group members")
+    @GraphQLQuery(name=GqlConstants.IS_EXPANDABLE, description="Denotes whether user can expand group members")
     public Boolean getCanExpand() { return ZmBoolean.toBool(canExpand); }
     @Override
-    @GraphQLQuery(name="id", description="Unique contact ID")
+    @GraphQLQuery(name=GqlConstants.ID, description="Unique contact ID")
     public String getId() { return id; }
     @Override
-    @GraphQLQuery(name="folder", description="The containing Folder ID")
+    @GraphQLQuery(name=GqlConstants.FOLDER_ID, description="The containing Folder ID")
     public String getFolder() { return folder; }
     @Override
-    @GraphQLQuery(name="flags", description="(f)lagged, has (a)ttachment")
+    @GraphQLQuery(name=GqlConstants.FLAGS, description="(f)lagged, has (a)ttachment")
     public String getFlags() { return flags; }
     @Override
     @GraphQLIgnore
     public String getTags() { return tags; }
     @Override
-    @GraphQLQuery(name="tagNames", description="Comma-separated list of tag names")
+    @GraphQLQuery(name=GqlConstants.TAG_NAMES, description="Comma-separated list of tag names")
     public String getTagNames() { return tagNames; }
     @Override
-    @GraphQLQuery(name="lastModified", description="Modified date in seconds")
+    @GraphQLQuery(name=GqlConstants.LAST_MODIFIED, description="Modified date in seconds")
     public Long getChangeDate() { return changeDate; }
     @Override
-    @GraphQLQuery(name="modifiedSequenceId", description="Modified sequence")
+    @GraphQLQuery(name=GqlConstants.MODIFIED_SEQUENCE, description="Modified sequence")
     public Integer getModifiedSequenceId() { return modifiedSequenceId; }
     @Override
-    @GraphQLQuery(name="date", description="Date in milliseconds")
+    @GraphQLQuery(name=GqlConstants.DATE, description="Date in milliseconds")
     public Long getDate() { return date; }
     @Override
-    @GraphQLQuery(name="revisionId", description="Saved sequence number")
+    @GraphQLQuery(name=GqlConstants.REVISION, description="Saved sequence number")
     public Integer getRevisionId() { return revisionId; }
     @Override
-    @GraphQLQuery(name="fileAs", description="Current fileAs string for display/sorting purposes")
+    @GraphQLQuery(name=GqlConstants.FILE_AS, description="Current fileAs string for display/sorting purposes")
     public String getFileAs() { return fileAs; }
     @Override
-    @GraphQLQuery(name="email", description="Contact email address")
+    @GraphQLQuery(name=GqlConstants.EMAIL, description="Contact email address")
     public String getEmail() { return email; }
     @Override
-    @GraphQLQuery(name="email2", description="Contact email address 2")
+    @GraphQLQuery(name=GqlConstants.EMAIL2, description="Contact email address 2")
     public String getEmail2() { return email2; }
     @Override
-    @GraphQLQuery(name="email3", description="Contact email address 3")
+    @GraphQLQuery(name=GqlConstants.EMAIL3, description="Contact email address 3")
     public String getEmail3() { return email3; }
     @Override
-    @GraphQLQuery(name="type", description="Contact type")
+    @GraphQLQuery(name=GqlConstants.TYPE, description="Contact type")
     public String getType() { return type; }
     @Override
-    @GraphQLQuery(name="dlist", description="Contact dlist")
+    @GraphQLQuery(name=GqlConstants.DLIST, description="Contact dlist")
     public String getDlist() { return dlist; }
     @Override
-    @GraphQLQuery(name="reference", description="Global Address List entry reference")
+    @GraphQLQuery(name=GqlConstants.REFERENCE, description="Global Address List entry reference")
     public String getReference() { return reference; }
     @Override
-    @GraphQLQuery(name="isTooManyMembers", description="Denotes whether the number of entries on a GAL group exceeds the specified max")
+    @GraphQLQuery(name=GqlConstants.IS_TOO_MANY_MEMBERS, description="Denotes whether the number of entries on a GAL group exceeds the specified max")
     public Boolean getTooManyMembers() { return ZmBoolean.toBool(tooManyMembers); }
 
-    @GraphQLQuery(name="metadatas", description="Custom metadata information")
+    @GraphQLQuery(name=GqlConstants.METADATAS, description="Custom metadata information")
     public List<MailCustomMetadata> getMetadatas() {
         return metadatas;
     }
     @Override
-    @GraphQLQuery(name="attrs", description="Attributes")
+    @GraphQLQuery(name=GqlConstants.ATTRIBUTES, description="Attributes")
     public List<ContactAttr> getAttrs() {
         return attrs;
     }
 
-    @GraphQLQuery(name="contactGroupMembers", description="Contact group members")
+    @GraphQLQuery(name=GqlConstants.CONTACT_GROUP_MEMBERS, description="Contact group members")
     public List<ContactGroupMember> getContactGroupMembers() {
         return Collections.unmodifiableList(contactGroupMembers);
     }
@@ -453,7 +454,7 @@ implements ContactInterface, SearchHit {
     }
 
     public void setImapUid(Integer imapUid) { this.imapUid = imapUid; }
-    @GraphQLQuery(name="imapUid", description="Imap UID")
+    @GraphQLQuery(name=GqlConstants.IMAP_UID, description="Imap UID")
     public Integer getImapUid() { return imapUid; }
 
     public MoreObjects.ToStringHelper addToStringInfo(MoreObjects.ToStringHelper helper) {

--- a/soap/src/java/com/zimbra/soap/mail/type/ContactSpec.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ContactSpec.java
@@ -96,7 +96,7 @@ public class ContactSpec implements SpecifyContact<NewContactAttr,NewContactGrou
     @Override
     @GraphQLInputField(name="id", description="ID - specified when modifying a contact")
     public void setId(Integer id) { this.id = id; }
-    @GraphQLInputField(name="folder", description="ID of folder to create contact in. Un-specified means use the default Contacts folder.")
+    @GraphQLInputField(name="folderId", description="ID of folder to create contact in. Un-specified means use the default Contacts folder.")
     public void setFolder(String folder) { this.folder = folder; }
     @Deprecated
     @GraphQLIgnore

--- a/soap/src/java/com/zimbra/soap/mail/type/ContactSpec.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ContactSpec.java
@@ -27,6 +27,7 @@ import javax.xml.bind.annotation.XmlElement;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.zimbra.common.gql.GqlConstants;
 import com.zimbra.common.soap.MailConstants;
 import com.zimbra.soap.base.SpecifyContact;
 
@@ -35,7 +36,7 @@ import io.leangen.graphql.annotations.GraphQLInputField;
 import io.leangen.graphql.annotations.types.GraphQLType;
 
 @XmlAccessorType(XmlAccessType.NONE)
-@GraphQLType(name="ContactSpec", description="Input for creating a new contact")
+@GraphQLType(name=GqlConstants.CLASS_CONTACT_SPEC, description="Input for creating a new contact")
 public class ContactSpec implements SpecifyContact<NewContactAttr,NewContactGroupMember> {
 
     // Used when modifying a contact
@@ -79,7 +80,7 @@ public class ContactSpec implements SpecifyContact<NewContactAttr,NewContactGrou
      * @zm-api-field-description Contact attributes.  Cannot specify <b>&lt;vcard></b> as well as these
      */
     @XmlElement(name=MailConstants.E_ATTRIBUTE /* a */, required=false)
-    @GraphQLInputField(name="attrs", description="Contact attributes.")
+    @GraphQLInputField(name=GqlConstants.ATTRIBUTES, description="Contact attributes.")
     private final List<NewContactAttr> attrs = Lists.newArrayList();
 
     /**
@@ -87,27 +88,27 @@ public class ContactSpec implements SpecifyContact<NewContactAttr,NewContactGrou
      * (has attribute type="group")
      */
     @XmlElement(name=MailConstants.E_CONTACT_GROUP_MEMBER /* m */, required=false)
-    @GraphQLInputField(name="contactGroupMembers", description="Valid only if the contact being created is a contact group")
+    @GraphQLInputField(name=GqlConstants.CONTACT_GROUP_MEMBERS, description="Valid only if the contact being created is a contact group")
     private final List<NewContactGroupMember> contactGroupMembers = Lists.newArrayList();
 
     public ContactSpec() {
     }
 
     @Override
-    @GraphQLInputField(name="id", description="ID - specified when modifying a contact")
+    @GraphQLInputField(name=GqlConstants.ID, description="ID - specified when modifying a contact")
     public void setId(Integer id) { this.id = id; }
-    @GraphQLInputField(name="folderId", description="ID of folder to create contact in. Un-specified means use the default Contacts folder.")
+    @GraphQLInputField(name=GqlConstants.FOLDER_ID, description="ID of folder to create contact in. Un-specified means use the default Contacts folder.")
     public void setFolder(String folder) { this.folder = folder; }
     @Deprecated
     @GraphQLIgnore
     public void setTags(String tags) { this.tags = tags; }
     @Override
-    @GraphQLInputField(name="tagNames", description="Comma-separated list of tag names")
+    @GraphQLInputField(name=GqlConstants.TAG_NAMES, description="Comma-separated list of tag names")
     public void setTagNames(String tagNames) { this.tagNames = tagNames; }
-    @GraphQLInputField(name="vcard", description="Either a vcard or attributes can be specified but not both")
+    @GraphQLInputField(name=GqlConstants.VCARD, description="Either a vcard or attributes can be specified but not both")
     public void setVcard(VCardInfo vcard) { this.vcard = vcard; }
     @Override
-    @GraphQLInputField(name="attrs", description="Contact attributes")
+    @GraphQLInputField(name=GqlConstants.ATTRIBUTES, description="Contact attributes")
     public void setAttrs(Iterable <NewContactAttr> attrs) {
         this.attrs.clear();
         if (attrs != null) {
@@ -138,7 +139,7 @@ public class ContactSpec implements SpecifyContact<NewContactAttr,NewContactGrou
     }
 
     @Override
-    @GraphQLInputField(name="contactGroupMembers", description="Valid only if the contact being created is a contact group")
+    @GraphQLInputField(name=GqlConstants.CONTACT_GROUP_MEMBERS, description="Valid only if the contact being created is a contact group")
     public void setContactGroupMembers(Iterable <NewContactGroupMember> contactGroupMembers) {
         this.contactGroupMembers.clear();
         if (contactGroupMembers != null) {

--- a/soap/src/java/com/zimbra/soap/mail/type/ContactSpec.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ContactSpec.java
@@ -30,7 +30,12 @@ import com.google.common.collect.Lists;
 import com.zimbra.common.soap.MailConstants;
 import com.zimbra.soap.base.SpecifyContact;
 
+import io.leangen.graphql.annotations.GraphQLIgnore;
+import io.leangen.graphql.annotations.GraphQLInputField;
+import io.leangen.graphql.annotations.types.GraphQLType;
+
 @XmlAccessorType(XmlAccessType.NONE)
+@GraphQLType(name="ContactSpec", description="Input for creating a new contact")
 public class ContactSpec implements SpecifyContact<NewContactAttr,NewContactGroupMember> {
 
     // Used when modifying a contact
@@ -54,6 +59,7 @@ public class ContactSpec implements SpecifyContact<NewContactAttr,NewContactGrou
      */
     @Deprecated
     @XmlAttribute(name=MailConstants.A_TAGS /* t */, required=false)
+    @GraphQLIgnore
     private String tags;
 
     /**
@@ -73,6 +79,7 @@ public class ContactSpec implements SpecifyContact<NewContactAttr,NewContactGrou
      * @zm-api-field-description Contact attributes.  Cannot specify <b>&lt;vcard></b> as well as these
      */
     @XmlElement(name=MailConstants.E_ATTRIBUTE /* a */, required=false)
+    @GraphQLInputField(name="attrs", description="Contact attributes.")
     private final List<NewContactAttr> attrs = Lists.newArrayList();
 
     /**
@@ -80,20 +87,27 @@ public class ContactSpec implements SpecifyContact<NewContactAttr,NewContactGrou
      * (has attribute type="group")
      */
     @XmlElement(name=MailConstants.E_CONTACT_GROUP_MEMBER /* m */, required=false)
+    @GraphQLInputField(name="contactGroupMembers", description="Valid only if the contact being created is a contact group")
     private final List<NewContactGroupMember> contactGroupMembers = Lists.newArrayList();
 
     public ContactSpec() {
     }
 
     @Override
+    @GraphQLInputField(name="id", description="ID - specified when modifying a contact")
     public void setId(Integer id) { this.id = id; }
+    @GraphQLInputField(name="folder", description="ID of folder to create contact in. Un-specified means use the default Contacts folder.")
     public void setFolder(String folder) { this.folder = folder; }
     @Deprecated
+    @GraphQLIgnore
     public void setTags(String tags) { this.tags = tags; }
     @Override
+    @GraphQLInputField(name="tagNames", description="Comma-separated list of tag names")
     public void setTagNames(String tagNames) { this.tagNames = tagNames; }
+    @GraphQLInputField(name="vcard", description="Either a vcard or attributes can be specified but not both")
     public void setVcard(VCardInfo vcard) { this.vcard = vcard; }
     @Override
+    @GraphQLInputField(name="attrs", description="Contact attributes")
     public void setAttrs(Iterable <NewContactAttr> attrs) {
         this.attrs.clear();
         if (attrs != null) {
@@ -102,25 +116,29 @@ public class ContactSpec implements SpecifyContact<NewContactAttr,NewContactGrou
     }
 
     @Override
+    @GraphQLIgnore
     public void addAttr(NewContactAttr attr) {
         this.attrs.add(attr);
     }
 
     @Override
+    @GraphQLIgnore
     public NewContactAttr addAttrWithName(String name) {
-        NewContactAttr nca = new NewContactAttr(name);
+        final NewContactAttr nca = new NewContactAttr(name);
         addAttr(nca);
         return nca;
     }
 
     @Override
+    @GraphQLIgnore
     public NewContactAttr addAttrWithNameAndValue(String name, String value) {
-        NewContactAttr nca = NewContactAttr.fromNameAndValue(name, value);
+        final NewContactAttr nca = NewContactAttr.fromNameAndValue(name, value);
         addAttr(nca);
         return nca;
     }
 
     @Override
+    @GraphQLInputField(name="contactGroupMembers", description="Valid only if the contact being created is a contact group")
     public void setContactGroupMembers(Iterable <NewContactGroupMember> contactGroupMembers) {
         this.contactGroupMembers.clear();
         if (contactGroupMembers != null) {
@@ -129,13 +147,15 @@ public class ContactSpec implements SpecifyContact<NewContactAttr,NewContactGrou
     }
 
     @Override
+    @GraphQLIgnore
     public void addContactGroupMember(NewContactGroupMember contactGroupMember) {
         this.contactGroupMembers.add(contactGroupMember);
     }
 
     @Override
+    @GraphQLIgnore
     public NewContactGroupMember addContactGroupMemberWithTypeAndValue(String type, String value) {
-        NewContactGroupMember ncgm = NewContactGroupMember.createForTypeAndValue(type, value);
+        final NewContactGroupMember ncgm = NewContactGroupMember.createForTypeAndValue(type, value);
         addContactGroupMember(ncgm);
         return ncgm;
     }

--- a/soap/src/java/com/zimbra/soap/mail/type/ConversationMsgHitInfo.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ConversationMsgHitInfo.java
@@ -31,7 +31,7 @@ import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.types.GraphQLType;
 
 @XmlAccessorType(XmlAccessType.NONE)
-@GraphQLType(name=GqlConstants.CONVERSATION_MESSAGE_HIT_INFO, description="Conversation search result information containing messages")
+@GraphQLType(name=GqlConstants.CLASS_CONVERSATION_MESSAGE_HIT_INFO, description="Conversation search result information containing messages")
 public class ConversationMsgHitInfo {
 
     /**

--- a/soap/src/java/com/zimbra/soap/mail/type/ConversationSummary.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ConversationSummary.java
@@ -39,7 +39,7 @@ import io.leangen.graphql.annotations.types.GraphQLType;
 
 @XmlAccessorType(XmlAccessType.NONE)
 @XmlType(propOrder = {"metadatas", "subject", "fragment", "emails"})
-@GraphQLType(name=GqlConstants.CONVERSATION_SUMMARY, description="Conversation search result information")
+@GraphQLType(name=GqlConstants.CLASS_CONVERSATION_SUMMARY, description="Conversation search result information")
 public class ConversationSummary {
 
     /**

--- a/soap/src/java/com/zimbra/soap/mail/type/EmailInfo.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/EmailInfo.java
@@ -143,7 +143,7 @@ implements EmailInfoInterface {
     @GraphQLQuery(name=GqlConstants.GROUP, description="Set if the email address is a group")
     public Boolean getGroup() { return ZmBoolean.toBool(group); }
     @Override
-    @GraphQLQuery(name=GqlConstants.CAN_EXPAND_GROUP_MEMBERS, description="Denotes that the group can be expanded showing its members")
+    @GraphQLQuery(name=GqlConstants.IS_GROUP_MEMBERS_EXPANDABLE, description="Denotes whether the group can be expanded showing its members")
     public Boolean getCanExpandGroupMembers() { return ZmBoolean.toBool(canExpandGroupMembers); }
 
     public static Iterable <EmailInfo> fromInterfaces(Iterable <EmailInfoInterface> ifs) {

--- a/soap/src/java/com/zimbra/soap/mail/type/EmailInfo.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/EmailInfo.java
@@ -35,7 +35,7 @@ import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.types.GraphQLType;
 
 @XmlAccessorType(XmlAccessType.NONE)
-@GraphQLType(name=GqlConstants.EMAIL_INFO, description="Email information")
+@GraphQLType(name=GqlConstants.CLASS_EMAIL_INFO, description="Email information")
 public class EmailInfo
 implements EmailInfoInterface {
 

--- a/soap/src/java/com/zimbra/soap/mail/type/MailCustomMetadata.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/MailCustomMetadata.java
@@ -37,7 +37,7 @@ import io.leangen.graphql.annotations.types.GraphQLType;
 
 @XmlAccessorType(XmlAccessType.NONE)
 @XmlRootElement(name=MailConstants.E_METADATA)
-@GraphQLType(name=GqlConstants.MAIL_CUSTOM_METADATA, description="Custom metadatas")
+@GraphQLType(name=GqlConstants.CLASS_MAIL_CUSTOM_METADATA, description="Custom metadatas")
 public class MailCustomMetadata
 extends MailKeyValuePairs
 implements CustomMetadataInterface {

--- a/soap/src/java/com/zimbra/soap/mail/type/MessageHitInfo.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/MessageHitInfo.java
@@ -37,7 +37,7 @@ import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.types.GraphQLType;
 
 @XmlAccessorType(XmlAccessType.NONE)
-@GraphQLType(name=GqlConstants.MESSAGE_HIT_INFO, description="Message search result information containing a list of messages")
+@GraphQLType(name=GqlConstants.CLASS_MESSAGE_HIT_INFO, description="Message search result information containing a list of messages")
 public class MessageHitInfo
 extends MessageInfo
 implements SearchHit {

--- a/soap/src/java/com/zimbra/soap/mail/type/MessageInfo.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/MessageInfo.java
@@ -46,7 +46,7 @@ import io.leangen.graphql.annotations.types.GraphQLType;
 @XmlType(propOrder = { "fragment", "emails", "subject",
     "messageIdHeader", "inReplyTo", "invite", "headers", "contentElems" })
 
-@GraphQLType(name=GqlConstants.MESSAGE_INFO, description="Message information")
+@GraphQLType(name=GqlConstants.CLASS_MESSAGE_INFO, description="Message information")
 public class MessageInfo
 extends MessageCommon
 implements MessageInfoInterface {

--- a/soap/src/java/com/zimbra/soap/mail/type/ModifyContactAttr.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ModifyContactAttr.java
@@ -22,9 +22,14 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 
 import com.google.common.base.MoreObjects;
+import com.zimbra.common.gql.GqlConstants;
 import com.zimbra.common.soap.MailConstants;
 
+import io.leangen.graphql.annotations.GraphQLInputField;
+import io.leangen.graphql.annotations.types.GraphQLType;
+
 @XmlAccessorType(XmlAccessType.NONE)
+@GraphQLType(name=GqlConstants.CLASS_MODIFY_CONTACT_ATTRIBUTE, description="Contact attributes to modify")
 public class ModifyContactAttr extends NewContactAttr {
 
     // See ParsedContact.FieldDelta.Op - values "+" or "-"
@@ -44,11 +49,12 @@ public class ModifyContactAttr extends NewContactAttr {
     }
 
     public static ModifyContactAttr fromNameAndValue(String name, String value) {
-        ModifyContactAttr mcs = new ModifyContactAttr(name);
+        final ModifyContactAttr mcs = new ModifyContactAttr(name);
         mcs.setValue(value);
         return mcs;
     }
 
+    @GraphQLInputField(name=GqlConstants.OPERATION, description="Specify + or - to add or remove")
     public void setOperation(String operation) { this.operation = operation; }
     public String getOperation() { return operation; }
 

--- a/soap/src/java/com/zimbra/soap/mail/type/ModifyContactGroupMember.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ModifyContactGroupMember.java
@@ -22,9 +22,14 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 
 import com.google.common.base.MoreObjects;
+import com.zimbra.common.gql.GqlConstants;
 import com.zimbra.common.soap.MailConstants;
 
+import io.leangen.graphql.annotations.GraphQLInputField;
+import io.leangen.graphql.annotations.types.GraphQLType;
+
 @XmlAccessorType(XmlAccessType.NONE)
+@GraphQLType(name=GqlConstants.CLASS_MODIFY_CONTACT_GROUP_MEMBER, description="Contact group members to modify")
 public class ModifyContactGroupMember extends NewContactGroupMember {
 
     /**
@@ -53,6 +58,7 @@ public class ModifyContactGroupMember extends NewContactGroupMember {
         return new ModifyContactGroupMember(type, value);
     }
 
+    @GraphQLInputField(name=GqlConstants.OPERATION, description="Specify + or - to add or remove")
     public void setOperation(ModifyGroupMemberOperation operation) { this.operation = operation; }
     public ModifyGroupMemberOperation getOperation() { return operation; }
 

--- a/soap/src/java/com/zimbra/soap/mail/type/ModifyContactSpec.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ModifyContactSpec.java
@@ -27,10 +27,17 @@ import javax.xml.bind.annotation.XmlElement;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.zimbra.common.gql.GqlConstants;
 import com.zimbra.common.soap.MailConstants;
 import com.zimbra.soap.base.SpecifyContact;
 
+import io.leangen.graphql.annotations.GraphQLIgnore;
+import io.leangen.graphql.annotations.GraphQLInputField;
+import io.leangen.graphql.annotations.GraphQLNonNull;
+import io.leangen.graphql.annotations.types.GraphQLType;
+
 @XmlAccessorType(XmlAccessType.NONE)
+@GraphQLType(name=GqlConstants.CLASS_MODIFY_CONTACT_SPEC)
 public class ModifyContactSpec implements SpecifyContact<ModifyContactAttr, ModifyContactGroupMember> {
 
     // Used when modifying a contact
@@ -53,6 +60,7 @@ public class ModifyContactSpec implements SpecifyContact<ModifyContactAttr, Modi
      * @zm-api-field-description Contact attributes.  Cannot specify <b>&lt;vcard></b> as well as these
      */
     @XmlElement(name=MailConstants.E_ATTRIBUTE /* a */, required=false)
+    @GraphQLInputField(name=GqlConstants.ATTRIBUTES, description="Cannot specify vcard as well as these")
     private final List<ModifyContactAttr> attrs = Lists.newArrayList();
 
     /**
@@ -60,22 +68,26 @@ public class ModifyContactSpec implements SpecifyContact<ModifyContactAttr, Modi
      * (has attribute type="group")
      */
     @XmlElement(name=MailConstants.E_CONTACT_GROUP_MEMBER /* m */, required=false)
+    @GraphQLInputField(name=GqlConstants.CONTACT_GROUP_MEMBERS, description="Contact group members.")
     private final List<ModifyContactGroupMember> contactGroupMembers = Lists.newArrayList();
 
     public ModifyContactSpec() {
     }
 
     public static ModifyContactSpec createForId(Integer id) {
-        ModifyContactSpec spec = new ModifyContactSpec();
+        final ModifyContactSpec spec = new ModifyContactSpec();
         spec.setId(id);
         return spec;
     }
 
     @Override
-    public void setId(Integer id) { this.id = id; }
+    @GraphQLInputField(name=GqlConstants.ID, description="Id of the contact to modify")
+    public void setId(@GraphQLNonNull Integer id) { this.id = id; }
     @Override
+    @GraphQLInputField(name=GqlConstants.TAG_NAMES, description="Comma-separated list of tag names")
     public void setTagNames(String tagNames) { this.tagNames = tagNames; }
     @Override
+    @GraphQLInputField(name=GqlConstants.ATTRIBUTES, description="Cannot specify vcard as well as these")
     public void setAttrs(Iterable <ModifyContactAttr> attrs) {
         this.attrs.clear();
         if (attrs != null) {
@@ -84,11 +96,13 @@ public class ModifyContactSpec implements SpecifyContact<ModifyContactAttr, Modi
     }
 
     @Override
+    @GraphQLIgnore
     public void addAttr(ModifyContactAttr attr) {
         this.attrs.add(attr);
     }
 
     @Override
+    @GraphQLInputField(name=GqlConstants.CONTACT_GROUP_MEMBERS, description="Contact group members.")
     public void setContactGroupMembers(Iterable <ModifyContactGroupMember> contactGroupMembers) {
         this.contactGroupMembers.clear();
         if (contactGroupMembers != null) {
@@ -97,6 +111,7 @@ public class ModifyContactSpec implements SpecifyContact<ModifyContactAttr, Modi
     }
 
     @Override
+    @GraphQLIgnore
     public void addContactGroupMember(ModifyContactGroupMember contactGroupMember) {
         this.contactGroupMembers.add(contactGroupMember);
     }
@@ -129,21 +144,21 @@ public class ModifyContactSpec implements SpecifyContact<ModifyContactAttr, Modi
 
     @Override
     public ModifyContactAttr addAttrWithName(String name) {
-        ModifyContactAttr mca = new ModifyContactAttr(name);
+        final ModifyContactAttr mca = new ModifyContactAttr(name);
         addAttr(mca);
         return mca;
     }
 
     @Override
     public ModifyContactAttr addAttrWithNameAndValue(String name, String value) {
-        ModifyContactAttr mca = ModifyContactAttr.fromNameAndValue(name, value);
+        final ModifyContactAttr mca = ModifyContactAttr.fromNameAndValue(name, value);
         addAttr(mca);
         return mca;
     }
 
     @Override
     public ModifyContactGroupMember addContactGroupMemberWithTypeAndValue(String type, String value) {
-        ModifyContactGroupMember mcgm = ModifyContactGroupMember.createForTypeAndValue(type, value);
+        final ModifyContactGroupMember mcgm = ModifyContactGroupMember.createForTypeAndValue(type, value);
         addContactGroupMember(mcgm);
         return mcgm;
     }

--- a/soap/src/java/com/zimbra/soap/mail/type/ModifySearchFolderSpec.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ModifySearchFolderSpec.java
@@ -30,7 +30,7 @@ import io.leangen.graphql.annotations.GraphQLNonNull;
 import io.leangen.graphql.annotations.types.GraphQLType;
 
 @XmlAccessorType(XmlAccessType.NONE)
-@GraphQLType(name=GqlConstants.MODIFY_SEARCH_FOLDER_SPEC, description="Input for modifying an existing search folder")
+@GraphQLType(name=GqlConstants.CLASS_MODIFY_SEARCH_FOLDER_SPEC, description="Input for modifying an existing search folder")
 public class ModifySearchFolderSpec {
 
     /**

--- a/soap/src/java/com/zimbra/soap/mail/type/NewContactAttr.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/NewContactAttr.java
@@ -23,6 +23,7 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlValue;
 
 import com.google.common.base.MoreObjects;
+import com.zimbra.common.gql.GqlConstants;
 import com.zimbra.common.soap.MailConstants;
 
 import io.leangen.graphql.annotations.GraphQLIgnore;
@@ -31,7 +32,7 @@ import io.leangen.graphql.annotations.GraphQLNonNull;
 import io.leangen.graphql.annotations.types.GraphQLType;
 
 @XmlAccessorType(XmlAccessType.NONE)
-@GraphQLType(name="NewContactAttr", description="Input for creating a new contact attribute")
+@GraphQLType(name=GqlConstants.CLASS_NEW_CONTACT_ATTRIBUTE, description="Input for creating a new contact attribute")
 public class NewContactAttr {
 
     /**
@@ -39,7 +40,7 @@ public class NewContactAttr {
      * @zm-api-field-description Attribute name
      */
     @XmlAttribute(name=MailConstants.A_ATTRIBUTE_NAME /* n */, required=true)
-    @GraphQLInputField(name="name", description="Attribute name")
+    @GraphQLInputField(name=GqlConstants.NAME, description="Attribute name")
     private String name;
 
     /**
@@ -47,7 +48,7 @@ public class NewContactAttr {
      * @zm-api-field-description Upload ID
      */
     @XmlAttribute(name=MailConstants.A_ATTACHMENT_ID /* aid */, required=false)
-    @GraphQLInputField(name="attachId", description ="Upload ID")
+    @GraphQLInputField(name=GqlConstants.ATTACHMENT_ID, description ="Upload ID")
     private String attachId;
 
     /**
@@ -55,7 +56,7 @@ public class NewContactAttr {
      * @zm-api-field-description Item ID.  Used in combination with <b>subpart-name</b>
      */
     @XmlAttribute(name=MailConstants.A_ID /* id */, required=false)
-    @GraphQLInputField(name="id", description ="Item ID. Used in combination with part")
+    @GraphQLInputField(name=GqlConstants.ID, description ="Item ID. Used in combination with part")
     private Integer id;
 
     /**
@@ -63,7 +64,7 @@ public class NewContactAttr {
      * @zm-api-field-description Subpart Name
      */
     @XmlAttribute(name=MailConstants.A_PART /* part */, required=false)
-    @GraphQLInputField(name="part", description ="Subpart name")
+    @GraphQLInputField(name=GqlConstants.PART, description ="Subpart name")
     private String part;
 
     /**
@@ -73,7 +74,7 @@ public class NewContactAttr {
      * if the year isn't specified <b>"--MM-dd"</b> format
      */
     @XmlValue
-    @GraphQLInputField(name="value", description ="Attribute value")
+    @GraphQLInputField(name=GqlConstants.VALUE, description ="Attribute value")
     private String value;
 
     /**
@@ -96,13 +97,13 @@ public class NewContactAttr {
 
     @GraphQLIgnore
     public NewContactAttr setName(String name) { this.name = name; return this; }
-    @GraphQLInputField(name="attachId", description ="Upload ID")
+    @GraphQLInputField(name=GqlConstants.ATTACHMENT_ID, description ="Upload ID")
     public NewContactAttr setAttachId(String attachId) { this.attachId = attachId; return this; }
-    @GraphQLInputField(name="id", description ="Item ID. Used in combination with part")
+    @GraphQLInputField(name=GqlConstants.ID, description ="Item ID. Used in combination with part")
     public NewContactAttr setId(Integer id) { this.id = id; return this; }
-    @GraphQLInputField(name="part", description ="Subpart name")
+    @GraphQLInputField(name=GqlConstants.PART, description ="Subpart name")
     public NewContactAttr setPart(String part) { this.part = part; return this; }
-    @GraphQLInputField(name="value", description ="Attribute value")
+    @GraphQLInputField(name=GqlConstants.VALUE, description ="Attribute value")
     public NewContactAttr setValue(String value) { this.value = value; return this; }
 
     public String getName() { return name; }

--- a/soap/src/java/com/zimbra/soap/mail/type/NewContactAttr.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/NewContactAttr.java
@@ -25,7 +25,13 @@ import javax.xml.bind.annotation.XmlValue;
 import com.google.common.base.MoreObjects;
 import com.zimbra.common.soap.MailConstants;
 
+import io.leangen.graphql.annotations.GraphQLIgnore;
+import io.leangen.graphql.annotations.GraphQLInputField;
+import io.leangen.graphql.annotations.GraphQLNonNull;
+import io.leangen.graphql.annotations.types.GraphQLType;
+
 @XmlAccessorType(XmlAccessType.NONE)
+@GraphQLType(name="NewContactAttr", description="Input for creating a new contact attribute")
 public class NewContactAttr {
 
     /**
@@ -33,6 +39,7 @@ public class NewContactAttr {
      * @zm-api-field-description Attribute name
      */
     @XmlAttribute(name=MailConstants.A_ATTRIBUTE_NAME /* n */, required=true)
+    @GraphQLInputField(name="name", description="Attribute name")
     private String name;
 
     /**
@@ -40,6 +47,7 @@ public class NewContactAttr {
      * @zm-api-field-description Upload ID
      */
     @XmlAttribute(name=MailConstants.A_ATTACHMENT_ID /* aid */, required=false)
+    @GraphQLInputField(name="attachId", description ="Upload ID")
     private String attachId;
 
     /**
@@ -47,6 +55,7 @@ public class NewContactAttr {
      * @zm-api-field-description Item ID.  Used in combination with <b>subpart-name</b>
      */
     @XmlAttribute(name=MailConstants.A_ID /* id */, required=false)
+    @GraphQLInputField(name="id", description ="Item ID. Used in combination with part")
     private Integer id;
 
     /**
@@ -54,6 +63,7 @@ public class NewContactAttr {
      * @zm-api-field-description Subpart Name
      */
     @XmlAttribute(name=MailConstants.A_PART /* part */, required=false)
+    @GraphQLInputField(name="part", description ="Subpart name")
     private String part;
 
     /**
@@ -63,6 +73,7 @@ public class NewContactAttr {
      * if the year isn't specified <b>"--MM-dd"</b> format
      */
     @XmlValue
+    @GraphQLInputField(name="value", description ="Attribute value")
     private String value;
 
     /**
@@ -73,20 +84,25 @@ public class NewContactAttr {
          this((String) null);
     }
 
-    public NewContactAttr(String name) {
+    public NewContactAttr(@GraphQLNonNull @GraphQLInputField String name) {
          this.name = name;
     }
 
     public static NewContactAttr fromNameAndValue(String name, String value) {
-        NewContactAttr ncs = new NewContactAttr(name);
+        final NewContactAttr ncs = new NewContactAttr(name);
         ncs.setValue(value);
         return ncs;
     }
 
+    @GraphQLIgnore
     public NewContactAttr setName(String name) { this.name = name; return this; }
+    @GraphQLInputField(name="attachId", description ="Upload ID")
     public NewContactAttr setAttachId(String attachId) { this.attachId = attachId; return this; }
+    @GraphQLInputField(name="id", description ="Item ID. Used in combination with part")
     public NewContactAttr setId(Integer id) { this.id = id; return this; }
+    @GraphQLInputField(name="part", description ="Subpart name")
     public NewContactAttr setPart(String part) { this.part = part; return this; }
+    @GraphQLInputField(name="value", description ="Attribute value")
     public NewContactAttr setValue(String value) { this.value = value; return this; }
 
     public String getName() { return name; }

--- a/soap/src/java/com/zimbra/soap/mail/type/NewContactGroupMember.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/NewContactGroupMember.java
@@ -24,7 +24,12 @@ import javax.xml.bind.annotation.XmlAttribute;
 import com.google.common.base.MoreObjects;
 import com.zimbra.common.soap.MailConstants;
 
+import io.leangen.graphql.annotations.GraphQLInputField;
+import io.leangen.graphql.annotations.GraphQLNonNull;
+import io.leangen.graphql.annotations.types.GraphQLType;
+
 @XmlAccessorType(XmlAccessType.NONE)
+@GraphQLType(name="NewContactGroupMember", description="Input for creating a new contact group member")
 public class NewContactGroupMember {
 
     /**
@@ -67,8 +72,10 @@ public class NewContactGroupMember {
         return new NewContactGroupMember(type, value);
     }
 
-    public void setType(String type) { this.type = type; }
-    public void setValue(String value) { this.value = value; }
+    @GraphQLInputField(name="type", description="Member type. C|G|I")
+    public void setType(@GraphQLNonNull String type) { this.type = type; }
+    @GraphQLInputField(name="value", description="Member value")
+    public void setValue(@GraphQLNonNull String value) { this.value = value; }
     public String getType() { return type; }
     public String getValue() { return value; }
 

--- a/soap/src/java/com/zimbra/soap/mail/type/NewContactGroupMember.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/NewContactGroupMember.java
@@ -22,6 +22,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 
 import com.google.common.base.MoreObjects;
+import com.zimbra.common.gql.GqlConstants;
 import com.zimbra.common.soap.MailConstants;
 
 import io.leangen.graphql.annotations.GraphQLInputField;
@@ -29,7 +30,7 @@ import io.leangen.graphql.annotations.GraphQLNonNull;
 import io.leangen.graphql.annotations.types.GraphQLType;
 
 @XmlAccessorType(XmlAccessType.NONE)
-@GraphQLType(name="NewContactGroupMember", description="Input for creating a new contact group member")
+@GraphQLType(name=GqlConstants.CLASS_NEW_CONTACT_GROUP_MEMBER, description="Input for creating a new contact group member")
 public class NewContactGroupMember {
 
     /**
@@ -72,9 +73,9 @@ public class NewContactGroupMember {
         return new NewContactGroupMember(type, value);
     }
 
-    @GraphQLInputField(name="type", description="Member type. C|G|I")
+    @GraphQLInputField(name=GqlConstants.TYPE, description="Member type. C|G|I")
     public void setType(@GraphQLNonNull String type) { this.type = type; }
-    @GraphQLInputField(name="value", description="Member value")
+    @GraphQLInputField(name=GqlConstants.VALUE, description="Member value")
     public void setValue(@GraphQLNonNull String value) { this.value = value; }
     public String getType() { return type; }
     public String getValue() { return value; }

--- a/soap/src/java/com/zimbra/soap/mail/type/SearchFolder.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/SearchFolder.java
@@ -43,7 +43,7 @@ import io.leangen.graphql.annotations.types.GraphQLType;
 // MailConstants.E_SEARCH == "search"
 @XmlAccessorType(XmlAccessType.NONE)
 @XmlRootElement(name=MailConstants.E_SEARCH)
-@GraphQLType(name=GqlConstants.SEARCH_FOLDER, description="Search folder details")
+@GraphQLType(name=GqlConstants.CLASS_SEARCH_FOLDER, description="Search folder details")
 public final class SearchFolder extends Folder {
 
     /**

--- a/soap/src/java/com/zimbra/soap/mail/type/VCardInfo.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/VCardInfo.java
@@ -17,15 +17,19 @@
 
 package com.zimbra.soap.mail.type;
 
-import com.google.common.base.MoreObjects;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlValue;
 
+import com.google.common.base.MoreObjects;
 import com.zimbra.common.soap.MailConstants;
 
+import io.leangen.graphql.annotations.GraphQLInputField;
+import io.leangen.graphql.annotations.types.GraphQLType;
+
 @XmlAccessorType(XmlAccessType.NONE)
+@GraphQLType(name="VCardInfo", description="Input for creating a new contact VCard")
 public class VCardInfo {
 
     /**
@@ -59,9 +63,13 @@ public class VCardInfo {
     public VCardInfo() {
     }
 
+    @GraphQLInputField(name="messageId", description="Message ID. Use in conjuction with part")
     public void setMessageId(String messageId) { this.messageId = messageId; }
+    @GraphQLInputField(name="attachId", description="Uploaded attachment ID")
     public void setAttachId(String attachId) { this.attachId = attachId; }
+    @GraphQLInputField(name="part", description="Part identifier. Use in conjunction with message id")
     public void setPart(String part) { this.part = part; }
+    @GraphQLInputField(name="value", description="VCARD data")
     public void setValue(String value) { this.value = value; }
     public String getMessageId() { return messageId; }
     public String getAttachId() { return attachId; }

--- a/soap/src/java/com/zimbra/soap/mail/type/VCardInfo.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/VCardInfo.java
@@ -23,13 +23,14 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlValue;
 
 import com.google.common.base.MoreObjects;
+import com.zimbra.common.gql.GqlConstants;
 import com.zimbra.common.soap.MailConstants;
 
 import io.leangen.graphql.annotations.GraphQLInputField;
 import io.leangen.graphql.annotations.types.GraphQLType;
 
 @XmlAccessorType(XmlAccessType.NONE)
-@GraphQLType(name="VCardInfo", description="Input for creating a new contact VCard")
+@GraphQLType(name=GqlConstants.CLASS_VCARD_INFO, description="Input for creating a new contact VCard")
 public class VCardInfo {
 
     /**
@@ -63,13 +64,13 @@ public class VCardInfo {
     public VCardInfo() {
     }
 
-    @GraphQLInputField(name="messageId", description="Message ID. Use in conjuction with part")
+    @GraphQLInputField(name=GqlConstants.MESSAGE_ID, description="Message ID. Use in conjuction with part")
     public void setMessageId(String messageId) { this.messageId = messageId; }
-    @GraphQLInputField(name="attachId", description="Uploaded attachment ID")
+    @GraphQLInputField(name=GqlConstants.ATTACHMENT_ID, description="Uploaded attachment ID")
     public void setAttachId(String attachId) { this.attachId = attachId; }
-    @GraphQLInputField(name="part", description="Part identifier. Use in conjunction with message id")
+    @GraphQLInputField(name=GqlConstants.PART, description="Part identifier. Use in conjunction with message id")
     public void setPart(String part) { this.part = part; }
-    @GraphQLInputField(name="value", description="VCARD data")
+    @GraphQLInputField(name=GqlConstants.VALUE, description="VCARD data")
     public void setValue(String value) { this.value = value; }
     public String getMessageId() { return messageId; }
     public String getAttachId() { return attachId; }

--- a/soap/src/java/com/zimbra/soap/type/ContactAttr.java
+++ b/soap/src/java/com/zimbra/soap/type/ContactAttr.java
@@ -21,13 +21,14 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 
+import com.zimbra.common.gql.GqlConstants;
 import com.zimbra.common.soap.MailConstants;
 
 import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.types.GraphQLType;
 
 @XmlAccessorType(XmlAccessType.NONE)
-@GraphQLType(name="ContactAttr", description="Contact attribute")
+@GraphQLType(name=GqlConstants.CLASS_CONTACT_ATTRIBUTE, description="Contact attribute")
 public class ContactAttr extends KeyValuePair {
 
     // part/contentType/size/contentFilename are required when
@@ -76,12 +77,12 @@ public class ContactAttr extends KeyValuePair {
         this.contentFilename = contentFilename;
     }
 
-    @GraphQLQuery(name="part", description="Part ID")
+    @GraphQLQuery(name=GqlConstants.PART, description="Part ID")
     public String getPart() { return part; }
-    @GraphQLQuery(name="contentType", description="Content type")
+    @GraphQLQuery(name=GqlConstants.CONTENT_TYPE, description="Content type")
     public String getContentType() { return contentType; }
-    @GraphQLQuery(name="size", description="Size")
+    @GraphQLQuery(name=GqlConstants.SIZE, description="Size")
     public Integer getSize() { return size; }
-    @GraphQLQuery(name="contentFilename", description="Content filename")
+    @GraphQLQuery(name=GqlConstants.CONTENT_FILENAME, description="Content filename")
     public String getContentFilename() { return contentFilename; }
 }

--- a/soap/src/java/com/zimbra/soap/type/ContactAttr.java
+++ b/soap/src/java/com/zimbra/soap/type/ContactAttr.java
@@ -23,7 +23,11 @@ import javax.xml.bind.annotation.XmlAttribute;
 
 import com.zimbra.common.soap.MailConstants;
 
+import io.leangen.graphql.annotations.GraphQLQuery;
+import io.leangen.graphql.annotations.types.GraphQLType;
+
 @XmlAccessorType(XmlAccessType.NONE)
+@GraphQLType(name="ContactAttr", description="Contact attribute")
 public class ContactAttr extends KeyValuePair {
 
     // part/contentType/size/contentFilename are required when
@@ -72,8 +76,12 @@ public class ContactAttr extends KeyValuePair {
         this.contentFilename = contentFilename;
     }
 
+    @GraphQLQuery(name="part", description="Part ID")
     public String getPart() { return part; }
+    @GraphQLQuery(name="contentType", description="Content type")
     public String getContentType() { return contentType; }
+    @GraphQLQuery(name="size", description="Size")
     public Integer getSize() { return size; }
+    @GraphQLQuery(name="contentFilename", description="Content filename")
     public String getContentFilename() { return contentFilename; }
 }

--- a/soap/src/java/com/zimbra/soap/type/CursorInfo.java
+++ b/soap/src/java/com/zimbra/soap/type/CursorInfo.java
@@ -29,7 +29,7 @@ import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.types.GraphQLType;
 
 @XmlAccessorType(XmlAccessType.NONE)
-@GraphQLType(name=GqlConstants.CURSOR_INFO, description="Cursor specification")
+@GraphQLType(name=GqlConstants.CLASS_CURSOR_INFO, description="Cursor specification")
 public final class CursorInfo {
 
     /**

--- a/soap/src/java/com/zimbra/soap/type/NamedValue.java
+++ b/soap/src/java/com/zimbra/soap/type/NamedValue.java
@@ -30,7 +30,7 @@ import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.types.GraphQLType;
 
 @XmlAccessorType(XmlAccessType.NONE)
-@GraphQLType(name=GqlConstants.NAMED_VALUE, description="attribute names and values")
+@GraphQLType(name=GqlConstants.CLASS_NAMED_VALUE, description="attribute names and values")
 public class NamedValue {
 
     /**

--- a/soap/src/java/com/zimbra/soap/type/TzOnsetInfo.java
+++ b/soap/src/java/com/zimbra/soap/type/TzOnsetInfo.java
@@ -29,7 +29,7 @@ import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.types.GraphQLType;
 
 @XmlAccessorType(XmlAccessType.NONE)
-@GraphQLType(name=GqlConstants.TZ_ONSET_INFO, description="Time/rule for transitioning from daylight time to standard time. Either specify week/wkday combo, or mday.")
+@GraphQLType(name=GqlConstants.CLASS_TZ_ONSET_INFO, description="Time/rule for transitioning from daylight time to standard time. Either specify week/wkday combo, or mday.")
 public class TzOnsetInfo {
 
     /**

--- a/soap/src/java/com/zimbra/soap/type/WantRecipsSetting.java
+++ b/soap/src/java/com/zimbra/soap/type/WantRecipsSetting.java
@@ -20,7 +20,12 @@ package com.zimbra.soap.type;
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
 
+import com.zimbra.common.gql.GqlConstants;
+
+import io.leangen.graphql.annotations.types.GraphQLType;
+
 @XmlEnum
+@GraphQLType(name=GqlConstants.CLASS_INCLUDE_RECIPS_SETTING)
 public enum WantRecipsSetting {
     @XmlEnumValue("0") PUT_SENDERS,
     @XmlEnumValue("1") PUT_RECIPIENTS,


### PR DESCRIPTION
* Annotations for gql contacts resolver.
* Updated some booleans for consistency (using `include`, `is`, `do` since they're most common).
  * This affects some gql search resource properties:
    * `wantHtml` -> `includeHtml`
    * `needCanExpand` -> `includeIsExpandable` (the resulting property as `isExpandable`)
    * `wantRecipients` -> `includeRecipients`
* Prefix class constants.

**Testing Done**
Minimal testing with basic properties for all resources, see jira ticket for some example queries/mutations.

**Testing to be done by QA**
See testrail.

See associated PR Zimbra/zm-gql#25 for more info.

I added a constructor to `ContactActionSelector` such that the update method can set the `ids` and `operation`.