### PR TITLE
zcs-8835:rename ResumeDeviceRequest

### DIFF
--- a/common/src/java/com/zimbra/common/soap/SyncAdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/SyncAdminConstants.java
@@ -41,8 +41,8 @@ public final class SyncAdminConstants {
     public static final String E_SUSPEND_DEVICE_RESPONSE = "SuspendDeviceResponse";
     public static final String E_BLOCK_DEVICE_REQUEST = "BlockDeviceRequest";
     public static final String E_BLOCK_DEVICE_RESPONSE = "BlockDeviceResponse";
-    public static final String E_RESUME_DEVICE_REQUEST = "ResumeDeviceRequest";
-    public static final String E_RESUME_DEVICE_RESPONSE = "ResumeDeviceResponse";
+    public static final String E_ALLOW_DEVICE_REQUEST = "AllowDeviceRequest";
+    public static final String E_ALLOW_DEVICE_RESPONSE = "AllowDeviceResponse";
     public static final String E_GET_SYNC_STATE_REQUEST = "GetSyncStateRequest";
     public static final String E_GET_SYNC_STATE_RESPONSE = "GetSyncStateResponse";
     public static final String E_REMOVE_STALE_DEVICE_METADATA_REQUEST = "RemoveStaleDeviceMetadataRequest";
@@ -66,8 +66,8 @@ public final class SyncAdminConstants {
     public static final QName SUSPEND_DEVICE_RESPONSE = QName.get(E_SUSPEND_DEVICE_RESPONSE, NAMESPACE);
     public static final QName BLOCK_DEVICE_REQUEST = QName.get(E_BLOCK_DEVICE_REQUEST, NAMESPACE);
     public static final QName BLOCK_DEVICE_RESPONSE = QName.get(E_BLOCK_DEVICE_RESPONSE, NAMESPACE);
-    public static final QName RESUME_DEVICE_REQUEST = QName.get(E_RESUME_DEVICE_REQUEST, NAMESPACE);
-    public static final QName RESUME_DEVICE_RESPONSE = QName.get(E_RESUME_DEVICE_RESPONSE, NAMESPACE);
+    public static final QName ALLOW_DEVICE_REQUEST = QName.get(E_ALLOW_DEVICE_REQUEST, NAMESPACE);
+    public static final QName ALLOW_DEVICE_RESPONSE = QName.get(E_ALLOW_DEVICE_RESPONSE, NAMESPACE);
     public static final QName GET_SYNC_STATE_REQUEST = QName.get(E_GET_SYNC_STATE_REQUEST, NAMESPACE);
     public static final QName GET_SYNC_STATE_RESPONSE = QName.get(E_GET_SYNC_STATE_RESPONSE, NAMESPACE);
     public static final QName REMOVE_STALE_DEVICE_METADATA_REQUEST = QName.get(E_REMOVE_STALE_DEVICE_METADATA_REQUEST, NAMESPACE);

--- a/common/src/java/com/zimbra/common/soap/SyncConstants.java
+++ b/common/src/java/com/zimbra/common/soap/SyncConstants.java
@@ -29,8 +29,8 @@ public final class SyncConstants {
     public static final String E_REMOVE_DEVICE_RESPONSE = "RemoveDeviceResponse";
     public static final String E_SUSPEND_DEVICE_REQUEST = "SuspendDeviceRequest";
     public static final String E_SUSPEND_DEVICE_RESPONSE = "SuspendDeviceResponse";
-    public static final String E_RESUME_DEVICE_REQUEST = "ResumeDeviceRequest";
-    public static final String E_RESUME_DEVICE_RESPONSE = "ResumeDeviceResponse";
+    public static final String E_ALLOW_DEVICE_REQUEST = "AllowDeviceRequest";
+    public static final String E_ALLOW_DEVICE_RESPONSE = "AllowDeviceResponse";
     public static final String E_REMOTE_WIPE_REQUEST = "RemoteWipeRequest";
     public static final String E_REMOTE_WIPE_RESPONSE = "RemoteWipeResponse";
     public static final String E_CANCEL_PENDING_REMOTE_WIPE_REQUEST = "CancelPendingRemoteWipeRequest";
@@ -42,8 +42,8 @@ public final class SyncConstants {
     public static final QName REMOVE_DEVICE_RESPONSE = QName.get(E_REMOVE_DEVICE_RESPONSE, NAMESPACE);
     public static final QName SUSPEND_DEVICE_REQUEST = QName.get(E_SUSPEND_DEVICE_REQUEST, NAMESPACE);
     public static final QName SUSPEND_DEVICE_RESPONSE = QName.get(E_SUSPEND_DEVICE_RESPONSE, NAMESPACE);
-    public static final QName RESUME_DEVICE_REQUEST = QName.get(E_RESUME_DEVICE_REQUEST, NAMESPACE);
-    public static final QName RESUME_DEVICE_RESPONSE = QName.get(E_RESUME_DEVICE_RESPONSE, NAMESPACE);
+    public static final QName ALLOW_DEVICE_REQUEST = QName.get(E_ALLOW_DEVICE_REQUEST, NAMESPACE);
+    public static final QName ALLOW_DEVICE_RESPONSE = QName.get(E_ALLOW_DEVICE_RESPONSE, NAMESPACE);
     public static final QName REMOTE_WIPE_REQUEST = QName.get(E_REMOTE_WIPE_REQUEST, NAMESPACE);
     public static final QName REMOTE_WIPE_RESPONSE = QName.get(E_REMOTE_WIPE_RESPONSE, NAMESPACE);
     public static final QName CANCEL_PENDING_REMOTE_WIPE_REQUEST = QName.get(E_CANCEL_PENDING_REMOTE_WIPE_REQUEST, NAMESPACE);

--- a/soap/src/java/com/zimbra/soap/JaxbUtil.java
+++ b/soap/src/java/com/zimbra/soap/JaxbUtil.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2018 Synacor, Inc.
+ * Copyright (C) 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2018, 2020 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -230,6 +230,8 @@ public final class JaxbUtil {
             com.zimbra.soap.admin.message.AdminDestroyWaitSetResponse.class,
             com.zimbra.soap.admin.message.AdminWaitSetRequest.class,
             com.zimbra.soap.admin.message.AdminWaitSetResponse.class,
+            com.zimbra.soap.admin.message.AllowDeviceRequest.class,
+            com.zimbra.soap.admin.message.AllowDeviceResponse.class,
             com.zimbra.soap.admin.message.AuthRequest.class,
             com.zimbra.soap.admin.message.AuthResponse.class,
             com.zimbra.soap.admin.message.AutoCompleteGalRequest.class,
@@ -696,8 +698,6 @@ public final class JaxbUtil {
             com.zimbra.soap.admin.message.ResetAllLoggersResponse.class,
             com.zimbra.soap.admin.message.RestoreRequest.class,
             com.zimbra.soap.admin.message.RestoreResponse.class,
-            com.zimbra.soap.admin.message.ResumeDeviceRequest.class,
-            com.zimbra.soap.admin.message.ResumeDeviceResponse.class,
             com.zimbra.soap.admin.message.RevokeRightRequest.class,
             com.zimbra.soap.admin.message.RevokeRightResponse.class,
             com.zimbra.soap.admin.message.RolloverRedoLogRequest.class,
@@ -1084,6 +1084,8 @@ public final class JaxbUtil {
             com.zimbra.soap.replication.message.StopFailoverClientResponse.class,
             com.zimbra.soap.replication.message.StopFailoverDaemonRequest.class,
             com.zimbra.soap.replication.message.StopFailoverDaemonResponse.class,
+            com.zimbra.soap.sync.message.AllowDeviceRequest.class,
+            com.zimbra.soap.sync.message.AllowDeviceResponse.class,
             com.zimbra.soap.sync.message.CancelPendingRemoteWipeRequest.class,
             com.zimbra.soap.sync.message.CancelPendingRemoteWipeResponse.class,
             com.zimbra.soap.sync.message.GetDeviceStatusRequest.class,
@@ -1092,8 +1094,6 @@ public final class JaxbUtil {
             com.zimbra.soap.sync.message.RemoteWipeResponse.class,
             com.zimbra.soap.sync.message.RemoveDeviceRequest.class,
             com.zimbra.soap.sync.message.RemoveDeviceResponse.class,
-            com.zimbra.soap.sync.message.ResumeDeviceRequest.class,
-            com.zimbra.soap.sync.message.ResumeDeviceResponse.class,
             com.zimbra.soap.sync.message.SuspendDeviceRequest.class,
             com.zimbra.soap.sync.message.SuspendDeviceResponse.class,
             com.zimbra.soap.voice.message.ChangeUCPasswordRequest.class,

--- a/soap/src/java/com/zimbra/soap/admin/message/AllowDeviceRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/AllowDeviceRequest.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2012, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2012, 2013, 2014, 2016, 2020 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -36,30 +36,30 @@ import com.zimbra.soap.type.AccountSelector;
  * This will cause a policy reset, but will not reset sync data.
  */
 @XmlAccessorType(XmlAccessType.NONE)
-@XmlRootElement(name=SyncAdminConstants.E_RESUME_DEVICE_REQUEST)
-public class ResumeDeviceRequest {
+@XmlRootElement(name=SyncAdminConstants.E_ALLOW_DEVICE_REQUEST)
+public class AllowDeviceRequest {
 
     /**
      * @zm-api-field-description Account selector
      */
-    @XmlElement(name=AdminConstants.E_ACCOUNT, required=true)
+    @XmlElement(name=AdminConstants.E_ACCOUNT, required=false)
     private AccountSelector account;
 
     /**
      * @zm-api-field-tag device-id
      * @zm-api-field-description Device ID
      */
-    @XmlElement(name=SyncConstants.E_DEVICE, required=false)
+    @XmlElement(name=SyncConstants.E_DEVICE, required=true)
     private DeviceId deviceId;
 
     /**
      * no-argument constructor wanted by JAXB
      */
     @SuppressWarnings("unused")
-    private ResumeDeviceRequest() {
+    private AllowDeviceRequest() {
     }
 
-    public ResumeDeviceRequest(AccountSelector account) {
+    public AllowDeviceRequest(AccountSelector account) {
         this.account = account;
     }
 

--- a/soap/src/java/com/zimbra/soap/admin/message/AllowDeviceResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/AllowDeviceResponse.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2011, 2012, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2012, 2013, 2014, 2016, 2020 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -15,35 +15,55 @@
  * ***** END LICENSE BLOCK *****
  */
 
-package com.zimbra.soap.sync.message;
+package com.zimbra.soap.admin.message;
 
-import com.google.common.base.MoreObjects;
+import java.util.Collections;
+import java.util.List;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
 
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.zimbra.common.soap.SyncAdminConstants;
 import com.zimbra.common.soap.SyncConstants;
-import com.zimbra.soap.sync.type.DeviceStatusInfo;
+import com.zimbra.soap.admin.type.DeviceStatusInfo;
 
 @XmlAccessorType(XmlAccessType.NONE)
-@XmlRootElement(name=SyncConstants.E_RESUME_DEVICE_RESPONSE)
-public class ResumeDeviceResponse {
+@XmlRootElement(name=SyncAdminConstants.E_ALLOW_DEVICE_RESPONSE)
+@XmlType(propOrder = {})
+public class AllowDeviceResponse {
 
     /**
-     * @zm-api-field-description Device status information
+     * @zm-api-field-description Information about device status
      */
     @XmlElement(name=SyncConstants.E_DEVICE /* device */, required=false)
-    private DeviceStatusInfo device;
+    private List<DeviceStatusInfo> devices = Lists.newArrayList();
 
-    public ResumeDeviceResponse() {
+    public AllowDeviceResponse() {
     }
 
-    public void setDevice(DeviceStatusInfo device) { this.device = device; }
-    public DeviceStatusInfo getDevice() { return device; }
+    public void setDevices(Iterable<DeviceStatusInfo> devices) {
+        this.devices.clear();
+        if (devices != null) {
+            Iterables.addAll(this.devices, devices);
+        }
+    }
+
+    public void addDevice(DeviceStatusInfo device) {
+        this.devices.add(device);
+    }
+
+    public List<DeviceStatusInfo> getDevices() {
+        return Collections.unmodifiableList(devices);
+    }
 
     public MoreObjects.ToStringHelper addToStringInfo(MoreObjects.ToStringHelper helper) {
-        return helper.add("device", device);
+        return helper.add("devices", devices);
     }
 
     @Override

--- a/soap/src/java/com/zimbra/soap/sync/message/AllowDeviceRequest.java
+++ b/soap/src/java/com/zimbra/soap/sync/message/AllowDeviceRequest.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2011, 2012, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2011, 2012, 2013, 2014, 2016, 2020 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -30,12 +30,12 @@ import com.zimbra.soap.sync.type.DeviceId;
  * @zm-api-command-network-edition
  * @zm-api-command-auth-required true
  * @zm-api-command-admin-auth-required false
- * @zm-api-command-description Resume sync with a device if currently suspended.
+ * @zm-api-command-description Allow sync with a device if currently suspended.
  * This will cause a policy reset, but will not reset sync data.
  */
 @XmlAccessorType(XmlAccessType.NONE)
-@XmlRootElement(name=SyncConstants.E_RESUME_DEVICE_REQUEST)
-public class ResumeDeviceRequest {
+@XmlRootElement(name=SyncConstants.E_ALLOW_DEVICE_REQUEST)
+public class AllowDeviceRequest {
 
     /**
      * @zm-api-field-description Specify the device to resume
@@ -47,11 +47,11 @@ public class ResumeDeviceRequest {
      * no-argument constructor wanted by JAXB
      */
     @SuppressWarnings("unused")
-    private ResumeDeviceRequest() {
+    private AllowDeviceRequest() {
         this((DeviceId) null);
     }
 
-    public ResumeDeviceRequest(DeviceId device) {
+    public AllowDeviceRequest(DeviceId device) {
         this.device = device;
     }
 

--- a/soap/src/java/com/zimbra/soap/sync/message/AllowDeviceResponse.java
+++ b/soap/src/java/com/zimbra/soap/sync/message/AllowDeviceResponse.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2012, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2011, 2012, 2013, 2014, 2016, 2020 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -15,55 +15,35 @@
  * ***** END LICENSE BLOCK *****
  */
 
-package com.zimbra.soap.admin.message;
+package com.zimbra.soap.sync.message;
 
-import java.util.Collections;
-import java.util.List;
-
+import com.google.common.base.MoreObjects;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.zimbra.common.soap.SyncAdminConstants;
 import com.zimbra.common.soap.SyncConstants;
-import com.zimbra.soap.admin.type.DeviceStatusInfo;
+import com.zimbra.soap.sync.type.DeviceStatusInfo;
 
 @XmlAccessorType(XmlAccessType.NONE)
-@XmlRootElement(name=SyncAdminConstants.E_RESUME_DEVICE_RESPONSE)
-@XmlType(propOrder = {})
-public class ResumeDeviceResponse {
+@XmlRootElement(name=SyncConstants.E_ALLOW_DEVICE_RESPONSE)
+public class AllowDeviceResponse {
 
     /**
-     * @zm-api-field-description Information about device status
+     * @zm-api-field-description Device status information
      */
     @XmlElement(name=SyncConstants.E_DEVICE /* device */, required=false)
-    private List<DeviceStatusInfo> devices = Lists.newArrayList();
+    private DeviceStatusInfo device;
 
-    public ResumeDeviceResponse() {
+    public AllowDeviceResponse() {
     }
 
-    public void setDevices(Iterable<DeviceStatusInfo> devices) {
-        this.devices.clear();
-        if (devices != null) {
-            Iterables.addAll(this.devices, devices);
-        }
-    }
-
-    public void addDevice(DeviceStatusInfo device) {
-        this.devices.add(device);
-    }
-
-    public List<DeviceStatusInfo> getDevices() {
-        return Collections.unmodifiableList(devices);
-    }
+    public void setDevice(DeviceStatusInfo device) { this.device = device; }
+    public DeviceStatusInfo getDevice() { return device; }
 
     public MoreObjects.ToStringHelper addToStringInfo(MoreObjects.ToStringHelper helper) {
-        return helper.add("devices", devices);
+        return helper.add("device", device);
     }
 
     @Override


### PR DESCRIPTION
**Issue :** 
rename ResumeDeviceRequest to AllowDeviceRequest. Rename all its related constants and implementations.

**Fix:**
- Renamed the ResumeDeviceRequest to AllowDeviceRequest in both the namespaces (admin and sync).
- Renamed all its constants and implementations.
- Made Device id mandatory and account as optional for the Admin API.
- Added two more unit tests as per the implementation.

**Test:**
- Ran the unit test and all are passing.
- Tested the Admin API with SOAP API for below scenarios.

    -  With device id and account by name
    - with device id and account by id
    - without account and with only device id.
    - when device is not passed, throw exception

* QA needs to verify all scenarios for AllowDeviceRequest.