### PR TITLE
ZBUG-1311: Fix for zimbraSmtpHostname should honour domain level value (if set) instead of server level

### DIFF
--- a/store/src/java/com/zimbra/cs/account/ldap/AutoProvision.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/AutoProvision.java
@@ -33,6 +33,7 @@ import javax.activation.DataHandler;
 import javax.activation.DataSource;
 import javax.mail.Address;
 import javax.mail.MessagingException;
+import javax.mail.Session;
 import javax.mail.Transport;
 import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
@@ -432,7 +433,8 @@ public abstract class AutoProvision {
         String toAddr = acct.getName();
 
         try {
-            SMTPMessage out = new SMTPMessage(JMSession.getSmtpSession());
+            Domain domain = Provisioning.getInstance().getDomain(acct);
+            SMTPMessage out = new SMTPMessage(JMSession.getSmtpSession(domain));
 
             InternetAddress addr = null;
             try {

--- a/store/src/java/com/zimbra/cs/account/ldap/AutoProvision.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/AutoProvision.java
@@ -77,6 +77,7 @@ import com.zimbra.cs.ldap.ZLdapFilterFactory;
 import com.zimbra.cs.ldap.ZLdapFilterFactory.FilterId;
 import com.zimbra.cs.ldap.ZSearchResultEntry;
 import com.zimbra.cs.ldap.ZSearchScope;
+import com.zimbra.cs.util.AccountUtil;
 import com.zimbra.cs.util.JMSession;
 
 public abstract class AutoProvision {
@@ -433,8 +434,7 @@ public abstract class AutoProvision {
         String toAddr = acct.getName();
 
         try {
-            Domain domain = Provisioning.getInstance().getDomain(acct);
-            SMTPMessage out = new SMTPMessage(JMSession.getSmtpSession(domain));
+            SMTPMessage out = AccountUtil.getSmtpMessageObj(acct);
 
             InternetAddress addr = null;
             try {

--- a/store/src/java/com/zimbra/cs/filter/FilterUtil.java
+++ b/store/src/java/com/zimbra/cs/filter/FilterUtil.java
@@ -68,6 +68,7 @@ import com.zimbra.common.zmime.ZMimeBodyPart;
 import com.zimbra.common.zmime.ZMimeMultipart;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.AuthToken;
+import com.zimbra.cs.account.Domain;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.filter.jsieve.ActionFlag;
 import com.zimbra.cs.filter.jsieve.Require;
@@ -519,7 +520,8 @@ public final class FilterUtil {
             charset = MimeConstants.P_CHARSET_UTF8;
         }
 
-        SMTPMessage report = new SMTPMessage(JMSession.getSmtpSession());
+        Domain domain = Provisioning.getInstance().getDomain(owner);
+        SMTPMessage report = new SMTPMessage(JMSession.getSmtpSession(domain));
 
         // add the forwarded header account names to detect the mail loop between accounts
         for (String headerFwdAccountName : Mime.getHeaders(mimeMessage, HEADER_FORWARDED)) {

--- a/store/src/java/com/zimbra/cs/filter/FilterUtil.java
+++ b/store/src/java/com/zimbra/cs/filter/FilterUtil.java
@@ -520,9 +520,7 @@ public final class FilterUtil {
             charset = MimeConstants.P_CHARSET_UTF8;
         }
 
-        Domain domain = Provisioning.getInstance().getDomain(owner);
-        SMTPMessage report = new SMTPMessage(JMSession.getSmtpSession(domain));
-
+        SMTPMessage report = AccountUtil.getSmtpMessageObj(owner);
         // add the forwarded header account names to detect the mail loop between accounts
         for (String headerFwdAccountName : Mime.getHeaders(mimeMessage, HEADER_FORWARDED)) {
             report.addHeader(HEADER_FORWARDED, headerFwdAccountName);

--- a/store/src/java/com/zimbra/cs/mailbox/Notification.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Notification.java
@@ -286,7 +286,7 @@ public class Notification implements LmtpCallback {
 
         // Send the message
         try {
-            SMTPMessage out = new SMTPMessage(JMSession.getSmtpSession());
+            SMTPMessage out = AccountUtil.getSmtpMessageObj(account);
 
             // Set From and Reply-To.
             out.setFrom(AccountUtil.getFromAddress(account));
@@ -651,8 +651,7 @@ public class Notification implements LmtpCallback {
                         attached.saveChanges();
                     }
 
-                    Domain domain = Provisioning.getInstance().getDomain(account);
-                    SMTPMessage out = new SMTPMessage(JMSession.getSmtpSession(domain));
+                    SMTPMessage out = AccountUtil.getSmtpMessageObj(account);
                     out.setHeader("Auto-Submitted", "auto-replied (zimbra; intercept)");
                     InternetAddress address = new JavaMailInternetAddress(from);
                     out.setFrom(address);

--- a/store/src/java/com/zimbra/cs/mailbox/Notification.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Notification.java
@@ -52,6 +52,7 @@ import com.zimbra.common.zmime.ZMimeBodyPart;
 import com.zimbra.common.zmime.ZMimeMessage;
 import com.zimbra.common.zmime.ZMimeMultipart;
 import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Domain;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.db.DbOutOfOffice;
 import com.zimbra.cs.db.DbPool;
@@ -507,7 +508,8 @@ public class Notification implements LmtpCallback {
 
         // Send the message
         try {
-            Session smtpSession = JMSession.getSmtpSession();
+            Domain domain = Provisioning.getInstance().getDomain(account);
+            Session smtpSession = JMSession.getSmtpSession(domain);
 
             // Assemble message components
             MimeMessage out = assembleNotificationMessage(account, msg, rcpt, destination, smtpSession);
@@ -649,7 +651,8 @@ public class Notification implements LmtpCallback {
                         attached.saveChanges();
                     }
 
-                    SMTPMessage out = new SMTPMessage(JMSession.getSmtpSession());
+                    Domain domain = Provisioning.getInstance().getDomain(account);
+                    SMTPMessage out = new SMTPMessage(JMSession.getSmtpSession(domain));
                     out.setHeader("Auto-Submitted", "auto-replied (zimbra; intercept)");
                     InternetAddress address = new JavaMailInternetAddress(from);
                     out.setFrom(address);

--- a/store/src/java/com/zimbra/cs/service/account/DistributionListAction.java
+++ b/store/src/java/com/zimbra/cs/service/account/DistributionListAction.java
@@ -49,6 +49,7 @@ import com.zimbra.common.zmime.ZMimeBodyPart;
 import com.zimbra.common.zmime.ZMimeMultipart;
 import com.zimbra.cs.account.AccessManager;
 import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Domain;
 import com.zimbra.cs.account.Group;
 import com.zimbra.cs.account.Group.GroupOwner;
 import com.zimbra.cs.account.Provisioning;
@@ -672,7 +673,8 @@ public class DistributionListAction extends DistributionListDocumentHandler {
 
         private void sendMessage() throws ServiceException {
             try {
-                SMTPMessage out = new SMTPMessage(JMSession.getSmtpSession());
+                Domain domain = Provisioning.getInstance().getDomain(ownerAcct);
+                SMTPMessage out = new SMTPMessage(JMSession.getSmtpSession(domain));
 
                 Address fromAddr = AccountUtil.getFriendlyEmailAddress(ownerAcct);
 

--- a/store/src/java/com/zimbra/cs/service/account/DistributionListAction.java
+++ b/store/src/java/com/zimbra/cs/service/account/DistributionListAction.java
@@ -673,9 +673,7 @@ public class DistributionListAction extends DistributionListDocumentHandler {
 
         private void sendMessage() throws ServiceException {
             try {
-                Domain domain = Provisioning.getInstance().getDomain(ownerAcct);
-                SMTPMessage out = new SMTPMessage(JMSession.getSmtpSession(domain));
-
+                SMTPMessage out = AccountUtil.getSmtpMessageObj(ownerAcct);
                 Address fromAddr = AccountUtil.getFriendlyEmailAddress(ownerAcct);
 
                 Address replyToAddr = fromAddr;

--- a/store/src/java/com/zimbra/cs/service/account/SubscribeDistributionList.java
+++ b/store/src/java/com/zimbra/cs/service/account/SubscribeDistributionList.java
@@ -45,6 +45,7 @@ import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.common.zmime.ZMimeBodyPart;
 import com.zimbra.common.zmime.ZMimeMultipart;
 import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Domain;
 import com.zimbra.cs.account.Group;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.util.AccountUtil;
@@ -169,7 +170,8 @@ public class SubscribeDistributionList extends DistributionListDocumentHandler {
 
         private void sendMessage(String[] owners) throws ServiceException {
             try {
-                SMTPMessage out = new SMTPMessage(JMSession.getSmtpSession());
+                Domain domain = Provisioning.getInstance().getDomain(requestingAcct);
+                SMTPMessage out = new SMTPMessage(JMSession.getSmtpSession(domain));
 
                 Address fromAddr = AccountUtil.getFriendlyEmailAddress(requestingAcct);
 

--- a/store/src/java/com/zimbra/cs/service/account/SubscribeDistributionList.java
+++ b/store/src/java/com/zimbra/cs/service/account/SubscribeDistributionList.java
@@ -170,8 +170,7 @@ public class SubscribeDistributionList extends DistributionListDocumentHandler {
 
         private void sendMessage(String[] owners) throws ServiceException {
             try {
-                Domain domain = Provisioning.getInstance().getDomain(requestingAcct);
-                SMTPMessage out = new SMTPMessage(JMSession.getSmtpSession(domain));
+                SMTPMessage out = AccountUtil.getSmtpMessageObj(requestingAcct);
 
                 Address fromAddr = AccountUtil.getFriendlyEmailAddress(requestingAcct);
 

--- a/store/src/java/com/zimbra/cs/service/admin/ComputeAggregateQuotaUsage.java
+++ b/store/src/java/com/zimbra/cs/service/admin/ComputeAggregateQuotaUsage.java
@@ -140,7 +140,7 @@ public class ComputeAggregateQuotaUsage extends AdminDocumentHandler {
             @Override
             public void run() {
                 try {
-                    SMTPMessage out = new SMTPMessage(JMSession.getSmtpSession());
+                    SMTPMessage out = new SMTPMessage(JMSession.getSmtpSession(domain));
 
                     // should From be configurable?
                     out.setFrom(new JavaMailInternetAddress("Postmaster <postmaster@" + domain.getName() + ">"));

--- a/store/src/java/com/zimbra/cs/service/mail/SendDeliveryReport.java
+++ b/store/src/java/com/zimbra/cs/service/mail/SendDeliveryReport.java
@@ -108,7 +108,6 @@ public class SendDeliveryReport extends MailDocumentHandler {
             InternetAddress[] recipients = Mime.parseAddressHeader(mm, "Disposition-Notification-To");
             if (recipients == null || recipients.length == 0)
                 return;
-
             Domain domain = Provisioning.getInstance().getDomain(authAccount);
             Session smtpSession = JMSession.getSmtpSession(domain);
             SMTPMessage report = new SMTPMessage(smtpSession);

--- a/store/src/java/com/zimbra/cs/service/mail/SendDeliveryReport.java
+++ b/store/src/java/com/zimbra/cs/service/mail/SendDeliveryReport.java
@@ -43,6 +43,7 @@ import com.zimbra.common.util.L10nUtil.MsgKey;
 import com.zimbra.common.zmime.ZMimeBodyPart;
 import com.zimbra.common.zmime.ZMimeMultipart;
 import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Domain;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.mailbox.ACL;
 import com.zimbra.cs.mailbox.Flag;
@@ -108,7 +109,8 @@ public class SendDeliveryReport extends MailDocumentHandler {
             if (recipients == null || recipients.length == 0)
                 return;
 
-            Session smtpSession = JMSession.getSmtpSession();
+            Domain domain = Provisioning.getInstance().getDomain(authAccount);
+            Session smtpSession = JMSession.getSmtpSession(domain);
             SMTPMessage report = new SMTPMessage(smtpSession);
             String subject = "Read-Receipt: " + msg.getSubject();
             report.setSubject(subject, CharsetUtil.checkCharset(subject, charset));

--- a/store/src/java/com/zimbra/cs/service/util/SpamHandler.java
+++ b/store/src/java/com/zimbra/cs/service/util/SpamHandler.java
@@ -45,6 +45,7 @@ import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.common.zmime.ZMimeBodyPart;
 import com.zimbra.common.zmime.ZMimeMultipart;
 import com.zimbra.cs.account.Config;
+import com.zimbra.cs.account.Domain;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.mailbox.MailItem;
 import com.zimbra.cs.mailbox.MailSender;
@@ -86,9 +87,11 @@ public class SpamHandler {
     private void sendReport(SpamReport sr) throws ServiceException, MessagingException {
         Config config = Provisioning.getInstance().getConfig();
         String isSpamString = sr.isSpam ? config.getSpamReportTypeSpam() : config.getSpamReportTypeHam();
-        SMTPMessage out = new SMTPMessage(JMSession.getSmtpSession());
 
         Mailbox mbox = MailboxManager.getInstance().getMailboxById(sr.mailboxId);
+        Domain domain = Provisioning.getInstance().getDomain(mbox.getAccount());
+        SMTPMessage out = new SMTPMessage(JMSession.getSmtpSession(domain));
+
         Message msg = mbox.getMessageById(null, sr.messageId);
 
         MimeMultipart mmp = new ZMimeMultipart("mixed");

--- a/store/src/java/com/zimbra/cs/service/util/SpamHandler.java
+++ b/store/src/java/com/zimbra/cs/service/util/SpamHandler.java
@@ -56,6 +56,7 @@ import com.zimbra.cs.mailbox.OperationContext;
 import com.zimbra.cs.mime.MailboxBlobDataSource;
 import com.zimbra.cs.mime.Mime;
 import com.zimbra.cs.store.MailboxBlob;
+import com.zimbra.cs.util.AccountUtil;
 import com.zimbra.cs.util.JMSession;
 
 public class SpamHandler {
@@ -89,8 +90,7 @@ public class SpamHandler {
         String isSpamString = sr.isSpam ? config.getSpamReportTypeSpam() : config.getSpamReportTypeHam();
 
         Mailbox mbox = MailboxManager.getInstance().getMailboxById(sr.mailboxId);
-        Domain domain = Provisioning.getInstance().getDomain(mbox.getAccount());
-        SMTPMessage out = new SMTPMessage(JMSession.getSmtpSession(domain));
+        SMTPMessage out = AccountUtil.getSmtpMessageObj(mbox.getAccount());
 
         Message msg = mbox.getMessageById(null, sr.messageId);
 

--- a/store/src/java/com/zimbra/cs/util/AccountUtil.java
+++ b/store/src/java/com/zimbra/cs/util/AccountUtil.java
@@ -41,6 +41,7 @@ import javax.mail.internet.MimeMultipart;
 
 import org.apache.commons.codec.binary.Hex;
 
+import com.sun.mail.smtp.SMTPMessage;
 import com.zimbra.common.account.Key;
 import com.zimbra.common.account.Key.DomainBy;
 import com.zimbra.common.localconfig.LC;
@@ -852,4 +853,16 @@ public class AccountUtil {
             }
         }
     }
+
+    /**
+     * 
+     * @param acct
+     * @return SMTPMessage object
+     * @throws ServiceException
+     * @throws MessagingException
+     */
+    public static SMTPMessage getSmtpMessageObj(Account acct) throws ServiceException, MessagingException {
+        return new SMTPMessage(JMSession.getSmtpSession(Provisioning.getInstance().getDomain(acct)));
+    }
 }
+    

--- a/store/src/java/com/zimbra/cs/util/JMSession.java
+++ b/store/src/java/com/zimbra/cs/util/JMSession.java
@@ -228,7 +228,7 @@ public final class JMSession {
      *
      * @param domain the domain, or {@code null} to use server settings
      */
-    private static Session getSmtpSession(Domain domain) throws MessagingException {
+    public static Session getSmtpSession(Domain domain) throws MessagingException {
         Server server;
         try {
             server = Provisioning.getInstance().getLocalServer();


### PR DESCRIPTION
- Updated code to use domain level value (if set) for zimbraSmtpHostname.
- Along with Read receipt and receiving notifcation, also fixed the other files listed in ticket description.

**Testing Done:**
Verified Read Receipt and Receiving Notification with domain level value set and empty both.
As per jira ticket comment OOO issue is not reproducible.

**Testing to be done by QA:**
Verify fixes done in other files as per ticket description.