### PR TITLE
ZCS-7568 Fixing exception while moving email to another folder

### DIFF
--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -2610,7 +2610,7 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
         int statusCode;
         try {
             MultipartEntityBuilder builder = MultipartEntityBuilder.create();
-            builder.addBinaryBody("upfile", in, ContentType.create(contentType), name);
+            builder.addBinaryBody("upfile", in, ContentType.DEFAULT_BINARY, name);
             HttpEntity httpEntity = builder.build();
             post.setEntity(httpEntity);
 


### PR DESCRIPTION
Fixing "java.lang.IllegalArgumentException: MIME type may not contain reserved characters
        at org.apache.http.util.Args.check(Args.java:36)" while moving item from shared folder to user folder.

Verified that the above exception does not happen an email or email with attachment is moved.
