### PR TITLE
ZCS-5909:Improved mail sender persona

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/MailSender.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailSender.java
@@ -539,8 +539,11 @@ public class MailSender {
                 if (acct.isSmtpRestrictEnvelopeFrom() && !isDataSourceSender()) {
                     mEnvelopeFrom = mbox.getAccount().getName();
                 } else {
-                    // Set envelope sender to Sender or From, in that order.
+                    // Set envelope sender to Sender or Reply-To or From, in that order.
                     Address envAddress = mm.getSender();
+                    if (envAddress == null) {
+                        envAddress =  ArrayUtil.getFirstElement(mm.getReplyTo());
+                    }
                     if (envAddress == null) {
                         envAddress = ArrayUtil.getFirstElement(mm.getFrom());
                     }


### PR DESCRIPTION
 When Persona Reply_To is configured, email address in Return-Path should be the email address 
 configured in reply-to rather than primary email address.

For this expected behaviour, zimbraSmtpRestrictEnvelopeFrom should be set to False. 