### PR TITLE
ZCS-7621:Whitelist display CSS property in owasp

### DIFF
--- a/store-conf/conf/owasp_policy.xml
+++ b/store-conf/conf/owasp_policy.xml
@@ -7,6 +7,7 @@
   <url_protocols>cid,http,https,mailto,data,smb</url_protocols>
   <disallow_text_in>applet,frameset,object,script,title</disallow_text_in>
   <allow_text_in>style</allow_text_in>
+  <css_whitelist>float,display</css_whitelist>
   <element name="a">
     <attributes>KBD,charset,coords,href,hreflang,name,rel,rev,shape,target,type</attributes>
     <url_protocols>cid,http,https,mailto,smb</url_protocols>

--- a/store/src/java-test/com/zimbra/cs/html/owasp/OwaspHtmlSanitizerTest.java
+++ b/store/src/java-test/com/zimbra/cs/html/owasp/OwaspHtmlSanitizerTest.java
@@ -27,7 +27,10 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.MethodRule;
+import org.junit.rules.TestName;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.CharStreams;
@@ -38,10 +41,13 @@ import com.zimbra.cs.mime.MPartInfo;
 import com.zimbra.cs.mime.Mime;
 import com.zimbra.cs.mime.ParsedMessage;
 import com.zimbra.cs.servlet.ZThreadLocal;
