### PR TITLE
ZCS-6759:Suppress MissingResourceException

### DIFF
--- a/common/src/java/com/zimbra/common/util/L10nUtil.java
+++ b/common/src/java/com/zimbra/common/util/L10nUtil.java
@@ -371,7 +371,11 @@ public class L10nUtil {
     }
 
     public static String getMessage(String basename, String key, Locale lc, Object... args) {
-        ResourceBundle rb;
+        return getMessage(true /* shoutIfMissing */, basename, key, lc, args);
+    }
+
+    public static String getMessage(boolean shoutIfMissing, String basename, String key, Locale lc, Object... args) {
+        ResourceBundle rb = null;
         try {
             if (lc == null) {
                 lc = Locale.getDefault();
@@ -384,8 +388,23 @@ public class L10nUtil {
                 return fmt;
             }
         } catch (MissingResourceException e) {
-            ZimbraLog.misc.warn("no resource bundle for base name " + basename + " can be found, " +
-                    "(locale=" + key + ")", e);
+            if (rb == null) {
+                if (shoutIfMissing) {
+                    ZimbraLog.misc.warn("no resource bundle found for (basename='%s', key='%s' locale='%s')",
+                            basename, key, lc, e);
+                } else {
+                    ZimbraLog.misc.info("no resource bundle found for (basename='%s', key='%s' locale='%s')",
+                            basename, key, lc);
+                }
+            } else {
+                if (shoutIfMissing) {
+                    ZimbraLog.misc.warn("no resource string found in bundle for (basename='%s', key='%s' locale='%s')",
+                            basename, key, lc, e);
+                } else {
+                    ZimbraLog.misc.info("no resource string found in bundle for (basename='%s', key='%s' locale='%s')",
+                            basename, key, lc);
+                }
+            }
             return null;
         }
     }

--- a/store/src/java/com/zimbra/cs/account/accesscontrol/RightCommand.java
+++ b/store/src/java/com/zimbra/cs/account/accesscontrol/RightCommand.java
@@ -1564,7 +1564,8 @@ public class RightCommand {
         eRight.addAttribute(AdminConstants.A_TARGET_TYPE, right.getTargetTypeStr());
         eRight.addAttribute(AdminConstants.A_RIGHT_CLASS, right.getRightClass().name());
 
-        String desc = L10nUtil.getMessage(L10nUtil.MSG_RIGHTS_FILE_BASENAME, right.getName(), locale);
+        String desc = L10nUtil.getMessage(false /* shoutIfMissing */,
+                L10nUtil.MSG_RIGHTS_FILE_BASENAME, right.getName(), locale);
         if (desc == null) {
             desc = right.getDesc();
         }

--- a/store/src/java/com/zimbra/cs/service/account/ToXML.java
+++ b/store/src/java/com/zimbra/cs/service/account/ToXML.java
@@ -195,20 +195,21 @@ public class ToXML {
 
     public static Element encodeLocale(Element parent, Locale locale, Locale inLocale) {
         Element e = parent.addNonUniqueElement(AccountConstants.E_LOCALE);
-		String id = locale.toString();
+        String id = locale.toString();
 
-		// name in the locale itself
-		String name = L10nUtil.getMessage(L10nUtil.L10N_MSG_FILE_BASENAME, id, Locale.getDefault());
-		if (name == null) {
-		    name = locale.getDisplayName(inLocale);
-		}
+        // name in the locale itself, if it is present.
+        String name = L10nUtil.getMessage(false /* shoutIfMissing */,
+                L10nUtil.L10N_MSG_FILE_BASENAME, id, Locale.getDefault());
+        if (name == null) {
+            name = locale.getDisplayName(inLocale);
+        }
 
-		// name in the locale of choice
-		String localName = locale.getDisplayName(inLocale);
+        // name in the locale of choice
+        String localName = locale.getDisplayName(inLocale);
 
-		e.addAttribute(AccountConstants.A_ID, id);
-		e.addAttribute(AccountConstants.A_NAME, name != null ? name : id);
-		e.addAttribute(AccountConstants.A_LOCAL_NAME, localName != null ? localName : id);
+        e.addAttribute(AccountConstants.A_ID, id);
+        e.addAttribute(AccountConstants.A_NAME, name != null ? name : id);
+        e.addAttribute(AccountConstants.A_LOCAL_NAME, localName != null ? localName : id);
         return e;
     }
 


### PR DESCRIPTION
`GetAllLocalesRequest` looks in the appropriate L10nMsg.properties
file for a localised string to describe a locale name.  For many of
them, there are descriptions but for some there aren't.  When there
aren't, another string is used.

`GetAllRightsRequest` looks in ZsMsgRights.properties for certain keys.
Again, if it isn't found, the code uses another string.

On the basis of the above 2 scenarios, added a new `L10nUtil.getMessage`
signature which has a selector on whether it is worth logging the
whole exception if MissingResourceException is thrown.  The default is
the same as it used to be but the 2 call sites above have been changed
to be less chatty.

Logging has also been improved with more details.  In particular, the
old error message implied that a resource bundle hadn't been found which
suggests a missing properties file but in this case, a resource bundle
WAS present, it just didn't have a value for the requested key.  These
2 scenarios are now treated differently.

`zmsoap -z GetAllRightsRequest` now logs:
```
mailbox.log:2019-03-29 15:56:49,061 INFO  [qtp1740797075-274:https:https://localhost:7071/service/admin/soap/GetAllRightsRequest] [name=zimbra;ua=zmsoap;soapId=2d2570bb;] misc - no resource string found in bundle for (basename='ZsMsgRights', key='manageAccountArchives' locale='en_US')
mailbox.log:2019-03-29 15:56:49,061 INFO  [qtp1740797075-274:https:https://localhost:7071/service/admin/soap/GetAllRightsRequest] [name=zimbra;ua=zmsoap;soapId=2d2570bb;] misc - no resource string found in bundle for (basename='ZsMsgRights', key='manageCalendarResourceArchives' locale='en_US')
```
and `zmsoap -z GetAllLocalesRequest` now logs:
```
mailbox.log:2019-03-29 16:30:35,354 INFO  [qtp1740797075-460:https:https://localhost:7071/service/admin/soap/GetAllLocalesRequest] [name=zimbra;ua=zmsoap;soapId=2d2570fd;] misc - no resource string found in bundle for (basename='L10nMsg', key='' locale='en_US')
mailbox.log:2019-03-29 16:30:35,354 INFO  [qtp1740797075-460:https:https://localhost:7071/service/admin/soap/GetAllLocalesRequest] [name=zimbra;ua=zmsoap;soapId=2d2570fd;] misc - no resource string found in bundle for (basename='L10nMsg', key='af' locale='en_US')
mailbox.log:2019-03-29 16:30:35,354 INFO  [qtp1740797075-460:https:https://localhost:7071/service/admin/soap/GetAllLocalesRequest] [name=zimbra;ua=zmsoap;soapId=2d2570fd;] misc - no resource string found in bundle for (basename='L10nMsg', key='af_NA' locale='en_US')
...
mailbox.log:2019-03-29 16:30:35,381 INFO  [qtp1740797075-460:https:https://localhost:7071/service/admin/soap/GetAllLocalesRequest] [name=zimbra;ua=zmsoap;soapId=2d2570fd;] misc - no resource string found in bundle for (basename='L10nMsg', key='zu' locale='en_US')
mailbox.log:2019-03-29 16:30:35,381 INFO  [qtp1740797075-460:https:https://localhost:7071/service/admin/soap/GetAllLocalesRequest] [name=zimbra;ua=zmsoap;soapId=2d2570fd;] misc - no resource string found in bundle for (basename='L10nMsg', key='zu_ZA' locale='en_US')
```