### PR TITLE
ZCS-6047 Fixing  regression

### DIFF
--- a/store/src/java/com/zimbra/cs/service/UserServlet.java
+++ b/store/src/java/com/zimbra/cs/service/UserServlet.java
@@ -276,11 +276,13 @@ public class UserServlet extends ZimbraServlet {
             return;
         }
         if (ctxt != null &&!ctxt.cookieAuthHappened && ctxt.basicAuthAllowed() && !ctxt.basicAuthHappened) {
+            resp.addHeader(AuthUtil.WWW_AUTHENTICATE_HEADER, getRealmHeader(req, null));
             resp.sendError(HttpServletResponse.SC_UNAUTHORIZED, L10nUtil.getMessage(MsgKey.errMustAuthenticate, req));
         } else if (ctxt != null && ctxt.cookieAuthHappened && !ctxt.isCsrfAuthSucceeded()
             && (req.getMethod().equalsIgnoreCase("POST") || req.getMethod().equalsIgnoreCase("PUT"))) {
             resp.sendError(HttpServletResponse.SC_UNAUTHORIZED, L10nUtil.getMessage(MsgKey.errMustAuthenticate, req));
         } else if (ctxt != null && ctxt.getAuthAccount() instanceof GuestAccount && ctxt.basicAuthAllowed() ) {
+            resp.addHeader(AuthUtil.WWW_AUTHENTICATE_HEADER, getRealmHeader(req, null));
                 resp.sendError(HttpServletResponse.SC_UNAUTHORIZED, L10nUtil.getMessage(MsgKey.errMustAuthenticate, req));
          } else {
                 resp.sendError(HttpServletResponse.SC_NOT_FOUND, message);


### PR DESCRIPTION
Add the BASIC auth header to both invalid account and valid account but wrong password flow.
This is to prevent account enumeration.

Verified that the following SOAP automation has not failure 
data/soapvalidator/RestServlet/Sharing/permissions_guest.xml
data/soapvalidator/RestServlet/Sharing/permissions_GranteeType.xml

Verified URL like when accessed from the browser
https://xxxx:8443/home/user1@xxxx/Briefcase/TestLog shows the prompt for username and pasword