### PR TITLE
NICPS-417: Changes to show capthca after specific failed login attempt

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -15862,6 +15862,15 @@ public class ZAttrProvisioning {
     public static final String A_zimbraShortTermGranteeCacheSize = "zimbraShortTermGranteeCacheSize";
 
     /**
+     * This attribute is used to show captcha on login screen when login
+     * fails count reaches to attribute value
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=5018)
+    public static final String A_zimbraShowCaptchaOnLoginFailedCount = "zimbraShowCaptchaOnLoginFailedCount";
+
+    /**
      * Whether edit header commands in admin sieve scripts are enabled or
      * disabled. If TRUE, the addheader, deleteheader and replaceheader
      * commands will be executed during admin sieve script execution.

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9778,5 +9778,10 @@ TODO: delete them permanently from here
 	<desc>This attribute is used to store the login history API url</desc>
 </attr>
 
+<attr id="5018" name="zimbraShowCaptchaOnLoginFailedCount" type="integer" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="8.8.9">
+    <globalConfigValue>2</globalConfigValue>
+	<desc>This attribute is used to show captcha on login screen when login fails count reaches to attribute value</desc>
+</attr>
+
 </attrs>
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -67426,6 +67426,83 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * This attribute is used to show captcha on login screen when login
+     * fails count reaches to attribute value
+     *
+     * @return zimbraShowCaptchaOnLoginFailedCount, or 2 if unset
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=5018)
+    public int getShowCaptchaOnLoginFailedCount() {
+        return getIntAttr(Provisioning.A_zimbraShowCaptchaOnLoginFailedCount, 2, true);
+    }
+
+    /**
+     * This attribute is used to show captcha on login screen when login
+     * fails count reaches to attribute value
+     *
+     * @param zimbraShowCaptchaOnLoginFailedCount new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=5018)
+    public void setShowCaptchaOnLoginFailedCount(int zimbraShowCaptchaOnLoginFailedCount) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraShowCaptchaOnLoginFailedCount, Integer.toString(zimbraShowCaptchaOnLoginFailedCount));
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * This attribute is used to show captcha on login screen when login
+     * fails count reaches to attribute value
+     *
+     * @param zimbraShowCaptchaOnLoginFailedCount new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=5018)
+    public Map<String,Object> setShowCaptchaOnLoginFailedCount(int zimbraShowCaptchaOnLoginFailedCount, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraShowCaptchaOnLoginFailedCount, Integer.toString(zimbraShowCaptchaOnLoginFailedCount));
+        return attrs;
+    }
+
+    /**
+     * This attribute is used to show captcha on login screen when login
+     * fails count reaches to attribute value
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=5018)
+    public void unsetShowCaptchaOnLoginFailedCount() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraShowCaptchaOnLoginFailedCount, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * This attribute is used to show captcha on login screen when login
+     * fails count reaches to attribute value
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=5018)
+    public Map<String,Object> unsetShowCaptchaOnLoginFailedCount(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraShowCaptchaOnLoginFailedCount, "");
+        return attrs;
+    }
+
+    /**
      * Deprecated since: 8.7.8. Variable feature is always enabled, hence
      * this attribute has been deprecated. Orig desc: Whether to enable the
      * Sieve &quot;Variables&quot; extension defined in RFC 5229 in the

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -48727,6 +48727,83 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
+     * This attribute is used to show captcha on login screen when login
+     * fails count reaches to attribute value
+     *
+     * @return zimbraShowCaptchaOnLoginFailedCount, or 2 if unset
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=5018)
+    public int getShowCaptchaOnLoginFailedCount() {
+        return getIntAttr(Provisioning.A_zimbraShowCaptchaOnLoginFailedCount, 2, true);
+    }
+
+    /**
+     * This attribute is used to show captcha on login screen when login
+     * fails count reaches to attribute value
+     *
+     * @param zimbraShowCaptchaOnLoginFailedCount new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=5018)
+    public void setShowCaptchaOnLoginFailedCount(int zimbraShowCaptchaOnLoginFailedCount) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraShowCaptchaOnLoginFailedCount, Integer.toString(zimbraShowCaptchaOnLoginFailedCount));
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * This attribute is used to show captcha on login screen when login
+     * fails count reaches to attribute value
+     *
+     * @param zimbraShowCaptchaOnLoginFailedCount new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=5018)
+    public Map<String,Object> setShowCaptchaOnLoginFailedCount(int zimbraShowCaptchaOnLoginFailedCount, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraShowCaptchaOnLoginFailedCount, Integer.toString(zimbraShowCaptchaOnLoginFailedCount));
+        return attrs;
+    }
+
+    /**
+     * This attribute is used to show captcha on login screen when login
+     * fails count reaches to attribute value
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=5018)
+    public void unsetShowCaptchaOnLoginFailedCount() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraShowCaptchaOnLoginFailedCount, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * This attribute is used to show captcha on login screen when login
+     * fails count reaches to attribute value
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=5018)
+    public Map<String,Object> unsetShowCaptchaOnLoginFailedCount(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraShowCaptchaOnLoginFailedCount, "");
+        return attrs;
+    }
+
+    /**
      * Deprecated since: 8.7.8. Variable feature is always enabled, hence
      * this attribute has been deprecated. Orig desc: Whether to enable the
      * Sieve &quot;Variables&quot; extension defined in RFC 5229 in the

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -5779,7 +5779,8 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
                 boolean mCaptchaEnabled = acct.getBooleanAttr(Provisioning.A_zimbraCAPTCHAEnabled, false);
                 if (mCaptchaEnabled) {
                     int loginFailCount = acct.getIntAttr(Provisioning.A_zimbraCAPTCHALoginFailedCount, 0);
-                    if (loginFailCount > 0 ) {
+                    int showCaptchaOnLoginfailCount = Integer.parseInt(Provisioning.getInstance().getConfig().getAttr(Provisioning.A_zimbraShowCaptchaOnLoginFailedCount, "2"));
+                    if (loginFailCount >= showCaptchaOnLoginfailCount - 1) {
                         throw AuthFailedServiceException.NEED_CAPTCHA();
                     }
                 }


### PR DESCRIPTION
Changes to show capthca after specific failed login attempt that count must be configurable by ldap attribute