### PR TITLE
ZCS-8895 correct handling of wildcard listing

### DIFF
--- a/store/src/java/com/zimbra/cs/imap/ImapPath.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapPath.java
@@ -386,7 +386,7 @@ public class ImapPath implements Comparable<ImapPath> {
             return imapFolderStore;
         }
         // for LIST *, LIST % and LIST %/% we do not need an instance of ImapFolderStore
-        if (mPath.indexOf("*") >= 0 || mPath.indexOf("%") >= 0) {
+        if ("*".equals(this.mPath) || "%".equals(this.mPath) || "%/%".equals(this.mPath)) {
             return null;
         }
         if (useReferent()) {


### PR DESCRIPTION
Because of the logic a `null pointer` was being returned and this caused any folder containing an `*` to be marked as `not visible` and tagged with a a `\NoSelect` flag.

The code was attempting to avoid returning an ImapFolder object in the case of an exact match to `*` but was instead returning it for any folder with an `*` character included.

**Note:** This is a bugfix discovered in Zimbra X but also applicable to Zimbra 8/9.

## Testing

Before change:

```
* LIST (\NoSelect \HasNoChildren) "/" "*_TEMP"
```

After change:

```
* OK IMAP4rev1 proxy server ready
. login user1@zmc.com test123
. OK [CAPABILITY IMAP4rev1 ACL BINARY CATENATE CHILDREN CONDSTORE ENABLE ESEARCH ESORT I18NLEVEL=1 ID IDLE LIST-EXTENDED LIST-STATUS LITERAL+ LOGIN-REFERRALS MULTIAPPEND NAMESPACE QRESYNC QUOTA RIGHTS=ektx SASL-IR SEARCHRES SORT THREAD=ORDEREDSUBJECT UIDPLUS UNSELECT WITHIN XLIST] LOGIN completed
. LIST "" "*_Testing"
* LIST (\HasNoChildren) "/" "*_Testing"
. OK LIST completed
. LIST "" "*"
* LIST (\HasNoChildren) "/" "*_Testing"
* LIST (\HasNoChildren) "/" "Chats"
* LIST (\HasNoChildren) "/" "Contacts"
* LIST (\HasNoChildren \Drafts) "/" "Drafts"
* LIST (\HasNoChildren) "/" "Emailed Contacts"
* LIST (\HasNoChildren) "/" "INBOX"
* LIST (\NoInferiors \Junk) "/" "Junk"
* LIST (\HasNoChildren \Sent) "/" "Sent"
* LIST (\HasNoChildren \Trash) "/" "Trash"
. OK LIST completed
. logout
* BYE zmc-mailbox Zimbra IMAP4rev1 server closing connection
. OK LOGOUT completed
```