### PR TITLE
ZCS-6903:Fix test cases with OWASP-5

### DIFF
--- a/store/conf/owasp_policy.xml
+++ b/store/conf/owasp_policy.xml
@@ -4,11 +4,14 @@
      LANG = dir,lang,xml:lang
      KBD = accesshtml,tabindex-->
 <owasp_policy>
-  <url_protocols>cid,http,https,mailto,data</url_protocols>
+  <url_protocols>cid,http,https,mailto,data,smb</url_protocols>
   <disallow_text_in>applet,frameset,object,script,style,title</disallow_text_in>
   <html element="a">
     <attributes>KBD,charset,coords,href,hreflang,name,rel,rev,shape,target,type</attributes>
-    <url_protocols>cid,http,https,mailto</url_protocols>
+    <url_protocols>cid,http,https,mailto,smb</url_protocols>
+  </html>
+  <html element="base">
+    <attributes>href</attributes>
   </html>
   <html element="address">
     <attributes>CORE,LANG</attributes>

--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -43,7 +43,7 @@
   <dependency org="com.101tec" name="zkclient" rev="0.1.0"/>
   <dependency org="xerces" name="xercesImpl" rev="2.9.1-patch-01"/>
   <dependency org="net.sourceforge.nekohtml" name="nekohtml" rev="1.9.13.1z"/>
-  <dependency org="com.googlecode.owasp-java-html-sanitizer" name="owasp-java-html-sanitizer" rev="20190325.1"/>
+  <dependency org="com.googlecode.owasp-java-html-sanitizer" name="owasp-java-html-sanitizer" rev="20190503.1"/>
   <dependency org="org.ehcache" name="ehcache" rev="3.1.2"/>
   <dependency org="ant-1.7.0-ziputil-patched" name="ant-1.7.0-ziputil-patched" rev="1.0"/>
   <dependency org="org.eclipse.jetty" name="jetty-continuation" rev="9.3.5.v20151012"/>

