### PR TITLE
ZBUG-1087: Java - Kerberos authentication is broken on upgrade

### DIFF
--- a/store/src/java/com/zimbra/cs/account/krb5/Krb5Login.java
+++ b/store/src/java/com/zimbra/cs/account/krb5/Krb5Login.java
@@ -14,7 +14,6 @@
  * If not, see <https://www.gnu.org/licenses/>.
  * ***** END LICENSE BLOCK *****
  */
-
 package com.zimbra.cs.account.krb5;
 
 import com.zimbra.common.service.ServiceException;
@@ -48,13 +47,21 @@ public class Krb5Login {
     public static void verifyPassword(String principal, String password) throws LoginException {
         LoginContext lc = null;
         try {
+            ZimbraLog.account.debug("Kerberos(krb5) principal login with password: " + principal + " and password: " + password);
             lc = Krb5Login.withPassword(principal, password);
             lc.login();
         } finally {
             if (lc != null) {
                 try {
+                    //Only log out if a login occured. If a login didn't occur, then a logout throws a NPE.
+                    if (lc.getSubject() != null
+                            && !lc.getSubject().getPrincipals().isEmpty()) {
+                        ZimbraLog.account.debug("Kerberos(krb5) Login Context subject and principal are not null. Safely logging out.");
                     lc.logout();
-                } catch(LoginException le) {
+                    }else{
+                        ZimbraLog.account.debug("Kerberos(krb5) Login Context subject and principal are null. Cannot safely logging out.");
+                    }
+                } catch (LoginException le) {
                     ZimbraLog.account.warn("krb5 logout failed", le);
                 }
             }
@@ -75,7 +82,7 @@ public class Krb5Login {
             if (lc != null) {
                 try {
                     lc.logout();
-                } catch(LoginException le) {
+                } catch (LoginException le) {
                     ZimbraLog.account.warn("krb5 logout failed", le);
                 }
             }
@@ -83,6 +90,7 @@ public class Krb5Login {
     }
 
     private static String S_CONFIG_NAME = "krb5";
+
     /**
      * private constructor.
      */
@@ -91,22 +99,22 @@ public class Krb5Login {
     }
 
     /**
-     * Constructs a new Krb5Config entry with the specified
-     * principal and keytab, logs in with that entry, and
-     * then removes that entry and returns the new LoginContext.
-     * <p>Equivalent to the following calls:
-     *<pre>
+     * Constructs a new Krb5Config entry with the specified principal and
+     * keytab, logs in with that entry, and then removes that entry and returns
+     * the new LoginContext.
+     * <p>
+     * Equivalent to the following calls:
+     * <pre>
      * Krb5Config kc = Krb5Config.getInstance();
      * kc.setPrincipal(principal);
      * kc.setKeyTab(keytab);
      * kc.setStoreKey(true);
      * LoginContext lc = Login.login(kc);
-     *</pre>
+     * </pre>
      */
     public static LoginContext withKeyTab(String principal,
                                           String keytab)
-        throws LoginException
-    {
+            throws LoginException {
         /*
          * com.sun.security.auth.module.Krb5LoginModule required 
          * useKeyTab=true 
@@ -124,29 +132,30 @@ public class Krb5Login {
         kc.setStoreKey(true);
         kc.setDoNotPrompt(true);
         kc.setUseTicketCache(true);
-        Configuration dc = new DynamicConfiguration(S_CONFIG_NAME, new AppConfigurationEntry[] {kc});
+        Configuration dc = new DynamicConfiguration(S_CONFIG_NAME, new AppConfigurationEntry[]{kc});
         return new LoginContext(S_CONFIG_NAME, null, null, dc);
     }
 
     /**
-     * Constructs a new Krb5Config entry with the specified
-     * ticket cache and logs in with that entry. 
-     *<p>If <code>cache</code> is <code>null</code>, then
-     * <code>Krb5Config.setTicketCache</code> will be set to
-     * <code>true</code> and the default ticket cache will be used.
-     * <p>Equivalent to the following calls:
-     *<pre>
+     * Constructs a new Krb5Config entry with the specified ticket cache and
+     * logs in with that entry.
+     * <p>
+     * If <code>cache</code> is <code>null</code>, then
+     * <code>Krb5Config.setTicketCache</code> will be set to <code>true</code>
+     * and the default ticket cache will be used.
+     * <p>
+     * Equivalent to the following calls:
+     * <pre>
      * Krb5Config kc = Krb5Config.getInstance();
      * if (cache != null) 
      *    kc.setTicketCache(cache);
      * else
      *    kc.setUseTicketCache(true);
      * LoginContext lc = Login.login(kc);
-     *</pre>
+     * </pre>
      */
     public static LoginContext withTicketCache(String cache)
-        throws LoginException
-    {
+            throws LoginException {
         Krb5Config kc = Krb5Config.getInstance();
         //kc.setStoreKey(true);
         if (cache != null) {
@@ -154,18 +163,17 @@ public class Krb5Login {
         } else {
             kc.setUseTicketCache(true);
         }
-        Configuration dc = new DynamicConfiguration(S_CONFIG_NAME, new AppConfigurationEntry[] {kc});
+        Configuration dc = new DynamicConfiguration(S_CONFIG_NAME, new AppConfigurationEntry[]{kc});
         return new LoginContext(S_CONFIG_NAME, null, null, dc);
     }
 
     public static LoginContext withPassword(String name, final String password)
-        throws LoginException
-    {
+            throws LoginException {
         Krb5Config kc = Krb5Config.getInstance();
         kc.setPrincipal(name);
         kc.setUseTicketCache(false);
         kc.setStoreKey(false);
-        Configuration dc = new DynamicConfiguration(S_CONFIG_NAME, new AppConfigurationEntry[] {kc});
+        Configuration dc = new DynamicConfiguration(S_CONFIG_NAME, new AppConfigurationEntry[]{kc});
         CallbackHandler handler = new CallbackHandler() {
             public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
                 for (Callback callback : callbacks) {
@@ -179,8 +187,8 @@ public class Krb5Login {
         return new LoginContext(S_CONFIG_NAME, null, handler, dc);
     }
 
-    static class DynamicConfiguration extends Configuration
-    {
+    static class DynamicConfiguration extends Configuration {
+
         private String mName;
         private AppConfigurationEntry[] mEntry;
 
@@ -190,31 +198,30 @@ public class Krb5Login {
         }
 
         /**
-         * Retrieve an array of AppConfigurationEntries which
-         * corresponds to the configuration of LoginModules for
-         * the given application.
+         * Retrieve an array of AppConfigurationEntries which corresponds to the
+         * configuration of LoginModules for the given application.
          */
         public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
             return name.equals(mName) ? mEntry : null;
         }
 
-        public void refresh() {}
+        public void refresh() {
+    }
     }
 
-    public static class Krb5Config extends AppConfigurationEntry
-    {
+    public static class Krb5Config extends AppConfigurationEntry {
+
         private Map<String, String> mOptions;
 
         private Krb5Config(String loginModuleName, LoginModuleControlFlag controlFlag, Map<String, ?> options) {
             super(loginModuleName, controlFlag, options);
         }
 
-        public static final AppConfigurationEntry.LoginModuleControlFlag
-                DEFAULT_CONTROL_FLAG =
-                AppConfigurationEntry.LoginModuleControlFlag.REQUIRED;
+        public static final AppConfigurationEntry.LoginModuleControlFlag DEFAULT_CONTROL_FLAG
+                = AppConfigurationEntry.LoginModuleControlFlag.REQUIRED;
 
-        private static final String DEFAULT_LOGIN_MODULE_NAME =
-                "com.sun.security.auth.module.Krb5LoginModule";
+        private static final String DEFAULT_LOGIN_MODULE_NAME
+                = "com.sun.security.auth.module.Krb5LoginModule";
 
         public static Krb5Config getInstance() {
             HashMap<String, String> options = new HashMap<String, String>();
@@ -223,17 +230,51 @@ public class Krb5Login {
             return kc;
         }
 
-        public Krb5Config setDebug(boolean value) { mOptions.put("debug", value ? "true" : "false"); return this; }
-        public Krb5Config setDoNotPrompt(boolean value)   { mOptions.put("doNotPrompt", value ? "true" : "false"); return this;}
-        public Krb5Config setKeyTab(String filename)      { mOptions.put("keyTab", filename); setUseKeyTab(true); return this; }
-        public Krb5Config setPrincipal(String principal)  { mOptions.put("principal", principal); return this; }
-        public Krb5Config setStoreKey(boolean value)      { mOptions.put("storeKey", value ? "true" : "false"); return this; }
-        public Krb5Config setTicketCache(String filename) { mOptions.put("ticketCache", filename); setUseTicketCache(true); return this; }
-        public Krb5Config setUseKeyTab(boolean value)     { mOptions.put("useKeyTab", value ? "true" : "false"); return this; }
-        public Krb5Config setUseTicketCache(boolean value) { mOptions.put("useTicketCache", value ? "true" : "false"); return this;}
+        public Krb5Config setDebug(boolean value) {
+            mOptions.put("debug", value ? "true" : "false");
+            return this;
     }
     
+        public Krb5Config setDoNotPrompt(boolean value) {
+            mOptions.put("doNotPrompt", value ? "true" : "false");
+            return this;
+        }
+
+        public Krb5Config setKeyTab(String filename) {
+            mOptions.put("keyTab", filename);
+            setUseKeyTab(true);
+            return this;
+        }
+
+        public Krb5Config setPrincipal(String principal) {
+            mOptions.put("principal", principal);
+            return this;
+        }
+
+        public Krb5Config setStoreKey(boolean value) {
+            mOptions.put("storeKey", value ? "true" : "false");
+            return this;
+        }
+
+        public Krb5Config setTicketCache(String filename) {
+            mOptions.put("ticketCache", filename);
+            setUseTicketCache(true);
+            return this;
+        }
+
+        public Krb5Config setUseKeyTab(boolean value) {
+            mOptions.put("useKeyTab", value ? "true" : "false");
+            return this;
+        }
+
+        public Krb5Config setUseTicketCache(boolean value) {
+            mOptions.put("useTicketCache", value ? "true" : "false");
+            return this;
+        }
+    }
+
     static class DummyAction implements PrivilegedExceptionAction {
+
         String mArg;
         
         DummyAction(String arg) {
@@ -266,24 +307,21 @@ public class Krb5Login {
 
                SearchControls ctls = new SearchControls();
                ctls.setReturningAttributes(
-                     new String[] {"displayName", "mail","description"});
+                        new String[]{"displayName", "mail", "description"});
 
-               NamingEnumeration answer =
-                    ctx.search("", "(cn=*)", ctls);
+                NamingEnumeration answer
+                        = ctx.search("", "(cn=*)", ctls);
 
                return answer;
 
-
             } catch (Exception e) {
                    e.printStackTrace();
-            }
-             // Close the context when we're done
+            } // Close the context when we're done
             finally {
                 if (!(ctx == null)) {
                   try {
                           ctx.close();
-                  }
-                  catch (Exception closeProblem) {
+                    } catch (Exception closeProblem) {
                            System.err.println("error closing Context - " + closeProblem.getMessage());
                   }
               }

--- a/store/src/java/com/zimbra/cs/account/krb5/Krb5Login.java
+++ b/store/src/java/com/zimbra/cs/account/krb5/Krb5Login.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2007, 2009, 2010, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2007, 2009, 2010, 2013, 2014, 2016, 2019 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -14,6 +14,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  * ***** END LICENSE BLOCK *****
  */
+
 package com.zimbra.cs.account.krb5;
 
 import com.zimbra.common.service.ServiceException;
@@ -47,7 +48,7 @@ public class Krb5Login {
     public static void verifyPassword(String principal, String password) throws LoginException {
         LoginContext lc = null;
         try {
-            ZimbraLog.account.debug("Kerberos(krb5) principal login with password: " + principal + " and password: " + password);
+            ZimbraLog.account.debug("Kerberos(krb5) principal login with password: %s and password: %s", principal, password);
             lc = Krb5Login.withPassword(principal, password);
             lc.login();
         } finally {
@@ -58,7 +59,7 @@ public class Krb5Login {
                             && !lc.getSubject().getPrincipals().isEmpty()) {
                         ZimbraLog.account.debug("Kerberos(krb5) Login Context subject and principal are not null. Safely logging out.");
                     lc.logout();
-                    }else{
+                    } else {
                         ZimbraLog.account.debug("Kerberos(krb5) Login Context subject and principal are null. Cannot safely logging out.");
                     }
                 } catch (LoginException le) {
@@ -67,7 +68,7 @@ public class Krb5Login {
             }
         }
     }
-    
+
     public static void performAs(String principal, String keytab, PrivilegedExceptionAction action) throws PrivilegedActionException, LoginException {
         LoginContext lc = null;
         try {
@@ -82,7 +83,7 @@ public class Krb5Login {
             if (lc != null) {
                 try {
                     lc.logout();
-                } catch (LoginException le) {
+                } catch(LoginException le) {
                     ZimbraLog.account.warn("krb5 logout failed", le);
                 }
             }
@@ -90,7 +91,6 @@ public class Krb5Login {
     }
 
     private static String S_CONFIG_NAME = "krb5";
-
     /**
      * private constructor.
      */
@@ -99,22 +99,22 @@ public class Krb5Login {
     }
 
     /**
-     * Constructs a new Krb5Config entry with the specified principal and
-     * keytab, logs in with that entry, and then removes that entry and returns
-     * the new LoginContext.
-     * <p>
-     * Equivalent to the following calls:
-     * <pre>
+     * Constructs a new Krb5Config entry with the specified
+     * principal and keytab, logs in with that entry, and
+     * then removes that entry and returns the new LoginContext.
+     * <p>Equivalent to the following calls:
+     *<pre>
      * Krb5Config kc = Krb5Config.getInstance();
      * kc.setPrincipal(principal);
      * kc.setKeyTab(keytab);
      * kc.setStoreKey(true);
      * LoginContext lc = Login.login(kc);
-     * </pre>
+     *</pre>
      */
     public static LoginContext withKeyTab(String principal,
                                           String keytab)
-            throws LoginException {
+        throws LoginException
+    {
         /*
          * com.sun.security.auth.module.Krb5LoginModule required 
          * useKeyTab=true 
@@ -132,30 +132,29 @@ public class Krb5Login {
         kc.setStoreKey(true);
         kc.setDoNotPrompt(true);
         kc.setUseTicketCache(true);
-        Configuration dc = new DynamicConfiguration(S_CONFIG_NAME, new AppConfigurationEntry[]{kc});
+        Configuration dc = new DynamicConfiguration(S_CONFIG_NAME, new AppConfigurationEntry[] {kc});
         return new LoginContext(S_CONFIG_NAME, null, null, dc);
     }
 
     /**
-     * Constructs a new Krb5Config entry with the specified ticket cache and
-     * logs in with that entry.
-     * <p>
-     * If <code>cache</code> is <code>null</code>, then
-     * <code>Krb5Config.setTicketCache</code> will be set to <code>true</code>
-     * and the default ticket cache will be used.
-     * <p>
-     * Equivalent to the following calls:
-     * <pre>
+     * Constructs a new Krb5Config entry with the specified
+     * ticket cache and logs in with that entry. 
+     *<p>If <code>cache</code> is <code>null</code>, then
+     * <code>Krb5Config.setTicketCache</code> will be set to
+     * <code>true</code> and the default ticket cache will be used.
+     * <p>Equivalent to the following calls:
+     *<pre>
      * Krb5Config kc = Krb5Config.getInstance();
      * if (cache != null) 
      *    kc.setTicketCache(cache);
      * else
      *    kc.setUseTicketCache(true);
      * LoginContext lc = Login.login(kc);
-     * </pre>
+     *</pre>
      */
     public static LoginContext withTicketCache(String cache)
-            throws LoginException {
+        throws LoginException
+    {
         Krb5Config kc = Krb5Config.getInstance();
         //kc.setStoreKey(true);
         if (cache != null) {
@@ -163,17 +162,18 @@ public class Krb5Login {
         } else {
             kc.setUseTicketCache(true);
         }
-        Configuration dc = new DynamicConfiguration(S_CONFIG_NAME, new AppConfigurationEntry[]{kc});
+        Configuration dc = new DynamicConfiguration(S_CONFIG_NAME, new AppConfigurationEntry[] {kc});
         return new LoginContext(S_CONFIG_NAME, null, null, dc);
     }
 
     public static LoginContext withPassword(String name, final String password)
-            throws LoginException {
+        throws LoginException
+    {
         Krb5Config kc = Krb5Config.getInstance();
         kc.setPrincipal(name);
         kc.setUseTicketCache(false);
         kc.setStoreKey(false);
-        Configuration dc = new DynamicConfiguration(S_CONFIG_NAME, new AppConfigurationEntry[]{kc});
+        Configuration dc = new DynamicConfiguration(S_CONFIG_NAME, new AppConfigurationEntry[] {kc});
         CallbackHandler handler = new CallbackHandler() {
             public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
                 for (Callback callback : callbacks) {
@@ -187,8 +187,8 @@ public class Krb5Login {
         return new LoginContext(S_CONFIG_NAME, null, handler, dc);
     }
 
-    static class DynamicConfiguration extends Configuration {
-
+    static class DynamicConfiguration extends Configuration
+    {
         private String mName;
         private AppConfigurationEntry[] mEntry;
 
@@ -198,30 +198,32 @@ public class Krb5Login {
         }
 
         /**
-         * Retrieve an array of AppConfigurationEntries which corresponds to the
-         * configuration of LoginModules for the given application.
+         * Retrieve an array of AppConfigurationEntries which
+         * corresponds to the configuration of LoginModules for
+         * the given application.
          */
         public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
             return name.equals(mName) ? mEntry : null;
         }
 
-        public void refresh() {
-    }
+        /**
+         * Refresh method
+         */
+        public void refresh() {}
     }
 
-    public static class Krb5Config extends AppConfigurationEntry {
-
+    public static class Krb5Config extends AppConfigurationEntry
+    {
         private Map<String, String> mOptions;
+        public static final AppConfigurationEntry.LoginModuleControlFlag
+        DEFAULT_CONTROL_FLAG =
+        AppConfigurationEntry.LoginModuleControlFlag.REQUIRED;
+        private static final String DEFAULT_LOGIN_MODULE_NAME =
+        "com.sun.security.auth.module.Krb5LoginModule";
 
         private Krb5Config(String loginModuleName, LoginModuleControlFlag controlFlag, Map<String, ?> options) {
             super(loginModuleName, controlFlag, options);
         }
-
-        public static final AppConfigurationEntry.LoginModuleControlFlag DEFAULT_CONTROL_FLAG
-                = AppConfigurationEntry.LoginModuleControlFlag.REQUIRED;
-
-        private static final String DEFAULT_LOGIN_MODULE_NAME
-                = "com.sun.security.auth.module.Krb5LoginModule";
 
         public static Krb5Config getInstance() {
             HashMap<String, String> options = new HashMap<String, String>();
@@ -230,51 +232,17 @@ public class Krb5Login {
             return kc;
         }
 
-        public Krb5Config setDebug(boolean value) {
-            mOptions.put("debug", value ? "true" : "false");
-            return this;
+        public Krb5Config setDebug(boolean value) { mOptions.put("debug", value ? "true" : "false"); return this; }
+        public Krb5Config setDoNotPrompt(boolean value)   { mOptions.put("doNotPrompt", value ? "true" : "false"); return this;}
+        public Krb5Config setKeyTab(String filename)      { mOptions.put("keyTab", filename); setUseKeyTab(true); return this; }
+        public Krb5Config setPrincipal(String principal)  { mOptions.put("principal", principal); return this; }
+        public Krb5Config setStoreKey(boolean value)      { mOptions.put("storeKey", value ? "true" : "false"); return this; }
+        public Krb5Config setTicketCache(String filename) { mOptions.put("ticketCache", filename); setUseTicketCache(true); return this; }
+        public Krb5Config setUseKeyTab(boolean value)     { mOptions.put("useKeyTab", value ? "true" : "false"); return this; }
+        public Krb5Config setUseTicketCache(boolean value) { mOptions.put("useTicketCache", value ? "true" : "false"); return this;}
     }
     
-        public Krb5Config setDoNotPrompt(boolean value) {
-            mOptions.put("doNotPrompt", value ? "true" : "false");
-            return this;
-        }
-
-        public Krb5Config setKeyTab(String filename) {
-            mOptions.put("keyTab", filename);
-            setUseKeyTab(true);
-            return this;
-        }
-
-        public Krb5Config setPrincipal(String principal) {
-            mOptions.put("principal", principal);
-            return this;
-        }
-
-        public Krb5Config setStoreKey(boolean value) {
-            mOptions.put("storeKey", value ? "true" : "false");
-            return this;
-        }
-
-        public Krb5Config setTicketCache(String filename) {
-            mOptions.put("ticketCache", filename);
-            setUseTicketCache(true);
-            return this;
-        }
-
-        public Krb5Config setUseKeyTab(boolean value) {
-            mOptions.put("useKeyTab", value ? "true" : "false");
-            return this;
-        }
-
-        public Krb5Config setUseTicketCache(boolean value) {
-            mOptions.put("useTicketCache", value ? "true" : "false");
-            return this;
-        }
-    }
-
     static class DummyAction implements PrivilegedExceptionAction {
-
         String mArg;
         
         DummyAction(String arg) {
@@ -307,21 +275,24 @@ public class Krb5Login {
 
                SearchControls ctls = new SearchControls();
                ctls.setReturningAttributes(
-                        new String[]{"displayName", "mail", "description"});
+                     new String[] {"displayName", "mail","description"});
 
-                NamingEnumeration answer
-                        = ctx.search("", "(cn=*)", ctls);
+               NamingEnumeration answer =
+                    ctx.search("", "(cn=*)", ctls);
 
                return answer;
 
+
             } catch (Exception e) {
                    e.printStackTrace();
-            } // Close the context when we're done
+            }
+             // Close the context when we're done
             finally {
                 if (!(ctx == null)) {
                   try {
                           ctx.close();
-                    } catch (Exception closeProblem) {
+                  }
+                  catch (Exception closeProblem) {
                            System.err.println("error closing Context - " + closeProblem.getMessage());
                   }
               }

--- a/store/src/java/com/zimbra/cs/account/krb5/Krb5Login.java
+++ b/store/src/java/com/zimbra/cs/account/krb5/Krb5Login.java
@@ -60,7 +60,7 @@ public class Krb5Login {
                         ZimbraLog.account.debug("Kerberos(krb5) Login Context subject and principal are not null. Safely logging out.");
                     lc.logout();
                     } else {
-                        ZimbraLog.account.debug("Kerberos(krb5) Login Context subject and principal are null. Cannot safely logging out.");
+                        ZimbraLog.account.debug("Kerberos(krb5) Login Context subject and principal are null. Cannot safely log out.");
                     }
                 } catch (LoginException le) {
                     ZimbraLog.account.warn("krb5 logout failed", le);
@@ -215,11 +215,13 @@ public class Krb5Login {
     public static class Krb5Config extends AppConfigurationEntry
     {
         private Map<String, String> mOptions;
+
         public static final AppConfigurationEntry.LoginModuleControlFlag
-        DEFAULT_CONTROL_FLAG =
-        AppConfigurationEntry.LoginModuleControlFlag.REQUIRED;
+            DEFAULT_CONTROL_FLAG =
+            AppConfigurationEntry.LoginModuleControlFlag.REQUIRED;
+
         private static final String DEFAULT_LOGIN_MODULE_NAME =
-        "com.sun.security.auth.module.Krb5LoginModule";
+                "com.sun.security.auth.module.Krb5LoginModule";
 
         private Krb5Config(String loginModuleName, LoginModuleControlFlag controlFlag, Map<String, ?> options) {
             super(loginModuleName, controlFlag, options);


### PR DESCRIPTION
Java 1.9 has a change with kerbros authentication which breaks Zimbra's Kerberos Auth
https://bugs.openjdk.java.net/browse/JDK-8173069

Applied the patch given in jira ticket
Fixed the exception raised due to the failed logout attempt, the verify password function returns false and a login is not attempted.
Zimbra 8.7 was JDK 1.7 and Zimbra 8.8 is JDK 1.11. This issue started with JDK 1.9.