### PR TITLE
zcs-6542:jetty upgrade to 9.4.15.xxx

### DIFF
--- a/common/ivy.xml
+++ b/common/ivy.xml
@@ -32,8 +32,8 @@
   <dependency org="org.easymock" name="easymock" rev="3.0" />
   <dependency org="cglib" name="cglib" rev="2.2.2" />
   <dependency org="asm" name="asm" rev="3.3.1" />
-  <dependency org="org.eclipse.jetty" name="jetty-rewrite" rev="9.3.5.v20151012" />
-  <dependency org="org.eclipse.jetty" name="jetty-util" rev="9.3.5.v20151012" />
+  <dependency org="org.eclipse.jetty" name="jetty-rewrite" rev="9.4.15.v20190215" />
+  <dependency org="org.eclipse.jetty" name="jetty-util" rev="9.4.15.v20190215" />
   <dependency org="zimbra" name="zm-native" rev="latest.integration" />
   <dependency org="ant-contrib" name="ant-contrib" rev="1.0b3" />
  </dependencies>

--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -46,14 +46,14 @@
   <dependency org="com.googlecode.owasp-java-html-sanitizer" name="owasp-java-html-sanitizer" rev="r239"/>
   <dependency org="org.ehcache" name="ehcache" rev="3.1.2"/>
   <dependency org="ant-1.7.0-ziputil-patched" name="ant-1.7.0-ziputil-patched" rev="1.0"/>
-  <dependency org="org.eclipse.jetty" name="jetty-continuation" rev="9.3.5.v20151012"/>
-  <dependency org="org.eclipse.jetty" name="jetty-security" rev="9.3.5.v20151012"/>
-  <dependency org="org.eclipse.jetty" name="jetty-http" rev="9.3.5.v20151012"/>
-  <dependency org="org.eclipse.jetty" name="jetty-io" rev="9.3.5.v20151012"/>
-  <dependency org="org.eclipse.jetty" name="jetty-server" rev="9.3.5.v20151012"/>
-  <dependency org="org.eclipse.jetty" name="jetty-servlet" rev="9.3.5.v20151012"/>
-  <dependency org="org.eclipse.jetty" name="jetty-servlets" rev="9.3.5.v20151012"/>
-  <dependency org="org.eclipse.jetty" name="jetty-util" rev="9.3.5.v20151012"/>
+  <dependency org="org.eclipse.jetty" name="jetty-continuation" rev="9.4.15.v20190215"/>
+  <dependency org="org.eclipse.jetty" name="jetty-security" rev="9.4.15.v20190215"/>
+  <dependency org="org.eclipse.jetty" name="jetty-http" rev="9.4.15.v20190215"/>
+  <dependency org="org.eclipse.jetty" name="jetty-io" rev="9.4.15.v20190215"/>
+  <dependency org="org.eclipse.jetty" name="jetty-server" rev="9.4.15.v20190215"/>
+  <dependency org="org.eclipse.jetty" name="jetty-servlet" rev="9.4.15.v20190215"/>
+  <dependency org="org.eclipse.jetty" name="jetty-servlets" rev="9.4.15.v20190215"/>
+  <dependency org="org.eclipse.jetty" name="jetty-util" rev="9.4.15.v20190215"/>
   <dependency org="commons-cli" name="commons-cli" rev="1.2"/>
   <dependency org="commons-pool" name="commons-pool" rev="1.6"/>
   <dependency org="commons-dbcp" name="commons-dbcp" rev="1.4"/>

--- a/store/src/java/com/zimbra/cs/service/authenticator/SpnegoAuthenticator.java
+++ b/store/src/java/com/zimbra/cs/service/authenticator/SpnegoAuthenticator.java
@@ -27,6 +27,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.security.DefaultUserIdentity;
 import org.eclipse.jetty.security.LoginService;
 import org.eclipse.jetty.security.SpnegoLoginService;
 import org.eclipse.jetty.security.SpnegoUserIdentity;
@@ -156,7 +157,9 @@ public class SpnegoAuthenticator extends SSOAuthenticator {
                 ZimbraPrincipal zimbraPrincipal = new ZimbraPrincipal(user.getName(), acct);
                 String clientName = ((SpnegoUserPrincipal)user).getName();
                 String role = clientName.substring(clientName.indexOf('@') + 1);
-                SpnegoUserIdentity spnegoUserIdentity = new SpnegoUserIdentity(identity.getSubject(), zimbraPrincipal, Arrays.asList(role));
+                String[] roles = new String[] {role};
+                DefaultUserIdentity defaultUserIdentity = new DefaultUserIdentity(identity.getSubject(), zimbraPrincipal, roles);
+                SpnegoUserIdentity spnegoUserIdentity = new SpnegoUserIdentity(identity.getSubject(), zimbraPrincipal, defaultUserIdentity);
                 Authentication authentication = new UserAuthentication(getAuthType(), spnegoUserIdentity);
                 request.setAuthentication(authentication);
                 response.addHeader(HttpHeader.WWW_AUTHENTICATE.toString(), HttpHeader.NEGOTIATE.toString() + " " + ((SpnegoUserPrincipal)user).getToken());

--- a/store/src/java/com/zimbra/cs/servlet/ZimbraLoginService.java
+++ b/store/src/java/com/zimbra/cs/servlet/ZimbraLoginService.java
@@ -22,11 +22,10 @@ import java.security.Principal;
 import javax.security.auth.Subject;
 import javax.servlet.ServletRequest;
 
+import org.eclipse.jetty.security.AbstractLoginService;
 import org.eclipse.jetty.security.DefaultIdentityService;
 import org.eclipse.jetty.security.IdentityService;
 import org.eclipse.jetty.security.LoginService;
-import org.eclipse.jetty.security.MappedLoginService.KnownUser;
-import org.eclipse.jetty.security.MappedLoginService.RolePrincipal;
 import org.eclipse.jetty.server.UserIdentity;
 import org.eclipse.jetty.util.security.Credential;
 
@@ -125,11 +124,11 @@ public class ZimbraLoginService implements LoginService {
         // only need 'user' role for current implementation protecting
         // /zimbra/downloads - expand to admin if needed later
         String roleName = "user";
-        Principal userPrincipal = new KnownUser(userName, credential);
+        Principal userPrincipal = new AbstractLoginService.UserPrincipal(userName, credential);
         Subject subject = new Subject();
         subject.getPrincipals().add(userPrincipal);
         subject.getPrivateCredentials().add(credential);
-        subject.getPrincipals().add(new RolePrincipal(roleName));
+        subject.getPrincipals().add(new AbstractLoginService.RolePrincipal(roleName));
         subject.setReadOnly();
 
         UserIdentity identity = identityService.newUserIdentity(subject,


### PR DESCRIPTION
issue: related to jetty 9.4.15.xxx
fix : in jetty 9.4.xxx some security related classed has been removed, so fixed all compile time errors. Tested that build passed successfully.

Testing to be done: Test with upgraded jetty version that everything works fine.

Linked PR: 
https://github.com/Zimbra/zm-jetty-conf/pull/4
https://github.com/Zimbra/zm-zcs-lib/pull/42