### PR TITLE
ZCS-8014: Third party vulnerabilities in dom4j

### DIFF
--- a/common/src/java/com/zimbra/common/soap/Element.java
+++ b/common/src/java/com/zimbra/common/soap/Element.java
@@ -257,7 +257,13 @@ public abstract class Element implements Cloneable {
 
     public QName getQName() {
         String uri = getNamespaceURI(mPrefix);
-        return uri == null ? QName.get(mName) : QName.get(getQualifiedName(), uri);
+        QName returnValue = null;
+        try {
+            returnValue = (uri == null) ? QName.get(mName) : QName.get(getQualifiedName(), uri);
+        } catch (Exception e) {
+            ZimbraLog.soap.error("Caught IllegalArgumentException: ", e);
+        }
+        return returnValue;
     }
 
     public static QName getQName(String qualifiedName) {

--- a/common/src/java/com/zimbra/common/soap/Element.java
+++ b/common/src/java/com/zimbra/common/soap/Element.java
@@ -260,7 +260,7 @@ public abstract class Element implements Cloneable {
         QName returnValue = null;
         try {
             returnValue = (uri == null) ? QName.get(mName) : QName.get(getQualifiedName(), uri);
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             ZimbraLog.soap.error("Caught IllegalArgumentException: ", e);
         }
         return returnValue;


### PR DESCRIPTION
Issue: Few SOAP test cases were failing due to the dom4j library upgrade, as newly updated library added an exception.

Fix: Update the codebase to catch the exception.