### PR TITLE
ZBUG-715: added DESC to "order by mi.id" to find correct item specified by cursor in message search

### DIFF
--- a/store/src/java/com/zimbra/cs/db/DbSearch.java
+++ b/store/src/java/com/zimbra/cs/db/DbSearch.java
@@ -187,11 +187,15 @@ public final class DbSearch {
             orderBy.append(" DESC");
         }
         if (sort.getKey() == SortBy.Key.UNREAD) {
+            /* See also ResultsPager.forwardFindFirst() */
             return orderBy.append(", mi.id DESC").toString();
         }
         /* Successive searches using cursors need a predictable order, so add additional search column. */
         if (Key.ID != sort.getKey()) {
-            return orderBy.append(", mi.id").toString();
+            orderBy.append(", mi.id");
+            if (sort.getDirection() == SortBy.Direction.DESC) {
+                orderBy.append(" DESC");
+            }
         } 
         return orderBy.toString();
     }

--- a/store/src/java/com/zimbra/cs/index/ResultsPager.java
+++ b/store/src/java/com/zimbra/cs/index/ResultsPager.java
@@ -174,7 +174,8 @@ public final class ResultsPager {
                 if (params.getCursor().getItemId().getId() == 0) { // special case prevId of 0
                     return hit;
                 }
-                if (params.getSortBy().getDirection() == SortBy.Direction.DESC) {
+                /* See also DbSearch.sortBy(SortBy, boolean) */
+                if (params.getSortBy().getDirection() == SortBy.Direction.DESC || params.getSortBy().getKey() == SortBy.Key.UNREAD) {
                     if (hit.getItemId() < params.getCursor().getItemId().getId()) {
                         return hit;
                     }


### PR DESCRIPTION
[Problem]
Copy action doesn't stop when more in the following case.
- 500 message exists in a folder
- some of messages have the same value in a field specified by sortVal of SearchRequest
- cursor of SearchRequest points one of them

[Root cause]
When SearchRequest is processed on mailstore, SELECT command is executed like this.
`SELECT mi.id, mi.type, mi.parent_id, mi.folder_id, mi.prev_folders, mi.index_id,mi.imap_id, mi.date, mi.size, mi.locator, mi.blob_digest, mi.unread, mi.flags, mi.tag_names, mi.subject,mi.name, mi.metadata, mi.mod_metadata, mi.change_date, mi.mod_content, mi.uuid, mi.date AS sortcol FROM mboxgroup5.mail_item AS mi FORCE INDEX (i_folder_id_date) WHERE mi.mailbox_id = 5 AND ((mi.type = 5 OR mi.type = 16) AND mi.folder_id = 44173) ORDER BY sortcol DESC, mi.id LIMIT 0,103`
The items are sorted by the column specified by "sortBy" ASC/DESC and then sorted by mi.id. The mi.id sort is always ACS.
Then an incorrect item is hit in ResultsPager.forwardFindFirst.

[Fix]
- Add DESC to mi.id sort when sortcol is sorted with DESC in DbSearch.java
- Add UNREAD condition to ResultsPager.forwardFindFirst because items are always sorted with DESC when sortBy is UNREAD.

[Note]
The issue still happens in Conversation View mode. Items in a folder are searched by message and then the hit messages are converted to ConversationHit. The ConversationHit items are not sorted by conversation id. Then cursor doesn't work as expected.

