### PR TITLE
ZCS-8815: ABQ - update database schema for table abq_devices

### DIFF
--- a/store/src/db/hsqldb/db.sql
+++ b/store/src/db/hsqldb/db.sql
@@ -216,6 +216,7 @@ CREATE TABLE current_sessions (
 ); 
 
 CREATE TABLE abq_devices (
+   id              INTEGER UNSIGNED NOT NULL AUTO_INCREMENT,
    device_id       VARCHAR(64) NOT NULL,
    account_id      VARCHAR(127),
    status          VARCHAR(20) check (status in ('allowed', 'quarantined', 'blocked')),
@@ -224,5 +225,9 @@ CREATE TABLE abq_devices (
    modified_time   DATETIME,
    modified_by     VARCHAR(255),
 
-   CONSTRAINT pk_abq_devices PRIMARY KEY (device_id)
+   CONSTRAINT pk_abq_devices PRIMARY KEY (id)
 );
+
+CREATE INDEX i_device_id ON abq_devices(device_id);
+CREATE INDEX i_account_id ON abq_devices(account_id);
+CREATE INDEX i_status ON abq_devices(status);


### PR DESCRIPTION
Issue: we can't keep the device along with account entries in the database.

Fix:
Remove the existing primary key from field device_id and create a new field with name 'id' AUTO_INCREMENT as a primary key. Add Index on fields device_id, account_id, and status

Testing is done:
- Created a new build on branch bugfix/ZCS-8815 on "zm-mailbox" and "zm-db-conf" repos
- Installed the build and verified the DB changes by connecting to MySQL DB.
- Added more details in the ticket