### PR TITLE
ZCS-6063 Adding  new params for endSession

### DIFF
--- a/common/src/java/com/zimbra/common/gql/GqlConstants.java
+++ b/common/src/java/com/zimbra/common/gql/GqlConstants.java
@@ -303,6 +303,8 @@ public class GqlConstants {
     public static final String LAST_ACCESSED = "lastAccessed";
     public static final String USER_AGENT = "userAgent";
     public static final String REQUEST_IP_ADDRESS = "requestIPAddress";
+    public static final String CLEAR_ALL_SOAP_SESSIONS = "clearAllSoapSessions";
+    public static final String EXCLUDE_CURRENT_SESSION = "excludeCurrentSession";
 
     // get info constants
     public static final String CLASS_GET_INFO_REQUEST = "GetInfoRequest";


### PR DESCRIPTION
Added support for 2 new params in endSession
clearAllSoapSessions
excludeCurrentSession

Tested the new attributes work in the GQL query