### PR TITLE
ZBUG-1017: modifyDataSource doesn't check the existence of zimbraDataSourceEmailAddress

### DIFF
--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -8576,6 +8576,17 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
         if (ds == null)
             throw AccountServiceException.NO_SUCH_DATA_SOURCE(dataSourceId);
 
+        List<DataSource> existing = getAllDataSources(account);
+
+        String dsEmailAddr = (String) attrs.get(A_zimbraDataSourceEmailAddress);
+        if (!StringUtil.isNullOrEmpty(dsEmailAddr)) {
+            for (DataSource datasource : existing) {
+                if (dsEmailAddr.equals(datasource.getEmailAddress())) {
+                    throw AccountServiceException.DATA_SOURCE_EXISTS(dsEmailAddr);
+                }
+            }
+        }
+
         account.setCachedData(DATA_SOURCE_LIST_CACHE_KEY, null);
 
         attrs.remove(A_zimbraDataSourceId);

--- a/store/src/java/com/zimbra/qa/unittest/prov/ldap/TestLdapProvDataSource.java
+++ b/store/src/java/com/zimbra/qa/unittest/prov/ldap/TestLdapProvDataSource.java
@@ -141,7 +141,37 @@ public class TestLdapProvDataSource extends LdapTest {
         deleteDataSource(acct,dataSource);
         deleteAccount(acct);
     }
-    
+
+    @Test
+    public void modifyDataSourceAlreadyExists() throws Exception {
+        String ACCT_NAME_LOCALPART = Names.makeAccountNameLocalPart(genAcctNameLocalPart());
+        String DATA_SOURCE_NAME = Names.makeDataSourceName(genDataSourceName());
+        String DATA_SOURCE_NAME_2 = Names.makeDataSourceName(genDataSourceName());
+
+        Account acct = createAccount(ACCT_NAME_LOCALPART);
+        DataSource dataSource = createDataSource(acct, DATA_SOURCE_NAME);
+        DataSource dataSource2 = createDataSource(acct, DATA_SOURCE_NAME_2);
+
+        Map<String, Object> attrs = new HashMap<String, Object>();
+        String MODIFIED_ATTR_NAME = Provisioning.A_zimbraDataSourceEmailAddress;
+        String MODIFIED_ATTR_VALUE = dataSource.getEmailAddress();
+        attrs.put(MODIFIED_ATTR_NAME, MODIFIED_ATTR_VALUE);
+
+        boolean caughtException = false;
+        try {
+            prov.modifyDataSource(acct, dataSource2.getId(), attrs);
+        } catch (AccountServiceException e) {
+            if (AccountServiceException.DATA_SOURCE_EXISTS.equals(e.getCode())) {
+                caughtException = true;
+            }
+        }
+        assertTrue(caughtException);
+
+        deleteDataSource(acct, dataSource);
+        deleteDataSource(acct, dataSource2);
+        deleteAccount(acct);
+    }
+
     @Test
     public void renameDataSource() throws Exception {
         String ACCT_NAME_LOCALPART = Names.makeAccountNameLocalPart(genAcctNameLocalPart());


### PR DESCRIPTION
Made fixes so that the existence of zimbraDataSourceEmailAddress is checked not only createDataSource but also at modifyDataSource