### PR TITLE
Fix for addictional quota counted multiple times.

### DIFF
--- a/store/src/java/com/zimbra/cs/db/DbMailbox.java
+++ b/store/src/java/com/zimbra/cs/db/DbMailbox.java
@@ -513,7 +513,7 @@ public final class DbMailbox {
             stmt.setInt(pos++, mbox.getLastItemId());
             stmt.setInt(pos++, mbox.getContactCount());
             stmt.setInt(pos++, mbox.getLastChangeID());
-            stmt.setLong(pos++, mbox.getSize());
+            stmt.setLong(pos++, mbox.getMailItemsSize());
             stmt.setInt(pos++, mbox.getRecentMessageCount());
             stmt.setInt(pos++, mbox.getId());
             stmt.executeUpdate();

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -1419,8 +1419,12 @@ public class Mailbox implements MailboxStore {
     /** Returns the total (uncompressed) size of the mailbox's contents. */
     @Override
     public long getSize() {
-        long additionalSize = getAdditionalSize();
-        return (currentChange().size == MailboxChange.NO_CHANGE ? mData.size : currentChange().size) + additionalSize;
+        return getMailItemsSize() + getAdditionalSize();
+    }
+
+    /** Returns only the mailbox size without the addictional size */
+    public long getMailItemsSize() {
+        return (currentChange().size == MailboxChange.NO_CHANGE ? mData.size : currentChange().size);
     }
 
     private long getAdditionalSize() {
@@ -1460,7 +1464,7 @@ public class Mailbox implements MailboxStore {
     public void checkSizeChange(long newSize) throws ServiceException {
         Account acct = getAccount();
         long acctQuota = AccountUtil.getEffectiveQuota(acct);
-        if (acctQuota != 0 && newSize + getAdditionalSize() > acctQuota) {
+        if (acctQuota != 0 && newSize > acctQuota) {
             throw MailServiceException.QUOTA_EXCEEDED(acctQuota);
         }
         Domain domain = Provisioning.getInstance().getDomain(acct);


### PR DESCRIPTION
The mailbox quota is stored by the DbMailbox at every end of transaction and loaded during mailbox initiaization.
The stored quota accounts for both mail items quota and addictional quota but the addictional quota is provided at run-time and should not be stored at all.
This fix split the size of the mailbox into mail items and addictional quota and store in database only the mail items size.
In the affected mailboxes a recalculation of the mailbox quota is needed.