### PR TITLE
ZBUG-674 changed to honor zimbraLastLogonTimeStampFrequency even when…

### DIFF
--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -5591,7 +5591,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     }
 
     private void updateLastLogon(Account acct) throws ServiceException {
-        try {
+        if (EphemeralStore.getFactory() instanceof LdapEphemeralStore.Factory) {
             Config config = Provisioning.getInstance().getConfig();
             long freq = config.getLastLogonTimestampFrequency();
             // never update timestamp if frequency is 0
@@ -5604,6 +5604,8 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
             if (lastLogon != null && (lastLogon.getTime() + freq > System.currentTimeMillis())) {
                 return;
             }
+        }
+        try {
             acct.setLastLogonTimestamp(new Date());
         } catch (ServiceException e) {
             ZimbraLog.account.warn("error updating zimbraLastLogonTimestamp", e);


### PR DESCRIPTION
Problem:
If it is configured to use Ephemeral (zimbraEphemeralBackendURL is set to ssdb:host.domain.com:8888), the zimbraLastLogonTimeStampFrequency is not honored.

Fix:
Remove "if" statement so that zimbraLastLogonTimeStampFrequency is always used.

This has been fixed by Koichi Kato