### PR TITLE
Bugfix: NullPointerException with certain calendar notification messages and broken mountpoints

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/Message.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Message.java
@@ -635,9 +635,15 @@ public class Message extends MailItem {
         AccountAddressMatcher acctMatcher = new AccountAddressMatcher(ownerAcct);
         for (Mountpoint sharedCal : getMailbox().getCalendarMountpoints(getMailbox().getOperationContext(), SortBy.NONE)) {
             if (sharedCal.canAccess(ACL.RIGHT_ACTION)) {
-                String calOwner = Provisioning.getInstance().get(AccountBy.id, sharedCal.getOwnerId()).getName();
-                if (acctMatcher.matches(calOwner)) {
-                    return true;
+                String calOwner;
+                Account calOwnerAcct = Provisioning.getInstance().get(AccountBy.id, sharedCal.getOwnerId());
+                if (calOwnerAcct == null) {
+                    ZimbraLog.account.info("Account ID = %s not present.", sharedCal.getOwnerId());
+                } else {
+                    calOwner = calOwnerAcct.getName();
+                    if (acctMatcher.matches(calOwner)) {
+                        return true;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Appointment notification messages for managed remote calendars can cause
NullPointerException exceptions in the presence of mountpoints
referencing non-existing accounts.
This could result in the web interface not loading if such messages lie
in the /Inbox folder or in the messages themselves missing portions of
metadata in the related DB objects once imported, for instance using the
Tar Formatter.

**Symptoms**
* Web Interface not loading, stuck on the loading screen
* Inability to perform a search request, even via the CLI interface
* Attempting to read certain message containing calendar invites results in a message mentioning a `java.lang.NullPointerException`

**Steps to reproduce**
* Create an account sharing a calendar ( e.g. cal_owner@example.com )
* Create an account managing the calendar of the sharer account ( e.g. cal_manager@example.com )
* Create an account invited to an event of the sharer account ( e.g. partecipant@example.com )
* Share the account of cal_owner@ to cal_manager@
* Create a mountpoint for it in the cal_manager@ mailbox
* As cal_manager@ create an event on the calendar of cal_owner@ inviting partecipant@
* As partecipant@ accept the invitation
* A notification will be delivered to cal_manager@ with a header `X-Zimbra-Calendar-Intended-For` set to cal_owner@example.com
* Destroy the account cal_owner@
* cal_manager@ now has a broken mountpoint for the calendar of the deleted cal_owner@ (ANY mountpoint referencing a non-existing account ID (or folder?) will generate the same behaviour)
* Create a new account cal_owner@ (which will have a different zimbraId compared to the recently deleted one)

Any action resulting in parsing the notification previously received by cal_manager@ will result in a `java.lang.NullPointerException`. If the e-mail is accessed automatically during the login (e.g. it’s located under /Inbox in cal_manager@) the exception will prevent the web interface from loading, unless the old html interface is used. Other situations, such as importing such invites through the tar formatter, will result in objects missing most the original metadata in the DB entry.

**Cause**
Mountpoints are cycled to locate one referencing a calendar of the owner mentioned in the `X-Zimbra-Calendar-Intended-For` header.
A method `getName` is called on the object resulting from querying the LDAP directory about the account with the `zimbraId` referenced by the mountpoint. However in case no such account exists in the directory the `getName` is called on a `null` value, triggering the exception.
