### PR TITLE
Ephemeral additions and backport extension http method support

### DIFF
--- a/store/src/java/com/zimbra/cs/ephemeral/EphemeralStore.java
+++ b/store/src/java/com/zimbra/cs/ephemeral/EphemeralStore.java
@@ -467,6 +467,9 @@ public abstract class EphemeralStore {
             return getBackendURL(backendType);
         }
 
+        public EphemeralStore getNewStore() throws ServiceException {
+            throw ServiceException.UNSUPPORTED();
+        }
         public abstract EphemeralStore getStore();
         public abstract void startup();
         public abstract void shutdown();

--- a/store/src/java/com/zimbra/cs/extension/ExtensionDispatcherServlet.java
+++ b/store/src/java/com/zimbra/cs/extension/ExtensionDispatcherServlet.java
@@ -111,7 +111,12 @@ public class ExtensionDispatcherServlet extends ZimbraServlet {
             handler.doGet(req, resp);
         } else if ("POST".equals(method)) {
             handler.doPost(req, resp);
-        } else {
+        } else if ("PUT".equals(method)) {
+            handler.doPut(req, resp);
+        } else if ("DELETE".equals(method)) {
+            handler.doDelete(req, resp);
+        }
+        else {
             throw new ServletException("request method " + method + " not supported");
         }
     }

--- a/store/src/java/com/zimbra/cs/extension/ExtensionHttpHandler.java
+++ b/store/src/java/com/zimbra/cs/extension/ExtensionHttpHandler.java
@@ -86,6 +86,28 @@ public abstract class ExtensionHttpHandler {
     }
 
     /**
+     * Processes HTTP PUT requests.
+     * @param req
+     * @param resp
+     * @throws IOException
+     * @throws ServletException
+     */
+    public void doPut(HttpServletRequest req, HttpServletResponse resp) throws IOException, ServletException {
+        throw new ServletException("HTTP PUT requests are not supported");
+    }
+
+    /**
+     * Processes HTTP DELETE requests.
+     * @param req
+     * @param resp
+     * @throws IOException
+     * @throws ServletException
+     */
+    public void doDelete(HttpServletRequest req, HttpServletResponse resp) throws IOException, ServletException {
+        throw new ServletException("HTTP DELETE requests are not supported");
+    }
+
+    /**
      * Called to initialize the handler. If initialization fails, the handler is not registered.
      * @param ext the extension to which this handler belongs
      * @throws ServiceException


### PR DESCRIPTION
This is a backport.

**Issue**
Existing singleton ephemeral store instance is not flexible enough for extensions to make changes to properties such as the attribute encoder.

**Solution**
Allow explicitly retrieving a new instance if the factory implements support for it.

**Changes**
* Add defaulted `getNewStore` method that ephemeral stores can override
  * This allows them to acquire an instance which no other process can alter.
* Backport extension http handler PUT, DELETE support (this is unrelated to the ephemeral issue, I can split this off into another PR if necessary)

See Also:
Zimbra/zm-ssdb-ephemeral-store#12