### PR TITLE
Fix sync issues with external accounts > 4GiB

### DIFF
--- a/store/src/java/com/zimbra/cs/db/DbDataSource.java
+++ b/store/src/java/com/zimbra/cs/db/DbDataSource.java
@@ -777,14 +777,14 @@ public class DbDataSource {
         return items;
     }
 
-    public static int getDataSourceUsage(DataSource ds) throws ServiceException {
+    public static long getDataSourceUsage(DataSource ds) throws ServiceException {
         Mailbox mbox = DataSourceManager.getInstance().getMailbox(ds);
         ZimbraLog.datasource.debug("Getting size of %s", ds.getName());
 
         DbConnection conn = null;
         PreparedStatement stmt = null;
         ResultSet rs = null;
-        int totalSize = 0;
+        long totalSize = 0L;
         try {
             conn = mbox.getOperationConnection();
             StringBuilder sb = new StringBuilder();
@@ -801,7 +801,7 @@ public class DbDataSource {
             stmt.setByte(pos++, MailItem.Type.MESSAGE.toByte());
             rs = stmt.executeQuery();
             while (rs.next()) {
-                totalSize = rs.getInt(1);
+                totalSize = rs.getLong(1);
                 break;
             }
             rs.close();


### PR DESCRIPTION
In ZCS 8.8.15_GA_3869, external accounts that are larger than 4 GiB fail to sync because a database query returns a number that does not fit into an integer, but `getDataSourceUsage()` attempts to call `ResultSet.getInt()` on it.

This raises an SQLException, which gets eventually converted into a message similar to the following, which ends up being displayed to the user:

> Error: system failure: Folder sync failed, system failure: Synchronization of folder '/DATASOURCE/Inbox' failed, system failure: UID FETCH failed: com.zimbra.cs.mailclient.CommandFailedException: UID FETCH failed: Error in response, UID FETCH failed: Error in response, Exception in response handler, system failure: Unable to get size of dataSource DATASOURCE, Out of range value for column 'sum(mi.size)' : value 7279378627 is not in class java.lang.Integer range

Fix this issue by using a long as return value and obtaining the value from the ResultSet as long.