### PR TITLE
ZBUG-1174: Web client does not show UTF-8 "Quoted-Printable"

### DIFF
--- a/store/build.xml
+++ b/store/build.xml
@@ -287,7 +287,6 @@
     <ivy:install organisation="asm" module="asm" revision="3.3.1" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="oauth" module="oauth" revision="1.4" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.apache.tika" module="tika-core" revision="1.22" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
-    <ivy:install organisation="org.owasp.antisamy" module="antisamy" revision="1.5.3" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.apache.xmlgraphics" module="batik-css" revision="1.7" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.w3c.css" module="sac" revision="1.3" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.apache.xmlgraphics" module="batik-i18n" revision="1.9" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>

--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -116,7 +116,9 @@
   <dependency org="org.apache.commons" name="commons-rng-simple" rev="1.0"/>
   <dependency org="com.google.javascript" name="closure-compiler" rev="v20180204"/>
   <dependency org="com.github.zafarkhaja" name="java-semver" rev="0.9.0"/>
-  <dependency org="org.owasp.antisamy" name="antisamy" rev="1.5.3"/>
+  <!--Build uses the custom version 1.5.8z of antisamy lib.
+  Not updating custom version here as the version 1.5.8 is only used for compilation.-->
+  <dependency org="org.owasp.antisamy" name="antisamy" rev="1.5.8"/>
   <dependency org="org.apache.xmlgraphics" name="batik-css" rev="1.7"/>
   <dependency org="org.w3c.css" name="sac" rev="1.3"/>
   <dependency org="org.apache.xmlgraphics" name="batik-i18n" rev="1.9"/>


### PR DESCRIPTION
Upgrading owasp Antisamy library to latest version, with added fix for ZBUG-1174 in new antisamy library

Ref PRs:
https://github.com/Zimbra/zm-build/pull/157
https://github.com/Zimbra/zm-mailbox/pull/982
https://github.com/Zimbra/zm-zcs-lib/pull/57
https://github.com/Zimbra/antisamy/pull/1