### PR TITLE
ZCS-7106 GC optimization config defaults

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -577,9 +577,12 @@ public final class LC {
             " -Dorg.apache.jasper.compiler.disablejsr199=true" +
             " -XX:+UseG1GC" +
             " -XX:SoftRefLRUPolicyMSPerMB=1" +
+            " -XX:+UnlockExperimentalVMOptions" +
+            " -XX:G1NewSizePercent=15" +
+            " -XX:G1MaxNewSizePercent=45" +
             " -XX:-OmitStackTraceInFastThrow" +
             " -verbose:gc" +
-            " -Xlog:gc*=debug,safepoint=info:file=/opt/zimbra/log/gc.log:time:filecount=20,filesize=10m");
+            " -Xlog:gc*=info,safepoint=info:file=/opt/zimbra/log/gc.log:time:filecount=20,filesize=10m");
     @Supported
     public static final KnownKey mailboxd_pidfile = KnownKey.newKey("${zimbra_log_directory}/mailboxd.pid");
 


### PR DESCRIPTION
* Few changes to default localconfig mailbox options arguments for G1GC
  * Shift lower/upper boundaries for new young gen size from 5%/60%.
  * Lower gc log level to reduce latency from excess writes.

See jira ticket for load testing results.

This resolves part of the known performance issues, more to go; see ticket for full discussion.