### PR TITLE
ZCS-8010: updating bouncycastle version to 1.64 from 1.55

### DIFF
--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -84,8 +84,8 @@
   <dependency org="com.unboundid" name="unboundid-ldapsdk" rev="2.3.5" />
   <dependency org="org.newsclub" name="junixsocket" rev="1.3" />
   <dependency org="net.freeutils.jtnef" name="tnef" rev="1.8.0" />
-  <dependency org="org.bouncycastle" name="bcprov-jdk15on" rev="1.55"/>
-  <dependency org="org.bouncycastle" name="bcpkix-jdk15on" rev="1.55"/>
+  <dependency org="org.bouncycastle" name="bcprov-jdk15on" rev="1.64"/>
+  <dependency org="org.bouncycastle" name="bcpkix-jdk15on" rev="1.64"/>
   <dependency org="com.googlecode.concurrentlinkedhashmap" name="concurrentlinkedhashmap-lru" rev="1.3.1" />
   <dependency org="org.apache.commons" name="commons-csv" rev="1.2"/>
   <dependency org="ch.ethz.ganymed" name="ganymed-ssh2" rev="build210" />


### PR DESCRIPTION
Issue:
Vulnerabilities in older version 1.55 of bouncy castle.

Fix:
Update version to 1.64