### PR TITLE
ZBUG-1315: An issue with data type range values for Mysql database ta…

### DIFF
--- a/store/src/java-test/com/zimbra/cs/mailbox/FolderTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/FolderTest.java
@@ -147,7 +147,7 @@ public final class FolderTest {
         int changeId = mbox.getLastChangeID();
         Folder inbox = mbox.getFolderById(null, Mailbox.ID_FOLDER_INBOX);
         int modMetadata = inbox.getModifiedSequence();
-        int modContent = inbox.getSavedSequence();
+        long modContent = inbox.getSavedSequence();
         Assert.assertEquals(0, inbox.getImapRECENTCutoff());
 
         mbox.recordImapSession(Mailbox.ID_FOLDER_INBOX);

--- a/store/src/java-test/com/zimbra/cs/mailbox/RenameTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/RenameTest.java
@@ -55,7 +55,7 @@ public class RenameTest {
     @Test
     public void renameModContentTest() throws Exception {
         int id = doc.getId();
-        int mod_content = doc.getSavedSequence();
+        long mod_content = doc.getSavedSequence();
         mbox.rename(null, id, doc.getType(), "newdoc.txt", folder.getId());
         mbox.purge(MailItem.Type.UNKNOWN);
         MailItem newdoc = mbox.getItemById(null, id, MailItem.Type.UNKNOWN, false);

--- a/store/src/java-test/com/zimbra/cs/store/MockStoreManager.java
+++ b/store/src/java-test/com/zimbra/cs/store/MockStoreManager.java
@@ -120,14 +120,31 @@ public final class MockStoreManager extends StoreManager {
     }
 
     @Override
-    public MailboxBlob copy(MailboxBlob src, Mailbox destMbox, int destItemId, int destRevision) {
+    public MailboxBlob copy(MailboxBlob src, Mailbox destMbox, int destItemId, long destRevision) {
         MockMailboxBlob blob = new MockMailboxBlob(destMbox, destItemId, destRevision, src.getLocator(), ((MockMailboxBlob) src).content);
         blobs.put(blobKey(destMbox, destItemId, destRevision), blob);
         return blob;
     }
 
     @Override
+    public MailboxBlob copy(MailboxBlob src, Mailbox destMbox, int destItemId, int destRevision) {
+        return copy(src, destMbox, destItemId, (long) destRevision);
+    }
+
+    @Override
+    public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destItemId, long destRevision) {
+        MockMailboxBlob blob = new MockMailboxBlob(destMbox, destItemId, destRevision, src.getLocator(), ((MockStagedBlob) src).content);
+        blobs.put(blobKey(destMbox, destItemId, destRevision), blob);
+        return blob;
+    }
+
+    @Override
     public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destItemId, int destRevision) {
+        return link(src, destMbox, destItemId, (long) destRevision);
+    }
+
+    @Override
+    public MailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destItemId, long destRevision) {
         MockMailboxBlob blob = new MockMailboxBlob(destMbox, destItemId, destRevision, src.getLocator(), ((MockStagedBlob) src).content);
         blobs.put(blobKey(destMbox, destItemId, destRevision), blob);
         return blob;
@@ -135,9 +152,7 @@ public final class MockStoreManager extends StoreManager {
 
     @Override
     public MailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destItemId, int destRevision) {
-        MockMailboxBlob blob = new MockMailboxBlob(destMbox, destItemId, destRevision, src.getLocator(), ((MockStagedBlob) src).content);
-        blobs.put(blobKey(destMbox, destItemId, destRevision), blob);
-        return blob;
+        return renameTo(src, destMbox, destItemId, (long) destRevision);
     }
 
     @Override
@@ -174,8 +189,13 @@ public final class MockStoreManager extends StoreManager {
     }
 
     @Override
-    public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, int revision, String locator, boolean validate) {
+    public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, long revision, String locator, boolean validate) {
         return blobs.get(blobKey(mbox, itemId, revision));
+    }
+
+    @Override
+    public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, int revision, String locator, boolean validate) {
+        return getMailboxBlob(mbox, itemId, (long) revision, locator, validate);
     }
 
     @Override
@@ -192,12 +212,7 @@ public final class MockStoreManager extends StoreManager {
     public boolean deleteStore(Mailbox mbox, Iterable<MailboxBlob.MailboxBlobInfo> mblobs) throws IOException {
         assert mblobs != null : "we require a blob iterator for testing purposes";
         for (MailboxBlob.MailboxBlobInfo mbinfo : mblobs) {
-            try {
-                delete(getMailboxBlob(mbox, mbinfo.itemId, mbinfo.revision, mbinfo.locator, true));
-            } catch (ServiceException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
-            }
+            delete(getMailboxBlob(mbox, mbinfo.itemId, mbinfo.revision, mbinfo.locator, true));
         }
         return true;
     }
@@ -294,7 +309,7 @@ public final class MockStoreManager extends StoreManager {
         final byte[] content;
         MockLocalBlob blob = null;
 
-        MockMailboxBlob(Mailbox mbox, int itemId, int revision, String locator, byte[] data) {
+        MockMailboxBlob(Mailbox mbox, int itemId, long revision, String locator, byte[] data) {
             super(mbox, itemId, revision, locator);
             content = data;
         }
@@ -335,33 +350,5 @@ public final class MockStoreManager extends StoreManager {
 
             return mockblob;
         }
-    }
-
-    @Override
-    public MailboxBlob copy(MailboxBlob src, Mailbox destMbox, int destMsgId, long destRevision)
-            throws IOException, ServiceException {
-        // TODO Auto-generated method stub
-        return null;
-    }
-
-    @Override
-    public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision)
-            throws IOException, ServiceException {
-        // TODO Auto-generated method stub
-        return null;
-    }
-
-    @Override
-    public MailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision)
-            throws IOException, ServiceException {
-        // TODO Auto-generated method stub
-        return null;
-    }
-
-    @Override
-    public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, long revision, String locator, boolean validate)
-            throws ServiceException {
-        // TODO Auto-generated method stub
-        return null;
     }
 }

