### PR TITLE
ZCS-5709:Modify GetDistributionListMembers to get habGroup members

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -2902,15 +2902,6 @@ public class ZAttrProvisioning {
     public static final String A_zimbraAccountExtraObjectClass = "zimbraAccountExtraObjectClass";
 
     /**
-     * seniority index of the account which will determine the sorting order
-     * in the hierarchical address book
-     *
-     * @since ZCS 8.8.10
-     */
-    @ZAttr(id=3030)
-    public static final String A_zimbraAccountSeniorityIndex = "zimbraAccountSeniorityIndex";
-
-    /**
      * account status. active - active lockout - no login until lockout
      * duration is over, mail delivery OK. locked - no login, mail delivery
      * OK. maintenance - no login, no delivery(lmtp server returns 4.x.x
@@ -7739,29 +7730,21 @@ public class ZAttrProvisioning {
     public static final String A_zimbraGroupId = "zimbraGroupId";
 
     /**
-     * members in the hierarchical address book group
-     *
-     * @since ZCS 8.8.10
-     */
-    @ZAttr(id=3027)
-    public static final String A_zimbraHABGroupMember = "zimbraHABGroupMember";
-
-    /**
-     * parent of the hierarchical address book group
-     *
-     * @since ZCS 8.8.10
-     */
-    @ZAttr(id=3028)
-    public static final String A_zimbraHABGroupParent = "zimbraHABGroupParent";
-
-    /**
-     * seniority index of the group which will determine the sorting order in
-     * the hierarchical address book
+     * LDAP attribute to HAB Group Member attribute mapping
      *
      * @since ZCS 8.8.10
      */
     @ZAttr(id=3029)
-    public static final String A_zimbraHABGroupSeniorityIndex = "zimbraHABGroupSeniorityIndex";
+    public static final String A_zimbraHABMemberLdapAttrMap = "zimbraHABMemberLdapAttrMap";
+
+    /**
+     * seniority index of the group or group member which will determine the
+     * sorting order in the hierarchical address book
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=3027)
+    public static final String A_zimbraHABSeniorityIndex = "zimbraHABSeniorityIndex";
 
     /**
      * help URL for admin
@@ -7806,7 +7789,7 @@ public class ZAttrProvisioning {
      *
      * @since ZCS 8.8.10
      */
-    @ZAttr(id=3031)
+    @ZAttr(id=3028)
     public static final String A_zimbraHierarchicalAddressBookRoot = "zimbraHierarchicalAddressBookRoot";
 
     /**

--- a/common/src/java/com/zimbra/common/soap/AccountConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AccountConstants.java
@@ -580,6 +580,7 @@ public class AccountConstants {
     public static final String E_RESET_PASSWORD_REQUEST = "ResetPasswordRequest";
     public static final String E_RESET_PASSWORD_RESPONSE = "ResetPasswordResponse";
     public static final QName RESET_PASSWORD_REQUEST = QName.get(E_RESET_PASSWORD_REQUEST, NAMESPACE);
+
     //Hab
     public static final String A_HAB_ROOT_GROUP_ID = "habRootGroupId";
     public static final String E_HAB_GROUP = "habGroup";
@@ -588,4 +589,7 @@ public class AccountConstants {
     public static final String A_PARENT_HAB_GROUP_ID = "parentHabGroupId";
     public static final String A_HAB_GROUPS= "habGroups";
     public static final String A_HAB_SENIORITY_INDEX = "seniorityIndex";
+    public static final String E_HAB_GROUP_MEMBERS = "groupMembers";
+    public static final String E_HAB_GROUP_MEMBER = "groupMember";
+
 }

--- a/soap/src/java/com/zimbra/soap/account/message/GetDistributionListMembersResponse.java
+++ b/soap/src/java/com/zimbra/soap/account/message/GetDistributionListMembersResponse.java
@@ -17,10 +17,6 @@
 
 package com.zimbra.soap.account.message;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-
 import java.util.Collections;
 import java.util.List;
 
@@ -28,9 +24,15 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.zimbra.common.soap.AccountConstants;
+import com.zimbra.soap.account.type.HABGroupMember;
+import com.zimbra.soap.json.jackson.annotate.ZimbraJsonArrayForWrapper;
 import com.zimbra.soap.type.ZmBoolean;
 
 @XmlAccessorType(XmlAccessType.NONE)
@@ -57,6 +59,14 @@ public class GetDistributionListMembersResponse {
     @XmlElement(name=AccountConstants.E_DLM /* dlm */, required=false)
     private List<String> dlMembers = Lists.newArrayList();
 
