### PR TITLE
ZCS-8181: update LC name to zimbra_two_factor_apppasswd_update_authtime

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -794,7 +794,7 @@ public final class LC {
 
     // ZCS-8181 if below flag is false, do not update zimbraAppSpecificPassword attr
     //          with last authentication time during authentication of app specific password.
-    public static final KnownKey zimbra_two_factor_apppassword_update_authtime = KnownKey.newKey(true);
+    public static final KnownKey zimbra_two_factor_apppasswd_update_authtime = KnownKey.newKey(true);
     // XXX REMOVE AND RELEASE NOTE
     public static final KnownKey data_source_trust_self_signed_certs = KnownKey.newKey(false);
     public static final KnownKey data_source_fetch_size = KnownKey.newKey(5);


### PR DESCRIPTION
As current LC had "password" string in it, we had to use zmlocalconfig -s
Modified LC name to address this issue  - "zimbra_two_factor_apppasswd_update_authtime"

Related PR: https://github.com/Zimbra/zm-twofactorauth-store/pull/11
Related Original PRs:

https://github.com/Zimbra/zm-twofactorauth-store/pull/10
https://github.com/Zimbra/zm-mailbox/pull/975