### PR TITLE
zcs-7680 : Modified logic for alias check

### DIFF
--- a/store/src/java/com/zimbra/cs/util/AccountUtil.java
+++ b/store/src/java/com/zimbra/cs/util/AccountUtil.java
@@ -834,14 +834,22 @@ public class AccountUtil {
     }
 
     public static void checkAliasLoginAllowed(Account acct, String loginEmailAddr) throws ServiceException {
-        if (LC.alias_login_enabled.booleanValue()) {
-            return;
-        }
-
         String accountName = acct.getName();
-        if (!accountName.equals(loginEmailAddr) && !accountName.contains(loginEmailAddr)) {
-            ZimbraLog.account.debug("Alias login not enabled. '%s' is the alias account", loginEmailAddr);
+        if (!LC.alias_login_enabled.booleanValue()) {
+            if (accountName.indexOf('@') != -1 && loginEmailAddr.indexOf('@') != -1 &&
+                    !accountName.equalsIgnoreCase(loginEmailAddr)) {
+                ZimbraLog.account.debug("Alias login not enabled. '%s' is the alias account", loginEmailAddr);
                 throw AuthFailedServiceException.AUTH_FAILED(loginEmailAddr, loginEmailAddr, "alias login not enabled.");
+            } else {
+                String acctLocalPart = EmailUtil.getLocalPartAndDomain(accountName) == null ?
+                        accountName : EmailUtil.getLocalPartAndDomain(accountName)[0];
+                String loginEmailLocalPart = EmailUtil.getLocalPartAndDomain(loginEmailAddr) == null ?
+                        loginEmailAddr : EmailUtil.getLocalPartAndDomain(loginEmailAddr)[0];
+                if (!acctLocalPart.equalsIgnoreCase(loginEmailLocalPart)) {
+                    ZimbraLog.account.debug("Alias login not enabled. '%s' is the alias account", loginEmailAddr);
+                    throw AuthFailedServiceException.AUTH_FAILED(loginEmailAddr, loginEmailAddr, "alias login not enabled.");
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
issue :  The current logic had a check for `contains` which might result the condition as success and allow an alias login. found another scenario which is mentioned in the [ZCS-7680](https://jira.corp.synacor.com/browse/ZCS-7680). Need to identify ways to fix that.

Fix: Removed the `contains` check and removed the empty `return` as well. if the login email address has domain value and account name also has domain value then comparing both values otherwise taking out the local parts and comparing both values and based on this throwing exception.

Test: Tested that alias login is blocked when LC value is `false` and alias login works when LC value set to `true`.