+    /**
+     * @zm-api-field-description HAB Group members
+     */
+    @ZimbraJsonArrayForWrapper
+    @XmlElementWrapper(name=AccountConstants.E_HAB_GROUP_MEMBERS /* groupMembers */, required=false)
+    @XmlElement(name=AccountConstants.E_HAB_GROUP_MEMBER /* groupMember */, required=false)
+    private List<HABGroupMember> habGroupMembers;
+
     public GetDistributionListMembersResponse() {
     }
 
@@ -80,12 +90,29 @@ public class GetDistributionListMembersResponse {
         return Collections.unmodifiableList(dlMembers);
     }
 
+    public void setHABGroupMembers(Iterable <HABGroupMember> habGroupMembers) {
+        this.habGroupMembers.clear();
+        if (habGroupMembers != null) {
+            Iterables.addAll(this.habGroupMembers,habGroupMembers);
+        }
+    }
+
+    public GetDistributionListMembersResponse addHABGroupMember(HABGroupMember habGroupMember) {
+        this.habGroupMembers.add(habGroupMember);
+        return this;
+    }
+
+    public List<HABGroupMember> getHABGroupMembers() {
+        return Collections.unmodifiableList(habGroupMembers);
+    }
+
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
             .add("more", more)
             .add("total", total)
             .add("dlMembers", dlMembers)
+            .add("habGroupMembers", habGroupMembers)
             .toString();
     }
 }

--- a/soap/src/java/com/zimbra/soap/account/type/HABGroup.java
+++ b/soap/src/java/com/zimbra/soap/account/type/HABGroup.java
@@ -23,11 +23,9 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
 
 import com.google.common.collect.Lists;
 import com.zimbra.common.soap.AccountConstants;
-import com.zimbra.soap.account.type.Attr;
 import com.zimbra.soap.json.jackson.annotate.ZimbraKeyValuePairs;
 import com.zimbra.soap.type.ZmBoolean;
 
@@ -40,25 +38,19 @@ import com.zimbra.soap.type.ZmBoolean;
  * @zm-api-command-description Returns a list of HABGroup and its children
  */
 @XmlAccessorType(XmlAccessType.NONE)
-public class HABGroup {
-    /**
-     * @zm-api-field-description name of the HAB Group
-     */
-    @XmlElement(name=AccountConstants.A_NAME, required=false)
-    private String name;
-    
+public class HABGroup extends HABMember {
+
     /**
      * @zm-api-field-description id of the HAB group
      */
     @XmlElement(name=AccountConstants.A_ID, required=false)
     private String id;
-    
+
     /**
      * @zm-api-field-description List of HabGroups under this HAB group
      */
     @XmlElement(name=AccountConstants.A_HAB_GROUPS, required=false)
     private List<HABGroup> childGroups = new ArrayList<HABGroup>();
-    
 
     /**
      * @zm-api-field-description Attributes of the HAB group
@@ -66,7 +58,7 @@ public class HABGroup {
     @ZimbraKeyValuePairs
     @XmlElement(name=AccountConstants.E_ATTR /* attr */, required=true)
     private List<Attr> attrs = Lists.newArrayList();
-    
+
     /**
      * @zm-api-field-tag rootGroup indicator
      * @zm-api-field-description indicates whether a HAB group is the parent group in the Hierarchy
@@ -74,37 +66,17 @@ public class HABGroup {
     @XmlAttribute(name = AccountConstants.A_ROOT_HAB_GROUP /* rootHabGroup */, required = false)
     private ZmBoolean rootGroup;
 
-    
     /**
      * @zm-api-field-tag parentGroupId
      * @zm-api-field-description id of the parent group
      */
     @XmlAttribute(name = AccountConstants.A_PARENT_HAB_GROUP_ID /* parentHabGroupId */, required = false)
     private String parentGroupId;
-    
-    /**
-     * @zm-api-field-tag seniorityIndex
-     * @zm-api-field-description seniorityIndexOfTheHAB group
-     */
-    @XmlAttribute(name = AccountConstants.A_HAB_SENIORITY_INDEX /* seniorityIndex */, required = false)
-    private int seniorityIndex;
-    
-    
-    public String getName() {
-        return name;
-    }
 
-    
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    
     public String getId() {
         return id;
     }
 
-    
     public void setId(String id) {
         this.id = id;
     }
@@ -149,27 +121,13 @@ public class HABGroup {
         this.attrs = attrs;
     }
 
-
-
-    
-    public int getSeniorityIndex() {
-        return seniorityIndex;
-    }
-
-
-    
-    public void setSeniorityIndex(int seniorityIndex) {
-        this.seniorityIndex = seniorityIndex;
-    }
-
-
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();
         builder.append("HABGroup [");
-        if (name != null) {
+        if (getName() != null) {
             builder.append("name=");
-            builder.append(name);
+            builder.append(getName());
             builder.append(", ");
         }
         if (id != null) {
@@ -198,10 +156,9 @@ public class HABGroup {
             builder.append(", ");
         }
         builder.append("seniorityIndex=");
-        builder.append(seniorityIndex);
+        builder.append(getSeniorityIndex());
         builder.append("]\n");
         return builder.toString();
     }
-
 
 }

