### PR TITLE
ZCS-6042 Fixing zmprov gethab command

### DIFF
--- a/store/src/java/com/zimbra/cs/account/ProvUtil.java
+++ b/store/src/java/com/zimbra/cs/account/ProvUtil.java
@@ -860,7 +860,7 @@ public class ProvUtil implements HttpDebugListener {
         CREATE_HAB_GROUP("createHABGroup", "chg",
             "{groupName} {ouName} {name@domain} {TRUE|FALSE} [attr1 value1 [attr2 value2...]]", Category.HAB , 3, Integer.MAX_VALUE),
         GET_HAB("getHAB", "ghab",
-            "{habRootGrpId}", Category.HAB, 1, 1),
+            "{habRootGrpId}", Category.HAB, 2, 2),
         MOVE_HAB_GROUP("moveHABGroup", "mhg",
             "{habRootGrpId} {habParentGrpId} {targetHabParentGrpId}", Category.HAB , 3, 3),
         ADD_HAB_GROUP_MEMBER("addHABGroupMember", "ahgm", "{name@domain|id} {member@domain}+",
@@ -1796,7 +1796,7 @@ public class ProvUtil implements HttpDebugListener {
     }
 
     private void doGetHab(String[] args)  throws ServiceException {
-        if(args.length != 2) { 
+        if(args.length != 3) { 
             usage();
             return;
         }
@@ -1804,7 +1804,8 @@ public class ProvUtil implements HttpDebugListener {
             throwSoapOnly();
         }
         SoapProvisioning sp = (SoapProvisioning) prov;
-        sp.getHab(args[1]);
+        Element response = sp.getHab(lookupAccount(args[1]), args[2]);
+        printOutput(response.prettyPrint());
     }
 
     private void modifyHabGroup(String[] args)  throws ServiceException {

--- a/store/src/java/com/zimbra/cs/account/soap/SoapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/soap/SoapProvisioning.java
@@ -3157,10 +3157,10 @@ public class SoapProvisioning extends Provisioning {
      * @return GetHabResponse object
      * @throws ServiceException if an error occurs while fetching hierarchy from ldap
      */
-    public GetHABResponse getHab(String rootHabGroupId) throws ServiceException {
+    public Element getHab(Account account, String rootHabGroupId) throws ServiceException {
         XMLElement req = new XMLElement(AccountConstants.GET_HAB_REQUEST);
         req.addAttribute(AccountConstants.A_HAB_ROOT_GROUP_ID, rootHabGroupId);
-        GetHABResponse resp = invokeJaxb(new GetHABRequest(rootHabGroupId));
+        Element resp = invokeOnTargetAccount(req, account.getId());
         return resp;
     }
 


### PR DESCRIPTION
Added a parameter to accept account.
Invoked the SOAP request on the provided account
Added GetHAB handler to the AdminSoapServlet.

zmprov ghab user1@rdesai.zdev.local b340356b-17d3-4b4f-acd5-ed946bba21d7
```

<GetHABResponse xmlns="urn:zimbraAccount">
  <ou name="zimbraHAbOrg1">
    <habGroup seniorityIndex="0" name="dev@rdesai.zdev.local" id="b340356b-17d3-4b4f-acd5-ed946bba21d7">
      <attr name="zimbraMailAlias">dev@rdesai.zdev.local</attr>
      <attr name="uid">dev</attr>
      <attr name="mail">dev@rdesai.zdev.local</attr>
      <attr name="displayName">Development</attr>
      <attr name="zimbraId">b340356b-17d3-4b4f-acd5-ed946bba21d7</attr>
      <attr name="objectClass">zimbraDistributionList</attr>
      <attr name="objectClass">zimbraMailRecipient</attr>
      <attr name="objectClass">zimbraHabGroup</attr>
      <attr name="zimbraMailHost">rdesai.zdev.local</attr>
      <attr name="cn">dev</attr>
      <attr name="zimbraCreateTimestamp">20180924000916.880Z</attr>
      <attr name="zimbraMailStatus">enabled</attr>
      <attr name="zimbraHABSeniorityIndex">0</attr>
    </habGroup>
  </ou>
</GetHABResponse>
```
