### PR TITLE
ZCS-5696 Defanger fix for attachment with XSS

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/DebugConfig.java
+++ b/common/src/java/com/zimbra/common/localconfig/DebugConfig.java
@@ -265,6 +265,8 @@ public final class DebugConfig {
     public static final String defangImgSkipOwaspSanitize = value("defang_img_skip_owasp_sanitize", "^cid:.*@");
     public static final String defangOwaspValidImgTag = value("owasp_valid_img_tag", "<\\s*img");
     public static final String defangStyleUnwantedStrgPattern = value("defang_style_unwanted_strg_pattern", "\\s*(('){2,})");
+    public static final String defangOwaspAlert = value("defang_owasp_alert_tag", "alert\\((.*)\\)");
+    public static final String defangOwaspJavaScript = value("defang_owasp_javascript_tag", ".*javascript\\s*");
 
     /*
      * Default maximum size of convertd response. This reduces OOME in case of

--- a/store/src/java-test/com/zimbra/cs/html/DefangFilterTest.java
+++ b/store/src/java-test/com/zimbra/cs/html/DefangFilterTest.java
@@ -1431,4 +1431,21 @@ public class DefangFilterTest {
         Assert.assertTrue(!result.contains("'''''"));
         
     }
+
+    /**
+     * Check alert is removed from script.
+     */
+    @Test
+    public void testZCS5696() throws Exception {
+        String html = "<textarea></textarea/><body/oNloAd=alert('bug109020-2')>bug109020-2";
+        InputStream htmlStream = new ByteArrayInputStream(html.getBytes());
+        String result = DefangFactory.getDefanger(MimeConstants.CT_TEXT_HTML).defang(htmlStream,
+            true);
+        Assert.assertTrue(!result.contains("alert"));
+
+        html = "<textarea></textarea/><body/oNloAd=javascript:alert('bug109020-2')>bug109020-2";
+        htmlStream = new ByteArrayInputStream(html.getBytes());
+        result = DefangFactory.getDefanger(MimeConstants.CT_TEXT_HTML).defang(htmlStream, true);
+        Assert.assertTrue(!result.contains("alert"));
+    }
 }

