### PR TITLE
ZCS-6135 GraphQL support for ChangePassword

### DIFF
--- a/common/src/java/com/zimbra/common/gql/GqlConstants.java
+++ b/common/src/java/com/zimbra/common/gql/GqlConstants.java
@@ -402,4 +402,10 @@ public class GqlConstants {
     public static final String LICENSE = "license";
     public static final String IS_TRACKING_IMAP = "isTrackingIMAP";
     public static final String CLASS_ATTRS_IMPL = "AttrsImpl";
+    
+    //Change password related constansts
+    public static final String CLASS_CHANGE_PASSWORD_RESPONSE = "ChangePasswordResponse";
+    public static final String OLD_PASSWORD = "oldPassword";
+    public static final String NEW_PASSWORD = "newPassword";
+    public static final String ACCOUNT_SELECTOR = "accountSelector";
 }

--- a/common/src/java/com/zimbra/common/gql/GqlConstants.java
+++ b/common/src/java/com/zimbra/common/gql/GqlConstants.java
@@ -411,4 +411,5 @@ public class GqlConstants {
     public static final String NEW_PASSWORD = "newPassword";
     public static final String ACCOUNT_SELECTOR = "accountSelector";
     public static final String AUTH_TOKEN = "authToken";
+
 }

--- a/common/src/java/com/zimbra/common/gql/GqlConstants.java
+++ b/common/src/java/com/zimbra/common/gql/GqlConstants.java
@@ -303,6 +303,8 @@ public class GqlConstants {
     public static final String LAST_ACCESSED = "lastAccessed";
     public static final String USER_AGENT = "userAgent";
     public static final String REQUEST_IP_ADDRESS = "requestIPAddress";
+    public static final String CLEAR_ALL_SOAP_SESSIONS = "clearAllSoapSessions";
+    public static final String EXCLUDE_CURRENT_SESSION = "excludeCurrentSession";
 
     // get info constants
     public static final String CLASS_GET_INFO_REQUEST = "GetInfoRequest";
@@ -408,4 +410,5 @@ public class GqlConstants {
     public static final String OLD_PASSWORD = "oldPassword";
     public static final String NEW_PASSWORD = "newPassword";
     public static final String ACCOUNT_SELECTOR = "accountSelector";
+    public static final String AUTH_TOKEN = "authToken";
 }

--- a/soap/src/java/com/zimbra/soap/account/message/ChangePasswordResponse.java
+++ b/soap/src/java/com/zimbra/soap/account/message/ChangePasswordResponse.java
@@ -21,8 +21,12 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
+import com.zimbra.common.gql.GqlConstants;
 import com.zimbra.common.soap.AccountConstants;
 import com.zimbra.soap.json.jackson.annotate.ZimbraJsonAttribute;
+
+import io.leangen.graphql.annotations.GraphQLQuery;
+import io.leangen.graphql.annotations.types.GraphQLType;
 
 /**
 <ChangePasswordResponse>
@@ -32,6 +36,7 @@ import com.zimbra.soap.json.jackson.annotate.ZimbraJsonAttribute;
  * @zm-api-response-description Note: Returns new authToken, as old authToken will be invalidated on password change.
  */
 @XmlRootElement(name=AccountConstants.E_CHANGE_PASSWORD_RESPONSE)
+@GraphQLType(name=GqlConstants.CLASS_CHANGE_PASSWORD_RESPONSE, description="The response to change password request.")
 @XmlType(propOrder = {})
 public class ChangePasswordResponse {
 
@@ -51,7 +56,9 @@ public class ChangePasswordResponse {
     public ChangePasswordResponse() {
     }
 
+    @GraphQLQuery(name="authToken", description="Auth token based on the new password")
     public String getAuthToken() { return authToken; }
+    @GraphQLQuery(name="lifetime", description="Life time of the auth token")
     public long getLifetime() { return lifetime; }
 
     public ChangePasswordResponse setAuthToken(String authToken) {

--- a/soap/src/java/com/zimbra/soap/account/message/ChangePasswordResponse.java
+++ b/soap/src/java/com/zimbra/soap/account/message/ChangePasswordResponse.java
@@ -56,7 +56,7 @@ public class ChangePasswordResponse {
     public ChangePasswordResponse() {
     }
 
-    @GraphQLQuery(name="authToken", description="Auth token based on the new password")
+    @GraphQLQuery(name=GqlConstants.AUTH_TOKEN, description="Auth token based on the new password")
     public String getAuthToken() { return authToken; }
     @GraphQLQuery(name=GqlConstants.LIFETIME, description="Life time of the auth token")
     public long getLifetime() { return lifetime; }

--- a/soap/src/java/com/zimbra/soap/account/message/ChangePasswordResponse.java
+++ b/soap/src/java/com/zimbra/soap/account/message/ChangePasswordResponse.java
@@ -58,7 +58,7 @@ public class ChangePasswordResponse {
 
     @GraphQLQuery(name="authToken", description="Auth token based on the new password")
     public String getAuthToken() { return authToken; }
-    @GraphQLQuery(name="lifetime", description="Life time of the auth token")
+    @GraphQLQuery(name=GqlConstants.LIFETIME, description="Life time of the auth token")
     public long getLifetime() { return lifetime; }
 
     public ChangePasswordResponse setAuthToken(String authToken) {

--- a/soap/src/java/com/zimbra/soap/account/type/AuthToken.java
+++ b/soap/src/java/com/zimbra/soap/account/type/AuthToken.java
@@ -23,6 +23,7 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlValue;
 
 import com.google.common.base.MoreObjects;
+import com.zimbra.common.gql.GqlConstants;
 import com.zimbra.common.soap.AccountConstants;
 import com.zimbra.soap.type.ZmBoolean;
 
@@ -66,9 +67,10 @@ public class AuthToken {
         this.verifyAccount = ZmBoolean.fromBool(verifyAccount);
     }
 
-    @GraphQLQuery(name="value", description="Value for authorization token")
+    @GraphQLQuery(name=GqlConstants.VALUE, description="Value for authorization token")
     public String getValue() { return value; }
-    @GraphQLInputField(name="value", description="Value for authorization token")
+
+    @GraphQLInputField(name=GqlConstants.VALUE, description="Value for authorization token")
     public void setValue(String value) { this.value = value; }
 
     @GraphQLQuery(name="verifyAccount", description="Denotes whether to verify account data in the request")
@@ -76,12 +78,12 @@ public class AuthToken {
     @GraphQLInputField(name="verifyAccount", description="Denotes whether to verify account data in the request")
     public void setVerifyAccount(Boolean verifyAccount) { this.verifyAccount = ZmBoolean.fromBool(verifyAccount); }
 
-    @GraphQLQuery(name="lifetime", description="Life time of the auth token")
+    @GraphQLQuery(name=GqlConstants.LIFETIME, description="Life time of the auth token")
     public Long getLifetime() {
         return lifetime;
     }
 
-    @GraphQLInputField(name="lifetime", description="Life time of the auth token")
+    @GraphQLInputField(name=GqlConstants.LIFETIME, description="Life time of the auth token")
     public void setLifetime(Long lifetime) {
         this.lifetime = lifetime;
     }


### PR DESCRIPTION
Implemented changePassword API in GraphQL.

Tested scenarios with invalid old and new password, not providing required attributes.

mutation test {
changePassword (oldPassword: "test123",
newPassword: "test456", accountSelector: {
accountBy:name,
key: "user1@example.com"
})
{
authToken
lifetime
}
}