### PR TITLE
ZBUG-1017: update business logic for email address check

### DIFF
--- a/store/src/java-test/com/zimbra/cs/account/MockProvisioning.java
+++ b/store/src/java-test/com/zimbra/cs/account/MockProvisioning.java
@@ -781,7 +781,7 @@ public final class MockProvisioning extends Provisioning {
             return result;
         }
 
-        return new ArrayList<>();
+        return new ArrayList<DataSource>();
     }
 
     @Override

--- a/store/src/java-test/com/zimbra/cs/service/mail/ModifyDataSourceTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/mail/ModifyDataSourceTest.java
@@ -1,0 +1,121 @@
+package com.zimbra.cs.service.mail;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+
+import org.junit.Rule;
+//import org.junit.jupiter.api.Test;
+
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+
+import com.google.common.collect.Maps;
+import com.zimbra.common.account.Key;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.MailConstants;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.MockProvisioning;
+import com.zimbra.cs.account.Provisioning;
+
+import com.zimbra.cs.ldap.LdapConstants;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.service.mail.ModifyDataSource;
+import com.zimbra.soap.type.DataSource.ConnectionType;
+
+public class ModifyDataSourceTest {
+
+    @Rule
+    public static TestName testInfo = new TestName();
+
+    private static String NAME_PREFIX;
+
+    @BeforeClass
+    public static void init() throws Exception {
+        MailboxTestUtil.initServer();
+        MockProvisioning prov = new MockProvisioning();
+        Provisioning.setInstance(prov);
+
+        Map<String, Object> attrs = Maps.newHashMap();
+        prov.createDomain("zimbra.com", attrs);
+
+        attrs = Maps.newHashMap();
+        prov.createAccount("test@zimbra.com", "secret", attrs);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        NAME_PREFIX = String.format("%s-%s", ModifyDataSourceTest.class.getSimpleName(), testInfo.getMethodName()).toLowerCase();
+        MailboxTestUtil.clearData();
+    }
+
+
+    @Test
+    public void testValidateDataSourceEmail() {
+
+        Account acct = null;
+        try {
+            acct = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
+        } catch (ServiceException e3) {
+            e3.printStackTrace();
+        }
+
+        Element request = new Element.XMLElement(MailConstants.E_CREATE_DATA_SOURCE_REQUEST);
+
+        Element ds1 = request.addUniqueElement(MailConstants.E_DS_POP3);
+
+        ds1.addAttribute(MailConstants.A_NAME, NAME_PREFIX + " testDataSourceEmailAddress1");
+        ds1.addAttribute(MailConstants.A_DS_IS_ENABLED, LdapConstants.LDAP_FALSE);
+        ds1.addAttribute(MailConstants.A_DS_HOST, "testhost.com");
+        ds1.addAttribute(MailConstants.A_DS_PORT, "0");
+        ds1.addAttribute(MailConstants.A_DS_USERNAME, "testuser1");
+        ds1.addAttribute(MailConstants.A_DS_EMAIL_ADDRESS, "testuser2@testhost.com");
+        ds1.addAttribute(MailConstants.A_DS_PASSWORD, "testpass");
+        ds1.addAttribute(MailConstants.A_FOLDER, "1");
+        ds1.addAttribute(MailConstants.A_DS_CONNECTION_TYPE, ConnectionType.cleartext.toString());
+       
+        try {
+            new CreateDataSource().handle(request, ServiceTestUtil.getRequestContext(acct));
+        } catch (Exception e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+        Element request2 = new Element.XMLElement(MailConstants.E_CREATE_DATA_SOURCE_REQUEST);
+
+        Element ds2 = request2.addUniqueElement(MailConstants.E_DS_POP3);
+
+        ds2.addAttribute(MailConstants.A_NAME, NAME_PREFIX + " testDataSourceEmailAddress2");
+        ds2.addAttribute(MailConstants.A_DS_IS_ENABLED, LdapConstants.LDAP_FALSE);
+        ds2.addAttribute(MailConstants.A_DS_HOST, "testhost.com");
+        ds2.addAttribute(MailConstants.A_DS_PORT, "0");
+        ds2.addAttribute(MailConstants.A_DS_USERNAME, "testuser2");
+        ds2.addAttribute(MailConstants.A_DS_EMAIL_ADDRESS, "testuser3@testhost.com");
+        ds2.addAttribute(MailConstants.A_DS_PASSWORD, "testpass");
+        ds2.addAttribute(MailConstants.A_FOLDER, "1");
+        ds2.addAttribute(MailConstants.A_DS_CONNECTION_TYPE, ConnectionType.cleartext.toString());
+       
+        try {
+            new CreateDataSource().handle(request2, ServiceTestUtil.getRequestContext(acct));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        ds1.addAttribute(MailConstants.A_DS_EMAIL_ADDRESS, "testuser3@testhost.com");
+
+       try {
+            ModifyDataSource.validateDataSourceEmail(acct, ds1);
+        } catch (ServiceException e) {
+            String expected = "data source already exists: testuser3@testhost.com";
+            assertTrue(e.getMessage().indexOf(expected)  != -1);
+            assertNotNull(e);
+        }
+
+    }
+
+}

--- a/store/src/java-test/com/zimbra/cs/service/mail/ModifyDataSourceTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/mail/ModifyDataSourceTest.java
@@ -1,7 +1,25 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2019 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
 package com.zimbra.cs.service.mail;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.Map;
 
@@ -58,64 +76,55 @@ public class ModifyDataSourceTest {
 
     @Test
     public void testValidateDataSourceEmail() {
-
-        Account acct = null;
         try {
+            Account acct = null;
             acct = Provisioning.getInstance().get(Key.AccountBy.name, "test@zimbra.com");
-        } catch (ServiceException e3) {
-            e3.printStackTrace();
-        }
 
-        Element request = new Element.XMLElement(MailConstants.E_CREATE_DATA_SOURCE_REQUEST);
+            Element request = new Element.XMLElement(MailConstants.E_CREATE_DATA_SOURCE_REQUEST);
 
-        Element ds1 = request.addUniqueElement(MailConstants.E_DS_POP3);
+            Element ds1 = request.addUniqueElement(MailConstants.E_DS_POP3);
 
-        ds1.addAttribute(MailConstants.A_NAME, NAME_PREFIX + " testDataSourceEmailAddress1");
-        ds1.addAttribute(MailConstants.A_DS_IS_ENABLED, LdapConstants.LDAP_FALSE);
-        ds1.addAttribute(MailConstants.A_DS_HOST, "testhost.com");
-        ds1.addAttribute(MailConstants.A_DS_PORT, "0");
-        ds1.addAttribute(MailConstants.A_DS_USERNAME, "testuser1");
-        ds1.addAttribute(MailConstants.A_DS_EMAIL_ADDRESS, "testuser2@testhost.com");
-        ds1.addAttribute(MailConstants.A_DS_PASSWORD, "testpass");
-        ds1.addAttribute(MailConstants.A_FOLDER, "1");
-        ds1.addAttribute(MailConstants.A_DS_CONNECTION_TYPE, ConnectionType.cleartext.toString());
-       
-        try {
+            ds1.addAttribute(MailConstants.A_NAME, NAME_PREFIX + " testDataSourceEmailAddress1");
+            ds1.addAttribute(MailConstants.A_DS_IS_ENABLED, LdapConstants.LDAP_FALSE);
+            ds1.addAttribute(MailConstants.A_DS_HOST, "testhost.com");
+            ds1.addAttribute(MailConstants.A_DS_PORT, "0");
+            ds1.addAttribute(MailConstants.A_DS_USERNAME, "testuser1");
+            ds1.addAttribute(MailConstants.A_DS_EMAIL_ADDRESS, "testuser2@testhost.com");
+            ds1.addAttribute(MailConstants.A_DS_PASSWORD, "testpass");
+            ds1.addAttribute(MailConstants.A_FOLDER, "1");
+            ds1.addAttribute(MailConstants.A_DS_CONNECTION_TYPE, ConnectionType.cleartext.toString());
+
             new CreateDataSource().handle(request, ServiceTestUtil.getRequestContext(acct));
-        } catch (Exception e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
-        Element request2 = new Element.XMLElement(MailConstants.E_CREATE_DATA_SOURCE_REQUEST);
 
-        Element ds2 = request2.addUniqueElement(MailConstants.E_DS_POP3);
+            Element request2 = new Element.XMLElement(MailConstants.E_CREATE_DATA_SOURCE_REQUEST);
 
-        ds2.addAttribute(MailConstants.A_NAME, NAME_PREFIX + " testDataSourceEmailAddress2");
-        ds2.addAttribute(MailConstants.A_DS_IS_ENABLED, LdapConstants.LDAP_FALSE);
-        ds2.addAttribute(MailConstants.A_DS_HOST, "testhost.com");
-        ds2.addAttribute(MailConstants.A_DS_PORT, "0");
-        ds2.addAttribute(MailConstants.A_DS_USERNAME, "testuser2");
-        ds2.addAttribute(MailConstants.A_DS_EMAIL_ADDRESS, "testuser3@testhost.com");
-        ds2.addAttribute(MailConstants.A_DS_PASSWORD, "testpass");
-        ds2.addAttribute(MailConstants.A_FOLDER, "1");
-        ds2.addAttribute(MailConstants.A_DS_CONNECTION_TYPE, ConnectionType.cleartext.toString());
-       
-        try {
+            Element ds2 = request2.addUniqueElement(MailConstants.E_DS_POP3);
+
+            ds2.addAttribute(MailConstants.A_NAME, NAME_PREFIX + " testDataSourceEmailAddress2");
+            ds2.addAttribute(MailConstants.A_DS_IS_ENABLED, LdapConstants.LDAP_FALSE);
+            ds2.addAttribute(MailConstants.A_DS_HOST, "testhost.com");
+            ds2.addAttribute(MailConstants.A_DS_PORT, "0");
+            ds2.addAttribute(MailConstants.A_DS_USERNAME, "testuser2");
+            ds2.addAttribute(MailConstants.A_DS_EMAIL_ADDRESS, "testuser3@testhost.com");
+            ds2.addAttribute(MailConstants.A_DS_PASSWORD, "testpass");
+            ds2.addAttribute(MailConstants.A_FOLDER, "1");
+            ds2.addAttribute(MailConstants.A_DS_CONNECTION_TYPE, ConnectionType.cleartext.toString());
+
             new CreateDataSource().handle(request2, ServiceTestUtil.getRequestContext(acct));
+
+            // try to modify data source 1 to have an existing data source email address.
+            ds1.addAttribute(MailConstants.A_DS_EMAIL_ADDRESS, "testuser3@testhost.com");
+
+           try {
+                ModifyDataSource.validateDataSourceEmail(acct, ds1);
+            } catch (ServiceException e) {
+                String expected = "data source already exists: testuser3@testhost.com";
+                assertTrue(e.getMessage().indexOf(expected)  != -1);
+                assertNotNull(e);
+            }
         } catch (Exception e) {
-            e.printStackTrace();
+            fail("No exception should be thrown" + e);
         }
-
-        ds1.addAttribute(MailConstants.A_DS_EMAIL_ADDRESS, "testuser3@testhost.com");
-
-       try {
-            ModifyDataSource.validateDataSourceEmail(acct, ds1);
-        } catch (ServiceException e) {
-            String expected = "data source already exists: testuser3@testhost.com";
-            assertTrue(e.getMessage().indexOf(expected)  != -1);
-            assertNotNull(e);
-        }
-
     }
 
 }

--- a/store/src/java-test/com/zimbra/cs/service/mail/ModifyDataSourceTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/mail/ModifyDataSourceTest.java
@@ -115,6 +115,7 @@ public class ModifyDataSourceTest {
 
            try {
                 ModifyDataSource.validateDataSourceEmail(acct, ds1);
+                fail("datasource email validation failed");
             } catch (ServiceException e) {
                 String expected = "data source already exists: testuser3@testhost.com";
                 assertTrue(e.getMessage().indexOf(expected)  != -1);

--- a/store/src/java-test/com/zimbra/cs/service/mail/ModifyDataSourceTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/mail/ModifyDataSourceTest.java
@@ -24,11 +24,9 @@ import static org.junit.Assert.fail;
 import java.util.Map;
 
 import org.junit.Rule;
-//import org.junit.jupiter.api.Test;
 
 import org.junit.Test;
 import org.junit.rules.TestName;
-
 
 import org.junit.Before;
 import org.junit.BeforeClass;

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -8431,14 +8431,6 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
         if (existing.size() >= account.getLongAttr(A_zimbraDataSourceMaxNumEntries, 20)) {
             throw AccountServiceException.TOO_MANY_DATA_SOURCES();
         }
-        String dsEmailAddr = (String) dataSourceAttrs.get(A_zimbraDataSourceEmailAddress);
-        if (!StringUtil.isNullOrEmpty(dsEmailAddr)) {
-            for (DataSource ds : existing) {
-                if (dsEmailAddr.equals(ds.getEmailAddress())) {
-                    throw AccountServiceException.DATA_SOURCE_EXISTS(dsEmailAddr);
-                }
-            }
-        }
 
         dataSourceAttrs.put(A_zimbraDataSourceName, dsName); // must be the same
         dataSourceAttrs.put(Provisioning.A_zimbraDataSourceType, dsType.toString());

--- a/store/src/java/com/zimbra/cs/service/mail/CreateDataSource.java
+++ b/store/src/java/com/zimbra/cs/service/mail/CreateDataSource.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016 Synacor, Inc.
+ * Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2019 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -29,8 +29,10 @@ import com.zimbra.common.account.ZAttrProvisioning.DataSourceAuthMechanism;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.MailConstants;
+import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.AccountServiceException;
 import com.zimbra.cs.account.DataSource;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.datasource.DataSourceListner;
@@ -109,7 +111,7 @@ public class CreateDataSource extends MailDocumentHandler {
         processSmtpAttrs(dsAttrs, eDataSource, false, null);
 
         // Common optional attributes
-        ModifyDataSource.processCommonOptionalAttrs(dsAttrs, eDataSource);
+        ModifyDataSource.processCommonOptionalAttrs(account, dsAttrs, eDataSource);
 
         // POP3-specific attributes
         if (type == DataSourceType.pop3) {
@@ -249,6 +251,21 @@ public class CreateDataSource extends MailDocumentHandler {
                         }
                 }
             } catch (NoSuchItemException ignored) {
+            }
+        }
+    }
+    /**
+     * Confirms that the zimbraDataSourceEmailAddress attribute is unique
+     * 
+     */
+    static void validateEmailAddr(Account account, Element eDataSource)
+    throws ServiceException {
+        String dsEmailAddr = eDataSource.getAttribute(MailConstants.A_DS_EMAIL_ADDRESS, null);
+        if (!StringUtil.isNullOrEmpty(dsEmailAddr)) {
+            for (DataSource ds : account.getAllDataSources()) {
+                if (dsEmailAddr.equals(ds.getEmailAddress())) {
+                    throw AccountServiceException.DATA_SOURCE_EXISTS(dsEmailAddr);
+                }
             }
         }
     }

--- a/store/src/java/com/zimbra/cs/service/mail/CreateDataSource.java
+++ b/store/src/java/com/zimbra/cs/service/mail/CreateDataSource.java
@@ -258,7 +258,7 @@ public class CreateDataSource extends MailDocumentHandler {
      * Confirms that the zimbraDataSourceEmailAddress attribute is unique
      * 
      */
-    static void validateEmailAddr(Account account, Element eDataSource)
+    default static void validateEmailAddr(Account account, Element eDataSource)
     throws ServiceException {
         String dsEmailAddr = eDataSource.getAttribute(MailConstants.A_DS_EMAIL_ADDRESS, null);
         if (!StringUtil.isNullOrEmpty(dsEmailAddr)) {

--- a/store/src/java/com/zimbra/cs/service/mail/CreateDataSource.java
+++ b/store/src/java/com/zimbra/cs/service/mail/CreateDataSource.java
@@ -213,7 +213,7 @@ public class CreateDataSource extends MailDocumentHandler {
     /**
      * Gets the data source element from the given request.
      */
-    static Element getDataSourceElement(Element request)
+    public static Element getDataSourceElement(Element request)
     throws ServiceException {
         List<Element> subElements = request.listElements();
         if (subElements.size() != 1) {
@@ -228,7 +228,7 @@ public class CreateDataSource extends MailDocumentHandler {
      * Confirms that the folder attribute specifies a valid folder id and is not
      * within the subtree of another datasource
      */
-    static void validateFolderId(Account account, Mailbox mbox, Element eDataSource, DataSourceType dsType)
+    public static void validateFolderId(Account account, Mailbox mbox, Element eDataSource, DataSourceType dsType)
     throws ServiceException {
         int folderId = eDataSource.getAttributeInt(MailConstants.A_FOLDER);
         String id = eDataSource.getAttribute(MailConstants.A_ID, null);
@@ -258,7 +258,7 @@ public class CreateDataSource extends MailDocumentHandler {
      * Confirms that the zimbraDataSourceEmailAddress attribute is unique
      * 
      */
-    default static void validateEmailAddr(Account account, Element eDataSource)
+    public static void validateDataSourceEmail(Account account, Element eDataSource)
     throws ServiceException {
         String dsEmailAddr = eDataSource.getAttribute(MailConstants.A_DS_EMAIL_ADDRESS, null);
         if (!StringUtil.isNullOrEmpty(dsEmailAddr)) {
@@ -270,7 +270,7 @@ public class CreateDataSource extends MailDocumentHandler {
         }
     }
 
-    static void processSmtpAttrs(Map<String, Object> dsAttrs, Element eDataSource, boolean encryptPasswordHere,
+    public static void processSmtpAttrs(Map<String, Object> dsAttrs, Element eDataSource, boolean encryptPasswordHere,
             String dsId)
             throws ServiceException {
         boolean smtpEnabled = false;

--- a/store/src/java/com/zimbra/cs/service/mail/CreateDataSource.java
+++ b/store/src/java/com/zimbra/cs/service/mail/CreateDataSource.java
@@ -29,10 +29,8 @@ import com.zimbra.common.account.ZAttrProvisioning.DataSourceAuthMechanism;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.MailConstants;
-import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
-import com.zimbra.cs.account.AccountServiceException;
 import com.zimbra.cs.account.DataSource;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.datasource.DataSourceListner;
@@ -251,21 +249,6 @@ public class CreateDataSource extends MailDocumentHandler {
                         }
                 }
             } catch (NoSuchItemException ignored) {
-            }
-        }
-    }
-    /**
-     * Confirms that the zimbraDataSourceEmailAddress attribute is unique
-     * 
-     */
-    public static void validateDataSourceEmail(Account account, Element eDataSource)
-    throws ServiceException {
-        String dsEmailAddr = eDataSource.getAttribute(MailConstants.A_DS_EMAIL_ADDRESS, null);
-        if (!StringUtil.isNullOrEmpty(dsEmailAddr)) {
-            for (DataSource ds : account.getAllDataSources()) {
-                if (dsEmailAddr.equals(ds.getEmailAddress())) {
-                    throw AccountServiceException.DATA_SOURCE_EXISTS(dsEmailAddr);
-                }
             }
         }
     }

--- a/store/src/java/com/zimbra/cs/service/mail/ModifyDataSource.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ModifyDataSource.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016 Synacor, Inc.
+ * Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2019 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -189,7 +189,7 @@ public class ModifyDataSource extends MailDocumentHandler {
             TestDataSource.testDataSourceConnection(prov, eDataSource, type, account);
         }
 
-        processCommonOptionalAttrs(dsAttrs, eDataSource);
+        processCommonOptionalAttrs(account, dsAttrs, eDataSource);
 
         prov.modifyDataSource(account, id, dsAttrs);
 
@@ -198,11 +198,12 @@ public class ModifyDataSource extends MailDocumentHandler {
         return response;
     }
 
-    public static void processCommonOptionalAttrs(Map<String, Object> dsAttrs, Element eDataSource) throws ServiceException {
+    public static void processCommonOptionalAttrs(Account account, Map<String, Object> dsAttrs, Element eDataSource) throws ServiceException {
         String value;
 
         value = eDataSource.getAttribute(MailConstants.A_DS_EMAIL_ADDRESS, null);
         if (value != null) {
+            CreateDataSource.validateEmailAddr(account, eDataSource);
             dsAttrs.put(Provisioning.A_zimbraDataSourceEmailAddress, value);
         }
 

--- a/store/src/java/com/zimbra/cs/service/mail/ModifyDataSource.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ModifyDataSource.java
@@ -259,7 +259,7 @@ public class ModifyDataSource extends MailDocumentHandler {
      * Confirms that the zimbraDataSourceEmailAddress attribute is unique
      *
      */
-    private static void validateDataSourceEmail(Account account, Element eDataSource)
+    public static void validateDataSourceEmail(Account account, Element eDataSource)
     throws ServiceException {
         String dsEmailAddr = eDataSource.getAttribute(MailConstants.A_DS_EMAIL_ADDRESS, null);
         if (!StringUtil.isNullOrEmpty(dsEmailAddr)) {

--- a/store/src/java/com/zimbra/cs/service/mail/ModifyDataSource.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ModifyDataSource.java
@@ -27,7 +27,9 @@ import com.zimbra.soap.admin.type.DataSourceType;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.MailConstants;
+import com.zimbra.common.util.StringUtil;
 import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.AccountServiceException;
 import com.zimbra.cs.account.DataSource;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.datasource.DataSourceManager;
@@ -203,7 +205,7 @@ public class ModifyDataSource extends MailDocumentHandler {
 
         value = eDataSource.getAttribute(MailConstants.A_DS_EMAIL_ADDRESS, null);
         if (value != null) {
-            CreateDataSource.validateDataSourceEmail(account, eDataSource);
+            validateDataSourceEmail(account, eDataSource);
             dsAttrs.put(Provisioning.A_zimbraDataSourceEmailAddress, value);
         }
 
@@ -250,6 +252,22 @@ public class ModifyDataSource extends MailDocumentHandler {
         		attrList.add(attrs.next().getText());
         	}
         	dsAttrs.put(Provisioning.A_zimbraDataSourceAttribute, attrList.toArray(new String[0]));
+        }
+    }
+
+    /**
+     * Confirms that the zimbraDataSourceEmailAddress attribute is unique
+     *
+     */
+    private static void validateDataSourceEmail(Account account, Element eDataSource)
+    throws ServiceException {
+        String dsEmailAddr = eDataSource.getAttribute(MailConstants.A_DS_EMAIL_ADDRESS, null);
+        if (!StringUtil.isNullOrEmpty(dsEmailAddr)) {
+            for (DataSource ds : account.getAllDataSources()) {
+                if (dsEmailAddr.equals(ds.getEmailAddress())) {
+                    throw AccountServiceException.DATA_SOURCE_EXISTS(dsEmailAddr);
+                }
+            }
         }
     }
 }

--- a/store/src/java/com/zimbra/cs/service/mail/ModifyDataSource.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ModifyDataSource.java
@@ -203,7 +203,7 @@ public class ModifyDataSource extends MailDocumentHandler {
 
         value = eDataSource.getAttribute(MailConstants.A_DS_EMAIL_ADDRESS, null);
         if (value != null) {
-            CreateDataSource.validateEmailAddr(account, eDataSource);
+            CreateDataSource.validateDataSourceEmail(account, eDataSource);
             dsAttrs.put(Provisioning.A_zimbraDataSourceEmailAddress, value);
         }
 

--- a/store/src/java/com/zimbra/cs/service/mail/TestDataSource.java
+++ b/store/src/java/com/zimbra/cs/service/mail/TestDataSource.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2013, 2014, 2015, 2016 Synacor, Inc.
+ * Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2013, 2014, 2015, 2016, 2019 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -141,7 +141,7 @@ public class TestDataSource extends MailDocumentHandler {
         CreateDataSource.processSmtpAttrs(testAttrs, eDataSource, true, testId);
 
         // Common optional attributes
-        ModifyDataSource.processCommonOptionalAttrs(testAttrs, eDataSource);
+        ModifyDataSource.processCommonOptionalAttrs(account, testAttrs, eDataSource);
 
         // Perform test and assemble response
 


### PR DESCRIPTION
Made fixes so that the existence of zimbraDataSourceEmailAddress is checked not only createDataSource but also at modifyDataSource