### PR TITLE
ZCS-8016: updating commons fileupload version from 1.2.2 to 1.4

### DIFF
--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -62,7 +62,7 @@
   <dependency org="commons-codec" name="commons-codec" rev="1.7"/>
   <dependency org="commons-io" name="commons-io" rev="1.4"/>
   <dependency org="commons-lang" name="commons-lang" rev="2.6"/>
-  <dependency org="commons-fileupload" name="commons-fileupload" rev="1.2.2"/>
+  <dependency org="commons-fileupload" name="commons-fileupload" rev="1.4"/>
   <dependency org="commons-collections" name="commons-collections" rev="3.2.2" />
   <dependency org="commons-logging" name="commons-logging" rev="1.1.1"/>
   <dependency org="org.apache.httpcomponents" name="httpclient" rev="${httpclient.version}"/>

--- a/store/src/java-test/com/zimbra/cs/service/FileUploadServletTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/FileUploadServletTest.java
@@ -118,6 +118,9 @@ public class FileUploadServletTest {
     private List<Upload> uploadForm(byte[] form) throws Exception {
         URL url = new URL("http://localhost:7070/service/upload?fmt=extended");
         MockHttpServletRequest req = new MockHttpServletRequest(form, url, "multipart/form-data; boundary=" + boundary);
+        HashMap<String, String> headersMap = new HashMap<String, String>();
+        headersMap.put("Content-length", Integer.toString(form.length));
+        req.headers = headersMap;
         MockHttpServletResponse resp = new MockHttpServletResponse();
         return servlet.handleMultipartUpload(req, resp, "extended", testAccount, false, null, true);
     }


### PR DESCRIPTION
Issue:
commons-fileupload older version have vulnerabilities in older version.

Fix:
Updating version from 1.2.2 to 1.4

Related PRs:
https://github.com/Zimbra/zm-zcs-lib/pull/56
https://github.com/Zimbra/zm-genesis/pull/40
https://github.com/Zimbra/zm-soap-harness/pull/93
https://github.com/Zimbra/zm-taglib/pull/33
https://github.com/Zimbra/zm-clientuploader-store/pull/3
https://github.com/Zimbra/zm-clam-scanner-store/pull/2

[zcs-8016-soap-tests.zip](https://github.com/Zimbra/zm-mailbox/files/3872885/zcs-8016-soap-tests.zip)