### PR TITLE
ZCS-8757: Create Admin API for listing ABQ devices

### DIFF
--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -1104,6 +1104,12 @@ public final class AdminConstants {
     public static final QName GET_ADDRESS_LIST_INFO_RESPONSE = QName.get(E_GET_ADDRESS_LIST_INFO_RESPONSE, NAMESPACE);
 
 
+    //ABQ
+    public static final String E_GET_ABQ_DEVICES_LIST_REQUEST = "GetABQDevicesListRequest";
+    public static final String E_GET_ABQ_DEVICES_LIST_RESPONSE = "GetABQDevicesListResponse";
+    public static final QName GET_ABQ_DEVICES_LIST_REQUEST = QName.get(E_GET_ABQ_DEVICES_LIST_REQUEST, NAMESPACE);
+    public static final QName GET_ABQ_DEVICES_LIST_RESPONSE = QName.get(E_GET_ABQ_DEVICES_LIST_RESPONSE, NAMESPACE);
+
     // DumpSessions
     public static final String E_SESSION = "session";
     public static final String A_ZIMBRA_ID = "zid";
@@ -1604,5 +1610,14 @@ public final class AdminConstants {
         public static ABQ_DEVICE_STATUS fromString(String s) {
             return ABQ_DEVICE_STATUS.valueOf(s);
         }
-    }
+    };
+
+    public static final String E_ABQ_DEVICE = "abqevice";
+    public static final String A_DEVICE_ID = "devid";
+    public static final String A_ACCOUNT_ID = "accid";
+    public static final String A_DEVICE_STATUS = "ds";
+    public static final String A_CREATED_ON = "cd";
+    public static final String A_CREATED_BY = "cb";
+    public static final String A_MODIFIED_ON = "md";
+    public static final String A_MODIFIED_BY = "mb";
 }