--- a/soap/src/java/com/zimbra/soap/account/type/HABGroupMember.java
+++ b/soap/src/java/com/zimbra/soap/account/type/HABGroupMember.java
@@ -1,0 +1,74 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.account.type;
+
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.zimbra.common.soap.AccountConstants;
+import com.zimbra.soap.json.jackson.annotate.ZimbraKeyValuePairs;
+import com.zimbra.soap.type.NamedValue;
+
+@XmlAccessorType(XmlAccessType.NONE)
+public class HABGroupMember extends HABMember {
+
+    public HABGroupMember(String name) {
+        super(name);
+    }
+
+    /**
+     * @zm-api-field-description Member attributes. Currently only these attributes are returned:
+     * <table>
+     * <tr><td> <b>zimbraId</b>       </td><td> the unique UUID of the hab member </td></tr>
+     * <tr><td> <b>displayName</b>    </td><td> display name for the member </td></tr>
+     * </table>
+     */
+    @ZimbraKeyValuePairs
+    @XmlElement(name=AccountConstants.E_ATTR /* attr */, required=true)
+    private List<NamedValue> attrs = Lists.newArrayList();
+
+    public List<NamedValue> getAttrs() {
+        return attrs;
+    }
+
+    public void setAttrs(Iterable <NamedValue> attrs) {
+        this.attrs.clear();
+        if (attrs != null) {
+            Iterables.addAll(this.attrs,attrs);
+        }
+    }
+
+    public HABGroupMember addAttr(NamedValue attr) {
+        this.attrs.add(attr);
+        return this;
+    }
+
+    public MoreObjects.ToStringHelper addToStringInfo(
+            MoreObjects.ToStringHelper helper) {
+    super.addToStringInfo(helper);
+    return helper
+        .add("attrs", attrs);
+}
+
+}

