### PR TITLE
ZBUG-859: added params for restCalendar

### DIFF
--- a/store/src/java/com/zimbra/cs/service/UserServlet.java
+++ b/store/src/java/com/zimbra/cs/service/UserServlet.java
@@ -261,6 +261,31 @@ public class UserServlet extends ZimbraServlet {
 
     protected static final String MSGPAGE_BLOCK = "errorpage.attachment.blocked";
 
+    // used in restCalendar
+    public static final String QP_ACTION = "action";
+    public static final String QP_BODYPART = "bodypart";
+    public static final String QP_COLOR = "color";
+    public static final String QP_DATE = "date";
+    public static final String QP_EX_COMP_NUM = "exCompNum";
+    public static final String QP_EX_INV_ID = "exInvId";
+    public static final String QP_FOLDER_IDS = "folderIds";
+    public static final String QP_IM_ID = "im_id";
+    public static final String QP_IM_PART = "im_part";
+    public static final String QP_IM_XIM = "im_xim";
+    public static final String QP_INST_DURATION = "instDuration";
+    public static final String QP_INST_START_TIME = "instStartTime";
+    public static final String QP_INV_COMP_NUM = "invCompNum";
+    public static final String QP_INV_ID = "invId";
+    public static final String QP_NOTOOLBAR = "notoolbar";
+    public static final String QP_NUMDAYS = "numdays";
+    public static final String QP_PSTAT = "pstat";
+    public static final String QP_REFRESH = "refresh";
+    public static final String QP_SKIN = "skin";
+    public static final String QP_SQ = "sq";
+    public static final String QP_TZ = "tz";
+    public static final String QP_USE_INSTANCE = "useInstance";
+    public static final String QP_XIM = "xim";
+
     public static final Log log = LogFactory.getLog(UserServlet.class);
 
     /** Returns the REST URL for the account. */

--- a/store/src/java/com/zimbra/cs/service/UserServletContext.java
+++ b/store/src/java/com/zimbra/cs/service/UserServletContext.java
@@ -496,6 +496,102 @@ public class UserServletContext {
         return params.get(UserServlet.QP_TYPES);
     }
 
+    public String getAction() {
+        return params.get(UserServlet.QP_ACTION);
+    }
+
+    public String getBodypart() {
+        return params.get(UserServlet.QP_BODYPART);
+    }
+
+    public String getColor() {
+        return params.get(UserServlet.QP_COLOR);
+    }
+
+    public String getDate() {
+        return params.get(UserServlet.QP_DATE);
+    }
+
+    public String getExCompNum() {
+        return params.get(UserServlet.QP_EX_COMP_NUM);
+    }
+
+    public String getExInvId() {
+        return params.get(UserServlet.QP_EX_INV_ID);
+    }
+
+    public String getFmt() {
+        return params.get(UserServlet.QP_FMT);
+    }
+
+    public String getFolderIds() {
+        return params.get(UserServlet.QP_FOLDER_IDS);
+    }
+
+    public String getImId() {
+        return params.get(UserServlet.QP_IM_ID);
+    }
+
+    public String getImPart() {
+        return params.get(UserServlet.QP_IM_PART);
+    }
+
+    public String getImXim() {
+        return params.get(UserServlet.QP_IM_XIM);
+    }
+
+    public String getInstDuration() {
+        return params.get(UserServlet.QP_INST_DURATION);
+    }
+
+    public String getInstStartTime() {
+        return params.get(UserServlet.QP_INST_START_TIME);
+    }
+
+    public String getInvCompNum() {
+        return params.get(UserServlet.QP_INV_COMP_NUM);
+    }
+
+    public String getInvId() {
+        return params.get(UserServlet.QP_INV_ID);
+    }
+
+    public String getNotoolbar() {
+        return params.get(UserServlet.QP_NOTOOLBAR);
+    }
+
+    public String getNumdays() {
+        return params.get(UserServlet.QP_NUMDAYS);
+    }
+
+    public String getPstat() {
+        return params.get(UserServlet.QP_PSTAT);
+    }
+
+    public String getRefresh() {
+        return params.get(UserServlet.QP_REFRESH);
+    }
+
+    public String getSkin() {
+        return params.get(UserServlet.QP_SKIN);
+    }
+
+    public String getSq() {
+        return params.get(UserServlet.QP_SQ);
+    }
+
+    public String getTz() {
+        return params.get(UserServlet.QP_TZ);
+    }
+
+    public String getUseInstance() {
+        return params.get(UserServlet.QP_USE_INSTANCE);
+    }
+
+    public String getXim() {
+        return params.get(UserServlet.QP_XIM);
+    }
+
     /** Returns <tt>true</tt> if {@link UserServlet#QP_BODY} is not
      *  specified or is set to a non-zero value. */
     public boolean shouldReturnBody() {

--- a/store/src/java/com/zimbra/cs/service/formatter/HtmlFormatter.java
+++ b/store/src/java/com/zimbra/cs/service/formatter/HtmlFormatter.java
@@ -238,7 +238,6 @@ public class HtmlFormatter extends Formatter {
             context.req.setAttribute(ATTR_TARGET_USE_INSTANCE, context.getUseInstance());
             context.req.setAttribute(ATTR_TARGET_XIM, context.getXim());
             context.req.setAttribute(ATTR_TARGET_VIEW, context.getView());
-
         } else {
             context.req.setAttribute(ATTR_TARGET_ITEM_COLOR, Color.getMappedColor(null));
         }

--- a/store/src/java/com/zimbra/cs/service/formatter/HtmlFormatter.java
+++ b/store/src/java/com/zimbra/cs/service/formatter/HtmlFormatter.java
@@ -277,6 +277,7 @@ public class HtmlFormatter extends Formatter {
                 sb.append(attrName).append("=").append(HttpUtil.urlEscape(attrValue)).append("&");
             }
             HttpGet postMethod = new HttpGet(sb.toString());
+            postMethod.setHeader("Accept-Language", context.getLocale().getLanguage());
 
             HttpResponse httpResp;
             try {

--- a/store/src/java/com/zimbra/cs/service/formatter/HtmlFormatter.java
+++ b/store/src/java/com/zimbra/cs/service/formatter/HtmlFormatter.java
@@ -72,6 +72,31 @@ public class HtmlFormatter extends Formatter {
     private static final String ATTR_TARGET_ITEM_VIEW    = "zimbra_target_item_view";
     private static final String ATTR_TARGET_ITEM_PATH    = "zimbra_target_item_path";
     private static final String ATTR_TARGET_ITEM_NAME    = "zimbra_target_item_name";
+    private static final String ATTR_TARGET_ACTION       = "action";
+    private static final String ATTR_TARGET_BODYPART     = "bodypart";
+    private static final String ATTR_TARGET_COLOR        = "color";
+    private static final String ATTR_TARGET_DATE         = "date";
+    private static final String ATTR_TARGET_EX_COMP_NUM  = "exCompNum";
+    private static final String ATTR_TARGET_EX_INV_ID    = "exInvId";
+    private static final String ATTR_TARGET_FMT          = "fmt";
+    private static final String ATTR_TARGET_FOLDER_IDS   = "folderIds";
+    private static final String ATTR_TARGET_IM_ID        = "im_id";
+    private static final String ATTR_TARGET_IM_PART      = "im_part";
+    private static final String ATTR_TARGET_IM_XIM       = "im_xim";
+    private static final String ATTR_TARGET_INST_DURATION = "instDuration";
+    private static final String ATTR_TARGET_INST_START_TIME = "instStartTime";
+    private static final String ATTR_TARGET_INV_COMP_NUM = "invCompNum";
+    private static final String ATTR_TARGET_INV_ID       = "invId";
+    private static final String ATTR_TARGET_NOTOOLBAR    = "notoolbar";
+    private static final String ATTR_TARGET_NUMDAYS      = "numdays";
+    private static final String ATTR_TARGET_PSTAT        = "pstat";
+    private static final String ATTR_TARGET_REFRESH      = "refresh";
+    private static final String ATTR_TARGET_SKIN         = "skin";
+    private static final String ATTR_TARGET_SQ           = "sq";
+    private static final String ATTR_TARGET_TZ           = "tz";
+    private static final String ATTR_TARGET_USE_INSTANCE = "useInstance";
+    private static final String ATTR_TARGET_XIM          = "xim";
+    private static final String ATTR_TARGET_VIEW         = "view";
 
     private static final String ATTR_TARGET_ACCOUNT_PREF_TIME_ZONE   = "zimbra_target_account_prefTimeZoneId";
     private static final String ATTR_TARGET_ACCOUNT_PREF_SKIN   = "zimbra_target_account_prefSkin";
@@ -188,6 +213,32 @@ public class HtmlFormatter extends Formatter {
             if (targetItem instanceof Folder) {
                 context.req.setAttribute(ATTR_TARGET_ITEM_VIEW, ((Folder) targetItem).getDefaultView().toString());
             }
+            context.req.setAttribute(ATTR_TARGET_ACTION, context.getAction());
+            context.req.setAttribute(ATTR_TARGET_BODYPART, context.getBodypart());
+            context.req.setAttribute(ATTR_TARGET_COLOR, context.getColor());
+            context.req.setAttribute(ATTR_TARGET_DATE, context.getDate());
+            context.req.setAttribute(ATTR_TARGET_EX_COMP_NUM, context.getExCompNum());
+            context.req.setAttribute(ATTR_TARGET_EX_INV_ID, context.getExInvId());
+            context.req.setAttribute(ATTR_TARGET_FMT, context.getFmt());
+            context.req.setAttribute(ATTR_TARGET_FOLDER_IDS, context.getFolderIds());
+            context.req.setAttribute(ATTR_TARGET_IM_ID, context.getImId());
+            context.req.setAttribute(ATTR_TARGET_IM_PART, context.getImPart());
+            context.req.setAttribute(ATTR_TARGET_IM_XIM, context.getImXim());
+            context.req.setAttribute(ATTR_TARGET_INST_DURATION, context.getInstDuration());
+            context.req.setAttribute(ATTR_TARGET_INST_START_TIME, context.getInstStartTime());
+            context.req.setAttribute(ATTR_TARGET_INV_COMP_NUM, context.getInvCompNum());
+            context.req.setAttribute(ATTR_TARGET_INV_ID, context.getInvId());
+            context.req.setAttribute(ATTR_TARGET_NOTOOLBAR, context.getNotoolbar());
+            context.req.setAttribute(ATTR_TARGET_NUMDAYS, context.getNumdays());
+            context.req.setAttribute(ATTR_TARGET_PSTAT, context.getPstat());
+            context.req.setAttribute(ATTR_TARGET_REFRESH, context.getRefresh());
+            context.req.setAttribute(ATTR_TARGET_SKIN, context.getSkin());
+            context.req.setAttribute(ATTR_TARGET_SQ, context.getSq());
+            context.req.setAttribute(ATTR_TARGET_TZ, context.getTz());
+            context.req.setAttribute(ATTR_TARGET_USE_INSTANCE, context.getUseInstance());
+            context.req.setAttribute(ATTR_TARGET_XIM, context.getXim());
+            context.req.setAttribute(ATTR_TARGET_VIEW, context.getView());
+
         } else {
             context.req.setAttribute(ATTR_TARGET_ITEM_COLOR, Color.getMappedColor(null));
         }


### PR DESCRIPTION
**Problem:**
buttons and links don't work in Calendar in separate window on web-split environment.

**Root cause:**
The behavior is different between on single server environment and web-split environment.

**on single server environment:** 
GET request has view and date params like
`https://SERVER/service/home/test1@xmail.test.com/Calendar.html?view=week&date=20181026`

**on web-split environment:** 
GET request is sent to Mailstore. Then Mailstore generates and sends GET request to UI server (via proxy).

    https://dev.zimbra.com/h/rest?
    zimbra_target_item_color=0&
    CsrfTokenCheck=false&
    zimbra_request_uri=/home/test1@dev.zimbra.com/Calendar.html&
    zimbra_target_account_prefSkin=harmony&
    zimbra_target_account_prefCalendarDayHourEnd=18&
    zimbra_target_item_type=folder&
    zimbra_target_item_id=10&
    zimbra_target_item_name=Calendar&
    zimbra_target_account_name=test1@dev.zimbra.com&
    zimbraCsrfTokenCheckEnabled=true&
    zimbra_target_account_prefTimeZoneId=Asia/Tokyo&
    requestedPath=/home/test1@dev.zimbra.com/Calendar.html&
    zimbra_target_item_path=/Calendar&
    javax.servlet.request.key_size=256&
    javax.servlet.request.cipher_suite=TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384&
    javax.servlet.request.ssl_session_id=xxxxxx&
    CSRF_SALT=1793971179&
    zimbra_authToken=xxxxxx&
    zimbra_csrfEnabled=true&
    zimbra_target_account_id=64627fa1-1c33-4a8e-ad8c-eb0af548adac&
    zimbra_target_account_prefCalendarFirstDayOfWeek=0&
    zimbra_internal_dispatch=yes&
    zimbra_target_account_prefCalendarDayHourStart=8&
    zimbra_target_item_view=appointment&

It doesn't contain necessary parameters. Then incorrect link URLs are set to buttons/links.

**Fix:**
Add response parameters for restCalendar.

**Related PR:** https://github.com/Zimbra/zm-web-client/pull/434