### PR TITLE
ZCS-8785 Fixing int/long issue with NG module

### DIFF
--- a/client/src/java/com/zimbra/client/ZFolder.java
+++ b/client/src/java/com/zimbra/client/ZFolder.java
@@ -85,7 +85,7 @@ public class ZFolder implements ZItem, FolderStore, Comparable<Object>, ToZJSONO
     private int mImapMessageCount;
     private String mParentId;
     private int mModifiedSequence;
-    private int mContentSequence;
+    private long mContentSequence;
     private int mImapUIDNEXT;
     private int mImapMODSEQ;
     private String mAbsolutePath;
@@ -276,7 +276,7 @@ public class ZFolder implements ZItem, FolderStore, Comparable<Object>, ToZJSONO
         mImapMessageCount = (int) e.getAttributeLong(MailConstants.A_IMAP_NUM, mMessageCount);
         mDefaultView = View.fromString(e.getAttribute(MailConstants.A_DEFAULT_VIEW, null));
         mModifiedSequence = (int) e.getAttributeLong(MailConstants.A_MODIFIED_SEQUENCE, -1);
-        mContentSequence = (int) e.getAttributeLong(MailConstants.A_REVISION, -1);
+        mContentSequence = e.getAttributeLong(MailConstants.A_REVISION, -1);
         mImapUIDNEXT = (int) e.getAttributeLong(MailConstants.A_IMAP_UIDNEXT, -1);
         mImapMODSEQ = (int) e.getAttributeLong(MailConstants.A_IMAP_MODSEQ, -1);
         mRemoteURL = e.getAttribute(MailConstants.A_URL, null);
@@ -530,7 +530,7 @@ public class ZFolder implements ZItem, FolderStore, Comparable<Object>, ToZJSONO
      * @see Folder#getSavedSequence()
      **/
     @Override