--- a/soap/src/java/com/zimbra/soap/account/type/HABMember.java
+++ b/soap/src/java/com/zimbra/soap/account/type/HABMember.java
@@ -1,0 +1,83 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.soap.account.type;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+
+import com.google.common.base.MoreObjects;
+import com.zimbra.common.soap.AccountConstants;
+import com.zimbra.soap.json.jackson.annotate.ZimbraJsonAttribute;
+
+public abstract class HABMember {
+
+    /**
+     * @zm-api-field-tag member-email-address
+     * @zm-api-field-description HAB Member name - an email address (user@domain)
+     */
+    @ZimbraJsonAttribute
+    @XmlElement(name=AccountConstants.A_NAME /* name */, required=true)
+    private String name;
+
+    /**
+     * @zm-api-field-tag seniorityIndex
+     * @zm-api-field-description seniorityIndex of the HAB group member
+     */
+    @XmlAttribute(name = AccountConstants.A_HAB_SENIORITY_INDEX /* seniorityIndex */, required = false)
+    private int seniorityIndex;
+
+    /**
+     * no-argument constructor wanted by JAXB
+     */
+    @SuppressWarnings("unused")
+    public HABMember() {
+        this((String) null);
+    }
+
+    public HABMember(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getSeniorityIndex() {
+        return seniorityIndex;
+    }
+
+    public void setSeniorityIndex(int seniorityIndex) {
+        this.seniorityIndex = seniorityIndex;
+    }
+
+    public MoreObjects.ToStringHelper addToStringInfo(
+                MoreObjects.ToStringHelper helper) {
+        return helper
+            .add("name", name)
+            .add("seniorityIndex", seniorityIndex);
+    }
+
+    @Override
+    public String toString() {
+        return addToStringInfo(MoreObjects.toStringHelper(this))
+                .toString();
+    }
+}

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9714,24 +9714,31 @@ TODO: delete them permanently from here
   <desc>OAuth consumer API scope. It is in the format of apiscope1{separator character}apiscope2:consumer-app-name. The separator between apiscope1 and apiscope2 is consumer-app specific</desc>
 </attr>
 
-<attr id="3027" name="zimbraHABGroupMember" type="string" cardinality="multi" optionalIn="habGroup" since="8.8.10">
-  <desc>members in the hierarchical address book group</desc>
+<attr id="3027" name="zimbraHABSeniorityIndex" type="integer" cardinality="single" optionalIn="habGroup,account" since="8.8.10">
+  <desc>seniority index of the group or group member which will determine the sorting order in the hierarchical address book</desc>
 </attr>
 
-<attr id="3028" name="zimbraHABGroupParent" type="string" cardinality="single" optionalIn="habGroup" since="8.8.10">
-  <desc>parent of the hierarchical address book group</desc>
-</attr>
-
-<attr id="3029" name="zimbraHABGroupSeniorityIndex" type="integer" cardinality="single" optionalIn="habGroup" since="8.8.10">
-  <desc>seniority index of the group which will determine the sorting order in the hierarchical address book</desc>
-</attr>
-
-<attr id="3030" name="zimbraAccountSeniorityIndex" type="integer" cardinality="single" optionalIn="account" since="8.8.10">
-  <desc>seniority index of the account which will determine the sorting order in the hierarchical address book</desc>
-</attr>
-
-<attr id="3031" name="zimbraHierarchicalAddressBookRoot" type="string" cardinality="multi" optionalIn="domain" flags="domainInfo" since="8.8.10">
+<attr id="3028" name="zimbraHierarchicalAddressBookRoot" type="string" cardinality="multi" optionalIn="domain" flags="domainInfo" since="8.8.10">
   <desc>domain level root of hierarchical address book</desc>
+</attr>
+
+<attr id="3029" name="zimbraHABMemberLdapAttrMap" type="string" max="4096" cardinality="multi" optionalIn="globalConfig" since="8.8.10">
+  <globalConfigValue>firstName=givenName</globalConfigValue>
+  <globalConfigValue>lastName=sn</globalConfigValue>
+  <globalConfigValue>displayName=displayName</globalConfigValue>
+  <globalConfigValue>commonName=cn</globalConfigValue>
+  <globalConfigValue>initials=initials</globalConfigValue>
+  <globalConfigValue>company=company</globalConfigValue>
+  <globalConfigValue>department=ou</globalConfigValue>
+  <globalConfigValue>jobTitle=title</globalConfigValue>
+  <globalConfigValue>workStreet=streetAddress</globalConfigValue>
+  <globalConfigValue>workPhone=telephoneNumber</globalConfigValue>
+  <globalConfigValue>workState=st</globalConfigValue>
+  <globalConfigValue>workCity=l</globalConfigValue>
+  <globalConfigValue>country=co</globalConfigValue>
+  <globalConfigValue>office=physicalDeliveryOfficeName</globalConfigValue>
+  <globalConfigValue>alias=zimbraMailAlias</globalConfigValue>
+  <desc>LDAP attribute to HAB Group Member attribute mapping</desc>
 </attr>
 
 </attrs>

--- a/store/docs/soap.txt
+++ b/store/docs/soap.txt
@@ -4338,6 +4338,9 @@ Ajax client can use this request to ask the server for help in generating a prop
 
 <GetDistributionListMembersResponse more="{more-flag}" [total="{total}"]>
     <dlm>{member email}</dlm>+
+    <groupMember name={member email}>
+      <attr name={attribute-name}>{attribute-value}</attr>+
+    </groupMember>+
 </GetDistributionListMembersResponse>
 
 Notes:
@@ -4347,7 +4350,8 @@ Notes:
     more-flag = true if more members left to return
     total = total number of distribution lists (not affected by limit/offset)
     
-    returns group members sorted ascendingly by email address.
+    returns group members in <dlm> element, sorted ascendingly by email address for non-hab distribution lists
+    For HAB Groups, it returns group members with their details in groupMember element, sorted by seniorityIndex and then by name.
 
 -----------------------------
 

--- a/store/src/java/com/zimbra/cs/account/EntryCacheDataKey.java
+++ b/store/src/java/com/zimbra/cs/account/EntryCacheDataKey.java
@@ -69,7 +69,8 @@ public enum EntryCacheDataKey {
     /*
      * group
      */
-    GROUP_MEMBERS;
+    GROUP_MEMBERS,
+    HAB_GROUP_MEMBERS;
 
     // all access of the key name must be through this,
     // not calling name() or toString() directly

--- a/store/src/java/com/zimbra/cs/account/Group.java
+++ b/store/src/java/com/zimbra/cs/account/Group.java
@@ -34,6 +34,7 @@ import com.zimbra.cs.account.accesscontrol.GranteeType;
 import com.zimbra.cs.account.accesscontrol.Right;
 import com.zimbra.cs.account.accesscontrol.Rights.User;
 import com.zimbra.cs.account.accesscontrol.ZimbraACE;
+import com.zimbra.soap.account.type.HABGroupMember;
 
 /**
  * @author pshao
@@ -61,6 +62,10 @@ public abstract class Group extends MailTarget implements AliasedEntry {
      * Use Provisioning.getGroupMembers() to get cached results.
      */
     public abstract String[] getAllMembers() throws ServiceException;
+
+    public List<HABGroupMember> getHABMembers() throws ServiceException {
+        throw ServiceException.UNSUPPORTED(); 
+    }
 
     /**
      * Ldap implementation of Group will cost a LDAP search.

--- a/store/src/java/com/zimbra/cs/account/Provisioning.java
+++ b/store/src/java/com/zimbra/cs/account/Provisioning.java
@@ -56,6 +56,7 @@ import com.zimbra.cs.ldap.ZLdapFilterFactory.FilterId;
 import com.zimbra.cs.mime.MimeTypeInfo;
 import com.zimbra.cs.util.AccountUtil;
 import com.zimbra.cs.util.Zimbra;
+import com.zimbra.soap.account.type.HABGroupMember;
 import com.zimbra.soap.admin.type.CacheEntryType;
 import com.zimbra.soap.admin.type.CmdRightsInfo;
 import com.zimbra.soap.admin.type.CountObjectsType;
@@ -1848,6 +1849,10 @@ public abstract class Provisioning extends ZAttrProvisioning {
 
     public String[] getGroupMembers(Group group) throws ServiceException {
         return group.getAllMembers();
+    }
+
+    public List<HABGroupMember> getHABGroupMembers(Group group) throws ServiceException {
+        throw ServiceException.UNSUPPORTED();
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -2786,83 +2786,6 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * seniority index of the account which will determine the sorting order
-     * in the hierarchical address book
-     *
-     * @return zimbraAccountSeniorityIndex, or -1 if unset
-     *
-     * @since ZCS 8.8.10
-     */
-    @ZAttr(id=3030)
-    public int getAccountSeniorityIndex() {
-        return getIntAttr(Provisioning.A_zimbraAccountSeniorityIndex, -1, true);
-    }
-
-    /**
-     * seniority index of the account which will determine the sorting order
-     * in the hierarchical address book
-     *
-     * @param zimbraAccountSeniorityIndex new value
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 8.8.10
-     */
-    @ZAttr(id=3030)
-    public void setAccountSeniorityIndex(int zimbraAccountSeniorityIndex) throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraAccountSeniorityIndex, Integer.toString(zimbraAccountSeniorityIndex));
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * seniority index of the account which will determine the sorting order
-     * in the hierarchical address book
-     *
-     * @param zimbraAccountSeniorityIndex new value
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 8.8.10
-     */
-    @ZAttr(id=3030)
-    public Map<String,Object> setAccountSeniorityIndex(int zimbraAccountSeniorityIndex, Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraAccountSeniorityIndex, Integer.toString(zimbraAccountSeniorityIndex));
-        return attrs;
-    }
-
-    /**
-     * seniority index of the account which will determine the sorting order
-     * in the hierarchical address book
-     *
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 8.8.10
-     */
-    @ZAttr(id=3030)
-    public void unsetAccountSeniorityIndex() throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraAccountSeniorityIndex, "");
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * seniority index of the account which will determine the sorting order
-     * in the hierarchical address book
-     *
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 8.8.10
-     */
-    @ZAttr(id=3030)
-    public Map<String,Object> unsetAccountSeniorityIndex(Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraAccountSeniorityIndex, "");
-        return attrs;
-    }
-
-    /**
      * account status. active - active lockout - no login until lockout
      * duration is over, mail delivery OK. locked - no login, mail delivery
      * OK. maintenance - no login, no delivery(lmtp server returns 4.x.x
@@ -22405,6 +22328,83 @@ public abstract class ZAttrAccount  extends MailTarget {
     public Map<String,Object> unsetGalSyncAccountBasedAutoCompleteEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraGalSyncAccountBasedAutoCompleteEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * seniority index of the group or group member which will determine the
+     * sorting order in the hierarchical address book
+     *
+     * @return zimbraHABSeniorityIndex, or -1 if unset
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=3027)
+    public int getHABSeniorityIndex() {
+        return getIntAttr(Provisioning.A_zimbraHABSeniorityIndex, -1, true);
+    }
+
+    /**
+     * seniority index of the group or group member which will determine the
+     * sorting order in the hierarchical address book
+     *
+     * @param zimbraHABSeniorityIndex new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=3027)
+    public void setHABSeniorityIndex(int zimbraHABSeniorityIndex) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHABSeniorityIndex, Integer.toString(zimbraHABSeniorityIndex));
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * seniority index of the group or group member which will determine the
+     * sorting order in the hierarchical address book
+     *
+     * @param zimbraHABSeniorityIndex new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=3027)
+    public Map<String,Object> setHABSeniorityIndex(int zimbraHABSeniorityIndex, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHABSeniorityIndex, Integer.toString(zimbraHABSeniorityIndex));
+        return attrs;
+    }
+
+    /**
+     * seniority index of the group or group member which will determine the
+     * sorting order in the hierarchical address book
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=3027)
+    public void unsetHABSeniorityIndex() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHABSeniorityIndex, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * seniority index of the group or group member which will determine the
+     * sorting order in the hierarchical address book
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=3027)
+    public Map<String,Object> unsetHABSeniorityIndex(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHABSeniorityIndex, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -19304,6 +19304,140 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * LDAP attribute to HAB Group Member attribute mapping
+     *
+     * @return zimbraHABMemberLdapAttrMap, or empty array if unset
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=3029)
+    public String[] getHABMemberLdapAttrMap() {
+        String[] value = getMultiAttr(Provisioning.A_zimbraHABMemberLdapAttrMap, true, true); return value.length > 0 ? value : new String[] {"firstName=givenName","lastName=sn","displayName=displayName","initials=initials","company=company","department=ou","jobTitle=title","workStreet=streetAddress","workPhone=telephoneNumber","workState=st","workCity=l","country=co","office=physicalDeliveryOfficeName","email=zimbraMailDeliveryAddress","alias=zimbraMailAlias"};
+    }
+
+    /**
+     * LDAP attribute to HAB Group Member attribute mapping
+     *
+     * @param zimbraHABMemberLdapAttrMap new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=3029)
+    public void setHABMemberLdapAttrMap(String[] zimbraHABMemberLdapAttrMap) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHABMemberLdapAttrMap, zimbraHABMemberLdapAttrMap);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * LDAP attribute to HAB Group Member attribute mapping
+     *
+     * @param zimbraHABMemberLdapAttrMap new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=3029)
+    public Map<String,Object> setHABMemberLdapAttrMap(String[] zimbraHABMemberLdapAttrMap, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHABMemberLdapAttrMap, zimbraHABMemberLdapAttrMap);
+        return attrs;
+    }
+
+    /**
+     * LDAP attribute to HAB Group Member attribute mapping
+     *
+     * @param zimbraHABMemberLdapAttrMap new to add to existing values
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=3029)
+    public void addHABMemberLdapAttrMap(String zimbraHABMemberLdapAttrMap) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraHABMemberLdapAttrMap, zimbraHABMemberLdapAttrMap);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * LDAP attribute to HAB Group Member attribute mapping
+     *
+     * @param zimbraHABMemberLdapAttrMap new to add to existing values
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=3029)
+    public Map<String,Object> addHABMemberLdapAttrMap(String zimbraHABMemberLdapAttrMap, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraHABMemberLdapAttrMap, zimbraHABMemberLdapAttrMap);
+        return attrs;
+    }
+
+    /**
+     * LDAP attribute to HAB Group Member attribute mapping
+     *
+     * @param zimbraHABMemberLdapAttrMap existing value to remove
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=3029)
+    public void removeHABMemberLdapAttrMap(String zimbraHABMemberLdapAttrMap) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraHABMemberLdapAttrMap, zimbraHABMemberLdapAttrMap);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * LDAP attribute to HAB Group Member attribute mapping
+     *
+     * @param zimbraHABMemberLdapAttrMap existing value to remove
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=3029)
+    public Map<String,Object> removeHABMemberLdapAttrMap(String zimbraHABMemberLdapAttrMap, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraHABMemberLdapAttrMap, zimbraHABMemberLdapAttrMap);
+        return attrs;
+    }
+
+    /**
+     * LDAP attribute to HAB Group Member attribute mapping
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=3029)
+    public void unsetHABMemberLdapAttrMap() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHABMemberLdapAttrMap, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * LDAP attribute to HAB Group Member attribute mapping
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.10
+     */
+    @ZAttr(id=3029)
+    public Map<String,Object> unsetHABMemberLdapAttrMap(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHABMemberLdapAttrMap, "");
+        return attrs;
+    }
+
+    /**
      * help URL for admin
      *
      * @return zimbraHelpAdminURL, or null if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -14408,7 +14408,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 8.8.10
      */
