### PR TITLE
ZBUG-795 imap shared mailbox not visible

### DIFF
--- a/store/src/java/com/zimbra/cs/imap/ImapPath.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapPath.java
@@ -639,17 +639,19 @@ public class ImapPath implements Comparable<ImapPath> {
         }
         try {
             // you cannot access your own mailbox via the /home/username mechanism
-            if (mOwner != null && belongsTo(mCredentials))
+            if (mOwner != null && belongsTo(mCredentials)) {
                 return false;
+            }
             getFolder();
             if (folder !=null) {
-                int folderId = asItemId().getId();
-                // the mailbox root folder is not visible
-                if (folderId == Mailbox.ID_FOLDER_USER_ROOT && mScope != Scope.REFERENCE) {
+                /* the mailbox root folder is not visible (although note that if a whole mailbox has been
+                 * shared then the mountpoint used to represent that uses the user root folder as its
+                 * target and that SHOULD be allowed  - ZBUG-795) */
+                if (mItemId.getId() == Mailbox.ID_FOLDER_USER_ROOT && mScope != Scope.REFERENCE) {
                     return false;
                 }
                 // hide spam folder unless anti-spam feature is enabled.
-                if (folderId == Mailbox.ID_FOLDER_SPAM && !getOwnerAccount().isFeatureAntispamEnabled()) {
+                if (asItemId().getId() == Mailbox.ID_FOLDER_SPAM && !getOwnerAccount().isFeatureAntispamEnabled()) {
                     return false;
                 }
                 boolean isMailFolders = Provisioning.getInstance().getLocalServer().isImapDisplayMailFoldersOnly();


### PR DESCRIPTION
When ZWC is used to add a shared folder for "All applications", the resulting sub-folder hierarchy was not visible via IMAP.

This regression was introduced when IMAP daemon support was added.  A mountpoint was rejected when accumulating paths because the referent's folder id was the user root whereas before (and now again) the folder's id is compared.

Fix validated using Thunderbird to subscribe to folders.
New RunUnitTests test passes against local imap, remote imap and imap daemon.