--- a/store/src/java-test/com/zimbra/cs/store/MockStoreManager.java
+++ b/store/src/java-test/com/zimbra/cs/store/MockStoreManager.java
@@ -114,6 +114,10 @@ public final class MockStoreManager extends StoreManager {
     private String blobKey(Mailbox mbox, int itemId, int revision) {
         return mbox.getId() + "-" + itemId + "-" + revision;
     }
+    
+    private String blobKey(Mailbox mbox, int itemId, long revision) {
+        return mbox.getId() + "-" + itemId + "-" + revision;
+    }
 
     @Override
     public MailboxBlob copy(MailboxBlob src, Mailbox destMbox, int destItemId, int destRevision) {
@@ -188,7 +192,12 @@ public final class MockStoreManager extends StoreManager {
     public boolean deleteStore(Mailbox mbox, Iterable<MailboxBlob.MailboxBlobInfo> mblobs) throws IOException {
         assert mblobs != null : "we require a blob iterator for testing purposes";
         for (MailboxBlob.MailboxBlobInfo mbinfo : mblobs) {
-            delete(getMailboxBlob(mbox, mbinfo.itemId, mbinfo.revision, mbinfo.locator, true));
+            try {
+                delete(getMailboxBlob(mbox, mbinfo.itemId, mbinfo.revision, mbinfo.locator, true));
+            } catch (ServiceException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
         }
         return true;
     }
@@ -326,5 +335,33 @@ public final class MockStoreManager extends StoreManager {
 
             return mockblob;
         }
+    }
+
+    @Override
+    public MailboxBlob copy(MailboxBlob src, Mailbox destMbox, int destMsgId, long destRevision)
+            throws IOException, ServiceException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision)
+            throws IOException, ServiceException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public MailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision)
+            throws IOException, ServiceException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, long revision, String locator, boolean validate)
+            throws ServiceException {
+        // TODO Auto-generated method stub
+        return null;
     }
 }

--- a/store/src/java-test/com/zimbra/cs/store/http/HttpStoreManagerTest.java
+++ b/store/src/java-test/com/zimbra/cs/store/http/HttpStoreManagerTest.java
@@ -17,6 +17,7 @@
 package com.zimbra.cs.store.http;
 
 import java.io.File;
+import java.io.IOException;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -41,6 +42,8 @@ import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.MailboxManager;
 import com.zimbra.cs.mailbox.MailboxTest;
 import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.store.MailboxBlob;
+import com.zimbra.cs.store.StagedBlob;
 import com.zimbra.cs.store.StoreManager;
 import com.zimbra.cs.store.external.AbstractExternalStoreManagerTest;
 
@@ -72,6 +75,34 @@ public class HttpStoreManagerTest extends AbstractExternalStoreManagerTest {
                 String[] parts = locator.trim().split("/");
                 return parts[parts.length - 1];
             }
+        }
+
+        @Override
+        public MailboxBlob copy(MailboxBlob src, Mailbox destMbox, int destMsgId, long destRevision)
+                throws IOException, ServiceException {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+        @Override
+        public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision)
+                throws IOException, ServiceException {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+        @Override
+        public MailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision)
+                throws IOException, ServiceException {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+        @Override
+        public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, long revision, String locator, boolean validate)
+                throws ServiceException {
+            // TODO Auto-generated method stub
+            return null;
         }
     }
 

--- a/store/src/java-test/com/zimbra/cs/store/http/HttpStoreManagerTest.java
+++ b/store/src/java-test/com/zimbra/cs/store/http/HttpStoreManagerTest.java
@@ -76,34 +76,6 @@ public class HttpStoreManagerTest extends AbstractExternalStoreManagerTest {
                 return parts[parts.length - 1];
             }
         }
-
-        @Override
-        public MailboxBlob copy(MailboxBlob src, Mailbox destMbox, int destMsgId, long destRevision)
-                throws IOException, ServiceException {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision)
-                throws IOException, ServiceException {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public MailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision)
-                throws IOException, ServiceException {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, long revision, String locator, boolean validate)
-                throws ServiceException {
-            // TODO Auto-generated method stub
-            return null;
-        }
     }
 
     @Override

