### PR TITLE
ZBUG-1295 Check if authtoken is expired abd reauthenticate

### DIFF
--- a/store/src/java/com/zimbra/cs/store/file/BlobConsistencyUtil.java
+++ b/store/src/java/com/zimbra/cs/store/file/BlobConsistencyUtil.java
@@ -39,8 +39,8 @@ import com.zimbra.cs.account.soap.SoapProvisioning;
 import com.zimbra.cs.db.DbPool;
 import com.zimbra.cs.store.file.BlobConsistencyChecker.BlobInfo;
 import com.zimbra.soap.admin.message.ExportAndDeleteItemsRequest;
-import com.zimbra.soap.admin.type.ExportAndDeleteMailboxSpec;
 import com.zimbra.soap.admin.type.ExportAndDeleteItemSpec;
+import com.zimbra.soap.admin.type.ExportAndDeleteMailboxSpec;
 
 public class BlobConsistencyUtil {
 
@@ -200,6 +200,9 @@ public class BlobConsistencyUtil {
         	DbPool.startup();
         	for (int mboxId : mailboxIds) {
         		System.out.println("Checking mailbox " + mboxId + ".");
+                if (prov.isExpired()) {
+                  prov.soapZimbraAdminAuthenticate();
+                }
         		checkMailbox(mboxId, prov);
         	}
         }  finally{

--- a/store/src/java/com/zimbra/cs/store/file/BlobConsistencyUtil.java
+++ b/store/src/java/com/zimbra/cs/store/file/BlobConsistencyUtil.java
@@ -200,9 +200,6 @@ public class BlobConsistencyUtil {
         	DbPool.startup();
         	for (int mboxId : mailboxIds) {
         		System.out.println("Checking mailbox " + mboxId + ".");
-                if (prov.isExpired()) {
-                  prov.soapZimbraAdminAuthenticate();
-                }
         		checkMailbox(mboxId, prov);
         	}
         }  finally{
@@ -246,6 +243,9 @@ public class BlobConsistencyUtil {
         request.addAttribute(AdminConstants.A_CHECK_SIZE, !skipSizeCheck);
         request.addAttribute(AdminConstants.A_REPORT_USED_BLOBS, outputUsedBlobs || usedBlobWriter != null);
 
+        if (prov.isExpired()) {
+            prov.soapZimbraAdminAuthenticate();
+        }
         Element response = prov.invoke(request);
         for (Element mboxEl : response.listElements(AdminConstants.E_MAILBOX)) {
             // Print results.


### PR DESCRIPTION
Added a condition to check if auth token is expired, if it is then authenticate the admin user before making the SOAP request.

Verified by setting the expiration lifetime to a very low value, add a sleep in the for loop and letting the token expire.
Validated that the token is reauthenticated and zmblobchk continues.