### PR TITLE
ZCS-6874:Fixing pnsrc img attribute

### DIFF
--- a/store/src/java-test/com/zimbra/cs/html/owasp/OwaspHtmlSanitizerTest.java
+++ b/store/src/java-test/com/zimbra/cs/html/owasp/OwaspHtmlSanitizerTest.java
@@ -385,7 +385,7 @@ public class OwaspHtmlSanitizerTest {
         InputStream htmlStream = getHtmlBody(fileName);
         String html = CharStreams.toString(new InputStreamReader(htmlStream, Charsets.UTF_8));
         String result = new OwaspHtmlSanitizer(html,true).sanitize();
-        Assert.assertFalse(result.contains("src=\"image001.gif\""));
+        Assert.assertTrue(result.contains("pnsrc=\"image001.gif\""));
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/html/owasp/HtmlElement.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/HtmlElement.java
@@ -1,9 +1,5 @@
 package com.zimbra.cs.html.owasp;
 
-import static com.zimbra.cs.html.owasp.HtmlElementsBuilder.COMMA;
-
-import java.util.Arrays;
-import java.util.List;
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
@@ -20,9 +16,12 @@ import java.util.List;
  * If not, see <https://www.gnu.org/licenses/>.
  * ***** END LICENSE BLOCK *****
  */
+
+import static com.zimbra.cs.html.owasp.HtmlElementsBuilder.COMMA;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import org.owasp.html.AttributePolicy;
 import org.owasp.html.ElementPolicy;
 import org.owasp.html.FilterUrlByProtocolAttributePolicy;
@@ -56,7 +55,6 @@ public class HtmlElement {
 
     public void configure(HtmlPolicyBuilder policyBuilder, boolean neuterImages) {
         String elementName = getElement();
-
         if (elementPolicy.isPresent()) {
             policyBuilder.allowElements(elementPolicy.get(), elementName);
         } else {

--- a/store/src/java/com/zimbra/cs/html/owasp/HtmlElementsBuilder.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/HtmlElementsBuilder.java
@@ -29,6 +29,7 @@ import com.zimbra.cs.html.owasp.policies.AElementPolicy;
 import com.zimbra.cs.html.owasp.policies.AreaElementPolicy;
 import com.zimbra.cs.html.owasp.policies.BaseElementPolicy;
 import com.zimbra.cs.html.owasp.policies.DivElementPolicy;
+import com.zimbra.cs.html.owasp.policies.ImgElementPolicy;
 
 /*
  * Build the list of HtmlElements from policy file
@@ -48,6 +49,7 @@ public class HtmlElementsBuilder {
         elementSpecificPolicies.put("a", new AElementPolicy());
         elementSpecificPolicies.put("area", new AreaElementPolicy());
         elementSpecificPolicies.put("base", new BaseElementPolicy());
+        elementSpecificPolicies.put("img", new ImgElementPolicy());
         // add any other element policies
     }
 

--- a/store/src/java/com/zimbra/cs/html/owasp/OwaspDefang.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/OwaspDefang.java
@@ -52,7 +52,9 @@ public class OwaspDefang extends AbstractDefang {
     public void defang(Reader reader, boolean neuterImages, Writer out) throws IOException {
         String html = CharStreams.toString(reader);
         String sanitizedHtml = runSanitizer(html, neuterImages);
-        out.write(sanitizedHtml);
+        if (sanitizedHtml != null) {
+            out.write(sanitizedHtml);
+        }
         out.close();
     }
 

--- a/store/src/java/com/zimbra/cs/html/owasp/OwaspPolicy.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/OwaspPolicy.java
@@ -107,6 +107,7 @@ public class OwaspPolicy {
                 throw new DocumentException(
                     String.format("Problem parsing owasp policy file '%s'", policyFile));
             }
+            ZimbraLog.mailbox.info("OWASP policy '%s' loaded", mPolicyFile);
         } else {
             ZimbraLog.mailbox
                 .warn(String.format("Owasp policy file '%s' is not readable", mPolicyFile));
@@ -137,7 +138,6 @@ public class OwaspPolicy {
      */
     static synchronized void load(String path) throws DocumentException, Exception {
         mOwaspPolicy = new OwaspPolicy(path);
-        ZimbraLog.mailbox.info("OWASP policy '%s' loaded", mPolicyFile);
     }
 
     public static Set<String> getAllowedElements() {

--- a/store/src/java/com/zimbra/cs/html/owasp/policies/BaseElementPolicy.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/policies/BaseElementPolicy.java
@@ -33,7 +33,7 @@ public class BaseElementPolicy implements ElementPolicy {
             String hrefValue = attrs.get(hrefIndex + 1);
             OwaspHtmlSanitizer.zThreadLocal.set(hrefValue);
         }
-        return "base";
+        return null;
     }
 
 }

--- a/store/src/java/com/zimbra/cs/html/owasp/policies/ImgElementPolicy.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/policies/ImgElementPolicy.java
@@ -1,0 +1,55 @@
+package com.zimbra.cs.html.owasp.policies;
+
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2019 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.owasp.html.ElementPolicy;
+
+import com.zimbra.common.localconfig.DebugConfig;
+
+public class ImgElementPolicy implements ElementPolicy {
+
+    private static final Pattern VALID_IMG_FILE = Pattern.compile(DebugConfig.defangValidImgFile);
+    private static final Pattern VALID_INT_IMG = Pattern.compile(DebugConfig.defangValidIntImg,
+        Pattern.CASE_INSENSITIVE);
+    // matches the file format that convertd uses so it doesn't get removed
+    private static final Pattern VALID_CONVERTD_FILE = Pattern
+        .compile(DebugConfig.defangValidConvertdFile);
+
+    @Override
+    public String apply(String elementName, List<String> attrs) {
+        final int srcIndex = attrs.indexOf("src");
+        if (srcIndex == -1) {
+            return "img";
+        }
+        String srcValue = attrs.get(srcIndex + 1);
+        if (!VALID_INT_IMG.matcher(srcValue).find() && VALID_IMG_FILE.matcher(srcValue).find()
+            && !VALID_CONVERTD_FILE.matcher(srcValue).find()) {
+            // Replace src with pnsrc
+            attrs.remove(srcIndex);
+            attrs.remove(srcIndex);// value
+            attrs.add("pnsrc");
+            attrs.add(srcValue);
+        }
+        return "img";
+
+    }
+
+}


### PR DESCRIPTION
Changelist:
1. If the img src contains valid image file name, the src attribute should be converted to pnsrc attribute for client to fetch it from mime part

2. Removing the 'base' tag since we are converting it to absolute paths now, so its not required.

Testing done:
manual testing. Changed unit test for pnsrc.