### PR TITLE
ZCS-7327:Fix for CSRF attack through local post

### DIFF
--- a/store/src/java-test/com/zimbra/cs/html/owasp/OwaspHtmlSanitizerTest.java
+++ b/store/src/java-test/com/zimbra/cs/html/owasp/OwaspHtmlSanitizerTest.java
@@ -72,7 +72,7 @@ public class OwaspHtmlSanitizerTest {
         + "            )";
 
     private void defangHtmlString(String html, String expected) throws IOException {
-        String result = new OwaspHtmlSanitizer(html, true).sanitize();
+        String result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertEquals("Defanged HTML result", expected, result);
     }
 
@@ -123,7 +123,7 @@ public class OwaspHtmlSanitizerTest {
         String fileName = "bug_46948.txt";
         InputStream htmlStream = getHtmlBody(fileName);
         String html = CharStreams.toString(new InputStreamReader(htmlStream, Charsets.UTF_8));
-        String result = new OwaspHtmlSanitizer(html, true).sanitize();
+        String result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         // Make sure each area tag has a target
         int index = result.indexOf("<area");
         while (index >= 0) {
@@ -140,39 +140,39 @@ public class OwaspHtmlSanitizerTest {
     @Test
     public void testBug98215() throws Exception {
         String html = "<a href=\"vbscript:alert(parent.csrfToken)\">CLICK</a>";
-        String result = new OwaspHtmlSanitizer(html, true).sanitize();
+        String result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertEquals(result, "CLICK"); // a tag removed
 
         html = "<a href=\"Vbscr&amp;#0009;ip&#009;t:alert(parent.csrfToken)\">CLICK</a>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertTrue(!result.contains("Vbscript:alert(parent.csrfToken)"));
 
         html = "<a href=\"java&amp;Tab;script:alert(parent.csrfToken)\">CLICK</a>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertEquals(result, "CLICK"); // a tag removed
 
         html = "<a href=\"&amp;Tab;javascript:alert(parent.csrfToken)\">CLICK</a>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertEquals(result, "CLICK"); // a tag removed
 
         html = "<a href=\"javascr&amp;#09;ipt:alert(parent.csrfToken)\">CLICK</a>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertTrue(!result.contains("javascript:alert(parent.csrfToken)"));
 
         html = "<form id=\"test\" action=\"javascript:alert(1)\"><p>test</p>"
             + "<button form=\"test\">Test</button></form>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         // action attribute removed
         Assert.assertEquals(result, "<form id=\"test\"><p>test</p><button>Test</button></form>");
 
         html = "<form id=\"test\" action=\"ja&amp;Tab;vascript:alert(1)\"><p>test</p>"
             + "<button form=\"test\">Test</button></form>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         // action attribute removed
         Assert.assertEquals(result, "<form id=\"test\"><p>test</p><button>Test</button></form>");
 
         html = "<a href=\"&amp;#009;java&#00009;scr&amp;#09;i\t\tpt:alert(parent.csrfToken)\">CLICK</a>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertTrue(!result.contains("javascript:alert(parent.csrfToken)"));
     }
 
@@ -186,33 +186,33 @@ public class OwaspHtmlSanitizerTest {
     public void testBug105001() throws Exception {
         String html = "<html><body><div> <a href=\"javascript\n: alert('XSS')\">XSS LINK</a>"
             + "<br data-mce-bogus=\"1\"></div></div></body></html>";
-        String result = new OwaspHtmlSanitizer(html, true).sanitize();
+        String result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertEquals(result, "<html><body><div> XSS LINK<br /></div></body></html>");
 
         html = "<a href=\"vbscript\n\n:alert(parent.csrfToken)\">CLICK</a>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         // a tag removed
         Assert.assertEquals(result, "CLICK");
 
         html = "<a href=\"Vbscr&amp;#0009;ip&#009;t\n\n:alert(parent.csrfToken)\">CLICK</a>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertTrue(!result.contains("Vbscript:alert(parent.csrfToken)"));
 
         html = "<a href=\"Vbscr&amp;#0009;ip&#009;t\r\n:alert(parent.csrfToken)\">CLICK</a>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertTrue(!result.contains("Vbscript:alert(parent.csrfToken)"));
 
         html = "<a href=\"Vbscr&amp;#0009;ip&#009;t\r&#009\n:alert(parent.csrfToken)\">CLICK</a>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertTrue(!result.contains("Vbscript:alert(parent.csrfToken)"));
 
         html = "<html>" + " <body>\n" + " <a href=\"j\n" + " av\n" + " ascript\n" + " :\n"
             + "alert(1)\n" + "\"\n" + ">XSS(1)</a>\n" + "</body>\n" + "</html>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertEquals(result, "<html><body>\n XSS(1)\n</body></html>");
 
         html = "<a href=j&#97;v&#97;script&#x3A;&#97;lert(document.domain)>ClickMe</a>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         // a tag removed
         Assert.assertEquals(result, "ClickMe");
 
@@ -223,70 +223,70 @@ public class OwaspHtmlSanitizerTest {
         String html = "<a href=\"http://ebobby.org/2013/05/18/"
             + "Fun-with-Javascript-and-function-tracing.html\" "
             + "style=\"color: #187AAB; text-decoration: none\" target=\"_blank\">";
-        String result = new OwaspHtmlSanitizer(html, true).sanitize();
+        String result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertTrue(result.contains("Fun-with-Javascript-and-function-tracing.html"));
 
         html = "<a href=\"javascript-and-function-tracing.html\" "
             + "style=\"color: #187AAB; text-decoration: none\" target=\"_blank\">";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertTrue(result.contains("javascript-and-function-tracing.html"));
 
         html = "<a href=\"javascript:myJsFunc()\">Link Text</a>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertFalse(result.contains("javascript"));
 
         html = "<a href=\"javascriptlessDestination.html\" onclick=\"myJSFunc(); "
             + "return false;\">Link text</a>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertTrue(result.contains("javascriptlessDestination.html"));
 
         html = "<a href=\"javascript:alert('Hello');\"></a>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertFalse(result.contains("javascript"));
 
         html = "<a href=\"http://ebobby.org/2013/05/18/" + "javascript/Lessonsinjavascript.html\" "
             + "style=\"color: #187AAB; text-decoration: none\" target=\"_blank\">";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertTrue(result.contains("javascript/Lessonsinjavascript.html"));
 
         html = "<a href='javascript:myFunction()'> Click Me! <a/>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertFalse(result.contains("javascript"));
 
         html = " <a href=\"javascript:void(0)\" onclick=\"loadProducts(<?php echo $categoryId ?>)\"> ";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertFalse(result.contains("javascript"));
 
         html = "<a href=\"#\" onclick=\"someFunction();\" return false;\">LINK</a>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertTrue(result.equals("<a href=\"#\" rel=\"nofollow\">LINK</a>"));
 
         html = "<a href='javascript:my_Function()'> Click Me! <a/>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertFalse(result.contains("javascript"));
 
         html = "<a href='javascript:myFunction(field1, field2)'> Click Me! <a/>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertFalse(result.contains("javascript"));
 
         html = "<a href='javaScript:document.f1.findString(this.t1.value)'>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertFalse(result.contains("javascript"));
 
         html = "<a href='javaScript:document.f1.findString(this.t1.value)'>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertFalse(result.contains("javascript"));
 
         html = "<a href=\"#\" onclick=\"findString(document.getElementById('t1').value); return false;\">Click Me</a>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertTrue(result.contains("<a href=\"#\" rel=\"nofollow\">Click Me</a>"));
 
         html = "<a href=\"javascript:alert('0');\">Click Me</a>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertFalse(result.contains("javascript"));
 
         html = "<a href=\"  javascript:alert('0');\">Click Me</a>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertFalse(result.contains("javascript"));
 
     }
@@ -298,14 +298,14 @@ public class OwaspHtmlSanitizerTest {
     @Test
     public void testBug67537() throws Exception {
         String html = "<html><body><span style=\"color: rgb(255, 0, 0);\">This is RED</span></body></html>";
-        String result = new OwaspHtmlSanitizer(html,true).sanitize();
+        String result = new OwaspHtmlSanitizer(html,true,null).sanitize();
         Assert.assertTrue(result.contains("style=\"color:rgb( 255 , 0 , 0 )\""));
     }
 
     @Test
     public void testBug76500() throws Exception {
         String html = "<blockquote style=\"border-left:2px solid rgb(16, 16, 255);\">";
-        String result = new OwaspHtmlSanitizer(html,true).sanitize();
+        String result = new OwaspHtmlSanitizer(html,true,null).sanitize();
         Assert.assertTrue(result.contains("rgb( 16 , 16 , 255 )"));
     }
 
@@ -314,7 +314,7 @@ public class OwaspHtmlSanitizerTest {
         String html = "<html><head></head><body><table><tr><td><B>javascript-blocked test </B></td>"
             + "</tr><tr><td><a href=\"javascript:alert('Hello!');\">alert</a>"
             + "</td></tr></table></body></html>";
-        String result = new OwaspHtmlSanitizer(html,true).sanitize();
+        String result = new OwaspHtmlSanitizer(html,true,null).sanitize();
         Assert.assertTrue(result
             .contains("<body><table><tbody><tr><td><b>javascript-blocked test </b></td></tr><tr><td>alert</td></tr></tbody></table></body>"));
 
@@ -322,7 +322,7 @@ public class OwaspHtmlSanitizerTest {
             + "<table><tr><td><B>javascript-blocked test</B></td></tr><tr><td>"
             + "<a href=\"javascript:alert('Hello!');\">alert</a></td></tr></table>"
             + "</body></html>";
-        result = new OwaspHtmlSanitizer(html,true).sanitize();
+        result = new OwaspHtmlSanitizer(html,true,null).sanitize();
         Assert.assertTrue(result
                 .contains("<body><table><tbody><tr><td><b>javascript-blocked test</b></td></tr><tr><td>alert</td></tr></tbody></table></body>"));
     }
@@ -331,7 +331,7 @@ public class OwaspHtmlSanitizerTest {
     public void testBug78902() throws Exception {
 
         String html = "<html><head></head><body><a target=\"_blank\" href=\"Neptune.gif\"></a></body></html>";
-        String result = new OwaspHtmlSanitizer(html,true).sanitize();
+        String result = new OwaspHtmlSanitizer(html,true,null).sanitize();
         Assert.assertTrue(result
                 .contains("<a href=\"Neptune.gif\" target=\"_blank\" rel=\"nofollow noopener noreferrer\"></a>"));
 
@@ -339,22 +339,22 @@ public class OwaspHtmlSanitizerTest {
         html = "<html><body>My pictures <a href=\"javascript:document.write('%3C%61%20%68%72%65%66%3D%22%6A%61%76%"
             + "61%73%63%72%69%70%74%3A%61%6C%65%72%74%28%31%29%22%20%6F%6E%4D%6F%75%73%65%4F%76%65%72%3D%61%6C%65%"
             + "72%74%28%5C%22%70%30%77%6E%5C%22%29%3E%4D%6F%75%73%65%20%6F%76%65%72%20%68%65%72%65%3C%2F%61%3E')\">here</a></body></html>";
-        result = new OwaspHtmlSanitizer(html,true).sanitize();
+        result = new OwaspHtmlSanitizer(html,true,null).sanitize();
         Assert.assertEquals(result,
                 "<html><body>My pictures here</body></html>");
 
         html =  "<html><head></head><body><a target=\"_blank\" href=\"Neptune.txt\"></a></body></html>";
-        result = new OwaspHtmlSanitizer(html,true).sanitize();
+        result = new OwaspHtmlSanitizer(html,true,null).sanitize();
         Assert.assertEquals(result,
                 "<html><head></head><body><a href=\"Neptune.txt\" target=\"_blank\" rel=\"nofollow noopener noreferrer\"></a></body></html>");
 
         html =  "<html><head></head><body><a target=\"_blank\" href=\"Neptune.pptx\"></a></body></html>";
-        result = new OwaspHtmlSanitizer(html,true).sanitize();
+        result = new OwaspHtmlSanitizer(html,true,null).sanitize();
         Assert.assertEquals(result,
                 "<html><head></head><body><a href=\"Neptune.pptx\" target=\"_blank\" rel=\"nofollow noopener noreferrer\"></a></body></html>");
 
         html = "<li><a href=\"poc.zip?view=html&archseq=0\">\"/><script>alert(1);</script>AAAAAAAAAA</a></li>";
-        result = new OwaspHtmlSanitizer(html,true).sanitize();
+        result = new OwaspHtmlSanitizer(html,true,null).sanitize();
         Assert.assertTrue(!result
                 .contains("<script>"));
     }
@@ -362,16 +362,16 @@ public class OwaspHtmlSanitizerTest {
     @Test
     public void testBug101813() throws Exception {
         String html = "<textarea><img title=\"</<!-- -->textarea><img src=x onerror=alert(1)></img>";
-        String result = new OwaspHtmlSanitizer(html, true).sanitize();
+        String result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         // make sure that the javascript content is escaped
         Assert.assertTrue(result.contains("onerror&#61;alert(1)&gt;"));
 
         html = "<textarea><IMG title=\"</<!-- -->textarea><img src=x onerror=alert(1)></img>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertTrue(result.contains("onerror&#61;alert(1)&gt;"));
 
         html = "<textarea><   img title=\"</<!-- -->textarea><img src=x onerror=alert(1)></img>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertTrue(result.contains("onerror&#61;alert(1)&gt;"));
     }
 
@@ -384,7 +384,7 @@ public class OwaspHtmlSanitizerTest {
         String fileName = "bug_60769.txt";
         InputStream htmlStream = getHtmlBody(fileName);
         String html = CharStreams.toString(new InputStreamReader(htmlStream, Charsets.UTF_8));
-        String result = new OwaspHtmlSanitizer(html,true).sanitize();
+        String result = new OwaspHtmlSanitizer(html,true,null).sanitize();
         Assert.assertTrue(result.contains("pnsrc=\"image001.gif\""));
     }
 
@@ -398,7 +398,7 @@ public class OwaspHtmlSanitizerTest {
         InputStream htmlStream = getHtmlBody(fileName);
         Assert.assertNotNull(htmlStream);
         String html = CharStreams.toString(new InputStreamReader(htmlStream, Charsets.UTF_8));
-        String result = new OwaspHtmlSanitizer(html,true).sanitize();
+        String result = new OwaspHtmlSanitizer(html,true,null).sanitize();
         // just make sure we made it here, as this was NPEing out..
         Assert.assertNotNull(result);
         // Make sure the input got changed
@@ -415,12 +415,12 @@ public class OwaspHtmlSanitizerTest {
         InputStream htmlStream = getHtmlBody(fileName);
         Assert.assertNotNull(htmlStream);
         String html = CharStreams.toString(new InputStreamReader(htmlStream, Charsets.UTF_8));
-        String result = new OwaspHtmlSanitizer(html,true).sanitize();
+        String result = new OwaspHtmlSanitizer(html,true,null).sanitize();
         Assert.assertNotNull(result);
         Assert.assertFalse(result.contains(" src=\"https://grepular.com/email_privacy_tester/"));
         Assert.assertTrue(result.contains("dfsrc=\"https://grepular.com/email_privacy_tester/"));
 
-        result = new OwaspHtmlSanitizer(html,false).sanitize();
+        result = new OwaspHtmlSanitizer(html,false,null).sanitize();
         Assert.assertNotNull(result);
         Assert.assertTrue(result.contains(" src=\"https://grepular.com/email_privacy_tester/"));
         Assert.assertFalse(result.contains("dfsrc=\"https://grepular.com/email_privacy_tester/"));
@@ -433,7 +433,7 @@ public class OwaspHtmlSanitizerTest {
     @Test
     public void testBug64974() throws Exception {
         String html = "<html><body><![CDATA[--><a href=\"data:text/html;base64,PHNjcmlwdD4KYWxlcnQoZG9jdW1lbnQuY29va2llKQo8L3NjcmlwdD4=\">click</a]]></body></html>";
-        String result = new OwaspHtmlSanitizer(html,true).sanitize();
+        String result = new OwaspHtmlSanitizer(html,true,null).sanitize();
         Assert.assertTrue(result.equals("<html><body>click</body></html>"));
     }
 
@@ -445,12 +445,12 @@ public class OwaspHtmlSanitizerTest {
     public void testBug104666() throws Exception {
         String html = "<div></div><div></div><div id=\"5589f382-9e9b-47cd-ab09-3ea973fd4f6a\" data-marker=\"__SIG_PRE__\">"
             + "<div>LIne 1</div>" + "</div>" + "<div>Line 2</div>" + "</div>";
-        String result = new OwaspHtmlSanitizer(html,true).sanitize();
+        String result = new OwaspHtmlSanitizer(html,true,null).sanitize();
         Assert.assertTrue(result.contains("<div>LIne 1</div></div><div>Line 2</div>"));
 
         html = "<div>Thanks</div><div><img src=\"/home/ews01@zdev-vm002.eng.zimbra.com/Briefcase/rupali.jpeg\" "
                 + "data-mce-src=\"/home/ews01@zdev-vm002.eng.zimbra.com/Briefcase/rupali.jpeg\"></div>";
-        result = new OwaspHtmlSanitizer(html,true).sanitize();
+        result = new OwaspHtmlSanitizer(html,true,null).sanitize();
         Assert.assertTrue(result.contains("data-mce-src=\"/home/ews01"));
     }
 
@@ -463,7 +463,7 @@ public class OwaspHtmlSanitizerTest {
 
         String html = "<div>Thanks</div><div><img src=\"/home/ews01@zdev-vm002.eng.zimbra.com/Briefcase/rupali.jpeg\" "
                 + "data-mce-src=\"/home/ews01@zdev-vm002.eng.zimbra.com/Briefcase/rupali.jpeg\"></div>";
-        String result = new OwaspHtmlSanitizer(html,true).sanitize();
+        String result = new OwaspHtmlSanitizer(html,true,null).sanitize();
         Assert.assertTrue(result.contains("data-mce-src=\"/home/ews01"));
     }
 
@@ -471,52 +471,52 @@ public class OwaspHtmlSanitizerTest {
     public void testBug85478() throws Exception {
         String html = "<a href=\"data:text/html;base64,PHNjcmlwdD5hbGVydCgiSGVsbG8hIik7PC9zY3JpcHQ+\" "
             + "data-mce-href=\"data:text/html;base64,PHNjcmlwdD5hbGVydCgiSGVsbG8hIik7PC9zY3JpcHQ+\">Bug</a>";
-        String result = new OwaspHtmlSanitizer(html, true).sanitize();
+        String result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         // make sure that it removed the href link with 'data' URI
         Assert.assertEquals(result, "Bug");
 
         html = "<a href=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAErkJggg==\" />Bug</a>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertEquals(result, "Bug");
 
         html = "<a target=_blank href=\"data:text/html,<script>alert(opener.document.body.innerHTML)</script>\">"
             + " clickme in Opera/FF</a>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertEquals(result, "<a target=\"_blank\"> clickme in Opera/FF</a>");
 
         html = "<a target=_blank href=\"data.html\"> Data fIle</a>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertTrue(result.contains("data.html"));
 
         html = "<a href=\"data:;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAErkJggg==\" />Bug</a>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertEquals(result, "Bug");
 
         // make sure that it doesn't remove the img src with 'data' URI
         html = "<img src=\"data:image/jpeg;base64,/9j/4AAAAAxITGlubwIQAABtbnRyUkdCI\"><br>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertTrue(
             result.contains("data:image/jpeg;base64,/9j/4AAAAAxITGlubwIQAABtbnRyUkdCI"));
 
         html = "<img src=\"DaTa:image/jpeg;base64,/9j/4AAAAAxITGlubwIQAABtbnRyUkdCI\"><br>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertTrue(
             result.contains("DaTa:image/jpeg;base64,/9j/4AAAAAxITGlubwIQAABtbnRyUkdCI"));
 
         html = "<a href=\"DATA:;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAErkJggg==\" />Bug</a>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertEquals(result, "Bug");
 
         html = "<a href=\"data\n\n:\n\ntext/html;base64,PHNjcmlwdD5hbGVydCgiSGVsbG8hIik7PC9zY3JpcHQ+\">Bug</a>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertEquals(result, "Bug");
 
         html = "<a href=\"data\r\n:text/html;base64,PHNjcmlwdD5hbGVydCgiSGVsbG8hIik7PC9zY3JpcHQ+\">Bug</a>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertEquals(result, "Bug");
 
         html = "<a href=\"data:text/html;base64,PHNjcmlwdD5hbGVydCgiSGVsbG8hIik7PC9zY3JpcHQ+\">Bug</a>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertEquals(result, "Bug");
 
     }
@@ -524,34 +524,30 @@ public class OwaspHtmlSanitizerTest {
     @Test
     public void testBug83999() throws IOException {
 
-        RequestContext reqContext = new RequestContext();
-        reqContext.setVirtualHost("mail.zimbra.com");
-        ZThreadLocal.setContext(reqContext);
-
         String html = "<FORM NAME=\"buy\" ENCTYPE=\"text/plain\" " +
                 "action=\"http://mail.zimbra.com:7070/service/soap/ModifyFilterRulesRequest\" METHOD=\"POST\">";
 
-        String result = new OwaspHtmlSanitizer(html, true).sanitize();
+        String result = new OwaspHtmlSanitizer(html, true, "mail.zimbra.com").sanitize();
 
         Assert.assertTrue(result.contains("SAMEHOSTFORMPOST-BLOCKED"));
 
         html = "<FORM NAME=\"buy\" ENCTYPE=\"text/plain\" "
             + "action=\"http://zimbra.vmware.com:7070/service/soap/ModifyFilterRulesRequest\" METHOD=\"POST\">";
 
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, "mail.zimbra.com").sanitize();
 
         Assert.assertTrue(!result.contains("SAMEHOSTFORMPOST-BLOCKED"));
 
         html = "<FORM NAME=\"buy\" ENCTYPE=\"text/plain\" "
             + "action=\"http://mail.zimbra.com/service/soap/ModifyFilterRulesRequest\" METHOD=\"POST\">";
 
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, "mail.zimbra.com").sanitize();
         Assert.assertTrue(result.contains("SAMEHOSTFORMPOST-BLOCKED"));
 
         html = "<FORM NAME=\"buy\" ENCTYPE=\"text/plain\" "
             + "action=\"/service/soap/ModifyFilterRulesRequest\" METHOD=\"POST\">";
 
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, "mail.zimbra.com").sanitize();
         Assert.assertTrue(result.contains("SAMEHOSTFORMPOST-BLOCKED"));
 
         ZThreadLocal.unset();
@@ -566,7 +562,7 @@ public class OwaspHtmlSanitizerTest {
                 + "#114&amp;#105&amp;#112&amp;#116&amp;#058&amp;#097&amp;#108&amp;#101&amp;#114&amp;#116&amp;#040&amp;"
                 + "#039&amp;#088&amp;#083&amp;#083&amp;#039&amp;#041\">test</a><br data-mce-bogus=\"1\"></div><div>"
                 + "<br data-mce-bogus=\"1\"></div><div>Test message<br data-mce-bogus=\"1\"></div></div></body></html>";
-        String result = new OwaspHtmlSanitizer(html, true).sanitize();
+        String result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertTrue(!result.contains("javascript:alert('XSS')"));
         Assert.assertTrue(result.contains("&amp;#106&amp;#097&amp;#118&amp;#097&amp;#115&amp;#099&amp;#114&amp;#105&amp;#112&amp;#116&amp;#058&amp;#097&amp;#108&amp;#101&amp;#114&amp;#116&amp;#040&amp;#039&amp;#088&amp;#083&amp;#083&amp;#039&amp;#041"));
     }
@@ -576,24 +572,24 @@ public class OwaspHtmlSanitizerTest {
         String html = "<html><head></head><body><a target=\"_blank\"" +
         " href=\"smb://Aurora._smb._tcp.local/untitled/folder/03 DANDIYA MIX.mp3\"></a></body></html>";
         String hrefVal = "smb://Aurora._smb._tcp.local/untitled/folder/03%20DANDIYA%20MIX.mp3";
-        String result = new OwaspHtmlSanitizer(html, true).sanitize();
+        String result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertTrue(result.contains(hrefVal));
 
         html = "<html><head></head><body><a target=\"_blank\"" +
             " href=\"smb://Aurora._smb._tcp.local/untitled/folder/03%20DANDIYA%20MIX.mp3\"></a></body></html>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertTrue(result.contains(hrefVal));
 
         html = "<html><head></head><body><a target=\"_blank\"" +
             " href=\"//Shared_srv/folder/file.txt\"></a></body></html>";
         hrefVal = "//Shared_srv/folder/file.txt";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertTrue(result.contains(hrefVal));
 
         html = "<html><head></head><body><a target=\"_blank\"" +
             " href=\"//Shared_srv/folder/file with spaces.txt\"></a></body></html>";
         hrefVal = "//Shared_srv/folder/file%20with%20spaces.txt";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertTrue(result.contains(hrefVal));
     }
 
@@ -602,7 +598,7 @@ public class OwaspHtmlSanitizerTest {
         String fileName = "bug_73874.txt";
         InputStream htmlStream = getHtmlBody(fileName);
         String html = CharStreams.toString(new InputStreamReader(htmlStream, Charsets.UTF_8));
-        String result = new OwaspHtmlSanitizer(html, true).sanitize();
+        String result = new OwaspHtmlSanitizer(html, true, null).sanitize();
 
         // and make sure we have the the complete URL for
         Assert.assertTrue(result
@@ -615,7 +611,7 @@ public class OwaspHtmlSanitizerTest {
             + "<img  width=\"100\"  src=\"/download/thumbnails/27132023/Screen+Shot+"
             + "2012-05-02+at+08.08.12+AM.png?version=3D1&modificationDate=3D1335967057"
             + "000\"/></body></html>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertTrue(result
                 .contains("https://wiki.tomsawyer.com/download/thumbnails/27132023/Screen&#43;Shot&#43;2012-05-02&#43;at&#43;08.08.12&#43;"
               + "AM.png?version&#61;3D1&amp;modificationDate&#61;3D1335967057000"));
@@ -626,7 +622,7 @@ public class OwaspHtmlSanitizerTest {
             + "<img  width=\"100\"  src=\"download/thumbnails/27132023/Screen+Shot+"
             + "2012-05-02+at+08.08.12+AM.png?version=3D1&modificationDate=3D1335967057"
             + "000\"/></body></html>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertTrue(result
                 .contains("https://wiki.tomsawyer.com/download/thumbnails/27132023/Screen&#43;Shot&#43;2012-05-02&#43;at&#43;08.08.12&#43;"
               + "AM.png?version&#61;3D1&amp;modificationDate&#61;3D1335967057000"));
@@ -636,7 +632,7 @@ public class OwaspHtmlSanitizerTest {
             + "</head><body>"
             + "<img  width=\"100\"  src=\"download/thumbnails/27132023/Screen+Shot+"
             + "2012-05-02+at+08.08.12+AM.png?version=3D1\"/></body></html>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertTrue(result
                 .contains("https://wiki.tomsawyer.com/download/thumbnails/27132023/Screen&#43;Shot&#43;2012-05-02&#43;at&#43;08.08.12&#43;"
               + "AM.png?version&#61;3D1"));
@@ -646,7 +642,7 @@ public class OwaspHtmlSanitizerTest {
             + "</head><body>"
             + "<img  width=\"100\"  src=\"download/thumbnails/27132023/Screen+Shot+"
             + "2012-05-02+at+08.08.12+AM.png\"/></body></html>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertTrue(result
                 .contains("https://wiki.tomsawyer.com/download/thumbnails/27132023/Screen&#43;Shot&#43;2012-05-02&#43;at&#43;08.08.12&#43;"
               + "AM.png"));
@@ -655,7 +651,7 @@ public class OwaspHtmlSanitizerTest {
         html = "<html><head><base href=\"https://wiki.tomsawyer.com/\" />"
             + "</head><body>"
             + "<img  width=\"100\"  src=\"download/thumbnails/27132023/Screen+Shot.pngTest.gif\"/></body></html>";
-        result = new OwaspHtmlSanitizer(html, true).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertTrue(!result
                 .contains("https://wiki.tomsawyer.com/download/thumbnails/27132023/Screen&#43;Shot&#43;2012-05-02&#43;at&#43;08.08.12&#43;"
               + "AM.png"));
@@ -666,7 +662,7 @@ public class OwaspHtmlSanitizerTest {
         String html = "<div><img pnsrc=\"cid:1040f05975d4d4b8fcf8747be3eb9ae3c08e5cd4@zimbra\" "
             + "data-mce-src=\"cid:1040f05975d4d4b8fcf8747be3eb9ae3c08e5cd4@zimbra\" "
             + "src=\"cid:1040f05975d4d4b8fcf8747be3eb9ae3c08e5cd4@zimbra\"></div>";
-        String result = new OwaspHtmlSanitizer(html, true).sanitize();
+        String result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertTrue(!result.contains("@zimbra"));
         Assert.assertTrue(result.contains("&#64;zimbra"));
     }

--- a/store/src/java/com/zimbra/cs/html/owasp/OwaspDefang.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/OwaspDefang.java
@@ -34,6 +34,7 @@ import com.google.common.io.CharStreams;
 import com.zimbra.common.localconfig.DebugConfig;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.html.AbstractDefang;
+import com.zimbra.cs.servlet.ZThreadLocal;
 
 public class OwaspDefang extends AbstractDefang {
 
@@ -59,7 +60,11 @@ public class OwaspDefang extends AbstractDefang {
     }
 
     private String runSanitizer(String html, boolean neuterImages) {
-        Callable<String> task = new OwaspHtmlSanitizer(html, neuterImages);
+        String vHost = null;
+        if (ZThreadLocal.getRequestContext() != null) {
+            vHost = ZThreadLocal.getRequestContext().getVirtualHost();
+        }
+        Callable<String> task = new OwaspHtmlSanitizer(html, neuterImages, vHost);
         Future<String> future = executor.submit(task);
         String sanitizedHtml = null;
         try {

--- a/store/src/java/com/zimbra/cs/html/owasp/OwaspThreadLocal.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/OwaspThreadLocal.java
@@ -14,25 +14,27 @@
  * If not, see <https://www.gnu.org/licenses/>.
  * ***** END LICENSE BLOCK *****
  */
-package com.zimbra.cs.html.owasp.policies;
+package com.zimbra.cs.html.owasp;
 
-import java.util.List;
+public class OwaspThreadLocal {
 
-import org.owasp.html.ElementPolicy;
+    private String baseHref;
 
-import com.zimbra.cs.html.owasp.OwaspHtmlSanitizer;
+    private String vHost;
 
-public class BaseElementPolicy implements ElementPolicy {
-
-    @Override
-    public String apply(String elementName, List<String> attrs) {
-
-        final int hrefIndex = attrs.indexOf("href");
-        if (hrefIndex != -1) {
-            String hrefValue = attrs.get(hrefIndex + 1);
-            OwaspHtmlSanitizer.zThreadLocal.get().setBaseHref(hrefValue);
-        }
-        return null;
+    public String getBaseHref() {
+        return baseHref;
     }
 
+    public void setBaseHref(String baseHref) {
+        this.baseHref = baseHref;
+    }
+
+    public String getVHost() {
+        return vHost;
+    }
+
+    public void setVHost(String vHost) {
+        this.vHost = vHost;
+    }
 }

--- a/store/src/java/com/zimbra/cs/html/owasp/policies/AElementPolicy.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/policies/AElementPolicy.java
@@ -1,5 +1,3 @@
-package com.zimbra.cs.html.owasp.policies;
-
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
@@ -16,6 +14,7 @@ package com.zimbra.cs.html.owasp.policies;
  * If not, see <https://www.gnu.org/licenses/>.
  * ***** END LICENSE BLOCK *****
  */
+package com.zimbra.cs.html.owasp.policies;
 
 import java.util.List;
 
@@ -53,7 +52,7 @@ public class AElementPolicy implements ElementPolicy {
 
         hrefIndex = attrs.indexOf("href");
         hrefValue = attrs.get(hrefIndex + 1);
-        String base = OwaspHtmlSanitizer.zThreadLocal.get();
+        String base = OwaspHtmlSanitizer.zThreadLocal.get().getBaseHref();
         if (base != null && hrefValue != null) {
             URI baseHrefURI = null;
             try {

--- a/store/src/java/com/zimbra/cs/html/owasp/policies/ActionAttributePolicy.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/policies/ActionAttributePolicy.java
@@ -1,5 +1,3 @@
-package com.zimbra.cs.html.owasp.policies;
-
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
@@ -16,6 +14,8 @@ package com.zimbra.cs.html.owasp.policies;
  * If not, see <https://www.gnu.org/licenses/>.
  * ***** END LICENSE BLOCK *****
  */
+package com.zimbra.cs.html.owasp.policies;
+
 import java.net.MalformedURLException;
 import java.net.URL;
 
@@ -23,7 +23,8 @@ import org.owasp.html.AttributePolicy;
 
 import com.zimbra.common.localconfig.DebugConfig;
 import com.zimbra.common.util.ZimbraLog;
-import com.zimbra.cs.servlet.ZThreadLocal;
+import com.zimbra.cs.html.owasp.OwaspHtmlSanitizer;
+import com.zimbra.cs.html.owasp.OwaspThreadLocal;
 
 public class ActionAttributePolicy implements AttributePolicy {
 
@@ -33,9 +34,10 @@ public class ActionAttributePolicy implements AttributePolicy {
     @Override
     public String apply(String elementName, String attributeName, String value) {
         // The Host header received in the request.
+        OwaspThreadLocal threadLocalInstance = OwaspHtmlSanitizer.zThreadLocal.get();
         String reqVirtualHost = null;
-        if (ZThreadLocal.getRequestContext() != null) {
-            reqVirtualHost = ZThreadLocal.getRequestContext().getVirtualHost();
+        if (threadLocalInstance != null) {
+            reqVirtualHost = OwaspHtmlSanitizer.zThreadLocal.get().getVHost();
         }
         if (sameHostFormPostCheck && reqVirtualHost != null) {
             try {

--- a/store/src/java/com/zimbra/cs/html/owasp/policies/AreaElementPolicy.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/policies/AreaElementPolicy.java
@@ -1,5 +1,3 @@
-package com.zimbra.cs.html.owasp.policies;
-
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
@@ -16,6 +14,7 @@ package com.zimbra.cs.html.owasp.policies;
  * If not, see <https://www.gnu.org/licenses/>.
  * ***** END LICENSE BLOCK *****
  */
+package com.zimbra.cs.html.owasp.policies;
 
 import java.util.List;
 
@@ -53,7 +52,7 @@ public class AreaElementPolicy implements ElementPolicy {
 
         hrefIndex = attrs.indexOf("href");
         hrefValue = attrs.get(hrefIndex + 1);
-        String base = OwaspHtmlSanitizer.zThreadLocal.get();
+        String base = OwaspHtmlSanitizer.zThreadLocal.get().getBaseHref();
         if (base != null && hrefValue != null) {
             URI baseHrefURI = null;
             try {

--- a/store/src/java/com/zimbra/cs/servlet/CsrfFilter.java
+++ b/store/src/java/com/zimbra/cs/servlet/CsrfFilter.java
@@ -153,6 +153,12 @@ public class CsrfFilter implements Filter {
             }
         }
 
+        // We need virtual host information in DefangFilter
+        // Set them in ThreadLocal here
+        RequestContext reqCtxt = new RequestContext();
+        String host = CsrfUtil.getRequestHost(req);
+        reqCtxt.setVirtualHost(host);
+        ZThreadLocal.setContext(reqCtxt);
         if (!csrfCheckEnabled) {
             req.setAttribute(CSRF_TOKEN_CHECK, Boolean.FALSE);
             chain.doFilter(req, resp);
@@ -168,19 +174,7 @@ public class CsrfFilter implements Filter {
             }
             chain.doFilter(req, resp);
         }
-
-        try {
-            // We need virtual host information in DefangFilter
-            // Set them in ThreadLocal here
-            RequestContext reqCtxt = new RequestContext();
-            String host = CsrfUtil.getRequestHost(req);
-            reqCtxt.setVirtualHost(host);
-            ZThreadLocal.setContext(reqCtxt);
-
-        } finally {
-            // Unset the variables set in thread local
-            ZThreadLocal.unset();
-        }
+        ZThreadLocal.unset();
 
     }
 


### PR DESCRIPTION
Fixed CSRF attack issue.

If form action URL contains the same host, the request is blocked by replacing it with 'SAMEHOSTFORMPOST-BLOCKED'

Testing done: 
Manual testing done. The URL host getting replaced with SAMEHOSTFORMPOST-BLOCKED if the virtual host is same.
Changed unit tests. Unit tests are passing.