### PR TITLE
ZCS-8510: adding ABQ configs admin api

### DIFF
--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016 Synacor, Inc.
+ * Copyright (C) 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2020 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -151,6 +151,10 @@ public final class AdminConstants {
     public static final String E_MODIFY_CONFIG_RESPONSE = "ModifyConfigResponse";
     public static final String E_GET_ALL_CONFIG_REQUEST = "GetAllConfigRequest";
     public static final String E_GET_ALL_CONFIG_RESPONSE = "GetAllConfigResponse";
+
+    public static final String E_ABQ_CONFIG_REQUEST = "ABQConfigRequest";
+    public static final String E_ABQ_CONFIG_RESPONSE = "ABQConfigResponse";
+    public static final String E_ABQ_CONFIG_APPEND = "append";
 
     public static final String E_GET_SERVICE_STATUS_REQUEST = "GetServiceStatusRequest";
     public static final String E_GET_SERVICE_STATUS_RESPONSE = "GetServiceStatusResponse";
@@ -658,6 +662,9 @@ public final class AdminConstants {
     public static final QName MODIFY_CONFIG_RESPONSE = QName.get(E_MODIFY_CONFIG_RESPONSE, NAMESPACE);
     public static final QName GET_ALL_CONFIG_REQUEST = QName.get(E_GET_ALL_CONFIG_REQUEST, NAMESPACE);
     public static final QName GET_ALL_CONFIG_RESPONSE = QName.get(E_GET_ALL_CONFIG_RESPONSE, NAMESPACE);
+
+    public static final QName ABQ_CONFIG_REQUEST = QName.get(E_ABQ_CONFIG_REQUEST, NAMESPACE);
+    public static final QName ABQ_CONFIG_RESPONSE = QName.get(E_ABQ_CONFIG_RESPONSE, NAMESPACE);
 
     public static final QName GET_SERVICE_STATUS_REQUEST = QName.get(E_GET_SERVICE_STATUS_REQUEST, NAMESPACE);
     public static final QName GET_SERVICE_STATUS_RESPONSE = QName.get(E_GET_SERVICE_STATUS_RESPONSE, NAMESPACE);
@@ -1563,8 +1570,12 @@ public final class AdminConstants {
         permissive,
         interactive,
         strict,
-        disabled
-    };
+        disabled;
+
+        public static ABQ_MODE_ENUM fromString(String s) {
+            return ABQ_MODE_ENUM.valueOf(s);
+        }
+    }
     public enum ABQ_DEVICE_STATUS {
         allowed,
         quarantined,

--- a/soap/src/java/com/zimbra/soap/JaxbUtil.java
+++ b/soap/src/java/com/zimbra/soap/JaxbUtil.java
@@ -204,6 +204,8 @@ public final class JaxbUtil {
             com.zimbra.soap.account.message.SyncGalResponse.class,
             com.zimbra.soap.account.message.GetAllAddressListsRequest.class,
             com.zimbra.soap.account.message.GetAllAddressListsResponse.class,
+            com.zimbra.soap.admin.message.ABQConfigRequest.class,
+            com.zimbra.soap.admin.message.ABQConfigResponse.class,
             com.zimbra.soap.admin.message.GetAllAddressListsRequest.class,
             com.zimbra.soap.admin.message.GetAllAddressListsResponse.class,
             com.zimbra.soap.admin.message.DeleteAddressListRequest.class,

--- a/soap/src/java/com/zimbra/soap/admin/message/ABQConfigRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/ABQConfigRequest.java
@@ -1,0 +1,155 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2020 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.AdminConstants;
+
+/**
+ * @zm-api-command-auth-required true
+ * @zm-api-command-admin-auth-required true
+ * @zm-api-command-description Get ABQ Configs
+ */
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name=AdminConstants.E_ABQ_CONFIG_REQUEST)
+public class ABQConfigRequest {
+    @XmlEnum
+    public enum AbqConfigOperation {
+        // case must match
+        get, add, modify, delete;
+
+        public static AbqConfigOperation fromString(String s) throws ServiceException {
+            try {
+                return AbqConfigOperation.valueOf(s);
+            } catch (IllegalArgumentException e) {
+                throw ServiceException.INVALID_REQUEST("unknown key: "+s, e);
+            }
+        }
+    }
+
+    /**
+     * @zm-api-field-tag op
+     * @zm-api-field-description op can be either get, add, modify, delete
+     */
+    @XmlAttribute(name=AdminConstants.A_OP /* op */, required=true)
+    private AbqConfigOperation op;
+
+    /**
+     * @zm-api-field-tag config-name
+     * @zm-api-field-description ABQ config name
+     */
+    @XmlAttribute(name=AdminConstants.A_NAME /* s */, required=true)
+    private String configName;
+
+    /**
+     * @zm-api-field-tag config-value
+     * @zm-api-field-description ABQ config value
+     */
+    @XmlAttribute(name=AdminConstants.A_VALUE /* s */, required=false)
+    private String configValue;
+
+    /**
+     * @zm-api-field-tag config-desc
+     * @zm-api-field-description ABQ config description
+     */
+    @XmlAttribute(name=AdminConstants.A_DESCRIPTION /* s */, required=false)
+    private String configDesc;
+
+    /**
+     * @zm-api-field-tag config-append
+     * @zm-api-field-description ABQ config append to replace or append the value
+     */
+    @XmlAttribute(name=AdminConstants.E_ABQ_CONFIG_APPEND /* s */, required=false)
+    private boolean configAppend;
+
+    /**
+     * @return the op
+     */
+    public AbqConfigOperation getOp() {
+        return op;
+    }
+
+    /**
+     * @param op the op to set
+     */
+    public void setOp(AbqConfigOperation op) {
+        this.op = op;
+    }
+
+    /**
+     * @return the configName
+     */
+    public String getConfigName() {
+        return configName;
+    }
+
+    /**
+     * @param configName the configName to set
+     */
+    public void setConfigName(String configName) {
+        this.configName = configName;
+    }
+
+    /**
+     * @return the configValue
+     */
+    public String getConfigValue() {
+        return configValue;
+    }
+
+    /**
+     * @param configValue the configValue to set
+     */
+    public void setConfigValue(String configValue) {
+        this.configValue = configValue;
+    }
+
+    /**
+     * @return the configDesc
+     */
+    public String getConfigDesc() {
+        return configDesc;
+    }
+
+    /**
+     * @param configDesc the configDesc to set
+     */
+    public void setConfigDesc(String configDesc) {
+        this.configDesc = configDesc;
+    }
+
+    /**
+     * @return the configAppend
+     */
+    public boolean isConfigAppend() {
+        return configAppend;
+    }
+
+    /**
+     * @param configAppend the configAppend to set
+     */
+    public void setConfigAppend(boolean configAppend) {
+        this.configAppend = configAppend;
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/ABQConfigResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/ABQConfigResponse.java
@@ -1,0 +1,70 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2020 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.AdminConstants;
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name=AdminConstants.E_ABQ_CONFIG_RESPONSE)
+public class ABQConfigResponse {
+    /**
+     * @zm-api-field-tag configName
+     * @zm-api-field-description abq config name
+     */
+    @XmlElement(name=AdminConstants.A_NAME /* config name */, required=true)
+    private String configName;
+
+    /**
+     * @zm-api-field-tag configValue
+     * @zm-api-field-description abq config value
+     */
+    @XmlElement(name=AdminConstants.A_VALUE /* config value */, required=true)
+    private String configValue;
+
+    /**
+     * @return the configName
+     */
+    public String getConfigName() {
+        return configName;
+    }
+
+    /**
+     * @param configName the configName to set
+     */
+    public void setConfigName(String configName) {
+        this.configName = configName;
+    }
+
+    /**
+     * @return the configValue
+     */
+    public String getConfigValue() {
+        return configValue;
+    }
+
+    /**
+     * @param configValue the configValue to set
+     */
+    public void setConfigValue(String configValue) {
+        this.configValue = configValue;
+    }
+}

--- a/store/src/java/com/zimbra/cs/util/Config.java
+++ b/store/src/java/com/zimbra/cs/util/Config.java
@@ -93,11 +93,16 @@ public final class Config {
 
     public static synchronized void setString(String name, String value)
     throws ServiceException {
+        setString(name, value, null);
+    }
+
+    public static synchronized void setString(String name, String value, String description)
+            throws ServiceException {
         initConfig();
         DbConnection conn = null;
         try {
             conn = DbPool.getConnection();
-            DbConfig c = DbConfig.set(conn, name, value);
+            DbConfig c = DbConfig.set(conn, name, value, description);
             mConfigMap.put(name, c);
             conn.commit();
         } finally {


### PR DESCRIPTION
Adding soap API '**AbqConfigRequest**' to manage ABQ config values for Mode, Admin Email List, Notification Interval, Notification Time.

**Operations supported**: Get, Add, Modify.

Admin email list config update uses '**append**' attribute with boolean value to allow appending to existing list on true, replaces on false value.

https://github.com/Zimbra/zm-network-store/pull/40