### PR TITLE
ZCS-8730:ABQ-database changes to support ABQ

### DIFF
--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -1551,9 +1551,4 @@ public final class AdminConstants {
     public static final String E_GAL_FILTER = "galFilter";
     public static final String E_LDAP_FILTER = "ldapFilter";
     public static final String A_CLEAR_FILTER = "clearFilter";
-
-    //ABQ constants
-    public static final String ENABLE_ABQ = "enable_abq";
-    public static final String ABQ_NOTIFICATION_EMAIL = "abq_notification_email";
-    public static final String ABQ_NOTIFICATION_INTERVAL = "abq_notification_interval";
 }

--- a/store/src/db/hsqldb/db.sql
+++ b/store/src/db/hsqldb/db.sql
@@ -185,8 +185,6 @@ CREATE TABLE mobile_devices (
    phone_number        VARCHAR(64),
    unapproved_appl_list VARCHAR(512),
    approved_appl_list   VARCHAR(512),
-   added_to_quarantine  BOOLEAN DEFAULT 0,
-   quarantine_status    VARCHAR(64) NULL,
 
    CONSTRAINT pk_mobile_devices PRIMARY KEY (mailbox_id, device_id),
    CONSTRAINT fk_mobile_mailbox_id FOREIGN KEY (mailbox_id) REFERENCES mailbox(id) ON DELETE CASCADE,

--- a/store/src/db/hsqldb/db.sql
+++ b/store/src/db/hsqldb/db.sql
@@ -129,6 +129,15 @@ CREATE TABLE config (
    modified     TIMESTAMP
 );
 
+INSERT INTO config (name, value, description, modified)
+  VALUES ('abq_mode', 'disabled', 'Whether ABQ mode is on/off', CURRENT_TIMESTAMP);
+INSERT INTO config (name, description, modified)
+  VALUES ('abq_admin_email_list', 'ABQ admin email list', CURRENT_TIMESTAMP);
+INSERT INTO config (name, value, description, modified)
+  VALUES ('abq_notification_interval', '8h', 'ABQ notification interval', CURRENT_TIMESTAMP);
+INSERT INTO config (name, description, modified)
+  VALUES ('abq_last_notification_time', 'ABQ last notification time', CURRENT_TIMESTAMP);
+
 CREATE TABLE table_maintenance (
    database_name       VARCHAR(64) NOT NULL,
    table_name          VARCHAR(64) NOT NULL,
@@ -187,6 +196,7 @@ CREATE TABLE mobile_devices (
    approved_appl_list   VARCHAR(512),
 
    CONSTRAINT pk_mobile_devices PRIMARY KEY (mailbox_id, device_id),
+   INDEX i_device_id (device_id),
    CONSTRAINT fk_mobile_mailbox_id FOREIGN KEY (mailbox_id) REFERENCES mailbox(id) ON DELETE CASCADE,
 );
 
@@ -206,4 +216,16 @@ CREATE TABLE current_sessions (
 	PRIMARY KEY (id, server_id)
 ); 
 
+CREATE TABLE abq_devices (
+   device_id       VARCHAR(64) NOT NULL,
+   account_id      VARCHAR(127) NOT NULL,
+   status          VARCHAR(64),
+   created_time    DATETIME,
+   created_by      VARCHAR(255),
+   modified_time   DATETIME,
+   modified_by     VARCHAR(255),
 
+   CONSTRAINT pk_abq_devices PRIMARY KEY (device_id, account_id),
+   CONSTRAINT fk_abq_devices_device_id FOREIGN KEY (device_id) REFERENCES mobile_devices(device_id) ON DELETE CASCADE,
+   CONSTRAINT fk_abq_devices_account_id FOREIGN KEY (account_id) REFERENCES mailbox(account_id) ON DELETE CASCADE
+);


### PR DESCRIPTION
Revert changes done to ZCS-8670

Added following keys to configs:
ABQMode, Admin email list, notification interval, last notification time.

Added new ABQ devices table which will have following columns:
Device ID
Account ID
Status
Created Time
Created By
Modified time
Modified By

Testing done:
Manual testing by creating and deploying ZCS-build. Check if the database has new changes.

Ref PR: https://github.com/Zimbra/zm-db-conf/pull/10