### PR TITLE
ZCS-6232:GetContacts returns DL members even if expansion/viewing is …

### DIFF
--- a/store/src/java/com/zimbra/cs/gal/GalSearchResultCallback.java
+++ b/store/src/java/com/zimbra/cs/gal/GalSearchResultCallback.java
@@ -142,15 +142,14 @@ public class GalSearchResultCallback implements GalContact.Visitor {
     }
 
     public void handleContact(GalContact c) throws ServiceException {
-		Element eGalContact = ToXML.encodeGalContact(mResponse, c);
+        String zimbraId = c.getSingleAttr(ContactConstants.A_zimbraId);
+        boolean canExpand = GalSearchControl
+            .canExpandGalGroup(c.getSingleAttr(ContactConstants.A_email), zimbraId, mAuthAcct);
+		Element eGalContact = ToXML.encodeGalContact(mResponse, c, null, canExpand);
 		eGalContact.addAttribute(AccountConstants.A_REF, c.getId());
 
 		if (c.isGroup()) {
-		    String zimbraId = c.getSingleAttr(ContactConstants.A_zimbraId);
-
     		if (mNeedCanExpand) {
-    		    boolean canExpand = GalSearchControl.canExpandGalGroup(
-    		            c.getSingleAttr(ContactConstants.A_email), zimbraId, mAuthAcct);
     		    eGalContact.addAttribute(AccountConstants.A_EXP, canExpand);
     		}
 

--- a/store/src/java/com/zimbra/cs/service/mail/GetContacts.java
+++ b/store/src/java/com/zimbra/cs/service/mail/GetContacts.java
@@ -65,7 +65,8 @@ public final class GetContacts extends MailDocumentHandler  {
         Mailbox mbox = getRequestedMailbox(zsc);
         OperationContext octxt = getOperationContext(zsc, context);
         ItemIdFormatter ifmt = new ItemIdFormatter(zsc);
-
+        Account mRequestedAcct = getRequestedAccount(zsc);
+        Account mAuthedAcct = getAuthenticatedAccount(zsc);
         GetContactsRequest req = zsc.elementToJaxb(request);
         boolean sync = req.getSync() == null ? false : req.getSync();
         boolean derefContactGroupMember = req.getDerefGroupMember();
@@ -191,7 +192,7 @@ public final class GetContacts extends MailDocumentHandler  {
                         ToXML.encodeContact(response, ifmt, octxt, con, contactGroup,
                                 memberAttrs, false /* summary */, attrs, fields, migratedDlist,
                                 returnHiddenAttrs, maxMembers, returnCertInfo,
-                                ContactMemberOfMap.setOfMemberOf(zsc.getRequestedAccountId(), id, memberOfMap));
+                                ContactMemberOfMap.setOfMemberOf(zsc.getRequestedAccountId(), id, memberOfMap), mRequestedAcct, mAuthedAcct);
                     }
                 }
             }

--- a/store/src/java/com/zimbra/cs/service/mail/ToXML.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ToXML.java
@@ -96,8 +96,10 @@ import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.Server;
 import com.zimbra.cs.account.accesscontrol.GranteeType;
 import com.zimbra.cs.account.accesscontrol.ZimbraACE;
+import com.zimbra.cs.account.accesscontrol.Rights.User;
 import com.zimbra.cs.fb.FreeBusy;
 import com.zimbra.cs.gal.GalGroup.GroupInfo;
+import com.zimbra.cs.gal.GalGroup;
 import com.zimbra.cs.gal.GalGroupInfoProvider;
 import com.zimbra.cs.gal.GalGroupMembers.ContactDLMembers;
 import com.zimbra.cs.html.BrowserDefang;
@@ -157,6 +159,7 @@ import com.zimbra.cs.service.util.ItemId;
 import com.zimbra.cs.service.util.ItemIdFormatter;
 import com.zimbra.cs.session.PendingModifications.Change;
 import com.zimbra.cs.smime.SmimeHandler;
+import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.admin.type.DataSourceType;
 import com.zimbra.soap.mail.type.AlarmDataInfo;
 import com.zimbra.soap.mail.type.CalendarReply;
@@ -741,13 +744,27 @@ public final class ToXML {
                 fields, migratedDlist, returnHiddenAttrs, maxMembers, returnCertInfo, (Set<String>) null);
     }
 
+    public static Element encodeContact(Element parent, ItemIdFormatter ifmt,
+        OperationContext octxt, Contact contact, ContactGroup contactGroup,
+        Collection<String> memberAttrFilter, boolean summary, Collection<String> attrFilter,
+        int fields, String migratedDlist, boolean returnHiddenAttrs, long maxMembers,
+        boolean returnCertInfo, Set<String> memberOfIds) throws ServiceException {
+        return encodeContact(parent, ifmt, octxt, contact, contactGroup, memberAttrFilter, summary,
+            attrFilter, fields, migratedDlist, returnHiddenAttrs, maxMembers, returnCertInfo,
+            memberOfIds, null, null);
+    }
+
     /**
      * @param memberOfIds set of IDs of contact groups this contact is a member of
+     * @param mRequestedAcct requested account
+     * @param mAuthedAcct authenticated account
      */
