### PR TITLE
ZBUG-1080 Fixing code that sets auth token in cookie

### DIFF
--- a/common/src/java/com/zimbra/common/soap/SoapHttpTransport.java
+++ b/common/src/java/com/zimbra/common/soap/SoapHttpTransport.java
@@ -28,7 +28,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -77,7 +76,7 @@ import com.zimbra.common.util.ZimbraHttpConnectionManager;
 import com.zimbra.common.util.ZimbraLog;
 
 public class SoapHttpTransport extends SoapTransport {
-    private HttpClient mClient = ZimbraHttpConnectionManager.getInternalHttpConnMgr().getDefaultHttpClient().build();
+    private HttpClientBuilder mClientBuilder = ZimbraHttpConnectionManager.getInternalHttpConnMgr().getDefaultHttpClient();
     private Map<String, String> mCustomHeaders;
     private ProxyHostConfiguration mHostConfig = null;
     private HttpDebugListener mHttpDebugListener;
@@ -121,9 +120,9 @@ public class SoapHttpTransport extends SoapTransport {
      * Frees any resources such as connection pool held by this transport.
      */
     public void shutdown() {
-        if (mClient != null && mClient != ZimbraHttpConnectionManager.getInternalHttpConnMgr().getDefaultHttpClient()) {
-            mClient.getConnectionManager().closeIdleConnections(0, TimeUnit.MILLISECONDS);
-            mClient = null;
+        if (mClientBuilder != null && mClientBuilder != ZimbraHttpConnectionManager.getInternalHttpConnMgr().getDefaultHttpClient()) {
+            ZimbraHttpConnectionManager.getInternalHttpConnMgr().closeIdleConnections();
+            mClientBuilder = null;
             mHostConfig = null;
         }
     }
@@ -223,6 +222,7 @@ public class SoapHttpTransport extends SoapTransport {
             String changeToken, String tokenType, NotificationFormat nFormat, String curWaitSetID, ResponseHandler respHandler)
             throws IOException, ServiceException {
         HttpPost method = null;
+        HttpClient client = null;
 
         try {
             // Assemble post method.  Append document name, so that the request
@@ -269,6 +269,7 @@ public class SoapHttpTransport extends SoapTransport {
 
             String host = method.getURI().getHost();
             ZAuthToken zToken = getAuthToken();
+
             BasicCookieStore cookieStore = HttpClientUtil.newHttpState(zToken, host, this.isAdmin());
             String trustedToken = getTrustedToken();
             if (trustedToken != null) {
@@ -291,15 +292,21 @@ public class SoapHttpTransport extends SoapTransport {
             method.setProtocolVersion(HttpVersion.HTTP_1_1);
             method.addHeader("Connection", mKeepAlive ? "Keep-alive" : "Close");
 
+
+            client = mClientBuilder.setDefaultRequestConfig(reqConfig)
+               .setDefaultSocketConfig(socketConfig)
+               .setDefaultCookieStore(cookieStore).build();
+
             if (mHostConfig != null && mHostConfig.getUsername() != null && mHostConfig.getPassword() != null) {
 
                 Credentials credentials = new UsernamePasswordCredentials(mHostConfig.getUsername(), mHostConfig.getPassword());
                 AuthScope authScope = new AuthScope(null, -1);
                 CredentialsProvider credsProvider = new BasicCredentialsProvider();
                 credsProvider.setCredentials(authScope, credentials);
-                mClient = HttpClientBuilder.create().setDefaultCredentialsProvider(credsProvider)
+                client = HttpClientBuilder.create().setDefaultCredentialsProvider(credsProvider)
                     .setDefaultRequestConfig(reqConfig)
                     .setDefaultSocketConfig(socketConfig)
+                    .setDefaultCookieStore(cookieStore)
                     .build();
             }
 
@@ -307,7 +314,7 @@ public class SoapHttpTransport extends SoapTransport {
                 mHttpDebugListener.sendSoapMessage(method, soapReq, cookieStore);
             }
 
-            HttpResponse response = mClient.execute(method);
+            HttpResponse response = client.execute(method);
             int responseCode = response.getStatusLine().getStatusCode();
             // SOAP allows for "200" on success and "500" on failure;
             //   real server issues will probably be "503" or "404"
@@ -350,7 +357,7 @@ public class SoapHttpTransport extends SoapTransport {
             // if called from CLI, all connections will be closed when the CLI
             // exits.  Leave it here anyway.
             if (!mKeepAlive)
-                mClient.getConnectionManager().closeIdleConnections(0, TimeUnit.MILLISECONDS);
+                ZimbraHttpConnectionManager.getInternalHttpConnMgr().closeIdleConnections();
         }
     }
 

--- a/common/src/java/com/zimbra/common/util/ZimbraHttpConnectionManager.java
+++ b/common/src/java/com/zimbra/common/util/ZimbraHttpConnectionManager.java
@@ -21,6 +21,7 @@ import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.TimeUnit;
+
 import javax.net.ssl.SSLContext;
 
 import org.apache.http.client.config.RequestConfig;
@@ -275,6 +276,10 @@ private static class ExternalConnMgrParams extends ZimbraConnMgrParams {
      */
     public HttpClientBuilder getDefaultHttpClient() {
         return defaultHttpClient;
+    }
+
+    public void closeIdleConnections () {
+        this.httpConnMgr.closeIdleConnections(0, TimeUnit.MILLISECONDS);
     }
 
     private String getName() {


### PR DESCRIPTION
FIxed the code that set the auth token in cookie for HttpClient object.

Verified that login and logout works without errors with  zimbraCsrfTokenCheckEnabled set to true and false.
Verified no connection pool shutdown error is seen in the logs.