### PR TITLE
ZCS-5825:fix ghgm issues

### DIFF
--- a/soap/src/java/com/zimbra/soap/account/type/HABMember.java
+++ b/soap/src/java/com/zimbra/soap/account/type/HABMember.java
@@ -70,9 +70,11 @@ public abstract class HABMember {
 
     public MoreObjects.ToStringHelper addToStringInfo(
                 MoreObjects.ToStringHelper helper) {
-        return helper
-            .add("name", name)
-            .add("seniorityIndex", seniorityIndex);
+         helper.add("name", name);
+         if (seniorityIndex != 0) {
+             helper.add("seniorityIndex", seniorityIndex);
+         }
+         return helper;
     }
 
     @Override

--- a/store/src/java/com/zimbra/cs/account/EntryCacheDataKey.java
+++ b/store/src/java/com/zimbra/cs/account/EntryCacheDataKey.java
@@ -69,8 +69,7 @@ public enum EntryCacheDataKey {
     /*
      * group
      */
-    GROUP_MEMBERS,
-    HAB_GROUP_MEMBERS;
+    GROUP_MEMBERS;
 
     // all access of the key name must be through this,
     // not calling name() or toString() directly

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -9772,25 +9772,15 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     @Override
     public List<HABGroupMember> getHABGroupMembers(Group group) throws ServiceException {
-        EntryCacheDataKey cacheKey = EntryCacheDataKey.HAB_GROUP_MEMBERS;
         List<HABGroupMember> members = null;
         if (group.isHABGroup()) {
             if (group instanceof DynamicGroup) {
                 DynamicGroup dynGroup = getDynamicGroup(Key.DistributionListBy.name, group.getName(), null, Boolean.FALSE);
                 members = getHABDynamicGroupMemberDetails(dynGroup);
             } else {
-                members = (List<HABGroupMember>) group.getCachedData(cacheKey);
-                if (members != null) {
-                    return members;
-                }
-                members = getHABGroupMemberDetails(group);  // should never be null
-                assert(members != null);
-                group.setCachedData(cacheKey, members);
+                members = getHABGroupMemberDetails(group);
             }
-        } else {
-            //throw error
         }
-
         return members;
     }
 


### PR DESCRIPTION
1.removed seniorityIndex from toString as it should not be displayed in zmprov ghgm response.
2.removed caching of ghgm result for static group as cache is not updated when seniorityIndex is modified.