### PR TITLE
ZCS-5871 updated is:unread condition to fix non null error

### DIFF
--- a/store/src/java/com/zimbra/cs/index/SearchParams.java
+++ b/store/src/java/com/zimbra/cs/index/SearchParams.java
@@ -557,7 +557,7 @@ public final class SearchParams implements Cloneable, ZimbraSearchParams {
             params.setTypes(types);
         }
         params.setSortBy(soapParams.getSortBy());
-        if (query.toLowerCase().contains("is:unread") && isSortByReadFlag(SortBy.of(soapParams.getSortBy()))) {
+        if (query.toLowerCase().contains("is:unread") && soapParams.getSortBy() != null && isSortByReadFlag(SortBy.of(soapParams.getSortBy()))) {
             params.setSortBy(SortBy.DATE_DESC);
         } else {
             params.setSortBy(soapParams.getSortBy());

--- a/store/src/java/com/zimbra/cs/index/SearchParams.java
+++ b/store/src/java/com/zimbra/cs/index/SearchParams.java
@@ -557,7 +557,7 @@ public final class SearchParams implements Cloneable, ZimbraSearchParams {
             params.setTypes(types);
         }
         params.setSortBy(soapParams.getSortBy());
-        if (query.toLowerCase().contains("is:unread") && soapParams.getSortBy() != null && isSortByReadFlag(SortBy.of(soapParams.getSortBy()))) {
+        if (soapParams.getSortBy() != null && query.toLowerCase().contains("is:unread") && isSortByReadFlag(SortBy.of(soapParams.getSortBy()))) {
             params.setSortBy(SortBy.DATE_DESC);
         } else {
             params.setSortBy(soapParams.getSortBy());
@@ -641,6 +641,9 @@ public final class SearchParams implements Cloneable, ZimbraSearchParams {
      * @return
      */
     public static boolean isSortByReadFlag(SortBy sortBy) {
+        if (sortBy == null) {
+            return false;
+        }
         return (sortBy.getKey() == SortBy.READ_ASC.getKey() 
             || sortBy.getKey() == SortBy.READ_DESC.getKey());
     }


### PR DESCRIPTION
Was able to replicate error, and then updated condition to prevent the non null exception.

For testing remove sortby value in searchRequest while querying "is:unread"

```Java
<soap:Body>
	<SearchRequest xmlns="urn:zimbraMail" types="message" needExp="1" recip="0" limit="100" offset="0">
		<query>is:unread</query>
	</SearchRequest>
</soap:Body>
```
