### PR TITLE
ZCS-7765: Fix DAV related failures in zm-soap-harness legacy

### DIFF
--- a/store/src/java/com/zimbra/cs/dav/client/WebDavClient.java
+++ b/store/src/java/com/zimbra/cs/dav/client/WebDavClient.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 
+
 import org.apache.http.Consts;
 import org.apache.http.Header;
 import org.apache.http.HttpException;
@@ -132,6 +133,12 @@ public class WebDavClient {
             }
         }
         return ret;
+    }
+
+    public HttpResponse  sendCustomRequest(DavRequest req) throws IOException, DavException, HttpException {
+        ZimbraLog.dav.debug("Send Request 1 : \n",req.getMethod().toString());
+        HttpResponse response = executeFollowRedirect(req);
+        return response;
     }
 
     public HttpInputStream sendRequest(DavRequest req) throws IOException, DavException, HttpException {
@@ -278,6 +285,7 @@ public class WebDavClient {
         m.addHeader("Depth", depth);
         logRequestInfo(m, bodyForLogging);
         HttpResponse response = client.execute(m, context);
+
         logResponseInfo(response);
 
         return response;

--- a/store/src/java/com/zimbra/cs/dav/client/WebDavClient.java
+++ b/store/src/java/com/zimbra/cs/dav/client/WebDavClient.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2008, 2009, 2010, 2013, 2014, 2015, 2016, 2018 Synacor, Inc.
+ * Copyright (C) 2008, 2009, 2010, 2013, 2014, 2015, 2016, 2018, 2019 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -21,7 +21,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
-
 
 import org.apache.http.Consts;
 import org.apache.http.Header;
@@ -136,7 +135,6 @@ public class WebDavClient {
     }
 
     public HttpResponse  sendCustomRequest(DavRequest req) throws IOException, DavException, HttpException {
-        ZimbraLog.dav.debug("Send Request 1 : \n",req.getMethod().toString());
         HttpResponse response = executeFollowRedirect(req);
         return response;
     }
@@ -287,7 +285,6 @@ public class WebDavClient {
         HttpResponse response = client.execute(m, context);
 
         logResponseInfo(response);
-
         return response;
     }
 

--- a/store/src/java/com/zimbra/cs/dav/service/DavServlet.java
+++ b/store/src/java/com/zimbra/cs/dav/service/DavServlet.java
@@ -806,7 +806,7 @@ public class DavServlet extends ZimbraServlet {
         }
         ctxt.getResponse().setStatus(statusCode);
         ctxt.setStatus(statusCode);
-        if (httpResponse.getEntity() != null && httpResponse.getEntity() != null)
+        if (httpResponse.getEntity() != null && httpResponse.getEntity().getContent() != null)
         {
             try (InputStream in = httpResponse.getEntity().getContent()) {
                 switch (statusCode) {

--- a/store/src/java/com/zimbra/cs/dav/service/DavServlet.java
+++ b/store/src/java/com/zimbra/cs/dav/service/DavServlet.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016 Synacor, Inc.
+ * Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2019 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -402,13 +402,10 @@ public class DavServlet extends ZimbraServlet {
                     resp.setStatus(ctxt.getStatus());
                 }
             }
-
             if (!ctxt.isResponseSent()) {
-
                 logResponseInfo(resp);
             }
         } catch (DavException e) {
-
             if (e.getCause() instanceof MailServiceException.NoSuchItemException ||
                     e.getStatus() == HttpServletResponse.SC_NOT_FOUND)
                 ZimbraLog.dav.info(ctxt.getUri()+" not found");


### PR DESCRIPTION
Issue:
Getting NPE due to invoking of super() method for empty response (SC.NO_CONTENT) in DELETE, COPY and few other request methods in UserServlet.java at line no. 939.

Fix:
Implement a custom method which does not invoke HttpInputStream.

/opt/qa/soapvalidator/data/soapvalidator/Dav/CalDav/Calendar/Appointments/DeleteAppointment.xml
/opt/qa/soapvalidator/data/soapvalidator/Dav/CalDav/Calendar/Folders/DeleteCalendar.xml
/opt/qa/soapvalidator/data/soapvalidator/Dav/WebDav/copy.xml
/opt/qa/soapvalidator/data/soapvalidator/Dav/WebDav/lock.xml
/opt/qa/soapvalidator/data/soapvalidator/Dav/WebDav/move.xml

Also fixes tests failing previously in -
/opt/qa/soapvalidator/data/soapvalidator/Dav/CalDav/Calendar/Mountpoints/DeleteAppointment.xml

Related soap-harness PR - https://github.com/Zimbra/zm-soap-harness/pull/81