### PR TITLE
ZCS-5709: fix limit and name issue in getDL for hab group

### DIFF
--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -10768,6 +10768,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
                     .collect(Collectors.toMap(e -> e.split("=")[0], e -> e.split("=")[1]));
             List<String> ldapAttrList = new ArrayList<String>(habMemberAttrMap.values());
             ldapAttrList.add(Provisioning.A_objectClass);
+            ldapAttrList.add(Provisioning.A_mail);
             ldapAttrList.add(Provisioning.A_zimbraMailDeliveryAddress);
             ldapAttrList.add(Provisioning.A_zimbraHABSeniorityIndex);
 

--- a/store/src/java/com/zimbra/cs/gal/GalGroupMembers.java
+++ b/store/src/java/com/zimbra/cs/gal/GalGroupMembers.java
@@ -250,10 +250,10 @@ public class GalGroupMembers {
         @Override
         public void encodeMembers(int beginIndex, int endIndex, Element resp) {
             if (endIndex <= getTotal() && getTotal() != 0) {
-                for (HABGroupMember habMember : habMembers) {
+                for (int i = beginIndex; i < endIndex; i++) {
                     Element habGroupMember = resp.addNonUniqueElement(AccountConstants.E_HAB_GROUP_MEMBER);
-                    habGroupMember.addAttribute(AccountConstants.A_NAME, habMember.getName());
-                    for (NamedValue nv : habMember.getAttrs()) {
+                    habGroupMember.addAttribute(AccountConstants.A_NAME, habMembers.get(i).getName());
+                    for (NamedValue nv : habMembers.get(i).getAttrs()) {
                         habGroupMember.addKeyValuePair(nv.getName(), nv.getValue(), AccountConstants.E_ATTR, AccountConstants.A_NAME);
                     }
                 }


### PR DESCRIPTION
- fixed the limit and offset pagination for hab group member response.
- fixed the missing name attribute in response.