### PR TITLE
ZCS-6225:Postfix long queue IDs support.

### DIFF
--- a/store/src/java/com/zimbra/cs/rmgmt/RemoteMailQueue.java
+++ b/store/src/java/com/zimbra/cs/rmgmt/RemoteMailQueue.java
@@ -124,7 +124,7 @@ public class RemoteMailQueue {
             if (id == null) {
                 throw new IOException("no ID defined near line=" + lineNo);
             }
-            doc.add(new Field(QueueAttr.id.toString(), id.toLowerCase(),
+            doc.add(new Field(QueueAttr.id.toString(), id,
                     Field.Store.YES, Field.Index.NOT_ANALYZED, Field.TermVector.NO));
 
             String time = map.get(QueueAttr.time.toString());
@@ -441,11 +441,7 @@ public class RemoteMailQueue {
                     }
                     sb.append(field.stringValue());
                 }
-                if (attr ==  QueueAttr.id) {
-                    qitem.put(attr, sb.toString().toUpperCase());
-                } else {
-                    qitem.put(attr, sb.toString());
-                }
+                qitem.put(attr, sb.toString());
             }
         }
         return qitem;
@@ -577,12 +573,12 @@ public class RemoteMailQueue {
                         sb.append(",");
                     }
                     if (!all) {
-                        Term toDelete = new Term(QueueAttr.id.toString(), ids[i].toLowerCase());
+                        Term toDelete = new Term(QueueAttr.id.toString(), ids[i]);
                         int numDeleted = indexReader.deleteDocuments(toDelete);
                         mNumMessages.getAndAdd(-numDeleted);
                         if (ZimbraLog.rmgmt.isDebugEnabled()) ZimbraLog.rmgmt.debug("deleting term:" + toDelete + ", docs deleted=" + numDeleted);
                     }
-                    sb.append(ids[i].toUpperCase());
+                    sb.append(ids[i]);
                 }
                 done = last;
                 rm.execute(sb.toString());


### PR DESCRIPTION
This an official integration of the already approved pull request https://github.com/Zimbra/zm-mailbox/pull/794

Removed case alterations to queue IDs.

In order to support the long format of Postfix queue IDs, which is
case-sensitive, IDs are no longer subject to case alterations.