### PR TITLE
add tyep in params

### DIFF
--- a/store/src/java/com/zimbra/cs/service/account/SearchGal.java
+++ b/store/src/java/com/zimbra/cs/service/account/SearchGal.java
@@ -241,6 +241,7 @@ public class SearchGal extends GalDocumentHandler {
 
     public static Map<String, String> getQueries(Domain domain, GalSearchParams params, GalSearchType type, EntrySearchFilter filter, ZimbraSoapContext zsc) throws ServiceException {
         // set default values in params
+        params.setType(type);
         params.setQuery("");
         params.setOp(GalOp.search);
         params.setNeedCanExpand(true);


### PR DESCRIPTION
**Problem:** if type is "all", !(#zimbraAccountCalendarUserType:RESOURCE) should not be added in gal and ldap query.

**Fix:** missed to add type in params, so account was being set as default value and !(#zimbraAccountCalendarUserType:RESOURCE) was being added in the query.

**Testing done:**
- Tested create address list api manually for different values of "type" and queries are generated according to type.

**Testing to be done by QA:**
- verify gal and ldap queries are generated according to type and given conditions.