### PR TITLE
ZCS-7660 ProxyServlet not working

### DIFF
--- a/store/src/java/com/zimbra/cs/zimlet/ProxyServlet.java
+++ b/store/src/java/com/zimbra/cs/zimlet/ProxyServlet.java
@@ -40,7 +40,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.client.params.ClientPNames;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.DefaultRedirectStrategy;
@@ -290,7 +289,7 @@ public class ProxyServlet extends ZimbraServlet {
                 if (canProxyHeader(hdr)) {
                 	ZimbraLog.zimlet.debug("outgoing: " + hdr + ": " + req.getHeader(hdr));
                 	if (hdr.equalsIgnoreCase("x-host"))
-                	    method.getParams().setParameter(ClientPNames.VIRTUAL_HOST, req.getHeader(hdr));
+                	    method.setHeader("Host", req.getHeader(hdr));
                 	else
                 		method.addHeader(hdr, req.getHeader(hdr));
                 }
@@ -301,9 +300,8 @@ public class ProxyServlet extends ZimbraServlet {
                 if (!(reqMethod.equalsIgnoreCase("POST") || reqMethod.equalsIgnoreCase("PUT"))) {
                     clientBuilder.setRedirectStrategy(new DefaultRedirectStrategy());
                 }
-                
+
                 HttpClient client = clientBuilder.build();
-                client.getParams().setParameter(ClientPNames.HANDLE_AUTHENTICATION, true);
                 httpResp = HttpClientUtil.executeMethod(client, method);
             } catch (HttpException ex) {
                 ZimbraLog.zimlet.info("exception while proxying " + target, ex);


### PR DESCRIPTION
Removed the deprecated method.
Verified that when a url is passed to a proxy servlet it opens the target URL and no 503 is not seen.

Verified that Basic Auth also works for target URL
