### PR TITLE
ZCS-7020 Grantee name and id can be null in share info elements.

### DIFF
--- a/soap/src/java/com/zimbra/soap/type/ShareInfo.java
+++ b/soap/src/java/com/zimbra/soap/type/ShareInfo.java
@@ -199,7 +199,6 @@ public class ShareInfo {
         this.granteeId = granteeId;
     }
 
-    @GraphQLNonNull
     @GraphQLQuery(name=GqlConstants.RIGHTS, description="rights")
     public String getGranteeId() { return granteeId; }
 
@@ -207,7 +206,6 @@ public class ShareInfo {
         this.granteeName = granteeName;
     }
 
-    @GraphQLNonNull
     @GraphQLQuery(name=GqlConstants.GRNATEE_NAME, description="grantee name")
     public String getGranteeName() { return granteeName; }
 


### PR DESCRIPTION
* Allow grantee name and id to be null in graphql responses - as it may be in soap responses.
  * This resolves an exception when gql is parsing responses that do not have a granteeName or granteeId.

**Testing Done**
Testing basic fetches on zdev and local machines with data highlighting this issue.

**Testing to be done by QA**
See jira ticket.