### PR TITLE
ZCS-8297 Use openjdk8 for travisci.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 java:
 


### PR DESCRIPTION
**Issue**
travisci build job is failing due to unsupported `oraclejdk8` version in the new default `xenial` dist.

**Solution**
Use `openjdk8` to match Zimbra's java defaults (rather than swap to `trusty` dist).

Details:
https://travis-ci.community/t/install-of-oracle-jdk8-is-failing/4365