### PR TITLE
ZCS-6075 GetAddressListInfo API constants, models, and util methods.

### DIFF
--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -1080,6 +1080,10 @@ public final class AdminConstants {
     public static final String E_MODIFY_ADDRESS_LIST_RESPONSE = "ModifyAddressListResponse";
     public static final QName MODIFY_ADDRESS_LIST_REQUEST = QName.get(E_MODIFY_ADDRESS_LIST_REQUEST, NAMESPACE);
     public static final QName MODIFY_ADDRESS_LIST_RESPONSE = QName.get(E_MODIFY_ADDRESS_LIST_RESPONSE, NAMESPACE);
+    public static final String E_GET_ADDRESS_LIST_INFO_REQUEST = "GetAddressListInfoRequest";
+    public static final String E_GET_ADDRESS_LIST_INFO_RESPONSE = "GetAddressListInfoResponse";
+    public static final QName GET_ADDRESS_LIST_INFO_REQUEST = QName.get(E_GET_ADDRESS_LIST_INFO_REQUEST, NAMESPACE);
+    public static final QName GET_ADDRESS_LIST_INFO_RESPONSE = QName.get(E_GET_ADDRESS_LIST_INFO_RESPONSE, NAMESPACE);
 
 
     // DumpSessions

--- a/soap/src/java/com/zimbra/soap/JaxbUtil.java
+++ b/soap/src/java/com/zimbra/soap/JaxbUtil.java
@@ -1117,7 +1117,9 @@ public final class JaxbUtil {
             com.zimbra.soap.voice.message.VoiceMsgActionRequest.class,
             com.zimbra.soap.voice.message.VoiceMsgActionResponse.class,
             com.zimbra.soap.account.message.GetAddressListMembersRequest.class,
-            com.zimbra.soap.account.message.GetAddressListMemberResponse.class
+            com.zimbra.soap.account.message.GetAddressListMemberResponse.class,
+            com.zimbra.soap.admin.message.GetAddressListInfoRequest.class,
+            com.zimbra.soap.admin.message.GetAddressListInfoResponse.class
         };
 
         try {

--- a/soap/src/java/com/zimbra/soap/admin/message/GetAddressListInfoRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/GetAddressListInfoRequest.java
@@ -1,0 +1,125 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <http://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.common.util.StringUtil;
+import com.zimbra.soap.admin.type.DomainSelector;
+
+/**
+ * @zm-api-command-auth-required true
+ * @zm-api-command-admin-auth-required true
+ * @zm-api-command-description get address list info request
+ */
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name=AdminConstants.E_GET_ADDRESS_LIST_INFO_REQUEST)
+public class GetAddressListInfoRequest {
+
+    /**
+     * @zm-api-field-tag id
+     * @zm-api-field-description zimbra id of the address list to get
+     */
+    @XmlAttribute(name=AdminConstants.E_ID /* id */, required=false)
+    private String id;
+
+    /**
+     * @zm-api-field-tag name
+     * @zm-api-field-description name of the address list to get
+     */
+    @XmlElement(name=AdminConstants.E_NAME /* name */, required=false)
+    private String name;
+
+    /**
+     * @zm-api-field-tag domain
+     * @zm-api-field-description domain of the address list to get (needed with name)
+     */
+    @XmlElement(name=AdminConstants.E_DOMAIN, /* domain */ required=false)
+    private final DomainSelector domain;
+
+    /**
+     * default private constructor to block the usage
+     */
+    @SuppressWarnings("unused")
+    private GetAddressListInfoRequest() {
+        this(null, null, null);
+    }
+
+    /**
+     * @param id
+     * @param name
+     * @param domain
+     */
+    public GetAddressListInfoRequest(String id, String name, DomainSelector domain) {
+        this.id = id;
+        this.name = name;
+        this.domain = domain;
+    }
+
+    /**
+     * @return The id
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * @param id The id to set
+     */
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param name the name to set
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return The domain selector
+     */
+    public DomainSelector getDomain() {
+        return domain;
+    }
+
+    public void validateGetAddressListInfoRequest() throws ServiceException {
+        if (StringUtil.isNullOrEmpty(id) && (StringUtil.isNullOrEmpty(name) || domain == null)) {
+            throw ServiceException
+                .INVALID_REQUEST("Get address list info requires either an id, or a name/domain pair", null);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "GetAddressListInfoRequest [id=" + id + ", name=" + name + ", domain=" + domain + "]";
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/GetAddressListInfoResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/GetAddressListInfoResponse.java
@@ -46,7 +46,7 @@ public class GetAddressListInfoResponse {
      * @zm-api-field-tag name
      * @zm-api-field-description name of the address list
      */
-    @XmlElement(name=AdminConstants.E_NAME /* name */, required=false)
+    @XmlElement(name=AdminConstants.E_NAME /* name */, required=true)
     private String name;
 
     /**
@@ -67,7 +67,7 @@ public class GetAddressListInfoResponse {
      * @zm-api-field-tag type
      * @zm-api-field-description gal search type
      */
-    @XmlAttribute(name=AdminConstants.A_TYPE /* type */, required=false)
+    @XmlAttribute(name=AdminConstants.A_TYPE /* type */, required=true)
     private GalSearchType type;
 
     /**

--- a/soap/src/java/com/zimbra/soap/admin/message/GetAddressListInfoResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/GetAddressListInfoResponse.java
@@ -1,0 +1,149 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <http://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.soap.admin.type.EntrySearchFilterInfo;
+import com.zimbra.soap.type.GalSearchType;
+
+/**
+ * @zm-api-command-auth-required true
+ * @zm-api-command-admin-auth-required true
+ * @zm-api-command-description get address list info response
+ */
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name=AdminConstants.E_GET_ADDRESS_LIST_INFO_RESPONSE)
+public class GetAddressListInfoResponse {
+
+    /**
+     * @zm-api-field-tag id
+     * @zm-api-field-description zimbra id of the address list
+     */
+    @XmlAttribute(name=AdminConstants.E_ID /* id */, required=true)
+    private String id;
+
+    /**
+     * @zm-api-field-tag name
+     * @zm-api-field-description name of the address list
+     */
+    @XmlElement(name=AdminConstants.E_NAME /* name */, required=false)
+    private String name;
+
+    /**
+     * @zm-api-field-tag desc
+     * @zm-api-field-description description of the address list
+     */
+    @XmlElement(name=AdminConstants.E_DESC /* desc */, required=false)
+    private String desc;
+
+    /**
+     * @zm-api-field-tag searchFilter
+     * @zm-api-field-description search filter for conditions
+     */
+    @XmlElement(name=AdminConstants.E_SEARCH_FILTER /* searchFilter */, required=false)
+    private EntrySearchFilterInfo searchFilter;
+
+    /**
+     * @zm-api-field-tag type
+     * @zm-api-field-description gal search type
+     */
+    @XmlAttribute(name=AdminConstants.A_TYPE /* type */, required=false)
+    private GalSearchType type;
+
+    /**
+     * @return The id
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * @param id The id to set
+     */
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param name the name to set
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return the desc
+     */
+    public String getDesc() {
+        return desc;
+    }
+
+    /**
+     * @param desc the desc to set
+     */
+    public void setDesc(String desc) {
+        this.desc = desc;
+    }
+
+    /**
+     * @return the searchFilter
+     */
+    public EntrySearchFilterInfo getSearchFilter() {
+        return searchFilter;
+    }
+
+    /**
+     * @param searchFilter the searchFilter to set
+     */
+    public void setSearchFilter(EntrySearchFilterInfo searchFilter) {
+        this.searchFilter = searchFilter;
+    }
+
+    /**
+     * @return the type
+     */
+    public GalSearchType getType() {
+        return type;
+    }
+
+    /**
+     * @param type the type to set
+     */
+    public void setType(GalSearchType type) {
+        this.type = type;
+    }
+
+    @Override
+    public String toString() {
+        return "GetAddressListInfoResponse [type=" + type + ", id=" + id + ", name=" + name
+            + ", desc=" + desc + ", searchFilter=" + searchFilter + "]";
+    }
+
+}

--- a/store/src/java/com/zimbra/cs/account/Provisioning.java
+++ b/store/src/java/com/zimbra/cs/account/Provisioning.java
@@ -2712,6 +2712,10 @@ public abstract class Provisioning extends ZAttrProvisioning {
     public AddressList getAddressList(String id) throws ServiceException {
         throw ServiceException.UNSUPPORTED();
     }
+
+    public AddressListInfo getAddressListByName(String name, Domain domain) throws ServiceException {
+        throw ServiceException.UNSUPPORTED();
+    }
     
 
     public List<AddressListInfo> getAllAddressLists(Domain domain, boolean activeOnly) throws ServiceException {

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -11467,6 +11467,20 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     }
 
     @Override
+    public AddressListInfo getAddressListByName(String name, Domain domain) throws ServiceException {
+        LdapEntry ldapEntry = (LdapEntry) (domain instanceof LdapEntry ? domain : getDomainById(domain.getId()));
+        if (ldapEntry == null) {
+            throw AccountServiceException.NO_SUCH_DOMAIN(domain.getName());
+        }
+        List<AddressListInfo> result = getAddressListByQuery(ldapEntry.getDN(), filterFactory.addressListByName(name), false);
+        if (result.size() < 1) {
+            throw AccountServiceException.NO_SUCH_ADDRESS_LIST(name);
+        }
+        // first should be what we want, ignore extras
+        return result.get(0);
+    }
+
+    @Override
     public void modifyAddressList(AddressList addressList, String name, Map<String, String> attrs)
         throws ServiceException {
         ZLdapContext zlc = null;

--- a/store/src/java/com/zimbra/cs/ldap/ZLdapFilterFactory.java
+++ b/store/src/java/com/zimbra/cs/ldap/ZLdapFilterFactory.java
@@ -155,6 +155,7 @@ public abstract class ZLdapFilterFactory extends ZLdapElement {
 	//address lists
         ALL_ADDRESS_LISTS(SINGLETON.allAddressLists()),
         ADDRESS_LIST_BY_ID(SINGLETON.addressListById("{ADDRESS-LIST-ID}")),
+        ADDRESS_LIST_BY_NAME(SINGLETON.addressListByName("{ADDRESS-LIST-NAME}")),
 
         //
         // =====================================
@@ -513,6 +514,7 @@ public abstract class ZLdapFilterFactory extends ZLdapElement {
      */
     public abstract ZLdapFilter allAddressLists();
     public abstract ZLdapFilter addressListById(String id);
+    public abstract ZLdapFilter addressListByName(String name);
     /*
      * util
      */

--- a/store/src/java/com/zimbra/cs/ldap/unboundid/UBIDLdapFilterFactory.java
+++ b/store/src/java/com/zimbra/cs/ldap/unboundid/UBIDLdapFilterFactory.java
@@ -1325,4 +1325,13 @@ public class UBIDLdapFilterFactory extends ZLdapFilterFactory {
                         Filter.createEqualityFilter(Provisioning.A_zimbraId, id),
                         FILTER_ALL_ADDRESS_LISTS));
     }
+
+    @Override
+    public ZLdapFilter addressListByName(String name) {
+        return new UBIDLdapFilter(
+                FilterId.ADDRESS_LIST_BY_NAME,
+                Filter.createANDFilter(
+                        Filter.createEqualityFilter(Provisioning.A_uid, name),
+                        FILTER_ALL_ADDRESS_LISTS));
+    }
 }


### PR DESCRIPTION
* Added constants, models, and ldap util methods for GetAddressListInfo - this API returns the meta info of the address list, and does not execute the query.

**Testing Done**
See jira ticket.

**Testing to be done by QA**
See testrail.