### PR TITLE
ZCS-6140: remove NonNull for ownerName in ShareInfo response

### DIFF
--- a/soap/src/java/com/zimbra/soap/type/ShareInfo.java
+++ b/soap/src/java/com/zimbra/soap/type/ShareInfo.java
@@ -150,7 +150,6 @@ public class ShareInfo {
         this.ownerDisplayName = ownerDisplayName;
     }
 
-    @GraphQLNonNull
     @GraphQLQuery(name=GqlConstants.OWNER_NAME, description="owner display name")
     public String getOwnerDisplayName() { return ownerDisplayName; }
 


### PR DESCRIPTION
ZCS-6140: remove NonNull for ownerName in ShareInfo response
ownerName is marked as required=true in SOAP request but still it's not returned in response in some scenarios. Hence removed NonNull annotation in GraphQL response.