### PR TITLE
Support the excludeUid attribute

### DIFF
--- a/store/src/java/com/zimbra/cs/fb/RemoteFreeBusyProvider.java
+++ b/store/src/java/com/zimbra/cs/fb/RemoteFreeBusyProvider.java
@@ -222,6 +222,9 @@ public class RemoteFreeBusyProvider extends FreeBusyProvider {
                 req.addAttribute(MailConstants.A_CAL_START_TIME, mStart);
                 req.addAttribute(MailConstants.A_CAL_END_TIME, mEnd);
                 req.addAttribute(MailConstants.A_UID, paramStr);
+                
+                if (mExApptUid != null)
+                    req.addAttribute(MailConstants.A_APPT_FREEBUSY_EXCLUDE_UID, mExApptUid);
 
                 // hack: use the ID of the first user
                 Account acct = prov.get(AccountBy.name, idStrs[0], mSoapCtxt.getAuthToken());


### PR DESCRIPTION
Support the excludeUid attribute in the GetFreeBusy soap request as documented in
https://files.zimbra.com/docs/soap_api/8.8.8/api-reference/zimbraMail/GetFreeBusy.html

This commit partially fix the bug reported in https://bugzilla.zimbra.com/show_bug.cgi?id=109149.

Please merge this fix in the 8.8 and 9.x branches.