--- a/store/src/java/com/zimbra/cs/account/ProvUtil.java
+++ b/store/src/java/com/zimbra/cs/account/ProvUtil.java
@@ -860,7 +860,7 @@ public class ProvUtil implements HttpDebugListener {
         CREATE_HAB_GROUP("createHABGroup", "chg",
             "{groupName} {ouName} {name@domain} {TRUE|FALSE} [attr1 value1 [attr2 value2...]]", Category.HAB , 3, Integer.MAX_VALUE),
         GET_HAB("getHAB", "ghab",
-            "{habRootGrpId}", Category.HAB, 1, 1),
+            "{habRootGrpId}", Category.HAB, 2, 2),
         MOVE_HAB_GROUP("moveHABGroup", "mhg",
             "{habRootGrpId} {habParentGrpId} {targetHabParentGrpId}", Category.HAB , 3, 3),
         ADD_HAB_GROUP_MEMBER("addHABGroupMember", "ahgm", "{name@domain|id} {member@domain}+",
@@ -1796,7 +1796,7 @@ public class ProvUtil implements HttpDebugListener {
     }
 
     private void doGetHab(String[] args)  throws ServiceException {
-        if(args.length != 2) { 
+        if(args.length != 3) { 
             usage();
             return;
         }
@@ -1804,7 +1804,8 @@ public class ProvUtil implements HttpDebugListener {
             throwSoapOnly();
         }
         SoapProvisioning sp = (SoapProvisioning) prov;
-        sp.getHab(args[1]);
+        Element response = sp.getHab(lookupAccount(args[1]), args[2]);
+        printOutput(response.prettyPrint());
     }
 
     private void modifyHabGroup(String[] args)  throws ServiceException {

--- a/store/src/java/com/zimbra/cs/account/ProvUtil.java
+++ b/store/src/java/com/zimbra/cs/account/ProvUtil.java
@@ -860,7 +860,7 @@ public class ProvUtil implements HttpDebugListener {
         CREATE_HAB_GROUP("createHABGroup", "chg",
             "{groupName} {ouName} {name@domain} {TRUE|FALSE} [attr1 value1 [attr2 value2...]]", Category.HAB , 3, Integer.MAX_VALUE),
         GET_HAB("getHAB", "ghab",
-            "{habRootGrpId}", Category.HAB, 2, 2),
+            "{name@domain} {habRootGrpId}", Category.HAB, 2, 2),
         MOVE_HAB_GROUP("moveHABGroup", "mhg",
             "{habRootGrpId} {habParentGrpId} {targetHabParentGrpId}", Category.HAB , 3, 3),
         ADD_HAB_GROUP_MEMBER("addHABGroupMember", "ahgm", "{name@domain|id} {member@domain}+",

--- a/store/src/java/com/zimbra/cs/account/soap/SoapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/soap/SoapProvisioning.java
@@ -3157,10 +3157,10 @@ public class SoapProvisioning extends Provisioning {
      * @return GetHabResponse object
      * @throws ServiceException if an error occurs while fetching hierarchy from ldap
      */
-    public GetHABResponse getHab(String rootHabGroupId) throws ServiceException {
+    public Element getHab(Account account, String rootHabGroupId) throws ServiceException {
         XMLElement req = new XMLElement(AccountConstants.GET_HAB_REQUEST);
         req.addAttribute(AccountConstants.A_HAB_ROOT_GROUP_ID, rootHabGroupId);
-        GetHABResponse resp = invokeJaxb(new GetHABRequest(rootHabGroupId));
+        Element resp = invokeOnTargetAccount(req, account.getId());
         return resp;
     }
 

--- a/store/src/java/com/zimbra/cs/html/HtmlPurifier.java
+++ b/store/src/java/com/zimbra/cs/html/HtmlPurifier.java
@@ -34,9 +34,13 @@ public class HtmlPurifier extends Purifier {
 
     private static final Pattern VALID_IMG_TAG = Pattern.compile(
         DebugConfig.defangOwaspValidImgTag, Pattern.CASE_INSENSITIVE);
-    private static final PolicyFactory sanitizer = Sanitizers.IMAGES;
+    private static final PolicyFactory sanitizer = Sanitizers.FORMATTING.and(Sanitizers.IMAGES);
     private static final Pattern IMG_SKIP_OWASPSANITIZE = Pattern.compile(
         DebugConfig.defangImgSkipOwaspSanitize, Pattern.CASE_INSENSITIVE);
+    private static final Pattern VALID_SCRIPT_TAG = Pattern.compile(
+        DebugConfig.defangOwaspJavaScript, Pattern.CASE_INSENSITIVE);
+    private static final Pattern VALID_ALERT_TAG = Pattern.compile(
+        DebugConfig.defangOwaspAlert, Pattern.CASE_INSENSITIVE);
 
     /* (non-Javadoc)
      * @see org.cyberneko.html.filters.Purifier#purifyText(org.apache.xerces.xni.XMLString)
@@ -50,6 +54,10 @@ public class HtmlPurifier extends Purifier {
         }
 
         if (VALID_IMG_TAG.matcher(temp).find()) {
+            temp = sanitizer.sanitize(temp);
+        }
+
+        if (VALID_ALERT_TAG.matcher(temp).find() || VALID_SCRIPT_TAG.matcher(temp).find()) {
             temp = sanitizer.sanitize(temp);
         }
 


### PR DESCRIPTION
Added fix to pass the HTML through OWASP sanitizer if "alert" or "javascript" is seen.
The existing defanger code skipped sanitizing the XSS in the attachment because one of the tags was not complete.

Added new unit test
Verified that all existing Defanger unit test  and other unit test ran without any failures. Also 

Tests | Failures | Errors | Skipped | Success rate | Time
1315  | 0 | 0 | 10 | 100.00% | 342.201

