### PR TITLE
ZCS-6871 Make OWASP filtering configurable

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -16973,6 +16973,14 @@ public class ZAttrProvisioning {
     public static final String A_zimbraUCVoicemailURL = "zimbraUCVoicemailURL";
 
     /**
+     * If true, use owasp html sanitizer else use neko html defanger
+     *
+     * @since ZCS 8.8.12
+     */
+    @ZAttr(id=3077)
+    public static final String A_zimbraUseOwaspHtmlSanitizer = "zimbraUseOwaspHtmlSanitizer";
+
+    /**
      * whether end-user services on SOAP and LMTP interfaces are enabled
      */
     @ZAttr(id=146)

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9762,5 +9762,9 @@ TODO: delete them permanently from here
   <desc>filter to decide members of the address list using ldap</desc>
 </attr>
 
-</attrs>
+<attr id="3077" name="zimbraUseOwaspHtmlSanitizer" type="boolean" cardinality="single" optionalIn="globalConfig" since="8.8.12">
+  <globalConfigValue>TRUE</globalConfigValue>
+  <desc>If true, use owasp html sanitizer else use neko html defanger</desc>
+</attr>
 
+</attrs>

--- a/store/src/java-test/com/zimbra/cs/html/DefangFilterTest.java
+++ b/store/src/java-test/com/zimbra/cs/html/DefangFilterTest.java
@@ -42,6 +42,7 @@ import com.zimbra.cs.mailbox.MailboxTestUtil;
 import com.zimbra.cs.mime.MPartInfo;
 import com.zimbra.cs.mime.Mime;
 import com.zimbra.cs.mime.ParsedMessage;
+import com.zimbra.cs.service.mail.ToXML;
 import com.zimbra.cs.servlet.ZThreadLocal;
 import com.zimbra.soap.RequestContext;
 
@@ -55,9 +56,10 @@ public class DefangFilterTest {
     private static String EMAIL_BASE_DIR = "data/unittest/email/";
     @BeforeClass
     public static void init() throws Exception {
-        MailboxTestUtil.initServer("store/");
-        EMAIL_BASE_DIR = MailboxTestUtil.getZimbraServerDir("store/") + EMAIL_BASE_DIR;
+        MailboxTestUtil.initServer();
+        EMAIL_BASE_DIR = MailboxTestUtil.getZimbraServerDir("") + EMAIL_BASE_DIR;
         Provisioning prov = Provisioning.getInstance();
+        prov.getConfig().setUseOwaspHtmlSanitizer(false);
         Account acct = prov.createAccount("test@in.telligent.com", "secret", new HashMap<String, Object>());
     }
 
@@ -1464,10 +1466,25 @@ public class DefangFilterTest {
      */
     @Test
     public void testzbug736Mime1() throws Exception {
+        Provisioning.getInstance().getConfig().setUseOwaspHtmlSanitizer(false);
         String fileName = "zbug736_2.txt";
         InputStream htmlStream = getHtmlBody(fileName);
         String result = DefangFactory.getDefanger(MimeConstants.CT_TEXT_HTML).defang(htmlStream,
             true);
         Assert.assertTrue(result != null);
+    }
+
+    /**
+     * Checking zimbraUseOwaspHtmlSanitizer is true
+     * @throws Exception
+     */
+    @Test
+    public void testzcs6871OwaspDefanger() throws Exception {
+        BrowserDefang defanger2 = DefangFactory.getDefanger(null);
+        Assert.assertFalse(defanger2 instanceof OwaspHtmlSanitizer);
+
+        Provisioning.getInstance().getConfig().setUseOwaspHtmlSanitizer(true);
+        BrowserDefang defanger = DefangFactory.getDefanger(null);
+        Assert.assertTrue(defanger instanceof OwaspHtmlSanitizer);
     }
 }

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -72846,6 +72846,78 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * If true, use owasp html sanitizer else use neko html defanger
+     *
+     * @return zimbraUseOwaspHtmlSanitizer, or true if unset
+     *
+     * @since ZCS 8.8.12
+     */
+    @ZAttr(id=3077)
+    public boolean isUseOwaspHtmlSanitizer() {
+        return getBooleanAttr(Provisioning.A_zimbraUseOwaspHtmlSanitizer, true, true);
+    }
+
+    /**
+     * If true, use owasp html sanitizer else use neko html defanger
+     *
+     * @param zimbraUseOwaspHtmlSanitizer new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.12
+     */
+    @ZAttr(id=3077)
+    public void setUseOwaspHtmlSanitizer(boolean zimbraUseOwaspHtmlSanitizer) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraUseOwaspHtmlSanitizer, zimbraUseOwaspHtmlSanitizer ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * If true, use owasp html sanitizer else use neko html defanger
+     *
+     * @param zimbraUseOwaspHtmlSanitizer new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.12
+     */
+    @ZAttr(id=3077)
+    public Map<String,Object> setUseOwaspHtmlSanitizer(boolean zimbraUseOwaspHtmlSanitizer, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraUseOwaspHtmlSanitizer, zimbraUseOwaspHtmlSanitizer ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * If true, use owasp html sanitizer else use neko html defanger
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.12
+     */
+    @ZAttr(id=3077)
+    public void unsetUseOwaspHtmlSanitizer() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraUseOwaspHtmlSanitizer, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * If true, use owasp html sanitizer else use neko html defanger
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.12
+     */
+    @ZAttr(id=3077)
+    public Map<String,Object> unsetUseOwaspHtmlSanitizer(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraUseOwaspHtmlSanitizer, "");
+        return attrs;
+    }
+
+    /**
      * Time interval after which Zimbra version check detects a new version.
      * Must be in valid duration format: {digits}{time-unit}. digits: 0-9,
      * time-unit: [hmsd]|ms. h - hours, m - minutes, s - seconds, d - days,

--- a/store/src/java/com/zimbra/cs/html/DefangFactory.java
+++ b/store/src/java/com/zimbra/cs/html/DefangFactory.java
@@ -17,6 +17,8 @@
 package com.zimbra.cs.html;
 
 import com.zimbra.common.mime.MimeConstants;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.Provisioning;
 
 /**
  * This factory is used to determine the proper defanger based on content type for
@@ -35,12 +37,17 @@ public class DefangFactory {
      * The xml defanger, used for xhtml and svg 
      */
     private static XHtmlDefang xhtmlDefang = new XHtmlDefang();
-    
+
     /**
      * This defanger does nothing. Here for
      * backwards compatibility
      */
     private static NoopDefang noopDefang = new NoopDefang();
+
+    /**
+     * This defanger is used for OWASP
+     */
+    private static OwaspHtmlSanitizer owaspDefang = new OwaspHtmlSanitizer();
     
     /**
      * 
@@ -48,6 +55,16 @@ public class DefangFactory {
      * @return
      */
     public static BrowserDefang getDefanger(String contentType){
+        try {
+            boolean isOwasp = Provisioning.getInstance().getConfig().getBooleanAttr(Provisioning.A_zimbraUseOwaspHtmlSanitizer, Boolean.TRUE);
+            if (isOwasp) {
+                return owaspDefang;
+            }
+        } catch (ServiceException e) {
+            // in case of exception, return noopDefang
+            return noopDefang;
+        }
+
         if(contentType == null) {
             return noopDefang;
         }

--- a/store/src/java/com/zimbra/cs/html/OwaspHtmlSanitizer.java
+++ b/store/src/java/com/zimbra/cs/html/OwaspHtmlSanitizer.java
@@ -1,0 +1,36 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2019 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.html;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.Writer;
+
+public class OwaspHtmlSanitizer extends AbstractDefang {
+
+    @Override
+    public void defang(InputStream is, boolean neuterImages, Writer out) throws IOException {
+        // TODO to be implemented later
+    }
+
+    @Override
+    public void defang(Reader reader, boolean neuterImages, Writer out) throws IOException {
+        // TODO to be implemented later
+    }
+}


### PR DESCRIPTION
**Problem:** Make OWASP filtering configurable

**Fix:**
- Created OwaspHtmlSanitizer class for owasp filtering which will be implemented later
- Created zimbraUseOwaspHtmlSanitizer, boolean ldap attribute at globalConfig level
- Updated DefangFactory class to use zimbraUseOwaspHtmlSanitizer to decide which defang class to use for filtering.

**Testing done:**
- Build successful.
- zimbraUseOwaspHtmlSanitizer is available at global config level with default value as TRUE
- Added unit test
[report.zip](https://github.com/Zimbra/zm-mailbox/files/3062667/report.zip)


**Testing to be done by QA:**
- Make sure zimbraUseOwaspHtmlSanitizer is available at global config level with default value TRUE.
- If zimbraUseOwaspHtmlSanitizer set false, HtmlDefang filter should be used.