--- a/soap/src/java/com/zimbra/soap/JaxbUtil.java
+++ b/soap/src/java/com/zimbra/soap/JaxbUtil.java
@@ -388,6 +388,8 @@ public final class JaxbUtil {
             com.zimbra.soap.admin.message.FlushCacheResponse.class,
             com.zimbra.soap.admin.message.GenCSRRequest.class,
             com.zimbra.soap.admin.message.GenCSRResponse.class,
+            com.zimbra.soap.admin.message.GetABQDevicesListRequest.class,
+            com.zimbra.soap.admin.message.GetABQDevicesListResponse.class,
             com.zimbra.soap.admin.message.GetAccountInfoRequest.class,
             com.zimbra.soap.admin.message.GetAccountInfoResponse.class,
             com.zimbra.soap.admin.message.GetAccountLoggersRequest.class,

--- a/soap/src/java/com/zimbra/soap/admin/message/GetABQDevicesListRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/GetABQDevicesListRequest.java
@@ -1,0 +1,63 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2020 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.AdminConstants;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name=AdminConstants.E_GET_ABQ_DEVICES_LIST_REQUEST)
+public class GetABQDevicesListRequest {
+
+    /**
+     * @zm-api-field-tag status
+     * @zm-api-field-description device status
+     */
+    @XmlAttribute(name = AdminConstants.A_DEVICE_STATUS /* deviceStatus */, required = false)
+    private String deviceStatus;
+
+    public GetABQDevicesListRequest() {
+        
+    }
+
+    public GetABQDevicesListRequest(String deviceStatus) {
+        this.deviceStatus = deviceStatus;
+    }
+
+    /**
+     * @return deviceStatus
+     */
+    public String getDeviceStatus() {
+        return deviceStatus;
+    }
+
+    /**
+     * @param deviceStatus the deviceStatus to set
+     */
+    public void setDeviceStatus(String deviceStatus) {
+        this.deviceStatus = deviceStatus;
+    }
+
+    @Override
+    public String toString() {
+        return "GetAbqDevicesListRequest [deviceStatus=" + deviceStatus + "]";
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/GetABQDevicesListResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/GetABQDevicesListResponse.java
@@ -1,0 +1,63 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2020 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.soap.admin.message;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.soap.admin.type.ABQDevice;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name=AdminConstants.E_GET_ABQ_DEVICES_LIST_RESPONSE /* GetAbqDevicesListResponse */)
+public class GetABQDevicesListResponse {
+
+    /**
+     * @zm-api-field-description list of ABQ devices
+     */
+    @XmlElement(name=AdminConstants.E_ABQ_DEVICE /* abqDevice */, required = false)
+    private List<ABQDevice> abqDevices;
+
+    public GetABQDevicesListResponse() {
+        this.abqDevices = null;
+    }
+
+    public GetABQDevicesListResponse(List<ABQDevice> abqDevices) {
+        this.abqDevices = abqDevices;
+    }
+
+    public List<ABQDevice> getAbqDevices() {
+        return abqDevices;
+    }
+
+    public void setAbqDevices(List<ABQDevice> abqDevices) {
+        this.abqDevices = new ArrayList<ABQDevice>();
+        this.abqDevices.addAll(abqDevices);
+    }
+
+    public void addAbqDevice(ABQDevice device) {
+        if (this.abqDevices == null) {
+            this.abqDevices = new ArrayList<ABQDevice>();
+        }
+        this.abqDevices.add(device);
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/type/ABQDevice.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/ABQDevice.java
@@ -1,0 +1,177 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2020 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.soap.admin.type;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
+
+import com.zimbra.common.soap.AdminConstants;
+
+/**
+ * 
+ * @author jyotiranjan.jena
+ *
+ */
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlType(propOrder = {})
+public class ABQDevice {
+
+    /**
+     * @zm-api-field-tag deviceId
+     * @zm-api-field-description device id
+     */
+    @XmlAttribute(name = AdminConstants.A_DEVICE_ID /* devid */)
+    private String device_id;
+    /**
+     * @zm-api-field-tag accountId
+     * @zm-api-field-description account id
+     */
+    @XmlAttribute(name = AdminConstants.A_ACCOUNT_ID /* acid */)
+    private String account_id;
+    /**
+     * @zm-api-field-tag deviceStatus
+     * @zm-api-field-description device status
+     */
+    @XmlAttribute(name = AdminConstants.A_DEVICE_STATUS /* ds */)
+    private String status;
+
+    @XmlAttribute(name = AdminConstants.A_CREATED_ON /* cd */)
+    private String created_on;
+
+    @XmlAttribute(name = AdminConstants.A_CREATED_BY /* cb */)
+    private String created_by;
+
+    @XmlAttribute(name = AdminConstants.A_MODIFIED_ON /* md */)
+    private String modified_on;
+
+    @XmlAttribute(name = AdminConstants.A_MODIFIED_BY /* mb */)
+    private String modified_by;
+
+    public ABQDevice() {
+        
+    }
+
+    public ABQDevice(String deviceId, String accountId, String status, String created, String createdBy, String modified, String modifiedBy) {
+        this.account_id = accountId;
+        this.device_id = deviceId;
+        this.status = status;
+        this.created_on = created;
+        this.created_by = createdBy;
+        this.modified_on = modified;
+        this.modified_by = modifiedBy;
+    }
+
+    /**
+     * @return deviceId
+     */
+    public String getDevice_id() {
+        return device_id;
+    }
+
+    /**
+     * @param device_id the device id to set.
+     */
+    public void setDevice_id(String device_id) {
+        this.device_id = device_id;
+    }
+
+    /**
+     * @return accountId for the device
+     */
+    public String getAccount_id() {
+        return account_id;
+    }
+
+    /**
+     * @param account_id the account id to be set for the device.
+     */
+    public void setAccount_id(String account_id) {
+        this.account_id = account_id;
+    }
+
+    /**
+     * @return device status
+     */
+    public String getStatus() {
+        return status;
+    }
+
+    /**
+     * @param status device status to be set.
+     */
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    /**
+     * @return created date
+     */
+    public String getCreated_on() {
+        return created_on;
+    }
+
+    /**
+     * @param created_on the created date to set
+     */
+    public void setCreated_on(String created_on) {
+        this.created_on = created_on;
+    }
+
+    /**
+     * @return created_by
+     */
+    public String getCreated_by() {
+        return created_by;
+    }
+
+    /**
+     * @param created_by the created_by to set
+     */
+    public void setCreated_by(String created_by) {
+        this.created_by = created_by;
+    }
+
+    /**
+     * @return modified date
+     */
+    public String getModified_on() {
+        return modified_on;
+    }
+
+    /**
+     * @param modified_on the modified date to set
+     */
+    public void setModified_on(String modified_on) {
+        this.modified_on = modified_on;
+    }
+
+    /**
+     * @return modified by
+     */
+    public String getModified_by() {
+        return modified_by;
+    }
+
+    /**
+     * @param modified_by the modified by to set
+     */
+    public void setModified_by(String modified_by) {
+        this.modified_by = modified_by;
+    }
+}


### PR DESCRIPTION
Issue : Create Admin API for listing ABQ devices.

Fix: Added API `GetABQDeviceListRequest` which has one optional attribute `status`.
If status is passed then it will get status specific ABQ device list.
If status is not passed, then it will return all the ABQ device list.
Allowed ABQ device status are : `allowed`, `blocked`, `quarantined`. If status is passed other than these allowed values, the API will throw ServiceException.

Test: Tested with passing specific status, it only returns the status specific device list.
If status is not passed then it returns all the device list.
