### PR TITLE
ZCS-6830 Modify getinfo api to get hab roots

### DIFF
--- a/common/src/java/com/zimbra/common/soap/AccountConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AccountConstants.java
@@ -390,6 +390,8 @@ public class AccountConstants {
     public static final String E_VIRTUAL_HOST = "virtualHost";
     public static final String E_SKIN = "skin";
     public static final String E_LICENSE = "license";
+    public static final String E_HAB_ROOTS = "habRoots";
+    public static final String E_HAB = "hab";
     public static final String E_IDENTITIES = "identities";
     public static final String E_SIGNATURES = "signatures";
     public static final String E_IDENTITY = "identity";


### PR DESCRIPTION
**Problem:** When license store is installed, hab roots should be returned in GetInfoResponse.
**Fix:** Added <habRoot> element in the response. Format will be as below
```
<habRoot>
    <hab>xxxxx</hab>
    ....
</habRoot>
```
**Testing done:** Tested GetInfo api manually from SoapUI, and hab root is being return in the response.
**Testing to be done by QA:** Verify GetInfoResponse with and without license store installed.
**Linked PR:** https://github.com/Zimbra/zm-license-store/pull/4