### PR TITLE
ZCS-8781 Fixing proxy request with new Httpclient

### DIFF
--- a/store/src/java/com/zimbra/cs/service/FeedManager.java
+++ b/store/src/java/com/zimbra/cs/service/FeedManager.java
@@ -83,7 +83,6 @@ import com.zimbra.common.soap.Element;
 import com.zimbra.common.util.DateUtil;
 import com.zimbra.common.util.FileUtil;
 import com.zimbra.common.util.StringUtil;
-import com.zimbra.common.util.ZimbraHttpConnectionManager;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.common.zmime.ZMimeBodyPart;
 import com.zimbra.common.zmime.ZMimeMultipart;
@@ -313,7 +312,7 @@ public class FeedManager {
     throws ServiceException, HttpException, IOException {
         assert !Strings.isNullOrEmpty(url);
 
-        HttpClientBuilder clientBuilder = ZimbraHttpConnectionManager.getExternalHttpConnMgr().newHttpClient();
+        HttpClientBuilder clientBuilder = HttpClientBuilder.create();
         HttpProxyUtil.configureProxy(clientBuilder);
 
         // cannot set connection timeout because it'll affect all HttpClients associated with the conn mgr.


### PR DESCRIPTION
Proxy settings were not taking effect with hew Httpclient.
Created a new HttpClientBuilder and set the proxy settings on it, instead of using the one initialized  when Zimbra starts.
Verified by installing in NIC environment and verified connection through squid proxy to external site happens.