### PR TITLE
ZBUG-694 grantRight deletes previous right if next grantRight runs wi…

### DIFF
--- a/store/src/java/com/zimbra/cs/account/accesscontrol/ACLUtil.java
+++ b/store/src/java/com/zimbra/cs/account/accesscontrol/ACLUtil.java
@@ -133,7 +133,7 @@ public final class ACLUtil {
         for (ZimbraACE ace : aces) {
             ZimbraACE.validate(ace);
         }
-        ZimbraACL acl = getACL(target);
+        ZimbraACL acl = getACL(target, Boolean.TRUE);
         List<ZimbraACE> granted = null;
 
         if (acl == null) {
@@ -163,7 +163,7 @@ public final class ACLUtil {
      */
     public static List<ZimbraACE> revokeRight(Provisioning prov, Entry target, Set<ZimbraACE> aces)
     throws ServiceException {
-        ZimbraACL acl = getACL(target);
+        ZimbraACL acl = getACL(target, Boolean.TRUE);
         if (acl == null) {
             return new ArrayList<ZimbraACE>(); // return empty list
         }
@@ -198,10 +198,25 @@ public final class ACLUtil {
      * @throws ServiceException
      */
     static ZimbraACL getACL(Entry entry) throws ServiceException {
-        ZimbraACL acl = (ZimbraACL) entry.getCachedData(ACL_CACHE_KEY);
+        return getACL(entry, Boolean.FALSE);
+    }
+    /**
+     * Get cached grants, if not in cache, load from LDAP.
+     *
+     * @param entry the LDAP entry object for which we need ACLs
+     * @param loadFromLdap when true we always load from LDAP, when false we try the cache first.
+     * @return
+     * @throws ServiceException
+     */
+    static ZimbraACL getACL(Entry entry, boolean loadFromLdap) throws ServiceException {
+        ZimbraACL acl = null;
+        if (!loadFromLdap) {
+            acl = (ZimbraACL) entry.getCachedData(ACL_CACHE_KEY);
+        }
         if (acl != null) {
             return acl;
         } else {
+            acl = null;
             String[] aces = entry.getMultiAttr(Provisioning.A_zimbraACE);
             if (aces.length == 0) {
                 return null;


### PR DESCRIPTION
Issue : grantRight deletes previous right if next grantRight runs within LC.ldap_cache_domain_maxage on multi-server system.

Resolution: Grant rights were previously fetched from cache only, after fix it will fetch grant rights from LDAP for grant and revoke request,.

after running the grant right command it is observed that grant rights for the domain is not being overridden with the previous grant rights. all grant rights are preserved for the domain.


