### PR TITLE
Bug 109088: Avoid DoS via catastrophic backtracking in HtmlPurifier

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/DebugConfig.java
+++ b/common/src/java/com/zimbra/common/localconfig/DebugConfig.java
@@ -265,8 +265,7 @@ public final class DebugConfig {
     public static final String defangImgSkipOwaspSanitize = value("defang_img_skip_owasp_sanitize", "^cid:.*@");
     public static final String defangOwaspValidImgTag = value("owasp_valid_img_tag", "<\\s*img");
     public static final String defangStyleUnwantedStrgPattern = value("defang_style_unwanted_strg_pattern", "\\s*(('){2,})");
-    public static final String defangOwaspAlert = value("defang_owasp_alert_tag", "alert\\((.*)\\)");
-    public static final String defangOwaspJavaScript = value("defang_owasp_javascript_tag", ".*javascript\\s*");
+    public static final String defangOwaspJavaScript = value("defang_owasp_javascript", "javascript\\s*:");
 
     /*
      * Default maximum size of convertd response. This reduces OOME in case of

--- a/store/src/java-test/com/zimbra/cs/html/DefangFilterTest.java
+++ b/store/src/java-test/com/zimbra/cs/html/DefangFilterTest.java
@@ -1437,15 +1437,9 @@ public class DefangFilterTest {
      */
     @Test
     public void testZCS5696() throws Exception {
-        String html = "<textarea></textarea/><body/oNloAd=alert('bug109020-2')>bug109020-2";
+        String html = "<textarea></textarea/><body/oNloAd=javascript:alert('bug109020-2')>bug109020-2";
         InputStream htmlStream = new ByteArrayInputStream(html.getBytes());
-        String result = DefangFactory.getDefanger(MimeConstants.CT_TEXT_HTML).defang(htmlStream,
-            true);
-        Assert.assertTrue(!result.contains("alert"));
-
-        html = "<textarea></textarea/><body/oNloAd=javascript:alert('bug109020-2')>bug109020-2";
-        htmlStream = new ByteArrayInputStream(html.getBytes());
-        result = DefangFactory.getDefanger(MimeConstants.CT_TEXT_HTML).defang(htmlStream, true);
+        String result = DefangFactory.getDefanger(MimeConstants.CT_TEXT_HTML).defang(htmlStream, true);
         Assert.assertTrue(!result.contains("alert"));
     }
 }

--- a/store/src/java/com/zimbra/cs/html/HtmlPurifier.java
+++ b/store/src/java/com/zimbra/cs/html/HtmlPurifier.java
@@ -37,10 +37,8 @@ public class HtmlPurifier extends Purifier {
     private static final PolicyFactory sanitizer = Sanitizers.FORMATTING.and(Sanitizers.IMAGES);
     private static final Pattern IMG_SKIP_OWASPSANITIZE = Pattern.compile(
         DebugConfig.defangImgSkipOwaspSanitize, Pattern.CASE_INSENSITIVE);
-    private static final Pattern VALID_SCRIPT_TAG = Pattern.compile(
+    private static final Pattern JAVASCRIPT = Pattern.compile(
         DebugConfig.defangOwaspJavaScript, Pattern.CASE_INSENSITIVE);
-    private static final Pattern VALID_ALERT_TAG = Pattern.compile(
-        DebugConfig.defangOwaspAlert, Pattern.CASE_INSENSITIVE);
 
     /* (non-Javadoc)
      * @see org.cyberneko.html.filters.Purifier#purifyText(org.apache.xerces.xni.XMLString)
@@ -57,7 +55,7 @@ public class HtmlPurifier extends Purifier {
             temp = sanitizer.sanitize(temp);
         }
 
-        if (VALID_ALERT_TAG.matcher(temp).find() || VALID_SCRIPT_TAG.matcher(temp).find()) {
+        if (JAVASCRIPT.matcher(temp).find()) {
             temp = sanitizer.sanitize(temp);
         }
 


### PR DESCRIPTION
This issue was introduced with the fix for ZCS-5696/Bug 109020.  It probably fixes some XSS issue; since the bugs are private nobody can tell.

But unfortunately did the fix also introduce a case of catastrophic backtracking with the regex
```
.*javascript\s*
```

This patch drops the initial greedy match since it is unneeded.  It could also drop the trailing greedy match since it is unneeded as well but instead appends a colon since that's probably the intention here.

It also drops the check for `alert()` because... seriously guys?  An `alert()` is just a symptom of a test XSS, no real XSS will ever do an `alert()` but you run this regex on any HTML content.