### PR TITLE
ZCS-5388 Support clearFilter when modifying address list.

### DIFF
--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -1546,4 +1546,5 @@ public final class AdminConstants {
     public static final String E_SEARCH_FILTER = "searchFilter";
     public static final String E_GAL_FILTER = "galFilter";
     public static final String E_LDAP_FILTER = "ldapFilter";
+    public static final String A_CLEAR_FILTER = "clearFilter";
 }

--- a/soap/src/java/com/zimbra/soap/admin/message/ModifyAddressListRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/ModifyAddressListRequest.java
@@ -185,15 +185,15 @@ public class ModifyAddressListRequest {
     /**
      * @return the clearFilter
      */
-    public ZmBoolean getClearFilter() {
-        return clearFilter;
+    public Boolean getClearFilter() {
+        return ZmBoolean.toBool(clearFilter);
     }
 
     /**
      * @param clearFilter clearFilter to set
      */
-    public void setClearFilter(ZmBoolean clearFilter) {
-        this.clearFilter = clearFilter;
+    public void setClearFilter(Boolean clearFilter) {
+        this.clearFilter = ZmBoolean.fromBool(clearFilter);
     }
 
     public void validateModifyAddressListRequest() throws ServiceException {

--- a/soap/src/java/com/zimbra/soap/admin/message/ModifyAddressListRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/ModifyAddressListRequest.java
@@ -74,6 +74,13 @@ public class ModifyAddressListRequest {
     private EntrySearchFilterInfo searchFilter;
 
     /**
+     * @zm-api-field-tag clearFilter
+     * @zm-api-field-description remove all filter conditions if no searchFilter is specified
+     */
+    @XmlAttribute(name=AdminConstants.A_CLEAR_FILTER /* clearFilter */, required=false)
+    private Boolean clearFilter;
+
+    /**
      * default private constructor to block the usage
      */
     @SuppressWarnings("unused")
@@ -172,6 +179,20 @@ public class ModifyAddressListRequest {
      */
     public void setSearchFilter(EntrySearchFilterInfo searchFilter) {
         this.searchFilter = searchFilter;
+    }
+
+    /**
+     * @return the clearFilter
+     */
+    public Boolean getClearFilter() {
+        return clearFilter;
+    }
+
+    /**
+     * @param clearFilter clearFilter to set
+     */
+    public void setClearFilter(Boolean clearFilter) {
+        this.clearFilter = clearFilter;
     }
 
     public void validateModifyAddressListRequest() throws ServiceException {

--- a/soap/src/java/com/zimbra/soap/admin/message/ModifyAddressListRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/ModifyAddressListRequest.java
@@ -28,6 +28,7 @@ import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.soap.admin.type.EntrySearchFilterInfo;
 import com.zimbra.soap.type.GalSearchType;
+import com.zimbra.soap.type.ZmBoolean;
 
 /**
  * @zm-api-command-auth-required true
@@ -78,7 +79,7 @@ public class ModifyAddressListRequest {
      * @zm-api-field-description remove all filter conditions if no searchFilter is specified
      */
     @XmlAttribute(name=AdminConstants.A_CLEAR_FILTER /* clearFilter */, required=false)
-    private Boolean clearFilter;
+    private ZmBoolean clearFilter;
 
     /**
      * default private constructor to block the usage
@@ -184,14 +185,14 @@ public class ModifyAddressListRequest {
     /**
      * @return the clearFilter
      */
-    public Boolean getClearFilter() {
+    public ZmBoolean getClearFilter() {
         return clearFilter;
     }
 
     /**
      * @param clearFilter clearFilter to set
      */
-    public void setClearFilter(Boolean clearFilter) {
+    public void setClearFilter(ZmBoolean clearFilter) {
         this.clearFilter = clearFilter;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -11480,7 +11480,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
             if (!StringUtil.isNullOrEmpty(name) && !StringUtil.equal(name, oldName)) {
                 String oldDn = addressList.getDN();
                 String newDn = oldDn.replaceFirst(LdapConstants.ATTR_uid + "=" + oldName,
-                    LdapConstants.ATTR_uid + "=" + name);
+                    LdapConstants.ATTR_uid + "=" + LdapUtil.escapeRDNValue(name));
                 zlc.renameEntry(oldDn, newDn);
                 ZimbraLog.addresslist.debug("New entry DN: %s", newDn);
             }


### PR DESCRIPTION
* Added `clearFilter` attribute
  * Ignored if filter is non-null
  * When true, create base search filters with no conditions
* Update domain fetch from old gal query to support condition-less query
* LDAP escape the new name before rename

**Testing Done**
All cases outlined in new jira comment request

**Testing to be done by QA**
See jira ticket