+import com.zimbra.cs.util.ZTestWatchman;
 
 public class OwaspHtmlSanitizerTest {
 
     private static String EMAIL_BASE_DIR = "data/unittest/email/";
+    @Rule public TestName testName = new TestName();
+    @Rule public MethodRule watchman = new ZTestWatchman();
 
     @BeforeClass
     public static void init() throws Exception {
@@ -678,6 +684,14 @@ public class OwaspHtmlSanitizerTest {
         String result = new OwaspHtmlSanitizer(html, true, null).sanitize();
         Assert.assertTrue(!result.contains("@zimbra"));
         Assert.assertTrue(result.contains("&#64;zimbra"));
+    }
+
+    @Test
+    public void testZCS7621() throws Exception {
+        String html = "<div class=\"gmail\" style=\"display:none; width:0; overflow:hidden; float:left; max-height:0;\" align=\"center\">";
+        String result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        Assert.assertTrue(result.contains("display"));
+        Assert.assertTrue(result.contains("float"));
     }
 
 }

--- a/store/src/java/com/zimbra/cs/html/owasp/OwaspPolicy.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/OwaspPolicy.java
@@ -34,6 +34,7 @@ import org.dom4j.Element;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.soap.W3cDomUtil;
 import com.zimbra.common.soap.XmlParseException;
+import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
 
 /*
@@ -45,6 +46,7 @@ public class OwaspPolicy {
     public static final String E_OWASP_POLICY = "owasp_policy";
     public static final String E_DISALLOW_TEXT_IN = "disallow_text_in";
     public static final String E_ALLOW_TEXT_IN = "allow_text_in";
+    public static final String E_CSS_WHITELIST = "css_whitelist";
     public static final String E_URL_PROTOCOLS = "url_protocols";
     public static final String E_ELEMENT = "element";
     public static final String A_NAME = "name";
@@ -59,6 +61,7 @@ public class OwaspPolicy {
     private static final Map<String, String> mConfiguredElements = new HashMap<String, String>();
     private static final Set<String> mDisallowTextElements = new HashSet<String>();
     private static final Set<String> mAllowTextElements = new HashSet<String>();
+    private static final Set<String> mCssWhitelist = new HashSet<String>();
     private static final Set<String> mURLProtocols = new HashSet<String>();
     private static final Map<String, String> mElementUrlProtocols = new HashMap<String, String>();
 
@@ -98,11 +101,21 @@ public class OwaspPolicy {
                     set(name, attributes, urlProtocols);
                 }
                 String disallowTextElements = root.elementText(E_DISALLOW_TEXT_IN);
-                mDisallowTextElements.addAll(Arrays.asList(disallowTextElements.split(COMMA)));
+                if (!StringUtil.isNullOrEmpty(disallowTextElements)) {
+                    mDisallowTextElements.addAll(Arrays.asList(disallowTextElements.split(COMMA)));
+                }
                 String allowTextElements = root.elementText(E_ALLOW_TEXT_IN);
-                mAllowTextElements.addAll(Arrays.asList(allowTextElements.split(COMMA)));
+                if (!StringUtil.isNullOrEmpty(allowTextElements)) {
+                    mAllowTextElements.addAll(Arrays.asList(allowTextElements.split(COMMA)));
+                }
+                String cssWhitelist = root.elementText(E_CSS_WHITELIST);
+                if (!StringUtil.isNullOrEmpty(cssWhitelist)) {
+                    mCssWhitelist.addAll(Arrays.asList(cssWhitelist.split(COMMA)));
+                }
                 String urlProtocols = root.elementText(E_URL_PROTOCOLS);
-                mURLProtocols.addAll(Arrays.asList(urlProtocols.split(COMMA)));
+                if (!StringUtil.isNullOrEmpty(urlProtocols)) {
+                    mURLProtocols.addAll(Arrays.asList(urlProtocols.split(COMMA)));
+                }
             } catch (IOException | XmlParseException e) {
                 ZimbraLog.mailbox
                     .warn(String.format("Problem parsing owasp policy file '%s'", policyFile), e);
@@ -161,6 +174,10 @@ public class OwaspPolicy {
 
     public static Set<String> getAllowTextElements() {
         return mAllowTextElements;
+    }
+
+    public static Set<String> getCssWhitelist() {
+        return mCssWhitelist;
     }
 
     public static Set<String> getURLProtocols() {

--- a/store/src/java/com/zimbra/cs/html/owasp/OwaspPolicyProducer.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/OwaspPolicyProducer.java
@@ -22,7 +22,6 @@ import java.util.Set;
 import org.owasp.html.CssSchema;
 import org.owasp.html.HtmlPolicyBuilder;
 import org.owasp.html.PolicyFactory;
-import com.google.common.collect.ImmutableSet;
 
 /*
  * Instantiate owasp policy instance with neuter images true/false at load time
@@ -31,14 +30,6 @@ public class OwaspPolicyProducer {
 
     private static PolicyFactory policyNeuterImagesTrue;
     private static PolicyFactory policyNeuterImagesFalse;
-
-    /**
-     * The following CSS properties do not appear in the default whitelist from
-     * OWASP, but they improve the fidelity of the HTML display without
-     * unacceptable risk.
-     */
-    private static final CssSchema ADDITIONAL_CSS = CssSchema
-        .withProperties(ImmutableSet.of("float"));
 
     private static void setUp(boolean neuterImages) {
         HtmlElementsBuilder builder = new HtmlElementsBuilder(new HtmlAttributesBuilder(), neuterImages);
@@ -56,19 +47,31 @@ public class OwaspPolicyProducer {
         for (String allowTextElement : allowTextElements) {
             policyBuilder.allowTextIn(allowTextElement.trim());
         }
+        /**
+         * The following CSS properties do not appear in the default whitelist from
+         * OWASP, but they improve the fidelity of the HTML display without
+         * unacceptable risk.
+         */
+        Set<String> cssWhitelist = OwaspPolicy.getCssWhitelist();
+        CssSchema ADDITIONAL_CSS = null;
+        if (!cssWhitelist.isEmpty()) {
+            ADDITIONAL_CSS = CssSchema.withProperties(cssWhitelist);
+        }
         Set<String> urlProtocols = OwaspPolicy.getURLProtocols();
         for (String urlProtocol : urlProtocols) {
             policyBuilder.allowUrlProtocols(urlProtocol.trim());
         }
         if (neuterImages) {
             if (policyNeuterImagesTrue == null) {
-                policyNeuterImagesTrue = policyBuilder
-                    .allowStyling(CssSchema.union(CssSchema.DEFAULT, ADDITIONAL_CSS)).toFactory();
+                policyNeuterImagesTrue = policyBuilder.allowStyling(ADDITIONAL_CSS == null
+                    ? CssSchema.DEFAULT : CssSchema.union(CssSchema.DEFAULT, ADDITIONAL_CSS))
+                    .toFactory();
             }
         } else {
             if (policyNeuterImagesFalse == null) {
-                policyNeuterImagesFalse = policyBuilder
-                    .allowStyling(CssSchema.union(CssSchema.DEFAULT, ADDITIONAL_CSS)).toFactory();
+                policyNeuterImagesFalse = policyBuilder.allowStyling(ADDITIONAL_CSS == null
+                    ? CssSchema.DEFAULT : CssSchema.union(CssSchema.DEFAULT, ADDITIONAL_CSS))
+                    .toFactory();
             }
         }
     }


### PR DESCRIPTION
Added 'display' css property into whitelist for owasp html sanitization.
Made the css whitelist configurable through owasp policy xml file

Added junit test.