--- a/store/src/java/com/zimbra/cs/db/DbMailItem.java
+++ b/store/src/java/com/zimbra/cs/db/DbMailItem.java
@@ -1314,6 +1314,11 @@ public class DbMailItem {
     }
 
     public static int updateLocatorAndDigest(DbConnection conn, Mailbox mbox, String tableName, String idColumn, int itemId,
+            long revision, String locator, String digest) throws ServiceException {
+        return updateLocatorAndDigest(conn, mbox, tableName, idColumn, itemId, revision, locator, digest);
+    }
+
+    public static int updateLocatorAndDigest(DbConnection conn, Mailbox mbox, String tableName, String idColumn, int itemId,
             int revision, String locator, String digest) throws ServiceException {
         PreparedStatement stmt = null;
         try {

--- a/store/src/java/com/zimbra/cs/db/DbMailItem.java
+++ b/store/src/java/com/zimbra/cs/db/DbMailItem.java
@@ -194,7 +194,7 @@ public class DbMailItem {
             } else {
                 stmt.setNull(pos++, Types.INTEGER);
             }
-            stmt.setInt(pos++, data.modContent);
+            stmt.setLong(pos++, data.modContent);
             stmt.setString(pos++, data.uuid);
             int num = stmt.executeUpdate();
             if (num != 1) {
@@ -982,7 +982,7 @@ public class DbMailItem {
             stmt.setString(pos++, checkMetadataLength(metadata));
             stmt.setInt(pos++, mbox.getOperationChangeID());
             stmt.setInt(pos++, mbox.getOperationTimestamp());
-            stmt.setInt(pos++, item.getSavedSequence());
+            stmt.setLong(pos++, item.getSavedSequence());
             pos = setMailboxId(stmt, mbox, pos);
             stmt.setInt(pos++, item.getId());
             stmt.executeUpdate();
@@ -1011,7 +1011,7 @@ public class DbMailItem {
             } else {
                 stmt.setNull(pos++, Types.INTEGER);
             }
-            stmt.setInt(pos++, item.getSavedSequence());
+            stmt.setLong(pos++, item.getSavedSequence());
             pos = setMailboxId(stmt, mbox, pos);
             stmt.setInt(pos++, item.getId());
             stmt.executeUpdate();
@@ -1136,7 +1136,7 @@ public class DbMailItem {
             stmt.setString(pos++, checkMetadataLength(metadata.toString()));
             stmt.setInt(pos++, mailbox.getOperationChangeID());
             stmt.setInt(pos++, mailbox.getOperationTimestamp());
-            stmt.setInt(pos++, item.getSavedSequence());
+            stmt.setLong(pos++, item.getSavedSequence());
             stmt.setString(pos++, item.getLocator());
             pos = setMailboxId(stmt, mailbox, pos);
             stmt.setInt(pos++, item.getId());
@@ -3990,7 +3990,7 @@ public class DbMailItem {
         data.name = rs.getString(CI_NAME + offset);
         data.metadata = decodeMetadata(rs.getString(CI_METADATA + offset));
         data.modMetadata = rs.getInt(CI_MODIFIED + offset);
-        data.modContent = rs.getInt(CI_SAVED + offset);
+        data.modContent = rs.getLong(CI_SAVED + offset);
         data.dateChanged = rs.getInt(CI_MODIFY_DATE + offset);
         // make sure to handle NULL column values
         if (data.parentId == 0) {

--- a/store/src/java/com/zimbra/cs/db/DbVolumeBlobs.java
+++ b/store/src/java/com/zimbra/cs/db/DbVolumeBlobs.java
@@ -59,7 +59,7 @@ public final class DbVolumeBlobs {
             stmt.setShort(pos++, vol.getId());
             stmt.setInt(pos++, mbox.getId());
             stmt.setInt(pos++, item.getId());
-            stmt.setInt(pos++, item.getSavedSequence());
+            stmt.setLong(pos++, item.getSavedSequence());
             stmt.setString(pos++, item.getDigest());
             stmt.setBoolean(pos++, false);
             stmt.executeUpdate();
@@ -82,7 +82,7 @@ public final class DbVolumeBlobs {
             stmt.setShort(pos++, volId);
             stmt.setInt(pos++, info.mailboxId);
             stmt.setInt(pos++, info.itemId);
-            stmt.setInt(pos++, info.revision);
+            stmt.setLong(pos++, info.revision);
             stmt.setString(pos++, info.digest);
             stmt.setBoolean(pos++, false);
             stmt.executeUpdate();

--- a/store/src/java/com/zimbra/cs/mailbox/Folder.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Folder.java
@@ -1691,7 +1691,7 @@ public class Folder extends MailItem implements FolderStore {
      **/
     @Override
     public int getUIDValidity() {
-        return Math.max(getSavedSequence(), 1);
+        return (int) Math.max(getSavedSequence(), 1);
     }
 
     @Override

--- a/store/src/java/com/zimbra/cs/mailbox/MailItem.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailItem.java
@@ -308,7 +308,7 @@ public abstract class MailItem implements Comparable<MailItem>, ScheduledTaskRes
         public String metadata;
         public int modMetadata;
         public int dateChanged; /* Seconds since 1970-01-01 00:00:00 UTC */
-        public int modContent;
+        public long modContent;
         public String uuid;
 
         public String getSubject() {
@@ -985,7 +985,7 @@ public abstract class MailItem implements Comparable<MailItem>, ScheduledTaskRes
     /** Returns the change ID corresponding to the last time the item's
      *  content was modified.  For immutable objects (e.g. received messages),
      *  this will be the same change ID as when the item was created. */
-    public int getSavedSequence() {
+    public long getSavedSequence() {
         return mData.modContent;
     }
 
@@ -2169,7 +2169,7 @@ public abstract class MailItem implements Comparable<MailItem>, ScheduledTaskRes
                 // monotonically increasing in the revisions list. (f(n) <= f(n+1))
 
                 // Filter out blobs that are still in use; mark the rest for deletion.
-                int oldestRemainingSavedSequence =
+                long oldestRemainingSavedSequence =
                     revisions.isEmpty() ? mData.modContent : revisions.get(0).getSavedSequence();
                 for (MailItem revision : toPurge) {
                     if (revision.getSavedSequence() < oldestRemainingSavedSequence) {
@@ -2253,7 +2253,7 @@ public abstract class MailItem implements Comparable<MailItem>, ScheduledTaskRes
                 // monotonically increasing in the revisions list. (f(n) <= f(n+1))
 
                 // Filter out blobs that are still in use; mark the rest for deletion.
-                int oldestRemainingSavedSequence =
+                long oldestRemainingSavedSequence =
                     revisions.isEmpty() ? item.mData.modContent : revisions.get(0).getSavedSequence();
                 for (MailItem revision : toPurge) {
                     if (revision.getSavedSequence() < oldestRemainingSavedSequence) {

--- a/store/src/java/com/zimbra/cs/mailbox/MailServiceException.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailServiceException.java
@@ -335,7 +335,7 @@ public class MailServiceException extends ServiceException {
         return new MailServiceException("WaitSet not found: " + id, NO_SUCH_WAITSET, SENDERS_FAULT, new Argument(ID, id, Argument.Type.STR));
     }
 
-    public static MailServiceException NO_SUCH_BLOB(int mboxId, int itemId, int revision) {
+    public static MailServiceException NO_SUCH_BLOB(int mboxId, int itemId, long revision) {
         return new MailServiceException("No such blob: mailbox=" + mboxId + ", item=" + itemId + ", change=" + revision, NO_SUCH_BLOB, SENDERS_FAULT,
             new Argument(ITEM_ID, itemId, Argument.Type.IID), new Argument(REVISION, revision, Argument.Type.NUM));
     }

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -1260,7 +1260,7 @@ public class Mailbox implements MailboxStore {
         return checkItemChangeID(item.getModifiedSequence(), item.getSavedSequence());
     }
 
-    public boolean checkItemChangeID(int modMetadata, int modContent) throws ServiceException {
+    public boolean checkItemChangeID(int modMetadata, long modContent) throws ServiceException {
         if (currentChange().octxt == null || currentChange().octxt.change < 0) {
             return true;
         }
@@ -5253,9 +5253,17 @@ public class Mailbox implements MailboxStore {
         public final int invId;
         public final int compNum;
         public final int modSeq;
-        public final int rev;
+        public final long rev;
 
         private AddInviteData(int calItemId, int invId, int compNum, int modSeq, int rev) {
+            this.calItemId = calItemId;
+            this.invId = invId;
+            this.compNum = compNum;
+            this.modSeq = modSeq;
+            this.rev = rev;
+        }
+
+        private AddInviteData(int calItemId, int invId, int compNum, int modSeq, long rev) {
             this.calItemId = calItemId;
             this.invId = invId;
             this.compNum = compNum;

--- a/store/src/java/com/zimbra/cs/mailbox/VirtualConversation.java
+++ b/store/src/java/com/zimbra/cs/mailbox/VirtualConversation.java
@@ -88,7 +88,7 @@ public class VirtualConversation extends Conversation {
         data.folderId = Mailbox.ID_FOLDER_CONVERSATIONS;
         data.setSubject(msg.getSubject());
         data.date = (int) (msg.getDate() / 1000);
-        data.modMetadata = msg.getSavedSequence();
+        data.modMetadata = (int) msg.getSavedSequence();
         data.modContent = msg.getSavedSequence();
         data.size = 1;
         data.unreadCount = msg.getUnreadCount();

--- a/store/src/java/com/zimbra/cs/mailbox/calendar/cache/CalendarItemData.java
+++ b/store/src/java/com/zimbra/cs/mailbox/calendar/cache/CalendarItemData.java
@@ -37,7 +37,7 @@ public class CalendarItemData {
     private String mTagIds;
     private boolean mIsPublic;
     private int mModMetadata; // mod_metadata db column; this serves the function of last-modified-time
-    private int mModContent;  // mod_content db column
+    private long mModContent;  // mod_content db column
     private long mDate;       // date db column; unix time in millis
     private long mChangeDate; // change_date db column; unix time in millis
     private long mSize;       // size db column
@@ -73,7 +73,7 @@ public class CalendarItemData {
     public String getTagIds()   { return mTagIds; }
     public boolean isPublic() { return mIsPublic; }
     public int getModMetadata()  { return mModMetadata; }
-    public int getModContent()   { return mModContent; }
+    public long getModContent()   { return mModContent; }
     public long getDate()         { return mDate; }
     public long getChangeDate()   { return mChangeDate; }
     public long getSize()         { return mSize; }
@@ -97,7 +97,7 @@ public class CalendarItemData {
     }
 
     CalendarItemData(MailItem.Type type, int folderId, int calItemId, String flags, String[] tags, String tagIds, int modMetadata,
-            int modContent, long date, long changeDate, long size, String uid, boolean isRecurring, boolean hasExceptions, boolean isPublic,
+            long modContent, long date, long changeDate, long size, String uid, boolean isRecurring, boolean hasExceptions, boolean isPublic,
             AlarmData alarm, FullInstanceData defaultData) {
         this.type = type;
         mFolderId = folderId;

--- a/store/src/java/com/zimbra/cs/service/formatter/ContactFolderFormatter.java
+++ b/store/src/java/com/zimbra/cs/service/formatter/ContactFolderFormatter.java
@@ -110,7 +110,7 @@ public class ContactFolderFormatter extends Formatter {
         // revision
         out.write(MailConstants.A_REVISION.getBytes("UTF-8"));
         out.write(FIELD_DELIMITER);
-        out.write(Integer.toString(item.getSavedSequence()).getBytes("UTF-8"));
+        out.write(Long.toString(item.getSavedSequence()).getBytes("UTF-8"));
         out.write(FIELD_DELIMITER);
         // fileAsStr
         try {

--- a/store/src/java/com/zimbra/cs/service/mail/RestoreContacts.java
+++ b/store/src/java/com/zimbra/cs/service/mail/RestoreContacts.java
@@ -80,7 +80,7 @@ public class RestoreContacts extends MailDocumentHandler {
                             + MailConstants.A_CONTACTS_RESTORE_RESOLVE + "=" + resolve;
                     }
                     File file = new File(FileBlobStore.getBlobPath(mbox, doc.getId(),
-                        doc.getSavedSequence(), Short.valueOf(doc.getLocator())));
+                        (int) doc.getSavedSequence(), Short.valueOf(doc.getLocator())));
                     if (!file.exists()) {
                         throw ServiceException
                             .INVALID_REQUEST(FILE_NOT_FOUND + contactBackupFileName, null);

--- a/store/src/java/com/zimbra/cs/service/mail/ToXML.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ToXML.java
@@ -1417,7 +1417,7 @@ public final class ToXML {
             boolean encodeMissingBlobs, MsgContent wantContent, int fields)
     throws ServiceException {
         Mailbox mbox = msg.getMailbox();
-        int changeId = msg.getSavedSequence();
+        long changeId = msg.getSavedSequence();
         while (true) {
             try {
                 return encodeMessageAsMPHelper(false /* bestEffort */, parent, ifmt, octxt, msg, part, maxSize,
@@ -1817,7 +1817,7 @@ public final class ToXML {
         final int MAX_RETRIES = LC.calendar_item_get_max_retries.intValue();
         Element elem = null;
         Mailbox mbox = calItem.getMailbox();
-        int changeId = calItem.getSavedSequence();
+        long changeId = calItem.getSavedSequence();
         int numTries = 0;
         while (numTries < MAX_RETRIES) {
             numTries++;

--- a/store/src/java/com/zimbra/cs/store/MailboxBlob.java
+++ b/store/src/java/com/zimbra/cs/store/MailboxBlob.java
@@ -44,6 +44,15 @@ public abstract class MailboxBlob {
             this.locator = locator;
             this.digest = digest;
         }
+
+        public MailboxBlobInfo(String accountId, int mailboxId, int itemId, long revision, String locator, String digest) {
+            this.accountId = accountId;
+            this.mailboxId = mailboxId;
+            this.itemId = itemId;
+            this.revision = revision;
+            this.locator = locator;
+            this.digest = digest;
+        }
     }
 
     private final Mailbox mailbox;

--- a/store/src/java/com/zimbra/cs/store/MailboxBlob.java
+++ b/store/src/java/com/zimbra/cs/store/MailboxBlob.java
@@ -32,7 +32,7 @@ public abstract class MailboxBlob {
         public String accountId;
         public int mailboxId;
         public int itemId;
-        public int revision;
+        public long revision;
         public String locator;
         public String digest;
 
@@ -49,7 +49,7 @@ public abstract class MailboxBlob {
     private final Mailbox mailbox;
 
     private final int itemId;
-    private final int revision;
+    private final long revision;
     private final String locator;
     protected Long size;
     protected String digest;
@@ -61,11 +61,18 @@ public abstract class MailboxBlob {
         this.locator = locator;
     }
 
+    protected MailboxBlob(Mailbox mbox, int itemId, long revision, String locator) {
+        this.mailbox = mbox;
+        this.itemId = itemId;
+        this.revision = revision;
+        this.locator = locator;
+    }
+
     public int getItemId() {
         return itemId;
     }
 
-    public int getRevision() {
+    public long getRevision() {
         return revision;
     }
 

--- a/store/src/java/com/zimbra/cs/store/StoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/StoreManager.java
@@ -225,6 +225,21 @@ public abstract class StoreManager {
     throws IOException, ServiceException;
 
     /**
+     * Create a copy in destMbox mailbox with message ID of destMsgId that
+     * points to srcBlob.
+     * Implementations may choose to use linking where appropriate (i.e. files on same filesystem)
+     * @param src
+     * @param destMbox
+     * @param destMsgId mail_item.id value for message in destMbox
+     * @param destRevision mail_item.mod_content value for message in destMbox
+     * @return MailboxBlob object representing the copied blob
+     * @throws IOException
+     * @throws ServiceException
+     */
+    public abstract MailboxBlob copy(MailboxBlob src, Mailbox destMbox, int destMsgId, long destRevision)
+    throws IOException, ServiceException;
+
+    /**
      * Create a link in destMbox mailbox with message ID of destMsgId that
      * points to srcBlob.
      * If staging creates permanent blobs, this just needs to return mailbox blob with pointer to location of staged blob
@@ -241,6 +256,22 @@ public abstract class StoreManager {
     throws IOException, ServiceException;
 
     /**
+     * Create a link in destMbox mailbox with message ID of destMsgId that
+     * points to srcBlob.
+     * If staging creates permanent blobs, this just needs to return mailbox blob with pointer to location of staged blob
+     * If staging is done to temporary area such as our incoming directory this operation finishes it
+     * @param src
+     * @param destMbox
+     * @param destMsgId mail_item.id value for message in destMbox
+     * @param destRevision mail_item.mod_content value for message in destMbox
+     * @return MailboxBlob object representing the linked blob
+     * @throws IOException
+     * @throws ServiceException
+     */
+    public abstract MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision)
+    throws IOException, ServiceException;
+
+    /**
      * Rename a blob to a blob in mailbox directory.
      * This effectively makes the StagedBlob permanent, implementations may not need to do anything if the stage operation creates permanent items
      * @param src
@@ -252,6 +283,20 @@ public abstract class StoreManager {
      * @throws ServiceException
      */
     public abstract MailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destMsgId, int destRevision)
+    throws IOException, ServiceException;
+
+    /**
+     * Rename a blob to a blob in mailbox directory.
+     * This effectively makes the StagedBlob permanent, implementations may not need to do anything if the stage operation creates permanent items
+     * @param src
+     * @param destMbox
+     * @param destMsgId mail_item.id value for message in destMbox
+     * @param destRevision mail_item.mod_content value for message in destMbox
+     * @return MailboxBlob object representing the renamed blob
+     * @throws IOException
+     * @throws ServiceException
+     */
+    public abstract MailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision)
     throws IOException, ServiceException;
 
     /**
@@ -352,6 +397,34 @@ public abstract class StoreManager {
     throws ServiceException {
         return getMailboxBlob(mbox, itemId, revision, locator, true);
     }
+
+    /**
+     * Find the MailboxBlob in mailbox mbox with matching item ID.
+     * @param mbox
+     * @param itemId mail_item.id value for item
+     * @param revision mail_item.mod_content value for item
+     * @return the <code>MailboxBlob</code>, or <code>null</code> if the file
+     * does not exist
+     *
+     * @throws ServiceException
+     */
+    public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, long revision, String locator)
+    throws ServiceException {
+        return getMailboxBlob(mbox, itemId, revision, locator, true);
+    }
+
+    /**
+     * Find the MailboxBlob in int mailboxId, String accountId with matching item ID.
+     * @param mbox
+     * @param itemId mail_item.id value for item
+     * @param revision mail_item.mod_content value for item
+     * @return the <code>MailboxBlob</code>, or <code>null</code> if the file
+     * does not exist
+     *
+     * @throws ServiceException
+     */
+    public abstract MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, long revision, String locator, boolean validate)
+    throws ServiceException;
 
     /**
      * Find the MailboxBlob in int mailboxId, String accountId with matching item ID.

--- a/store/src/java/com/zimbra/cs/store/external/ExternalMailboxBlob.java
+++ b/store/src/java/com/zimbra/cs/store/external/ExternalMailboxBlob.java
@@ -34,6 +34,10 @@ public class ExternalMailboxBlob extends MailboxBlob {
         super(mbox, itemId, revision, locator);
     }
 
+    protected ExternalMailboxBlob(Mailbox mbox, int itemId, long revision, String locator) {
+        super(mbox, itemId, revision, locator);
+    }
+
     @Override
     public Blob getLocalBlob() throws IOException {
         ExternalStoreManager sm = (ExternalStoreManager) StoreManager.getInstance();

--- a/store/src/java/com/zimbra/cs/store/external/ImapTransientStoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/external/ImapTransientStoreManager.java
@@ -26,6 +26,8 @@ import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.FileUtil;
 import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.store.MailboxBlob;
+import com.zimbra.cs.store.StagedBlob;
 
 /**
  * Simple ExternalStoreManager implementation that is intended for use in storing
@@ -85,5 +87,33 @@ public class ImapTransientStoreManager extends ExternalStoreManager {
             return File.createTempFile(mbox.getAccountId(), ".msg", baseDirectory);
         }
     }
+
+	@Override
+	public MailboxBlob copy(MailboxBlob src, Mailbox destMbox, int destMsgId, long destRevision)
+			throws IOException, ServiceException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision)
+			throws IOException, ServiceException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public MailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision)
+			throws IOException, ServiceException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, long revision, String locator, boolean validate)
+			throws ServiceException {
+		// TODO Auto-generated method stub
+		return null;
+	}
 
 }

--- a/store/src/java/com/zimbra/cs/store/external/ImapTransientStoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/external/ImapTransientStoreManager.java
@@ -87,33 +87,4 @@ public class ImapTransientStoreManager extends ExternalStoreManager {
             return File.createTempFile(mbox.getAccountId(), ".msg", baseDirectory);
         }
     }
-
-	@Override
-	public MailboxBlob copy(MailboxBlob src, Mailbox destMbox, int destMsgId, long destRevision)
-			throws IOException, ServiceException {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision)
-			throws IOException, ServiceException {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public MailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision)
-			throws IOException, ServiceException {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, long revision, String locator, boolean validate)
-			throws ServiceException {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
 }

--- a/store/src/java/com/zimbra/cs/store/external/SimpleStoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/external/SimpleStoreManager.java
@@ -126,32 +126,4 @@ public class SimpleStoreManager extends ExternalStoreManager {
             return super.supports(feature);
         }
     }
-
-	@Override
-	public MailboxBlob copy(MailboxBlob src, Mailbox destMbox, int destMsgId, long destRevision)
-			throws IOException, ServiceException {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision)
-			throws IOException, ServiceException {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public MailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision)
-			throws IOException, ServiceException {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, long revision, String locator, boolean validate)
-			throws ServiceException {
-		// TODO Auto-generated method stub
-		return null;
-	}
 }

--- a/store/src/java/com/zimbra/cs/store/external/SimpleStoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/external/SimpleStoreManager.java
@@ -33,6 +33,8 @@ import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.FileUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.store.MailboxBlob;
+import com.zimbra.cs.store.StagedBlob;
 
 /**
  * Example implementation of ExternalStoreManager which writes to a flat directory structure
@@ -124,4 +126,32 @@ public class SimpleStoreManager extends ExternalStoreManager {
             return super.supports(feature);
         }
     }
+
+	@Override
+	public MailboxBlob copy(MailboxBlob src, Mailbox destMbox, int destMsgId, long destRevision)
+			throws IOException, ServiceException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision)
+			throws IOException, ServiceException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public MailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision)
+			throws IOException, ServiceException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, long revision, String locator, boolean validate)
+			throws ServiceException {
+		// TODO Auto-generated method stub
+		return null;
+	}
 }

--- a/store/src/java/com/zimbra/cs/store/file/FileBlobStore.java
+++ b/store/src/java/com/zimbra/cs/store/file/FileBlobStore.java
@@ -437,4 +437,66 @@ public final class FileBlobStore extends StoreManager {
     private static void ensureParentDirExists(File file) throws IOException {
         ensureDirExists(file.getParentFile());
     }
+
+	@Override
+	public MailboxBlob copy(MailboxBlob src, Mailbox destMbox, int destMsgId, long destRevision) throws IOException, ServiceException {
+	    // TODO Auto-generated method stub
+	    return null;
+	}
+
+	@Override
+	public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision)
+		throws IOException, ServiceException {
+	    // TODO Auto-generated method stub
+	    return null;
+	}
+
+	@Override
+	public MailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision) throws IOException, ServiceException {
+	    // TODO Auto-generated method stub
+	    return null;
+	}
+
+	@Override
+	public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, long revision, String locator, boolean validate) throws ServiceException {
+	    short volumeId = Short.valueOf(locator);
+	    File file = getMailboxBlobFile(mbox, itemId, revision, volumeId, validate);
+	    if (file == null) {
+	        return null;
+	    }
+	    return new VolumeMailboxBlob(mbox, itemId, revision, locator, new VolumeBlob(file, volumeId));
+	}
+
+	private File getMailboxBlobFile(Mailbox mbox, int itemId, long revision, short volumeId, boolean check) throws ServiceException {
+	    File file = new File(getBlobPath(mbox, itemId, revision, volumeId));
+	    if (!check || file.exists()) {
+	        return file;
+	    }
+	    // fallback for very very *very* old installs where blob paths were based on item id only
+	    file = new File(getBlobPath(mbox, itemId, -1, volumeId));
+	    return (file.exists() ? file : null);
+	}
+
+	public static String getBlobPath(Mailbox mbox, int itemId, long revision, short volumeId) throws ServiceException {
+	    return getBlobPath(mbox.getId(), itemId, revision, volumeId);
+	}
+
+	public static String getBlobPath(int mboxId, int itemId, long revision, short volumeId) throws ServiceException {
+	    Volume vol = MANAGER.getVolume(volumeId);
+	    String path = vol.getBlobDir(mboxId, itemId);
+	    int buflen = path.length() + 15 + (revision < 0 ? 0 : 11);
+
+	    StringBuilder sb = new StringBuilder(buflen);
+	    sb.append(path).append(File.separator);
+	    appendFilename(sb, itemId, revision);
+	    return sb.toString();
+	}
+
+	public static void appendFilename(StringBuilder sb, int itemId, long revision) {
+	    sb.append(itemId);
+	    if (revision >= 0) {
+	        sb.append('-').append(revision);
+	    }
+        sb.append(".msg");
+	}
 }

--- a/store/src/java/com/zimbra/cs/store/file/FileBlobStore.java
+++ b/store/src/java/com/zimbra/cs/store/file/FileBlobStore.java
@@ -130,6 +130,13 @@ public final class FileBlobStore extends StoreManager {
         return link(src.getLocalBlob(), destMbox, destItemId, destRevision, volume.getId());
     }
 
+    @Override
+    public MailboxBlob copy(MailboxBlob src, Mailbox destMbox, int destItemId, long destRevision) throws IOException, ServiceException {
+        Volume volume = MANAGER.getCurrentMessageVolume();
+        //FileBlobStore optimizes copy by using link where possible
+        return link(src.getLocalBlob(), destMbox, destItemId, destRevision, volume.getId());
+    }
+
     /**
      * Create a copy of a blob in volume/path specified by dest* parameters.
      * Note this method is not part of the StoreManager interface
@@ -200,7 +207,20 @@ public final class FileBlobStore extends StoreManager {
         return link(blob, destMbox, destItemId, destRevision, volume.getId());
     }
 
+    @Override
+    public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destItemId, long destRevision)
+    throws IOException, ServiceException {
+        Volume volume = MANAGER.getCurrentMessageVolume();
+        VolumeBlob blob = ((VolumeStagedBlob) src).getLocalBlob();
+        return link(blob, destMbox, destItemId, destRevision, volume.getId());
+    }
+
     public VolumeMailboxBlob link(Blob src, Mailbox destMbox, int destItemId, int destRevision, short destVolumeId)
+            throws IOException, ServiceException {
+        return link(src, destMbox, destItemId, (long)destRevision, destVolumeId);
+    }
+
+    public VolumeMailboxBlob link(Blob src, Mailbox destMbox, int destItemId, long destRevision, short destVolumeId)
     throws IOException, ServiceException {
         File srcFile = src.getFile();
         if (!srcFile.exists()) {
@@ -264,7 +284,12 @@ public final class FileBlobStore extends StoreManager {
     }
 
     @Override
-    public VolumeMailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destItemId, int destRevision)
+    public VolumeMailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destMsgId, int destRevision) throws IOException, ServiceException {
+        return renameTo(src, destMbox, destMsgId, (long) destRevision);
+    }
+
+    @Override
+    public VolumeMailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destItemId, long destRevision)
     throws IOException, ServiceException {
         Volume volume = MANAGER.getCurrentMessageVolume();
         VolumeBlob blob = ((VolumeStagedBlob) src).getLocalBlob();
@@ -437,25 +462,6 @@ public final class FileBlobStore extends StoreManager {
     private static void ensureParentDirExists(File file) throws IOException {
         ensureDirExists(file.getParentFile());
     }
-
-	@Override
-	public MailboxBlob copy(MailboxBlob src, Mailbox destMbox, int destMsgId, long destRevision) throws IOException, ServiceException {
-	    // TODO Auto-generated method stub
-	    return null;
-	}
-
-	@Override
-	public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision)
-		throws IOException, ServiceException {
-	    // TODO Auto-generated method stub
-	    return null;
-	}
-
-	@Override
-	public MailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision) throws IOException, ServiceException {
-	    // TODO Auto-generated method stub
-	    return null;
-	}
 
 	@Override
 	public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, long revision, String locator, boolean validate) throws ServiceException {

--- a/store/src/java/com/zimbra/cs/store/file/VolumeMailboxBlob.java
+++ b/store/src/java/com/zimbra/cs/store/file/VolumeMailboxBlob.java
@@ -27,6 +27,11 @@ public class VolumeMailboxBlob extends MailboxBlob {
         this.blob = blob;
     }
 
+    protected VolumeMailboxBlob(Mailbox mbox, int itemId, long revision, String locator, VolumeBlob blob) {
+        super(mbox, itemId, revision, locator);
+        this.blob = blob;
+    }
+
     @Override
     public MailboxBlob setSize(long size) {
         super.setSize(size);

--- a/store/src/java/com/zimbra/cs/store/triton/TritonBlobStoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/triton/TritonBlobStoreManager.java
@@ -47,6 +47,8 @@ import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.service.UserServlet;
 import com.zimbra.cs.store.Blob;
+import com.zimbra.cs.store.MailboxBlob;
+import com.zimbra.cs.store.StagedBlob;
 import com.zimbra.cs.store.external.ExternalResumableIncomingBlob;
 import com.zimbra.cs.store.external.ExternalResumableUpload;
 import com.zimbra.cs.store.external.ExternalUploadedBlob;
@@ -322,4 +324,28 @@ public class TritonBlobStoreManager extends SisStore implements ExternalResumabl
             default: return super.supports(feature);
         }
     }
+
+	@Override
+	public MailboxBlob copy(MailboxBlob src, Mailbox destMbox, int destMsgId, long destRevision) throws IOException, ServiceException {
+	    // TODO Auto-generated method stub
+	    return null;
+	}
+
+	@Override
+	public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision) throws IOException, ServiceException {
+	    // TODO Auto-generated method stub
+	    return null;
+	}
+
+	@Override
+	public MailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision) throws IOException, ServiceException {
+	    // TODO Auto-generated method stub
+	    return null;
+	}
+
+	@Override
+	public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, long revision, String locator, boolean validate) throws ServiceException {
+	    // TODO Auto-generated method stub
+	    return null;
+	}
 }

--- a/store/src/java/com/zimbra/cs/store/triton/TritonBlobStoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/triton/TritonBlobStoreManager.java
@@ -324,28 +324,4 @@ public class TritonBlobStoreManager extends SisStore implements ExternalResumabl
             default: return super.supports(feature);
         }
     }
-
-	@Override
-	public MailboxBlob copy(MailboxBlob src, Mailbox destMbox, int destMsgId, long destRevision) throws IOException, ServiceException {
-	    // TODO Auto-generated method stub
-	    return null;
-	}
-
-	@Override
-	public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision) throws IOException, ServiceException {
-	    // TODO Auto-generated method stub
-	    return null;
-	}
-
-	@Override
-	public MailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision) throws IOException, ServiceException {
-	    // TODO Auto-generated method stub
-	    return null;
-	}
-
-	@Override
-	public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, long revision, String locator, boolean validate) throws ServiceException {
-	    // TODO Auto-generated method stub
-	    return null;
-	}
 }


### PR DESCRIPTION
Field 'mod_content' has a data type int (10) unsigned, so can accept values range from 0 to 4294967295 in db.

Problem: Currently when "mod_content" value goes beyond integer range (above 2147483647) then in java, we accessing that value using getInt() method which is not capable to hold unsigned int range

Fix: Used getLong() instead of getInt() as mentioned here - https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-reference-type-conversions.html
and did respective changes in the code base.

Testing done:
1. Manually reproduce the issue as per steps mentioned in the ticket and verified it is fixed.
2. Checked back and restore functionality using following steps
    1. Took full backup using the command   `zmbackup -a all -f`
    2. Restore the data from backup for few accounts and check the logs.
       `zmrestore -a t1@`zmhostname`
       `zmrestore -a admin@`zmhostname`