### PR TITLE
ZCS-6952 Fix class namespace conflict for gql contacts.

### DIFF
--- a/common/src/java/com/zimbra/common/gql/GqlConstants.java
+++ b/common/src/java/com/zimbra/common/gql/GqlConstants.java
@@ -251,9 +251,11 @@ public class GqlConstants {
     public static final String CLASS_MODIFY_CONTACT_GROUP_MEMBER = "ModifyContactGroupMember";
     public static final String CLASS_MODIFY_CONTACT_ATTRIBUTE = "ModifyContactAttribute";
     public static final String CLASS_MODIFY_CONTACT_SPEC = "ModifyContactSpec";
-    public static final String CLASS_CONTACT_GROUP_MEMBER = "ContactGroupMember";
+    public static final String CLASS_ACCOUNT_CONTACT_GROUP_MEMBER = "AccountContactGroupMember";
+    public static final String CLASS_MAIL_CONTACT_GROUP_MEMBER = "MailContactGroupMember";
     public static final String CLASS_CONTACT_ATTRIBUTE = "ContactAttribute";
-    public static final String CLASS_CONTACT_INFO = "ContactInfo";
+    public static final String CLASS_ACCOUNT_CONTACT_INFO = "AccountContactInfo";
+    public static final String CLASS_MAIL_CONTACT_INFO = "MailContactInfo";
     public static final String CLASS_ACTION_RESULT = "ActionResult";
     public static final String CLASS_NEW_CONTACT_GROUP_MEMBER = "NewContactGroupMember";
     public static final String CLASS_VCARD_INFO = "VCardInfo";

--- a/soap/src/java/com/zimbra/soap/account/type/ContactGroupMember.java
+++ b/soap/src/java/com/zimbra/soap/account/type/ContactGroupMember.java
@@ -38,7 +38,7 @@ import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.types.GraphQLType;
 
 @XmlAccessorType(XmlAccessType.NONE)
-@GraphQLType(name=GqlConstants.CLASS_CONTACT_GROUP_MEMBER, description="Contact group member")
+@GraphQLType(name=GqlConstants.CLASS_ACCOUNT_CONTACT_GROUP_MEMBER, description="Contact group member")
 public class ContactGroupMember
 implements ContactGroupMemberInterface {
 

--- a/soap/src/java/com/zimbra/soap/account/type/ContactInfo.java
+++ b/soap/src/java/com/zimbra/soap/account/type/ContactInfo.java
@@ -43,7 +43,7 @@ import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.types.GraphQLType;
 
 @XmlAccessorType(XmlAccessType.NONE)
-@GraphQLType(name=GqlConstants.CLASS_CONTACT_INFO, description="Contact information")
+@GraphQLType(name=GqlConstants.CLASS_ACCOUNT_CONTACT_INFO, description="Contact information")
 public class ContactInfo
 implements ContactInterface {
 

--- a/soap/src/java/com/zimbra/soap/mail/type/ContactGroupMember.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ContactGroupMember.java
@@ -37,7 +37,7 @@ import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.types.GraphQLType;
 
 @XmlAccessorType(XmlAccessType.NONE)
-@GraphQLType(name=GqlConstants.CLASS_CONTACT_GROUP_MEMBER, description="Contact group member")
+@GraphQLType(name=GqlConstants.CLASS_MAIL_CONTACT_GROUP_MEMBER, description="Contact group member")
 public class ContactGroupMember
 implements ContactGroupMemberInterface {
 

--- a/soap/src/java/com/zimbra/soap/mail/type/ContactInfo.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/ContactInfo.java
@@ -51,7 +51,7 @@ import io.leangen.graphql.annotations.types.GraphQLType;
  * {@link SearchHit} is used in {@link SearchResponse} as the element type for a List
  */
 @XmlAccessorType(XmlAccessType.NONE)
-@GraphQLType(name=GqlConstants.CLASS_CONTACT_INFO, description="Contact information")
+@GraphQLType(name=GqlConstants.CLASS_MAIL_CONTACT_INFO, description="Contact information")
 public class ContactInfo
 implements ContactInterface, SearchHit {
 


### PR DESCRIPTION
* Differentiate between account/mail namespace duplicate models for both `ContactInfo` and `ContactGroupMember` to resolve collision conflict when generating schema.