### PR TITLE
zcs-7680 : Ability to have an option to block login using the alias

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1296,6 +1296,8 @@ public final class LC {
     public static final KnownKey zm_oauth_classes_handlers_google = KnownKey.newKey("com.zimbra.oauth.handlers.impl.GoogleOAuth2Handler");
     public static final KnownKey zm_oauth_classes_handlers_facebook = KnownKey.newKey("com.zimbra.oauth.handlers.impl.FacebookOAuth2Handler");
 
+    // alias login
+    public static final KnownKey alias_login_enabled = KnownKey.newKey(true);
 
     // Feed Manager comma-separated blacklist. addresses can be CIDR notation, or single ip. no wild-cards (default blacklist private networks)
     public static final KnownKey zimbra_feed_manager_blacklist = KnownKey.newKey("10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,fd00::/8");

--- a/store/src/java/com/zimbra/cs/service/account/Auth.java
+++ b/store/src/java/com/zimbra/cs/service/account/Auth.java
@@ -20,6 +20,7 @@
  */
 package com.zimbra.cs.service.account;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -34,6 +35,7 @@ import org.apache.commons.lang.StringUtils;
 import com.zimbra.common.account.Key;
 import com.zimbra.common.account.Key.AccountBy;
 import com.zimbra.common.account.ZAttrProvisioning.AutoProvAuthMech;
+import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AccountConstants;
 import com.zimbra.common.soap.Element;
@@ -115,6 +117,11 @@ public class Auth extends AccountDocumentHandler {
                 }
             }
             acct = prov.get(acctBy, acctValue);
+            if (Arrays.asList(acct.getAliases()).contains(acctValue) 
+                    && !LC.alias_login_enabled.booleanValue()) {
+                ZimbraLog.account.debug("Alias login not enabled. '%s' is the alias account for [ %s ]", acctValue, acct.getMail());
+                throw AuthFailedServiceException.AUTH_FAILED(acctValue, acctValuePassedIn, "alias login not enabled for account");
+            }
         }
 
         TrustedDeviceToken trustedToken = null;


### PR DESCRIPTION
**Issue:**
When the accounts has aliases, accounts kept getting locked out due to bots trying to login with alias instead of actual email address. Currently there is no option to block the alias login.

**Fix:**
Added a Local config which will be `true` by default that means alias login is enabled.
If we want to block alias login modify the Local config value to `false`. After that all alias login will be blocked.

**Test:**
- Manual testing done. Created an alias for an account. default local config value is set to `true`, so the user successfully logged in.
- when the local config value modified to `false`, all alias login blocked.

**Testing to be done by QA:**
- Test that login with email address works.
- Login with alias account works.
- when local config set to `false`, only alias login will blocked but login with email address would work.