### PR TITLE
ZCS-4905 Store original user agent

### DIFF
--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -413,6 +413,7 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
         private String mClientIp;
         private String mUserAgentName;
         private String mUserAgentVersion;
+        private String mOriginalUserAgent;
         private int mTimeout = -1;
         private int mRetryCount = -1;
         private SoapTransport.DebugListener mDebugListener;
@@ -526,6 +527,12 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
         public Options setUserAgent(String name, String version) {
             mUserAgentName = name;
             mUserAgentVersion = version;
+            return this;
+        }
+
+        public String getOriginalUserAgent() { return mOriginalUserAgent; }
+        public Options setOriginalUserAgent(String userAgent) {
+            this.mOriginalUserAgent = userAgent;
             return this;
         }
 
@@ -923,6 +930,9 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
             mTransport.setUserAgent("zclient", SystemUtil.getProductVersion());
         } else {
             mTransport.setUserAgent(options.getUserAgentName(), options.getUserAgentVersion());
+        }
+        if (options.getOriginalUserAgent() != null) {
+            mTransport.setOriginalUserAgent(options.getOriginalUserAgent());
         }
         mTransport.setMaxNotifySeq(0);
         mTransport.setClientIp(mClientIp);

--- a/common/src/java/com/zimbra/common/soap/HeaderConstants.java
+++ b/common/src/java/com/zimbra/common/soap/HeaderConstants.java
@@ -84,6 +84,9 @@ public final class HeaderConstants {
     public static final String EQ_OP = "eq";
     public static final String NE_OP = "ne";
 
+    // http request headers
+    public static final String HTTP_HEADER_ORIG_USER_AGENT = "Original-User-Agent";
+
     private HeaderConstants() {
     }
 }

--- a/common/src/java/com/zimbra/common/soap/SoapHttpTransport.java
+++ b/common/src/java/com/zimbra/common/soap/SoapHttpTransport.java
@@ -235,6 +235,12 @@ public class SoapHttpTransport extends SoapTransport {
                 method.setRequestHeader(new Header("User-Agent", agentName));
             }
 
+            // Set the original user agent if it's specified.
+            String originalUserAgent = getOriginalUserAgent();
+            if (originalUserAgent != null) {
+                method.setRequestHeader(new Header("Original-User-Agent", originalUserAgent));
+            }
+
             // the content-type charset will determine encoding used
             // when we set the request body
             method.setRequestHeader("Content-Type", getRequestProtocol().getContentType());
@@ -431,4 +437,5 @@ public class SoapHttpTransport extends SoapTransport {
         CloseableHttpAsyncClient httpClient = ZimbraHttpClientManager.getInstance().getInternalAsyncHttpClient();
         return httpClient.execute(post, context, cb);
     }
+
 }

