### PR TITLE
ZBUG-1459:Abuse of File upload functionality in Zimbra webmail

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1400,6 +1400,9 @@ public final class LC {
     // owasp handler
     public static final KnownKey zimbra_use_owasp_html_sanitizer = KnownKey.newKey(true);
 
+    // file content type blacklist
+    public static final KnownKey zimbra_file_content_type_blacklist = KnownKey.newKey("application/x-ms*");
+
     public static final KnownKey enable_delegated_admin_ldap_access = KnownKey.newKey(true);
 
     // OAuth2 Social


### PR DESCRIPTION
Issue:
A user can upload malicious files in the Contact section of the mailbox as avatar image for a contact.

Fix: 
Added new LC parameter to have blacklisted content type during any file upload. The value can be regex value to blacklist certain category of files.
Default value is set to 'application/x-mx*' to blacklist all exe files.

Testing done:
Manual testing done. The exe file upload now throws 403 forbidden error.