### PR TITLE
ZCS-4856 Update constants and added annotations for LicenseInfo

### DIFF
--- a/common/src/java/com/zimbra/common/gql/GqlConstants.java
+++ b/common/src/java/com/zimbra/common/gql/GqlConstants.java
@@ -45,6 +45,7 @@ public class GqlConstants {
     public static final String COMMUNITY_URL = "communityURL";
     public static final String ADMIN_URL = "adminURL";
     public static final String BOSH_URL = "boshURL";
+    public static final String LICENSE = "License";
 
     // named value constants
     public static final String CLASS_NAMED_VALUE = "NamedValue";
@@ -295,4 +296,7 @@ public class GqlConstants {
     public static final String LAST_ACCESSED = "lastAccessed";
     public static final String USER_AGENT = "userAgent";
     public static final String REQUEST_IP_ADDRESS = "requestIPAddress";
+    
+    // license constants
+    public static final String CLASS_LICENSE_INFO = "LicenseInfo";
 }

--- a/soap/src/java/com/zimbra/soap/account/type/LicenseInfo.java
+++ b/soap/src/java/com/zimbra/soap/account/type/LicenseInfo.java
@@ -28,10 +28,16 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 
+//import io.leangen.graphql.annotations.GraphQLInputField;
+import com.zimbra.common.gql.GqlConstants;
+import io.leangen.graphql.annotations.GraphQLQuery;
+import io.leangen.graphql.annotations.types.GraphQLType;
+
 import com.zimbra.common.soap.AccountConstants;
 import com.zimbra.soap.type.LicenseStatus;
 
 @XmlAccessorType(XmlAccessType.NONE)
+@GraphQLType(name=GqlConstants.CLASS_LICENSE_INFO, description="License information")
 public class LicenseInfo {
 
     /**
@@ -65,8 +71,9 @@ public class LicenseInfo {
         }
         this.attrs.add(attr);
     }
-
+    @GraphQLQuery(name="status", description="license information status")
     public LicenseStatus getStatus() { return status; }
+    @GraphQLQuery(name="licenseAttributes", description="license information attributes")
     public List<LicenseAttr> getAttrs() {
         return attrs;
     }


### PR DESCRIPTION
The graphQL query accountInfoGet now includes LicenseInfo details from the LicenseInfo Class.