### PR TITLE
ZCS-5398 Restrict adding groups in hierarchy which belong to different Org Unit(OU)

### DIFF
--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -1160,7 +1160,7 @@ public final class AdminConstants {
     //HAB
     public static final String E_HAB_GROUP_OPERATION ="habGroupOperation";
 
-    public static final String A_HAB_GROUP_NAME = "habGroupName";
+    public static final String A_HAB_DISPLAY_NAME = "habDisplayName";
     public static final String A_HAB_ORG_UNIT = "habOrgUnit";
     public static final String A_HAB_GROUP_ID ="habGroupId";
     public static final String A_CURRENT_PARENT_HAB_GROUP_ID = "currentParentHabGroupId";

--- a/soap/src/java/com/zimbra/soap/admin/message/CreateHABGroupRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/CreateHABGroupRequest.java
@@ -36,14 +36,14 @@ import com.zimbra.soap.admin.type.Attr;
 @XmlRootElement(name=AdminConstants.E_CREATE_HAB_GROUP_REQUEST)
 public class CreateHABGroupRequest extends CreateDistributionListRequest {
      /**
-      * @zm-api-field-tag hab-group-name
-      * @zm-api-field-description Name for group in HAB
+      * @zm-api-field-tag hab-display-name
+      * @zm-api-field-description Display Name for group in HAB
       */
-     @XmlAttribute(name=AdminConstants.A_HAB_GROUP_NAME /* habGroupName */, required=false)
-     private String habGroupName;
+     @XmlAttribute(name=AdminConstants.A_HAB_DISPLAY_NAME /* habDisplayName */, required=false)
+     private String habDisplayName;
 
      /**
-      * @zm-api-field-tag hab-group-name
+      * @zm-api-field-tag hab-orgunit-name
       * @zm-api-field-description organizational unit of the HAB Group
       */
      @XmlAttribute(name=AdminConstants.A_HAB_ORG_UNIT /* habOrgUnit */, required=true)
@@ -63,20 +63,20 @@ public class CreateHABGroupRequest extends CreateDistributionListRequest {
 
      public CreateHABGroupRequest(String habGroupName, String habOrgUnit, String name, Collection<Attr> attrs, boolean dynamic) {
          super(name, attrs, dynamic);
-         this.habGroupName = habGroupName;
+         this.habDisplayName = habGroupName;
          this.habOrgUnit = habOrgUnit;
      }
 
-     public String getHabGroupName() {
-         return habGroupName;
+     public String getHabDisplayName() {
+         return habDisplayName;
      }
 
      public String getHabOrgUnit() {
          return habOrgUnit;
      }
 
-     public void setHabGroupName(String habGroupName) {
-         this.habGroupName = habGroupName;
+     public void setHabDisplayName(String habGroupName) {
+         this.habDisplayName = habGroupName;
      }
 
      public void setHabOrgUnit(String habOrgUnit) {

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9719,7 +9719,7 @@ TODO: delete them permanently from here
 </attr>
 
 <attr id="3028" name="zimbraHierarchicalAddressBookRoot" type="string" cardinality="multi" optionalIn="domain" flags="domainInfo" since="8.8.10">
-  <desc>domain level root of hierarchical address book</desc>
+  <desc>root group id of hierarchical address book</desc>
 </attr>
 
 <attr id="3029" name="zimbraHABMemberLdapAttrMap" type="string" max="4096" cardinality="multi" optionalIn="globalConfig" since="8.8.10">

--- a/store/docs/soap-admin.txt
+++ b/store/docs/soap-admin.txt
@@ -3217,7 +3217,7 @@ error : error occurred while starting or stopping contact backup on this server
 stopped : stopped contact backup on this server.
 
 ----------------------------
-<CreateHABGroupRequest [habGroupName={habGroupName}] habOrgUnit={habOrgUnit}>
+<CreateHABGroupRequest [habDispalyName={habDisplayName}] habOrgUnit={habOrgUnit}>
 </CreateHABGroupRequest>
 
 <CreateHABGroupResponse>

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -36,7 +36,6 @@ import java.util.Set;
 import java.util.Stack;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -4637,11 +4637,11 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
         if (listAttrs.get(AdminConstants.A_HAB_ORG_UNIT) != null) {
             habOrgUnit = (String) listAttrs.get(AdminConstants.A_HAB_ORG_UNIT);
             isHabGroup = true;
-            if (listAttrs.get(AdminConstants.A_HAB_GROUP_NAME) != null) {
-                habGroupName = (String) listAttrs.get(AdminConstants.A_HAB_GROUP_NAME);
+            if (listAttrs.get(AdminConstants.A_HAB_DISPLAY_NAME) != null) {
+                habGroupName = (String) listAttrs.get(AdminConstants.A_HAB_DISPLAY_NAME);
             }
             listAttrs.remove(AdminConstants.A_HAB_ORG_UNIT);
-            listAttrs.remove(AdminConstants.A_HAB_GROUP_NAME);
+            listAttrs.remove(AdminConstants.A_HAB_DISPLAY_NAME);
             String orgUnitDN = getOrgUnitDNByName(habOrgUnit, domain, zlc);
             if (StringUtils.isEmpty(orgUnitDN)) {
                 throw AccountServiceException.NO_SUCH_ORG_UNIT(habOrgUnit);

--- a/store/src/java/com/zimbra/cs/service/admin/CreateHABGroup.java
+++ b/store/src/java/com/zimbra/cs/service/admin/CreateHABGroup.java
@@ -48,7 +48,7 @@ public class CreateHABGroup extends CreateDistributionList {
         }
 
         attrs.put(AdminConstants.A_HAB_ORG_UNIT, orgUnitRDN);
-        attrs.put(AdminConstants.A_HAB_GROUP_NAME, req.getHabGroupName());
+        attrs.put(AdminConstants.A_HAB_DISPLAY_NAME, req.getHabDisplayName());
     }
 
     @Override


### PR DESCRIPTION
Made three changes as part of this bug:

- Restrict adding groups in hierarchy which belong to different Org Unit(OU)
- Rename habGroupName attribute of CreateHABRequest
- Correct the description of zimbraHierarchicalAddressBookRoot ldap attr