### PR TITLE
ZBUG-1148:Loosing table format with owasp sanitizer

### DIFF
--- a/store/build.xml
+++ b/store/build.xml
@@ -286,7 +286,6 @@
     <ivy:install organisation="org.apache.curator" module="curator-framework" revision="2.0.1-incubating" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="asm" module="asm" revision="3.3.1" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="oauth" module="oauth" revision="1.4" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
-    <ivy:install organisation="com.googlecode.owasp-java-html-sanitizer" module="owasp-java-html-sanitizer" revision="20160924.1" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.apache.tika" module="tika-core" revision="1.22" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.owasp.antisamy" module="antisamy" revision="1.5.3" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.apache.xmlgraphics" module="batik-css" revision="1.7" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>


### PR DESCRIPTION
Upgrading OWASP library to latest version, which resolves ZBUG-1148
Added fix for ZCS-7497 in new owasp library

Ref PRs:
https://github.com/Zimbra/java-html-sanitizer-release-20190610.1/pull/1
https://github.com/Zimbra/zm-build/pull/154
https://github.com/Zimbra/zm-zcs-lib/pull/54