### PR TITLE
ZCS7167 Fixing issues found in SOAP automation

### DIFF
--- a/common/src/java/com/zimbra/common/net/ProtocolSocketFactoryWrapper.java
+++ b/common/src/java/com/zimbra/common/net/ProtocolSocketFactoryWrapper.java
@@ -19,6 +19,7 @@ package com.zimbra.common.net;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.net.UnknownHostException;
 
 import javax.net.SocketFactory;
 
@@ -36,7 +37,7 @@ class ProtocolSocketFactoryWrapper implements ConnectionSocketFactory {
     }
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see
      * org.apache.http.conn.socket.ConnectionSocketFactory#createSocket(org.
      * apache.http.protocol.HttpContext)
@@ -46,25 +47,14 @@ class ProtocolSocketFactoryWrapper implements ConnectionSocketFactory {
         if (context != null) {
             HttpClientContext clientContext = HttpClientContext.adapt(context);
             HttpHost  host = clientContext.getTargetHost();
-            if(host.getPort() == -1) {
-                if (host.getSchemeName().equalsIgnoreCase("http")) {
-                    factory.createSocket(host.getHostName(), 80);
-                } else if (host.getSchemeName().equalsIgnoreCase("https")) {
-                    factory.createSocket(host.getHostName(), 443);
-                } else {
-                    throw new IOException("Unknown scheme");
-                }
-
-            } else {
-                factory.createSocket(host.getHostName(), host.getPort());
-            }
+            return createSocketFromHostInfo(host);
         }
         return factory.createSocket();
     }
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see
      * org.apache.http.conn.socket.ConnectionSocketFactory#connectSocket(int,
      * java.net.Socket, org.apache.http.HttpHost, java.net.InetSocketAddress,
@@ -90,6 +80,26 @@ class ProtocolSocketFactoryWrapper implements ConnectionSocketFactory {
         } else {
             sock.connect(remoteAddress, connectTimeout);
             return sock;
+        }
+    }
+
+    /**
+     * @param host
+     * @return
+     * @throws IOException
+     * @throws UnknownHostException
+     */
+    public Socket createSocketFromHostInfo(HttpHost host) throws IOException, UnknownHostException {
+        if(host.getPort() == -1) {
+            if (host.getSchemeName().equalsIgnoreCase("http")) {
+               return  factory.createSocket(host.getHostName(), 80);
+            } else if (host.getSchemeName().equalsIgnoreCase("https")) {
+               return  factory.createSocket(host.getHostName(), 443);
+            } else {
+                throw new IOException("Unknown scheme for connecting  to host, Received  +  host.toHostString()");
+            }
+        } else {
+           return  factory.createSocket(host.getHostName(), host.getPort());
         }
     }
 

--- a/common/src/java/com/zimbra/common/net/SecureProtocolSocketFactoryWrapper.java
+++ b/common/src/java/com/zimbra/common/net/SecureProtocolSocketFactoryWrapper.java
@@ -49,21 +49,12 @@ implements LayeredConnectionSocketFactory {
         if (context != null) {
             HttpClientContext clientContext = HttpClientContext.adapt(context);
             HttpHost  host = clientContext.getTargetHost();
-            if(host.getPort() == -1) {
-                if (host.getSchemeName().equalsIgnoreCase("http")) {
-                   return  factory.createSocket(host.getHostName(), 80);
-                } else if (host.getSchemeName().equalsIgnoreCase("https")) {
-                   return  factory.createSocket(host.getHostName(), 443);
-                } else {
-                    throw new IOException("Unknown scheme for connecting  to host, Received  +  host.toHostString()");
-                }
-            } else {
-               return  factory.createSocket(host.getHostName(), host.getPort());
-            }
-
+            return createSocketFromHostInfo(host);
         }
         return factory.createSocket();
     }
