### PR TITLE
ZCS-7498:Creating signature through ZCO puts extra space within sign

### DIFF
--- a/store/src/java/com/zimbra/cs/html/owasp/OwaspDefang.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/OwaspDefang.java
@@ -70,9 +70,7 @@ public class OwaspDefang extends AbstractDefang {
         try {
             sanitizedHtml = future.get(finishBefore, TimeUnit.SECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
-            if (ZimbraLog.soap.isDebugEnabled()) {
-                ZimbraLog.soap.debug("Exception during HTML sanitization", e);
-            }
+            ZimbraLog.soap.debug("Exception during HTML sanitization", e);
             ZimbraLog.soap.warn("Exception during HTML sanitization: %s", e.getMessage());
             return null;
         }

--- a/store/src/java/com/zimbra/cs/html/owasp/OwaspPolicy.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/OwaspPolicy.java
@@ -66,9 +66,7 @@ public class OwaspPolicy {
         try {
             load(null);
         } catch (Exception e) {
-            if (ZimbraLog.mailbox.isDebugEnabled()) {
-                ZimbraLog.mailbox.debug("Failed to load OWASP policy file", e);
-            }
+            ZimbraLog.mailbox.debug("Failed to load OWASP policy file", e);
             ZimbraLog.mailbox.warn("Failed to load OWASP policy file: %s", e.getMessage());
         }
     }

--- a/store/src/java/com/zimbra/cs/html/owasp/policies/StyleTagReceiver.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/policies/StyleTagReceiver.java
@@ -47,10 +47,11 @@ public class StyleTagReceiver implements HtmlStreamEventReceiver {
         try {
             URL url = myFile.toURI().toURL();
             policy = Policy.getInstance(url);
+            ZimbraLog.mailbox.info("Antisamy policy loaded");
         } catch (PolicyException | MalformedURLException e) {
+            ZimbraLog.mailbox.debug("Failed to load antisamy policy", e);
             ZimbraLog.mailbox.warn("Failed to load antisamy policy: %s", e.getMessage());
         }
-        ZimbraLog.mailbox.info("Antisamy policy loaded");
     }
 
     public StyleTagReceiver(HtmlStreamEventReceiver wrapped) {
@@ -91,8 +92,11 @@ public class StyleTagReceiver implements HtmlStreamEventReceiver {
                         .getCleanHTML();
                     sanitizedStyle = sanitizedStyle.replace(STYLE_OPENING_TAG, "")
                         .replace(STYLE_CLOSING_TAG, "");
+                    sanitizedStyle = sanitizedStyle.replace("<![CDATA[", "/*<![CDATA[*/");
+                    sanitizedStyle = sanitizedStyle.replace("]]>", "/*]]>*/");
                 } catch (ScanException | PolicyException e) {
-                    ZimbraLog.mailbox.warn("Failed to sanitize html style element");
+                    ZimbraLog.mailbox.debug("Failed to sanitize html style element", e);
+                    ZimbraLog.mailbox.warn("Failed to sanitize html style element: %s", e.getMessage());
                     sanitizedStyle = "";
                 }
             }


### PR DESCRIPTION
Issue: Signature created through outlook style was not getting applied

Fix: 
Most major browsers don't support CDATA sections when they parse the document as HTML. Commenting out the CDATA section markers. This way, if CDATA sections aren't supported, the section markers will be effectively ignored, and if they are supported, the markers will be properly interpreted.

Other changes: Few log statements