### PR TITLE
zcs-7675:Domainfo request is not returning 'zimbraFeatureResetPasswordStatus' attribute

### DIFF
--- a/store/src/java/com/zimbra/cs/service/admin/GetDomainInfo.java
+++ b/store/src/java/com/zimbra/cs/service/admin/GetDomainInfo.java
@@ -54,7 +54,8 @@ public class GetDomainInfo extends AdminDocumentHandler {
             ZAttrProvisioning.A_zimbraSkinForegroundColor,
             ZAttrProvisioning.A_zimbraSkinSecondaryColor,
             ZAttrProvisioning.A_zimbraSkinSelectionColor,
-            ZAttrProvisioning.A_zimbraSkinFavicon);
+            ZAttrProvisioning.A_zimbraSkinFavicon,
+            ZAttrProvisioning.A_zimbraFeatureResetPasswordStatus);
 
     @Override
     public Element handle(Element request, Map<String, Object> context) throws ServiceException {


### PR DESCRIPTION
Issue:  zimbraFeatureResetPasswordStatus was removed from bootstrapInfoAttrs list.
```
zmprov md <domainName> zimbraFeatureResetPasswordStatus enabled.
Trigger domainInfo request for given domain.
Expected : zimbraFeatureResetPasswordStatus should be returned in the response
Actual: zimbraFeatureResetPasswordStatus is not returned in the response
```

Fix : Added `zimbraFeatureResetPasswordStatus` in bootstrapInfoAttrs.

Test: Forgot password flow is working as expected.