### PR TITLE
Register AdditionalQuotaProvider to MailboxManager for Drive quota (target 8.8.10p3)

### DIFF
--- a/store/src/java-test/com/zimbra/cs/mailbox/MailboxTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/MailboxTest.java
@@ -640,6 +640,63 @@ public final class MailboxTest {
         Assert.assertEquals(2, count);
     }
 
+    @Test
+    public void testAdditionalQuotaProviderExceedsQuota() throws Exception {
+        AdditionalQuotaProvider additionalQuotaProvider = new AdditionalQuotaProvider() {
+            @Override
+            public long getAdditionalQuota(Mailbox mailbox) {
+                return 10;
+            }
+        };
+        MailboxManager.getInstance().addAdditionalQuotaProvider(additionalQuotaProvider);
+        Provisioning prov = Provisioning.getInstance();
+        Map<String, Object> attrs = new HashMap<String, Object>();
+        attrs.put("zimbraMailQuota", "5");
+        Account acct = prov.createAccount("testAdditionalQuotaProvider@zimbra.com", "secret", attrs);
+        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+        try {
+            mbox.checkSizeChange(0);
+            Assert.fail("Expected QUOTA_EXCEEDED exception");
+        }
+        catch (MailServiceException ignored) {}
+
+        Assert.assertEquals(10L, mbox.getSize());
+
+        MailboxManager.getInstance().removeAdditionalQuotaProvider(additionalQuotaProvider);
+        try {
+            mbox.checkSizeChange(5);
+        }
+        catch (MailServiceException ignored) {
+            Assert.fail("Unexpected QUOTA_EXCEEDED exception");
+        }
+
+        Assert.assertEquals(0L, mbox.getSize());
+    }
+
+    @Test
+    public void testAdditionalQuotaProviderRespectsQuota() throws Exception {
+        MailboxManager.getInstance().addAdditionalQuotaProvider(
+          new AdditionalQuotaProvider() {
+              public long getAdditionalQuota(Mailbox mbox) {
+                  return 10;
+              }
+          }
+        );
+        Provisioning prov = Provisioning.getInstance();
+        Map<String, Object> attrs = new HashMap<String, Object>();
+        attrs.put("zimbraMailQuota", "30");
+        Account acct = prov.createAccount("testAdditionalQuotaProvider@zimbra.com", "secret", attrs);
+        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+        try {
+            mbox.checkSizeChange(10);
+        }
+        catch (MailServiceException ignored) {
+            Assert.fail("Unexpected QUOTA_EXCEEDED exception");
+        }
+
+        Assert.assertEquals(10L, mbox.getSize());
+    }
+
     /**
      * @throws java.lang.Exception
      */

--- a/store/src/java-test/com/zimbra/cs/mailbox/MailboxTestUtil.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/MailboxTestUtil.java
@@ -183,6 +183,7 @@ public final class MailboxTestUtil {
      */
     public static void clearData() throws Exception {
         clearData("");
+        MailboxManager.getInstance().clearAdditionalQuotaProviders();
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/mailbox/AdditionalQuotaProvider.java
+++ b/store/src/java/com/zimbra/cs/mailbox/AdditionalQuotaProvider.java
@@ -1,0 +1,5 @@
+package com.zimbra.cs.mailbox;
+
+public interface AdditionalQuotaProvider {
+  long getAdditionalQuota(Mailbox mailbox);
+}

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -1419,7 +1419,21 @@ public class Mailbox implements MailboxStore {
     /** Returns the total (uncompressed) size of the mailbox's contents. */
     @Override
     public long getSize() {
-        return currentChange().size == MailboxChange.NO_CHANGE ? mData.size : currentChange().size;
+        long additionalSize = getAdditionalSize();
+        return (currentChange().size == MailboxChange.NO_CHANGE ? mData.size : currentChange().size) + additionalSize;
+    }
+
+    private long getAdditionalSize() {
+        long additionalSize = 0L;
+        try {
+            for (AdditionalQuotaProvider listener : MailboxManager.getInstance().getAdditionalQuotaProviders()) {
+                additionalSize += listener.getAdditionalQuota(this);
+            }
+        }
+        catch (ServiceException e ) {
+            ZimbraLog.mailbox.warn("could not get mailbox total size", e);
+        }
+        return additionalSize;
     }
 
     /** change the current size of the mailbox */
@@ -1443,10 +1457,10 @@ public class Mailbox implements MailboxStore {
         currentChange().size = size;
     }
 
-    void checkSizeChange(long newSize) throws ServiceException {
+    public void checkSizeChange(long newSize) throws ServiceException {
         Account acct = getAccount();
         long acctQuota = AccountUtil.getEffectiveQuota(acct);
-        if (acctQuota != 0 && newSize > acctQuota) {
+        if (acctQuota != 0 && newSize + getAdditionalSize() > acctQuota) {
             throw MailServiceException.QUOTA_EXCEEDED(acctQuota);
         }
         Domain domain = Provisioning.getInstance().getDomain(acct);

--- a/store/src/java/com/zimbra/cs/mailbox/MailboxManager.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailboxManager.java
@@ -79,6 +79,26 @@ public class MailboxManager {
 
     private ConcurrentHashMap<String, MailboxMaintenance> maintenanceLocks = new ConcurrentHashMap<String, MailboxMaintenance>();
 
+    private CopyOnWriteArrayList<AdditionalQuotaProvider> mAdditionalQuotaProviders = new CopyOnWriteArrayList<AdditionalQuotaProvider>();
+
+    public void addAdditionalQuotaProvider(AdditionalQuotaProvider additionalQuotaProvider) {
+        assert(!mAdditionalQuotaProviders.contains(additionalQuotaProvider));
+        mAdditionalQuotaProviders.add(additionalQuotaProvider);
+    }
+
+    public void removeAdditionalQuotaProvider(AdditionalQuotaProvider additionalQuotaProvider) {
+        assert(mAdditionalQuotaProviders.contains(additionalQuotaProvider));
+        mAdditionalQuotaProviders.remove(additionalQuotaProvider);
+    }
+
+    public void clearAdditionalQuotaProviders() {
+        mAdditionalQuotaProviders.clear();
+    }
+
+    List<AdditionalQuotaProvider> getAdditionalQuotaProviders() {
+        return mAdditionalQuotaProviders;
+    }
+
     private CopyOnWriteArrayList<Listener> mListeners = new CopyOnWriteArrayList<Listener>();
 
     public void addListener(Listener listener) {


### PR DESCRIPTION
Added ability to add AdditionalQuotaProviders to MailboxManager to register additional external quota to mailboxes
Said quota is considered when checking if account quota exceeds limitations
This will be used to include drive quota when checking mailbox size
AdditionalQuotaProvider quota is volatile from mailbox prospective and not saved on DB

Thanks
bye