### PR TITLE
ZBUG-1109: spell check is not working correctly with 8.8.15

### DIFF
--- a/store/src/java/com/zimbra/cs/service/mail/CheckSpelling.java
+++ b/store/src/java/com/zimbra/cs/service/mail/CheckSpelling.java
@@ -199,7 +199,7 @@ public class CheckSpelling extends MailDocumentHandler {
         if (ignoreAllCaps) {
             nvps.add(new BasicNameValuePair("ignoreAllCaps", "on"));
         }
-        post.setEntity(new UrlEncodedFormEntity(nvps));
+        post.setEntity(new UrlEncodedFormEntity(nvps, "UTF-8"));
         HttpClient http = ZimbraHttpConnectionManager.getExternalHttpConnMgr().newHttpClient().build();
         ServerResponse response = new ServerResponse();
         HttpResponse httpResp = null;


### PR DESCRIPTION
Problem:  Spell check was not working

Approach And Fix: After checking, found that spellcheck has an issue with special chars so added "UTF-8" to fix it.

Testing done: Created signature with the MIME attached to the ticket and with few manual sample signatures and verified the spellcheck functionality.

Testing to be done by QA: Verify the spellcheck using the MIME attached to the ticket