-    @ZAttr(id=3031)
+    @ZAttr(id=3028)
     public String[] getHierarchicalAddressBookRoot() {
         return getMultiAttr(Provisioning.A_zimbraHierarchicalAddressBookRoot, true, true);
     }
@@ -14421,7 +14421,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 8.8.10
      */
-    @ZAttr(id=3031)
+    @ZAttr(id=3028)
     public void setHierarchicalAddressBookRoot(String[] zimbraHierarchicalAddressBookRoot) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraHierarchicalAddressBookRoot, zimbraHierarchicalAddressBookRoot);
@@ -14437,7 +14437,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 8.8.10
      */
-    @ZAttr(id=3031)
+    @ZAttr(id=3028)
     public Map<String,Object> setHierarchicalAddressBookRoot(String[] zimbraHierarchicalAddressBookRoot, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraHierarchicalAddressBookRoot, zimbraHierarchicalAddressBookRoot);
@@ -14452,7 +14452,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 8.8.10
      */
-    @ZAttr(id=3031)
+    @ZAttr(id=3028)
     public void addHierarchicalAddressBookRoot(String zimbraHierarchicalAddressBookRoot) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraHierarchicalAddressBookRoot, zimbraHierarchicalAddressBookRoot);
@@ -14468,7 +14468,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 8.8.10
      */
