### PR TITLE
zcs-7680 - Added alias check at common place and added unit test

### DIFF
--- a/store/src/java-test/com/zimbra/soap/AuthRequestTest.java
+++ b/store/src/java-test/com/zimbra/soap/AuthRequestTest.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.rules.TestName;
 
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
@@ -43,6 +44,7 @@ import com.zimbra.cs.service.mail.ServiceTestUtil;
 import com.zimbra.soap.account.message.AuthRequest;
 import com.zimbra.soap.account.type.PreAuth;
 import com.zimbra.soap.type.AccountSelector;
+import com.zimbra.cs.util.ZTestWatchman;
 
 import junit.framework.Assert;
 
@@ -60,6 +62,8 @@ public class AuthRequestTest {
     private static final String account = "testAlias@zimbra.com";
     private static final String defaultPwd = "test123";
     private static final String accountAlias = "alias@zimbra.com";
+    @Rule public TestName testName = new TestName();
+    @Rule public MethodRule watchman = new ZTestWatchman();
 
     @BeforeClass
     public static void init() throws Exception {

--- a/store/src/java-test/com/zimbra/soap/AuthRequestTest.java
+++ b/store/src/java-test/com/zimbra/soap/AuthRequestTest.java
@@ -18,19 +18,33 @@
  */
 package com.zimbra.soap;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.HashMap;
+
+import org.junit.After;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
-import com.zimbra.soap.JaxbUtil;
+import com.zimbra.common.soap.AccountConstants;
+import com.zimbra.common.soap.Element;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.AccountServiceException.AuthFailedServiceException;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.service.account.Auth;
+import com.zimbra.cs.service.mail.SendMsgTest.DirectInsertionMailboxManager;
+import com.zimbra.cs.service.mail.ServiceTestUtil;
 import com.zimbra.soap.account.message.AuthRequest;
 import com.zimbra.soap.account.type.PreAuth;
 import com.zimbra.soap.type.AccountSelector;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
-
-
-import com.zimbra.common.soap.Element;
+import junit.framework.Assert;
 
 
 public class AuthRequestTest {
@@ -42,6 +56,24 @@ public class AuthRequestTest {
     private final long expires = 1600000;
 
     private final long timestamp = expires + 60000;
+
+    private static final String account = "testAlias@zimbra.com";
+    private static final String defaultPwd = "test123";
+    private static final String accountAlias = "alias@zimbra.com";
+
+    @BeforeClass
+    public static void init() throws Exception {
+        MailboxTestUtil.initServer();
+        Provisioning prov = Provisioning.getInstance();
+        Account acct = prov.createAccount(account, defaultPwd, new HashMap<String, Object>());
+        prov.addAlias(acct, accountAlias);
+        MailboxManager.setInstance(new DirectInsertionMailboxManager());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        MailboxTestUtil.clearData();
+    }
 
     @Test
     public void testBuildAuthRequestWithPassword()
@@ -88,4 +120,57 @@ public class AuthRequestTest {
         }
     }
 
+    @Test
+    public void testAccountLoginWithLCEnabled() throws Exception {
+        try {
+            Element response = getAuthResponse(true, account);
+            Assert.assertNotNull(response.getElement(AccountConstants.E_AUTH_TOKEN));
+        } catch (ServiceException se) {
+            fail("Encountered a problem: " + se);
+        }
+    }
+
+    @Test
+    public void testAccountLoginWithLCDisabled() throws Exception {
+        try {
+            Element response = getAuthResponse(false, account);
+            Assert.assertNotNull(response.getElement(AccountConstants.E_AUTH_TOKEN));
+        } catch (ServiceException se) {
+            fail("Encountered a problem: " + se);
+        }
+    }
+
+    @Test
+    public void testAliasLoginWithLCEnabled() throws Exception {
+        try {
+            // Login with alias would success as alias login is enabled.
+            Element response = getAuthResponse(true, accountAlias);
+            Assert.assertNotNull(response.getElement(AccountConstants.E_AUTH_TOKEN));
+        } catch (ServiceException se) {
+            fail("Encountered a problem: " + se);
+        }
+    }
+
+    @Test(expected = AuthFailedServiceException.class)
+    public void testAliasLoginWithLCDisabled() throws Exception {
+      //Expects AuthFailedServiceException as we are trying to login with alias when alias login is disabled.
+        getAuthResponse(false, accountAlias);
+    }
+
+    private Element getAuthResponse(boolean value, String userName) throws Exception {
+        String user = null;
+        Element response = null;
+        LC.alias_login_enabled.setDefault(value);
+        Account acct = Provisioning.getInstance().getAccountByName(account);
+        if (userName.equals(account)) {
+            user = account;
+        } else if (userName.equals(accountAlias)) {
+            user = accountAlias;
+        }
+        Element request = new Element.JSONElement(AccountConstants.E_AUTH_REQUEST);
+        request.addUniqueElement(AccountConstants.E_ACCOUNT).addAttribute(AccountConstants.A_BY, AccountConstants.A_NAME).addText(user);
+        request.addUniqueElement(AccountConstants.E_PASSWORD).addText(defaultPwd);
+        response = new Auth().handle(request, ServiceTestUtil.getRequestContext(acct));
+        return response;
+    }
 }

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -215,6 +215,7 @@ import com.zimbra.cs.mime.MimeTypeInfo;
 import com.zimbra.cs.service.util.JWEUtil;
 import com.zimbra.cs.service.util.ResetPasswordUtil;
 import com.zimbra.cs.service.util.SortBySeniorityIndexThenName;
+import com.zimbra.cs.util.AccountUtil;
 import com.zimbra.cs.util.Zimbra;
 import com.zimbra.cs.zimlet.ZimletException;
 import com.zimbra.cs.zimlet.ZimletUtil;
@@ -5858,6 +5859,9 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
             Map<String, Object> authCtxt)
     throws ServiceException {
         synchronized (acct) {
+            //Checking alias login allowed or not
+            String accountNamePassedIn = (String) authCtxt.get(AuthContext.AC_ACCOUNT_NAME_PASSEDIN);
+            AccountUtil.checkAliasLoginAllowed(acct, accountNamePassedIn);
             LdapLockoutPolicy lockoutPolicy = new LdapLockoutPolicy(this, acct);
             if (lockoutPolicy.isLockedOut() && !isRecoveryCodeBasedAuth(authCtxt)) {
                 try {

--- a/store/src/java/com/zimbra/cs/service/account/Auth.java
+++ b/store/src/java/com/zimbra/cs/service/account/Auth.java
@@ -20,7 +20,6 @@
  */
 package com.zimbra.cs.service.account;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -35,7 +34,6 @@ import org.apache.commons.lang.StringUtils;
 import com.zimbra.common.account.Key;
 import com.zimbra.common.account.Key.AccountBy;
 import com.zimbra.common.account.ZAttrProvisioning.AutoProvAuthMech;
-import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AccountConstants;
 import com.zimbra.common.soap.Element;
@@ -117,11 +115,6 @@ public class Auth extends AccountDocumentHandler {
                 }
             }
             acct = prov.get(acctBy, acctValue);
-            if (Arrays.asList(acct.getAliases()).contains(acctValue) 
-                    && !LC.alias_login_enabled.booleanValue()) {
-                ZimbraLog.account.debug("Alias login not enabled. '%s' is the alias account for [ %s ]", acctValue, acct.getMail());
-                throw AuthFailedServiceException.AUTH_FAILED(acctValue, acctValuePassedIn, "alias login not enabled for account");
-            }
         }
 
         TrustedDeviceToken trustedToken = null;


### PR DESCRIPTION
**_Issue :_** 
- Alias login was successful though `LC` value `alias_login_enabled` set to `false` in case of `IMAP`, `POP` and `EWS` as well because auth provisioning is different for different protocol. 
- We had only a check in `Auth.java` where only `ZWC` login request was getting blocked for alias but all other auth request were getting successful. 
- Another problem was that when we send the whole email address in request and `LC` set to `false` the login request was getting failed where as when we send only the display name like `test` instead of `test@test.com` it was getting successful.

**_Fix:_**
- Ultimately when auth request comes from any other client other than ZWC like IMAP, POP and EWS, it encounters `prov.authAccount()` call which verifies the password in `LDAPProvisioning.java`. 
- Now I have moved the alias check logic inside `verifypassword()` method. Also created an utility method in `AccountUtil.java` which check for alias login allowed or not before verification of password.
- Also put a check for the display name if we does not get the whole email address in request as well.
- Added unit tests and modified logic in `MockProvisioning.java` for unit tests.

**_Test:_**
- Manual testing done for ZWC, EWS, IMAP, POP and Active-sync as well. Alias login is blocked in all cases when `LC` value set to `false`;
- All Unit tests are passing.

**_Testing to be done by QA:_**
- Test Auth request for different auth mode like ZWC, EWS, IMAP, POP, Active-sync.
- Auth request should pass with actual account and alias account when `LC` value set to `true`.
- Auth request should pass for actual account and fail for alias account when `LC` value set to `false`. 