### PR TITLE
zbug-903:Problem with sendAs delegate rights and Save a copy of sent messages to my Sent folder

### DIFF
--- a/store/src/java/com/zimbra/soap/SoapEngine.java
+++ b/store/src/java/com/zimbra/soap/SoapEngine.java
@@ -31,6 +31,9 @@ import javax.xml.stream.XMLStreamReader;
 import org.eclipse.jetty.continuation.ContinuationSupport;
 
 import com.google.common.base.Strings;
+import com.zimbra.common.account.Key;
+import com.zimbra.common.account.ProvisioningConstants;
+import com.zimbra.common.account.Key.AccountBy;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
@@ -51,8 +54,10 @@ import com.zimbra.cs.account.AccessManager;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.AccountServiceException;
 import com.zimbra.cs.account.AccountServiceException.AuthFailedServiceException;
+import com.zimbra.cs.account.accesscontrol.generated.RightConsts;
 import com.zimbra.cs.account.AuthToken;
 import com.zimbra.cs.account.GuestAccount;
+import com.zimbra.cs.account.Identity;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.MailboxManager;
@@ -327,6 +332,22 @@ public class SoapEngine {
         Element ectxt = soapProto.getHeader(envelope, HeaderConstants.CONTEXT);
         try {
             zsc = new ZimbraSoapContext(ectxt, doc.getQName(), handler, context, soapProto);
+            if (doc.getName().equals("SendMsgRequest")) {
+                Element msgEle = doc.getElement(MailConstants.E_MSG);
+                String identityId = msgEle.getAttribute(MailConstants.A_IDENTITY_ID, null);
+                if (identityId != null) {
+                    Identity identity = Provisioning.getInstance().get(DocumentHandler.getOperationContext(zsc, context)
+                            .getAuthenticatedUser(), Key.IdentityBy.id, identityId);
+                    if (identity != null &&
+                            !identity.getAttr(Provisioning.A_zimbraPrefIdentityName).equals(ProvisioningConstants.DEFAULT_IDENTITY_NAME) &&
+                            !StringUtil.isNullOrEmpty(identity.getAttr(Provisioning.A_zimbraPrefFromAddressType)) &&
+                            (identity.getAttr(Provisioning.A_zimbraPrefFromAddressType).equals(RightConsts.RT_sendAs) ||
+                                    identity.getAttr(Provisioning.A_zimbraPrefFromAddressType).equals(RightConsts.RT_sendOnBehalfOf))) {
+                        Account targetAccount = Provisioning.getInstance().get(AccountBy.name, identity.getAttr(Provisioning.A_zimbraPrefFromAddress));
+                        zsc.setmRequestedAccountId(targetAccount.getId());
+                    }
+                }
+            }
         } catch (ServiceException e) {
             return soapFaultEnv(soapProto, "unable to construct SOAP context", e);
         }

--- a/store/src/java/com/zimbra/soap/ZimbraSoapContext.java
+++ b/store/src/java/com/zimbra/soap/ZimbraSoapContext.java
@@ -1065,4 +1065,8 @@ public final class ZimbraSoapContext {
     public SoapProtocol getmResponseProtocol() {
         return mResponseProtocol;
     }
+
+    public void setmRequestedAccountId(String mRequestedAccountId) {
+        this.mRequestedAccountId = mRequestedAccountId;
+    }
 }


### PR DESCRIPTION
**Issue :** 

The option "Save a copy of sent messages to my Sent folder" doesn't work with a persona in the web client.

- UserA has given userB "SendAs" or "Send of Behalf". and selected the option "Save a copy of sent messages to my Sent folder"
- UseB has created a persona for userA and sent an email to userC.  Sent email did't save in userA's sent folder.

**Approach and Fix:**

When the `SendMsgRequest` comes for `sendAs` and `sendOnBehalf`  from the logged in user account, the request header contains the actual user accountId and in this case we get the target mailbox is the userA, but in case of Persona the header contains the logged in user accountId which is userB, so the target mailbox is always the logged in user mailbox and when the message sent successfully it stores in the target mailbox sent folder.

Every user account has a default persona(identity). So when we add a persona, it creates another identity. So if the SendMsgRequest comes from persona, checking if the identity has `sendAs` or `sendOnBehalf`  rights and then getting the account from the identity mail address and target mailbox for the account. Now the sent message will be stored in the actual user's sent folder

**Test:**
Manually testing done. QA needs to verify all the required scenarios. 