### PR TITLE
Fix: incomplete attribute removal deleting domains

### DIFF
--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -3668,7 +3668,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
         deleteDomain(zimbraId, false);
     }
 
-    public List<String> getEmptyAliasDomainIds(ZLdapContext zlc, Domain targetDomain, boolean suboridinateCheck)
+    public List<String> getEmptyAliasDomainIds(ZLdapContext zlc, Domain targetDomain, boolean subordinateCheck)
     throws ServiceException {
         List<String> aliasDomainIds = new ArrayList<String>();
 
@@ -3692,9 +3692,9 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
                 String acctBaseDn = mDIT.domainDNToAccountBaseDN(aliasDomainDn);
                 String dynGroupsBaseDn = mDIT.domainDNToDynamicGroupsBaseDN(aliasDomainDn);
 
-                if (suboridinateCheck && (hasSubordinates(zlc, acctBaseDn) || hasSubordinates(zlc, dynGroupsBaseDn))) {
+                if (subordinateCheck && (hasSubordinates(zlc, acctBaseDn) || hasSubordinates(zlc, dynGroupsBaseDn))) {
                     throw ServiceException.FAILURE("alias domain " + aliasDomainName +
-                            " of doamin " + targetDomain.getName() + " is not empty", null);
+                            " of domain " + targetDomain.getName() + " is not empty", null);
                 }
 
                 if (aliasDomainId != null) {
@@ -3733,7 +3733,10 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
         String acctBaseDn = null;
         String dynGroupsBaseDn = null;
         try {
-            domain = (LdapDomain) getDomainById(zimbraId, zlc);
+            // bypass the cached Domain data, in case a subdomain exists and deletion
+            // of the domain transforms into attribute removal, in which case attributes
+            // might be missing from a stale cached Domain object
+            domain = (LdapDomain) getDomainByIdInternal(zimbraId, zlc, GetFromDomainCacheOption.NEGATIVE);
             if (domain == null) {
                 throw AccountServiceException.NO_SUCH_DOMAIN(zimbraId);
             }
@@ -3767,11 +3770,13 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
                 // remove from cache before nuking all attrs
                 domainCache.remove(domain);
                 // assume subdomains exist and turn into plain dc object
-                Map<String, String> attrs = new HashMap<String, String>();
-                attrs.put("-"+A_objectClass, "zimbraDomain");
+                Map<String, Object> attrs = new HashMap<String, Object>();
+                List<String> objClasses = new ArrayList<String>();
+                objClasses.addAll(Arrays.asList("zimbraDomain", "amavisAccount", "DKIM"));
+                attrs.put("-"+A_objectClass, objClasses);
                 // remove all zimbra attrs
                 for (String key : domain.getAttrs(false).keySet()) {
-                    if (key.startsWith("zimbra"))
+                    if (key.startsWith("zimbra") || key.startsWith("amavis") || key.startsWith("DKIM"))
                         attrs.put(key, "");
                 }
                 // cannot invoke callback here.  If another domain attr is added in a callback,
@@ -3779,6 +3784,10 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
                 // schema violation naming error(zimbraDomain is removed, thus there cannot be
                 // any zimbraAttrs left) and the modify will fail.
                 modifyAttrs(domain, attrs, false, false);
+
+                // necessary to remove the cached object re-created/refreshed by
+                // refreshEntry() down the line from modifyAttrs()?
+                domainCache.remove(domain);
             }
 
             String defaultDomain = getConfig().getAttr(A_zimbraDefaultDomainName, null);


### PR DESCRIPTION
Given the existence, for example, of a zimbraDomain
subdomain.example.com and of a zimbraDomain example.com, deleting the
domain example.com the ldap object dc=example,dc=com cannot be deleted
given the presence of the domain subdomain.example.com .
Instead all zimbra-related attributes are removed from the object
dc=example,dc=com .
The code however just removes attributes related to the zimbraDomain object
class but not the amavisAccount and DKIM object Classes with their
related attributes, since quite likely the code predates the introduction of those
objectClasses/attributes at domain level.
The fix is to handle the removal of those as well.

Also bypassing/clearing the domain Cache is necessary to get an up-to-date domain Object before clearing the attributes and to remove it from the cache after modifying the Object.

A few typo corrections are added as well.

The bug with the original code can be reproduced as follows
```
$ zmprov createDomain domain.tld
d41d6200-d202-49d7-91ed-57fe963bec61
$ zmprov createDomain subdomain.domain.tld
41cf7592-32bf-47ec-808d-2186e98aed3

$ ldapsearch -b 'dc=domain,dc=tld'
[...]
dn: dc=domain,dc=tld
zimbraDomainStatus: active
zimbraDomainName: domain.tld
zimbraId: d41d6200-d202-49d7-91ed-57fe963bec61
objectClass: dcObject
objectClass: organization
objectClass: zimbraDomain
objectClass: amavisAccount
zimbraDomainType: local
zimbraCreateTimestamp: 20181105132622Z
zimbraMailStatus: enabled
o: domain.tld domain
dc: domain

[...]
dn: dc=subdomain,dc=domain,dc=tld
zimbraDomainStatus: active
zimbraDomainType: local
objectClass: dcObject
objectClass: organization
objectClass: zimbraDomain
objectClass: amavisAccount
zimbraId: 41cf7592-32bf-47ec-808d-2186e98aed32
zimbraCreateTimestamp: 20181105132612Z
zimbraDomainName: subdomain.domain.tld
zimbraMailStatus: enabled
o: subdomain.domain.tld domain
dc: subdomain
[...]

#
# Notice the "objectClass: amavisAccount" attribute
#

$ /opt/zimbra/libexec/zmdkimkeyutil -a -b 4096 -d domain.tld
DKIM Data added to LDAP for domain domain.tld with selector 109AB39A-E0FF-11E8-854B-F84B1FF26769
[...]

$ ldapsearch -b 'dc=domain,dc=tld' -s base
dn: dc=domain,dc=tld
zimbraDomainStatus: active
zimbraDomainName: domain.tld
zimbraId: d41d6200-d202-49d7-91ed-57fe963bec61
objectClass: dcObject
objectClass: organization
objectClass: zimbraDomain
objectClass: amavisAccount
objectClass: DKIM
zimbraDomainType: local
zimbraCreateTimestamp: 20181105132622Z
zimbraMailStatus: enabled
o: domain.tld domain
dc: domain
DKIMSelector: 109AB39A-E0FF-11E8-854B-F84B1FF26769
DKIMDomain: domain.tld
DKIMKey:: [...]
DKIMPublicKey:: [...]
DKIMIdentity: domain.tld

# 
# Now "objectClass: DKIM" and several DKIM* attributes have been added
# 

$ zmprov deleteDomain domain.tld

$ ldapsearch  -b 'dc=domain,dc=tld' -s base
dn: dc=domain,dc=tld
objectClass: dcObject
objectClass: organization
objectClass: amavisAccount
objectClass: DKIM
o: domain.tld domain
dc: domain
DKIMSelector: 109AB39A-E0FF-11E8-854B-F84B1FF26769
DKIMDomain: domain.tld
DKIMKey:: [...]
DKIMPublicKey:: [...]
DKIMIdentity: domain.tld

# 
# The code removed "objectClass: zimbraDomain" and the zimbra* attributes, 
# leaving the object classes amavisAccount and DKIM with related attributes
#

$ zmprov createDomain domain.tld
ERROR: account.DOMAIN_EXISTS (domain already exists: domain.tld)

# This is due to the missing removal of the cached domain object
# in the code after the attribute modification

$ zmprov fc all

$ zmprov createDomain domain.tld
ERROR: ldap.OBJECT_CLASS_VIOLATION (object class violation - unable to modify attributes: ldap host=ldap1.zimbraopen.it:389: attribute 'DKIMSelector' not allowed)

# 
# From what I understand the code creating the domain tries to set 
# the objectClass to amavisAccount and zimbraDomain, removing 
# the leftover DKIM objectClass, which is not allowed given the presence of DKIM* attributes.
# 

```



This PR ought to fix the issue described at https://bugzilla.zimbra.com/show_bug.cgi?id=102326