-    @ZAttr(id=3031)
+    @ZAttr(id=3028)
     public Map<String,Object> addHierarchicalAddressBookRoot(String zimbraHierarchicalAddressBookRoot, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraHierarchicalAddressBookRoot, zimbraHierarchicalAddressBookRoot);
@@ -14483,7 +14483,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 8.8.10
      */
-    @ZAttr(id=3031)
+    @ZAttr(id=3028)
     public void removeHierarchicalAddressBookRoot(String zimbraHierarchicalAddressBookRoot) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraHierarchicalAddressBookRoot, zimbraHierarchicalAddressBookRoot);
@@ -14499,7 +14499,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 8.8.10
      */
-    @ZAttr(id=3031)
+    @ZAttr(id=3028)
     public Map<String,Object> removeHierarchicalAddressBookRoot(String zimbraHierarchicalAddressBookRoot, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraHierarchicalAddressBookRoot, zimbraHierarchicalAddressBookRoot);
@@ -14513,7 +14513,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 8.8.10
      */
-    @ZAttr(id=3031)
+    @ZAttr(id=3028)
     public void unsetHierarchicalAddressBookRoot() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraHierarchicalAddressBookRoot, "");
@@ -14528,7 +14528,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 8.8.10
      */
-    @ZAttr(id=3031)
+    @ZAttr(id=3028)
     public Map<String,Object> unsetHierarchicalAddressBookRoot(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraHierarchicalAddressBookRoot, "");

