### PR TITLE
ZCS-4905 Store user agent, ip address, and auth token

### DIFF
--- a/store/src/java/com/zimbra/cs/imap/ImapListener.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapListener.java
@@ -45,6 +45,7 @@ import com.zimbra.cs.imap.ImapMessage.ImapMessageSet;
 import com.zimbra.cs.mailbox.Flag;
 import com.zimbra.cs.mailbox.MailItem;
 import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.OperationContext;
 import com.zimbra.cs.session.PendingModifications;
 import com.zimbra.cs.session.PendingModifications.Change;
 import com.zimbra.cs.session.PendingModifications.ModificationKey;
@@ -386,6 +387,11 @@ public abstract class ImapListener extends Session {
         mIsVirtual = i4folder.isVirtual();
         mFolder    = i4folder;
         this.handler = handler;
+        final OperationContext octxt = i4folder.getCredentials().getContext();
+        if (octxt != null) {
+            userAgent = octxt.getUserAgent();
+            requestIPAddress = octxt.getRequestIP();
+        }
 
         i4folder.setSession(this);
     }

--- a/store/src/java/com/zimbra/cs/session/Session.java
+++ b/store/src/java/com/zimbra/cs/session/Session.java
@@ -27,6 +27,7 @@ import com.zimbra.common.mailbox.MailboxStore;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
 import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.AuthToken;
 import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.MailboxManager;
 
@@ -52,6 +53,8 @@ public abstract class Session {
     private   boolean   mIsRegistered;
     private   boolean   mAddedToCache;
     protected int lastChangeId;
+    protected String userAgent;
+    protected String requestIPAddress;
 
 
     /**
@@ -360,6 +363,14 @@ public abstract class Session {
 
     public boolean isDelegatedSession() {
         return !mAuthenticatedAccountId.equalsIgnoreCase(mTargetAccountId);
+    }
+
+    public String getUserAgent() {
+        return userAgent;
+    }
+
+    public String getRequestIPAddress() {
+        return requestIPAddress;
     }
 
     public MoreObjects.ToStringHelper addToStringInfo(MoreObjects.ToStringHelper helper) {

--- a/store/src/java/com/zimbra/cs/session/SoapSession.java
+++ b/store/src/java/com/zimbra/cs/session/SoapSession.java
@@ -46,6 +46,7 @@ import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.AccessManager;
 import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.AuthToken;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.Server;
 import com.zimbra.cs.httpclient.URLUtil;
@@ -479,6 +480,7 @@ public class SoapSession extends Session {
     private boolean isOffline = false;
     private final SoapProtocol responseProtocol;
     private String curWaitSetID;
+    protected AuthToken authToken;
 
     /** Creates a <tt>SoapSession</tt> owned by the given account and
      *  listening on its {@link Mailbox}.
@@ -488,6 +490,9 @@ public class SoapSession extends Session {
         this.asAdmin = zsc.isUsingAdminPrivileges();
         responseProtocol = zsc.getResponseProtocol();
         curWaitSetID = zsc.getCurWaitSetID();
+        userAgent = zsc.getUserAgent();
+        requestIPAddress = zsc.getRequestIP();
+        authToken = zsc.getAuthToken();
     }
 
     @Override
@@ -1663,5 +1668,9 @@ public class SoapSession extends Session {
 
     public String getCurWaitSetID() {
         return curWaitSetID;
+    }
+
+    public AuthToken getAuthToken() {
+        return authToken;
     }
 }


### PR DESCRIPTION
* Store user agent, and request ip in Session to associate with session id
* Store auth token only in SoapSession to associate with session id

**Testing Done**
Manual logins, session creation from various places (webclient, gql, etc)- fetched sessions associated with test accounts to determine property retention

**Testing to be done by QA**
Session creation