### PR TITLE
NICPS-431: ldap schema changes to add new attribute type intl_email

### DIFF
--- a/common/ivy.xml
+++ b/common/ivy.xml
@@ -17,7 +17,8 @@
   <dependency org="ical4j" name="ical4j" rev="0.9.16-patched" />
   <dependency org="junit" name="junit" rev="4.8.2" />
   <dependency org="log4j" name="log4j" rev="1.2.16" />
-  <dependency org="javax.mail" name="mail" rev="1.4.5" />
+  <dependency org="com.sun.mail" name="javax.mail" rev="1.6.2"/>
+  <dependency org="javax.mail" name="javax.mail-api" rev="1.6.2"/>
   <dependency org="net.sourceforge.nekohtml" name="nekohtml" rev="1.9.13.1z" />
   <dependency org="javax.servlet" name="javax.servlet-api" rev="3.1.0" />
   <dependency org="xerces" name="xercesImpl" rev="2.9.1-patch-01" />

--- a/common/src/java/com/zimbra/common/io/TcpServerInputStream.java
+++ b/common/src/java/com/zimbra/common/io/TcpServerInputStream.java
@@ -30,6 +30,7 @@ import java.nio.charset.StandardCharsets;
 public class TcpServerInputStream extends BufferedInputStream {
 
     StringBuilder buffer;
+    BufferedReader br;
     protected static final int CR = 13;
     protected static final int LF = 10;
 
@@ -54,9 +55,9 @@ public class TcpServerInputStream extends BufferedInputStream {
      */
 	public String readLine() throws IOException {
 		buffer.delete(0, buffer.length());
-		BufferedReader br = new BufferedReader(new InputStreamReader(this, StandardCharsets.UTF_8));
+		br = new BufferedReader(new InputStreamReader(this, StandardCharsets.UTF_8));
 		while (true) {
-			int ch = read();
+			int ch = br.read();
 			if (ch == -1) {
 				return null;
 			} else if (ch == CR) {
@@ -67,4 +68,8 @@ public class TcpServerInputStream extends BufferedInputStream {
 			buffer.append((char)ch);
 		}
 	}
+
+	public void close ()  throws IOException {
+	   br.close();
+	} 
 }

--- a/common/src/java/com/zimbra/common/io/TcpServerInputStream.java
+++ b/common/src/java/com/zimbra/common/io/TcpServerInputStream.java
@@ -69,7 +69,8 @@ public class TcpServerInputStream extends BufferedInputStream {
 		}
 	}
 
-	public void close ()  throws IOException {
-	   br.close();
+	 public void close ()  throws IOException {
+        br.close();
+		super.close();
 	} 
 }

--- a/common/src/java/com/zimbra/common/io/TcpServerInputStream.java
+++ b/common/src/java/com/zimbra/common/io/TcpServerInputStream.java
@@ -57,23 +57,27 @@ public class TcpServerInputStream extends BufferedInputStream {
      *         the end of the stream has been reached
      * @throws IOException
      */
-	public String readLine() throws IOException {
-		buffer.delete(0, buffer.length());
-		while (true) {
-			int ch = br.read();
-			if (ch == -1) {
-				return null;
-			} else if (ch == CR) {
-				continue;
-			} else if (ch == LF) {
-				return buffer.toString();
-			}
-			buffer.append((char)ch);
-		}
-	}
+    public String readLine() throws IOException {
+        buffer.delete(0, buffer.length());
+        while (true) {
+            int ch = br.read();
+            if (ch == -1) {
+                return null;
+            } else if (ch == CR) {
+                continue;
+            } else if (ch == LF) {
+                return buffer.toString();
+            }
+            buffer.append((char)ch);
+        }
+    }
 
-	 public void close ()  throws IOException {
-        br.close();
-		super.close();
-	} 
+    public void close ()  throws IOException {
+        try {
+           br.close();
+           super.close();
+        } catch (IOException $e) {
+            // @TODO --> handle / log exception
+        }
+    }
 }

--- a/common/src/java/com/zimbra/common/io/TcpServerInputStream.java
+++ b/common/src/java/com/zimbra/common/io/TcpServerInputStream.java
@@ -36,11 +36,15 @@ public class TcpServerInputStream extends BufferedInputStream {
 
     public TcpServerInputStream(InputStream in) {
         super(in);
+
+        br = new BufferedReader(new InputStreamReader(this, StandardCharsets.UTF_8));
         buffer = new StringBuilder(128);
     }
 
     public TcpServerInputStream(InputStream in, int size) {
         super(in, size);
+
+        br = new BufferedReader(new InputStreamReader(this, StandardCharsets.UTF_8));
         buffer = new StringBuilder(128);
     }
     /**
@@ -55,7 +59,6 @@ public class TcpServerInputStream extends BufferedInputStream {
      */
 	public String readLine() throws IOException {
 		buffer.delete(0, buffer.length());
-		br = new BufferedReader(new InputStreamReader(this, StandardCharsets.UTF_8));
 		while (true) {
 			int ch = br.read();
 			if (ch == -1) {

--- a/common/src/java/com/zimbra/common/io/TcpServerInputStream.java
+++ b/common/src/java/com/zimbra/common/io/TcpServerInputStream.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2004, 2005, 2006, 2007, 2009, 2010, 2011, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2004, 2005, 2006, 2007, 2009, 2010, 2011, 2013, 2014, 2016, 2018 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -72,12 +72,12 @@ public class TcpServerInputStream extends BufferedInputStream {
         }
     }
 
-    public void close ()  throws IOException {
+    public void close()  throws IOException {
         try {
-           br.close();
-           super.close();
-        } catch (IOException $e) {
-            // @TODO --> handle / log exception
+            br.close();
+        } catch (IOException e) {
+            // Nothing to do with the exception.
         }
+        super.close();
     }
 }

--- a/common/src/java/com/zimbra/common/io/TcpServerInputStream.java
+++ b/common/src/java/com/zimbra/common/io/TcpServerInputStream.java
@@ -30,7 +30,7 @@ import java.nio.charset.StandardCharsets;
 public class TcpServerInputStream extends BufferedInputStream {
 
     StringBuilder buffer;
-    BufferedReader br;
+    private BufferedReader br;
     protected static final int CR = 13;
     protected static final int LF = 10;
 

--- a/common/src/java/com/zimbra/common/io/TcpServerInputStream.java
+++ b/common/src/java/com/zimbra/common/io/TcpServerInputStream.java
@@ -42,7 +42,6 @@ public class TcpServerInputStream extends BufferedInputStream {
         super(in, size);
         buffer = new StringBuilder(128);
     }
-
     /**
      * Reads a line from the stream.  A line is terminated with either
      * CRLF or bare LF.  (This is different from the behavior of
@@ -53,32 +52,19 @@ public class TcpServerInputStream extends BufferedInputStream {
      *         the end of the stream has been reached
      * @throws IOException
      */
-    public String readLine() throws IOException {
-
-        BufferedReader br = new BufferedReader(new InputStreamReader(this, StandardCharsets.UTF_8));
-        br.close();
-        buffer.delete(0, buffer.length());
-
-        int c;
-        while( (c = br.read()) != -1) {
-           if (c == CR) {
-             continue;
-           } else if (c == LF) {
-             buffer.append((char) c);
-           }
-        }
-        return buffer.toString();
-/*
-        while (true) {
-            int ch = read();
-            if (ch == -1) {
-                return null;
-            } else if (ch == CR) {
-                continue;
-            } else if (ch == LF) {
-                return buffer.toString();
-            }
-            buffer.append((char)ch);
-        }*/
-    }
+	public String readLine() throws IOException {
+		buffer.delete(0, buffer.length());
+		BufferedReader br = new BufferedReader(new InputStreamReader(this, StandardCharsets.UTF_8));
+		while (true) {
+			int ch = read();
+			if (ch == -1) {
+				return null;
+			} else if (ch == CR) {
+				continue;
+			} else if (ch == LF) {
+				return buffer.toString();
+			}
+			buffer.append((char)ch);
+		}
+	}
 }

--- a/common/src/java/com/zimbra/common/io/TcpServerInputStream.java
+++ b/common/src/java/com/zimbra/common/io/TcpServerInputStream.java
@@ -19,6 +19,9 @@ package com.zimbra.common.io;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 /**
  * @since 2004. 10. 26.
@@ -51,7 +54,21 @@ public class TcpServerInputStream extends BufferedInputStream {
      * @throws IOException
      */
     public String readLine() throws IOException {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(this, StandardCharsets.UTF_8));
+        br.close();
         buffer.delete(0, buffer.length());
+
+        int c;
+        while( (c = br.read()) != -1) {
+           if (c == CR) {
+             continue;
+           } else if (c == LF) {
+             buffer.append((char) c);
+           }
+        }
+        return buffer.toString();
+/*
         while (true) {
             int ch = read();
             if (ch == -1) {
@@ -62,6 +79,6 @@ public class TcpServerInputStream extends BufferedInputStream {
                 return buffer.toString();
             }
             buffer.append((char)ch);
-        }
+        }*/
     }
 }

--- a/common/src/java/com/zimbra/common/io/TcpServerInputStream.java
+++ b/common/src/java/com/zimbra/common/io/TcpServerInputStream.java
@@ -71,13 +71,4 @@ public class TcpServerInputStream extends BufferedInputStream {
             buffer.append((char)ch);
         }
     }
-
-    public void close()  throws IOException {
-        try {
-            br.close();
-        } catch (IOException e) {
-            // Nothing to do with the exception.
-        }
-        super.close();
-    }
 }

--- a/common/src/java/com/zimbra/common/mime/shim/JavaMailInternetHeaders.java
+++ b/common/src/java/com/zimbra/common/mime/shim/JavaMailInternetHeaders.java
@@ -70,8 +70,8 @@ public class JavaMailInternetHeaders extends InternetHeaders implements JavaMail
     @SuppressWarnings("unchecked")
     JavaMailInternetHeaders(InternetHeaders jmheaders) {
         this();
-        for (Enumeration<InternetHeader> en = jmheaders.getAllHeaders(); en.hasMoreElements(); ) {
-            InternetHeader jmheader = en.nextElement();
+        for (Enumeration<Header> en = jmheaders.getAllHeaders(); en.hasMoreElements(); ) {
+            InternetHeader jmheader =  (InternetHeader) en.nextElement();
             addHeader(jmheader.getName(), jmheader.getValue());
         }
     }

--- a/common/src/java/com/zimbra/common/zmime/ZInternetHeaders.java
+++ b/common/src/java/com/zimbra/common/zmime/ZInternetHeaders.java
@@ -34,6 +34,7 @@ import com.zimbra.common.zmime.ZMimeUtility.ByteBuilder;
 
 public class ZInternetHeaders extends InternetHeaders {
     private static final boolean ZPARSER = ZMimeMessage.ZPARSER;
+    protected List headers;
 
     private ZMimePart parent;
     private boolean ordered = true;

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -365,13 +365,13 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
                   The use case is for hosted.  New account creation based on invites 
                   that are not completed until user accepts TOS on account creation confirmation page.  
     closed      - no login, no delivery(lmtp server returns 5.x.x Permanent Failure),
-                  all addresses (account main email and all aliases) of the 
+                  all addresses (account main intl_email and all aliases) of the 
                   account are removed from all distribution lists.
   </desc>
 </attr>
 
-<attr id="3" name="zimbraMailAddress" type="email" max="256" immutable="1" cardinality="multi" optionalIn="mailRecipient">
-  <desc>RFC822 email address of this recipient for accepting mail</desc>
+<attr id="3" name="zimbraMailAddress" type="intl_email" max="256" immutable="1" cardinality="multi" optionalIn="mailRecipient">
+  <desc>RFC822 intl_email address of this recipient for accepting mail</desc>
 </attr>
 
 <attr id="4" name="zimbraMailHost" type="astring" max="256" callback="MailHost" cardinality="single" optionalIn="mailRecipient,group">
@@ -396,11 +396,11 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
   <desc>dynamic group membership</desc>
 </attr>
 
-<attr id="12" name="zimbraMailForwardingAddress" type="email" max="256" cardinality="multi" optionalIn="mailRecipient,groupStaticUnit" flags="accountInfo,domainAdminModifiable">
+<attr id="12" name="zimbraMailForwardingAddress" type="intl_email" max="256" cardinality="multi" optionalIn="mailRecipient,groupStaticUnit" flags="accountInfo,domainAdminModifiable">
   <desc>RFC822 forwarding address for an account</desc>
 </attr>
 
-<attr id="13" name="zimbraMailDeliveryAddress" type="email" max="256" immutable="1" cardinality="multi" optionalIn="mailRecipient">
+<attr id="13" name="zimbraMailDeliveryAddress" type="intl_email" max="256" immutable="1" cardinality="multi" optionalIn="mailRecipient">
   <desc>RFC822 email address of this recipient for local delivery</desc>
 </attr>
 
@@ -429,7 +429,7 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
   <desc>name of the domain</desc>
 </attr>
 
-<attr id="20" name="zimbraMailAlias" type="email" max="256" immutable="1" cardinality="multi" optionalIn="mailRecipient,group,groupDynamicUnit" flags="accountInfo">
+<attr id="20" name="zimbraMailAlias" type="intl_email" max="256" immutable="1" cardinality="multi" optionalIn="mailRecipient,group,groupDynamicUnit" flags="accountInfo">
   <desc>RFC822 email address of this recipient for accepting mail</desc>
 </attr>
 
@@ -813,7 +813,7 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
   <desc>whether or not new mail notification is enabled</desc>
 </attr>
 
-<attr id="127" name="zimbraPrefNewMailNotificationAddress" type="email" max="256" cardinality="single" optionalIn="account" flags="domainAdminModifiable">
+<attr id="127" name="zimbraPrefNewMailNotificationAddress" type="intl_email" max="256" cardinality="single" optionalIn="account" flags="domainAdminModifiable">
   <desc>RFC822 email address for email notifications</desc>
 </attr>
 
@@ -1292,7 +1292,7 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
   <desc>should be one of: local, alias</desc>
 </attr>
 
-<attr id="213" name="zimbraMailCanonicalAddress" type="email" max="256" cardinality="single" optionalIn="mailRecipient" flags="domainAdminModifiable">
+<attr id="213" name="zimbraMailCanonicalAddress" type="intl_email" max="256" cardinality="single" optionalIn="mailRecipient" flags="domainAdminModifiable">
   <desc>RFC822 email address for senders outbound messages</desc>
 </attr>
 
@@ -1424,11 +1424,11 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
   <desc>compatibility mode for calendar server</desc>
 </attr>
 
-<attr id="244" name="zimbraSpamIsSpamAccount" type="email" max="256" cardinality="single" optionalIn="globalConfig">
+<attr id="244" name="zimbraSpamIsSpamAccount" type="intl_email" max="256" cardinality="single" optionalIn="globalConfig">
   <desc>When user classifies a message as spam forward message via SMTP to this account</desc>
 </attr>
 
-<attr id="245" name="zimbraSpamIsNotSpamAccount" type="email" max="256" cardinality="single" optionalIn="globalConfig">
+<attr id="245" name="zimbraSpamIsNotSpamAccount" type="intl_email" max="256" cardinality="single" optionalIn="globalConfig">
   <desc>When user classifies a message as not spam forward message via SMTP to this account</desc>
 </attr>
 
@@ -1803,7 +1803,7 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
   <desc>name of contact in charge of resource</desc>
 </attr>
 
-<attr id="332" name="zimbraCalResContactEmail" type="email" cardinality="single" optionalIn="calendarResource" flags="domainAdminModifiable">
+<attr id="332" name="zimbraCalResContactEmail" type="intl_email" cardinality="single" optionalIn="calendarResource" flags="domainAdminModifiable">
   <desc>email of contact in charge of resource</desc>
 </attr>
 
@@ -1864,7 +1864,7 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
   <desc>enable end-user mail forwarding features</desc>
 </attr>
 
-<attr id="343" name="zimbraPrefMailForwardingAddress" type="cs_emailp" cardinality="single" optionalIn="account" flags="domainAdminModifiable" callback="PrefMailForwardingAddress" >
+<attr id="343" name="zimbraPrefMailForwardingAddress" type="intl_email" cardinality="single" optionalIn="account" flags="domainAdminModifiable" callback="PrefMailForwardingAddress" >
   <desc>RFC822 forwarding address for an account</desc>
 </attr>
 
@@ -2062,7 +2062,7 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
   <desc>server remembers addresses to which notifications have been sent for this interval, and does not send duplicate notifications in this interval</desc>
 </attr>
 
-<attr id="387" name="zimbraPrefOutOfOfficeDirectAddress" type="email" cardinality="multi" optionalIn="account" flags="domainAdminModifiable">
+<attr id="387" name="zimbraPrefOutOfOfficeDirectAddress" type="intl_email" cardinality="multi" optionalIn="account" flags="domainAdminModifiable">
   <desc>per RFC 3834 no out of office notifications are sent if recipients address is not directly specified in the To/CC headers - for this check, we check to see if To/CC contained accounts address, aliases, canonical address.  But when external accounts are forwarded to Zimbra, and you want notifications sent to messages that contain their external address in To/Cc, add those address, then you can specify those external addresses here.</desc>
 </attr>
 
@@ -2243,11 +2243,11 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
   <desc>Whether this account can use any from address.  Not changeable by domain admin to allow arbitrary addresses</desc>
 </attr>
 
-<attr id="428" name="zimbraAllowFromAddress" type="email" max="256" cardinality="multi" optionalIn="account" flags="accountInfo,domainAdminModifiable" callback="AllowFromAddress">
+<attr id="428" name="zimbraAllowFromAddress" type="intl_email" max="256" cardinality="multi" optionalIn="account" flags="accountInfo,domainAdminModifiable" callback="AllowFromAddress">
   <desc>Addresses that this account is permitted to use in From: header on sent messages. Only applicable when zimbraAllowAnyFromAddress is set to false.</desc>
 </attr>
 
-<attr id="429" name="zimbraArchiveAccount" type="email" max="256" cardinality="multi" optionalIn="account">
+<attr id="429" name="zimbraArchiveAccount" type="intl_email" max="256" cardinality="multi" optionalIn="account">
   <desc>
     Mailboxes in which the current account in archived.  Multi-value
     attr with eg values { user-2006@example.com.archive,
@@ -2256,7 +2256,7 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
   </desc>
 </attr>
 
-<attr id="430" name="zimbraArchiveMailFrom" type="email" max="256" cardinality="single" optionalIn="globalConfig">
+<attr id="430" name="zimbraArchiveMailFrom" type="intl_email" max="256" cardinality="single" optionalIn="globalConfig">
   <desc>
     Address to which archive message bounces should be sent.
     Typically could be an admin account.  This is global across all
@@ -3051,7 +3051,7 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
   <deprecateDesc>was added for Yahoo calendar, no longer used</deprecateDesc>
 </attr>
 
-<attr id="575" name="zimbraPrefCalendarReminderEmail" type="email" max="256" cardinality="single" optionalIn="account" flags="domainAdminModifiable" since="7.0.0">
+<attr id="575" name="zimbraPrefCalendarReminderEmail" type="intl_email" max="256" cardinality="single" optionalIn="account" flags="domainAdminModifiable" since="7.0.0">
   <desc>RFC822 email address for receiving reminders for appointments and tasks</desc>
 </attr>
 
@@ -4914,7 +4914,7 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
   <desc>whether to send a notification message if Zimbra version check detects a new version</desc>
 </attr>
 
-<attr id="1063" name="zimbraVersionCheckNotificationEmail" type="cs_emailp" cardinality="single" optionalIn="globalConfig" since="6.0.2">
+<attr id="1063" name="zimbraVersionCheckNotificationEmail" type="intl_email" cardinality="single" optionalIn="globalConfig" since="6.0.2">
   <desc>email address to send mail to for the Zimbra version check notification message</desc>
 </attr>
 
@@ -5123,7 +5123,7 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
   <desc>If TRUE, a mailbox that exceeds its quota is still allowed to receive mail, but is not allowed to send.</desc>
 </attr>
 
-<attr id="1100" name="zimbraAmavisQuarantineAccount" type="email" max="256" cardinality="single" optionalIn="globalConfig" since="7.0.0">
+<attr id="1100" name="zimbraAmavisQuarantineAccount" type="intl_email" max="256" cardinality="single" optionalIn="globalConfig" since="7.0.0">
   <desc>When a virus is detected quarantine message to this account</desc>
 </attr>
 
@@ -5316,7 +5316,7 @@ TODO: delete them permanently from here
   <desc>Maximum number of entries for zimbraPrefMailTrustedSenderList.</desc>
 </attr>
 
-<attr id="1140" name="zimbraCalendarReminderDeviceEmail" type="email" max="256" cardinality="single" optionalIn="account" flags="accountInfo,domainAdminModifiable" since="7.0.0">
+<attr id="1140" name="zimbraCalendarReminderDeviceEmail" type="intl_email" max="256" cardinality="single" optionalIn="account" flags="accountInfo,domainAdminModifiable" since="7.0.0">
   <desc>email address identifying the default device for receiving reminders for appointments and tasks</desc>
 </attr>
 
@@ -6173,7 +6173,7 @@ TODO: delete them permanently from here
   <desc>whether it is an external user account</desc>
 </attr>
 
-<attr id="1244" name="zimbraExternalUserMailAddress" type="email" cardinality="single" optionalIn="account" flags="accountInfo" since="8.0.0">
+<attr id="1244" name="zimbraExternalUserMailAddress" type="intl_email" cardinality="single" optionalIn="account" flags="accountInfo" since="8.0.0">
   <desc>External email address of an external user. Applicable only when zimbraIsExternalVirtualAccount is set to TRUE.</desc>
 </attr>
 
@@ -6681,7 +6681,7 @@ TODO: delete them permanently from here
   <desc>percentage threshold for domain aggregate quota warnings</desc>
 </attr>
 
-<attr id="1331" name="zimbraDomainAggregateQuotaWarnEmailRecipient" type="email" cardinality="multi" optionalIn="domain,globalConfig" flags="domainInherited" since="8.0.0">
+<attr id="1331" name="zimbraDomainAggregateQuotaWarnEmailRecipient" type="intl_email" cardinality="multi" optionalIn="domain,globalConfig" flags="domainInherited" since="8.0.0">
   <desc>email recipients to be notified when zimbraAggregateQuotaLastUsage reaches zimbraDomainAggregateQuotaWarnPercent of the zimbraDomainAggregateQuota</desc>
 </attr>
 
@@ -6690,7 +6690,7 @@ TODO: delete them permanently from here
         addr of upstream server connecting to which the error happens</desc>
 </attr>
 
-<attr id="1333" name="zimbraPrefAllowAddressForDelegatedSender" type="email" max="256" cardinality="multi" optionalIn="account,distributionList,group" flags="accountInfo,domainAdminModifiable" callback="AllowAddressForDelegatedSender" since="8.0.0">
+<attr id="1333" name="zimbraPrefAllowAddressForDelegatedSender" type="intl_email" max="256" cardinality="multi" optionalIn="account,distributionList,group" flags="accountInfo,domainAdminModifiable" callback="AllowAddressForDelegatedSender" since="8.0.0">
   <desc>Addresses of the account that can be used by allowed delegated senders as From and Sender address.</desc>
 </attr>
 
@@ -7169,7 +7169,7 @@ TODO: delete them permanently from here
   <desc>whether mobile sync notification enabled or not</desc>
 </attr>
 
-<attr id="1422" name="zimbraMobileNotificationAdminAddress" type="email" max="256" cardinality="single" optionalIn="account,cos" flags="accountInherited" since="8.5.0">
+<attr id="1422" name="zimbraMobileNotificationAdminAddress" type="intl_email" max="256" cardinality="single" optionalIn="account,cos" flags="accountInherited" since="8.5.0">
   <desc>admin email address used for receiving notifications</desc>
 </attr>
 
@@ -9436,7 +9436,7 @@ TODO: delete them permanently from here
   <desc>Expiry time for end-user email address verification</desc>
 </attr>
 
-<attr id="2128" name="zimbraFeatureAddressUnderVerification" type="cs_emailp" cardinality="single" optionalIn="account" callback="PrefMailForwardingAddress" since="8.8.5">
+<attr id="2128" name="zimbraFeatureAddressUnderVerification" type="intl_email" cardinality="single" optionalIn="account" callback="PrefMailForwardingAddress" since="8.8.5">
   <desc>RFC822 email address under verification for an account</desc>
 </attr>
 
@@ -9467,7 +9467,7 @@ TODO: delete them permanently from here
   <desc>status of password reset feature</desc>
 </attr>
 
-<attr id="2135" name="zimbraPrefPasswordRecoveryAddress" type="cs_emailp" cardinality="single" optionalIn="account" flags="accountInfo" callback="RecoveryEmailCallback" since="8.8.9">
+<attr id="2135" name="zimbraPrefPasswordRecoveryAddress" type="intl_email" cardinality="single" optionalIn="account" flags="accountInfo" callback="RecoveryEmailCallback" since="8.8.9">
   <desc>RFC822 recovery email address for an account</desc>
 </attr>
 

--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -18,7 +18,8 @@
   <dependency org="org.slf4j" name="slf4j-api" rev="1.6.4"/>
   <dependency org="org.slf4j" name="slf4j-log4j12" rev="1.6.4"/>
   <dependency org="junit" name="junit" rev="4.8.2" />
-  <dependency org="javax.mail" name="mail" rev="1.4.5" />
+  <dependency org="com.sun.mail" name="javax.mail" rev="1.6.2"/>
+  <dependency org="javax.mail" name="javax.mail-api" rev="1.6.2"/>
   <dependency org="jaxen" name="jaxen" rev="1.1-beta-10"/>
   <dependency org="dom4j" name="dom4j" rev="1.5.2" />
   <dependency org="log4j" name="log4j" rev="1.2.16" />

--- a/store/src/java/com/zimbra/cs/account/AttributeInfo.java
+++ b/store/src/java/com/zimbra/cs/account/AttributeInfo.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2016, 2018 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -341,6 +341,7 @@ public class AttributeInfo {
                 throw AccountServiceException.INVALID_ATTR_VALUE(
                         mName+" value length("+value.length()+") larger than max allowed: "+mMax, null);
             validEmailAddress(value, false);
+            return;
         case TYPE_EMAIL:
             if (value.length() > mMax)
                 throw AccountServiceException.INVALID_ATTR_VALUE(

--- a/store/src/java/com/zimbra/cs/account/AttributeInfo.java
+++ b/store/src/java/com/zimbra/cs/account/AttributeInfo.java
@@ -336,6 +336,11 @@ public class AttributeInfo {
                 throw AccountServiceException.INVALID_ATTR_VALUE(
                         mName+" is longer than max allowed: "+mMaxDuration, null);
             return;
+        case TYPE_INTL_EMAIL:
+            if (value.length() > mMax)
+                throw AccountServiceException.INVALID_ATTR_VALUE(
+                        mName+" value length("+value.length()+") larger than max allowed: "+mMax, null);
+            validEmailAddress(value, false);
         case TYPE_EMAIL:
             if (value.length() > mMax)
                 throw AccountServiceException.INVALID_ATTR_VALUE(

--- a/store/src/java/com/zimbra/cs/account/AttributeManagerUtil.java
+++ b/store/src/java/com/zimbra/cs/account/AttributeManagerUtil.java
@@ -429,6 +429,12 @@ public class AttributeManagerUtil {
             substr = "caseIgnoreSubstringsMatch";
             break;
 
+        case TYPE_INTL_EMAIL:
+            syntax = "1.3.6.1.4.1.1466.115.121.1.15{256}";
+            equality = "caseIgnoreMatch";
+            substr = "caseIgnoreSubstringsMatch";
+            break;
+
         case TYPE_GENTIME:
             syntax = "1.3.6.1.4.1.1466.115.121.1.24";
             equality = "generalizedTimeMatch";

--- a/store/src/java/com/zimbra/cs/account/AttributeType.java
+++ b/store/src/java/com/zimbra/cs/account/AttributeType.java
@@ -28,6 +28,7 @@ public enum AttributeType {
     TYPE_GENTIME("gentime"),
     TYPE_EMAIL("email"),
     TYPE_EMAILP("emailp"),
+    TYPE_INTL_EMAIL("intl_email"),
     TYPE_CS_EMAILP("cs_emailp"),
     TYPE_ENUM("enum"),
     TYPE_ID("id"),

--- a/store/src/java/com/zimbra/cs/account/names/NameUtil.java
+++ b/store/src/java/com/zimbra/cs/account/names/NameUtil.java
@@ -16,7 +16,9 @@
  */
 package com.zimbra.cs.account.names;
 
-import javax.mail.internet.AddressException;
+//import javax.mail.internet.AddressException;
+
+import java.io.UnsupportedEncodingException;
 import javax.mail.internet.InternetAddress;
 
 import com.google.common.base.Strings;
@@ -59,10 +61,18 @@ public class NameUtil {
 
     public static void validEmailAddress(String addr) throws ServiceException {
         try {
-            InternetAddress ia = new InternetAddress(addr, true);
+            int index = addr.indexOf('@');
+            String localPart;
+            if (index == -1) {
+               localPart = addr;
+            } else {
+               localPart = addr.substring(0, index);
+            }
+            //InternetAddress ia = new InternetAddress(addr, true);
+            InternetAddress ia = new InternetAddress(addr, localPart, "utf-8");
             if (ia.getPersonal() != null && !ia.getPersonal().equals(""))
                 throw ServiceException.INVALID_REQUEST("invalid email address", null);
-        } catch (AddressException e) {
+        } catch (UnsupportedEncodingException e) {
             throw ServiceException.INVALID_REQUEST("invalid email address", e);
         }
     }

--- a/store/src/java/com/zimbra/cs/account/names/NameUtil.java
+++ b/store/src/java/com/zimbra/cs/account/names/NameUtil.java
@@ -17,6 +17,7 @@
 package com.zimbra.cs.account.names;
 
 import java.io.UnsupportedEncodingException;
+import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
 
 import com.google.common.base.Strings;
@@ -59,15 +60,9 @@ public class NameUtil {
 
     public static void validEmailAddress(String addr) throws ServiceException {
         try {
-            int index = addr.indexOf('@');
-            String localPart;
-            if (index == -1) {
-               localPart = addr;
-            } else {
-               localPart = addr.substring(0, index);
-            }
-
-            InternetAddress ia = new InternetAddress(addr, localPart, "utf-8");
+            InternetAddress ia = new InternetAddress(addr, "", "UTF-8");
+            if (ia.getPersonal() != null && !ia.getPersonal().equals(""))
+                throw ServiceException.INVALID_REQUEST("invalid email address", null);
         } catch (UnsupportedEncodingException e) {
             throw ServiceException.INVALID_REQUEST("invalid email address", e);
         }

--- a/store/src/java/com/zimbra/cs/account/names/NameUtil.java
+++ b/store/src/java/com/zimbra/cs/account/names/NameUtil.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2009, 2010, 2011, 2012, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2009, 2010, 2011, 2012, 2013, 2014, 2016, 2018 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -16,8 +16,6 @@
  */
 package com.zimbra.cs.account.names;
 
-//import javax.mail.internet.AddressException;
-
 import java.io.UnsupportedEncodingException;
 import javax.mail.internet.InternetAddress;
 
@@ -26,7 +24,6 @@ import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.EmailUtil;
 import com.zimbra.cs.account.Config;
 import com.zimbra.cs.account.Provisioning;
-//import com.zimbra.common.util.ZimbraLog;
 
 public class NameUtil {
     private static final int MAX_DOMAIN_NAME_LEN = 255; // bug 15919, (RFC 1035)
@@ -69,11 +66,8 @@ public class NameUtil {
             } else {
                localPart = addr.substring(0, index);
             }
-            //InternetAddress ia = new InternetAddress(addr, true);
 
             InternetAddress ia = new InternetAddress(addr, localPart, "utf-8");
-            //ZimbraLog.mailbox.info(" *********** Address is not set  " + addr );
-
         } catch (UnsupportedEncodingException e) {
             throw ServiceException.INVALID_REQUEST("invalid email address", e);
         }

--- a/store/src/java/com/zimbra/cs/account/names/NameUtil.java
+++ b/store/src/java/com/zimbra/cs/account/names/NameUtil.java
@@ -17,7 +17,6 @@
 package com.zimbra.cs.account.names;
 
 import java.io.UnsupportedEncodingException;
-import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
 
 import com.google.common.base.Strings;

--- a/store/src/java/com/zimbra/cs/account/names/NameUtil.java
+++ b/store/src/java/com/zimbra/cs/account/names/NameUtil.java
@@ -26,6 +26,7 @@ import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.EmailUtil;
 import com.zimbra.cs.account.Config;
 import com.zimbra.cs.account.Provisioning;
+//import com.zimbra.common.util.ZimbraLog;
 
 public class NameUtil {
     private static final int MAX_DOMAIN_NAME_LEN = 255; // bug 15919, (RFC 1035)
@@ -69,9 +70,10 @@ public class NameUtil {
                localPart = addr.substring(0, index);
             }
             //InternetAddress ia = new InternetAddress(addr, true);
+
             InternetAddress ia = new InternetAddress(addr, localPart, "utf-8");
-            if (ia.getPersonal() != null && !ia.getPersonal().equals(""))
-                throw ServiceException.INVALID_REQUEST("invalid email address", null);
+            //ZimbraLog.mailbox.info(" *********** Address is not set  " + addr );
+
         } catch (UnsupportedEncodingException e) {
             throw ServiceException.INVALID_REQUEST("invalid email address", e);
         }

--- a/store/src/java/com/zimbra/cs/lmtpserver/LmtpAddress.java
+++ b/store/src/java/com/zimbra/cs/lmtpserver/LmtpAddress.java
@@ -40,7 +40,6 @@ public class LmtpAddress {
     private String mRemoteServer; // if mOnLocalServer is false
 
     public LmtpAddress(String arg, String[] allowedParameters, String rcptDelim) {
-
 	mAllowedParameters = allowedParameters;
 	mParameters = new HashMap<String, String>();
 	mIsValid = parse(arg);
@@ -353,7 +352,7 @@ public class LmtpAddress {
     }
 
     private boolean isLetter(int c) {
-        return Character.isAlphabetic(c);
+      return Character.isAlphabetic(c);
     }
 
     private boolean skipAddress() {

--- a/store/src/java/com/zimbra/cs/lmtpserver/LmtpAddress.java
+++ b/store/src/java/com/zimbra/cs/lmtpserver/LmtpAddress.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2004, 2005, 2006, 2007, 2009, 2010, 2011, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2004, 2005, 2006, 2007, 2009, 2010, 2011, 2013, 2014, 2016, 2018 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,

--- a/store/src/java/com/zimbra/cs/lmtpserver/LmtpAddress.java
+++ b/store/src/java/com/zimbra/cs/lmtpserver/LmtpAddress.java
@@ -18,7 +18,6 @@
 package com.zimbra.cs.lmtpserver;
 
 import java.util.Map;
-import com.zimbra.common.util.ZimbraLog;
 import java.util.HashMap;
 
 public class LmtpAddress {
@@ -41,8 +40,6 @@ public class LmtpAddress {
     private String mRemoteServer; // if mOnLocalServer is false
 
     public LmtpAddress(String arg, String[] allowedParameters, String rcptDelim) {
-
-	ZimbraLog.mailbox.info("###### LMTP EMAIL ADDRESS LDAP attribute " + arg);
 
 	mAllowedParameters = allowedParameters;
 	mParameters = new HashMap<String, String>();
@@ -356,7 +353,7 @@ public class LmtpAddress {
     }
 
     private boolean isLetter(int c) {
-	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+        return Character.isAlphabetic(c);
     }
 
     private boolean skipAddress() {
@@ -464,9 +461,12 @@ public class LmtpAddress {
 	     *               and 127)
 	     */
 	    if (ch < 33 || ch > 126) { // 32 is ' '
-		if (debug) say("illegal character < 33 or > 126");
-		return false; // any one of the 128 ascii characters
-	    }
+            if (debug) say("illegal character < 33 or > 126: " + ch);
+            if (debug) say("but... is it alphabetic? " + Character.isAlphabetic(ch));
+            if (!Character.isAlphabetic(ch)) {
+               return false; // any one of the 128 ascii characters
+            }
+        }
 
 	    if ("<()[]\\,;:\"".indexOf(ch) > -1) {
 		/* Left out '>' and '@' which are terminators in this

--- a/store/src/java/com/zimbra/cs/lmtpserver/LmtpAddress.java
+++ b/store/src/java/com/zimbra/cs/lmtpserver/LmtpAddress.java
@@ -120,7 +120,7 @@ public class LmtpAddress {
     }
 
     public boolean isValid() {
-		return true;
+        return mIsValid;
     }
 
     public Map<String, String> getParameters() {

--- a/store/src/java/com/zimbra/cs/lmtpserver/LmtpAddress.java
+++ b/store/src/java/com/zimbra/cs/lmtpserver/LmtpAddress.java
@@ -18,6 +18,7 @@
 package com.zimbra.cs.lmtpserver;
 
 import java.util.Map;
+import com.zimbra.common.util.ZimbraLog;
 import java.util.HashMap;
 
 public class LmtpAddress {
@@ -40,6 +41,9 @@ public class LmtpAddress {
     private String mRemoteServer; // if mOnLocalServer is false
 
     public LmtpAddress(String arg, String[] allowedParameters, String rcptDelim) {
+
+	ZimbraLog.mailbox.info("###### LMTP EMAIL ADDRESS LDAP attribute " + arg);
+
 	mAllowedParameters = allowedParameters;
 	mParameters = new HashMap<String, String>();
 	mIsValid = parse(arg);
@@ -119,7 +123,7 @@ public class LmtpAddress {
     }
 
     public boolean isValid() {
-	return mIsValid;
+		return true;
     }
 
     public Map<String, String> getParameters() {

--- a/store/src/java/com/zimbra/cs/util/JMSession.java
+++ b/store/src/java/com/zimbra/cs/util/JMSession.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016 Synacor, Inc.
+ * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2018 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,

--- a/store/src/java/com/zimbra/cs/util/JMSession.java
+++ b/store/src/java/com/zimbra/cs/util/JMSession.java
@@ -333,6 +333,8 @@ public final class JMSession {
         props.setProperty("mail.smtp.port", getValue(server, domain, Provisioning.A_zimbraSmtpPort));
         props.setProperty("mail.smtp.localhost", LC.zimbra_server_hostname.value());
 
+        props.setProperty("mail.mime.allowutf8", "true");
+
         // Get timeout value in seconds from LDAP, convert to millis, and set on the session.
         String sTimeout = getValue(server, domain, Provisioning.A_zimbraSmtpTimeout);
         long timeout = (sTimeout == null ? 60 : Long.parseLong(sTimeout));


### PR DESCRIPTION
Part 1 - LDAP schema changes to support RFC6530 i.e. UTF8 characters in local part of email address .
Part 2 - updating java mail library to make compatible to support utf8 in local part of email address  
Screenshot ->
http://synscreen.buf.synacor.com/view/93030f.png