### PR TITLE
Returning raw messages for "show original" requests setting a charset

### DIFF
--- a/store/src/java/com/zimbra/cs/service/formatter/NativeFormatter.java
+++ b/store/src/java/com/zimbra/cs/service/formatter/NativeFormatter.java
@@ -165,6 +165,11 @@ public final class NativeFormatter extends Formatter {
             handleMessagePart(context, mp, msg);
         } else {
             context.resp.setContentType(MimeConstants.CT_TEXT_PLAIN);
+            context.resp.setCharacterEncoding(
+                    context.params.get("charset") == null
+                        ? context.targetAccount.getAttr(Provisioning.A_zimbraPrefMailDefaultCharset, Charsets.UTF_8.name())
+                        : context.params.get("charset")
+                );
             long size = msg.getSize();
             if (size > 0)
                 context.resp.setContentLength((int)size);
@@ -235,6 +240,11 @@ public final class NativeFormatter extends Formatter {
                     MimeConstants.CT_MESSAGE_RFC822.equals(contentType));
             if (simpleText) {
                 contentType = MimeConstants.CT_TEXT_PLAIN;
+                context.resp.setCharacterEncoding(
+                        context.params.get("charset") == null
+                            ? context.targetAccount.getAttr(Provisioning.A_zimbraPrefMailDefaultCharset, Charsets.UTF_8.name())
+                            : context.params.get("charset")
+                    );
             }
             boolean html = checkGlobalOverride(Provisioning.A_zimbraAttachmentsViewInHtmlOnly,
                     context.getAuthAccount()) || (context.hasView() && context.getView().equals(HTML_VIEW));


### PR DESCRIPTION
When a user requests the raw message via the "show original" web
interface link a text/plain page is returned, without any charset
indication in the ``Content-Type`` header of the response.

That often enough leads to text encoded as UTF-8 or other encodings to
be processes as Windows CP-1252, with incorrect characters displayed to the user.

For example an e-mail containing a fragment such as
```
Content-Type: text/plain; charset=utf-8
Content-Transfer-Encoding: 8bit

dd 🙵🙵🙵🙵 
```
might be displayed as
```
Content-Type: text/plain; charset=utf-8
Content-Transfer-Encoding: 8bit

dd ðŸ™µðŸ™µðŸ™µðŸ™µ 
```
which confuses the user, although it does not change the actual contents of the message.

This commit introduces a selection of the charset for the ``Content-Type`` header of the
response using, in the following order, (a) the value of an optional
"charset" parameter in the request or (b) the value, if set, of the
zimbraPrefMailDefaultCharset for the target account or (c) a sane(r) default of "utf-8".


