### PR TITLE
ZBUG-711:convertd exhausts system memory when .har file is indexed

### DIFF
--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -119,5 +119,6 @@
   <dependency org="org.w3c.css" name="sac" rev="1.3"/>
   <dependency org="org.apache.xmlgraphics" name="batik-i18n" rev="1.9"/>
   <dependency org="org.apache.xmlgraphics" name="batik-util" rev="1.8"/>
+  <dependency org="org.apache.tika" name="tika-core" rev="1.22"/>
  </dependencies>
 </ivy-module>


### PR DESCRIPTION
Issue: convertd exhausts system memory when .har file is indexed. 
CPU spikes for httpd process

Fix: Checking the content type of the .har file using tika library and using the mime handler class based on the detected content type.

Testing done:
Upload .har file into briefcase - File gets uploaded. No CPU spike.
Search any keyword from the file - file appears in search result. No CPU spike.
Attach .har file to message and send the message - message is sent
Search any keyword from the file - sent message appears in search result. No CPU spike.