--- a/store/src/java/com/zimbra/cs/gal/GalGroupMembers.java
+++ b/store/src/java/com/zimbra/cs/gal/GalGroupMembers.java
@@ -17,6 +17,7 @@
 package com.zimbra.cs.gal;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -38,8 +39,10 @@ import com.zimbra.cs.account.Group;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.mailbox.Contact;
 import com.zimbra.cs.service.AuthProvider;
-import com.zimbra.soap.type.GalSearchType;
 import com.zimbra.soap.ZimbraSoapContext;
+import com.zimbra.soap.account.type.HABGroupMember;
+import com.zimbra.soap.type.GalSearchType;
+import com.zimbra.soap.type.NamedValue;
 
 public class GalGroupMembers {
 
@@ -226,6 +229,45 @@ public class GalGroupMembers {
         @Override
         public int getTotal() {
             return allMembers.length;
+        }
+
+        @Override
+        protected Set<String> getAllMembers() throws ServiceException {
+            return group.getAllMembersSet();
+        }
+
+    }
+
+    public static class LdapHABMembers extends DLMembers {
+        private Group group;
+        private List<HABGroupMember> habMembers;
+
+        public LdapHABMembers(Group group) throws ServiceException {
+            this.group = group;
+            this.habMembers = Provisioning.getInstance().getHABGroupMembers(group);
+        }
+
+        @Override
+        public void encodeMembers(int beginIndex, int endIndex, Element resp) {
+            if (endIndex <= getTotal() && getTotal() != 0) {
+                for (HABGroupMember habMember : habMembers) {
+                    Element habGroupMember = resp.addNonUniqueElement(AccountConstants.E_HAB_GROUP_MEMBER);
+                    habGroupMember.addAttribute(AccountConstants.A_NAME, habMember.getName());
+                    for (NamedValue nv : habMember.getAttrs()) {
+                        habGroupMember.addKeyValuePair(nv.getName(), nv.getValue(), AccountConstants.E_ATTR, AccountConstants.A_NAME);
+                    }
+                }
+            }
+        }
+
+        @Override
+        public String getDLZimbraId() {
+            return group.getId();
+        }
+
+        @Override
+        public int getTotal() {
+            return habMembers.size();
         }
 
         @Override

--- a/store/src/java/com/zimbra/cs/service/account/GetDistributionListMembers.java
+++ b/store/src/java/com/zimbra/cs/service/account/GetDistributionListMembers.java
@@ -209,7 +209,7 @@ public class GetDistributionListMembers extends GalDocumentHandler {
         if (group.hideInGal()) {
             allow = GroupOwner.isOwner(account, group);
         } else {
-            allow = GroupOwner.isOwner(account, group) || group.isMemberOf(account);
+            allow = GroupOwner.isOwner(account, group) || group.isMemberOf(account) || group.isHABGroup();
         }
 
         if (allow) {

--- a/store/src/java/com/zimbra/cs/service/account/GetDistributionListMembers.java
+++ b/store/src/java/com/zimbra/cs/service/account/GetDistributionListMembers.java
@@ -35,6 +35,7 @@ import com.zimbra.cs.gal.GalGroupMembers;
 import com.zimbra.cs.gal.GalGroupMembers.DLMembers;
 import com.zimbra.cs.gal.GalGroupMembers.DLMembersResult;
 import com.zimbra.cs.gal.GalGroupMembers.LdapDLMembers;
+import com.zimbra.cs.gal.GalGroupMembers.LdapHABMembers;
 import com.zimbra.cs.gal.GalGroupMembers.ProxiedDLMembers;
 import com.zimbra.cs.gal.GalSearchControl;
 import com.zimbra.soap.ZimbraSoapContext;
@@ -205,20 +206,24 @@ public class GetDistributionListMembers extends GalDocumentHandler {
 
     private DLMembersResult getMembersFromLdap(Account account, Group group)
     throws ServiceException {
-        boolean allow = false;
-        if (group.hideInGal()) {
-            allow = GroupOwner.isOwner(account, group);
+        if (group.isHABGroup()) {
+            ZimbraLog.account.debug("Retrieving hab group members from LDAP for group %s", group.getName());
+            return new LdapHABMembers(group);
         } else {
-            allow = GroupOwner.isOwner(account, group) || group.isMemberOf(account) || group.isHABGroup();
-        }
-
-        if (allow) {
-            ZimbraLog.account.debug("Retrieving group members from LDAP for group %s", group.getName());
-            return new LdapDLMembers(group);
-        } else {
-            ZimbraLog.account.debug("account %s is not allowed to get members from ldap for group %s",
-                    account.getName(), group.getName());
-            return null;
+            boolean allow = false;
+            if (group.hideInGal()) {
+                allow = GroupOwner.isOwner(account, group);
+            } else {
+                allow = GroupOwner.isOwner(account, group) || group.isMemberOf(account);
+            }
+            if (allow) {
+                ZimbraLog.account.debug("Retrieving group members from LDAP for group %s", group.getName());
+                return new LdapDLMembers(group);
+            } else {
+                ZimbraLog.account.debug("account %s is not allowed to get members from ldap for group %s",
+                        account.getName(), group.getName());
+                return null;
+            }
         }
     }
 

--- a/store/src/java/com/zimbra/cs/service/account/GetHAB.java
+++ b/store/src/java/com/zimbra/cs/service/account/GetHAB.java
@@ -64,7 +64,7 @@ public class GetHAB extends AccountDocumentHandler {
         grp.setId(group.getId());
         grp.setName(group.getName());
         grp.setRootGroup(ZmBoolean.TRUE);
-        grp.setSeniorityIndex(group.getIntAttr(Provisioning.A_zimbraHABGroupSeniorityIndex, 0));
+        grp.setSeniorityIndex(group.getIntAttr(Provisioning.A_zimbraHABSeniorityIndex, 0));
         groups.put(group.getMail(), grp);
         grp.setAttrs(Attr.fromMap(group.getAttrs()));
 
@@ -94,7 +94,7 @@ public class GetHAB extends AccountDocumentHandler {
             habGrp.setId(list.getId());
             habGrp.setName(list.getName());
             habGrp.setAttrs(Attr.fromMap(list.getAttrs()));
-            habGrp.setSeniorityIndex(list.getIntAttr(Provisioning.A_zimbraHABGroupSeniorityIndex, 0));
+            habGrp.setSeniorityIndex(list.getIntAttr(Provisioning.A_zimbraHABSeniorityIndex, 0));
             groups.put(key, habGrp);
             List<HABGroup> children = new ArrayList<HABGroup>();
             

--- a/store/src/java/com/zimbra/cs/service/util/SortBySeniorityIndexThenName.java
+++ b/store/src/java/com/zimbra/cs/service/util/SortBySeniorityIndexThenName.java
@@ -18,16 +18,16 @@ package com.zimbra.cs.service.util;
 
 import java.util.Comparator;
 
-import com.zimbra.soap.account.type.HABGroup;
+import com.zimbra.soap.account.type.HABMember;
 
 /**
  * @author zimbra
  *
  */
-public class SortBySeniorityIndexThenName implements Comparator<HABGroup> {
+public class SortBySeniorityIndexThenName implements Comparator<HABMember> {
 
     @Override
-    public int compare(HABGroup a, HABGroup b) {
+    public int compare(HABMember a, HABMember b) {
         if (a == null || b == null) {
             return 0;
         }


### PR DESCRIPTION
enhanced GetDistributionListMembers implementation to:

- return static dl members from ldap query if it's hab group. 
- return members of dynamic group if it's a hab group

Further enhancement done to return details of members also.
- Added ldap attribute zimbraHABMemberLdapAttrMap which controls which attributes (member details) will be returned in response and their source attribute in ldap.
- replaced zimbraHABGroupSeniorityIndex and zimbraAccountSeniorityIndex with single attribute:  zimbraHABSeniorityIndex