### PR TITLE
ZCS-8474: Add new Feature enable attributes for Zimbra 9

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -6693,6 +6693,14 @@ public class ZAttrProvisioning {
     public static final String A_zimbraFeatureMarkMailForwardedAsRead = "zimbraFeatureMarkMailForwardedAsRead";
 
     /**
+     * Whether to allow a user to access Zimbra mobile App
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public static final String A_zimbraFeatureMobileAppEnabled = "zimbraFeatureMobileAppEnabled";
+
+    /**
      * Whether to enable Zimbra Mobile Gateway feature
      *
      * @since ZCS 8.7.0,9.0.0
@@ -6721,14 +6729,6 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=3082)
     public static final String A_zimbraFeatureModernDesktopEnabled = "zimbraFeatureModernDesktopEnabled";
-
-    /**
-     * Whether to allow a user to access Zimbra modern mobile UI
-     *
-     * @since ZCS 8.9.0
-     */
-    @ZAttr(id=3081)
-    public static final String A_zimbraFeatureModernMobileUIEnabled = "zimbraFeatureModernMobileUIEnabled";
 
     /**
      * Whether user can create address books
@@ -7030,7 +7030,9 @@ public class ZAttrProvisioning {
     public static final String A_zimbraFeatureZimbraAssistantEnabled = "zimbraFeatureZimbraAssistantEnabled";
 
     /**
-     * Whether to allow a user to access Zimbra X desktop
+     * Deprecated since: 8.9.0. deprecated with attribute
+     * zimbraFeatureModernDesktopEnabled. Orig desc: Whether to allow a user
+     * to access Zimbra X desktop
      *
      * @since ZCS 8.9.0
      */

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -6715,6 +6715,22 @@ public class ZAttrProvisioning {
     public static final String A_zimbraFeatureMobileSyncEnabled = "zimbraFeatureMobileSyncEnabled";
 
     /**
+     * Whether to allow a user to access Zimbra modern desktop
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3082)
+    public static final String A_zimbraFeatureModernDesktopEnabled = "zimbraFeatureModernDesktopEnabled";
+
+    /**
+     * Whether to allow a user to access Zimbra modern mobile UI
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public static final String A_zimbraFeatureModernMobileUIEnabled = "zimbraFeatureModernMobileUIEnabled";
+
+    /**
      * Whether user can create address books
      *
      * @since ZCS 5.0.4

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9770,9 +9770,9 @@ TODO: delete them permanently from here
   <deprecateDesc>deprecated with attribute zimbraFeatureModernDesktopEnabled</deprecateDesc>
 </attr>
 
-<attr id="3081" name="zimbraFeatureModernMobileUIEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited" since="8.9.0">
+<attr id="3081" name="zimbraFeatureMobileAppEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited" since="8.9.0">
   <defaultCOSValue>FALSE</defaultCOSValue>
-  <desc>Whether to allow a user to access Zimbra modern mobile UI</desc>
+  <desc>Whether to allow a user to access Zimbra mobile App</desc>
 </attr>
 
 <attr id="3082" name="zimbraFeatureModernDesktopEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited" since="8.9.0">

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9769,4 +9769,13 @@ TODO: delete them permanently from here
   <desc>Whether to allow a user to access Zimbra X desktop</desc>
 </attr>
 
+<attr id="3081" name="zimbraFeatureModernMobileUIEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited" since="8.9.0">
+  <defaultCOSValue>FALSE</defaultCOSValue>
+  <desc>Whether to allow a user to access Zimbra modern mobile UI</desc>
+</attr>
+
+<attr id="3082" name="zimbraFeatureModernDesktopEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited" since="8.9.0">
+  <defaultCOSValue>FALSE</defaultCOSValue>
+  <desc>Whether to allow a user to access Zimbra modern desktop</desc>
+</attr>
 </attrs>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9764,9 +9764,10 @@ TODO: delete them permanently from here
   <desc>Whether to allow a user to access Zimbra X web client</desc>
 </attr>
 
-<attr id="3080" name="zimbraFeatureZXDesktopEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited" since="8.9.0">
+<attr id="3080" name="zimbraFeatureZXDesktopEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited" since="8.9.0" deprecatedSince="8.9.0">
   <defaultCOSValue>FALSE</defaultCOSValue>
   <desc>Whether to allow a user to access Zimbra X desktop</desc>
+  <deprecateDesc>deprecated with attribute zimbraFeatureModernDesktopEnabled</deprecateDesc>
 </attr>
 
 <attr id="3081" name="zimbraFeatureModernMobileUIEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited" since="8.9.0">

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -16726,6 +16726,78 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * Whether to allow a user to access Zimbra mobile App
+     *
+     * @return zimbraFeatureMobileAppEnabled, or false if unset
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public boolean isFeatureMobileAppEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureMobileAppEnabled, false, true);
+    }
+
+    /**
+     * Whether to allow a user to access Zimbra mobile App
+     *
+     * @param zimbraFeatureMobileAppEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public void setFeatureMobileAppEnabled(boolean zimbraFeatureMobileAppEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMobileAppEnabled, zimbraFeatureMobileAppEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to allow a user to access Zimbra mobile App
+     *
+     * @param zimbraFeatureMobileAppEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public Map<String,Object> setFeatureMobileAppEnabled(boolean zimbraFeatureMobileAppEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMobileAppEnabled, zimbraFeatureMobileAppEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether to allow a user to access Zimbra mobile App
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public void unsetFeatureMobileAppEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMobileAppEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to allow a user to access Zimbra mobile App
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public Map<String,Object> unsetFeatureMobileAppEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMobileAppEnabled, "");
+        return attrs;
+    }
+
+    /**
      * Whether to enable Zimbra Mobile Gateway feature
      *
      * @return zimbraFeatureMobileGatewayEnabled, or false if unset
@@ -17000,78 +17072,6 @@ public abstract class ZAttrAccount  extends MailTarget {
     public Map<String,Object> unsetFeatureModernDesktopEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureModernDesktopEnabled, "");
-        return attrs;
-    }
-
-    /**
-     * Whether to allow a user to access Zimbra modern mobile UI
-     *
-     * @return zimbraFeatureModernMobileUIEnabled, or false if unset
-     *
-     * @since ZCS 8.9.0
-     */
-    @ZAttr(id=3081)
-    public boolean isFeatureModernMobileUIEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraFeatureModernMobileUIEnabled, false, true);
-    }
-
-    /**
-     * Whether to allow a user to access Zimbra modern mobile UI
-     *
-     * @param zimbraFeatureModernMobileUIEnabled new value
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 8.9.0
-     */
-    @ZAttr(id=3081)
-    public void setFeatureModernMobileUIEnabled(boolean zimbraFeatureModernMobileUIEnabled) throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraFeatureModernMobileUIEnabled, zimbraFeatureModernMobileUIEnabled ? TRUE : FALSE);
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Whether to allow a user to access Zimbra modern mobile UI
-     *
-     * @param zimbraFeatureModernMobileUIEnabled new value
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 8.9.0
-     */
-    @ZAttr(id=3081)
-    public Map<String,Object> setFeatureModernMobileUIEnabled(boolean zimbraFeatureModernMobileUIEnabled, Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraFeatureModernMobileUIEnabled, zimbraFeatureModernMobileUIEnabled ? TRUE : FALSE);
-        return attrs;
-    }
-
-    /**
-     * Whether to allow a user to access Zimbra modern mobile UI
-     *
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 8.9.0
-     */
-    @ZAttr(id=3081)
-    public void unsetFeatureModernMobileUIEnabled() throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraFeatureModernMobileUIEnabled, "");
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Whether to allow a user to access Zimbra modern mobile UI
-     *
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 8.9.0
-     */
-    @ZAttr(id=3081)
-    public Map<String,Object> unsetFeatureModernMobileUIEnabled(Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraFeatureModernMobileUIEnabled, "");
         return attrs;
     }
 
