### PR TITLE
ZCS-5849 Sync address list to the GAL

### DIFF
--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -567,7 +567,7 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
   <globalConfigValue>zimbraGroupSync:(|(objectclass=zimbraDistributionList)(objectclass=zimbraGroup))</globalConfigValue>
   <globalConfigValue>zimbraAutoComplete:(&amp;(|(displayName=%s*)(cn=%s*)(sn=%s*)(gn=%s*)(zimbraPhoneticFirstName=%s*)(zimbraPhoneticLastName=%s*)(mail=%s*)(zimbraMailDeliveryAddress=%s*)(zimbraMailAlias=%s*))(|(objectclass=zimbraAccount)(objectclass=zimbraDistributionList)(objectclass=zimbraGroup)))</globalConfigValue>
   <globalConfigValue>zimbraSearch:(&amp;(|(displayName=*%s*)(cn=*%s*)(sn=*%s*)(gn=*%s*)(zimbraPhoneticFirstName=*%s*)(zimbraPhoneticLastName=*%s*)(mail=*%s*)(zimbraMailDeliveryAddress=*%s*)(zimbraMailAlias=*%s*))(|(objectclass=zimbraAccount)(objectclass=zimbraDistributionList)(objectclass=zimbraGroup)))</globalConfigValue>
-  <globalConfigValue>zimbraSync:(&amp;(|(objectclass=zimbraAccount)(objectclass=zimbraDistributionList)(objectclass=zimbraGroup))(!(&amp;(objectclass=zimbraCalendarResource)(!(zimbraAccountStatus=active)))))</globalConfigValue>
+  <globalConfigValue>zimbraSync:(&amp;(|(objectclass=zimbraAccount)(objectclass=zimbraDistributionList)(objectclass=zimbraGroup)(objectclass=zimbraAddressList))(!(&amp;(objectclass=zimbraCalendarResource)(!(|(zimbraAccountStatus=active)(zimbraIsAddressListActive=TRUE))))))</globalConfigValue>
   <globalConfigValue>ad:(&amp;(|(displayName=*%s*)(cn=*%s*)(sn=*%s*)(givenName=*%s*)(mail=*%s*))(!(msExchHideFromAddressLists=TRUE))(|(&amp;(objectCategory=person)(objectClass=user)(!(homeMDB=*))(!(msExchHomeServerName=*)))(&amp;(objectCategory=person)(objectClass=user)(|(homeMDB=*)(msExchHomeServerName=*)))(&amp;(objectCategory=person)(objectClass=contact))(objectCategory=group)(objectCategory=publicFolder)(objectCategory=msExchDynamicDistributionList)))</globalConfigValue>
   <globalConfigValue>adAutoComplete:(&amp;(|(displayName=%s*)(cn=%s*)(sn=%s*)(givenName=%s*)(mail=%s*))(!(msExchHideFromAddressLists=TRUE))(|(&amp;(objectCategory=person)(objectClass=user)(!(homeMDB=*))(!(msExchHomeServerName=*)))(&amp;(objectCategory=person)(objectClass=user)(|(homeMDB=*)(msExchHomeServerName=*)))(&amp;(objectCategory=person)(objectClass=contact))(objectCategory=group)(objectCategory=publicFolder)(objectCategory=msExchDynamicDistributionList)))</globalConfigValue>
   <globalConfigValue>externalLdapAutoComplete:(|(cn=%s*)(sn=%s*)(gn=%s*)(mail=%s*))</globalConfigValue>
@@ -594,6 +594,7 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
   <globalConfigValue>nickname_has:(|(displayName=*%s*)(cn=*%s*))</globalConfigValue>
   <globalConfigValue>phoneticFirstName_has:(zimbraPhoneticFirstName=*%s*)</globalConfigValue>
   <globalConfigValue>phoneticLastName_has:(zimbraPhoneticLastName=*%s*)</globalConfigValue>
+  <globalConfigValue>notes_has:(description=*%s*)</globalConfigValue>
   <desc>LDAP search filter definitions for GAL queries</desc>
 </attr>
 


### PR DESCRIPTION
**Problem:** Sync address list to the GAL

**Fix:**
- Added address list in zimbra sync in zimbraGalLdapFilterDef
- Also added description search with has in the same

**Testing done:**
- Testing done manually.
- Address list is being synced in the Gal
- Address list is being searched from the gal
- Search is working for description with has 

**Testing to be done by QA:**
- verify address list is being synced in gal
- verify address list is being searched from gal
- verify search is working for description with has 