### PR TITLE
ZCS-7163 Make zimbraUseOwaspHtmlSanitizer available on server level

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -16975,7 +16975,7 @@ public class ZAttrProvisioning {
     /**
      * If true, use owasp html sanitizer else use neko html defanger
      *
-     * @since ZCS 8.8.12
+     * @since ZCS 8.8.15
      */
     @ZAttr(id=3077)
     public static final String A_zimbraUseOwaspHtmlSanitizer = "zimbraUseOwaspHtmlSanitizer";

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9762,7 +9762,7 @@ TODO: delete them permanently from here
   <desc>filter to decide members of the address list using ldap</desc>
 </attr>
 
-<attr id="3077" name="zimbraUseOwaspHtmlSanitizer" type="boolean" cardinality="single" optionalIn="globalConfig" since="8.8.12">
+<attr id="3077" name="zimbraUseOwaspHtmlSanitizer" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited"  since="8.8.15">
   <globalConfigValue>TRUE</globalConfigValue>
   <desc>If true, use owasp html sanitizer else use neko html defanger</desc>
 </attr>

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -72850,7 +72850,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @return zimbraUseOwaspHtmlSanitizer, or true if unset
      *
-     * @since ZCS 8.8.12
+     * @since ZCS 8.8.15
      */
     @ZAttr(id=3077)
     public boolean isUseOwaspHtmlSanitizer() {
@@ -72863,7 +72863,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param zimbraUseOwaspHtmlSanitizer new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.8.12
+     * @since ZCS 8.8.15
      */
     @ZAttr(id=3077)
     public void setUseOwaspHtmlSanitizer(boolean zimbraUseOwaspHtmlSanitizer) throws com.zimbra.common.service.ServiceException {
@@ -72879,7 +72879,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.8.12
+     * @since ZCS 8.8.15
      */
     @ZAttr(id=3077)
     public Map<String,Object> setUseOwaspHtmlSanitizer(boolean zimbraUseOwaspHtmlSanitizer, Map<String,Object> attrs) {
@@ -72893,7 +72893,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 8.8.12
+     * @since ZCS 8.8.15
      */
     @ZAttr(id=3077)
     public void unsetUseOwaspHtmlSanitizer() throws com.zimbra.common.service.ServiceException {
@@ -72908,7 +72908,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 8.8.12
+     * @since ZCS 8.8.15
      */
     @ZAttr(id=3077)
     public Map<String,Object> unsetUseOwaspHtmlSanitizer(Map<String,Object> attrs) {

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -50549,6 +50549,78 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
+     * If true, use owasp html sanitizer else use neko html defanger
+     *
+     * @return zimbraUseOwaspHtmlSanitizer, or true if unset
+     *
+     * @since ZCS 8.8.15
+     */
+    @ZAttr(id=3077)
+    public boolean isUseOwaspHtmlSanitizer() {
+        return getBooleanAttr(Provisioning.A_zimbraUseOwaspHtmlSanitizer, true, true);
+    }
+
+    /**
+     * If true, use owasp html sanitizer else use neko html defanger
+     *
+     * @param zimbraUseOwaspHtmlSanitizer new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.15
+     */
+    @ZAttr(id=3077)
+    public void setUseOwaspHtmlSanitizer(boolean zimbraUseOwaspHtmlSanitizer) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraUseOwaspHtmlSanitizer, zimbraUseOwaspHtmlSanitizer ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * If true, use owasp html sanitizer else use neko html defanger
+     *
+     * @param zimbraUseOwaspHtmlSanitizer new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.15
+     */
+    @ZAttr(id=3077)
+    public Map<String,Object> setUseOwaspHtmlSanitizer(boolean zimbraUseOwaspHtmlSanitizer, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraUseOwaspHtmlSanitizer, zimbraUseOwaspHtmlSanitizer ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * If true, use owasp html sanitizer else use neko html defanger
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.8.15
+     */
+    @ZAttr(id=3077)
+    public void unsetUseOwaspHtmlSanitizer() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraUseOwaspHtmlSanitizer, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * If true, use owasp html sanitizer else use neko html defanger
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.8.15
+     */
+    @ZAttr(id=3077)
+    public Map<String,Object> unsetUseOwaspHtmlSanitizer(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraUseOwaspHtmlSanitizer, "");
+        return attrs;
+    }
+
+    /**
      * whether end-user services on SOAP and LMTP interfaces are enabled
      *
      * @return zimbraUserServicesEnabled, or false if unset


### PR DESCRIPTION
**Problem:** zimbraUseOwaspHtmlSanitizer should be available on GlobalConfig and Server both.

**Fix:** Added server level on zimbraUseOwaspHtmlSanitizer with inheritance from globalconfig

**Testing done:**
- Tested by setting value on global config level and getting value from server level. 

**Testing to be done by QA:**
- Verify zimbraUseOwaspHtmlSanitizer is available on both globalconfig and server level
- Server should inherit value from globalconfig if value is not set on server level