@@ -19871,7 +19871,9 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * Whether to allow a user to access Zimbra X desktop
+     * Deprecated since: 8.9.0. deprecated with attribute
+     * zimbraFeatureModernDesktopEnabled. Orig desc: Whether to allow a user
+     * to access Zimbra X desktop
      *
      * @return zimbraFeatureZXDesktopEnabled, or false if unset
      *
@@ -19883,7 +19885,9 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * Whether to allow a user to access Zimbra X desktop
+     * Deprecated since: 8.9.0. deprecated with attribute
+     * zimbraFeatureModernDesktopEnabled. Orig desc: Whether to allow a user
+     * to access Zimbra X desktop
      *
      * @param zimbraFeatureZXDesktopEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -19898,7 +19902,9 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * Whether to allow a user to access Zimbra X desktop
+     * Deprecated since: 8.9.0. deprecated with attribute
+     * zimbraFeatureModernDesktopEnabled. Orig desc: Whether to allow a user
+     * to access Zimbra X desktop
      *
      * @param zimbraFeatureZXDesktopEnabled new value
      * @param attrs existing map to populate, or null to create a new map
@@ -19914,7 +19920,9 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * Whether to allow a user to access Zimbra X desktop
+     * Deprecated since: 8.9.0. deprecated with attribute
+     * zimbraFeatureModernDesktopEnabled. Orig desc: Whether to allow a user
+     * to access Zimbra X desktop
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -19928,7 +19936,9 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * Whether to allow a user to access Zimbra X desktop
+     * Deprecated since: 8.9.0. deprecated with attribute
+     * zimbraFeatureModernDesktopEnabled. Orig desc: Whether to allow a user
+     * to access Zimbra X desktop
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -16932,6 +16932,150 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * Whether to allow a user to access Zimbra modern desktop
+     *
+     * @return zimbraFeatureModernDesktopEnabled, or false if unset
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3082)
+    public boolean isFeatureModernDesktopEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureModernDesktopEnabled, false, true);
+    }
+
+    /**
+     * Whether to allow a user to access Zimbra modern desktop
+     *
+     * @param zimbraFeatureModernDesktopEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3082)
+    public void setFeatureModernDesktopEnabled(boolean zimbraFeatureModernDesktopEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernDesktopEnabled, zimbraFeatureModernDesktopEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to allow a user to access Zimbra modern desktop
+     *
+     * @param zimbraFeatureModernDesktopEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3082)
+    public Map<String,Object> setFeatureModernDesktopEnabled(boolean zimbraFeatureModernDesktopEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernDesktopEnabled, zimbraFeatureModernDesktopEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether to allow a user to access Zimbra modern desktop
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3082)
+    public void unsetFeatureModernDesktopEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernDesktopEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to allow a user to access Zimbra modern desktop
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3082)
+    public Map<String,Object> unsetFeatureModernDesktopEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernDesktopEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * Whether to allow a user to access Zimbra modern mobile UI
+     *
+     * @return zimbraFeatureModernMobileUIEnabled, or false if unset
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public boolean isFeatureModernMobileUIEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureModernMobileUIEnabled, false, true);
+    }
+
+    /**
+     * Whether to allow a user to access Zimbra modern mobile UI
+     *
+     * @param zimbraFeatureModernMobileUIEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public void setFeatureModernMobileUIEnabled(boolean zimbraFeatureModernMobileUIEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernMobileUIEnabled, zimbraFeatureModernMobileUIEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to allow a user to access Zimbra modern mobile UI
+     *
+     * @param zimbraFeatureModernMobileUIEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public Map<String,Object> setFeatureModernMobileUIEnabled(boolean zimbraFeatureModernMobileUIEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernMobileUIEnabled, zimbraFeatureModernMobileUIEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether to allow a user to access Zimbra modern mobile UI
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public void unsetFeatureModernMobileUIEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernMobileUIEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to allow a user to access Zimbra modern mobile UI
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public Map<String,Object> unsetFeatureModernMobileUIEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernMobileUIEnabled, "");
+        return attrs;
+    }
+
+    /**
      * Whether user can create address books
      *
      * @return zimbraFeatureNewAddrBookEnabled, or true if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -11593,6 +11593,150 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * Whether to allow a user to access Zimbra modern desktop
+     *
+     * @return zimbraFeatureModernDesktopEnabled, or false if unset
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3082)
+    public boolean isFeatureModernDesktopEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureModernDesktopEnabled, false, true);
+    }
+
+    /**
+     * Whether to allow a user to access Zimbra modern desktop
+     *
+     * @param zimbraFeatureModernDesktopEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3082)
+    public void setFeatureModernDesktopEnabled(boolean zimbraFeatureModernDesktopEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernDesktopEnabled, zimbraFeatureModernDesktopEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to allow a user to access Zimbra modern desktop
+     *
+     * @param zimbraFeatureModernDesktopEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3082)
+    public Map<String,Object> setFeatureModernDesktopEnabled(boolean zimbraFeatureModernDesktopEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernDesktopEnabled, zimbraFeatureModernDesktopEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether to allow a user to access Zimbra modern desktop
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3082)
+    public void unsetFeatureModernDesktopEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernDesktopEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to allow a user to access Zimbra modern desktop
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3082)
+    public Map<String,Object> unsetFeatureModernDesktopEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernDesktopEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * Whether to allow a user to access Zimbra modern mobile UI
+     *
+     * @return zimbraFeatureModernMobileUIEnabled, or false if unset
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public boolean isFeatureModernMobileUIEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureModernMobileUIEnabled, false, true);
+    }
+
+    /**
+     * Whether to allow a user to access Zimbra modern mobile UI
+     *
+     * @param zimbraFeatureModernMobileUIEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public void setFeatureModernMobileUIEnabled(boolean zimbraFeatureModernMobileUIEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernMobileUIEnabled, zimbraFeatureModernMobileUIEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to allow a user to access Zimbra modern mobile UI
+     *
+     * @param zimbraFeatureModernMobileUIEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public Map<String,Object> setFeatureModernMobileUIEnabled(boolean zimbraFeatureModernMobileUIEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernMobileUIEnabled, zimbraFeatureModernMobileUIEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether to allow a user to access Zimbra modern mobile UI
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public void unsetFeatureModernMobileUIEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernMobileUIEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to allow a user to access Zimbra modern mobile UI
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public Map<String,Object> unsetFeatureModernMobileUIEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernMobileUIEnabled, "");
+        return attrs;
+    }
+
+    /**
      * Whether user can create address books
      *
      * @return zimbraFeatureNewAddrBookEnabled, or true if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -11387,6 +11387,78 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * Whether to allow a user to access Zimbra mobile App
+     *
+     * @return zimbraFeatureMobileAppEnabled, or false if unset
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public boolean isFeatureMobileAppEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureMobileAppEnabled, false, true);
+    }
+
+    /**
+     * Whether to allow a user to access Zimbra mobile App
+     *
+     * @param zimbraFeatureMobileAppEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public void setFeatureMobileAppEnabled(boolean zimbraFeatureMobileAppEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMobileAppEnabled, zimbraFeatureMobileAppEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to allow a user to access Zimbra mobile App
+     *
+     * @param zimbraFeatureMobileAppEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public Map<String,Object> setFeatureMobileAppEnabled(boolean zimbraFeatureMobileAppEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMobileAppEnabled, zimbraFeatureMobileAppEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether to allow a user to access Zimbra mobile App
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public void unsetFeatureMobileAppEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMobileAppEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to allow a user to access Zimbra mobile App
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public Map<String,Object> unsetFeatureMobileAppEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMobileAppEnabled, "");
+        return attrs;
+    }
+
+    /**
      * Whether to enable Zimbra Mobile Gateway feature
      *
      * @return zimbraFeatureMobileGatewayEnabled, or false if unset
@@ -11661,78 +11733,6 @@ public abstract class ZAttrCos extends NamedEntry {
     public Map<String,Object> unsetFeatureModernDesktopEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureModernDesktopEnabled, "");
-        return attrs;
-    }
-
-    /**
-     * Whether to allow a user to access Zimbra modern mobile UI
-     *
-     * @return zimbraFeatureModernMobileUIEnabled, or false if unset
-     *
-     * @since ZCS 8.9.0
-     */
-    @ZAttr(id=3081)
-    public boolean isFeatureModernMobileUIEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraFeatureModernMobileUIEnabled, false, true);
-    }
-
-    /**
-     * Whether to allow a user to access Zimbra modern mobile UI
-     *
-     * @param zimbraFeatureModernMobileUIEnabled new value
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 8.9.0
-     */
-    @ZAttr(id=3081)
-    public void setFeatureModernMobileUIEnabled(boolean zimbraFeatureModernMobileUIEnabled) throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraFeatureModernMobileUIEnabled, zimbraFeatureModernMobileUIEnabled ? TRUE : FALSE);
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Whether to allow a user to access Zimbra modern mobile UI
-     *
-     * @param zimbraFeatureModernMobileUIEnabled new value
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 8.9.0
-     */
-    @ZAttr(id=3081)
-    public Map<String,Object> setFeatureModernMobileUIEnabled(boolean zimbraFeatureModernMobileUIEnabled, Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraFeatureModernMobileUIEnabled, zimbraFeatureModernMobileUIEnabled ? TRUE : FALSE);
-        return attrs;
-    }
-
-    /**
-     * Whether to allow a user to access Zimbra modern mobile UI
-     *
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 8.9.0
-     */
-    @ZAttr(id=3081)
-    public void unsetFeatureModernMobileUIEnabled() throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraFeatureModernMobileUIEnabled, "");
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Whether to allow a user to access Zimbra modern mobile UI
-     *
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 8.9.0
-     */
-    @ZAttr(id=3081)
-    public Map<String,Object> unsetFeatureModernMobileUIEnabled(Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraFeatureModernMobileUIEnabled, "");
         return attrs;
     }
 
