### PR TITLE
Correct log message to avoid confusion 

### DIFF
--- a/store/src/java/com/zimbra/cs/imap/NioImapHandler.java
+++ b/store/src/java/com/zimbra/cs/imap/NioImapHandler.java
@@ -174,7 +174,7 @@ final class NioImapHandler extends ImapHandler implements NioHandler {
 
     @Override
     public void connectionIdle() {
-        ZimbraLog.imap.debug("dropping connection for inactivity");
+        ZimbraLog.imap.debug("dropping NIO connection for inactivity");
         dropConnection();
     }
 

--- a/store/src/java/com/zimbra/cs/imap/TcpImapHandler.java
+++ b/store/src/java/com/zimbra/cs/imap/TcpImapHandler.java
@@ -174,7 +174,7 @@ final class TcpImapHandler extends ProtocolHandler {
 
         // TODO in the TcpServer case, is this duplicated effort with
         // session timeout code that also drops connections?
-        ZimbraLog.imap.debug("dropping connection for inactivity");
+        ZimbraLog.imap.debug("dropping TCP connection for inactivity");
         dropConnection();
     }
 

--- a/store/src/java/com/zimbra/cs/service/FileUploadServlet.java
+++ b/store/src/java/com/zimbra/cs/service/FileUploadServlet.java
@@ -349,7 +349,7 @@ public class FileUploadServlet extends ZimbraServlet {
             // sizeMax=-1 means "no limit"
             long size = ByteUtil.copy(is, true, fi.getOutputStream(), true, sizeMax < 0 ? sizeMax : sizeMax + 1);
             if (upload.getSizeMax() >= 0 && size > upload.getSizeMax()) {
-                mLog.info("Exceeded maximum upload size of " + upload.getSizeMax() + " bytes");
+                mLog.warn("Exceeded maximum upload size of " + upload.getSizeMax() + " bytes");
                 throw MailServiceException.UPLOAD_TOO_LARGE(filename, "upload too large");
             }
 


### PR DESCRIPTION
Correct two debug log messages to avoid confusion with other logs with the same exact message.