### PR TITLE
ZCS-6695 Fixing ObjectInputStream to deserialize only specified class

### DIFF
--- a/store/src/java-test/com/zimbra/cs/imap/Hacker.java
+++ b/store/src/java-test/com/zimbra/cs/imap/Hacker.java
@@ -1,0 +1,37 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2019 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.imap;
+
+import java.io.Serializable;
+
+/**
+ * @author zimbra
+ *
+ */
+public class Hacker implements Serializable {
+
+    private static final long serialVersionUID = 8550345789897309061L;
+    private String name;
+
+    public Hacker(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/store/src/java-test/com/zimbra/cs/imap/MemcachedImapCacheTest.java
+++ b/store/src/java-test/com/zimbra/cs/imap/MemcachedImapCacheTest.java
@@ -93,7 +93,6 @@ public class MemcachedImapCacheTest {
                     oout.close();
                 }
             } catch (Exception e) {
-                e.printStackTrace();
                 return bout.toByteArray();
             }
            return bout.toByteArray();
@@ -105,7 +104,6 @@ public class MemcachedImapCacheTest {
             try (ObjectOutputStream oout = new ObjectOutputStream(bout)) {
                 oout.writeObject(new Hacker("hacked"));
             } catch (Exception e) {
-                e.printStackTrace();
                 return false;
             }
             return true;

--- a/store/src/java-test/com/zimbra/cs/imap/MemcachedImapCacheTest.java
+++ b/store/src/java-test/com/zimbra/cs/imap/MemcachedImapCacheTest.java
@@ -1,0 +1,114 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2019 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.imap;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import java.io.ObjectOutputStream;
+
+import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.MethodRule;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.zimbra.common.util.memcached.ZimbraMemcachedClient;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.memcached.MemcachedConnector;
+import com.zimbra.cs.util.ZTestWatchman;
+
+/**
+ * @author zimbra
+ *
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ImapFolder.class, MemcachedImapCache.class, MemcachedConnector.class, ZimbraMemcachedClient.class})
+public class MemcachedImapCacheTest {
+
+    @Rule public TestName testName = new TestName();
+    @Rule public MethodRule watchman = new ZTestWatchman();
+    /**
+     * @throws java.lang.Exception
+     */
+    @Before
+    public void setUp() throws Exception {
+        MailboxTestUtil.initProvisioning("store/");
+    }
+
+    /**
+     * @throws java.lang.Exception
+     */
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void testInvalidObject() {
+        try {
+
+            PowerMockito.mockStatic(MemcachedConnector.class);
+            ZimbraMemcachedClient  memcachedClient = new MockZimbraMemcachedClient();
+            PowerMockito.when(MemcachedConnector.getClient()).thenReturn(memcachedClient);
+            ImapFolder folder = PowerMockito.mock(ImapFolder.class);
+            MemcachedImapCache imapCache = new MemcachedImapCache();
+            imapCache.put("trash", folder);
+            ImapFolder folderDeserz =  imapCache.get("trash");
+            assertNull(folderDeserz);
+        } catch (Exception e) {
+            fail("Exception should not be thrown");
+        }
+    }
+
+    public class MockZimbraMemcachedClient extends ZimbraMemcachedClient {
+
+        @Override
+        public Object get(String key) {
+            ByteArrayOutputStream bout = new ByteArrayOutputStream();
+            try {
+                if (key.equals("zmImap:trash")) {
+                    ObjectOutputStream oout = new ObjectOutputStream(bout);
+                    oout.writeObject(new Hacker("hacked"));
+                    oout.close();
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+                return bout.toByteArray();
+            }
+           return bout.toByteArray();
+        }
+
+        @Override
+        public boolean put(String key, Object value, boolean waitForAck) {
+            ByteArrayOutputStream bout = new ByteArrayOutputStream();
+            try (ObjectOutputStream oout = new ObjectOutputStream(bout)) {
+                oout.writeObject(new Hacker("hacked"));
+            } catch (Exception e) {
+                e.printStackTrace();
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/imap/DiskImapCache.java
+++ b/store/src/java/com/zimbra/cs/imap/DiskImapCache.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2011, 2012, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2011, 2012, 2013, 2014, 2016, 2019 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -27,6 +27,7 @@ import java.util.Comparator;
 
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.util.ByteUtil;
+import com.zimbra.cs.io.SecureObjectInputStream;
 
 /**
  * IMAP cache using local disk.
@@ -116,7 +117,7 @@ final class DiskImapCache implements ImapSessionManager.Cache<String, ImapFolder
         ObjectInputStream ois = null;
         try {
             // read serialized ImapFolder from cache
-            ois = new ObjectInputStream(fis = new FileInputStream(pagefile));
+            ois = new SecureObjectInputStream(fis = new FileInputStream(pagefile), ImapFolder.class.getName());
             return (ImapFolder) ois.readObject();
         } catch (Exception e) {
             ByteUtil.closeStream(ois);

--- a/store/src/java/com/zimbra/cs/imap/ImapCredentials.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapCredentials.java
@@ -20,6 +20,7 @@
  */
 package com.zimbra.cs.imap;
 
+import java.io.ObjectInputStream;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
@@ -240,5 +241,10 @@ public class ImapCredentials implements java.io.Serializable {
                 }
             }
         }
+    }
+
+    // ZCS-6695 Deserialization protection
+    private final void readObject(ObjectInputStream in) throws java.io.IOException {
+        throw new java.io.IOException("Cannot be deserialized");
     }
 }

--- a/store/src/java/com/zimbra/cs/imap/MemcachedImapCache.java
+++ b/store/src/java/com/zimbra/cs/imap/MemcachedImapCache.java
@@ -28,6 +28,7 @@ import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.common.util.memcached.MemcachedKey;
 import com.zimbra.common.util.memcached.MemcachedMap;
 import com.zimbra.common.util.memcached.MemcachedSerializer;
+import com.zimbra.cs.io.SecureObjectInputStream;
 import com.zimbra.cs.memcached.MemcachedConnector;
 import com.zimbra.cs.memcached.MemcachedKeyPrefix;
 
@@ -111,7 +112,7 @@ final class MemcachedImapCache implements ImapSessionManager.Cache<String, ImapF
         public ImapFolder deserialize(Object obj) throws ServiceException {
             ObjectInputStream in = null;
             try {
-                in = new ObjectInputStream(new ByteArrayInputStream((byte[]) obj));
+                in = new SecureObjectInputStream(new ByteArrayInputStream((byte[]) obj), ImapFolder.class.getName());
                 return (ImapFolder) in.readObject();
             } catch (Exception e) {
                 throw ServiceException.FAILURE("Failed to deserialize ImapFolder", e);

--- a/store/src/java/com/zimbra/cs/index/query/parser/Token.java
+++ b/store/src/java/com/zimbra/cs/index/query/parser/Token.java
@@ -18,6 +18,8 @@
 /* JavaCCOptions:TOKEN_EXTENDS=,KEEP_LINE_COL=null,SUPPORT_CLASS_VISIBILITY_PUBLIC=false */
 package com.zimbra.cs.index.query.parser;
 
+import java.io.ObjectInputStream;
+
 /**
  * Describes the input token stream.
  */
@@ -141,6 +143,11 @@ class Token implements java.io.Serializable {
   public static Token newToken(int ofKind)
   {
     return newToken(ofKind, null);
+  }
+
+  //ZCS-6695 Deserialization protection
+  private final void readObject(ObjectInputStream in) throws java.io.IOException {
+      throw new java.io.IOException("Cannot be deserialized");
   }
 
 }

--- a/store/src/java/com/zimbra/cs/index/query/parser/Token.java
+++ b/store/src/java/com/zimbra/cs/index/query/parser/Token.java
@@ -18,6 +18,7 @@
 /* JavaCCOptions:TOKEN_EXTENDS=,KEEP_LINE_COL=null,SUPPORT_CLASS_VISIBILITY_PUBLIC=false */
 package com.zimbra.cs.index.query.parser;
 
+import java.io.IOException;
 import java.io.ObjectInputStream;
 
 /**
@@ -115,7 +116,8 @@ class Token implements java.io.Serializable {
   /**
    * Returns the image.
    */
-  public String toString()
+  @Override
+public String toString()
   {
     return image;
   }
@@ -147,7 +149,7 @@ class Token implements java.io.Serializable {
 
   //ZCS-6695 Deserialization protection
   private final void readObject(ObjectInputStream in) throws java.io.IOException {
-      throw new java.io.IOException("Cannot be deserialized");
+      throw new IOException("Cannot be deserialized");
   }
 
 }

--- a/store/src/java/com/zimbra/cs/io/SecureObjectInputStream.java
+++ b/store/src/java/com/zimbra/cs/io/SecureObjectInputStream.java
@@ -1,0 +1,64 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2019 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InvalidClassException;
+import java.io.ObjectInputStream;
+import java.io.ObjectStreamClass;
+
+
+/**
+ * @author zimbra
+ *
+ */
+public class SecureObjectInputStream extends ObjectInputStream {
+
+    /**
+     * @param string
+     * @param fileInputStream
+     * @throws IOException
+     * @throws SecurityException
+     */
+
+    private String acceptedClassname = null;
+    protected SecureObjectInputStream() throws IOException, SecurityException {
+        super();
+    }
+
+    /**
+     * @param in
+     * @throws IOException
+     */
+    public SecureObjectInputStream(InputStream in, String acceptedClassname) throws IOException {
+        super(in);
+        this.acceptedClassname = acceptedClassname;
+    }
+
+    /**
+     * Only deserialize instances of known zimbra classes
+     */
+    @Override
+    protected Class<?> resolveClass(ObjectStreamClass desc)
+        throws IOException, ClassNotFoundException {
+        if (desc.getName().equals(this.acceptedClassname)) {
+            return super.resolveClass(desc);
+        }
+        throw new InvalidClassException("Unauthorized deserialization attempt", desc.getName());
+    }
+}

--- a/store/src/java/com/zimbra/cs/service/util/ItemId.java
+++ b/store/src/java/com/zimbra/cs/service/util/ItemId.java
@@ -19,6 +19,7 @@
  */
 package com.zimbra.cs.service.util;
 
+import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -235,7 +236,7 @@ public class ItemId implements java.io.Serializable {
 
     // ZCS-6695 Deserialization protection
     private final void readObject(ObjectInputStream in) throws java.io.IOException {
-        throw new java.io.IOException("Cannot be deserialized");
+        throw new IOException("Cannot be deserialized");
     }
 
     public static void main(String[] args) {

--- a/store/src/java/com/zimbra/cs/service/util/ItemId.java
+++ b/store/src/java/com/zimbra/cs/service/util/ItemId.java
@@ -19,6 +19,7 @@
  */
 package com.zimbra.cs.service.util;
 
+import java.io.ObjectInputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -230,6 +231,11 @@ public class ItemId implements java.io.Serializable {
             }
         }
         return foldersMap;
+    }
+
+    // ZCS-6695 Deserialization protection
+    private final void readObject(ObjectInputStream in) throws java.io.IOException {
+        throw new java.io.IOException("Cannot be deserialized");
     }
 
     public static void main(String[] args) {

--- a/store/src/java/com/zimbra/cs/session/PendingLocalModifications.java
+++ b/store/src/java/com/zimbra/cs/session/PendingLocalModifications.java
@@ -31,6 +31,7 @@ import com.zimbra.common.mailbox.MailboxStore;
 import com.zimbra.common.mailbox.ZimbraMailItem;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.io.SecureObjectInputStream;
 import com.zimbra.cs.mailbox.Folder;
 import com.zimbra.cs.mailbox.MailItem;
 import com.zimbra.cs.mailbox.MailItem.Type;
@@ -257,7 +258,7 @@ public final class PendingLocalModifications extends PendingModifications<MailIt
             throws IOException, ClassNotFoundException, ServiceException {
         ByteArrayInputStream bis = new ByteArrayInputStream(data);
         PendingLocalModifications pms = new PendingLocalModifications();
-        try (ObjectInputStream ois = new ObjectInputStream(bis)) {
+        try (ObjectInputStream ois = new SecureObjectInputStream(bis, Type.class.getName())) {
             pms.changedTypes = (Set<Type>) ois.readObject();
             pms.addChangedParentFolderIds((Set<Integer>) ois.readObject());
 

--- a/store/src/java/com/zimbra/cs/session/PendingModifications.java
+++ b/store/src/java/com/zimbra/cs/session/PendingModifications.java
@@ -20,6 +20,7 @@
  */
 package com.zimbra.cs.session;
 
+import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -410,7 +411,7 @@ public abstract class PendingModifications<T extends ZimbraMailItem> {
         }
 
         private final void readObject(ObjectInputStream in) throws java.io.IOException {
-            throw new java.io.IOException("Cannot be deserialized");
+            throw new IOException("Cannot be deserialized");
         }
 
     }
@@ -437,7 +438,7 @@ public abstract class PendingModifications<T extends ZimbraMailItem> {
         }
 
         private final void readObject(ObjectInputStream in) throws java.io.IOException {
-            throw new java.io.IOException("Cannot be deserialized");
+            throw new IOException("Cannot be deserialized");
          }
 
     }

--- a/store/src/java/com/zimbra/cs/session/PendingModifications.java
+++ b/store/src/java/com/zimbra/cs/session/PendingModifications.java
@@ -20,6 +20,7 @@
  */
 package com.zimbra.cs.session;
 
+import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -42,14 +43,14 @@ import com.zimbra.common.util.Pair;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.mailbox.Folder;
 import com.zimbra.cs.mailbox.MailItem;
-import com.zimbra.cs.mailbox.Tag;
 import com.zimbra.cs.mailbox.MailItem.Type;
 import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.Tag;
 import com.zimbra.cs.mailbox.util.TypedIdList;
 import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.mail.type.DeleteItemNotification;
-import com.zimbra.soap.mail.type.PendingFolderModifications;
 import com.zimbra.soap.mail.type.ModifyNotification.ModifyTagNotification;
+import com.zimbra.soap.mail.type.PendingFolderModifications;
 
 
 /**
@@ -408,6 +409,10 @@ public abstract class PendingModifications<T extends ZimbraMailItem> {
             this.itemId = itemId;
         }
 
+        private final void readObject(ObjectInputStream in) throws java.io.IOException {
+            throw new java.io.IOException("Cannot be deserialized");
+        }
+
     }
 
     public static final class ChangeMeta implements Serializable {
@@ -430,6 +435,10 @@ public abstract class PendingModifications<T extends ZimbraMailItem> {
             this.preModifyObjType = preModifyObjType;
             metaPreModifyObj = preModifyObj;
         }
+
+        private final void readObject(ObjectInputStream in) throws java.io.IOException {
+            throw new java.io.IOException("Cannot be deserialized");
+         }
 
     }
 

--- a/store/src/java/com/zimbra/cs/store/file/BlobReference.java
+++ b/store/src/java/com/zimbra/cs/store/file/BlobReference.java
@@ -16,6 +16,7 @@
  */
 package com.zimbra.cs.store.file;
 
+import java.io.ObjectInputStream;
 import java.io.Serializable;
 
 import com.zimbra.znative.IO.FileInfo;
@@ -75,13 +76,17 @@ public class BlobReference implements Serializable {
     public void setProcessed(boolean processed) {
         this.processed = processed;
     }
-    
+
     public FileInfo getFileInfo() {
         return fileInfo;
     }
-    
+
     public void setFileInfo(FileInfo fileInfo) {
         this.fileInfo = fileInfo;
+    }
+
+    private final void readObject(ObjectInputStream in) throws java.io.IOException {
+        throw new java.io.IOException("Cannot be deserialized");
     }
 
 }

--- a/store/src/java/com/zimbra/cs/store/file/BlobReference.java
+++ b/store/src/java/com/zimbra/cs/store/file/BlobReference.java
@@ -16,6 +16,7 @@
  */
 package com.zimbra.cs.store.file;
 
+import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
 
@@ -86,7 +87,7 @@ public class BlobReference implements Serializable {
     }
 
     private final void readObject(ObjectInputStream in) throws java.io.IOException {
-        throw new java.io.IOException("Cannot be deserialized");
+        throw new IOException("Cannot be deserialized");
     }
 
 }

--- a/store/src/java/com/zimbra/cs/util/Zimbra.java
+++ b/store/src/java/com/zimbra/cs/util/Zimbra.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016 Synacor, Inc.
+ * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2019 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -50,7 +50,6 @@ import com.zimbra.cs.db.Versions;
 import com.zimbra.cs.ephemeral.EphemeralStore;
 import com.zimbra.cs.ephemeral.LdapEphemeralStore;
 import com.zimbra.cs.extension.ExtensionUtil;
-import com.zimbra.cs.iochannel.MessageChannel;
 import com.zimbra.cs.mailbox.MailboxIndex;
 import com.zimbra.cs.mailbox.MailboxManager;
 import com.zimbra.cs.mailbox.PurgeThread;
@@ -347,14 +346,6 @@ public final class Zimbra {
             if (app.supports(ExternalAccountManagerTask.class)) {
                 long interval = server.getExternalAccountStatusCheckInterval();
                 sTimer.schedule(new ExternalAccountManagerTask(), interval, interval);
-            }
-
-            if (prov.getLocalServer().isMessageChannelEnabled()) {
-                try {
-                    MessageChannel.getInstance().startup();
-                } catch (IOException e) {
-                    ZimbraLog.misc.warn("can't start notification channels", e);
-                }
             }
 
             Server localServer = Provisioning.getInstance().getLocalServer();


### PR DESCRIPTION
Fixing ObjectInputStream to de-serialize only specified classes .
Followed the techniques specified in
 https://www.owasp.org/index.php/Deserialization_Cheat_Sheet#Java
 Add a SecureObjectInputStream to only de-serialize class specified in deserializing.

-------
Removed the code that initializes the MessageChannel. Tried to remove the MessageChannel code completely however it is being reference CrossMailbox notification and RemoteSoapSesssion. Hence decided against it.

Testing: Added unit test to verify that an incorrect object during de serialization causes exception and is not read.
 Installed the code changes on ZCS and verified that current functionality is not affected Verified that IMAP functionality is not affected .
Verified no new exceptions are thrown in the logs
Tests | Failures | Errors | Skipped | Success rate | Time 1319 | 0 | 0 | 10 | 100.00% | 2567.717

To be done: Complete SOAP automation

Deleted the original PR and recreated a new one
