### PR TITLE
zbug-1292:user is not able to send an email using send-as (persona) with an attachment

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/MailSender.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailSender.java
@@ -659,12 +659,17 @@ public class MailSender {
                 if (DebugConfig.disableOutgoingFilter) {
                     DeliveryOptions dopt = new DeliveryOptions().setFolderId(sentFolderId).setNoICal(true).setFlags(flags).setConversationId(convId);
                     Message msg = mbox.addMessage(octxt, pm, dopt, null);
-                    rollbacks.add(new RollbackData(msg));
+                    RollbackData rollback = new RollbackData(msg);
+                    rollbacks.add(rollback);
+                    returnItemId = rollback.msgId;
                 } else {
                     List<ItemId> addedItemIds =
                             RuleManager.applyRulesToOutgoingMessage(octxtTarget, mbox, pm, sentFolderId, true, flags, null, convId);
                     for (ItemId itemId : addedItemIds) {
                         rollbacks.add(new RollbackData(mbox, itemId.getId()));
+                        if (returnItemId == null) {
+                            returnItemId = itemId;
+                        }
                     }
                 }
             }

--- a/store/src/java/com/zimbra/cs/service/mail/SendMsg.java
+++ b/store/src/java/com/zimbra/cs/service/mail/SendMsg.java
@@ -206,7 +206,24 @@ public class SendMsg extends MailDocumentHandler {
                }
 
                if (iidDraft != null) {
-                   deleteDraft(iidDraft, octxt, mbox, zsc);
+                   String loggedInAccountId = zsc.getAuthtokenAccountId();
+                   String requestedAcctId = zsc.getRequestedAccountId();
+                   if (loggedInAccountId.equals(requestedAcctId)) {
+                       deleteDraft(iidDraft, octxt, mbox, zsc);
+                   } else {
+                       /** ZBUG-1292
+                        * This is to delete the message from draft in case the message is sent by Persona email
+                        * which is different than the logged in user email, because in this case the draft is
+                        * saved in the logged in user account mailbox.
+                        */
+                       iidDraft.setAccountId(loggedInAccountId);
+                       zsc.setmRequestedAccountId(loggedInAccountId);
+                       mbox = MailboxManager.getInstance().getMailboxByAccountId(loggedInAccountId);
+                       deleteDraft(iidDraft, octxt, mbox, zsc);
+                   }
+                   iidDraft.setAccountId(requestedAcctId);
+                   zsc.setmRequestedAccountId(requestedAcctId);
+                   mbox = MailboxManager.getInstance().getMailboxByAccountId(requestedAcctId);
                }
 
                Element response = zsc.createElement(respQname);

--- a/store/src/java/com/zimbra/cs/service/util/ItemId.java
+++ b/store/src/java/com/zimbra/cs/service/util/ItemId.java
@@ -48,7 +48,7 @@ import com.zimbra.soap.ZimbraSoapContext;
 public class ItemId implements java.io.Serializable {
     private static final long serialVersionUID = -9044615129495573523L;
 
-    private final String mAccountId;
+    private String mAccountId;
     private final int    mId;
     private int    mSubpartId = -1;
 
@@ -97,6 +97,10 @@ public class ItemId implements java.io.Serializable {
     public String getAccountId()  { return mAccountId; }
     public int getId()            { return mId; }
     public int getSubpartId()     { return mSubpartId; }
+
+    public void setAccountId(String accountId) {
+        this.mAccountId = accountId;
+    }
 
     public boolean hasSubpart()   { return mSubpartId >= 0; }
 


### PR DESCRIPTION
**_Issue:_**

Not able to send an email with send-as with a persona and gets the following error after updating Patch 5 on ZCS 8.8.15. Below is the exception
>2019-12-24 01:57:47,277 WARN  [qtp1225197672-10224:https://10.15.8.161/service/soap/SendMsgRequest] [name=user1@labzimbra.com;aname=user2@labzimbra.com;mid=18;oip=10.15.32.83;port=40532;ua=ZimbraWebClient - G
C79 (Win)/8.8.15_GA_3890;soapId=2be84d02;] SoapEngine - handler exception
com.zimbra.cs.mailbox.MailServiceException$NoSuchItemException: no such message: 367
ExceptionId:qtp1225197672-10224:https://10.15.8.161/service/soap/SendMsgRequest:1577132867277:7fc26d2ff004b110
Code:mail.NO_SUCH_MSG Arg:(itemId, IID, "367")
        at com.zimbra.cs.mailbox.MailServiceException.NO_SUCH_MSG(MailServiceException.java:219)
        at com.zimbra.cs.mailbox.MailItem.noSuchItem(MailItem.java:1761)
        at com.zimbra.cs.db.DbMailItem.getBy(DbMailItem.java:2540)
        at com.zimbra.cs.db.DbMailItem.getById(DbMailItem.java:2495)
        at com.zimbra.cs.mailbox.MailItem.getById(MailItem.java:1680)
        at com.zimbra.cs.mailbox.MailItem.getById(MailItem.java:1676)
        at com.zimbra.cs.mailbox.Mailbox.getItemById(Mailbox.java:2982)
        at com.zimbra.cs.mailbox.Mailbox.getItemById(Mailbox.java:2896)
        at com.zimbra.cs.mailbox.Mailbox.getItemById(Mailbox.java:2887)
        at com.zimbra.cs.mailbox.Mailbox.getMessageById(Mailbox.java:4552)
        at com.zimbra.cs.service.mail.ParseMimeMessage.attachPart(ParseMimeMessage.java:848)
        at com.zimbra.cs.service.mail.ParseMimeMessage.handleAttachments(ParseMimeMessage.java:495)
        at com.zimbra.cs.service.mail.ParseMimeMessage.parseMimeMsgSoap(ParseMimeMessage.java:384)
        at com.zimbra.cs.service.mail.ParseMimeMessage.parseMimeMsgSoap(ParseMimeMessage.java:206)
        at com.zimbra.cs.service.mail.SendMsg.handle(SendMsg.java:178)
        at com.zimbra.cs.service.mail.SendMsg.handle(SendMsg.java:107)
        at com.zimbra.soap.SoapEngine.dispatchRequest(SoapEngine.java:667)
        at com.zimbra.soap.SoapEngine.dispatch(SoapEngine.java:512)
        at com.zimbra.soap.SoapEngine.dispatch(SoapEngine.java:283)
        at com.zimbra.soap.SoapServlet.doWork(SoapServlet.java:308)
        at com.zimbra.soap.SoapServlet.doPost(SoapServlet.java:217)

**_Fix:_**

When the user creates a persona of another user and sends the message with attachment by using persona email the attachment is saved with in the logged in user mailbox and when it tries to find the item in the person user's mailbox it was unable to find the message. So catching the exact exception and then searching for the item in the logged in user's mailbox.

By this then message sent successfully but the same message is also saved into the logged in user's draft and never deleted, so deleting the draft once the message is sent.

**_Test:_**
Ran the automation and it is working as expected.