### PR TITLE
ZCS-8011: Third party vulnerabilities in Jackson databind

### DIFF
--- a/soap/ivy.xml
+++ b/soap/ivy.xml
@@ -18,10 +18,10 @@
   <dependency org="commons-cli" name="commons-cli" rev="1.2" />
   <dependency org="org.freemarker" name="freemarker" rev="2.3.23"/>
   <dependency org="log4j" name="log4j" rev="1.2.16" />
-  <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.9.2"/>
-  <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.9.2"/>
+  <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.10.1"/>
+  <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.10.1"/>
   <dependency org="com.fasterxml.jackson.module" name="jackson-module-jaxb-annotations" rev="2.8.9"/>
-  <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.9.2"/>
+  <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.10.1"/>
   <dependency org="com.fasterxml.jackson.dataformat" name="jackson-dataformat-xml" rev="2.9.2"/>
   <dependency org="org.apache.james" name="apache-jsieve-core" rev="0.5"/>
   <dependency org="zimbra" name="zm-common" rev="latest.integration" />

--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -104,9 +104,9 @@
   <dependency org="org.xmlunit" name="xmlunit-core" rev="2.3.0"/>
   <dependency org="ant-contrib" name="ant-contrib" rev="1.0b3" />
   <dependency org="io.jsonwebtoken" name="jjwt" rev="0.7.0"/>
-  <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.9.2"/>
-  <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.9.2"/>
-  <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.9.2"/>
+  <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.10.1"/>
+  <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.10.1"/>
+  <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.10.1"/>
   <dependency org="com.fasterxml.jackson.dataformat" name="jackson-dataformat-smile" rev="2.9.2" />
   <dependency org="com.fasterxml.jackson.module" name="jackson-module-jaxb-annotations" rev="2.8.9"/>
   <dependency org="org.apache.commons" name="commons-text" rev="1.1"/>


### PR DESCRIPTION
Issue: Third-party vulnerabilities in Jackson library
Fix: Upgrade the Jackson library to the latest version

Related PRs:
https://github.com/Zimbra/zm-oauth-social/pull/54
https://github.com/Zimbra/zm-zcs-lib/pull/59
https://github.com/Zimbra/zm-gql/pull/54
https://github.com/Zimbra/zm-gql-admin/pull/1
https://github.com/Zimbra/zm-network-gql/pull/5