--- a/store/src/java/com/zimbra/cs/html/owasp/HtmlElement.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/HtmlElement.java
@@ -79,8 +79,11 @@ public class HtmlElement {
                 }
                 AttributePolicy attrPolicy = attributesAndPolicies.get(attribute);
                 if (attrPolicy != null) {
-                    if (neuterImages && (attrPolicy instanceof SrcAttributePolicy
-                        || attrPolicy instanceof BackgroundAttributePolicy)) {
+                    if (attrPolicy instanceof SrcAttributePolicy || attrPolicy instanceof BackgroundAttributePolicy) {
+                        if (neuterImages) {
+                            attributesBuilder.matching(attrPolicy);
+                        }
+                    } else {
                         attributesBuilder.matching(attrPolicy);
 
                     }

--- a/store/src/java/com/zimbra/cs/html/owasp/HtmlElementsBuilder.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/HtmlElementsBuilder.java
@@ -22,10 +22,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import org.owasp.html.ElementPolicy;
 
 import com.zimbra.cs.html.owasp.policies.AElementPolicy;
 import com.zimbra.cs.html.owasp.policies.AreaElementPolicy;
+import com.zimbra.cs.html.owasp.policies.BaseElementPolicy;
 import com.zimbra.cs.html.owasp.policies.DivElementPolicy;
 
 /*
@@ -45,6 +47,7 @@ public class HtmlElementsBuilder {
         elementSpecificPolicies.put("div", new DivElementPolicy());
         elementSpecificPolicies.put("a", new AElementPolicy());
         elementSpecificPolicies.put("area", new AreaElementPolicy());
+        elementSpecificPolicies.put("base", new BaseElementPolicy());
         // add any other element policies
     }
 

--- a/store/src/java/com/zimbra/cs/html/owasp/OwaspHtmlSanitizer.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/OwaspHtmlSanitizer.java
@@ -3,6 +3,7 @@ package com.zimbra.cs.html.owasp;
 import java.util.concurrent.Callable;
 import java.util.regex.Pattern;
 
+import org.owasp.html.Encoding;
 import org.owasp.html.Handler;
 import org.owasp.html.HtmlSanitizer;
 import org.owasp.html.HtmlSanitizer.Policy;
@@ -19,6 +20,7 @@ public class OwaspHtmlSanitizer implements Callable<String> {
     private String html;
     private boolean neuterImages;
     private static final Pattern AV_TAB = Pattern.compile(DebugConfig.defangAvTab, Pattern.CASE_INSENSITIVE);
+    public static final ThreadLocal<String> zThreadLocal  = new ThreadLocal<String>(); 
 
     public OwaspHtmlSanitizer(String html, boolean neuterImages) {
         this.html = html;
@@ -61,6 +63,7 @@ public class OwaspHtmlSanitizer implements Callable<String> {
         instantiatePolicy();
         final Policy policy = POLICY_DEFINITION.apply(renderer);
         // run the html through the sanitizer
+        html = Encoding.decodeHtml(html);
         HtmlSanitizer.sanitize(html, policy);
         // return the resulting HTML from the builder
         return htmlBuilder.toString();

--- a/store/src/java/com/zimbra/cs/html/owasp/policies/ActionAttributePolicy.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/policies/ActionAttributePolicy.java
@@ -27,19 +27,16 @@ import com.zimbra.cs.servlet.ZThreadLocal;
 
 public class ActionAttributePolicy implements AttributePolicy {
 
-    /** enable same host post request for a form in email */
+    //enable same host post request for a form in email
     private static boolean sameHostFormPostCheck = DebugConfig.defang_block_form_same_host_post_req;
-    /** The Host header received in the request. */
-    private String reqVirtualHost = null;
-
-    public ActionAttributePolicy() {
-        if (ZThreadLocal.getRequestContext() != null) {
-            this.reqVirtualHost = ZThreadLocal.getRequestContext().getVirtualHost();
-        }
-    }
 
     @Override
     public String apply(String elementName, String attributeName, String value) {
+        // The Host header received in the request.
+        String reqVirtualHost = null;
+        if (ZThreadLocal.getRequestContext() != null) {
+            reqVirtualHost = ZThreadLocal.getRequestContext().getVirtualHost();
+        }
         if (sameHostFormPostCheck && reqVirtualHost != null) {
             try {
                 URL url = new URL(value);
@@ -49,9 +46,8 @@ public class ActionAttributePolicy implements AttributePolicy {
                     value = value.replace(formActionHost, "SAMEHOSTFORMPOST-BLOCKED");
                 }
             } catch (MalformedURLException e) {
-                ZimbraLog.soap.warn("Failure while trying to block malicious code. Check for URL"
-                    + " match between the host and the action URL of a FORM."
-                    + " Error parsing URL, possible relative URL." + e.getMessage());
+                ZimbraLog.soap.warn("Error parsing URL, possible relative URL." + e.getMessage());
+                value = "SAMEHOSTFORMPOST-BLOCKED";
             }
         }
         return value;

--- a/store/src/java/com/zimbra/cs/html/owasp/policies/BaseElementPolicy.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/policies/BaseElementPolicy.java
@@ -1,4 +1,5 @@
 package com.zimbra.cs.html.owasp.policies;
+
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
@@ -15,22 +16,24 @@ package com.zimbra.cs.html.owasp.policies;
  * If not, see <https://www.gnu.org/licenses/>.
  * ***** END LICENSE BLOCK *****
  */
-import org.owasp.html.AttributePolicy;
+
+import java.util.List;
+
+import org.owasp.html.ElementPolicy;
 
 import com.zimbra.cs.html.owasp.OwaspHtmlSanitizer;
 
-public class SrcAttributePolicy implements AttributePolicy {
+public class BaseElementPolicy implements ElementPolicy {
 
     @Override
-    public String apply(String elementName, String attributeName, String srcValue) {
-        String base = OwaspHtmlSanitizer.zThreadLocal.get();
-        if (base != null) {
-            if (!srcValue.startsWith("/")) {
-                srcValue = "/" + srcValue;
-            }
-            srcValue = base+srcValue;
+    public String apply(String elementName, List<String> attrs) {
+
+        final int hrefIndex = attrs.indexOf("href");
+        if (hrefIndex != -1) {
+            String hrefValue = attrs.get(hrefIndex + 1);
+            OwaspHtmlSanitizer.zThreadLocal.set(hrefValue);
         }
-        return srcValue;
+        return "base";
     }
 
 }


### PR DESCRIPTION
Modified owasp defanger code to fix following unit tests:

- testBug83999 - block same host form post
- testBug102637 - decimal character references
- testBug102910 - cid with @ being escaped -- test expectation fixed, @ will be escaped.
- testBug73037  - URL with spaces and URL like '//Shared_srv/folder/file with spaces.txt'
- testBug7387 - base href with src val