### PR TITLE
ZCS-8911 Allow extensions to support HTTP Patch method.

### DIFF
--- a/store/src/java/com/zimbra/cs/extension/ExtensionDispatcherServlet.java
+++ b/store/src/java/com/zimbra/cs/extension/ExtensionDispatcherServlet.java
@@ -115,6 +115,8 @@ public class ExtensionDispatcherServlet extends ZimbraServlet {
             handler.doPut(req, resp);
         } else if ("DELETE".equals(method)) {
             handler.doDelete(req, resp);
+        } else if ("PATCH".equals(method)) {
+            handler.doPatch(req, resp);
         }
         else {
             throw new ServletException("request method " + method + " not supported");

--- a/store/src/java/com/zimbra/cs/extension/ExtensionHttpHandler.java
+++ b/store/src/java/com/zimbra/cs/extension/ExtensionHttpHandler.java
@@ -108,6 +108,17 @@ public abstract class ExtensionHttpHandler {
     }
 
     /**
+     * Processes HTTP PATCH requests.
+     * @param req
+     * @param resp
+     * @throws IOException
+     * @throws ServletException
+     */
+    public void doPatch(HttpServletRequest req, HttpServletResponse resp) throws IOException, ServletException {
+        throw new ServletException("HTTP PATCH requests are not supported");
+    }
+
+    /**
      * Called to initialize the handler. If initialization fails, the handler is not registered.
      * @param ext the extension to which this handler belongs
      * @throws ServiceException


### PR DESCRIPTION
* Patch support is needed for oauth extension.