### PR TITLE
ZCS-5395 Admin API to delete static hierarchy in ldap

### DIFF
--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -1515,8 +1515,9 @@ public final class AdminConstants {
 
     // contact backup feature
     public static final String E_SERVERS = "servers";
-    
+
     //HAB
     public static final String A_NEW_NAME = "newName";
     public static final String A_FORCE_DELETE = "forceDelete";
+    public static final String A_CASCADE_DELETE = "cascadeDelete";
 }

--- a/soap/src/java/com/zimbra/soap/admin/message/DeleteDistributionListRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/DeleteDistributionListRequest.java
@@ -39,20 +39,33 @@ public class DeleteDistributionListRequest {
      * @zm-api-field-tag value-of-zimbra-id
      * @zm-api-field-description Zimbra ID
      */
-    @XmlAttribute(name=AdminConstants.E_ID, required=false)
+    @XmlAttribute(name=AdminConstants.E_ID, required=true)
     private final String id;
+
+    /**
+     * @zm-api-field-tag cascadeDelete
+     * @zm-api-field-description If true, cascade delete the hab-groups else return error
+     */
+    @XmlAttribute(name=AdminConstants.A_CASCADE_DELETE, required=false)
+    private final boolean cascadeDelete;
 
     /**
      * no-argument constructor wanted by JAXB
      */
      @SuppressWarnings("unused")
     private DeleteDistributionListRequest() {
-        this((String)null);
+        this(null);
     }
 
     public DeleteDistributionListRequest(String id) {
+        this(id, false);
+    }
+
+    public DeleteDistributionListRequest(String id, boolean cascadeDelete) {
         this.id = id;
+        this.cascadeDelete = cascadeDelete;
     }
 
     public String getId() { return id; }
+    public boolean isCascadeDelete() { return cascadeDelete; }
 }

--- a/store/src/java-test/com/zimbra/cs/account/MockProvisioning.java
+++ b/store/src/java-test/com/zimbra/cs/account/MockProvisioning.java
@@ -900,5 +900,8 @@ public final class MockProvisioning extends Provisioning {
         
     }
 
-    
+    @Override
+    public void deleteGroup(String zimbraId, boolean cascadeDelete) throws ServiceException {
+        // do nothing
+    }
 }

--- a/store/src/java/com/zimbra/cs/account/Provisioning.java
+++ b/store/src/java/com/zimbra/cs/account/Provisioning.java
@@ -1803,6 +1803,10 @@ public abstract class Provisioning extends ZAttrProvisioning {
         throw ServiceException.UNSUPPORTED();
     }
 
+    public void deleteGroup(String zimbraId, boolean cascadeDelete) throws ServiceException {
+        throw ServiceException.UNSUPPORTED();
+    }
+
     public void renameGroup(String zimbraId, String newName) throws ServiceException {
         throw ServiceException.UNSUPPORTED();
     }

--- a/store/src/java/com/zimbra/cs/account/soap/SoapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/soap/SoapProvisioning.java
@@ -990,6 +990,11 @@ public class SoapProvisioning extends Provisioning {
     }
 
     @Override
+    public void deleteGroup(String zimbraId, boolean cascadeDelete) throws ServiceException {
+        invokeJaxb(new DeleteDistributionListRequest(zimbraId, cascadeDelete));
+    }
+
+    @Override
     public void deleteDomain(String zimbraId) throws ServiceException {
         invokeJaxb( new DeleteDomainRequest(zimbraId));
     }

--- a/store/src/java/com/zimbra/cs/service/admin/DeleteDistributionList.java
+++ b/store/src/java/com/zimbra/cs/service/admin/DeleteDistributionList.java
@@ -30,7 +30,6 @@ import com.zimbra.cs.account.Group;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.accesscontrol.AdminRight;
 import com.zimbra.cs.account.accesscontrol.Rights.Admin;
-import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.admin.message.DeleteDistributionListRequest;
 import com.zimbra.soap.admin.message.DeleteDistributionListResponse;
@@ -68,10 +67,11 @@ public class DeleteDistributionList extends DistributionListDocumentHandler {
 
         Group group = getGroupFromContext(context);
         String id = req.getId();
+        boolean cascadeDelete = req.isCascadeDelete();
         defendAgainstGroupHarvesting(group, DistributionListBy.id, id, zsc,
             Admin.R_deleteGroup, Admin.R_deleteDistributionList);
 
-        prov.deleteGroup(group.getId());
+        prov.deleteGroup(group.getId(), cascadeDelete);
 
         ZimbraLog.security.info(ZimbraLog.encodeAttrs(
                 new String[] {"cmd", "DeleteDistributionList","name", group.getName(), "id", group.getId()}));


### PR DESCRIPTION
Problem: Cascade delete static hierarchy in ldap.

Fix:
- Added "cascadeDelete" param in DeleteDistributionListRequest.
- Made code changes to delete sub dls.
- Member will be deleted only if it's dl. And no else member will be deleted.

Testing done:
Tested the api with and without cascade delete param manually from soapui.

Testing needs to be done by QA:
- Test api with and without cascade delete param.
- Test DeleteDistributionListRequest and verify nothing is broken.
- Verify that only hierarchy is deleted and no actual accounts are deleted.