### PR TITLE
ZCS-8286 Add whitelist (blacklist exceptions) for FeedManager.

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1307,6 +1307,9 @@ public final class LC {
     // Feed Manager comma-separated blacklist. addresses can be CIDR notation, or single ip. no wild-cards (default blacklist private networks)
     public static final KnownKey zimbra_feed_manager_blacklist = KnownKey.newKey("10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,fd00::/8");
 
+    // Feed Manager comma-separated whitelist (exceptions to the blacklist). addresses can be CIDR notation, or single ip. no wild-cards
+    public static final KnownKey zimbra_feed_manager_whitelist = KnownKey.newKey("");
+
     // Zimbra valid class list to de-serialize
     public static final KnownKey zimbra_deserialize_classes = KnownKey.newKey("");
 

--- a/store/src/java/com/zimbra/cs/service/FeedManager.java
+++ b/store/src/java/com/zimbra/cs/service/FeedManager.java
@@ -274,27 +274,39 @@ public class FeedManager {
     }
 
     /**
-     * Returns true if target address is link-local, loopback, or blacklisted.
+     * Returns true if target address is not whitelisted,
+     * and is link-local, loopback, or blacklisted.
      * @param url The target
      * @return True if address is blocked for feed manager
      */
     protected static boolean isBlockedFeedAddress(URIBuilder url) {
+        InetAddress targetAddress;
+        try {
+            targetAddress = InetAddress.getByName(url.getHost());
+        } catch (UnknownHostException e) {
+            ZimbraLog.misc.warn("unable to identify feed manager target url host: %s", url);
+            return false;
+        }
+
+        String whitelistString = LC.zimbra_feed_manager_whitelist.value();
+        List<String> whitelist = new ArrayList<String>();
+        if (!StringUtil.isNullOrEmpty(whitelistString)) {
+            whitelist.addAll(Arrays.asList(whitelistString.trim().split(",")));
+        }
+        if (whitelist.stream().anyMatch(ip -> isAddressInRange(targetAddress, ip))) {
+            return false;
+        }
+
         String blacklistString = LC.zimbra_feed_manager_blacklist.value();
         List<String> blacklist = new ArrayList<String>();
         if (!StringUtil.isNullOrEmpty(blacklistString)) {
-            blacklist.addAll(Arrays.asList(blacklistString.split(",")));
+            blacklist.addAll(Arrays.asList(blacklistString.trim().split(",")));
         }
-        try {
-            InetAddress targetAddress = InetAddress.getByName(url.getHost());
-            return targetAddress.isAnyLocalAddress()
-                || targetAddress.isLinkLocalAddress()
-                || targetAddress.isLoopbackAddress()
-                || blacklist.stream()
-                    .anyMatch(ip -> isAddressInRange(targetAddress, ip));
-        } catch (UnknownHostException e) {
-            ZimbraLog.misc.warn("unable to identify feed manager target url host: %s", url);
-        }
-        return false;
+        return targetAddress.isAnyLocalAddress()
+            || targetAddress.isLinkLocalAddress()
+            || targetAddress.isLoopbackAddress()
+            || blacklist.stream()
+                .anyMatch(ip -> isAddressInRange(targetAddress, ip));
     }
 
     private static RemoteDataInfo retrieveRemoteData(String url, Folder.SyncData fsd)
@@ -342,7 +354,12 @@ public class FeedManager {
 
                 // validate target address (also handles followed `location` header addresses)
                 if (isBlockedFeedAddress(httpurl)) {
-                    throw ServiceException.INVALID_REQUEST(String.format("invalid url for feed: %s", url), null);
+                    ZimbraLog.misc.info(
+                        "Feed ip address blocked: %s. See localconfig for comma-separated ip list configuration: "
+                        + "zimbra_feed_manager_blacklist, zimbra_feed_manager_whitelist",
+                        url);
+                    throw ServiceException.INVALID_REQUEST(
+                        String.format("Address for feed is blocked: %s. See mailbox logs for details.", url), null);
                 }
                 // username and password are encoded in the URL as http://user:pass@host/...
                 if (url.indexOf('@') != -1) {


### PR DESCRIPTION
**Issue**
* Adjusting the FeedManager blacklist for individual IPs is too difficult.
* FeedManager blocked address error logging is too generic.

**Solution**
* Add a whitelist for exceptions to the blacklist ranges.
  * In localconfig `zimbra_feed_manager_whitelist`
  * Same format as blacklist (comma separated individual or CIDR notation IPs)
* Add additional information to logging around blocked IP address.

**Testing**
* See ZCS-8286 for details.

Relates to comments/requests for QoL from #863.