### PR TITLE
ZCS-6944:Defanger-CPU spikes for some messages

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/DebugConfig.java
+++ b/common/src/java/com/zimbra/common/localconfig/DebugConfig.java
@@ -200,7 +200,7 @@ public final class DebugConfig {
 
     public static final String defangStyleUnwantedFunc = value(
             "defang_style_unwanted_func",
-            "[\\S&&[^:]]+(?<!(rgb|and|not|media|,))\\s*\\(.*\\)");
+            "\\w+\\s*\\(.*?\\)");
     public static final String defangValidExtUrl = value(
             "defang_valid_ext_url",
             "^(https?://[\\w-].*|mailto:.*|notes:.*|smb:.*|ftp:.*|gopher:.*|news:.*|tel:.*|callto:.*|webcal:.*|feed:.*:|file:.*|#.+)");
@@ -229,6 +229,7 @@ public final class DebugConfig {
     public static final String defangStyleUnwantedImport = value(
             "defang_style_unwanted_import",
             "@import(\\s)*((\'|\")?(\\s)*(http://|https://)?([^\\s;]*)(\\s)*(\'|\")?(\\s)*;?)");
+    public static final int defangStyleValueLimit = value("defang_style_value_limit", 10000);
 
     public static final String xhtmlWhitelistedTags = value("defang_xhtml_whitelisted_tags",
         "a,abbr,acronym,blockquote,div,font,h1,h2,h3,h4,h5,h6,img,li,ol,p,span,table,td,th,tr,ul");

--- a/store/src/java-test/com/zimbra/cs/html/DefangFilterTest.java
+++ b/store/src/java-test/com/zimbra/cs/html/DefangFilterTest.java
@@ -27,6 +27,7 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Matcher;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -81,7 +82,16 @@ public class DefangFilterTest {
     }
 
     public void defangStyleUnwantedFunc(String styleValue, String expected) throws Exception {
-        String after = DefangFilter.STYLE_UNWANTED_FUNC.matcher(styleValue).replaceAll("");
+        Matcher matcher = DefangFilter.STYLE_UNWANTED_FUNC.matcher(styleValue);
+        StringBuffer stringBuffer = new StringBuffer();
+        while (matcher.find()) {
+            String match = matcher.group();
+            if(!match.startsWith("rgb")&&!match.startsWith("media")&&!match.startsWith("and")) {
+                matcher.appendReplacement(stringBuffer, "");
+            }
+        }
+        matcher.appendTail(stringBuffer);
+        String after = stringBuffer.toString();
         Assert.assertEquals("StyleUnwantedFunc result", expected, after);
     }
 


### PR DESCRIPTION
Issue: Some messages causing CPU spike since they had large style value 

Fix: Changed the unwanted function removal regex. Added limit for style value(debug configurable parameter/default 10000 characters)

Testing done:
All junit tests are passing