### PR TITLE
ZCS-5800 End specific session using sessionId 

### DIFF
--- a/common/src/java/com/zimbra/common/soap/AccountConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AccountConstants.java
@@ -574,4 +574,7 @@ public class AccountConstants {
     public static final String E_RESET_PASSWORD_REQUEST = "ResetPasswordRequest";
     public static final String E_RESET_PASSWORD_RESPONSE = "ResetPasswordResponse";
     public static final QName RESET_PASSWORD_REQUEST = QName.get(E_RESET_PASSWORD_REQUEST, NAMESPACE);
+
+    // Session activity feature
+    public static final String A_SESSION_ID = "sessionId";
 }

--- a/soap/src/java/com/zimbra/soap/account/message/EndSessionRequest.java
+++ b/soap/src/java/com/zimbra/soap/account/message/EndSessionRequest.java
@@ -39,6 +39,34 @@ public class EndSessionRequest {
      */
     @XmlAttribute(name=AccountConstants.A_LOG_OFF /* logoff */, required=false)
     private ZmBoolean logoff;
+
+    /**
+     * @zm-api-field-tag sessionId
+     * @zm-api-field-description end session for given session id
+     */
+    @XmlAttribute(name=AccountConstants.A_SESSION_ID /* sessionId */, required=false)
+    private String sessionId;
+
+    public void setLogOff (boolean logoff) {
+        this.logoff = ZmBoolean.fromBool(logoff);
+    }
+
+    public boolean isLogOff() {
+        return ZmBoolean.toBool(this.logoff, false);
+    }
+    /**
+     * @return the sessionId
+     */
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    /**
+     * @param sessionId the sessionId to set
+     */
+    public void setSessionId(String sessionId) {
+        this.sessionId = sessionId;
+    }
+
     
-    public void setLogOff (boolean logoff) {this.logoff = ZmBoolean.fromBool(logoff);} 
 }

--- a/store/docs/soap.txt
+++ b/store/docs/soap.txt
@@ -534,13 +534,14 @@ See ZimbraTwoFactorAuth server extension docs for more details on two-factor aut
 
 ---------------------------
 
-<EndSessionRequest xmlns="urn:zimbraAccount" [logoff="1"]/>
+<EndSessionRequest xmlns="urn:zimbraAccount" [logoff="1"] [sessionId="session_id"]/>
 
 Ends the current session, removing it from all caches.  Called when
 the browser app (or other session-using app) shuts down.  Has no
 effect if called in a <nosession> context.
 
 Setting logoff to "1" will prevent the cookie from being re-used.
+Setting sessionId will end session for given session id and not current session.
 
 ---------
  <GetPrefsRequest>


### PR DESCRIPTION
**Problem:** End specific session using sessionId 

**Fix:**
- Setting sessionId will end session for given session id and not current session.
- De-register auth token for given sessionId if "logoff" is true.
```
<EndSessionRequest xmlns="urn:zimbraAccount" [logoff="1"] [sessionId="session_id"]/>
```

**Testing done:**
- Tested api manually using soapui with and without session id param.

**Testing needs to be done by QA:**
- Test api changes
- Test existing funtionality
- Test overall end session api 