--- a/common/src/java/com/zimbra/common/soap/SoapHttpTransport.java
+++ b/common/src/java/com/zimbra/common/soap/SoapHttpTransport.java
@@ -238,7 +238,7 @@ public class SoapHttpTransport extends SoapTransport {
             // Set the original user agent if it's specified.
             String originalUserAgent = getOriginalUserAgent();
             if (originalUserAgent != null) {
-                method.setRequestHeader(new Header("Original-User-Agent", originalUserAgent));
+                method.setRequestHeader(new Header(HeaderConstants.HTTP_HEADER_ORIG_USER_AGENT, originalUserAgent));
             }
 
             // the content-type charset will determine encoding used

--- a/common/src/java/com/zimbra/common/soap/SoapTransport.java
+++ b/common/src/java/com/zimbra/common/soap/SoapTransport.java
@@ -53,6 +53,7 @@ public abstract class SoapTransport {
     private String trustedToken;
     private boolean voidOnExpired = false;
     private boolean isAdmin = false;
+    private String originalUserAgent;
     public static final String DEFAULT_USER_AGENT_NAME = "ZCS";
     private static String sDefaultUserAgentName = DEFAULT_USER_AGENT_NAME;
     private static String sDefaultUserAgentVersion;
@@ -508,6 +509,14 @@ public abstract class SoapTransport {
 
     public void setAdmin(boolean isAdmin) {
         this.isAdmin = isAdmin;
+    }
+
+    public String getOriginalUserAgent() {
+        return originalUserAgent;
+    }
+
+    public void setOriginalUserAgent(String originalUserAgent) {
+        this.originalUserAgent = originalUserAgent;
     }
 
 }

--- a/store/src/java/com/zimbra/cs/session/SoapSession.java
+++ b/store/src/java/com/zimbra/cs/session/SoapSession.java
@@ -481,6 +481,7 @@ public class SoapSession extends Session {
     private final SoapProtocol responseProtocol;
     private String curWaitSetID;
     protected AuthToken authToken;
+    protected String originalUserAgent;
 
     /** Creates a <tt>SoapSession</tt> owned by the given account and
      *  listening on its {@link Mailbox}.
@@ -493,6 +494,7 @@ public class SoapSession extends Session {
         userAgent = zsc.getUserAgent();
         requestIPAddress = zsc.getRequestIP();
         authToken = zsc.getAuthToken();
+        originalUserAgent = zsc.getOriginalUserAgent();
     }
 
     @Override
@@ -1672,5 +1674,9 @@ public class SoapSession extends Session {
 
     public AuthToken getAuthToken() {
         return authToken;
+    }
+
+    public String getOriginalUserAgent() {
+        return originalUserAgent;
     }
 }

--- a/store/src/java/com/zimbra/soap/SoapEngine.java
+++ b/store/src/java/com/zimbra/soap/SoapEngine.java
@@ -108,6 +108,9 @@ public class SoapEngine {
     /** context name of request port */
     public static final String REQUEST_PORT = "request.port";
 
+    /** context name of the original user agent */
+    public static final String ORIG_REQUEST_USER_AGENT = "orig.request.user.agent";
+
     private final DocumentDispatcher dispatcher = new DocumentDispatcher();
 
     SoapEngine() {

--- a/store/src/java/com/zimbra/soap/SoapServlet.java
+++ b/store/src/java/com/zimbra/soap/SoapServlet.java
@@ -30,6 +30,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.httpclient.HttpVersion;
 import org.apache.commons.httpclient.ProtocolException;
+import org.apache.http.HttpHeaders;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Function;
@@ -299,6 +300,7 @@ public class SoapServlet extends ZimbraServlet {
 
         //checkAuthToken(req.getCookies(), context);
         context.put(SoapEngine.REQUEST_PORT, req.getServerPort());
+        context.put(SoapEngine.ORIG_REQUEST_USER_AGENT, req.getHeader("Original-User-Agent"));
         Element envelope = null;
         try {
             envelope = mEngine.dispatch(req.getRequestURI(), buffer, context);

--- a/store/src/java/com/zimbra/soap/SoapServlet.java
+++ b/store/src/java/com/zimbra/soap/SoapServlet.java
@@ -41,6 +41,7 @@ import com.zimbra.common.auth.ZAuthToken;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.HeaderConstants;
 import com.zimbra.common.soap.SoapProtocol;
 import com.zimbra.common.util.BufferStream;
 import com.zimbra.common.util.ByteUtil;
@@ -300,7 +301,7 @@ public class SoapServlet extends ZimbraServlet {
 
         //checkAuthToken(req.getCookies(), context);
         context.put(SoapEngine.REQUEST_PORT, req.getServerPort());
-        context.put(SoapEngine.ORIG_REQUEST_USER_AGENT, req.getHeader("Original-User-Agent"));
+        context.put(SoapEngine.ORIG_REQUEST_USER_AGENT, req.getHeader(HeaderConstants.HTTP_HEADER_ORIG_USER_AGENT));
         Element envelope = null;
         try {
             envelope = mEngine.dispatch(req.getRequestURI(), buffer, context);

--- a/store/src/java/com/zimbra/soap/ZimbraSoapContext.java
+++ b/store/src/java/com/zimbra/soap/ZimbraSoapContext.java
@@ -154,6 +154,7 @@ public final class ZimbraSoapContext {
     private int mHopCount;
     private boolean mMountpointTraversed;
 
+    private String mOriginalUserAgent;
     private String mUserAgent;
     private String mRequestIP;
     private Integer mPort;
@@ -470,6 +471,7 @@ public final class ZimbraSoapContext {
 
         mRequestIP = (String) context.get(SoapEngine.REQUEST_IP);
         mPort = (Integer) context.get(SoapEngine.REQUEST_PORT);
+        mOriginalUserAgent = (String) context.get(SoapEngine.ORIG_REQUEST_USER_AGENT);
 
     }
 
@@ -944,6 +946,10 @@ public final class ZimbraSoapContext {
 
     public boolean isProxyRequest() {
         return mIsProxyRequest;
+    }
+
+    public String getOriginalUserAgent() {
+        return mOriginalUserAgent;
     }
 
     /**


### PR DESCRIPTION
Store the original user agent header as a separate value (originally named browserInfo, but renamed per request). 
* This header value is added to context, then passed through until ZSC then as a `SoapSession` is created where we can store it such that it winds up in the `SessionCache`.
* ZMailbox sends this header if it is set, since we need this on login/getinfo - this is done by respective tags using zclient requests.

See associated PRs:
Zimbra/zm-taglib#16
Zimbra/zm-gql#30

**Testing done**
Basic login tests and checks to verify that the information is visible. Login tests with no browser user agent.

**Testing to be done by QA**
Session creation, and verifying accessibility of the browser information.