### PR TITLE
ZCS 8290: Upgrade TLS in Zimbra classic

### DIFF
--- a/build-ivysettings.xml
+++ b/build-ivysettings.xml
@@ -3,6 +3,7 @@
   <property name="httpclient.version" value="4.5.8"/>
   <property name="httpclient.httpcore.version" value="4.4.11"/>
   <property name="httpclient.async.version" value="4.1.4"/>
+  <property name="jetty.version" value="9.4.18.v20190429"/>
 <settings defaultResolver="chain-resolver" />
   <caches defaultCacheDir="${dev.home}/.ivy2/cache"/>
   <resolvers>

--- a/common/ivy.xml
+++ b/common/ivy.xml
@@ -32,8 +32,8 @@
   <dependency org="org.easymock" name="easymock" rev="3.0" />
   <dependency org="cglib" name="cglib" rev="2.2.2" />
   <dependency org="asm" name="asm" rev="3.3.1" />
-  <dependency org="org.eclipse.jetty" name="jetty-rewrite" rev="9.4.18.v20190429" />
-  <dependency org="org.eclipse.jetty" name="jetty-util" rev="9.4.18.v20190429" />
+  <dependency org="org.eclipse.jetty" name="jetty-rewrite" rev="${jetty.version}" />
+  <dependency org="org.eclipse.jetty" name="jetty-util" rev="${jetty.version}" />
   <dependency org="zimbra" name="zm-native" rev="latest.integration" />
   <dependency org="ant-contrib" name="ant-contrib" rev="1.0b3" />
  </dependencies>

