### PR TITLE
ZBUG-1024: adding check to remove invalid XML chars while restoring a…

### DIFF
--- a/common/src/java-test/com/zimbra/common/soap/W3cDomUtilTest.java
+++ b/common/src/java-test/com/zimbra/common/soap/W3cDomUtilTest.java
@@ -1,5 +1,8 @@
 package com.zimbra.common.soap;
 
+import java.io.IOException;
+import java.io.InputStream;
+
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -12,6 +15,7 @@ import org.xml.sax.SAXException;
 import org.xml.sax.SAXNotRecognizedException;
 import org.xml.sax.SAXNotSupportedException;
 
+import com.google.common.io.ByteStreams;
 import com.zimbra.common.util.Constants;
 
 import junit.framework.Assert;
@@ -56,5 +60,34 @@ public class W3cDomUtilTest {
         TransformerFactory factory = W3cDomUtil.makeTransformerFactory();
         Assert.assertEquals("", factory.getAttribute(XMLConstants.ACCESS_EXTERNAL_DTD));
         Assert.assertEquals("", factory.getAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET));
+    }
+
+    @Test
+    public void testRemoveInvalidChars() throws IOException {
+        String invalidCharsXML = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" + "\n"
+                + "<backupMetadata xmlns=\"urn:zimbraBackupMeta\" version=\"7.1\">\n"
+                + "  <accountLdap zimbraId=\"3f38c5be-1b08-463c-8326-d7e26b2a515a\" email=\"account1@zcs804.zimbra.com\">\n"
+                + "    <attributes>\n" + "      <attribute name=\"zimbraMailSieveScript\">\n"
+                + "        <value>require [\"fileinto\", \"reject\", \"tag\", \"flag\"];\n" + "\n" + "# filter1\n"
+                + "if allof (address :all :contains :comparator \"i;ascii-casemap\" [\"from\"] \"foo&#7;bar &lt;acco&#7;unt2@zcs804.zimbra.com&gt;\",\n"
+                + "  header :is [\"subject\"] \"foobar &lt;account2@zcs804.zimbra.com&gt;\") {\n" + "    keep;\n"
+                + "    stop;\n" + "}\n" + "</value>\n" + "      </attribute>\n" + "    </attributes>\n"
+                + "  </accountLdap>\n" + "</backupMetadata>";
+
+        String validCharsXML = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" + "\n"
+                + "<backupMetadata xmlns=\"urn:zimbraBackupMeta\" version=\"7.1\">\n"
+                + "  <accountLdap zimbraId=\"3f38c5be-1b08-463c-8326-d7e26b2a515a\" email=\"account1@zcs804.zimbra.com\">\n"
+                + "    <attributes>\n" + "      <attribute name=\"zimbraMailSieveScript\">\n"
+                + "        <value>require [\"fileinto\", \"reject\", \"tag\", \"flag\"];\n" + "\n" + "# filter1\n"
+                + "if allof (address :all :contains :comparator \"i;ascii-casemap\" [\"from\"] \"foobar &lt;account2@zcs804.zimbra.com&gt;\",\n"
+                + "  header :is [\"subject\"] \"foobar &lt;account2@zcs804.zimbra.com&gt;\") {\n" + "    keep;\n"
+                + "    stop;\n" + "}\n" + "</value>\n" + "      </attribute>\n" + "    </attributes>\n"
+                + "  </accountLdap>\n" + "</backupMetadata>";
+
+        InputStream clean_xml_is = W3cDomUtil.removeInvalidXMLChars(invalidCharsXML.getBytes());
+        byte[] bytes = ByteStreams.toByteArray(clean_xml_is);
+        clean_xml_is.close();
+        String clean_xml = new String(bytes);
+        Assert.assertEquals(clean_xml, validCharsXML);
     }
 }

--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1303,6 +1303,9 @@ public final class LC {
     // Zimbra valid class list to de-serialize
     public static final KnownKey zimbra_deserialize_classes = KnownKey.newKey("");
 
+    // XML 1.0 invalid characters regex pattern
+    public static final KnownKey xml_invalid_chars_regex = KnownKey.newKey("\\&\\#(?:x([0-9a-fA-F]+)|([0-9]+))\\;");
+
     static {
         // Automatically set the key name with the variable name.
         for (Field field : LC.class.getFields()) {


### PR DESCRIPTION
ZBUG-1024: Fixing XML parsing error for invalid control characters while restoring account

Added check for control characters and removed them if found in xml for parsing while restoring the account. Verified account can be restored from 8.0.4 to 8.8.12

Testing Instructions:
- Use the backup added to ticket from 8.0.4 version and try zmrestore on 8.8.12
- Account domain in the back is different so test server will need adding the domain
- e.g. cmd: "zmrestore -a account1@zcs804.zimbra.com -ca -pre new_ -t /tmp/backup"