### PR TITLE
ZBUG-1112 reset the oos to flush buffer

### DIFF
--- a/store/src/java/com/zimbra/cs/util/SpoolingCache.java
+++ b/store/src/java/com/zimbra/cs/util/SpoolingCache.java
@@ -62,6 +62,7 @@ public class SpoolingCache<K extends Serializable> implements Iterable<K> {
                 oos = new ObjectOutputStream(new BufferedOutputStream(new FileOutputStream(diskcache)));
             }
             oos.writeObject(item);
+            oos.reset();
         }
         size++;
     }


### PR DESCRIPTION
Added code to reset the objectoutputstream to flush the buffer after each write and reset the stream's internal object cache.

Verified with mailbox move in a multinode setup that no exceptions are thrown