### PR TITLE
ZBUG-1112: SpoolingCache needs to be reset after the writeObject() to clear the object cache

### DIFF
--- a/store/src/java/com/zimbra/cs/util/SpoolingCache.java
+++ b/store/src/java/com/zimbra/cs/util/SpoolingCache.java
@@ -62,6 +62,7 @@ public class SpoolingCache<K extends Serializable> implements Iterable<K> {
                 oos = new ObjectOutputStream(new BufferedOutputStream(new FileOutputStream(diskcache)));
             }
             oos.writeObject(item);
+	    oos.reset();
         }
         size++;
     }


### PR DESCRIPTION
The object of SpoolingCache is to reduce the memory footprint by using the disk cache. But it actually does not reduce the memory until the ObjectOutputStream is closed. So the current SpoolingCache does not work as expected.
Therefore, it needs to reset the stream to avoid memory and resource leaks during serialization.