-    public static Element encodeContact(Element parent, ItemIdFormatter ifmt, OperationContext octxt, Contact contact,
-            ContactGroup contactGroup, Collection<String> memberAttrFilter, boolean summary,
-            Collection<String> attrFilter, int fields, String migratedDlist,
-            boolean returnHiddenAttrs, long maxMembers, boolean returnCertInfo, Set<String> memberOfIds)
+    public static Element encodeContact(Element parent, ItemIdFormatter ifmt,
+        OperationContext octxt, Contact contact, ContactGroup contactGroup,
+        Collection<String> memberAttrFilter, boolean summary, Collection<String> attrFilter,
+        int fields, String migratedDlist, boolean returnHiddenAttrs, long maxMembers,
+        boolean returnCertInfo, Set<String> memberOfIds, Account mRequestedAcct,
+        Account mAuthedAcct)
     throws ServiceException {
         Element el = parent.addNonUniqueElement(MailConstants.E_CONTACT);
         el.addAttribute(MailConstants.A_ID, ifmt.formatItemId(contact));
@@ -828,19 +845,22 @@ public final class ToXML {
             for (Map.Entry<String, String> me : contactFields.entrySet()) {
                 String name = me.getKey();
                 String value = me.getValue();
-
                 // don't put returnHiddenAttrs in one of the && condition because member
                 // can be configured as a hidden or non-hidden field
-                if (ContactConstants.A_member.equals(name) &&
-                            maxMembers != GetContacts.NO_LIMIT_MAX_MEMBERS) {
-                    // there is a limit on the max number of members to return
-                    ContactDLMembers dlMembers = new ContactDLMembers(contact);
-                    if (dlMembers.getTotal() > maxMembers) {
-                        el.addAttribute(MailConstants.A_TOO_MANY_MEMBERS, true);
+                if (ContactConstants.A_member.equals(name)) {
+                    String email = contactFields.get("email");
+                    if (!hasDLViewRight(email, mRequestedAcct, mAuthedAcct)) {
                         continue;
                     }
+                    if (maxMembers != GetContacts.NO_LIMIT_MAX_MEMBERS) {
+                        // there is a limit on the max number of members to return
+                        ContactDLMembers dlMembers = new ContactDLMembers(contact);
+                        if (dlMembers.getTotal() > maxMembers) {
+                            el.addAttribute(MailConstants.A_TOO_MANY_MEMBERS, true);
+                            continue;
+                        }
+                    }
                 }
-
                 if (name != null && !name.trim().isEmpty() && !Strings.isNullOrEmpty(value)) {
                     encodeContactAttr(el, name, value, contact, encodeContactGroupMembersBasic, octxt, returnCertInfo);
                 }
@@ -872,6 +892,19 @@ public final class ToXML {
                     Element.Disposition.CONTENT);
         }
         return el;
+    }
+
+    public static boolean hasDLViewRight(String email, Account mRequestedAcct,
+        Account mAuthedAcct) {
+        boolean canExpand = true;
+        if (mRequestedAcct != null && mAuthedAcct != null) {
+            GalGroup.GroupInfo groupInfo = GalGroupInfoProvider.getInstance().getGroupInfo(email,
+                true, mRequestedAcct, mAuthedAcct);
+            if (groupInfo != null) {
+                canExpand = (GalGroup.GroupInfo.CAN_EXPAND == groupInfo);
+            }
+        }
+        return canExpand;
     }
 
     private static void encodeContactAttr(Element elem, String name, String value,
@@ -3424,12 +3457,22 @@ throws ServiceException {
     }
 
     public static Element encodeGalContact(Element response, GalContact contact,
-            Collection<String> returnAttrs) {
+        Collection<String> returnAttrs) {
+        return encodeGalContact(response, contact, returnAttrs, true);
+    }
+
+    public static Element encodeGalContact(Element response, GalContact contact,
+            Collection<String> returnAttrs, boolean canExpand) {
         Element cn = response.addNonUniqueElement(MailConstants.E_CONTACT);
         cn.addAttribute(MailConstants.A_ID, contact.getId());
         Map<String, Object> attrs = contact.getAttrs();
         for (Map.Entry<String, Object> entry : attrs.entrySet()) {
             String key = entry.getKey();
+            if (ContactConstants.A_member.equals(key)) {
+                if (!canExpand) {
+                    continue;
+                }
+            }
             if (returnAttrs == null || returnAttrs.contains(key)) {
                 Object value = entry.getValue();
                 if (value instanceof String[]) {


### PR DESCRIPTION
Issue:
GetContacts SOAP command returns DL members even if expansion/viewing is disabled for user

Fix:
Do not add members to soap response element if the user does not have DL expansion right

Added junit test