### PR TITLE
ZCS-5707 Updating seniority index for HAB group

### DIFF
--- a/soap/src/java/com/zimbra/soap/account/type/HABGroup.java
+++ b/soap/src/java/com/zimbra/soap/account/type/HABGroup.java
@@ -56,7 +56,7 @@ public class HABGroup extends HABMember {
      * @zm-api-field-description Attributes of the HAB group
      */
     @ZimbraKeyValuePairs
-    @XmlElement(name=AccountConstants.E_ATTR /* attr */, required=true)
+    @XmlElement(name=AccountConstants.E_ATTR /* attr */, required=false)
     private List<Attr> attrs = Lists.newArrayList();
 
     /**

--- a/soap/src/java/com/zimbra/soap/admin/type/HABGroupOperation.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/HABGroupOperation.java
@@ -78,7 +78,7 @@ public class HABGroupOperation {
      * @zm-api-field-description the seniorityInex of HAB group
      */
     @XmlAttribute(name = AccountConstants.A_HAB_SENIORITY_INDEX /* op */, required = false)
-    int seniorityIndex;
+    privtea int seniorityIndex;
 
     /**
      * @zm-api-field-tag op

--- a/soap/src/java/com/zimbra/soap/admin/type/HABGroupOperation.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/HABGroupOperation.java
@@ -22,6 +22,7 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlEnum;
 
 import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.AccountConstants;
 import com.zimbra.common.soap.AdminConstants;
 
 /**
@@ -34,7 +35,7 @@ public class HABGroupOperation {
     @XmlEnum
     public enum HabGroupOp {
         // case must match
-        move, update;
+        move, assignSeniority;
 
         public static HabGroupOp fromString(String s) throws ServiceException {
             try {
@@ -69,9 +70,16 @@ public class HABGroupOperation {
      */
     @XmlAttribute(name = AdminConstants.A_TARGET_PARENT_HAB_GROUP_ID /*
                                                                       * habTargetParentGroupId
-                                                                      */, required = true)
+                                                                      */, required = false)
     private String targetHabGroupId;
-    
+
+    /**
+     * @zm-api-field-tag seniorityIndex
+     * @zm-api-field-description the seniorityInex of HAB group
+     */
+    @XmlAttribute(name = AccountConstants.A_HAB_SENIORITY_INDEX /* op */, required = false)
+    int seniorityIndex;
+
     /**
      * @zm-api-field-tag op
      * @zm-api-field-description operation
@@ -82,8 +90,6 @@ public class HABGroupOperation {
     public HABGroupOperation() {
 
     }
-
-    
 
     /**
      * @param habGroupId
@@ -97,6 +103,19 @@ public class HABGroupOperation {
         this.habGroupId = habGroupId;
         this.currentHabGroupId = currentHabGroupId;
         this.targetHabGroupId = targetHabGroupId;
+        this.op = op;
+    }
+
+    /**
+     * 
+     * @param habGroupId id of HAB group
+     * @param seniorityIndex seniorityIndex
+     * @param op type of modify operation
+     */
+    public HABGroupOperation(String habGroupId, int seniorityIndex, HabGroupOp op) {
+        super();
+        this.habGroupId = habGroupId;
+        this.seniorityIndex = seniorityIndex;
         this.op = op;
     }
 
@@ -130,9 +149,16 @@ public class HABGroupOperation {
         return op;
     }
 
-    
     public void setOp(HabGroupOp op) {
         this.op = op;
+    }
+
+    public int getSeniorityIndex() {
+        return seniorityIndex;
+    }
+
+    public void setSeniorityIndex(int seniorityIndex) {
+        this.seniorityIndex = seniorityIndex;
     }
 
     @Override
@@ -154,6 +180,10 @@ public class HABGroupOperation {
             builder.append(targetHabGroupId);
             builder.append(", ");
         }
