### PR TITLE
ZCS-8014: Third party vulnerabilities in dom4j

### DIFF
--- a/build-ivysettings.xml
+++ b/build-ivysettings.xml
@@ -3,6 +3,7 @@
   <property name="httpclient.version" value="4.5.8"/>
   <property name="httpclient.httpcore.version" value="4.4.11"/>
   <property name="httpclient.async.version" value="4.1.4"/>
+  <property name="dom4j.version" value="2.1.1"/>
 <settings defaultResolver="chain-resolver" />
   <caches defaultCacheDir="${dev.home}/.ivy2/cache"/>
   <resolvers>

--- a/client/ivy.xml
+++ b/client/ivy.xml
@@ -8,7 +8,7 @@
   <dependency org="junit" name="junit" rev="4.8.2" />
   <dependency org="javax.mail" name="mail" rev="1.4.5" />
   <dependency org="jaxen" name="jaxen" rev="1.1-beta-10"/>
-  <dependency org="dom4j" name="dom4j" rev="1.5.2" />
+  <dependency org="org.dom4j" name="dom4j" rev="${dom4j.version}" />
   <dependency org="log4j" name="log4j" rev="1.2.16" />
   <dependency org="com.google.guava" name="guava" rev="23.0" />
   <dependency org="org.json" name="json" rev="20090211" />

--- a/common/ivy.xml
+++ b/common/ivy.xml
@@ -13,7 +13,7 @@
   <dependency org="org.apache.httpcomponents" name="httpasyncclient" rev="${httpclient.async.version}"/>
   <dependency org="org.apache.httpcomponents" name="httpcore" rev="${httpclient.httpcore.version}"/> 
   <dependency org="org.apache.httpcomponents" name="httpcore-nio" rev="${httpclient.httpcore.version}"/>
-  <dependency org="dom4j" name="dom4j" rev="1.5.2" />
+  <dependency org="org.dom4j" name="dom4j" rev="${dom4j.version}" />
   <dependency org="ical4j" name="ical4j" rev="0.9.16-patched" />
   <dependency org="junit" name="junit" rev="4.8.2" />
   <dependency org="log4j" name="log4j" rev="1.2.16" />

--- a/common/src/java/com/zimbra/common/soap/Element.java
+++ b/common/src/java/com/zimbra/common/soap/Element.java
@@ -257,7 +257,13 @@ public abstract class Element implements Cloneable {
 
     public QName getQName() {
         String uri = getNamespaceURI(mPrefix);
-        return uri == null ? QName.get(mName) : QName.get(getQualifiedName(), uri);
+        QName returnValue = null;
+        try {
+            returnValue = (uri == null) ? QName.get(mName) : QName.get(getQualifiedName(), uri);
+        } catch (Exception e) {
+            ZimbraLog.soap.error("Caught IllegalArgumentException: ", e);
+        }
+        return returnValue;
     }
 
     public static QName getQName(String qualifiedName) {

--- a/soap/ivy.xml
+++ b/soap/ivy.xml
@@ -7,7 +7,7 @@
   <dependency org="junit" name="junit" rev="4.8.2" />
   <dependency org="xmlunit" name="xmlunit" rev="1.6"/>
   <dependency org="com.google.guava" name="guava" rev="23.0"/>
-  <dependency org="dom4j" name="dom4j" rev="1.5.2" />
+  <dependency org="org.dom4j" name="dom4j" rev="${dom4j.version}" />
   <dependency org="io.leangen.graphql" name="spqr" rev="0.9.7"/>
   <!-- Without this, dom4j pulls in an ancient version of xerces -->
   <dependency org="xerces" name="xercesImpl" rev="2.9.1-patch-01"/>

--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -20,7 +20,7 @@
   <dependency org="junit" name="junit" rev="4.8.2" />
   <dependency org="javax.mail" name="mail" rev="1.4.5" />
   <dependency org="jaxen" name="jaxen" rev="1.1-beta-10"/>
-  <dependency org="dom4j" name="dom4j" rev="1.5.2" />
+  <dependency org="org.dom4j" name="dom4j" rev="${dom4j.version}" />
   <dependency org="log4j" name="log4j" rev="1.2.16" />
   <dependency org="com.google.guava" name="guava" rev="23.0" />
   <dependency org="org.json" name="json" rev="20090211" />


### PR DESCRIPTION
Issue:  Few SOAP test cases were failing due to the dom4j library upgrade, as newly updated library added an exception.
Fix:   Update the codebase to catch the exception.