### PR TITLE
ZBUG-527 Check for invalid auth before attempting to refresh item id in cache.

### DIFF
--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -137,6 +137,7 @@ import com.zimbra.common.util.Pair;
 import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.SystemUtil;
 import com.zimbra.common.util.ZimbraHttpConnectionManager;
+import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.common.zclient.ZClientException;
 import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.account.message.AuthRequest;
@@ -1247,6 +1248,13 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
             mTransport.setMaxNotifySeq(0);
             mSize = event.getSize();
             if (root != null) {
+                try {
+                    // skip the cache update if invalid auth/zmailbox instance
+                    mailbox.getAccountId();
+                } catch (ServiceException e) {
+                    ZimbraLog.cache.error("Unable to refresh mailbox item id mappings due to missing auth info.");
+                    return;
+                }
                 mUserRoot = root;
                 addIdMappings(mUserRoot);
             }


### PR DESCRIPTION
* Skip item id cache refresh if the ZMailbox instance cannot acquire account id.
  * Resolves an issue of failing to fetch the account id for each item to be cached in the keying process, which resulted in many GetInfoRequests and lengthy load times when the refresh event was triggered by server side response to various jsp tag soap requests (refresh block in soap response)

**Testing Done**
Local tests with stale state session to trigger refresh.

**Testing to be done by QA**
See jira ticket.