### PR TITLE
ZBUG-913 SSRF vulnerability - restrict feed manager target addresses.

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1296,8 +1296,11 @@ public final class LC {
     public static final KnownKey zm_oauth_classes_handlers_yahoo = KnownKey.newKey("com.zimbra.oauth.handlers.impl.YahooOAuth2Handler");
     public static final KnownKey zm_oauth_classes_handlers_google = KnownKey.newKey("com.zimbra.oauth.handlers.impl.GoogleOAuth2Handler");
     public static final KnownKey zm_oauth_classes_handlers_facebook = KnownKey.newKey("com.zimbra.oauth.handlers.impl.FacebookOAuth2Handler");
-    
-    
+
+    // Feed Manager comma-separated ip blacklist
+    public static final KnownKey zimbra_feed_manager_ip_blacklist = KnownKey.newKey("");
+
+
     static {
         // Automatically set the key name with the variable name.
         for (Field field : LC.class.getFields()) {

--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1297,8 +1297,8 @@ public final class LC {
     public static final KnownKey zm_oauth_classes_handlers_google = KnownKey.newKey("com.zimbra.oauth.handlers.impl.GoogleOAuth2Handler");
     public static final KnownKey zm_oauth_classes_handlers_facebook = KnownKey.newKey("com.zimbra.oauth.handlers.impl.FacebookOAuth2Handler");
 
-    // Feed Manager comma-separated ip blacklist
-    public static final KnownKey zimbra_feed_manager_ip_blacklist = KnownKey.newKey("");
+    // Feed Manager comma-separated blacklist. addresses can be CIDR notation, or single ip. no wild-cards (default blacklist private networks)
+    public static final KnownKey zimbra_feed_manager_blacklist = KnownKey.newKey("10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,fd00::/8");
 
 
     static {

--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1300,7 +1300,6 @@ public final class LC {
     // Feed Manager comma-separated blacklist. addresses can be CIDR notation, or single ip. no wild-cards (default blacklist private networks)
     public static final KnownKey zimbra_feed_manager_blacklist = KnownKey.newKey("10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,fd00::/8");
 
-
     static {
         // Automatically set the key name with the variable name.
         for (Field field : LC.class.getFields()) {

--- a/store/src/java-test/com/zimbra/cs/service/FeedManagerTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/FeedManagerTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.net.InetAddress;
 import java.nio.charset.Charset;
 import java.util.List;
 
@@ -120,7 +121,117 @@ public class FeedManagerTest {
     }
 
     @Test
-    public void testIsBlockedFeedAddress() throws Exception {
+    public void testIsInRangePrivateAddressesIPv4() throws Exception {
+        Assert.assertFalse(FeedManager.isAddressInRange(InetAddress.getByName("9.0.0.0"), "10.0.0.0/8"));
+        Assert.assertFalse(FeedManager.isAddressInRange(InetAddress.getByName("9.255.255.255"), "10.0.0.0/8"));
+        Assert.assertTrue(FeedManager.isAddressInRange(InetAddress.getByName("10.0.0.0"), "10.0.0.0/8"));
+        Assert.assertTrue(FeedManager.isAddressInRange(InetAddress.getByName("10.50.50.55"), "10.0.0.0/8"));
+        Assert.assertTrue(FeedManager.isAddressInRange(InetAddress.getByName("10.50.0.255"), "10.0.0.0/8"));
+        Assert.assertTrue(FeedManager.isAddressInRange(InetAddress.getByName("10.50.255.0"), "10.0.0.0/8"));
+        Assert.assertTrue(FeedManager.isAddressInRange(InetAddress.getByName("10.255.255.255"), "10.0.0.0/8"));
+        Assert.assertFalse(FeedManager.isAddressInRange(InetAddress.getByName("11.0.0.0"), "10.0.0.0/8"));
+        Assert.assertFalse(FeedManager.isAddressInRange(InetAddress.getByName("11.255.255.255"), "10.0.0.0/8"));
+
+        Assert.assertFalse(FeedManager.isAddressInRange(InetAddress.getByName("172.15.255.255"), "172.16.0.0/12"));
+        Assert.assertFalse(FeedManager.isAddressInRange(InetAddress.getByName("172.15.0.0"), "172.16.0.0/12"));
+        Assert.assertTrue(FeedManager.isAddressInRange(InetAddress.getByName("172.16.0.0"), "172.16.0.0/12"));
+        Assert.assertTrue(FeedManager.isAddressInRange(InetAddress.getByName("172.16.50.50"), "172.16.0.0/12"));
+        Assert.assertTrue(FeedManager.isAddressInRange(InetAddress.getByName("172.16.0.255"), "172.16.0.0/12"));
+        Assert.assertTrue(FeedManager.isAddressInRange(InetAddress.getByName("172.16.255.0"), "172.16.0.0/12"));
+        Assert.assertTrue(FeedManager.isAddressInRange(InetAddress.getByName("172.31.255.255"), "172.16.0.0/12"));
+        Assert.assertFalse(FeedManager.isAddressInRange(InetAddress.getByName("172.32.0.0"), "172.16.0.0/12"));
+        Assert.assertFalse(FeedManager.isAddressInRange(InetAddress.getByName("172.32.255.255"), "172.16.0.0/12"));
+
+        Assert.assertFalse(FeedManager.isAddressInRange(InetAddress.getByName("192.167.0.0"), "192.168.0.0/16"));
+        Assert.assertFalse(FeedManager.isAddressInRange(InetAddress.getByName("192.167.255.255"), "192.168.0.0/16"));
+        Assert.assertTrue(FeedManager.isAddressInRange(InetAddress.getByName("192.168.0.0"), "192.168.0.0/16"));
+        Assert.assertTrue(FeedManager.isAddressInRange(InetAddress.getByName("192.168.1.131"), "192.168.0.0/16"));
+        Assert.assertTrue(FeedManager.isAddressInRange(InetAddress.getByName("192.168.0.255"), "192.168.0.0/16"));
+        Assert.assertTrue(FeedManager.isAddressInRange(InetAddress.getByName("192.168.255.0"), "192.168.0.0/16"));
+        Assert.assertTrue(FeedManager.isAddressInRange(InetAddress.getByName("192.168.255.255"), "192.168.0.0/16"));
+        Assert.assertFalse(FeedManager.isAddressInRange(InetAddress.getByName("192.169.255.255"), "192.168.0.0/16"));
+        Assert.assertFalse(FeedManager.isAddressInRange(InetAddress.getByName("192.169.0.0"), "192.168.0.0/16"));
+    }
+
+    @Test
+    public void testIsInRangeTestAddressesIPv4() throws Exception {
+        for (int i = 0; i < 256; i++) {
+            Assert.assertTrue(FeedManager.isAddressInRange(InetAddress.getByName("198.51.100." + i), "198.51.100.0/24"));
+        }
+        Assert.assertFalse(FeedManager.isAddressInRange(InetAddress.getByName("198.50.100.0"), "198.51.100.0/24"));
+        Assert.assertFalse(FeedManager.isAddressInRange(InetAddress.getByName("198.50.100.255"), "198.51.100.0/24"));
+        Assert.assertFalse(FeedManager.isAddressInRange(InetAddress.getByName("198.52.100.0"), "198.51.100.0/24"));
+        Assert.assertFalse(FeedManager.isAddressInRange(InetAddress.getByName("198.52.100.255"), "198.51.100.0/24"));
+
+        for (int i = 0; i < 256; i++) {
+            Assert.assertTrue(FeedManager.isAddressInRange(InetAddress.getByName("203.0.113." + i), "203.0.113.0/24"));
+        }
+        Assert.assertFalse(FeedManager.isAddressInRange(InetAddress.getByName("203.0.112.0"), "203.0.113.0/24"));
+        Assert.assertFalse(FeedManager.isAddressInRange(InetAddress.getByName("203.0.112.255"), "203.0.113.0/24"));
+        Assert.assertFalse(FeedManager.isAddressInRange(InetAddress.getByName("203.0.114.0"), "203.0.113.0/24"));
+        Assert.assertFalse(FeedManager.isAddressInRange(InetAddress.getByName("203.0.114.255"), "203.0.113.0/24"));
+    }
+
+    @Test
+    public void testIsInRangePrivateAddressesIPv6() throws Exception {
+        Assert.assertFalse(FeedManager.isAddressInRange(
+            InetAddress.getByName("fedd:0d17:76f7:3e82:0000:0000:0000:0000"), "fddd:0d17:76f7:3e82::/64"));
+        Assert.assertFalse(FeedManager.isAddressInRange(
+            InetAddress.getByName("fedd:0d17:76f7:3e82:ffff:ffff:ffff:ffff"), "fddd:0d17:76f7:3e82::/64"));
+        Assert.assertTrue(FeedManager.isAddressInRange(
+            InetAddress.getByName("fddd:0d17:76f7:3e82:0000:0000:0000:0000"), "fddd:0d17:76f7:3e82::/64"));
+        Assert.assertTrue(FeedManager.isAddressInRange(
+            InetAddress.getByName("fddd:0d17:76f7:3e82:1111:1234:5678:abcd"), "fddd:0d17:76f7:3e82::/64"));
+        Assert.assertTrue(FeedManager.isAddressInRange(
+            InetAddress.getByName("fddd:0d17:76f7:3e82:ffff:ffff:ffff:ffff"), "fddd:0d17:76f7:3e82::/64"));
+        Assert.assertFalse(FeedManager.isAddressInRange(
+            InetAddress.getByName("fddd:0d17:76f7:3e83:0000:0000:0000:0000"), "fddd:0d17:76f7:3e82::/64"));
+        Assert.assertFalse(FeedManager.isAddressInRange(
+            InetAddress.getByName("fddd:0d17:76f7:3e83:ffff:ffff:ffff:ffff"), "fddd:0d17:76f7:3e82::/64"));
+
+        Assert.assertFalse(FeedManager.isAddressInRange(
+            InetAddress.getByName("fcdd:0d17:76f7:3e82:0000:0000:0000:0000"), "fd00::/8"));
+        Assert.assertFalse(FeedManager.isAddressInRange(
+            InetAddress.getByName("fcdd:0d17:76f7:3e82:ffff:ffff:ffff:ffff"), "fd00::/8"));
+        Assert.assertTrue(FeedManager.isAddressInRange(
+            InetAddress.getByName("fddd:0d17:76f7:3e82:0000:0000:0000:0000"), "fd00::/8"));
+        Assert.assertTrue(FeedManager.isAddressInRange(
+            InetAddress.getByName("fddd:0d17:76f7:3e82:1111:755f:ffff:0d17"), "fd00::/8"));
+        Assert.assertTrue(FeedManager.isAddressInRange(
+            InetAddress.getByName("fddd:0d17:76f7:3e82:ffff:ffff:ffff:ffff"), "fd00::/8"));
+        Assert.assertFalse(FeedManager.isAddressInRange(
+            InetAddress.getByName("fedd:0d17:76f7:3e82:0000:0000:0000:0000"), "fd00::/8"));
+        Assert.assertFalse(FeedManager.isAddressInRange(
+            InetAddress.getByName("fedd:0d17:76f7:3e82:ffff:ffff:ffff:ffff"), "fd00::/8"));
+    }
+
+    @Test
+    public void testIsInRangeSingleAddressIPv4() throws Exception {
+        Assert.assertTrue(FeedManager.isAddressInRange(
+            InetAddress.getByName("192.168.1.0"), "192.168.1.0"));
+        for (int i = 1; i < 256; i++) {
+            Assert.assertTrue(FeedManager.isAddressInRange(
+                InetAddress.getByName("192.168.1." + i), "192.168.1." + i));
+            Assert.assertFalse(FeedManager.isAddressInRange(
+                InetAddress.getByName("192.168.1." + i), "192.168.1.0"));
+        }
+    }
+
+    @Test
+    public void testIsInRangeSingleAddressIPv6() throws Exception {
+        Assert.assertTrue(FeedManager.isAddressInRange(
+            InetAddress.getByName("fddd:0d17:76f7:3e82:0000:0000:ffff:ffff"),
+            "fddd:0d17:76f7:3e82:0000:0000:ffff:ffff"));
+        Assert.assertTrue(FeedManager.isAddressInRange(
+            InetAddress.getByName("fddd:0d17:76f7:3e82:1234:5678:abcd:efff"),
+            "fddd:0d17:76f7:3e82:1234:5678:abcd:efff"));
+        Assert.assertFalse(FeedManager.isAddressInRange(
+            InetAddress.getByName("fddd:0d17:0000:3e82:0000:0000:ffff:ffff"),
+            "fddd:0d17:76f7:3e82:0000:0000:ffff:0000"));
+    }
+
+    @Test
+    public void testIsBlockedFeedAddressDefaultBlacklist() throws Exception {
         // loopback
         Assert.assertTrue(FeedManager.isBlockedFeedAddress(new HttpURL("http://localhost/feed")));
         Assert.assertTrue(FeedManager.isBlockedFeedAddress(new HttpURL("http://localhost:8085/feed")));
@@ -134,26 +245,73 @@ public class FeedManagerTest {
         Assert.assertTrue(FeedManager.isBlockedFeedAddress(new HttpURL("http://192.168.5.1:8080/feed")));
         Assert.assertTrue(FeedManager.isBlockedFeedAddress(new HttpURL("http://192.168.166.150/feed")));
         Assert.assertTrue(FeedManager.isBlockedFeedAddress(new HttpURL("http://192.168.166.150:8081/feed")));
+        Assert.assertTrue(FeedManager.isBlockedFeedAddress(new HttpURL("http://10.0.0.1/feed")));
+        Assert.assertTrue(FeedManager.isBlockedFeedAddress(new HttpURL("http://10.15.150.140/feed")));
+    }
 
-        // public blacklisted
+    @Test
+    public void testIsBlockedFeedAddressPublicBlacklisted() throws Exception {
         Assert.assertFalse(FeedManager.isBlockedFeedAddress(new HttpURL("http://198.51.100.230:8081/feed")));
-        LC.zimbra_feed_manager_ip_blacklist.setDefault("198.51.100.230");
+        LC.zimbra_feed_manager_blacklist.setDefault("198.51.100.230");
         Assert.assertTrue(FeedManager.isBlockedFeedAddress(new HttpURL("http://198.51.100.230:8081/feed")));
         Assert.assertTrue(FeedManager.isBlockedFeedAddress(new HttpsURL("https://198.51.100.230:8082/feed")));
+    }
 
+    @Test
+    public void testIsBlockedFeedAddressPublicBlacklistedMultiple() throws Exception {
         Assert.assertFalse(FeedManager.isBlockedFeedAddress(new HttpURL("http://198.51.100.231:8081/feed")));
         Assert.assertFalse(FeedManager.isBlockedFeedAddress(new HttpURL("http://198.51.100.220:8081/feed")));
-        LC.zimbra_feed_manager_ip_blacklist.setDefault("198.51.100.230,198.51.100.231,198.51.100.220");
+        LC.zimbra_feed_manager_blacklist.setDefault("198.51.100.230,198.51.100.231,198.51.100.220");
         Assert.assertTrue(FeedManager.isBlockedFeedAddress(new HttpURL("http://198.51.100.230:8081/feed")));
         Assert.assertTrue(FeedManager.isBlockedFeedAddress(new HttpsURL("https://198.51.100.230:8082/feed")));
         Assert.assertTrue(FeedManager.isBlockedFeedAddress(new HttpURL("http://198.51.100.220:8081/feed")));
         Assert.assertTrue(FeedManager.isBlockedFeedAddress(new HttpURL("http://198.51.100.231:8081/feed")));
         Assert.assertTrue(FeedManager.isBlockedFeedAddress(new HttpURL("http://user:pass@198.51.100.231:8081/feed")));
+    }
 
-        // public non-blacklisted
+    @Test
+    public void testIsBlockedFeedAddressPublicBlacklistCIDR() throws Exception {
+        Assert.assertFalse(FeedManager.isBlockedFeedAddress(new HttpURL("http://198.51.100.130:8081/feed")));
+        Assert.assertFalse(FeedManager.isBlockedFeedAddress(new HttpURL("http://198.51.100.120:8081/feed")));
+        LC.zimbra_feed_manager_blacklist.setDefault("198.51.100.0/25");
+        Assert.assertTrue(FeedManager.isBlockedFeedAddress(new HttpURL("http://198.51.100.95:8081/feed")));
+        Assert.assertTrue(FeedManager.isBlockedFeedAddress(new HttpsURL("https://198.51.100.95:8082/feed")));
+        Assert.assertTrue(FeedManager.isBlockedFeedAddress(new HttpURL("http://198.51.100.101:8081/feed")));
+        Assert.assertTrue(FeedManager.isBlockedFeedAddress(new HttpURL("http://198.51.100.127:8081/feed")));
+        Assert.assertFalse(FeedManager.isBlockedFeedAddress(new HttpURL("http://198.51.100.128:8081/feed")));
+    }
+
+    @Test
+    public void testIsBlockedFeedAddressPublicBlacklistCIDRMultiple() throws Exception {
+        Assert.assertFalse(FeedManager.isBlockedFeedAddress(new HttpURL("http://203.0.113.167:8081/feed")));
+        LC.zimbra_feed_manager_blacklist.setDefault("198.51.100.0/24,203.0.113.0/24,192.0.2.121");
+        Assert.assertTrue(FeedManager.isBlockedFeedAddress(new HttpURL("http://203.0.113.227:8081/feed")));
+        Assert.assertTrue(FeedManager.isBlockedFeedAddress(new HttpURL("http://203.0.113.167:8081/feed")));
+        Assert.assertTrue(FeedManager.isBlockedFeedAddress(new HttpURL("http://198.51.100.120:8081/feed")));
+        Assert.assertTrue(FeedManager.isBlockedFeedAddress(new HttpURL("http://192.0.2.121:8081/feed")));
+    }
+
+    @Test
+    public void testIsBlockedFeedAddressPublicTest() throws Exception {
         Assert.assertFalse(FeedManager.isBlockedFeedAddress(new HttpURL("http://zimbra.test:8080/feed")));
         Assert.assertFalse(FeedManager.isBlockedFeedAddress(new HttpsURL("https://zimbra.test/feed")));
         Assert.assertFalse(FeedManager.isBlockedFeedAddress(new HttpsURL("https://user:pass@zimbra.test/feed")));
+        Assert.assertFalse(FeedManager.isBlockedFeedAddress(new HttpsURL("https://user:pass@192.0.2.165/feed")));
+    }
+
+    @Test
+    public void testIsBlockedFeedAddressPrivateNoBlacklist() throws Exception {
+        LC.zimbra_feed_manager_blacklist.setDefault("");
+        Assert.assertFalse(FeedManager.isBlockedFeedAddress(new HttpURL("http://10.15.150.140/feed")));
+        Assert.assertFalse(FeedManager.isBlockedFeedAddress(new HttpURL("http://172.16.150.140/feed")));
+        Assert.assertFalse(FeedManager.isBlockedFeedAddress(new HttpURL("http://192.168.5.1/feed")));
+    }
+
+    @Test
+    public void testIsBlockedFeedAddressUnknownAddressNoBlacklist() throws Exception {
+        LC.zimbra_feed_manager_blacklist.setDefault("");
+        Assert.assertFalse(FeedManager.isBlockedFeedAddress(new HttpURL("http://fake.test/feed")));
+        Assert.assertFalse(FeedManager.isBlockedFeedAddress(new HttpURL("http://example.test/feed")));
     }
 
     public static String streamToString(InputStream stream, Charset cs)

--- a/store/src/java/com/zimbra/cs/service/FeedManager.java
+++ b/store/src/java/com/zimbra/cs/service/FeedManager.java
@@ -26,8 +26,6 @@ import java.io.InputStream;
 import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
 import java.net.InetAddress;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -62,7 +60,6 @@ import org.apache.commons.httpclient.util.DateParseException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.io.Closeables;
-import com.google.common.net.InetAddresses;
 import com.zimbra.common.calendar.ZCalendar.ZCalendarBuilder;
 import com.zimbra.common.calendar.ZCalendar.ZVCalendar;
 import com.zimbra.common.httpclient.HttpClientUtil;
@@ -74,6 +71,7 @@ import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.util.DateUtil;
 import com.zimbra.common.util.FileUtil;
+import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraHttpConnectionManager;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.common.zmime.ZMimeBodyPart;
@@ -194,23 +192,95 @@ public class FeedManager {
     }
 
     /**
-     * Returns true if target address is private, link-local, loopback, or individually blacklisted.
+     * Determines if a target address falls within the specified subnet.<br>
+     * If the prefix has no bit-length, determines direct match with target address.
+     * @param targetAddress The address in question
+     * @param prefix CIDR notation (first ip and number of relevant bits), or single ip - no wildcards
+     * @return True if the address matches or is within subnet range
+     */
+    protected static boolean isAddressInRange(InetAddress targetAddress, String prefix) {
+        ZimbraLog.misc.debug("checking if ip: %s is in range of: %s", targetAddress, prefix);
+        // split first ip from bit length
+        String [] firstIpAndLength = prefix.split("/");
+        // the first ip in the subnet
+        InetAddress firstIp;
+        // the number of relevant bits in the entire address
+        int bitLength;
+        try {
+            firstIp = InetAddress.getByName(firstIpAndLength[0]);
+            // compare direct if no bit length
+            if (firstIpAndLength.length < 2) {
+                return targetAddress.getHostAddress().equals(firstIp.getHostAddress());
+            }
+            bitLength = Integer.parseInt(firstIpAndLength[1]);
+        } catch (UnknownHostException | NumberFormatException e) {
+            ZimbraLog.misc.error("ignoring unparsable ip address prefix: %s", prefix);
+            ZimbraLog.misc.debug(e);
+            return false;
+        }
+
+        // don't compare across ipv4 vs ipv6
+        if (!targetAddress.getClass().equals(firstIp.getClass())) {
+            ZimbraLog.misc.debug("cannot compare across ipv4 and ipv6 address. target: %s, first ip: %s",
+                targetAddress, firstIp);
+            return false;
+        }
+
+        // determine number of relevant bytes to compare
+        // e.g. /116 -> 116/8=14.5 -> 14 -> remaining bits handled below
+        // e.g. /30 -> 30/8=3.75 -> 4 -> remaining bits handled below
+        // e.g. /24 -> 24/8=3 -> 3
+        int maskLength = bitLength / Byte.SIZE;
+
+        // mask on and compare #maskLength bytes we care about
+        byte mask = (byte) 0xFF;
+        byte [] targetBytes = targetAddress.getAddress();
+        byte [] subBytes = firstIp.getAddress();
+        for (int i = 0; i < maskLength; i++) {
+            if ((targetBytes[i] & mask) != (subBytes[i] & mask)) {
+                return false;
+            }
+        }
+
+        // the number of relevant bits in the last byte of the address
+        int doCareLength = bitLength % Byte.SIZE;
+
+        // last byte is only relevant for non-multiples of 8
+        // last byte has all bits on except the don't cares specified by bit length
+        // e.g. /30 -> 30%8=6 -> 8-6=2 -> last 2 bits are off
+        // e.g. /29 -> 29%8=5 -> 8-5=3 -> last 3 bits are off
+        if (doCareLength != 0) {
+            // set on all bits
+            byte lastByteMask = (byte) 0xFF;
+            // set off the lowest bits remaining from a full byte
+            int dontCareLength = Byte.SIZE - doCareLength;
+            lastByteMask <<= dontCareLength;
+            return (targetBytes[maskLength] & lastByteMask) == (subBytes[maskLength] & lastByteMask);
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns true if target address is link-local, loopback, or blacklisted.
      * @param url The target
      * @return True if address is blocked for feed manager
      */
     protected static boolean isBlockedFeedAddress(HttpURL url) {
-        List<String> blacklist = Arrays.asList(LC.zimbra_feed_manager_ip_blacklist.value().split(","));
+        String blacklistString = LC.zimbra_feed_manager_blacklist.value();
+        List<String> blacklist = new ArrayList<String>();
+        if (!StringUtil.isNullOrEmpty(blacklistString)) {
+            blacklist.addAll(Arrays.asList(blacklistString.split(",")));
+        }
         try {
             InetAddress targetAddress = InetAddress.getByName(url.getHost());
-            if (targetAddress.isSiteLocalAddress()
-                || targetAddress.isAnyLocalAddress()
+            return targetAddress.isAnyLocalAddress()
                 || targetAddress.isLinkLocalAddress()
                 || targetAddress.isLoopbackAddress()
-                || blacklist.contains(targetAddress.getHostAddress())) {
-                    return true;
-                }
+                || blacklist.stream()
+                    .anyMatch(ip -> isAddressInRange(targetAddress, ip));
         } catch (URIException | UnknownHostException e) {
-            ZimbraLog.misc.warn("unable to parse url host: %s", url);
+            ZimbraLog.misc.warn("unable to parse feed manager target url host: %s", url);
         }
         return false;
     }


### PR DESCRIPTION
Issue:
* FeedManager has no target address restriction of user supplied RSS feed locations, resulting in potential misuse of the feed resource for SSRF to internal addresses. 

Solution:
* Restrict feed address from all private addresses by default with a localconfig (for now) blacklist which supports CIDR notation and single addresses - no wildcards.

Potential Solution Issue:
*  _Update: Private can be configured with the blacklist._ Restricting private addresses may cause problems in a corporate environment where an RSS service is available in a private ip range for employee use - this solution would prevent access if no public range ip is available for the service.

Other:
IPv6 feeds are not supported due to HttpURL parsing. (unchanged)

**Testing Done**
* Tested in webclient with original issue instructions on ticket.
* Tested various addresses along with hostname hacks, and random valid feed addresses.

**Testing to be done by QA**
See jira ticket + maybe closed loop server with http proxy.