### PR TITLE
ZCS-7500 Fixing null parameter

### DIFF
--- a/store/src/java/com/zimbra/cs/zimlet/ZimletUtil.java
+++ b/store/src/java/com/zimbra/cs/zimlet/ZimletUtil.java
@@ -1702,7 +1702,7 @@ public class ZimletUtil {
                     cookie.setSecure(false);
                     cookie.setExpiryDate(null);
                     cookieStore.addCookie(cookie);
-                    
+
                 }
                 clientBuilder.setDefaultCookieStore(cookieStore);
 
@@ -1716,20 +1716,21 @@ public class ZimletUtil {
                 (int) TimeUnit.MILLISECONDS.convert(LC.zimlet_deploy_timeout.intValue(),
                 TimeUnit.SECONDS)).build();
             clientBuilder.setDefaultSocketConfig(config);
-            
+
             int statusCode = -1;
             try {
                 String contentType = URLConnection.getFileNameMap().getContentTypeFor(name);
                 MultipartEntityBuilder builder = MultipartEntityBuilder.create();
-                builder.addBinaryBody("upfile", data, ContentType.create(contentType), null);
+                builder.addBinaryBody("upfile", data, ContentType.create(contentType), name);
                 HttpEntity httpEntity = builder.build();
                 post.setEntity(httpEntity);
                 HttpClient client = clientBuilder.build();
-                
+
                 HttpResponse httpResp = HttpClientUtil.executeMethod(client, post);
                 statusCode = httpResp.getStatusLine().getStatusCode();
                 if (statusCode == 200) {
                     String response = EntityUtils.toString(httpResp.getEntity());
+
                     // "raw" response should be of the format
                     //   200,'null','aac04dac-b3c8-4c26-b9c2-c2534f1d6ba1:79d2722f-d4c7-4304-9961-e7bcb146fc32'
                     String[] responseParts = response.split(",", 3);


### PR DESCRIPTION
ZCS-7500 Fixing null parameter while uploading attachment

verified the following command works in a multi node deployment
zmzimletctl deploy /opt/zimbra/zimlets-network/com_zimbra_smime.zip
[] INFO: Deploying Zimlet com_zimbra_smime in LDAP.
[] INFO: Installing Zimlet com_zimbra_smime on this host.
[] INFO: Deploying on service node zdev-vm011.eng.zimbra.com
[] INFO: post to server zdev-vm011.eng.zimbra.com, data size 543486
[] INFO: Deploy initiated. Check the server xxxx's mailbox.log for the status.