+
+        builder.append("seniorityIndex=");
+        builder.append(seniorityIndex);
+        builder.append(", ");
         if (op != null) {
             builder.append("op=");
             builder.append(op);

--- a/soap/src/java/com/zimbra/soap/admin/type/HABGroupOperation.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/HABGroupOperation.java
@@ -74,10 +74,10 @@ public class HABGroupOperation {
     private String targetHabGroupId;
 
     /**
-     * @zm-api-field-tag seniorityIndex
+     * @zm-api-field-tag seniorityIndex, not required, defaults to 0
      * @zm-api-field-description the seniorityInex of HAB group
      */
-    @XmlAttribute(name = AccountConstants.A_HAB_SENIORITY_INDEX /* op */, required = false)
+    @XmlAttribute(name = AccountConstants.A_HAB_SENIORITY_INDEX /* seniorityIndex */, required = false)
     private int seniorityIndex;
 
     /**

--- a/soap/src/java/com/zimbra/soap/admin/type/HABGroupOperation.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/HABGroupOperation.java
@@ -78,7 +78,7 @@ public class HABGroupOperation {
      * @zm-api-field-description the seniorityInex of HAB group
      */
     @XmlAttribute(name = AccountConstants.A_HAB_SENIORITY_INDEX /* op */, required = false)
-    privtea int seniorityIndex;
+    private int seniorityIndex;
 
     /**
      * @zm-api-field-tag op

--- a/soap/src/java/com/zimbra/soap/admin/type/HABGroupOperation.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/HABGroupOperation.java
@@ -78,7 +78,7 @@ public class HABGroupOperation {
      * @zm-api-field-description the seniorityInex of HAB group
      */
     @XmlAttribute(name = AccountConstants.A_HAB_SENIORITY_INDEX /* seniorityIndex */, required = false)
-    private int seniorityIndex;
+    private Integer seniorityIndex;
 
     /**
      * @zm-api-field-tag op
@@ -153,11 +153,12 @@ public class HABGroupOperation {
         this.op = op;
     }
 
-    public int getSeniorityIndex() {
+    public Integer getSeniorityIndex() {
         return seniorityIndex;
     }
 
-    public void setSeniorityIndex(int seniorityIndex) {
+    
+    public void setSeniorityIndex(Integer seniorityIndex) {
         this.seniorityIndex = seniorityIndex;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ProvUtil.java
+++ b/store/src/java/com/zimbra/cs/account/ProvUtil.java
@@ -308,7 +308,7 @@ public class ProvUtil implements HttpDebugListener {
                 "help on reverse proxy related commands"), RIGHT("help on right-related commands"), SEARCH(
                 "help on search-related commands"), SERVER("help on server-related commands"), ALWAYSONCLUSTER(
                 "help on alwaysOnCluster-related commands"), UCSERVICE("help on ucservice-related commands"), SHARE(
-                "help on share related commands");
+                "help on share related commands"), HAB("help on HAB Group commands");
 
         private final String description;
 
@@ -852,17 +852,19 @@ public class ProvUtil implements HttpDebugListener {
                Category.LOG, 0, 2),
         UNLOCK_MAILBOX("unlockMailbox", "ulm", "{name@domain|id} [hostname (When unlocking a mailbox after a failed move attempt provide the hostname of the server that was the target for the failed move. Otherwise, do not include hostname parameter)]", Category.MAILBOX, 1, 2, Via.soap),
         CREATE_HAB_OU("createHABOrgUnit", "chou",
-            "{domain} {ouName}", Category.MISC , 2, 2),
+            "{domain} {ouName}", Category.HAB , 2, 2),
         RENAME_HAB_OU("renameHABOrgUnit", "rhou",
-            "{domain} {ouName} {newName}", Category.MISC , 3, 3),
+            "{domain} {ouName} {newName}", Category.HAB , 3, 3),
         DELETE_HAB_OU("deleteHABOrgUnit", "dhou",
-            "{domain} {ouName}", Category.MISC , 2, 2),
+            "{domain} {ouName}", Category.HAB , 2, 2),
         CREATE_HAB_GROUP("createHabGroup", "chabg",
-            "{groupName} {ouName} {name@domain} {TRUE|FALSE} [attr1 value1 [attr2 value2...]]", Category.MISC , 3, Integer.MAX_VALUE),
+            "{groupName} {ouName} {name@domain} {TRUE|FALSE} [attr1 value1 [attr2 value2...]]", Category.HAB , 3, Integer.MAX_VALUE),
         GET_HAB("getHab", "ghab",
             "{habRootGrpId} ", Category.ACCOUNT , 1, 1),
         MODIFY_HAB_GROUP("modify HAB group", "mhab",
-            "{habRootGrpId} {habParentGrpId} {targetHabParentGrpId} ", Category.MISC , 3, 3);
+            "{habGrpId} {habParentGrpId} {targetHabParentGrpId} ", Category.HAB , 3, 3),
+        MODIFY_HAB_GROUP_SENIORITY("set seniority index of HAB group", "mhabsi",
+            "{habGrpId} {seniorityIndex} ", Category.HAB, 2, 2);
         private String mName;
         private String mAlias;
         private String mHelp;
@@ -1619,6 +1621,9 @@ public class ProvUtil implements HttpDebugListener {
         case MODIFY_HAB_GROUP:
             modifyHabGroup(args);
             break;
+        case MODIFY_HAB_GROUP_SENIORITY:
+            modifyHabGroupSeniority(args);
+            break;
         default:
             return false;
         }
@@ -1776,6 +1781,20 @@ public class ProvUtil implements HttpDebugListener {
             ((SoapProvisioning) prov).modifyHabGroup(args[1], args[2], args[3]);
         } else if (args.length == 3) {
             ((SoapProvisioning) prov).modifyHabGroup(args[1], null, args[2]);
+        } else {
+            usage();
+            return;
+        }
+    }
+    
+    private void modifyHabGroupSeniority(String[] args)  throws ServiceException {
+        if (!(prov instanceof SoapProvisioning)) {
+            throwSoapOnly();
+        }
+        
+        //{habGrpId} {seniorityIndex} 
+        if (args.length == 3) {
+            ((SoapProvisioning) prov).modifyHabGroupSeniority(args[1], args[2]);
         } else {
             usage();
             return;

--- a/store/src/java/com/zimbra/cs/account/ProvUtil.java
+++ b/store/src/java/com/zimbra/cs/account/ProvUtil.java
@@ -860,10 +860,10 @@ public class ProvUtil implements HttpDebugListener {
         CREATE_HAB_GROUP("createHabGroup", "chabg",
             "{groupName} {ouName} {name@domain} {TRUE|FALSE} [attr1 value1 [attr2 value2...]]", Category.HAB , 3, Integer.MAX_VALUE),
         GET_HAB("getHab", "ghab",
-            "{habRootGrpId} ", Category.ACCOUNT , 1, 1),
-        MODIFY_HAB_GROUP("modify HAB group", "mhab",
+            "{habRootGrpId} ", Category.HAB , 1, 1),
+        MODIFY_HAB_GROUP("modifyHabGroup", "mhab",
             "{habGrpId} {habParentGrpId} {targetHabParentGrpId} ", Category.HAB , 3, 3),
-        MODIFY_HAB_GROUP_SENIORITY("set seniority index of HAB group", "mhabsi",
+        MODIFY_HAB_GROUP_SENIORITY("modifyHabGroupSeniority", "mhsi",
             "{habGrpId} {seniorityIndex} ", Category.HAB, 2, 2);
         private String mName;
         private String mAlias;

--- a/store/src/java/com/zimbra/cs/account/soap/SoapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/soap/SoapProvisioning.java
@@ -3175,4 +3175,18 @@ public class SoapProvisioning extends Provisioning {
         invokeJaxb(new ModifyHABGroupRequest(operation));
     }
 
+    /**
+     * 
+     * @param habGroupId HAB group to be modified
+     * @param seniorityIndex seniority index
+     * @throws ServiceException if an aeeror occurs while modifying the HAB group
+     */
+    public void modifyHabGroupSeniority(String habGroupId, String seniorityIndex)
+        throws ServiceException {
+        HABGroupOperation operation = new HABGroupOperation(habGroupId,
+            Integer.parseInt(seniorityIndex), HabGroupOp.assignSeniority);
+        invokeJaxb(new ModifyHABGroupRequest(operation));
+
+    }
+
 }

--- a/store/src/java/com/zimbra/cs/account/soap/SoapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/soap/SoapProvisioning.java
@@ -3179,7 +3179,7 @@ public class SoapProvisioning extends Provisioning {
      * 
      * @param habGroupId HAB group to be modified
      * @param seniorityIndex seniority index
-     * @throws ServiceException if an aeeror occurs while modifying the HAB group
+     * @throws ServiceException if an error occurs while modifying the HAB group
      */
     public void modifyHabGroupSeniority(String habGroupId, String seniorityIndex)
         throws ServiceException {


### PR DESCRIPTION
Added operation to update seniority index to Modify HABGroup
 <urn1:ModifyHABGroupRequest>
         <urn1:habGroupOperation habGroupId="id"  seniorityIndex="34" op="assignSeniority"/>
 </urn1:ModifyHABGroupRequest>

Added zmprov command for updating seniority index of HAB group:
mhabsi  {habGrpId} {seniorityIndex}

Bulk updates can be done using
zmprov < update.txt
where update.txt contains:
mhabsi {id1} {seniorityIndex}
mhabsi {id2} {seniorityIndex}
mhabsi {id2} {seniorityIndex}