### PR TITLE
ZCS-8246 Fixing NPE with CSRF check

### DIFF
--- a/store/src/java-test/com/zimbra/cs/servlet/util/CsrfUtilTest.java
+++ b/store/src/java-test/com/zimbra/cs/servlet/util/CsrfUtilTest.java
@@ -184,7 +184,7 @@ public class CsrfUtilTest {
             assertEquals(false, validToken);
 
 
-        } catch (ServiceException  e) {
+        } catch (Exception  e) {
             fail("Should not throw exception.");
         }
     }

--- a/store/src/java-test/com/zimbra/cs/servlet/util/CsrfUtilTest.java
+++ b/store/src/java-test/com/zimbra/cs/servlet/util/CsrfUtilTest.java
@@ -171,6 +171,24 @@ public class CsrfUtilTest {
         }
     }
 
+    @Test
+    public final void testIsValidCsrfTokenForAccountWithNullAuthToken() {
+        try {
+            Account acct = Provisioning.getInstance().getAccountByName(
+                "test@zimbra.com");
+            AuthToken authToken = new ZimbraAuthToken(acct);
+
+            String csrfToken1 = CsrfUtil.generateCsrfToken(acct.getId(),
+                AUTH_TOKEN_EXPR, CSRFTOKEN_SALT, authToken);
+            boolean validToken = CsrfUtil.isValidCsrfToken(csrfToken1, null);
+            assertEquals(false, validToken);
+
+
+        } catch (ServiceException  e) {
+            fail("Should not throw exception.");
+        }
+    }
+
 
     @Test
     public final void testIsCsrfRequestWhenCsrfCheckIsTurnedOn() {

--- a/store/src/java/com/zimbra/cs/servlet/util/CsrfUtil.java
+++ b/store/src/java/com/zimbra/cs/servlet/util/CsrfUtil.java
@@ -255,7 +255,7 @@ public final class CsrfUtil {
     }
 
     public static boolean isValidCsrfToken(String csrfToken, AuthToken authToken) {
-        if (StringUtil.isNullOrEmpty(csrfToken)) {
+        if (StringUtil.isNullOrEmpty(csrfToken) || null == authToken) {
             return false;
         }
 


### PR DESCRIPTION
When a SOAP request is sent with Expired auth token and CSRF token enabled. The CSRF token validation fails as auth token is set to null in ZSC when auth token is expired.

Verified that NPE is not thrown
Added unit test


Tests | Failures | Errors | Skipped | Success rate | Time
1332 | 0 | 0 | 10 | 100.00% | 245.740

