### PR TITLE
ZCS-8365 Support for Active Sync protocol till 16.1

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1077,7 +1077,7 @@ public final class LC {
     public static final KnownKey data_source_eas_window_size = KnownKey.newKey(50);
     public static final KnownKey data_source_eas_mime_truncation = KnownKey.newKey(4);
 
-    public static final KnownKey zimbra_activesync_versions = KnownKey.newKey("2.0,2.1,2.5,12.0,12.1");
+    public static final KnownKey zimbra_activesync_versions = KnownKey.newKey("2.0,2.1,2.5,12.0,12.1,14.0,14.1,16.0,16.1");
     public static final KnownKey zimbra_activesync_contact_image_size = KnownKey.newKey(2*1024*1024);
     public static final KnownKey zimbra_activesync_autodiscover_url = KnownKey.newKey(null);
     public static final KnownKey zimbra_activesync_autodiscover_use_service_url = KnownKey.newKey(false);


### PR DESCRIPTION
**Problem:** If EAS protocol version is updated to support 16.1, account can not be configured on iPhone

**Fix:**
- Provision command updated to support DeviceInformation in the request
- Added supported protocol version methods

**Testing done:** Device configured account with EAS 16.1 and mails are syncing on iPhone

**Testing to be done by QA:**
- Verify accounts can be configured with EAS 16.1

**Linked PR:**
https://github.com/Zimbra/zm-sync-common/pull/7
https://github.com/Zimbra/zm-sync-store/pull/15