### PR TITLE
zcs-8670: database changes to support abq

### DIFF
--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -1551,4 +1551,9 @@ public final class AdminConstants {
     public static final String E_GAL_FILTER = "galFilter";
     public static final String E_LDAP_FILTER = "ldapFilter";
     public static final String A_CLEAR_FILTER = "clearFilter";
+
+    //ABQ constants
+    public static final String ENABLE_ABQ = "enable_abq";
+    public static final String ABQ_NOTIFICATION_EMAIL = "abq_notification_email";
+    public static final String ABQ_NOTIFICATION_INTERVAL = "abq_notification_interval";
 }

--- a/store/src/db/hsqldb/db.sql
+++ b/store/src/db/hsqldb/db.sql
@@ -184,7 +184,9 @@ CREATE TABLE mobile_devices (
    os_language         VARCHAR(64),
    phone_number        VARCHAR(64),
    unapproved_appl_list VARCHAR(512),
-   approved_appl_list   VARCHAR(512),  
+   approved_appl_list   VARCHAR(512),
+   added_to_quarantine  BOOLEAN DEFAULT 0,
+   quarantine_status    VARCHAR(64) NULL,
 
    CONSTRAINT pk_mobile_devices PRIMARY KEY (mailbox_id, device_id),
    CONSTRAINT fk_mobile_mailbox_id FOREIGN KEY (mailbox_id) REFERENCES mailbox(id) ON DELETE CASCADE,


### PR DESCRIPTION
Issue : For ABQ feature two more fields need to be added in zimba.mobile_devices table.

Fix : Added two more columns as per the description in ZCS-8670. created build and checked that new fields are present.
```
zimbra@ip-172-31-20-17:~$ zmcontrol -v
Release 8.8.15.GA.3031.UBUNTU16.64 UBUNTU16_64 NETWORK edition.
zimbra@ip-172-31-20-17:~$ mysql
Welcome to the MariaDB monitor.  Commands end with ; or \g.
Your MariaDB connection id is 247
Server version: 10.1.25-MariaDB Zimbra MariaDB binary distribution

Copyright (c) 2000, 2017, Oracle, MariaDB Corporation Ab and others.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

MariaDB [(none)]> use zimbra;
Reading table information for completion of table and column names
You can turn off this feature to get a quicker startup with -A

Database changed
MariaDB [zimbra]> desc mobile_devices;
+----------------------+---------------------+------+-----+---------+-------+
| Field                | Type                | Null | Key | Default | Extra |
+----------------------+---------------------+------+-----+---------+-------+
| mailbox_id           | int(10) unsigned    | NO   | PRI | NULL    |       |
| device_id            | varchar(64)         | NO   | PRI | NULL    |       |
| device_type          | varchar(64)         | NO   |     | NULL    |       |
| user_agent           | varchar(64)         | YES  |     | NULL    |       |
| protocol_version     | varchar(64)         | YES  |     | NULL    |       |
| provisionable        | tinyint(1)          | NO   |     | 0       |       |
| status               | tinyint(3) unsigned | NO   |     | 0       |       |
| policy_key           | int(10) unsigned    | YES  |     | NULL    |       |
| recovery_password    | varchar(64)         | YES  |     | NULL    |       |
| first_req_received   | int(10) unsigned    | NO   |     | NULL    |       |
| last_policy_update   | int(10) unsigned    | YES  |     | NULL    |       |
| remote_wipe_req      | int(10) unsigned    | YES  |     | NULL    |       |
| remote_wipe_ack      | int(10) unsigned    | YES  |     | NULL    |       |
| policy_values        | varchar(512)        | YES  |     | NULL    |       |
| last_used_date       | date                | YES  | MUL | NULL    |       |
| deleted_by_user      | tinyint(1)          | NO   |     | 0       |       |
| model                | varchar(64)         | YES  |     | NULL    |       |
| imei                 | varchar(64)         | YES  |     | NULL    |       |
| friendly_name        | varchar(512)        | YES  |     | NULL    |       |
| os                   | varchar(64)         | YES  |     | NULL    |       |
| os_language          | varchar(64)         | YES  |     | NULL    |       |
| phone_number         | varchar(64)         | YES  |     | NULL    |       |
| unapproved_appl_list | text                | YES  |     | NULL    |       |
| approved_appl_list   | text                | YES  |     | NULL    |       |
| added_to_quarantine  | tinyint(1)          | YES  |     | 0       |       |
| quarantine_status    | text                | YES  |     | NULL    |       |
+----------------------+---------------------+------+-----+---------+-------+
26 rows in set (0.00 sec)
```