+
+
 
     /* (non-Javadoc)
      * @see org.apache.http.conn.socket.LayeredConnectionSocketFactory#createLayeredSocket(java.net.Socket, java.lang.String, int, org.apache.http.protocol.HttpContext)
@@ -75,18 +66,7 @@ implements LayeredConnectionSocketFactory {
             if (context != null) {
                 HttpClientContext clientContext = HttpClientContext.adapt(context);
                 HttpHost  host = clientContext.getTargetHost();
-
-                if(host.getPort() == -1) {
-                    if (host.getSchemeName().equalsIgnoreCase("http")) {
-                       return  factory.createSocket(host.getHostName(), 80);
-                    } else if (host.getSchemeName().equalsIgnoreCase("https")) {
-                       return  factory.createSocket(host.getHostName(), 443);
-                    } else {
-                        throw new IOException("Unknown scheme for connecting  to host, Received  +  host.toHostString()");
-                    }
-                } else {
-                   return  factory.createSocket(host.getHostName(), host.getPort());
-                }
+                return createSocketFromHostInfo(host);
             } else {
                 return  factory.createSocket(target, port);
             }

--- a/common/src/java/com/zimbra/common/net/SocketFactories.java
+++ b/common/src/java/com/zimbra/common/net/SocketFactories.java
@@ -76,8 +76,8 @@ public final class SocketFactories {
         register(allowUntrustedCerts ? TrustManagers.dummyTrustManager() : null);
     }
 
-    private synchronized static void register(X509TrustManager tm) {
-        if (registered) return;
+    private synchronized static Registry<ConnectionSocketFactory> register(X509TrustManager tm) {
+        if (registered) return registry;
 
         // Set default TrustManager
         TrustManagers.setDefaultTrustManager(tm);
@@ -90,6 +90,8 @@ public final class SocketFactories {
             .register(HTTPS, spsf)
             .build();
 
+
+
         // HttpURLConnection already uses system ProxySelector by default
         // Set HttpsURLConnection SSL socket factory and optional hostname verifier
         HttpsURLConnection.setDefaultSSLSocketFactory(defaultSSLSocketFactory(false));
@@ -101,6 +103,8 @@ public final class SocketFactories {
         ProxySelector.setDefault(ProxySelectors.defaultProxySelector());
 
         registered = true;
+
+        return registry;
     }
 
     public synchronized static void resetRegisteredFlag() {
@@ -219,7 +223,7 @@ public final class SocketFactories {
         return defaultSSLSocketFactory(TrustManagers.dummyTrustManager(), true);
     }
 
-    
+
     public static Registry<ConnectionSocketFactory> getRegistry() {
         return registry;
     }

--- a/common/src/java/com/zimbra/common/soap/SoapHttpTransport.java
+++ b/common/src/java/com/zimbra/common/soap/SoapHttpTransport.java
@@ -257,7 +257,7 @@ public class SoapHttpTransport extends SoapTransport {
             Element soapReq = generateSoapMessage(document, raw, noSession, requestedAccountId, changeToken, tokenType, nFormat, curWaitSetID);
             String soapMessage = SoapProtocol.toString(soapReq, getPrettyPrint());
 
-            method.setEntity(new StringEntity(soapMessage, ContentType.create(null, "UTF-8")));
+            method.setEntity(new StringEntity(soapMessage, ContentType.create(ContentType.APPLICATION_XML.getMimeType(), "UTF-8")));
 
             if (getRequestProtocol().hasSOAPActionHeader())
                 method.addHeader("SOAPAction", mUri);
@@ -282,7 +282,7 @@ public class SoapHttpTransport extends SoapTransport {
             if (zToken instanceof ZJWToken) {
                 method.addHeader(Constants.AUTH_HEADER, Constants.BEARER + " " + zToken.getValue());
             }
-            
+
             RequestConfig reqConfig = RequestConfig.custom().
                 setCookieSpec(cookieStore.getCookies().size() == 0 ? CookieSpecs.IGNORE_COOKIES:
                CookieSpecs.BROWSER_COMPATIBILITY).build();
@@ -292,7 +292,7 @@ public class SoapHttpTransport extends SoapTransport {
             method.addHeader("Connection", mKeepAlive ? "Keep-alive" : "Close");
 
             if (mHostConfig != null && mHostConfig.getUsername() != null && mHostConfig.getPassword() != null) {
-                
+
                 Credentials credentials = new UsernamePasswordCredentials(mHostConfig.getUsername(), mHostConfig.getPassword());
                 AuthScope authScope = new AuthScope(null, -1);
                 CredentialsProvider credsProvider = new BasicCredentialsProvider();

--- a/common/src/java/com/zimbra/common/util/ZimbraHttpConnectionManager.java
+++ b/common/src/java/com/zimbra/common/util/ZimbraHttpConnectionManager.java
@@ -204,8 +204,7 @@ private static class ExternalConnMgrParams extends ZimbraConnMgrParams {
         this.httpConnMgr.setDefaultMaxPerRoute( zimbraConnMgrParams.getDefaultMaxConnectionsPerHost());
         this.httpConnMgr.setMaxTotal(zimbraConnMgrParams.getMaxTotalConnection());
 
-        this.httpConnMgr.setDefaultSocketConfig(zimbraConnMgrParams.socketConfig);
-
+        this.httpConnMgr.setDefaultSocketConfig(SocketConfig.custom().setSoTimeout(LC.socket_so_timeout.intValue()).build());
 
         this.defaultHttpClient = createHttpClient();
         


### PR DESCRIPTION
Fixed the code that created the Sockets.
For FeedManager changed the code for reading content type from HttpResponse

Verified that the following error is no longer seen
[] INFO: I/O exception (java.net.SocketException) caught when processing request to {s}->https://localhost:7071: Socket is closed
[] INFO: Retrying request to {s}->https://localhost:7071

Verified by running the failing SOAP automation test case

/opt/qa/soapvalidator/data/soapvalidator/MailClient/Folders/folders_url.xml


