### PR TITLE
NICPS-537: Add new Zimbra attribute for the file type check

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -7268,6 +7268,15 @@ public class ZAttrProvisioning {
     public static final String A_zimbraFileShareLifetime = "zimbraFileShareLifetime";
 
     /**
+     * Whether to check for file type regardless of extension while uploading
+     * in briefcase or not
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=5027)
+    public static final String A_zimbraFileTypeCheckEnabled = "zimbraFileTypeCheckEnabled";
+
+    /**
      * Maximum size in bytes for file uploads
      */
     @ZAttr(id=227)

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9813,7 +9813,7 @@ TODO: delete them permanently from here
 <attr id="5026" name="zimbraPrefCalendarMultiDayLength" type="integer" cardinality="single" optionalIn="account" flags="accountInfo" since="8.8.9">
 	<desc>This attribute is used to set the number of days to show for multi-day calendar view</desc>
 </attr>
-<attr id="5027" name="zimbraFileTypeCheckEnabled" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountInfo,accountInherited,domainAdminModifiable" since="8.8.9">
+<attr id="5027" name="zimbraFileTypeCheckEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="8.8.9">
   <defaultCOSValue>FALSE</defaultCOSValue>
   <defaultExternalCOSValue>FALSE</defaultExternalCOSValue>
   <desc>Whether to check for file type regardless of extension while uploading in briefcase or not</desc>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9813,7 +9813,7 @@ TODO: delete them permanently from here
 <attr id="5026" name="zimbraPrefCalendarMultiDayLength" type="integer" cardinality="single" optionalIn="account" flags="accountInfo" since="8.8.9">
 	<desc>This attribute is used to set the number of days to show for multi-day calendar view</desc>
 </attr>
-<attr id="5027" name="zimbraFileTypeCheckEnabled" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountInfo,accountInherited">
+<attr id="5027" name="zimbraFileTypeCheckEnabled" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountInfo,accountInherited,domainAdminModifiable" since="8.8.9">
   <defaultCOSValue>FALSE</defaultCOSValue>
   <defaultExternalCOSValue>FALSE</defaultExternalCOSValue>
   <desc>Whether to check for file type regardless of extension while uploading in briefcase or not</desc>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9813,5 +9813,10 @@ TODO: delete them permanently from here
 <attr id="5026" name="zimbraPrefCalendarMultiDayLength" type="integer" cardinality="single" optionalIn="account" flags="accountInfo" since="8.8.9">
 	<desc>This attribute is used to set the number of days to show for multi-day calendar view</desc>
 </attr>
+<attr id="5027" name="zimbraFileTypeCheckEnabled" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountInfo,accountInherited">
+  <defaultCOSValue>FALSE</defaultCOSValue>
+  <defaultExternalCOSValue>FALSE</defaultExternalCOSValue>
+  <desc>Whether to check for file type regardless of extension while uploading in briefcase or not</desc>
+</attr>
 </attrs>
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -21935,6 +21935,83 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * Whether to check for file type regardless of extension while uploading
+     * in briefcase or not
+     *
+     * @return zimbraFileTypeCheckEnabled, or false if unset
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=5027)
+    public boolean isFileTypeCheckEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFileTypeCheckEnabled, false, true);
+    }
+
+    /**
+     * Whether to check for file type regardless of extension while uploading
+     * in briefcase or not
+     *
+     * @param zimbraFileTypeCheckEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=5027)
+    public void setFileTypeCheckEnabled(boolean zimbraFileTypeCheckEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFileTypeCheckEnabled, zimbraFileTypeCheckEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to check for file type regardless of extension while uploading
+     * in briefcase or not
+     *
+     * @param zimbraFileTypeCheckEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=5027)
+    public Map<String,Object> setFileTypeCheckEnabled(boolean zimbraFileTypeCheckEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFileTypeCheckEnabled, zimbraFileTypeCheckEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether to check for file type regardless of extension while uploading
+     * in briefcase or not
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=5027)
+    public void unsetFileTypeCheckEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFileTypeCheckEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to check for file type regardless of extension while uploading
+     * in briefcase or not
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=5027)
+    public Map<String,Object> unsetFileTypeCheckEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFileTypeCheckEnabled, "");
+        return attrs;
+    }
+
+    /**
      * Maximum size in bytes for each attachment.
      *
      * @return zimbraFileUploadMaxSizePerFile, or 2147483648 if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -16209,6 +16209,83 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * Whether to check for file type regardless of extension while uploading
+     * in briefcase or not
+     *
+     * @return zimbraFileTypeCheckEnabled, or false if unset
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=5027)
+    public boolean isFileTypeCheckEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFileTypeCheckEnabled, false, true);
+    }
+
+    /**
+     * Whether to check for file type regardless of extension while uploading
+     * in briefcase or not
+     *
+     * @param zimbraFileTypeCheckEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=5027)
+    public void setFileTypeCheckEnabled(boolean zimbraFileTypeCheckEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFileTypeCheckEnabled, zimbraFileTypeCheckEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to check for file type regardless of extension while uploading
+     * in briefcase or not
+     *
+     * @param zimbraFileTypeCheckEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=5027)
+    public Map<String,Object> setFileTypeCheckEnabled(boolean zimbraFileTypeCheckEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFileTypeCheckEnabled, zimbraFileTypeCheckEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether to check for file type regardless of extension while uploading
+     * in briefcase or not
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=5027)
+    public void unsetFileTypeCheckEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFileTypeCheckEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to check for file type regardless of extension while uploading
+     * in briefcase or not
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=5027)
+    public Map<String,Object> unsetFileTypeCheckEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFileTypeCheckEnabled, "");
+        return attrs;
+    }
+
+    /**
      * Maximum size in bytes for each attachment.
      *
      * @return zimbraFileUploadMaxSizePerFile, or 2147483648 if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -9892,6 +9892,83 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
+     * Whether to check for file type regardless of extension while uploading
+     * in briefcase or not
+     *
+     * @return zimbraFileTypeCheckEnabled, or false if unset
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=5027)
+    public boolean isFileTypeCheckEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFileTypeCheckEnabled, false, true);
+    }
+
+    /**
+     * Whether to check for file type regardless of extension while uploading
+     * in briefcase or not
+     *
+     * @param zimbraFileTypeCheckEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=5027)
+    public void setFileTypeCheckEnabled(boolean zimbraFileTypeCheckEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFileTypeCheckEnabled, zimbraFileTypeCheckEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to check for file type regardless of extension while uploading
+     * in briefcase or not
+     *
+     * @param zimbraFileTypeCheckEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=5027)
+    public Map<String,Object> setFileTypeCheckEnabled(boolean zimbraFileTypeCheckEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFileTypeCheckEnabled, zimbraFileTypeCheckEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether to check for file type regardless of extension while uploading
+     * in briefcase or not
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=5027)
+    public void unsetFileTypeCheckEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFileTypeCheckEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to check for file type regardless of extension while uploading
+     * in briefcase or not
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.9
+     */
+    @ZAttr(id=5027)
+    public Map<String,Object> unsetFileTypeCheckEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFileTypeCheckEnabled, "");
+        return attrs;
+    }
+
+    /**
      * Maximum size in bytes for each attachment.
      *
      * @return zimbraFileUploadMaxSizePerFile, or 2147483648 if unset


### PR DESCRIPTION
NICPS-537: Add new Zimbra attribute for the file type check

An attribute named zimbraFileTypeCheckEnabled is added. This boolean attribute is responsible for enabling/disabling of file content type check while uploading a file in the briefcase.