@@ -14532,7 +14532,9 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Whether to allow a user to access Zimbra X desktop
+     * Deprecated since: 8.9.0. deprecated with attribute
+     * zimbraFeatureModernDesktopEnabled. Orig desc: Whether to allow a user
+     * to access Zimbra X desktop
      *
      * @return zimbraFeatureZXDesktopEnabled, or false if unset
      *
@@ -14544,7 +14546,9 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Whether to allow a user to access Zimbra X desktop
+     * Deprecated since: 8.9.0. deprecated with attribute
+     * zimbraFeatureModernDesktopEnabled. Orig desc: Whether to allow a user
+     * to access Zimbra X desktop
      *
      * @param zimbraFeatureZXDesktopEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -14559,7 +14563,9 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Whether to allow a user to access Zimbra X desktop
+     * Deprecated since: 8.9.0. deprecated with attribute
+     * zimbraFeatureModernDesktopEnabled. Orig desc: Whether to allow a user
+     * to access Zimbra X desktop
      *
      * @param zimbraFeatureZXDesktopEnabled new value
      * @param attrs existing map to populate, or null to create a new map
@@ -14575,7 +14581,9 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Whether to allow a user to access Zimbra X desktop
+     * Deprecated since: 8.9.0. deprecated with attribute
+     * zimbraFeatureModernDesktopEnabled. Orig desc: Whether to allow a user
+     * to access Zimbra X desktop
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -14589,7 +14597,9 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Whether to allow a user to access Zimbra X desktop
+     * Deprecated since: 8.9.0. deprecated with attribute
+     * zimbraFeatureModernDesktopEnabled. Orig desc: Whether to allow a user
+     * to access Zimbra X desktop
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs


### PR DESCRIPTION
Add attribute at Cos and account level
zimbraFeatureMobileAppEnabled
zimbraFeatureModernDesktopEnabled
 
This should be returned in the GetInfo Response license block

Testing Instructions:
Check the response of "GetInfoRequest" soap call, it should return values of above attributes in the license block

`zmsoap -z -m t1@`zmhostname` GetInfoRequest/ @sections="mbox,prefs,attrs,props,idents,sigs,dsrcs,children" -t account`