### PR TITLE
ZCS-4904:End all session using EndSession API

### DIFF
--- a/common/src/java/com/zimbra/common/soap/AccountConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AccountConstants.java
@@ -520,8 +520,10 @@ public class AccountConstants {
     public static final String A_ATTACHMENT_SIZE_LIMIT = "attSizeLimit";
     public static final String A_DOCUMENT_SIZE_LIMIT = "docSizeLimit";
 
-    //auth
+    //end session
     public static final String A_LOG_OFF = "logoff";
+    public static final String A_CLEAR_ALL_SOAP_SESSIONS = "all";
+    public static final String A_EXCLUDE_CURRENT_SESSION = "excludeCurrent";
 
     // Zimbra Mobile Gateway
     public static final String E_APP_ID = "appId";

--- a/soap/src/java/com/zimbra/soap/account/message/EndSessionRequest.java
+++ b/soap/src/java/com/zimbra/soap/account/message/EndSessionRequest.java
@@ -41,6 +41,20 @@ public class EndSessionRequest {
     private ZmBoolean logoff;
 
     /**
+     * @zm-api-field-description flag to clear all web sessions of the user
+     *     default is 0 (false)
+     */
+    @XmlAttribute(name=AccountConstants.A_CLEAR_ALL_SOAP_SESSIONS /* all */, required=false)
+    private ZmBoolean clearAllSoapSessions;
+
+    /**
+     * @zm-api-field-description flag to decide current session will be cleared or not
+     *     default is 0 (false)
+     */
+    @XmlAttribute(name=AccountConstants.A_EXCLUDE_CURRENT_SESSION /* excludeCurrent */, required=false)
+    private ZmBoolean excludeCurrentSession;
+
+    /**
      * @zm-api-field-tag sessionId
      * @zm-api-field-description end session for given session id
      */
@@ -51,9 +65,26 @@ public class EndSessionRequest {
         this.logoff = ZmBoolean.fromBool(logoff);
     }
 
+    public boolean isClearAllSoapSessions() {
+        return ZmBoolean.toBool(clearAllSoapSessions, false);
+    }
+
+    public boolean isExcludeCurrentSession() {
+        return ZmBoolean.toBool(excludeCurrentSession, false);
+    }
+
     public boolean isLogOff() {
         return ZmBoolean.toBool(this.logoff, false);
     }
+
+    public void setClearAllSoapSessions(boolean clearAllSoapSessions) {
+        this.clearAllSoapSessions = ZmBoolean.fromBool(clearAllSoapSessions);
+    }
+
+    public void setExcludeCurrentSession(boolean excludeCurrentSession) {
+        this.excludeCurrentSession = ZmBoolean.fromBool(excludeCurrentSession);
+    }
+
     /**
      * @return the sessionId
      */
@@ -68,5 +99,4 @@ public class EndSessionRequest {
         this.sessionId = sessionId;
     }
 
-    
 }

--- a/store/docs/soap.txt
+++ b/store/docs/soap.txt
@@ -533,8 +533,7 @@ See ZimbraTwoFactorAuth server extension docs for more details on two-factor aut
   Returns new authToken, as old authToken will be invalidated on password change.
 
 ---------------------------
-
-<EndSessionRequest xmlns="urn:zimbraAccount" [logoff="1"] [sessionId="session_id"]/>
+<EndSessionRequest xmlns="urn:zimbraAccount" [logoff="1"] [all="1"] [excludeCurrent="1"] [sessionId="session_id"]/>
 
 Ends the current session, removing it from all caches.  Called when
 the browser app (or other session-using app) shuts down.  Has no
@@ -542,6 +541,9 @@ effect if called in a <nosession> context.
 
 Setting logoff to "1" will prevent the cookie from being re-used.
 Setting sessionId will end session for given session id and not current session.
+
+When all is 1, all web sessions of the user will be cleared.
+When all is 1 and excludeCurrent is also 1, all web sessions of the user, except the current session will be cleared.
 
 ---------
  <GetPrefsRequest>

--- a/store/src/java/com/zimbra/cs/service/account/EndSession.java
+++ b/store/src/java/com/zimbra/cs/service/account/EndSession.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2008, 2009, 2010, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2008, 2009, 2010, 2013, 2014, 2016, 2018 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -16,6 +16,10 @@
  */
 package com.zimbra.cs.service.account;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
@@ -25,6 +29,7 @@ import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AccountConstants;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.util.StringUtil;
+import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.AuthToken;
 import com.zimbra.cs.account.AuthTokenException;
 import com.zimbra.cs.session.Session;
@@ -44,49 +49,72 @@ public class EndSession extends AccountDocumentHandler {
     @Override
     public Element handle(Element request, Map<String, Object> context)
     throws ServiceException {
+        ZimbraSoapContext zsc = getZimbraSoapContext(context);
         EndSessionRequest req = JaxbUtil.elementToJaxb(request);
         String sessionId = req.getSessionId();
         boolean clearCookies = req.isLogOff();
-        ZimbraSoapContext zsc = getZimbraSoapContext(context);
-        if (StringUtil.isNullOrEmpty(sessionId)) {
-            if (zsc.hasSession()) {
-                Session s = getSession(zsc);
-                endSession(s);
-                if (clearCookies || getAuthenticatedAccount(zsc).isForceClearCookies()) {
-                    AuthToken at = zsc.getAuthToken();
-                    clearCookies(context, zsc, at);
+        boolean clearAllSessions = req.isClearAllSoapSessions();
+        boolean excludeCurrrentSession = req.isExcludeCurrentSession();
+        Account account = getAuthenticatedAccount(zsc);
+
+        if (clearAllSessions) {
+            String currentSessionId = null;
+            if (excludeCurrrentSession && zsc.hasSession()) {
+                Session currentSession = getSession(zsc);
+                currentSessionId = currentSession.getSessionId();
+            }
+            Collection<Session> sessionCollection = SessionCache.getSoapSessions(account.getId());
+            if (sessionCollection != null) {
+                List<Session> sessions = new ArrayList<Session>(sessionCollection);
+                Iterator<Session> itr = sessions.iterator();
+                while (itr.hasNext()) {
+                    Session session = itr.next();
+                    itr.remove();
+                    clearSession(session, currentSessionId);
                 }
             }
-        } else {
-            Session s = SessionCache.lookup(sessionId, zsc.getAuthtokenAccountId());
+        } else if (!StringUtil.isNullOrEmpty(sessionId)) {
+            Session s = SessionCache.lookup(sessionId, account.getId());
             if (s == null) {
                 throw ServiceException.FAILURE("Failed to find session with given sessionId", null);
             } else {
+                clearSession(s, null);
+            }
+        } else {
+            if (zsc.hasSession()) {
+                Session s = getSession(zsc);
                 endSession(s);
             }
-            if (clearCookies || getAuthenticatedAccount(zsc).isForceClearCookies()) {
-                if (s instanceof SoapSession) {
-                    SoapSession ss = (SoapSession) s;
-                    AuthToken at = ss.getAuthToken();
-                    if (at != null) {
-                        clearCookies(context, zsc, at);
-                    }
+            if (clearCookies || account.isForceClearCookies()) {
+                context.put(SoapServlet.INVALIDATE_COOKIES, true);
+                try {
+                    AuthToken at = zsc.getAuthToken();
+                    HttpServletRequest httpReq = (HttpServletRequest) context.get(SoapServlet.SERVLET_REQUEST);
+                    HttpServletResponse httpResp = (HttpServletResponse) context.get(SoapServlet.SERVLET_RESPONSE);
+                    at.encode(httpReq, httpResp, true);
+                    at.deRegister();
+                } catch (AuthTokenException e) {
+                    throw ServiceException.FAILURE("Failed to de-register an auth token", e);
                 }
             }
         }
+
         Element response = zsc.createElement(AccountConstants.END_SESSION_RESPONSE);
         return response;
     }
 
-    private void clearCookies(Map<String, Object> context, ZimbraSoapContext zsc, AuthToken at) throws ServiceException {
-        context.put(SoapServlet.INVALIDATE_COOKIES, true);
-        try {
-            HttpServletRequest httpReq = (HttpServletRequest) context.get(SoapServlet.SERVLET_REQUEST);
-            HttpServletResponse httpResp = (HttpServletResponse) context.get(SoapServlet.SERVLET_RESPONSE);
-            at.encode(httpReq, httpResp, true);
-            at.deRegister();
-        } catch (AuthTokenException e) {
-            throw ServiceException.FAILURE("Failed to de-register an auth token", e);
+    private void clearSession(Session session, String currentSessionId) throws ServiceException {
+        if(session instanceof SoapSession && !session.getSessionId().equalsIgnoreCase(currentSessionId)) {
+            AuthToken at = ((SoapSession) session).getAuthToken();
+            if (at != null) {
+                try {
+                    at.deRegister();
+                } catch (AuthTokenException e) {
+                    throw ServiceException.FAILURE("Failed to de-register an auth token", e);
+                }
+            }
+            endSession(session);
         }
     }
+
 }


### PR DESCRIPTION
Added two attributes in EndSessionRequest: all and excludeCurrent.

- When all is 1, all soap sessions will be cleared.
- When all is 1 and excludeCurrent is also 1, all soap sessions except the current session will be cleared.
