### PR TITLE
zcs-8836:modify RemoveDeviceRequest

### DIFF
--- a/soap/src/java/com/zimbra/soap/admin/message/RemoveDeviceRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/RemoveDeviceRequest.java
@@ -42,13 +42,13 @@ public class RemoveDeviceRequest {
     /**
      * @zm-api-field-description Account Selector
      */
-    @XmlElement(name=AdminConstants.E_ACCOUNT, required=true)
+    @XmlElement(name=AdminConstants.E_ACCOUNT, required=false)
     private AccountSelector account;
 
     /**
-     * @zm-api-field-description Device specification - Note - if not supplied ALL devices will be removed.
+     * @zm-api-field-description Device specification - Note - it is mandatory to provide deviceId.
      */
-    @XmlElement(name=SyncConstants.E_DEVICE, required=false)
+    @XmlElement(name=SyncConstants.E_DEVICE, required=true)
     private DeviceId deviceId;
 
     /**


### PR DESCRIPTION
Issue : modify RemoveDeviceRequest to make account id an optional request element

Fix : Modified admin RemoveDeviceRequest to make account device optional.
1. if account id is present - remove device entry for given account and device id
2. if account id is not present - remove all device entries for given device id

Test: Ran Unit Test and all are passing.
Tested the API manually with SOAP API and it is working as per the condition.

QA needs to verify all scenarios according to the test cases.