### PR TITLE
ZBUG-711:convertd exhausts system memory when .har file is indexed

### DIFF
--- a/store/src/java/com/zimbra/cs/service/FileUploadServlet.java
+++ b/store/src/java/com/zimbra/cs/service/FileUploadServlet.java
@@ -678,6 +678,10 @@ public class FileUploadServlet extends ZimbraServlet {
             filename = new ContentDisposition(req.getHeader("Content-Disposition")).getParameter("filename");
         }
 
+        if (filename.endsWith(".har")) {
+            contentType = MimeConstants.CT_APPLICATION_JSON;
+        }
+
         if (filename == null || filename.trim().equals("")) {
             mLog.info("Rejecting upload with no name.");
             drainRequestStream(req);


### PR DESCRIPTION
Issue:
The convertd native process is stuck and CPU spikes if the .har file is uploaded to briefcase or in attachment

Fix:
When .har file is uploaded its content type was being set to 'application/octet-stream' by default(retrieved from HttpServletRequest instance)
But, the file actually contains data in json format. the convertd is trying to convert the document based on 'application/octet-stream' and failing.
Changing the content type of the uploaded .har document to 'application/json' resolves the issue.