### PR TITLE
ZBUG-1212 Fix Repetitive copy  from Apple mail client configured with Imap

### DIFF
--- a/store/src/java/com/zimbra/cs/imap/ImapCommandThrottle.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapCommandThrottle.java
@@ -53,7 +53,7 @@ public class ImapCommandThrottle {
             return false;
         } else if (command.throttle(lastCommand)) {
             // commands can implement their own throttle mechanism
-            ZimbraLog.imap.debug("throttled by command");
+            ZimbraLog.imap.debug("throttled by command " + command.getClass().getCanonicalName());
             return true;
         } else if (isCommandRepeated(command)) {
             repeats++;


### PR DESCRIPTION
Added code to add the list of processed sequences  and check when a new COPY UID command is received. If the sequence are already processed do no processing and return a OK to client.

This is only when emails are moved to Trash.

Sending the PR to get feedback on approach, will clean code once all testing is done