### PR TITLE
ZBUG-1075:A delegated domain admin can retrieve other domains users

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1291,6 +1291,8 @@ public final class LC {
     // owasp handler
     public static final KnownKey zimbra_use_owasp_html_sanitizer = KnownKey.newKey(true);
 
+    public static final KnownKey enable_delegated_admin_ldap_access = KnownKey.newKey(true);
+
     // OAuth2 Social
     public static final KnownKey zm_oauth_classes_handlers_yahoo = KnownKey.newKey("com.zimbra.oauth.handlers.impl.YahooOAuth2Handler");
     public static final KnownKey zm_oauth_classes_handlers_google = KnownKey.newKey("com.zimbra.oauth.handlers.impl.GoogleOAuth2Handler");

--- a/store/src/java/com/zimbra/cs/service/admin/GrantRight.java
+++ b/store/src/java/com/zimbra/cs/service/admin/GrantRight.java
@@ -27,7 +27,6 @@ import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.accesscontrol.AdminRight;
 import com.zimbra.cs.account.accesscontrol.RightCommand;
 import com.zimbra.cs.account.accesscontrol.RightModifier;
-import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.admin.message.FlushCacheRequest;
 import com.zimbra.soap.admin.message.GrantRightRequest;
@@ -45,7 +44,6 @@ public class GrantRight extends RightDocumentHandler {
     @Override
     public Element handle(Element request, Map<String, Object> context) throws ServiceException {
         ZimbraSoapContext zsc = getZimbraSoapContext(context);
-
         GrantRightRequest grReq = zsc.elementToJaxb(request);
         RightModifierInfo modifierInfo = grReq.getRight();
         if (modifierInfo == null) {
@@ -74,7 +72,6 @@ public class GrantRight extends RightDocumentHandler {
                 }
             }
         }
-
         Element response = zsc.createElement(AdminConstants.GRANT_RIGHT_RESPONSE);
         return response;
     }


### PR DESCRIPTION
Issue:
A delegated domain admin can retrieve other domains users

Fix:
- Added a LC flag 'enable_delegated_admin_ldap_access' to either allow/block access/modification to LDAP entries through SOAP API
- By default, the flag value would be true to have consistency with previous behavior.