### PR TITLE
zcs-6542 : upgrade jetty to 9.4.18.xxx

### DIFF
--- a/common/ivy.xml
+++ b/common/ivy.xml
@@ -32,8 +32,8 @@
   <dependency org="org.easymock" name="easymock" rev="3.0" />
   <dependency org="cglib" name="cglib" rev="2.2.2" />
   <dependency org="asm" name="asm" rev="3.3.1" />
-  <dependency org="org.eclipse.jetty" name="jetty-rewrite" rev="9.4.15.v20190215" />
-  <dependency org="org.eclipse.jetty" name="jetty-util" rev="9.4.15.v20190215" />
+  <dependency org="org.eclipse.jetty" name="jetty-rewrite" rev="9.4.18.v20190429" />
+  <dependency org="org.eclipse.jetty" name="jetty-util" rev="9.4.18.v20190429" />
   <dependency org="zimbra" name="zm-native" rev="latest.integration" />
   <dependency org="ant-contrib" name="ant-contrib" rev="1.0b3" />
  </dependencies>

--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -46,14 +46,14 @@
   <dependency org="com.googlecode.owasp-java-html-sanitizer" name="owasp-java-html-sanitizer" rev="r239"/>
   <dependency org="org.ehcache" name="ehcache" rev="3.1.2"/>
   <dependency org="ant-1.7.0-ziputil-patched" name="ant-1.7.0-ziputil-patched" rev="1.0"/>
-  <dependency org="org.eclipse.jetty" name="jetty-continuation" rev="9.4.15.v20190215"/>
-  <dependency org="org.eclipse.jetty" name="jetty-security" rev="9.4.15.v20190215"/>
-  <dependency org="org.eclipse.jetty" name="jetty-http" rev="9.4.15.v20190215"/>
-  <dependency org="org.eclipse.jetty" name="jetty-io" rev="9.4.15.v20190215"/>
-  <dependency org="org.eclipse.jetty" name="jetty-server" rev="9.4.15.v20190215"/>
-  <dependency org="org.eclipse.jetty" name="jetty-servlet" rev="9.4.15.v20190215"/>
-  <dependency org="org.eclipse.jetty" name="jetty-servlets" rev="9.4.15.v20190215"/>
-  <dependency org="org.eclipse.jetty" name="jetty-util" rev="9.4.15.v20190215"/>
+  <dependency org="org.eclipse.jetty" name="jetty-continuation" rev="9.4.18.v20190429"/>
+  <dependency org="org.eclipse.jetty" name="jetty-security" rev="9.4.18.v20190429"/>
+  <dependency org="org.eclipse.jetty" name="jetty-http" rev="9.4.18.v20190429"/>
+  <dependency org="org.eclipse.jetty" name="jetty-io" rev="9.4.18.v20190429"/>
+  <dependency org="org.eclipse.jetty" name="jetty-server" rev="9.4.18.v20190429"/>
+  <dependency org="org.eclipse.jetty" name="jetty-servlet" rev="9.4.18.v20190429"/>
+  <dependency org="org.eclipse.jetty" name="jetty-servlets" rev="9.4.18.v20190429"/>
+  <dependency org="org.eclipse.jetty" name="jetty-util" rev="9.4.18.v20190429"/>
   <dependency org="commons-cli" name="commons-cli" rev="1.2"/>
   <dependency org="commons-pool" name="commons-pool" rev="1.6"/>
   <dependency org="commons-dbcp" name="commons-dbcp" rev="1.4"/>


### PR DESCRIPTION
Previously upgraded to 9.4.15.xxx which I have tested with the 9.4.15 package provided by @Prashantsurana  and it was working as expected. As the latest jetty version has been released with 9.4.18.xxx it is better to use it. I have tested with 9.4.18.xxx deb package provided by @rupalid and it is working fine. Tested with ZWC as well as mac outlook. all basic mail functionalities are working fine.

Testing:
QA needs to verify it.

Related PR
https://github.com/Zimbra/zm-mailbox/pull/908