### PR TITLE
ZCS-7655 Fix MailboxMove API

### DIFF
--- a/store/src/java/com/zimbra/cs/account/AuthToken.java
+++ b/store/src/java/com/zimbra/cs/account/AuthToken.java
@@ -28,6 +28,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.impl.client.BasicCookieStore;
+import org.apache.http.impl.client.HttpClientBuilder;
 
 import com.zimbra.common.account.Key;
 import com.zimbra.common.auth.ZAuthToken;
@@ -232,6 +233,17 @@ public abstract class AuthToken {
         //do nothing
     }
 
+    /**
+     *
+     * @param clientBuilder
+     * @param method
+     * @param isAdminReq
+     * @param cookieDomain
+     * @throws ServiceException
+     */
+    public void encode(HttpClientBuilder clientBuilder, HttpRequestBase method, boolean isAdminReq, String cookieDomain) throws ServiceException{
+
+    }
     public abstract void encodeAuthResp(Element parent, boolean isAdmin) throws ServiceException;
 
     public abstract ZAuthToken toZAuthToken() throws ServiceException;

--- a/store/src/java/com/zimbra/cs/account/AuthToken.java
+++ b/store/src/java/com/zimbra/cs/account/AuthToken.java
@@ -242,7 +242,7 @@ public abstract class AuthToken {
      * @throws ServiceException
      */
     public void encode(HttpClientBuilder clientBuilder, HttpRequestBase method, boolean isAdminReq, String cookieDomain) throws ServiceException{
-
+        // EMpty method which can be implemented by  extending classes, avoiding changing existing signature
     }
     public abstract void encodeAuthResp(Element parent, boolean isAdmin) throws ServiceException;
 

--- a/store/src/java/com/zimbra/cs/account/ZimbraAuthToken.java
+++ b/store/src/java/com/zimbra/cs/account/ZimbraAuthToken.java
@@ -424,10 +424,32 @@ public class ZimbraAuthToken extends AuthToken implements Cloneable {
         cookie.setPath("/");
         cookie.setSecure(false);
         state.addCookie(cookie);
-        
+
         HttpClientBuilder clientBuilder = ZimbraHttpConnectionManager.getInternalHttpConnMgr().newHttpClient();
         clientBuilder.setDefaultCookieStore(state);
-        
+
+        RequestConfig reqConfig = RequestConfig.copy(
+            ZimbraHttpConnectionManager.getInternalHttpConnMgr().getZimbraConnMgrParams().getReqConfig())
+            .setCookieSpec(CookieSpecs.BROWSER_COMPATIBILITY).build();
+
+        clientBuilder.setDefaultRequestConfig(reqConfig);
+    }
+
+
+    @Override
+    public void encode(HttpClientBuilder clientBuilder, HttpRequestBase method, boolean isAdminReq, String cookieDomain)
+    throws ServiceException {
+        String origAuthData = AuthTokenUtil.getOrigAuthData(this);
+
+        BasicCookieStore state = new BasicCookieStore();
+        BasicClientCookie cookie = new BasicClientCookie( ZimbraCookie.authTokenCookieName(isAdminReq), origAuthData);
+        cookie.setDomain(cookieDomain);
+        cookie.setPath("/");
+        cookie.setSecure(false);
+        state.addCookie(cookie);
+
+        clientBuilder.setDefaultCookieStore(state);
+
         RequestConfig reqConfig = RequestConfig.copy(
             ZimbraHttpConnectionManager.getInternalHttpConnMgr().getZimbraConnMgrParams().getReqConfig())
             .setCookieSpec(CookieSpecs.BROWSER_COMPATIBILITY).build();
@@ -438,7 +460,7 @@ public class ZimbraAuthToken extends AuthToken implements Cloneable {
     @Override
     public void encode(BasicCookieStore state, boolean isAdminReq, String cookieDomain) throws ServiceException {
         String origAuthData = AuthTokenUtil.getOrigAuthData(this);
-        
+
         BasicClientCookie cookie = new BasicClientCookie( ZimbraCookie.authTokenCookieName(isAdminReq), origAuthData);
         cookie.setDomain(cookieDomain);
         cookie.setPath("/");

--- a/store/src/java/com/zimbra/cs/service/FileUploadServlet.java
+++ b/store/src/java/com/zimbra/cs/service/FileUploadServlet.java
@@ -53,6 +53,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
 
 import com.google.common.base.Strings;
 import com.zimbra.client.ZMailbox;
@@ -305,10 +306,11 @@ public class FileUploadServlet extends ZimbraServlet {
                ContentServlet.PARAM_EXPUNGE + "=true";
 
         // create an HTTP client with auth cookie to fetch the file from the remote ContentServlet
-        HttpClient client = ZimbraHttpConnectionManager.getInternalHttpConnMgr().newHttpClient().build();
+        HttpClientBuilder clientBuilder = ZimbraHttpConnectionManager.getInternalHttpConnMgr().newHttpClient();
         HttpGet get = new HttpGet(url);
 
-        authtoken.encode(client, get, false, hostname);
+        authtoken.encode(clientBuilder, get, false, hostname);
+        HttpClient client = clientBuilder.build();
         try {
             // fetch the remote item
             HttpResponse httpResp = HttpClientUtil.executeMethod(client, get);

--- a/store/src/java/com/zimbra/cs/service/doc/SaveDocument.java
+++ b/store/src/java/com/zimbra/cs/service/doc/SaveDocument.java
@@ -30,6 +30,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
 
 import com.zimbra.common.account.Key.AccountBy;
 import com.zimbra.common.account.ZAttrProvisioning;
@@ -148,7 +149,7 @@ public class SaveDocument extends DocDocumentHandler {
                 String inlineContent = docElem.getAttribute(MailConstants.E_CONTENT);
                 doc = new Doc(inlineContent, explicitName, explicitCtype, description);
             }
-            
+
             // set content-type based on file extension.
             setDocContentType(doc);
 
@@ -278,9 +279,10 @@ public class SaveDocument extends DocDocumentHandler {
         }
 
         String url = UserServlet.getRestUrl(acct) + "?auth=co&id=" + itemId + "&part=" + partId;
-        HttpClient client = ZimbraHttpConnectionManager.getInternalHttpConnMgr().newHttpClient().build();
+        HttpClientBuilder clientBuilder = ZimbraHttpConnectionManager.getInternalHttpConnMgr().newHttpClient();
         HttpGet get = new HttpGet(url);
-        authtoken.encode(client, get, false, acct.getAttr(ZAttrProvisioning.A_zimbraMailHost));
+        authtoken.encode(clientBuilder, get, false, acct.getAttr(ZAttrProvisioning.A_zimbraMailHost));
+        HttpClient client = clientBuilder.build();
         try {
             HttpResponse httpResp = HttpClientUtil.executeMethod(client, get);
             int statusCode = httpResp.getStatusLine().getStatusCode();


### PR DESCRIPTION
Fixed the code that set the auth token cookie on the Httpclient request object.

Verified that zmboxmove command works in a multi node setup. 
Verified that the account is moved to target server.
