### PR TITLE
ZCS-7168 fixing unit test

### DIFF
--- a/store/src/java-test/com/zimbra/cs/html/DefangFilterTest.java
+++ b/store/src/java-test/com/zimbra/cs/html/DefangFilterTest.java
@@ -33,6 +33,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.mime.MimeConstants;
 import com.zimbra.common.util.ByteUtil;
 import com.zimbra.common.util.StringUtil;
@@ -43,7 +44,6 @@ import com.zimbra.cs.mailbox.MailboxTestUtil;
 import com.zimbra.cs.mime.MPartInfo;
 import com.zimbra.cs.mime.Mime;
 import com.zimbra.cs.mime.ParsedMessage;
-import com.zimbra.cs.service.mail.ToXML;
 import com.zimbra.cs.servlet.ZThreadLocal;
 import com.zimbra.soap.RequestContext;
 
@@ -59,8 +59,8 @@ public class DefangFilterTest {
     public static void init() throws Exception {
         MailboxTestUtil.initServer();
         EMAIL_BASE_DIR = MailboxTestUtil.getZimbraServerDir("") + EMAIL_BASE_DIR;
+        LC.zimbra_use_owasp_html_sanitizer.setDefault(false);
         Provisioning prov = Provisioning.getInstance();
-        prov.getConfig().setUseOwaspHtmlSanitizer(false);
         Account acct = prov.createAccount("test@in.telligent.com", "secret", new HashMap<String, Object>());
     }
 
@@ -1467,7 +1467,7 @@ public class DefangFilterTest {
      */
     @Test
     public void testzbug736Mime1() throws Exception {
-        Provisioning.getInstance().getConfig().setUseOwaspHtmlSanitizer(false);
+        LC.zimbra_use_owasp_html_sanitizer.setDefault(false);
         String fileName = "zbug736_2.txt";
         InputStream htmlStream = getHtmlBody(fileName);
         String result = DefangFactory.getDefanger(MimeConstants.CT_TEXT_HTML).defang(htmlStream,
@@ -1484,7 +1484,7 @@ public class DefangFilterTest {
         BrowserDefang defanger2 = DefangFactory.getDefanger(MimeConstants.CT_TEXT_HTML);
         Assert.assertFalse(defanger2 instanceof OwaspDefang);
 
-        Provisioning.getInstance().getConfig().setUseOwaspHtmlSanitizer(true);
+        LC.zimbra_use_owasp_html_sanitizer.setDefault(true);
         BrowserDefang defanger = DefangFactory.getDefanger(MimeConstants.CT_TEXT_HTML);
         Assert.assertTrue(defanger instanceof OwaspDefang);
     }


### PR DESCRIPTION
**Problem:** DefangFilterTest broken
**Fix:** Fixed unit test to use LC
**Testing done:** Tested unit test
```
$ant -Dtest.name=com.zimbra.cs.html.DefangFilterTest  single-test
Buildfile: /Users/chinmay.pathak/Github/zm-mailbox/store/build.xml

build-init:

make-dirs:
     [echo] Creating dirs under /Users/chinmay.pathak/Github/zm-mailbox/store/build/dist

test.if.ivy.available:

download-ivy:

init-ivy:
Trying to override old definition of task antlib:org.apache.ivy.ant:buildobr
Trying to override old definition of task antlib:org.apache.ivy.ant:buildobr

resolve:
Trying to override old definition of task antlib:org.apache.ivy.ant:buildobr
[ivy:resolve] :: Apache Ivy 2.3.0 - 20130110142753 :: http://ant.apache.org/ivy/ ::
[ivy:resolve] :: loading settings :: file = /Users/chinmay.pathak/Github/zm-mailbox/build-ivysettings.xml
[ivy:resolve] :: resolving dependencies :: zimbra#zm-store;working@hollowspace.local
[ivy:resolve] 	confs: [default]
[ivy:resolve] 	found org.powermock#powermock-module-junit4;1.6.5 in maven
[ivy:resolve] 	found org.powermock#powermock-module-junit4-common;1.6.5 in maven
[ivy:resolve] 	found org.powermock#powermock-api-easymock;1.6.5 in maven
[ivy:resolve] 	found org.powermock#powermock-api-mockito;1.6.5 in maven
[ivy:resolve] 	found org.powermock#powermock-core;1.6.5 in maven
[ivy:resolve] 	found org.powermock#powermock-api-support;1.6.5 in maven
[ivy:resolve] 	found org.powermock#powermock-reflect;1.6.5 in maven
[ivy:resolve] 	found org.powermock#powermock-api-mockito-common;1.6.5 in maven
[ivy:resolve] 	found org.mockito#mockito-all;1.10.19 in maven
[ivy:resolve] 	found org.javassist#javassist;3.18.2-GA in maven
[ivy:resolve] 	found org.slf4j#slf4j-api;1.6.4 in maven
[ivy:resolve] 	found org.slf4j#slf4j-log4j12;1.6.4 in maven
[ivy:resolve] 	found junit#junit;4.8.2 in chain-resolver
[ivy:resolve] 	found javax.mail#mail;1.4.5 in chain-resolver
[ivy:resolve] 	found jaxen#jaxen;1.1-beta-10 in maven
[ivy:resolve] 	found dom4j#dom4j;1.5.2 in chain-resolver
[ivy:resolve] 	found log4j#log4j;1.2.16 in chain-resolver
[ivy:resolve] 	found com.google.guava#guava;23.0 in chain-resolver
[ivy:resolve] 	found org.json#json;20090211 in chain-resolver
[ivy:resolve] 	found javax.servlet#javax.servlet-api;3.1.0 in chain-resolver
[ivy:resolve] 	found ical4j#ical4j;0.9.16-patched in chain-resolver
[ivy:resolve] 	found net.spy#spymemcached;2.12.1 in chain-resolver
[ivy:resolve] 	found org.gnu.inet#libidn;1.24 in chain-resolver
[ivy:resolve] 	found commons-cli#commons-cli;1.2 in chain-resolver
[ivy:resolve] 	found commons-pool#commons-pool;1.6 in maven
[ivy:resolve] 	found commons-dbcp#commons-dbcp;1.4 in maven
[ivy:resolve] 	found commons-codec#commons-codec;1.7 in chain-resolver
[ivy:resolve] 	found commons-io#commons-io;1.4 in maven
[ivy:resolve] 	found com.ibm.icu#icu4j;4.8.1.1 in chain-resolver
[ivy:resolve] 	found oauth#oauth;1.4 in chain-resolver
[ivy:resolve] 	found zimbra#zm-ews-stub;2.0 in zimbra
[ivy:resolve] 	found org.apache.lucene#lucene-core;3.5.0 in maven
[ivy:resolve] 	found org.apache.lucene#lucene-analyzers;3.5.0 in maven
[ivy:resolve] 	found org.apache.zookeeper#zookeeper;3.4.5 in maven
[ivy:resolve] 	found ews_2010#ews_2010;1.0 in chain-resolver
[ivy:resolve] 	found com.101tec#zkclient;0.1.0 in maven
[ivy:resolve] 	found xerces#xercesImpl;2.9.1-patch-01 in maven-redhat
[ivy:resolve] 	found net.sourceforge.nekohtml#nekohtml;1.9.13.1z in chain-resolver
[ivy:resolve] 	found com.googlecode.owasp-java-html-sanitizer#owasp-java-html-sanitizer;20190503.1 in maven
[ivy:resolve] 	found org.ehcache#ehcache;3.1.2 in maven
[ivy:resolve] 	found ant-1.7.0-ziputil-patched#ant-1.7.0-ziputil-patched;1.0 in chain-resolver
[ivy:resolve] 	found org.eclipse.jetty#jetty-continuation;9.3.5.v20151012 in maven
[ivy:resolve] 	found org.eclipse.jetty#jetty-security;9.3.5.v20151012 in maven
[ivy:resolve] 	found org.eclipse.jetty#jetty-http;9.3.5.v20151012 in maven
[ivy:resolve] 	found org.eclipse.jetty#jetty-io;9.3.5.v20151012 in maven
[ivy:resolve] 	found org.eclipse.jetty#jetty-server;9.3.5.v20151012 in maven
[ivy:resolve] 	found org.eclipse.jetty#jetty-servlet;9.3.5.v20151012 in maven
[ivy:resolve] 	found org.eclipse.jetty#jetty-servlets;9.3.5.v20151012 in maven
[ivy:resolve] 	found org.eclipse.jetty#jetty-util;9.3.5.v20151012 in chain-resolver
[ivy:resolve] 	found commons-lang#commons-lang;2.6 in chain-resolver
[ivy:resolve] 	found commons-fileupload#commons-fileupload;1.2.2 in maven
[ivy:resolve] 	found commons-httpclient#commons-httpclient;3.1 in chain-resolver
[ivy:resolve] 	found commons-collections#commons-collections;3.2.2 in maven
[ivy:resolve] 	found commons-logging#commons-logging;1.1.1 in chain-resolver
[ivy:resolve] 	found org.apache.httpcomponents#httpclient;4.5.2 in chain-resolver
[ivy:resolve] 	found org.apache.httpcomponents#httpasyncclient;4.1.2 in chain-resolver
[ivy:resolve] 	found org.apache.httpcomponents#httpcore;4.4.5 in chain-resolver
[ivy:resolve] 	found org.apache.httpcomponents#httpcore-nio;4.4.5 in chain-resolver
[ivy:resolve] 	found org.apache.commons#commons-compress;1.10 in maven
[ivy:resolve] 	found org.apache.mina#mina-core;2.0.4 in maven
[ivy:resolve] 	found org.apache.curator#curator-recipes;2.0.1-incubating in maven
[ivy:resolve] 	found org.apache.curator#curator-client;2.0.1-incubating in maven
[ivy:resolve] 	found org.apache.curator#curator-x-discovery;2.0.1-incubating in maven
[ivy:resolve] 	found org.apache.curator#curator-framework;2.0.1-incubating in maven
[ivy:resolve] 	found org.apache.james#apache-jsieve-core;0.5 in maven
[ivy:resolve] 	found com.unboundid#unboundid-ldapsdk;2.3.5 in maven
[ivy:resolve] 	found org.newsclub#junixsocket;1.3 in chain-resolver
[ivy:resolve] 	found net.freeutils.jtnef#tnef;1.8.0 in chain-resolver
[ivy:resolve] 	found org.bouncycastle#bcprov-jdk15on;1.55 in maven
[ivy:resolve] 	found org.bouncycastle#bcpkix-jdk15on;1.55 in maven
[ivy:resolve] 	found com.googlecode.concurrentlinkedhashmap#concurrentlinkedhashmap-lru;1.3.1 in maven
[ivy:resolve] 	found org.apache.commons#commons-csv;1.2 in maven
[ivy:resolve] 	found ch.ethz.ganymed#ganymed-ssh2;build210 in maven
[ivy:resolve] 	found ant-tar-patched#ant-tar-patched;1.0 in chain-resolver
[ivy:resolve] 	found com.yahoo.platform.yui#yuicompressor;2.4.2-zimbra in chain-resolver
[ivy:resolve] 	found org.hsqldb#hsqldb;2.2.9 in maven
[ivy:resolve] 	found org.hsqldb#sqltool;2.2.9 in maven
[ivy:resolve] 	found org.easymock#easymock;3.0 in chain-resolver
[ivy:resolve] 	found cglib#cglib;2.2.2 in chain-resolver
[ivy:resolve] 	found cglib#cglib-nodep;2.2 in maven
[ivy:resolve] 	found org.objenesis#objenesis;1.2 in maven
[ivy:resolve] 	found asm#asm;3.3.1 in chain-resolver
[ivy:resolve] 	found zimbra#zm-common;8.8.12.1556776558 in local
[ivy:resolve] 	[8.8.12.1556776558] zimbra#zm-common;latest.integration
[ivy:resolve] 	found zimbra#zm-soap;8.8.12.1556776558 in local
[ivy:resolve] 	[8.8.12.1556776558] zimbra#zm-soap;latest.integration
[ivy:resolve] 	found zimbra#zm-client;8.8.12.1556776558 in local
[ivy:resolve] 	[8.8.12.1556776558] zimbra#zm-client;latest.integration
[ivy:resolve] 	found zimbra#zm-native;8.8.12.1556776558 in local
[ivy:resolve] 	[8.8.12.1556776558] zimbra#zm-native;latest.integration
[ivy:resolve] 	found org.xmlunit#xmlunit-core;2.3.0 in maven
[ivy:resolve] 	found ant-contrib#ant-contrib;1.0b3 in chain-resolver
[ivy:resolve] 	found io.jsonwebtoken#jjwt;0.7.0 in maven
[ivy:resolve] 	found com.fasterxml.jackson.core#jackson-core;2.9.2 in maven
[ivy:resolve] 	found com.fasterxml.jackson.core#jackson-annotations;2.9.2 in maven
[ivy:resolve] 	found com.fasterxml.jackson.core#jackson-databind;2.9.2 in maven
[ivy:resolve] 	found com.fasterxml.jackson.dataformat#jackson-dataformat-smile;2.9.2 in maven
[ivy:resolve] 	found com.fasterxml.jackson.module#jackson-module-jaxb-annotations;2.8.9 in maven
[ivy:resolve] 	found org.apache.commons#commons-text;1.1 in maven
[ivy:resolve] 	found org.apache.commons#commons-lang3;3.7 in maven
[ivy:resolve] 	found org.apache.commons#commons-rng-client-api;1.0 in maven
[ivy:resolve] 	found org.apache.commons#commons-rng-core;1.0 in maven
[ivy:resolve] 	found org.apache.commons#commons-rng-simple;1.0 in maven
[ivy:resolve] 	found com.google.javascript#closure-compiler;v20180204 in maven
[ivy:resolve] 	found com.github.zafarkhaja#java-semver;0.9.0 in maven
[ivy:resolve] :: resolution report :: resolve 732ms :: artifacts dl 26ms
	---------------------------------------------------------------------
	|                  |            modules            ||   artifacts   |
	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
	---------------------------------------------------------------------
	|      default     |  101  |   4   |   0   |   0   ||  101  |   0   |
	---------------------------------------------------------------------
[ivy:cachepath] DEPRECATED: 'ivy.conf.file' is deprecated, use 'ivy.settings.file' instead
[ivy:cachepath] :: loading settings :: file = /Users/chinmay.pathak/Github/zm-mailbox/build-ivysettings.xml

3rd-party-defines:

compile:
    [javac] Compiling 11 source files to /Users/chinmay.pathak/Github/zm-mailbox/store/build/classes

test-compile:
    [mkdir] Created dir: /Users/chinmay.pathak/Github/zm-mailbox/store/build/test-classes
    [javac] Compiling 276 source files to /Users/chinmay.pathak/Github/zm-mailbox/store/build/test-classes
    [javac] Note: Some input files use or override a deprecated API.
    [javac] Note: Recompile with -Xlint:deprecation for details.
    [javac] Note: Some input files use unchecked or unsafe operations.
    [javac] Note: Recompile with -Xlint:unchecked for details.
     [copy] Copying 32 files to /Users/chinmay.pathak/Github/zm-mailbox/store/build/test-classes

single-test:
    [mkdir] Created dir: /Users/chinmay.pathak/Github/zm-mailbox/store/build/test-com.zimbra.cs.html.DefangFilterTest/output
    [mkdir] Created dir: /Users/chinmay.pathak/Github/zm-mailbox/store/build/test-com.zimbra.cs.html.DefangFilterTest/report
    [mkdir] Created dir: /Users/chinmay.pathak/Github/zm-mailbox/store/build/test/extensions
     [move] Moving 2 files to /Users/chinmay.pathak/Github/zm-mailbox/store/build/test/extensions/com/zimbra/extensions
     [copy] Copying 1 file to /Users/chinmay.pathak/Github/zm-mailbox/store/build/test-classes
    [junit] Running com.zimbra.cs.html.DefangFilterTest
    [junit] 08 May 2019 12:24:19,343 [util.Log][main] :: INFO   Using Index Store LuceneIndex   
    [junit] 08 May 2019 12:24:19,381 [util.Log][main] :: INFO   message directory does not exist: build/zimbra/conf/msgs   
    [junit] Unable to determine platform because build/zimbra/.platform does not exist.
    [junit] 08 May 2019 12:24:19,802 [util.Log][main] :: INFO   Failure while trying to block mailicious code. Check for URL  match between the host and the action URL of a FORM.Error parsing URL, possible relative URL.no protocol: /service/soap/ModifyFilterRulesRequest   
    [junit] Tests run: 47, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.036 sec
[junitreport] Processing /Users/chinmay.pathak/Github/zm-mailbox/store/build/test-com.zimbra.cs.html.DefangFilterTest/report/TESTS-TestSuites.xml to /var/folders/3v/6trhwry51ksc_vtf99kc85dc0000gp/T/null1657432682
[junitreport] Loading stylesheet jar:file:/usr/local/Cellar/ant/1.10.5/libexec/lib/ant-junit.jar!/org/apache/tools/ant/taskdefs/optional/junit/xsl/junit-frames.xsl
[junitreport] Transform time: 274ms
[junitreport] Deleting: /var/folders/3v/6trhwry51ksc_vtf99kc85dc0000gp/T/null1657432682
     [echo] Test Report: /Users/chinmay.pathak/Github/zm-mailbox/store/build/test-com.zimbra.cs.html.DefangFilterTest/report/index.html

BUILD SUCCESSFUL
Total time: 11 seconds
```
Attached is the report for unit test [report.zip](https://github.com/Zimbra/zm-mailbox/files/3155918/report.zip)

**Testing to be done by QA:**
- Make sure unit test passes and build is successful for feature/owasp branch.