### PR TITLE
ZCS-8464 Fixing maven move to https only

### DIFF
--- a/build-ivysettings.xml
+++ b/build-ivysettings.xml
@@ -14,6 +14,12 @@
         <artifact pattern= "${dev.home}/.zcs-deps/[organisation].[ext]" />
 
       </filesystem>
+       <url name="maven-https-org">
+        <artifact pattern="https://repo1.maven.org/maven2/[organization]/[module]/[revision]/[artifact]-[revision].[ext]" />
+      </url>
+      <url name="maven-https-orgPath">
+        <artifact pattern="https://repo1.maven.org/maven2/[orgPath]/[module]/[revision]/[artifact]-[revision].[ext]" />
+      </url>
       <ibiblio name="maven" m2compatible="true" usepoms="false"/>
       <ibiblio name="maven-redhat" root="https://maven.repository.redhat.com/ga/" pattern="[organisation]/[module]/[revision]/[module]-[revision].[ext]"/>
       <url name="zimbra">


### PR DESCRIPTION
Maven central repo now supports https only also added support for orgPath 
orgPath
The organisation name where '.' has been replaced by '/'. This can be used to configure Maven 2-like repositories.

Cleared ivy2 cache and verified build is working.