-    public int getUIDValidity() {
+    public long getUIDValidity() {
         return getContentSequence();
     }
 
@@ -777,7 +777,7 @@ public class ZFolder implements ZItem, FolderStore, Comparable<Object>, ToZJSONO
 
     /** Returns the sequence number for the last change in the folder's location or name.
      */
-    public int getContentSequence() {
+    public long getContentSequence() {
         return mContentSequence;
     }
 

--- a/client/src/java/com/zimbra/client/event/ZModifyFolderEvent.java
+++ b/client/src/java/com/zimbra/client/event/ZModifyFolderEvent.java
@@ -158,8 +158,8 @@ public class ZModifyFolderEvent implements ZModifyItemEvent, ToZJSONObject {
      * @return new content sequence or defaultValue if unchanged
      * @throws ServiceException
      */
-    public int getContentSequence(int defaultValue) throws ServiceException {
-        return (int) mFolderEl.getAttributeLong(MailConstants.A_REVISION, defaultValue);
+    public long getContentSequence(long defaultValue) throws ServiceException {
+        return mFolderEl.getAttributeLong(MailConstants.A_REVISION, defaultValue);
     }
 
     /**

--- a/common/src/java/com/zimbra/common/mailbox/FolderStore.java
+++ b/common/src/java/com/zimbra/common/mailbox/FolderStore.java
@@ -38,7 +38,7 @@ public interface FolderStore extends BaseFolderInfo {
     public boolean inTrash();
     public boolean isVisibleInImap(boolean displayMailFoldersOnly);
     public List<ACLGrant> getACLGrants();
-    public int getUIDValidity();
+    public long getUIDValidity();
     /** @return number of items in folder, including IMAP \Deleted item */
     public int getImapMessageCount();
     /** @return number of unread items in folder, including IMAP \Deleted items */

--- a/store/conf/web.xml.production
+++ b/store/conf/web.xml.production
@@ -218,6 +218,12 @@
       <param-name>allowed.ports</param-name>
       <param-value>%%zimbraMailPort%%, %%zimbraMailSSLPort%%, %%zimbraAdminPort%%, 7070, 7072, 7443</param-value>
     </init-param>
+    <multipart-config>
+      <location>/opt/zimbra/data/tmp</location>
+      <max-file-size>%%zimbraFileUploadMaxSize%%</max-file-size>
+      <max-request-size>%%zimbraMailContentMaxSize%%</max-request-size>
+      <file-size-threshold>%%zimbraFileUploadMaxSize%%</file-size-threshold>
+    </multipart-config>
   </servlet>
 
   <servlet>

--- a/store/src/java-test/com/zimbra/cs/db/DbVolumeBlobsTest.java
+++ b/store/src/java-test/com/zimbra/cs/db/DbVolumeBlobsTest.java
@@ -135,7 +135,7 @@ public class DbVolumeBlobsTest {
         Message msg = mbox.addMessage(null, new ParsedMessage("From: from1@zimbra.com\r\nTo: to1@zimbra.com".getBytes(), false), opt, null);
 
         Volume vol = VolumeManager.getInstance().getCurrentMessageVolume();
-        MailboxBlobInfo blobInfo = new MailboxBlobInfo(null, mbox.getId(), msg.getId(), msg.getSavedSequence(), String.valueOf(vol.getId()), null);
+        MailboxBlobInfo blobInfo = new MailboxBlobInfo(null, mbox.getId(), msg.getId(), msg.getSavedSequenceLong(), String.valueOf(vol.getId()), null);
         DbVolumeBlobs.addBlobReference(conn, blobInfo);
         try {
             DbVolumeBlobs.addBlobReference(conn, blobInfo);

--- a/store/src/java-test/com/zimbra/cs/mailbox/FolderTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/FolderTest.java
@@ -147,7 +147,7 @@ public final class FolderTest {
         int changeId = mbox.getLastChangeID();
         Folder inbox = mbox.getFolderById(null, Mailbox.ID_FOLDER_INBOX);
         int modMetadata = inbox.getModifiedSequence();
-        int modContent = inbox.getSavedSequence();
+        long modContent = inbox.getSavedSequenceLong();
         Assert.assertEquals(0, inbox.getImapRECENTCutoff());
 
         mbox.recordImapSession(Mailbox.ID_FOLDER_INBOX);
@@ -155,7 +155,7 @@ public final class FolderTest {
         inbox = mbox.getFolderById(null, Mailbox.ID_FOLDER_INBOX);
         Assert.assertEquals(changeId, mbox.getLastChangeID());
         Assert.assertEquals(modMetadata, inbox.getModifiedSequence());
-        Assert.assertEquals(modContent, inbox.getSavedSequence());
+        Assert.assertEquals(modContent, inbox.getSavedSequenceLong());
         Assert.assertEquals(mbox.getLastItemId(), inbox.getImapRECENTCutoff());
     }
 

--- a/store/src/java-test/com/zimbra/cs/mailbox/RenameTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/RenameTest.java
@@ -55,10 +55,10 @@ public class RenameTest {
     @Test
     public void renameModContentTest() throws Exception {
         int id = doc.getId();
-        int mod_content = doc.getSavedSequence();
+        long mod_content = doc.getSavedSequenceLong();
         mbox.rename(null, id, doc.getType(), "newdoc.txt", folder.getId());
         mbox.purge(MailItem.Type.UNKNOWN);
         MailItem newdoc = mbox.getItemById(null, id, MailItem.Type.UNKNOWN, false);
-        Assert.assertEquals(mod_content, newdoc.getSavedSequence());
+        Assert.assertEquals(mod_content, newdoc.getSavedSequenceLong());
     }
 }

--- a/store/src/java-test/com/zimbra/cs/store/MockStoreManager.java
+++ b/store/src/java-test/com/zimbra/cs/store/MockStoreManager.java
@@ -111,26 +111,26 @@ public final class MockStoreManager extends StoreManager {
         return new MockStagedBlob(mbox, ((MockBlob) blob).content);
     }
 
-    private String blobKey(Mailbox mbox, int itemId, int revision) {
+    private String blobKey(Mailbox mbox, int itemId, long revision) {
         return mbox.getId() + "-" + itemId + "-" + revision;
     }
 
     @Override
-    public MailboxBlob copy(MailboxBlob src, Mailbox destMbox, int destItemId, int destRevision) {
+    public MailboxBlob copy(MailboxBlob src, Mailbox destMbox, int destItemId, long destRevision) {
         MockMailboxBlob blob = new MockMailboxBlob(destMbox, destItemId, destRevision, src.getLocator(), ((MockMailboxBlob) src).content);
         blobs.put(blobKey(destMbox, destItemId, destRevision), blob);
         return blob;
     }
 
     @Override
-    public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destItemId, int destRevision) {
+    public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destItemId, long destRevision) {
         MockMailboxBlob blob = new MockMailboxBlob(destMbox, destItemId, destRevision, src.getLocator(), ((MockStagedBlob) src).content);
         blobs.put(blobKey(destMbox, destItemId, destRevision), blob);
         return blob;
     }
 
     @Override
-    public MailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destItemId, int destRevision) {
+    public MailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destItemId, long destRevision) {
         MockMailboxBlob blob = new MockMailboxBlob(destMbox, destItemId, destRevision, src.getLocator(), ((MockStagedBlob) src).content);
         blobs.put(blobKey(destMbox, destItemId, destRevision), blob);
         return blob;
@@ -164,13 +164,13 @@ public final class MockStoreManager extends StoreManager {
 
     @Override
     public boolean delete(MailboxBlob mblob) throws IOException {
-        blobs.remove(blobKey(mblob.getMailbox(), mblob.getItemId(), mblob.getRevision()));
+        blobs.remove(blobKey(mblob.getMailbox(), mblob.getItemId(), mblob.getRevisionLong()));
         delete(((MockMailboxBlob) mblob).blob);
         return true;
     }
 
     @Override
-    public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, int revision, String locator, boolean validate) {
+    public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, long revision, String locator, boolean validate) {
         return blobs.get(blobKey(mbox, itemId, revision));
     }
 
@@ -285,7 +285,7 @@ public final class MockStoreManager extends StoreManager {
         final byte[] content;
         MockLocalBlob blob = null;
 
-        MockMailboxBlob(Mailbox mbox, int itemId, int revision, String locator, byte[] data) {
+        MockMailboxBlob(Mailbox mbox, int itemId, long revision, String locator, byte[] data) {
             super(mbox, itemId, revision, locator);
             content = data;
         }

--- a/store/src/java-test/com/zimbra/cs/store/MockStoreManager.java
+++ b/store/src/java-test/com/zimbra/cs/store/MockStoreManager.java
@@ -327,4 +327,25 @@ public final class MockStoreManager extends StoreManager {
             return mockblob;
         }
     }
+
+    @Override
+    public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, int destRevision)
+        throws IOException, ServiceException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, int revision, String locator)
+        throws ServiceException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, int revision, String locator,
+        boolean validate) throws ServiceException {
+        // TODO Auto-generated method stub
+        return null;
+    }
 }

--- a/store/src/java-test/com/zimbra/cs/store/external/MockValidationFailingStore.java
+++ b/store/src/java-test/com/zimbra/cs/store/external/MockValidationFailingStore.java
@@ -26,7 +26,7 @@ public class MockValidationFailingStore extends SimpleStoreManager {
 
     @Override
     public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId,
-            int revision, String locator, boolean validate)
+            long revision, String locator, boolean validate)
             throws ServiceException {
         if (!validate || !failOnValidate) {
             return super.getMailboxBlob(mbox, itemId, revision, locator, false);

--- a/store/src/java-test/com/zimbra/cs/store/http/HttpStoreManagerTest.java
+++ b/store/src/java-test/com/zimbra/cs/store/http/HttpStoreManagerTest.java
@@ -17,6 +17,7 @@
 package com.zimbra.cs.store.http;
 
 import java.io.File;
+import java.io.IOException;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -41,6 +42,8 @@ import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.MailboxManager;
 import com.zimbra.cs.mailbox.MailboxTest;
 import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.store.MailboxBlob;
+import com.zimbra.cs.store.StagedBlob;
 import com.zimbra.cs.store.StoreManager;
 import com.zimbra.cs.store.external.AbstractExternalStoreManagerTest;
 
@@ -72,6 +75,20 @@ public class HttpStoreManagerTest extends AbstractExternalStoreManagerTest {
                 String[] parts = locator.trim().split("/");
                 return parts[parts.length - 1];
             }
+        }
+
+        @Override
+        public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, int destRevision)
+            throws IOException, ServiceException {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+        @Override
+        public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, int revision, String locator)
+            throws ServiceException {
+            // TODO Auto-generated method stub
+            return null;
         }
     }
 

--- a/store/src/java/com/zimbra/cs/dav/resource/MailItemResource.java
+++ b/store/src/java/com/zimbra/cs/dav/resource/MailItemResource.java
@@ -542,7 +542,7 @@ public abstract class MailItemResource extends DavResource {
     }
 
     public static String getEtag(MailItem item) {
-        return getEtag(Long.toString(item.getModifiedSequence()), Long.toString(item.getSavedSequence()));
+        return getEtag(Long.toString(item.getModifiedSequence()), Long.toString(item.getSavedSequenceLong()));
     }
     public static String getEtag(String modMetadata, String modContent) {
         return "\""+modMetadata+"-"+modContent+"\"";

--- a/store/src/java/com/zimbra/cs/db/DbMailItem.java
+++ b/store/src/java/com/zimbra/cs/db/DbMailItem.java
@@ -194,7 +194,7 @@ public class DbMailItem {
             } else {
                 stmt.setNull(pos++, Types.INTEGER);
             }
-            stmt.setInt(pos++, data.modContent);
+            stmt.setLong(pos++, data.modContent);
             stmt.setString(pos++, data.uuid);
             int num = stmt.executeUpdate();
             if (num != 1) {
@@ -982,7 +982,7 @@ public class DbMailItem {
             stmt.setString(pos++, checkMetadataLength(metadata));
             stmt.setInt(pos++, mbox.getOperationChangeID());
             stmt.setInt(pos++, mbox.getOperationTimestamp());
-            stmt.setInt(pos++, item.getSavedSequence());
+            stmt.setLong(pos++, item.getSavedSequenceLong());
             pos = setMailboxId(stmt, mbox, pos);
             stmt.setInt(pos++, item.getId());
             stmt.executeUpdate();
@@ -1011,7 +1011,7 @@ public class DbMailItem {
             } else {
                 stmt.setNull(pos++, Types.INTEGER);
             }
-            stmt.setInt(pos++, item.getSavedSequence());
+            stmt.setLong(pos++, item.getSavedSequenceLong());
             pos = setMailboxId(stmt, mbox, pos);
             stmt.setInt(pos++, item.getId());
             stmt.executeUpdate();
@@ -1136,7 +1136,7 @@ public class DbMailItem {
             stmt.setString(pos++, checkMetadataLength(metadata.toString()));
             stmt.setInt(pos++, mailbox.getOperationChangeID());
             stmt.setInt(pos++, mailbox.getOperationTimestamp());
-            stmt.setInt(pos++, item.getSavedSequence());
+            stmt.setLong(pos++, item.getSavedSequenceLong());
             stmt.setString(pos++, item.getLocator());
             pos = setMailboxId(stmt, mailbox, pos);
             stmt.setInt(pos++, item.getId());
@@ -1314,7 +1314,7 @@ public class DbMailItem {
     }
 
     public static int updateLocatorAndDigest(DbConnection conn, Mailbox mbox, String tableName, String idColumn, int itemId,
-            int revision, String locator, String digest) throws ServiceException {
+            long revision, String locator, String digest) throws ServiceException {
         PreparedStatement stmt = null;
         try {
             stmt = conn.prepareStatement("UPDATE " + tableName +
@@ -1325,7 +1325,7 @@ public class DbMailItem {
             stmt.setString(pos++, digest);
             pos = setMailboxId(stmt, mbox, pos);
             stmt.setInt(pos++, itemId);
-            stmt.setInt(pos++, revision);
+            stmt.setLong(pos++, revision);
             return stmt.executeUpdate();
         } catch (SQLException e) {
             throw ServiceException.FAILURE("updating locator and digest " + itemId + "-" + revision, e);
@@ -3990,7 +3990,7 @@ public class DbMailItem {
         data.name = rs.getString(CI_NAME + offset);
         data.metadata = decodeMetadata(rs.getString(CI_METADATA + offset));
         data.modMetadata = rs.getInt(CI_MODIFIED + offset);
-        data.modContent = rs.getInt(CI_SAVED + offset);
+        data.modContent = rs.getLong(CI_SAVED + offset);
         data.dateChanged = rs.getInt(CI_MODIFY_DATE + offset);
         // make sure to handle NULL column values
         if (data.parentId == 0) {

--- a/store/src/java/com/zimbra/cs/db/DbVolumeBlobs.java
+++ b/store/src/java/com/zimbra/cs/db/DbVolumeBlobs.java
@@ -59,7 +59,7 @@ public final class DbVolumeBlobs {
             stmt.setShort(pos++, vol.getId());
             stmt.setInt(pos++, mbox.getId());
             stmt.setInt(pos++, item.getId());
-            stmt.setInt(pos++, item.getSavedSequence());
+            stmt.setLong(pos++, item.getSavedSequenceLong());
             stmt.setString(pos++, item.getDigest());
             stmt.setBoolean(pos++, false);
             stmt.executeUpdate();
@@ -82,7 +82,7 @@ public final class DbVolumeBlobs {
             stmt.setShort(pos++, volId);
             stmt.setInt(pos++, info.mailboxId);
             stmt.setInt(pos++, info.itemId);
-            stmt.setInt(pos++, info.revision);
+            stmt.setLong(pos++, info.revision);
             stmt.setString(pos++, info.digest);
             stmt.setBoolean(pos++, false);
             stmt.executeUpdate();

--- a/store/src/java/com/zimbra/cs/extension/ExtensionDispatcherServlet.java
+++ b/store/src/java/com/zimbra/cs/extension/ExtensionDispatcherServlet.java
@@ -115,6 +115,8 @@ public class ExtensionDispatcherServlet extends ZimbraServlet {
             handler.doPut(req, resp);
         } else if ("DELETE".equals(method)) {
             handler.doDelete(req, resp);
+        } else if ("PATCH".equals(method)) {
+            handler.doPatch(req, resp);
         }
         else {
             throw new ServletException("request method " + method + " not supported");

--- a/store/src/java/com/zimbra/cs/extension/ExtensionHttpHandler.java
+++ b/store/src/java/com/zimbra/cs/extension/ExtensionHttpHandler.java
@@ -108,6 +108,17 @@ public abstract class ExtensionHttpHandler {
     }
 
     /**
+     * Processes HTTP PATCH requests.
+     * @param req
+     * @param resp
+     * @throws IOException
+     * @throws ServletException
+     */
+    public void doPatch(HttpServletRequest req, HttpServletResponse resp) throws IOException, ServletException {
+        throw new ServletException("HTTP PATCH requests are not supported");
+    }
+
+    /**
      * Called to initialize the handler. If initialization fails, the handler is not registered.
      * @param ext the extension to which this handler belongs
      * @throws ServiceException

--- a/store/src/java/com/zimbra/cs/imap/ImapFolder.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapFolder.java
@@ -71,7 +71,7 @@ public final class ImapFolder implements ImapListener.ImapFolderData, java.io.Se
     private transient Map<Integer, ImapMessage> messageIds;
 
     private final ItemIdentifier folderIdentifier;
-    private final int uidValidity;
+    private final long uidValidity;
     private String query;
     private Set<MailItem.Type> typeConstraint = ImapHandler.ITEM_TYPES;
     private final List<ImapMessage> sequence = new ArrayList<ImapMessage>();
@@ -264,7 +264,7 @@ public final class ImapFolder implements ImapListener.ImapFolderData, java.io.Se
 
     /** Returns the folder's IMAP UID validity value.
      * @see #getUIDValidity(Folder) */
-    protected int getUIDValidity() {
+    protected long getUIDValidity() {
         return uidValidity;
     }
 
@@ -319,7 +319,7 @@ public final class ImapFolder implements ImapListener.ImapFolderData, java.io.Se
     /** Returns the UID Validity Value for the {@link FolderStore}.  This is the
      *  folder's <tt>MOD_CONTENT</tt> change sequence number.
      * @see Folder#getSavedSequence() */
-    protected static int getUIDValidity(FolderStore folder) {
+    protected static long getUIDValidity(FolderStore folder) {
         return folder.getUIDValidity();
     }
 

--- a/store/src/java/com/zimbra/cs/imap/ImapHandler.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapHandler.java
@@ -2737,7 +2737,7 @@ public abstract class ImapHandler {
         int messages;
         int recent;
         int uidnext;
-        int uvv;
+        long uvv;
         int unread;
         int modseq;
         MailboxStore mboxStore = path.getOwnerMailbox();
@@ -2824,7 +2824,7 @@ public abstract class ImapHandler {
                 }
             }
 
-            int uvv = folderStore.getUIDValidity();
+            long uvv = folderStore.getUIDValidity();
             if (appendHint != null && uvv > 0) {
                 appendHint.append("[APPENDUID ").append(uvv).append(' ')
                     .append(ImapFolder.encodeSubsequence(createdIds)).append("] ");
@@ -4445,7 +4445,7 @@ public abstract class ImapHandler {
                 selectedFolderInOtherMailbox = false;
                 fromFolderId = selectedFolder.getFolderItemIdentifier();
             }
-            int uvv = targetFolder.getUIDValidity();
+            long uvv = targetFolder.getUIDValidity();
             ItemId iidTarget = new ItemId(targetFolder, path.getOwnerAccount().getId());
             ItemIdentifier targetIdentifier = iidTarget.toItemIdentifier();
 

--- a/store/src/java/com/zimbra/cs/imap/ImapSessionManager.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapSessionManager.java
@@ -772,7 +772,7 @@ final class ImapSessionManager {
     private String cacheKey(FolderStore folder, boolean active) {
         MailboxStore mbox = folder.getMailboxStore();
         int modseq = folder instanceof SearchFolderStore ? mbox.getLastChangeID() : folder.getImapMODSEQ();
-        int uvv = folder instanceof SearchFolderStore ? mbox.getLastChangeID() : ImapFolder.getUIDValidity(folder);
+        long uvv = folder instanceof SearchFolderStore ? mbox.getLastChangeID() : ImapFolder.getUIDValidity(folder);
         String acctId = null;
         try {
             acctId = mbox.getAccountId();

--- a/store/src/java/com/zimbra/cs/mailbox/Folder.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Folder.java
@@ -1690,8 +1690,8 @@ public class Folder extends MailItem implements FolderStore {
      * @see Folder#getSavedSequence()
      **/
     @Override
-    public int getUIDValidity() {
-        return Math.max(getSavedSequence(), 1);
+    public long getUIDValidity() {
+        return Math.max(getSavedSequenceLong(), 1);
     }
 
     @Override

--- a/store/src/java/com/zimbra/cs/mailbox/MailServiceException.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailServiceException.java
@@ -335,7 +335,7 @@ public class MailServiceException extends ServiceException {
         return new MailServiceException("WaitSet not found: " + id, NO_SUCH_WAITSET, SENDERS_FAULT, new Argument(ID, id, Argument.Type.STR));
     }
 
-    public static MailServiceException NO_SUCH_BLOB(int mboxId, int itemId, int revision) {
+    public static MailServiceException NO_SUCH_BLOB(int mboxId, int itemId, long revision) {
         return new MailServiceException("No such blob: mailbox=" + mboxId + ", item=" + itemId + ", change=" + revision, NO_SUCH_BLOB, SENDERS_FAULT,
             new Argument(ITEM_ID, itemId, Argument.Type.IID), new Argument(REVISION, revision, Argument.Type.NUM));
     }

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -1257,10 +1257,10 @@ public class Mailbox implements MailboxStore {
         if (item == null) {
             return true;
         }
-        return checkItemChangeID(item.getModifiedSequence(), item.getSavedSequence());
+        return checkItemChangeID(item.getModifiedSequence(), item.getSavedSequenceLong());
     }
 
-    public boolean checkItemChangeID(int modMetadata, int modContent) throws ServiceException {
+    public boolean checkItemChangeID(int modMetadata, long modContent) throws ServiceException {
         if (currentChange().octxt == null || currentChange().octxt.change < 0) {
             return true;
         }
@@ -5253,9 +5253,9 @@ public class Mailbox implements MailboxStore {
         public final int invId;
         public final int compNum;
         public final int modSeq;
-        public final int rev;
+        public final long rev;
 
-        private AddInviteData(int calItemId, int invId, int compNum, int modSeq, int rev) {
+        private AddInviteData(int calItemId, int invId, int compNum, int modSeq, long rev) {
             this.calItemId = calItemId;
             this.invId = invId;
             this.compNum = compNum;
@@ -5759,7 +5759,7 @@ public class Mailbox implements MailboxStore {
             success = true;
             if (processed) {
                 return new AddInviteData(calItem.getId(), inv.getMailItemId(), inv.getComponentNum(),
-                        calItem.getModifiedSequence(), calItem.getSavedSequence());
+                        calItem.getModifiedSequence(), calItem.getSavedSequenceLong());
             } else {
                 return null;
             }

--- a/store/src/java/com/zimbra/cs/mailbox/VirtualConversation.java
+++ b/store/src/java/com/zimbra/cs/mailbox/VirtualConversation.java
@@ -89,7 +89,7 @@ public class VirtualConversation extends Conversation {
         data.setSubject(msg.getSubject());
         data.date = (int) (msg.getDate() / 1000);
         data.modMetadata = msg.getSavedSequence();
-        data.modContent = msg.getSavedSequence();
+        data.modContent = msg.getSavedSequenceLong();
         data.size = 1;
         data.unreadCount = msg.getUnreadCount();
         data.setFlags(msg.getInternalFlagBitmask());

--- a/store/src/java/com/zimbra/cs/mailbox/calendar/cache/CacheToXML.java
+++ b/store/src/java/com/zimbra/cs/mailbox/calendar/cache/CacheToXML.java
@@ -303,7 +303,7 @@ public class CacheToXML {
         calItemElem.addAttribute(MailConstants.A_DATE, calItemData.getDate());
         calItemElem.addAttribute(MailConstants.A_CHANGE_DATE, calItemData.getChangeDate() / 1000);  // as seconds
         calItemElem.addAttribute(MailConstants.A_MODIFIED_SEQUENCE, calItemData.getModMetadata());
-        calItemElem.addAttribute(MailConstants.A_REVISION, calItemData.getModContent());
+        calItemElem.addAttribute(MailConstants.A_REVISION, calItemData.getModContentLong());
 
         int calItemId = calItemData.getCalItemId();
         encodeInstanceData(calItemElem, ifmt, calItemId, defaultData, null,

--- a/store/src/java/com/zimbra/cs/mailbox/calendar/cache/CalSummaryCache.java
+++ b/store/src/java/com/zimbra/cs/mailbox/calendar/cache/CalSummaryCache.java
@@ -148,7 +148,7 @@ public class CalSummaryCache {
             calItemData = new CalendarItemData(
                     calItem.getType(), calItem.getFolderId(), calItem.getId(),
                     calItem.getFlagString(), calItem.getTags(), TagUtil.getTagIdString(calItem),
-                    calItem.getModifiedSequence(), calItem.getSavedSequence(),
+                    calItem.getModifiedSequence(), calItem.getSavedSequenceLong(),
                     calItem.getDate(), calItem.getChangeDate(), calItem.getSize(),
                     defaultInvite.getUid(), defaultInvite.isRecurrence(), calItem.hasExceptions(), calItem.isPublic(),
                     alarm, defaultData);

--- a/store/src/java/com/zimbra/cs/mailbox/calendar/cache/CalendarItemData.java
+++ b/store/src/java/com/zimbra/cs/mailbox/calendar/cache/CalendarItemData.java
@@ -37,7 +37,7 @@ public class CalendarItemData {
     private String mTagIds;
     private boolean mIsPublic;
     private int mModMetadata; // mod_metadata db column; this serves the function of last-modified-time
-    private int mModContent;  // mod_content db column
+    private long mModContent;  // mod_content db column
     private long mDate;       // date db column; unix time in millis
     private long mChangeDate; // change_date db column; unix time in millis
     private long mSize;       // size db column
@@ -73,7 +73,8 @@ public class CalendarItemData {
     public String getTagIds()   { return mTagIds; }
     public boolean isPublic() { return mIsPublic; }
     public int getModMetadata()  { return mModMetadata; }
-    public int getModContent()   { return mModContent; }
+    public int getModContent()   { return (int) mModContent; }
+    public long getModContentLong()   { return mModContent; }
     public long getDate()         { return mDate; }
     public long getChangeDate()   { return mChangeDate; }
     public long getSize()         { return mSize; }
@@ -97,7 +98,7 @@ public class CalendarItemData {
     }
 
     CalendarItemData(MailItem.Type type, int folderId, int calItemId, String flags, String[] tags, String tagIds, int modMetadata,
-            int modContent, long date, long changeDate, long size, String uid, boolean isRecurring, boolean hasExceptions, boolean isPublic,
+            long modContent, long date, long changeDate, long size, String uid, boolean isRecurring, boolean hasExceptions, boolean isPublic,
             AlarmData alarm, FullInstanceData defaultData) {
         this.type = type;
         mFolderId = folderId;

--- a/store/src/java/com/zimbra/cs/service/FeedManager.java
+++ b/store/src/java/com/zimbra/cs/service/FeedManager.java
@@ -83,7 +83,6 @@ import com.zimbra.common.soap.Element;
 import com.zimbra.common.util.DateUtil;
 import com.zimbra.common.util.FileUtil;
 import com.zimbra.common.util.StringUtil;
-import com.zimbra.common.util.ZimbraHttpConnectionManager;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.common.zmime.ZMimeBodyPart;
 import com.zimbra.common.zmime.ZMimeMultipart;
@@ -313,7 +312,7 @@ public class FeedManager {
     throws ServiceException, HttpException, IOException {
         assert !Strings.isNullOrEmpty(url);
 
-        HttpClientBuilder clientBuilder = ZimbraHttpConnectionManager.getExternalHttpConnMgr().newHttpClient();
+        HttpClientBuilder clientBuilder = HttpClientBuilder.create();
         HttpProxyUtil.configureProxy(clientBuilder);
 
         // cannot set connection timeout because it'll affect all HttpClients associated with the conn mgr.

--- a/store/src/java/com/zimbra/cs/service/formatter/ContactFolderFormatter.java
+++ b/store/src/java/com/zimbra/cs/service/formatter/ContactFolderFormatter.java
@@ -110,7 +110,7 @@ public class ContactFolderFormatter extends Formatter {
         // revision
         out.write(MailConstants.A_REVISION.getBytes("UTF-8"));
         out.write(FIELD_DELIMITER);
-        out.write(Integer.toString(item.getSavedSequence()).getBytes("UTF-8"));
+        out.write(Long.toString(item.getSavedSequenceLong()).getBytes("UTF-8"));
         out.write(FIELD_DELIMITER);
         // fileAsStr
         try {

--- a/store/src/java/com/zimbra/cs/service/formatter/NativeFormatter.java
+++ b/store/src/java/com/zimbra/cs/service/formatter/NativeFormatter.java
@@ -568,7 +568,7 @@ public final class NativeFormatter extends Formatter {
             resp.addHeader("X-Zimbra-Version", item.getVersion() + "");
             resp.addHeader("X-Zimbra-Modified", item.getChangeDate() + "");
             resp.addHeader("X-Zimbra-Change", item.getModifiedSequence() + "");
-            resp.addHeader("X-Zimbra-Revision", item.getSavedSequence() + "");
+            resp.addHeader("X-Zimbra-Revision", item.getSavedSequenceLong() + "");
             resp.addHeader("X-Zimbra-ItemType", item.getType().toString());
             try {
                 String val = item.getName();
@@ -589,8 +589,8 @@ public final class NativeFormatter extends Formatter {
         // set Last-Modified header to date when item's content was last modified
         resp.addDateHeader("Last-Modified", item.getDate());
         // set ETag header to item's mod_content value
-        resp.addHeader("ETag", String.valueOf(item.getSavedSequence()));
-        resp.addHeader(ETagHeaderFilter.ZIMBRA_ETAG_HEADER, String.valueOf(item.getSavedSequence()));
+        resp.addHeader("ETag", String.valueOf(item.getSavedSequenceLong()));
+        resp.addHeader(ETagHeaderFilter.ZIMBRA_ETAG_HEADER, String.valueOf(item.getSavedSequenceLong()));
     }
 
     private static final int READ_AHEAD_BUFFER_SIZE = 256;

--- a/store/src/java/com/zimbra/cs/service/formatter/SyncFormatter.java
+++ b/store/src/java/com/zimbra/cs/service/formatter/SyncFormatter.java
@@ -80,7 +80,7 @@ public class SyncFormatter extends Formatter {
         hdrs.add(new Pair<String, String>("X-Zimbra-Received", item.getDate() + ""));
         hdrs.add(new Pair<String, String>("X-Zimbra-Modified", item.getChangeDate() + ""));
         hdrs.add(new Pair<String, String>("X-Zimbra-Change", item.getModifiedSequence() + ""));
-        hdrs.add(new Pair<String, String>("X-Zimbra-Revision", item.getSavedSequence() + ""));
+        hdrs.add(new Pair<String, String>("X-Zimbra-Revision", item.getSavedSequenceLong() + ""));
         if (item instanceof Message)
             hdrs.add(new Pair<String, String>("X-Zimbra-Conv", ((Message) item).getConversationId() + ""));
         return hdrs;

--- a/store/src/java/com/zimbra/cs/service/mail/CounterCalendarItem.java
+++ b/store/src/java/com/zimbra/cs/service/mail/CounterCalendarItem.java
@@ -72,7 +72,7 @@ public class CounterCalendarItem extends CalendarRequest {
             int modSeq = (int) request.getAttributeLong(MailConstants.A_MODIFIED_SEQUENCE, 0);
             int revision = (int) request.getAttributeLong(MailConstants.A_REVISION, 0);
             if (modSeq != 0 && revision != 0 &&
-                    (modSeq < calItem.getModifiedSequence() || revision < calItem.getSavedSequence()))
+                    (modSeq < calItem.getModifiedSequence() || revision < calItem.getSavedSequenceLong()))
                 throw MailServiceException.INVITE_OUT_OF_DATE(iid.toString());
         
             int compNum = (int) request.getAttributeLong(MailConstants.A_CAL_COMP, 0);

--- a/store/src/java/com/zimbra/cs/service/mail/CreateCalendarItemException.java
+++ b/store/src/java/com/zimbra/cs/service/mail/CreateCalendarItemException.java
@@ -128,7 +128,7 @@ public class CreateCalendarItemException extends CalendarRequest {
             int modSeq = (int) request.getAttributeLong(MailConstants.A_MODIFIED_SEQUENCE, 0);
             int revision = (int) request.getAttributeLong(MailConstants.A_REVISION, 0);
             if (modSeq != 0 && revision != 0 &&
-                (modSeq < calItem.getModifiedSequence() || revision < calItem.getSavedSequence()))
+                (modSeq < calItem.getModifiedSequence() || revision < calItem.getSavedSequenceLong()))
                 throw MailServiceException.INVITE_OUT_OF_DATE(iid.toString());
 
             Invite inv = calItem.getInvite(iid.getSubpartId(), compNum);

--- a/store/src/java/com/zimbra/cs/service/mail/ModifyCalendarItem.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ModifyCalendarItem.java
@@ -132,7 +132,7 @@ public class ModifyCalendarItem extends CalendarRequest {
             int modSeq = (int) request.getAttributeLong(MailConstants.A_MODIFIED_SEQUENCE, 0);
             int revision = (int) request.getAttributeLong(MailConstants.A_REVISION, 0);
             if (modSeq != 0 && revision != 0 &&
-                    (modSeq < calItem.getModifiedSequence() || revision < calItem.getSavedSequence())) {
+                    (modSeq < calItem.getModifiedSequence() || revision < calItem.getSavedSequenceLong())) {
                 throw MailServiceException.INVITE_OUT_OF_DATE(iid.toString());
             }
 

--- a/store/src/java/com/zimbra/cs/service/mail/RestoreContacts.java
+++ b/store/src/java/com/zimbra/cs/service/mail/RestoreContacts.java
@@ -80,7 +80,7 @@ public class RestoreContacts extends MailDocumentHandler {
                             + MailConstants.A_CONTACTS_RESTORE_RESOLVE + "=" + resolve;
                     }
                     File file = new File(FileBlobStore.getBlobPath(mbox, doc.getId(),
-                        doc.getSavedSequence(), Short.valueOf(doc.getLocator())));
+                        doc.getSavedSequenceLong(), Short.valueOf(doc.getLocator())));
                     if (!file.exists()) {
                         throw ServiceException
                             .INVALID_REQUEST(FILE_NOT_FOUND + contactBackupFileName, null);

--- a/store/src/java/com/zimbra/cs/service/mail/Sync.java
+++ b/store/src/java/com/zimbra/cs/service/mail/Sync.java
@@ -351,7 +351,7 @@ public class Sync extends MailDocumentHandler {
                 // the client will request the whole object out of band -- potentially using the
                 // content servlet's "include metadata in headers" hack.
                 // If it's just the metadata that changed, send back the set of mutable attributes.
-                boolean created = item.getSavedSequence() > begin;
+                boolean created = item.getSavedSequenceLong() > begin;
                 ToXML.encodeItem(response, ifmt, octxt, item, created ? Change.FOLDER | Change.CONFLICT | Change.DATE | Change.PARENT : MUTABLE_FIELDS);
                 itemCount++;
             }

--- a/store/src/java/com/zimbra/cs/service/mail/ToXML.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ToXML.java
@@ -522,7 +522,7 @@ public final class ToXML {
             }
         }
         if (needToOutput(fields, Change.CONTENT)) {
-            elem.addAttribute(MailConstants.A_REVISION, folder.getSavedSequence());
+            elem.addAttribute(MailConstants.A_REVISION, folder.getSavedSequenceLong());
             // this attribute ("ms") *normally* goes with MODIFIED_CONFLICT, but we need it
             //   serialized in this case as well in order to make dav ctag caching work
             elem.addAttribute(MailConstants.A_MODIFIED_SEQUENCE, folder.getModifiedSequence());
@@ -774,11 +774,11 @@ public final class ToXML {
             el.addAttribute(MailConstants.A_CHANGE_DATE, contact.getChangeDate() / 1000);
             el.addAttribute(MailConstants.A_MODIFIED_SEQUENCE, contact.getModifiedSequence());
             el.addAttribute(MailConstants.A_DATE, contact.getDate());
-            el.addAttribute(MailConstants.A_REVISION, contact.getSavedSequence());
+            el.addAttribute(MailConstants.A_REVISION, contact.getSavedSequenceLong());
         } else {
             if (needToOutput(fields, Change.CONTENT)) {
                 el.addAttribute(MailConstants.A_DATE, contact.getDate());
-                el.addAttribute(MailConstants.A_REVISION, contact.getSavedSequence());
+                el.addAttribute(MailConstants.A_REVISION, contact.getSavedSequenceLong());
             }
             if (needToOutput(fields, Change.MODSEQ)) {
                 el.addAttribute(MailConstants.A_MODIFIED_SEQUENCE, contact.getModifiedSequence());
@@ -1006,8 +1006,8 @@ public final class ToXML {
     public static Element encodeNote(Element parent, ItemIdFormatter ifmt, OperationContext octxt, Note note, int fields) throws ServiceException {
         Element el = parent.addNonUniqueElement(MailConstants.E_NOTE);
         el.addAttribute(MailConstants.A_ID, ifmt.formatItemId(note));
-        if (needToOutput(fields, Change.CONTENT) && note.getSavedSequence() != 0) {
-            el.addAttribute(MailConstants.A_REVISION, note.getSavedSequence());
+        if (needToOutput(fields, Change.CONTENT) && note.getSavedSequenceLong() != 0) {
+            el.addAttribute(MailConstants.A_REVISION, note.getSavedSequenceLong());
         }
         if (needToOutput(fields, Change.FOLDER)) {
             el.addAttribute(MailConstants.A_FOLDER,
@@ -1061,7 +1061,7 @@ public final class ToXML {
         }
         if (needToOutput(fields, Change.CONFLICT)) {
             el.addAttribute(MailConstants.A_DATE, tag.getDate());
-            el.addAttribute(MailConstants.A_REVISION, tag.getSavedSequence());
+            el.addAttribute(MailConstants.A_REVISION, tag.getSavedSequenceLong());
             el.addAttribute(MailConstants.A_CHANGE_DATE, tag.getChangeDate() / 1000);
             el.addAttribute(MailConstants.A_MODIFIED_SEQUENCE, tag.getModifiedSequence());
         }
@@ -1417,7 +1417,7 @@ public final class ToXML {
             boolean encodeMissingBlobs, MsgContent wantContent, int fields)
     throws ServiceException {
         Mailbox mbox = msg.getMailbox();
-        int changeId = msg.getSavedSequence();
+        long changeId = msg.getSavedSequenceLong();
         while (true) {
             try {
                 return encodeMessageAsMPHelper(false /* bestEffort */, parent, ifmt, octxt, msg, part, maxSize,
@@ -1428,10 +1428,10 @@ public final class ToXML {
                 //   (this case generally means that the blob backing the MimeMessage disappeared halfway through)
                 try {
                     msg = mbox.getMessageById(octxt, msg.getId());
-                    if (msg.getSavedSequence() != changeId) {
+                    if (msg.getSavedSequenceLong() != changeId) {
                         // if a draft was re-saved and we failed because the old blob was deleted
                         //   out from under us, just fetch the new MimeMessage and try again
-                        changeId = msg.getSavedSequence();
+                        changeId = msg.getSavedSequenceLong();
                         ZimbraLog.soap.info("caught message content change while serializing; will retry");
                         continue;
                     }
@@ -1705,8 +1705,8 @@ public final class ToXML {
         calItemElem.addAttribute(MailConstants.A_FOLDER,
             ifmt.formatItemId(new ItemId(calItem.getMailbox().getAccountId(), calItem.getFolderId())));
 
-        if (needToOutput(fields, Change.CONTENT) && calItem.getSavedSequence() != 0) {
-            calItemElem.addAttribute(MailConstants.A_REVISION, calItem.getSavedSequence());
+        if (needToOutput(fields, Change.CONTENT) && calItem.getSavedSequenceLong() != 0) {
+            calItemElem.addAttribute(MailConstants.A_REVISION, calItem.getSavedSequenceLong());
         }
         if (needToOutput(fields, Change.SIZE)) {
             calItemElem.addAttribute(MailConstants.A_SIZE, calItem.getSize());
@@ -1817,7 +1817,7 @@ public final class ToXML {
         final int MAX_RETRIES = LC.calendar_item_get_max_retries.intValue();
         Element elem = null;
         Mailbox mbox = calItem.getMailbox();
-        int changeId = calItem.getSavedSequence();
+        long changeId = calItem.getSavedSequenceLong();
         int numTries = 0;
         while (numTries < MAX_RETRIES) {
             numTries++;
@@ -1840,9 +1840,9 @@ public final class ToXML {
                 elem = null;
                 try {
                     calItem = mbox.getCalendarItemById(octxt, calItem.getId());
-                    if (calItem.getSavedSequence() != changeId) {
+                    if (calItem.getSavedSequenceLong() != changeId) {
                         // just fetch the new item and try again
-                        changeId = calItem.getSavedSequence();
+                        changeId = calItem.getSavedSequenceLong();
                         ZimbraLog.soap.info("caught calendar item content change while serializing; will retry");
                         continue;
                     }
@@ -2128,15 +2128,15 @@ public final class ToXML {
             encodeAllCustomMetadata(elem, item, fields);
         }
         if (needToOutput(fields, Change.CONFLICT)) {
-            elem.addAttribute(MailConstants.A_REVISION, item.getSavedSequence());
+            elem.addAttribute(MailConstants.A_REVISION, item.getSavedSequenceLong());
             elem.addAttribute(MailConstants.A_CHANGE_DATE, item.getChangeDate() / 1000);
             elem.addAttribute(MailConstants.A_MODIFIED_SEQUENCE, item.getModifiedSequence());
         } else {
             if (needToOutput(fields, Change.MODSEQ) && item.getModifiedSequence() > 0) {
                 elem.addAttribute(MailConstants.A_MODIFIED_SEQUENCE, item.getModifiedSequence());
             }
-            if (needToOutput(fields, Change.CONTENT) && item.getSavedSequence() != 0) {
-                elem.addAttribute(MailConstants.A_REVISION, item.getSavedSequence());
+            if (needToOutput(fields, Change.CONTENT) && item.getSavedSequenceLong() != 0) {
+                elem.addAttribute(MailConstants.A_REVISION, item.getSavedSequenceLong());
             }
         }
         if (needToOutput(fields, Change.IMAP_UID)) {
@@ -3063,7 +3063,7 @@ throws ServiceException {
             m.addAttribute(MailConstants.A_MODIFIED_SEQUENCE, doc.getModifiedSequence());
             m.addAttribute(MailConstants.A_METADATA_VERSION, doc.getMetadataVersion());
             m.addAttribute(MailConstants.A_CHANGE_DATE, (doc.getChangeDate() / 1000));
-            m.addAttribute(MailConstants.A_REVISION, doc.getSavedSequence());
+            m.addAttribute(MailConstants.A_REVISION, doc.getSavedSequenceLong());
         }
         recordItemTags(m, doc, octxt, fields | Change.FLAGS);
         if (needToOutput(fields, Change.METADATA)) {

--- a/store/src/java/com/zimbra/cs/store/MailboxBlob.java
+++ b/store/src/java/com/zimbra/cs/store/MailboxBlob.java
@@ -32,11 +32,11 @@ public abstract class MailboxBlob {
         public String accountId;
         public int mailboxId;
         public int itemId;
-        public int revision;
+        public long revision;
         public String locator;
         public String digest;
 
-        public MailboxBlobInfo(String accountId, int mailboxId, int itemId, int revision, String locator, String digest) {
+        public MailboxBlobInfo(String accountId, int mailboxId, int itemId, long revision, String locator, String digest) {
             this.accountId = accountId;
             this.mailboxId = mailboxId;
             this.itemId = itemId;
@@ -49,12 +49,12 @@ public abstract class MailboxBlob {
     private final Mailbox mailbox;
 
     private final int itemId;
-    private final int revision;
+    private final long revision;
     private final String locator;
     protected Long size;
     protected String digest;
 
-    protected MailboxBlob(Mailbox mbox, int itemId, int revision, String locator) {
+    protected MailboxBlob(Mailbox mbox, int itemId, long revision, String locator) {
         this.mailbox = mbox;
         this.itemId = itemId;
         this.revision = revision;
@@ -66,6 +66,10 @@ public abstract class MailboxBlob {
     }
 
     public int getRevision() {
+        return (int) revision;
+    }
+
+    public long getRevisionLong() {
         return revision;
     }
 

--- a/store/src/java/com/zimbra/cs/store/StoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/StoreManager.java
@@ -221,7 +221,7 @@ public abstract class StoreManager {
      * @throws IOException
      * @throws ServiceException
      */
-    public abstract MailboxBlob copy(MailboxBlob src, Mailbox destMbox, int destMsgId, int destRevision)
+    public abstract MailboxBlob copy(MailboxBlob src, Mailbox destMbox, int destMsgId, long destRevision)
     throws IOException, ServiceException;
 
     /**
@@ -237,7 +237,7 @@ public abstract class StoreManager {
      * @throws IOException
      * @throws ServiceException
      */
-    public abstract MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, int destRevision)
+    public abstract MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision)
     throws IOException, ServiceException;
 
     /**
@@ -251,7 +251,7 @@ public abstract class StoreManager {
      * @throws IOException
      * @throws ServiceException
      */
-    public abstract MailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destMsgId, int destRevision)
+    public abstract MailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision)
     throws IOException, ServiceException;
 
     /**
@@ -348,7 +348,7 @@ public abstract class StoreManager {
      *
      * @throws ServiceException
      */
-    public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, int revision, String locator)
+    public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, long revision, String locator)
     throws ServiceException {
         return getMailboxBlob(mbox, itemId, revision, locator, true);
     }
@@ -363,7 +363,7 @@ public abstract class StoreManager {
      *
      * @throws ServiceException
      */
-    public abstract MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, int revision, String locator, boolean validate)
+    public abstract MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, long revision, String locator, boolean validate)
     throws ServiceException;
 
     /**
@@ -375,7 +375,7 @@ public abstract class StoreManager {
      * @throws ServiceException
      */
     public MailboxBlob getMailboxBlob(MailItem item) throws ServiceException {
-        MailboxBlob mblob = getMailboxBlob(item.getMailbox(), item.getId(), item.getSavedSequence(), item.getLocator());
+        MailboxBlob mblob = getMailboxBlob(item.getMailbox(), item.getId(), item.getSavedSequenceLong(), item.getLocator());
         if (mblob != null) {
             mblob.setDigest(item.getDigest()).setSize(item.getSize());
         }

--- a/store/src/java/com/zimbra/cs/store/StoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/StoreManager.java
@@ -237,8 +237,14 @@ public abstract class StoreManager {
      * @throws IOException
      * @throws ServiceException
      */
-    public abstract MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision)
-    throws IOException, ServiceException;
+    public  MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision)
+    throws IOException, ServiceException {
+
+        throw ServiceException.UNSUPPORTED();
+    }
+
+    public abstract MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, int destRevision)
+        throws IOException, ServiceException;
 
     /**
      * Rename a blob to a blob in mailbox directory.
@@ -353,6 +359,10 @@ public abstract class StoreManager {
         return getMailboxBlob(mbox, itemId, revision, locator, true);
     }
 
+    public abstract  MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, int revision, String locator)
+        throws ServiceException ;
+
+
     /**
      * Find the MailboxBlob in int mailboxId, String accountId with matching item ID.
      * @param mbox
@@ -363,7 +373,22 @@ public abstract class StoreManager {
      *
      * @throws ServiceException
      */
-    public abstract MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, long revision, String locator, boolean validate)
+    public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, long revision, String locator, boolean validate)
+    throws ServiceException {
+
+        throw ServiceException.UNSUPPORTED();
+    }
+    /**
+     * Find the MailboxBlob in int mailboxId, String accountId with matching item ID.
+     * @param mbox
+     * @param itemId mail_item.id value for item
+     * @param revision mail_item.mod_content value for item
+     * @return the <code>MailboxBlob</code>, or <code>null</code> if the file
+     * does not exist
+     *
+     * @throws ServiceException
+     */
+    public abstract MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, int revision, String locator, boolean validate)
     throws ServiceException;
 
     /**

--- a/store/src/java/com/zimbra/cs/store/external/ExternalMailboxBlob.java
+++ b/store/src/java/com/zimbra/cs/store/external/ExternalMailboxBlob.java
@@ -30,7 +30,7 @@ import com.zimbra.cs.store.StoreManager;
  */
 public class ExternalMailboxBlob extends MailboxBlob {
 
-    protected ExternalMailboxBlob(Mailbox mbox, int itemId, int revision, String locator) {
+    protected ExternalMailboxBlob(Mailbox mbox, int itemId, long revision, String locator) {
         super(mbox, itemId, revision, locator);
     }
 

--- a/store/src/java/com/zimbra/cs/store/external/ExternalStoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/external/ExternalStoreManager.java
@@ -93,7 +93,7 @@ public abstract class ExternalStoreManager extends StoreManager implements Exter
     };
 
     @Override
-    public MailboxBlob copy(MailboxBlob src, Mailbox destMbox, int destItemId, int destRevision)
+    public MailboxBlob copy(MailboxBlob src, Mailbox destMbox, int destItemId, long destRevision)
     throws IOException, ServiceException {
         //default implementation does not handle de-duping
         //stores which de-dupe need to override this method appropriately
@@ -206,20 +206,20 @@ public abstract class ExternalStoreManager extends StoreManager implements Exter
     }
 
     @Override
-    public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, int revision, String locator, boolean validate) throws ServiceException {
+    public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, long revision, String locator, boolean validate) throws ServiceException {
         ExternalMailboxBlob mblob = new ExternalMailboxBlob(mbox, itemId, revision, locator);
         return (!validate || mblob.validateBlob()) ? mblob : null;
     }
 
     @Override
-    public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, int destRevision) throws IOException,
+    public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision) throws IOException,
     ServiceException {
         // link is a noop
         return renameTo(src, destMbox, destMsgId, destRevision);
     }
 
     @Override
-    public MailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destMsgId, int destRevision) throws IOException,
+    public MailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision) throws IOException,
     ServiceException {
         // rename is a noop
         ExternalStagedBlob staged = (ExternalStagedBlob) src;

--- a/store/src/java/com/zimbra/cs/store/external/ExternalStoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/external/ExternalStoreManager.java
@@ -212,6 +212,11 @@ public abstract class ExternalStoreManager extends StoreManager implements Exter
     }
 
     @Override
+    public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, int revision, String locator, boolean validate) throws ServiceException {
+        return this.getMailboxBlob(mbox, itemId, (long)revision, locator, validate);
+    }
+
+    @Override
     public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, long destRevision) throws IOException,
     ServiceException {
         // link is a noop

--- a/store/src/java/com/zimbra/cs/store/external/ImapTransientStoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/external/ImapTransientStoreManager.java
@@ -26,6 +26,8 @@ import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.FileUtil;
 import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.store.MailboxBlob;
+import com.zimbra.cs.store.StagedBlob;
 
 /**
  * Simple ExternalStoreManager implementation that is intended for use in storing
@@ -86,4 +88,16 @@ public class ImapTransientStoreManager extends ExternalStoreManager {
         }
     }
 
+    @Override
+    public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, int destRevision)
+        throws IOException, ServiceException {
+        // TODO Auto-generated method stub
+        return this.link(src, destMbox, destMsgId, (long)destRevision);
+    }
+
+    @Override
+    public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, int revision, String locator)
+        throws ServiceException {
+        return this.getMailboxBlob(mbox, itemId, (long)revision, locator);
+    }
 }

--- a/store/src/java/com/zimbra/cs/store/external/ImapTransientStoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/external/ImapTransientStoreManager.java
@@ -91,7 +91,6 @@ public class ImapTransientStoreManager extends ExternalStoreManager {
     @Override
     public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, int destRevision)
         throws IOException, ServiceException {
-        // TODO Auto-generated method stub
         return this.link(src, destMbox, destMsgId, (long)destRevision);
     }
 

--- a/store/src/java/com/zimbra/cs/store/external/SimpleStoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/external/SimpleStoreManager.java
@@ -130,14 +130,12 @@ public class SimpleStoreManager extends ExternalStoreManager {
     @Override
     public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, int destRevision)
         throws IOException, ServiceException {
-        // TODO Auto-generated method stub
-        return null;
+        return this.link(src, destMbox, destMsgId, (long)destRevision);
     }
 
     @Override
     public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, int revision, String locator)
         throws ServiceException {
-        // TODO Auto-generated method stub
         return this.getMailboxBlob(mbox, itemId, (long) revision, locator);
     }
 }

--- a/store/src/java/com/zimbra/cs/store/external/SimpleStoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/external/SimpleStoreManager.java
@@ -26,13 +26,15 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.io.filefilter.FileFileFilter;
-import com.zimbra.common.localconfig.LC;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.FileUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.store.MailboxBlob;
+import com.zimbra.cs.store.StagedBlob;
 
 /**
  * Example implementation of ExternalStoreManager which writes to a flat directory structure
@@ -123,5 +125,19 @@ public class SimpleStoreManager extends ExternalStoreManager {
         } else {
             return super.supports(feature);
         }
+    }
+
+    @Override
+    public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, int destRevision)
+        throws IOException, ServiceException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, int revision, String locator)
+        throws ServiceException {
+        // TODO Auto-generated method stub
+        return this.getMailboxBlob(mbox, itemId, (long) revision, locator);
     }
 }

--- a/store/src/java/com/zimbra/cs/store/file/FileBlobStore.java
+++ b/store/src/java/com/zimbra/cs/store/file/FileBlobStore.java
@@ -123,7 +123,7 @@ public final class FileBlobStore extends StoreManager {
     }
 
     @Override
-    public VolumeMailboxBlob copy(MailboxBlob src, Mailbox destMbox, int destItemId, int destRevision)
+    public VolumeMailboxBlob copy(MailboxBlob src, Mailbox destMbox, int destItemId, long destRevision)
     throws IOException, ServiceException {
         Volume volume = MANAGER.getCurrentMessageVolume();
         //FileBlobStore optimizes copy by using link where possible
@@ -193,14 +193,14 @@ public final class FileBlobStore extends StoreManager {
     }
 
     @Override
-    public VolumeMailboxBlob link(StagedBlob src, Mailbox destMbox, int destItemId, int destRevision)
+    public VolumeMailboxBlob link(StagedBlob src, Mailbox destMbox, int destItemId, long destRevision)
     throws IOException, ServiceException {
         Volume volume = MANAGER.getCurrentMessageVolume();
         VolumeBlob blob = ((VolumeStagedBlob) src).getLocalBlob();
         return link(blob, destMbox, destItemId, destRevision, volume.getId());
     }
 
-    public VolumeMailboxBlob link(Blob src, Mailbox destMbox, int destItemId, int destRevision, short destVolumeId)
+    public VolumeMailboxBlob link(Blob src, Mailbox destMbox, int destItemId, long destRevision, short destVolumeId)
     throws IOException, ServiceException {
         File srcFile = src.getFile();
         if (!srcFile.exists()) {
@@ -264,7 +264,7 @@ public final class FileBlobStore extends StoreManager {
     }
 
     @Override
-    public VolumeMailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destItemId, int destRevision)
+    public VolumeMailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destItemId, long destRevision)
     throws IOException, ServiceException {
         Volume volume = MANAGER.getCurrentMessageVolume();
         VolumeBlob blob = ((VolumeStagedBlob) src).getLocalBlob();
@@ -354,7 +354,7 @@ public final class FileBlobStore extends StoreManager {
     }
 
     @Override
-    public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, int revision, String locator, boolean validate) throws ServiceException {
+    public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, long revision, String locator, boolean validate) throws ServiceException {
         short volumeId = Short.valueOf(locator);
         File file = getMailboxBlobFile(mbox, itemId, revision, volumeId, validate);
         if (file == null) {
@@ -388,7 +388,7 @@ public final class FileBlobStore extends StoreManager {
         return true;
     }
 
-    private File getMailboxBlobFile(Mailbox mbox, int itemId, int revision, short volumeId, boolean check)
+    private File getMailboxBlobFile(Mailbox mbox, int itemId, long revision, short volumeId, boolean check)
     throws ServiceException {
         File file = new File(getBlobPath(mbox, itemId, revision, volumeId));
         if (!check || file.exists()) {
@@ -399,11 +399,11 @@ public final class FileBlobStore extends StoreManager {
         return (file.exists() ? file : null);
     }
 
-    public static String getBlobPath(Mailbox mbox, int itemId, int revision, short volumeId) throws ServiceException {
+    public static String getBlobPath(Mailbox mbox, int itemId, long revision, short volumeId) throws ServiceException {
         return getBlobPath(mbox.getId(), itemId, revision, volumeId);
     }
 
-    public static String getBlobPath(int mboxId, int itemId, int revision, short volumeId) throws ServiceException {
+    public static String getBlobPath(int mboxId, int itemId, long revision, short volumeId) throws ServiceException {
         Volume vol = MANAGER.getVolume(volumeId);
         String path = vol.getBlobDir(mboxId, itemId);
         int buflen = path.length() + 15 + (revision < 0 ? 0 : 11);
@@ -414,7 +414,7 @@ public final class FileBlobStore extends StoreManager {
         return sb.toString();
     }
 
-    public static void appendFilename(StringBuilder sb, int itemId, int revision) {
+    public static void appendFilename(StringBuilder sb, int itemId, long revision) {
         sb.append(itemId);
         if (revision >= 0) {
             sb.append('-').append(revision);

--- a/store/src/java/com/zimbra/cs/store/file/FileBlobStore.java
+++ b/store/src/java/com/zimbra/cs/store/file/FileBlobStore.java
@@ -371,8 +371,8 @@ public final class FileBlobStore extends StoreManager {
     }
 
     @Override
-    public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, int revision, String locator, boolean validate) throws ServiceException {
-
+    public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, int revision, String locator, boolean validate)
+        throws ServiceException {
         return this.getMailboxBlob(mbox, itemId, (long)revision, locator, validate);
     }
 
@@ -416,14 +416,8 @@ public final class FileBlobStore extends StoreManager {
 
     private File getMailboxBlobFile(Mailbox mbox, int itemId, int revision, short volumeId, boolean check)
         throws ServiceException {
-            File file = new File(getBlobPath(mbox, itemId, revision, volumeId));
-            if (!check || file.exists()) {
-                return file;
-            }
-            // fallback for very very *very* old installs where blob paths were based on item id only
-            file = new File(getBlobPath(mbox, itemId, -1, volumeId));
-            return (file.exists() ? file : null);
-        }
+        return this.getMailboxBlobFile(mbox, itemId, (long) revision, volumeId, check);
+    }
 
     public static String getBlobPath(Mailbox mbox, int itemId, long revision, short volumeId) throws ServiceException {
         return getBlobPath(mbox.getId(), itemId, revision, volumeId);
@@ -468,7 +462,6 @@ public final class FileBlobStore extends StoreManager {
     @Override
     public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, int destRevision)
         throws IOException, ServiceException {
-        // TODO Auto-generated method stub
         return this.link(src, destMbox,destMsgId, (long)destRevision);
     }
 

--- a/store/src/java/com/zimbra/cs/store/file/FileBlobStore.java
+++ b/store/src/java/com/zimbra/cs/store/file/FileBlobStore.java
@@ -200,6 +200,13 @@ public final class FileBlobStore extends StoreManager {
         return link(blob, destMbox, destItemId, destRevision, volume.getId());
     }
 
+    public VolumeMailboxBlob link(Blob src, Mailbox destMbox, int destItemId, int destRevision, short destVolumeId)
+        throws IOException, ServiceException {
+
+        return this.link(src, destMbox, destItemId, (long)destRevision, destVolumeId);
+    }
+
+
     public VolumeMailboxBlob link(Blob src, Mailbox destMbox, int destItemId, long destRevision, short destVolumeId)
     throws IOException, ServiceException {
         File srcFile = src.getFile();
@@ -364,6 +371,14 @@ public final class FileBlobStore extends StoreManager {
     }
 
     @Override
+    public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, int revision, String locator, boolean validate) throws ServiceException {
+
+        return this.getMailboxBlob(mbox, itemId, (long)revision, locator, validate);
+    }
+
+
+
+    @Override
     public InputStream getContent(MailboxBlob mboxBlob) throws IOException {
         if (mboxBlob == null) {
             return null;
@@ -398,6 +413,17 @@ public final class FileBlobStore extends StoreManager {
         file = new File(getBlobPath(mbox, itemId, -1, volumeId));
         return (file.exists() ? file : null);
     }
+
+    private File getMailboxBlobFile(Mailbox mbox, int itemId, int revision, short volumeId, boolean check)
+        throws ServiceException {
+            File file = new File(getBlobPath(mbox, itemId, revision, volumeId));
+            if (!check || file.exists()) {
+                return file;
+            }
+            // fallback for very very *very* old installs where blob paths were based on item id only
+            file = new File(getBlobPath(mbox, itemId, -1, volumeId));
+            return (file.exists() ? file : null);
+        }
 
     public static String getBlobPath(Mailbox mbox, int itemId, long revision, short volumeId) throws ServiceException {
         return getBlobPath(mbox.getId(), itemId, revision, volumeId);
@@ -436,5 +462,19 @@ public final class FileBlobStore extends StoreManager {
 
     private static void ensureParentDirExists(File file) throws IOException {
         ensureDirExists(file.getParentFile());
+    }
+
+
+    @Override
+    public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, int destRevision)
+        throws IOException, ServiceException {
+        // TODO Auto-generated method stub
+        return this.link(src, destMbox,destMsgId, (long)destRevision);
+    }
+
+    @Override
+    public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, int revision, String locator)
+        throws ServiceException {
+        return this.getMailboxBlob(mbox, itemId, (long)revision, locator);
     }
 }

--- a/store/src/java/com/zimbra/cs/store/file/VolumeMailboxBlob.java
+++ b/store/src/java/com/zimbra/cs/store/file/VolumeMailboxBlob.java
@@ -22,7 +22,7 @@ import com.zimbra.cs.store.MailboxBlob;
 public class VolumeMailboxBlob extends MailboxBlob {
     private final VolumeBlob blob;
 
-    protected VolumeMailboxBlob(Mailbox mbox, int itemId, int revision, String locator, VolumeBlob blob) {
+    protected VolumeMailboxBlob(Mailbox mbox, int itemId, long revision, String locator, VolumeBlob blob) {
         super(mbox, itemId, revision, locator);
         this.blob = blob;
     }

--- a/store/src/java/com/zimbra/cs/store/triton/TritonBlobStoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/triton/TritonBlobStoreManager.java
@@ -47,6 +47,8 @@ import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.service.UserServlet;
 import com.zimbra.cs.store.Blob;
+import com.zimbra.cs.store.MailboxBlob;
+import com.zimbra.cs.store.StagedBlob;
 import com.zimbra.cs.store.external.ExternalResumableIncomingBlob;
 import com.zimbra.cs.store.external.ExternalResumableUpload;
 import com.zimbra.cs.store.external.ExternalUploadedBlob;
@@ -321,5 +323,22 @@ public class TritonBlobStoreManager extends SisStore implements ExternalResumabl
             case SINGLE_INSTANCE_SERVER_CREATE : return hashType == HashType.SHA256;
             default: return super.supports(feature);
         }
+    }
+
+    @Override
+    public  MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, int revision, String locator, boolean validate) {
+        return null;
+    }
+
+    @Override
+    public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, int destRevision)
+        throws IOException, ServiceException {
+        // TODO Auto-generated method stub
+        return this.link(src, destMbox, destMsgId, (long)destRevision);
+    }
+    @Override
+    public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, int revision, String locator)
+        throws ServiceException {
+        return this.getMailboxBlob(mbox, itemId, (long)revision, locator);
     }
 }

--- a/store/src/java/com/zimbra/cs/store/triton/TritonBlobStoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/triton/TritonBlobStoreManager.java
@@ -326,14 +326,14 @@ public class TritonBlobStoreManager extends SisStore implements ExternalResumabl
     }
 
     @Override
-    public  MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, int revision, String locator, boolean validate) {
-        return null;
+    public  MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, int revision, String locator, boolean validate)
+        throws ServiceException {
+        return this.getMailboxBlob(mbox, itemId, (long)revision, locator, validate);
     }
 
     @Override
     public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, int destRevision)
         throws IOException, ServiceException {
-        // TODO Auto-generated method stub
         return this.link(src, destMbox, destMsgId, (long)destRevision);
     }
     @Override


### PR DESCRIPTION
The changes made  as part of 8785 were causing issues when NG module was turned on.
Fixed the code to keep existing public interfaces for StoreManager and create a default  method with long  parameter which sub classes need to over ride.

Tested with NG modules enables no issues seen. 
Testing to be done
Verify ZBUG-1315, ZCS-8785, ZCS-8696.
Sanity testing without and with NG module
SOAP automation