### PR TITLE
ZCS-7784: Img tag style attribute getting truncated

### DIFF
--- a/store-conf/conf/owasp_policy.xml
+++ b/store-conf/conf/owasp_policy.xml
@@ -5,6 +5,7 @@
      KBD = accesshtml,tabindex-->
 <owasp_policy>
   <url_protocols>cid,http,https,mailto,data,smb</url_protocols>
+  <url_protocol_attributes>href,src</url_protocol_attributes>
   <disallow_text_in>applet,frameset,object,script,title</disallow_text_in>
   <allow_text_in>style</allow_text_in>
   <css_whitelist>float,display</css_whitelist>

--- a/store/src/java-test/com/zimbra/cs/html/owasp/OwaspHtmlSanitizerTest.java
+++ b/store/src/java-test/com/zimbra/cs/html/owasp/OwaspHtmlSanitizerTest.java
@@ -694,4 +694,10 @@ public class OwaspHtmlSanitizerTest {
         Assert.assertTrue(result.contains("float"));
     }
 
+    @Test
+    public void testZCS7784() throws Exception {
+        String html = "<img class=\"gmail\" style=\"display:none; width:0; overflow:hidden;\" src=\"https://localhost:8443/service/home/~/?auth=co&loc=en_US&id=285&part=2.2\" >";
+        String result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        Assert.assertTrue(result.contains("style"));
+    }
 }

--- a/store/src/java/com/zimbra/cs/html/owasp/HtmlElement.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/HtmlElement.java
@@ -67,12 +67,15 @@ public class HtmlElement {
         for (String attribute : allowedAttributes) {
             attributesBuilder = policyBuilder.allowAttributes(attribute);
             if (attributesBuilder != null) {
-                String urlProtocols = OwaspPolicy.getElementUrlProtocols(element);
-                if (!StringUtil.isNullOrEmpty(urlProtocols)) {
-                    String[] allowedProtocols = urlProtocols.split(COMMA);
-                    List<String> urlList = Arrays.asList(allowedProtocols);
-                    AttributePolicy URLPolicy = new FilterUrlByProtocolAttributePolicy(urlList);
-                    attributesBuilder.matching(URLPolicy);
+                Set<String> urlProtocolAttributes = OwaspPolicy.getElementUrlProtocolAttributes();
+                if(urlProtocolAttributes.contains(attribute) ) {
+	                String urlProtocols = OwaspPolicy.getElementUrlProtocols(element);
+	                if (!StringUtil.isNullOrEmpty(urlProtocols)) {
+	                    String[] allowedProtocols = urlProtocols.split(COMMA);
+	                    List<String> urlList = Arrays.asList(allowedProtocols);
+	                    AttributePolicy URLPolicy = new FilterUrlByProtocolAttributePolicy(urlList);
+	                    attributesBuilder.matching(URLPolicy);
+	                }
                 }
                 AttributePolicy attrPolicy = attributesAndPolicies.get(attribute);
                 if (attrPolicy != null) {

--- a/store/src/java/com/zimbra/cs/html/owasp/OwaspPolicy.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/OwaspPolicy.java
@@ -66,7 +66,6 @@ public class OwaspPolicy {
     private static final Set<String> mURLProtocols = new HashSet<String>();
     private static final Set<String> mURLProtocolAttrs = new HashSet<String>();
     private static final Map<String, String> mElementUrlProtocols = new HashMap<String, String>();
-    private static final Map<String, String> mElementUrlProtocolAttrs = new HashMap<String, String>();
 
     static {
         try {

--- a/store/src/java/com/zimbra/cs/html/owasp/OwaspPolicy.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/OwaspPolicy.java
@@ -48,6 +48,7 @@ public class OwaspPolicy {
     public static final String E_ALLOW_TEXT_IN = "allow_text_in";
     public static final String E_CSS_WHITELIST = "css_whitelist";
     public static final String E_URL_PROTOCOLS = "url_protocols";
+    public static final String E_URL_PROTOCOL_Attrs = "url_protocol_attributes";
     public static final String E_ELEMENT = "element";
     public static final String A_NAME = "name";
     public static final String A_REMOVE_TEXT = "removeText";
@@ -63,7 +64,9 @@ public class OwaspPolicy {
     private static final Set<String> mAllowTextElements = new HashSet<String>();
     private static final Set<String> mCssWhitelist = new HashSet<String>();
     private static final Set<String> mURLProtocols = new HashSet<String>();
+    private static final Set<String> mURLProtocolAttrs = new HashSet<String>();
     private static final Map<String, String> mElementUrlProtocols = new HashMap<String, String>();
+    private static final Map<String, String> mElementUrlProtocolAttrs = new HashMap<String, String>();
 
     static {
         try {
@@ -115,6 +118,10 @@ public class OwaspPolicy {
                 String urlProtocols = root.elementText(E_URL_PROTOCOLS);
                 if (!StringUtil.isNullOrEmpty(urlProtocols)) {
                     mURLProtocols.addAll(Arrays.asList(urlProtocols.split(COMMA)));
+                }
+                String urlProtocolAttrs = root.elementText(E_URL_PROTOCOL_Attrs);
+                if (!StringUtil.isNullOrEmpty(urlProtocolAttrs)) {
+                    mURLProtocolAttrs.addAll(Arrays.asList(urlProtocolAttrs.split(COMMA)));
                 }
             } catch (IOException | XmlParseException e) {
                 ZimbraLog.mailbox
@@ -184,4 +191,7 @@ public class OwaspPolicy {
         return mURLProtocols;
     }
 
+    public static Set<String> getElementUrlProtocolAttributes() {
+        return mURLProtocolAttrs;
+    }
 }


### PR DESCRIPTION
Issue:  Owasp was removing style attribute of image component

eg.
<img style=\"display: none !important\" src=\"http://jan-sampark.nic.in/jansampark/read.jsp?tab=pmo&lat=2019&mid=124c7b6ff039235af7904980673156118997caea\" />