--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -570,8 +570,8 @@ public final class LC {
 
     @Supported
     public static final KnownKey mailboxd_java_options = KnownKey.newKey("-server" +
-            " -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2" +
-            " -Djdk.tls.client.protocols=TLSv1,TLSv1.1,TLSv1.2" +
+            " -Dhttps.protocols=TLSv1.2" +
+            " -Djdk.tls.client.protocols=TLSv1.2" +
             " -Djava.awt.headless=true" +
             " -Dsun.net.inetaddr.ttl=${networkaddress_cache_ttl}" +
             " -Dorg.apache.jasper.compiler.disablejsr199=true" +
@@ -862,8 +862,8 @@ public final class LC {
     public static final KnownKey zimbra_jwt_cookie_size_limit = KnownKey.newKey(4096);
     public static final KnownKey zimbra_authtoken_cookie_domain = KnownKey.newKey("");
     public static final KnownKey zimbra_zmjava_options = KnownKey.newKey("-Xmx256m" +
-            " -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2" +
-            " -Djdk.tls.client.protocols=TLSv1,TLSv1.1,TLSv1.2");
+            " -Dhttps.protocols=TLSv1.2" +
+            " -Djdk.tls.client.protocols=TLSv1.2");
     public static final KnownKey zimbra_zmjava_java_library_path = KnownKey.newKey("");
     public static final KnownKey zimbra_zmjava_java_ext_dirs = KnownKey.newKey("");
     public static final KnownKey debug_xmpp_disable_client_tls = KnownKey.newKey(0);

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -3413,6 +3413,8 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
 
 <attr id="639" name="zimbraSSLExcludeCipherSuites" type="string" cardinality="multi" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mailbox" since="5.0.5">
   <globalConfigValue>.*_RC4_.*</globalConfigValue>
+  <globalConfigValue>^.*_(MD5|SHA|SHA1)$</globalConfigValue>
+  <globalConfigValue>^TLS_RSA_.*</globalConfigValue>
   <desc>exact name or regular expression of cipher suites to exclude</desc>
 </attr>
 
@@ -8379,7 +8381,6 @@ TODO: delete them permanently from here
   <globalConfigValue>TLSv1</globalConfigValue>
   <globalConfigValue>TLSv1.1</globalConfigValue>
   <globalConfigValue>TLSv1.2</globalConfigValue>
-  <globalConfigValue>SSLv2Hello</globalConfigValue>
   <desc>List of SSL/TLS protocols (as documented by SunJSSE Provider Protocols and used in setEnabledProtocols) to be enabled in Jetty for HTTPS, IMAPS, POP3S, and STARTTLS (including LMTP)</desc>
 </attr>
 

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -8358,8 +8358,6 @@ TODO: delete them permanently from here
 </attr>
 
 <attr id="1653" name="zimbraReverseProxySSLProtocols" type="string" cardinality="multi" optionalIn="globalConfig,server" flags="serverInherited" since="8.6.0">
-  <globalConfigValue>TLSv1</globalConfigValue>
-  <globalConfigValue>TLSv1.1</globalConfigValue>
   <globalConfigValue>TLSv1.2</globalConfigValue>
   <desc>SSL protocols enabled for the proxy</desc>
 </attr>
@@ -8378,8 +8376,6 @@ TODO: delete them permanently from here
 <!-- attr id="1656" name="zimbraMobileShareCalendarEnabled" for 9.0 -->
 
 <attr id="1657" name="zimbraMailboxdSSLProtocols" type="string" cardinality="multi" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mailbox" since="8.6.0">
-  <globalConfigValue>TLSv1</globalConfigValue>
-  <globalConfigValue>TLSv1.1</globalConfigValue>
   <globalConfigValue>TLSv1.2</globalConfigValue>
   <desc>List of SSL/TLS protocols (as documented by SunJSSE Provider Protocols and used in setEnabledProtocols) to be enabled in Jetty for HTTPS, IMAPS, POP3S, and STARTTLS (including LMTP)</desc>
 </attr>

--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -48,14 +48,14 @@
   <dependency org="com.googlecode.owasp-java-html-sanitizer" name="owasp-java-html-sanitizer" rev="20190610.1"/>
   <dependency org="org.ehcache" name="ehcache" rev="3.1.2"/>
   <dependency org="ant-1.7.0-ziputil-patched" name="ant-1.7.0-ziputil-patched" rev="1.0"/>
-  <dependency org="org.eclipse.jetty" name="jetty-continuation" rev="9.4.18.v20190429"/>
-  <dependency org="org.eclipse.jetty" name="jetty-security" rev="9.4.18.v20190429"/>
-  <dependency org="org.eclipse.jetty" name="jetty-http" rev="9.4.18.v20190429"/>
-  <dependency org="org.eclipse.jetty" name="jetty-io" rev="9.4.18.v20190429"/>
-  <dependency org="org.eclipse.jetty" name="jetty-server" rev="9.4.18.v20190429"/>
-  <dependency org="org.eclipse.jetty" name="jetty-servlet" rev="9.4.18.v20190429"/>
-  <dependency org="org.eclipse.jetty" name="jetty-servlets" rev="9.4.18.v20190429"/>
-  <dependency org="org.eclipse.jetty" name="jetty-util" rev="9.4.18.v20190429"/>
+  <dependency org="org.eclipse.jetty" name="jetty-continuation" rev="${jetty.version}"/>
+  <dependency org="org.eclipse.jetty" name="jetty-security" rev="${jetty.version}"/>
+  <dependency org="org.eclipse.jetty" name="jetty-http" rev="${jetty.version}"/>
+  <dependency org="org.eclipse.jetty" name="jetty-io" rev="${jetty.version}"/>
+  <dependency org="org.eclipse.jetty" name="jetty-server" rev="${jetty.version}"/>
+  <dependency org="org.eclipse.jetty" name="jetty-servlet" rev="${jetty.version}"/>
+  <dependency org="org.eclipse.jetty" name="jetty-servlets" rev="${jetty.version}"/>
+  <dependency org="org.eclipse.jetty" name="jetty-util" rev="${jetty.version}"/>
   <dependency org="commons-cli" name="commons-cli" rev="1.2"/>
   <dependency org="commons-pool" name="commons-pool" rev="1.6"/>
   <dependency org="commons-dbcp" name="commons-dbcp" rev="1.4"/>

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -29931,7 +29931,7 @@ public abstract class ZAttrConfig extends Entry {
      */
     @ZAttr(id=1657)
     public String[] getMailboxdSSLProtocols() {
-        String[] value = getMultiAttr(Provisioning.A_zimbraMailboxdSSLProtocols, true, true); return value.length > 0 ? value : new String[] {"TLSv1","TLSv1.1","TLSv1.2"};
+        String[] value = getMultiAttr(Provisioning.A_zimbraMailboxdSSLProtocols, true, true); return value.length > 0 ? value : new String[] {"TLSv1.2"};
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -29931,7 +29931,7 @@ public abstract class ZAttrConfig extends Entry {
      */
     @ZAttr(id=1657)
     public String[] getMailboxdSSLProtocols() {
-        String[] value = getMultiAttr(Provisioning.A_zimbraMailboxdSSLProtocols, true, true); return value.length > 0 ? value : new String[] {"TLSv1","TLSv1.1","TLSv1.2","SSLv2Hello"};
+        String[] value = getMultiAttr(Provisioning.A_zimbraMailboxdSSLProtocols, true, true); return value.length > 0 ? value : new String[] {"TLSv1","TLSv1.1","TLSv1.2"};
     }
 
     /**
@@ -64795,7 +64795,7 @@ public abstract class ZAttrConfig extends Entry {
      */
     @ZAttr(id=639)
     public String[] getSSLExcludeCipherSuites() {
-        String[] value = getMultiAttr(Provisioning.A_zimbraSSLExcludeCipherSuites, true, true); return value.length > 0 ? value : new String[] {".*_RC4_.*"};
+        String[] value = getMultiAttr(Provisioning.A_zimbraSSLExcludeCipherSuites, true, true); return value.length > 0 ? value : new String[] {".*_RC4_.*","^.*_(MD5|SHA|SHA1)$","^TLS_RSA_.*"};
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -19444,7 +19444,7 @@ public abstract class ZAttrServer extends NamedEntry {
      */
     @ZAttr(id=1657)
     public String[] getMailboxdSSLProtocols() {
-        String[] value = getMultiAttr(Provisioning.A_zimbraMailboxdSSLProtocols, true, true); return value.length > 0 ? value : new String[] {"TLSv1","TLSv1.1","TLSv1.2"};
+        String[] value = getMultiAttr(Provisioning.A_zimbraMailboxdSSLProtocols, true, true); return value.length > 0 ? value : new String[] {"TLSv1.2"};
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -19444,7 +19444,7 @@ public abstract class ZAttrServer extends NamedEntry {
      */
     @ZAttr(id=1657)
     public String[] getMailboxdSSLProtocols() {
-        String[] value = getMultiAttr(Provisioning.A_zimbraMailboxdSSLProtocols, true, true); return value.length > 0 ? value : new String[] {"TLSv1","TLSv1.1","TLSv1.2","SSLv2Hello"};
+        String[] value = getMultiAttr(Provisioning.A_zimbraMailboxdSSLProtocols, true, true); return value.length > 0 ? value : new String[] {"TLSv1","TLSv1.1","TLSv1.2"};
     }
 
     /**
@@ -46016,7 +46016,7 @@ public abstract class ZAttrServer extends NamedEntry {
      */
     @ZAttr(id=639)
     public String[] getSSLExcludeCipherSuites() {
-        String[] value = getMultiAttr(Provisioning.A_zimbraSSLExcludeCipherSuites, true, true); return value.length > 0 ? value : new String[] {".*_RC4_.*"};
+        String[] value = getMultiAttr(Provisioning.A_zimbraSSLExcludeCipherSuites, true, true); return value.length > 0 ? value : new String[] {".*_RC4_.*","^.*_(MD5|SHA|SHA1)$","^TLS_RSA_.*"};
     }
 
     /**


### PR DESCRIPTION
TLS1.0 and TLS1.1 support are going to expire in all major browsers, so we are making it off by default.

If users want to use it, they can on it by setting the values of some LDAP variables manually.