### PR TITLE
ZBUG-1283 Read timeout with new HttpClient

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -955,7 +955,7 @@ public final class LC {
      * Bug: 47051 Known key for the CLI utilities SOAP HTTP transport timeout.
      * The default value is set to 0 i.e. no timeout.
      */
-    public static final KnownKey cli_httpclient_soaphttptransport_so_timeout  = KnownKey.newKey(0);
+    public static final KnownKey cli_httpclient_soaphttptransport_so_timeout  = KnownKey.newKey(Integer.MAX_VALUE);
 
 
     public static final KnownKey httpclient_convertd_so_timeout = KnownKey.newKey(-1);

--- a/common/src/java/com/zimbra/common/soap/SoapHttpTransport.java
+++ b/common/src/java/com/zimbra/common/soap/SoapHttpTransport.java
@@ -284,10 +284,13 @@ public class SoapHttpTransport extends SoapTransport {
                 method.addHeader(Constants.AUTH_HEADER, Constants.BEARER + " " + zToken.getValue());
             }
 
+            ZimbraLog.soap.trace("Httpclient timeout: %s" , mTimeout);
             RequestConfig reqConfig = RequestConfig.custom().
                 setCookieSpec(cookieStore.getCookies().size() == 0 ? CookieSpecs.IGNORE_COOKIES:
-               CookieSpecs.BROWSER_COMPATIBILITY).build();
-            SocketConfig socketConfig = SocketConfig.custom().setSoTimeout(LC.httpclient_external_connmgr_so_timeout.intValue())
+               CookieSpecs.BROWSER_COMPATIBILITY)
+                .setSocketTimeout(mTimeout)
+                .build();
+            SocketConfig socketConfig = SocketConfig.custom().setSoTimeout(mTimeout)
                 .setTcpNoDelay(LC.httpclient_external_connmgr_tcp_nodelay.booleanValue()).build();
             method.setProtocolVersion(HttpVersion.HTTP_1_1);
             method.addHeader("Connection", mKeepAlive ? "Keep-alive" : "Close");
@@ -296,6 +299,7 @@ public class SoapHttpTransport extends SoapTransport {
             client = mClientBuilder.setDefaultRequestConfig(reqConfig)
                .setDefaultSocketConfig(socketConfig)
                .setDefaultCookieStore(cookieStore).build();
+            ZimbraLog.soap.trace("Httpclient request config timeout: %s" , reqConfig.getSocketTimeout());
 
             if (mHostConfig != null && mHostConfig.getUsername() != null && mHostConfig.getPassword() != null) {
 


### PR DESCRIPTION
Add code to set socket timeout on request config object based on the value of member variable mTimeout.
SoapCLI command set timeout in old http client to 0 which meant infinite. '0' is not longer infinite with new httpclient, so setting it to Integer.MAX_VALUE.

Verified by running zmmboxmove , zmbackup and zmrestore that read timeout is no longer observed.