### PR TITLE
ZCS-8181: zimbraAppSpecificPassword (2FA) is not scalable, need to be scalable for millions of accounts

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -792,6 +792,9 @@ public final class LC {
     public static final KnownKey zimbra_class_jsieve_comparators_octet = KnownKey.newKey("com.zimbra.cs.filter.ZimbraOctet");
     public static final KnownKey zimbra_class_two_factor_auth_factory = KnownKey.newKey("com.zimbra.cs.account.auth.twofactor.TwoFactorAuth$DefaultFactory");
 
+    // ZCS-8181 if below flag is false, do not update zimbraAppSpecificPassword attr
+    //          with last authentication time during authentication of app specific password.
+    public static final KnownKey zimbra_two_factor_apppassword_authtime = KnownKey.newKey(true);
     // XXX REMOVE AND RELEASE NOTE
     public static final KnownKey data_source_trust_self_signed_certs = KnownKey.newKey(false);
     public static final KnownKey data_source_fetch_size = KnownKey.newKey(5);

--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -794,7 +794,7 @@ public final class LC {
 
     // ZCS-8181 if below flag is false, do not update zimbraAppSpecificPassword attr
     //          with last authentication time during authentication of app specific password.
-    public static final KnownKey zimbra_two_factor_apppassword_authtime = KnownKey.newKey(true);
+    public static final KnownKey zimbra_two_factor_apppassword_update_authtime = KnownKey.newKey(true);
     // XXX REMOVE AND RELEASE NOTE
     public static final KnownKey data_source_trust_self_signed_certs = KnownKey.newKey(false);
     public static final KnownKey data_source_fetch_size = KnownKey.newKey(5);


### PR DESCRIPTION
Implemented a new LC config for not updating auth time in zimbraAppSpecificPassword attr value.

Related PR - https://github.com/Zimbra/zm-twofactorauth-store/pull/10