### PR TITLE
ZCS-8822:Support for showing display names for Zimbra X zimlets on admin UI

### DIFF
--- a/common/src/java/com/zimbra/common/util/Props2Js.java
+++ b/common/src/java/com/zimbra/common/util/Props2Js.java
@@ -119,10 +119,10 @@ public class Props2Js {
 
     private static void printHead(DataOutputStream out, String classname) throws
         IOException {
-        out.writeBytes("if (!window."+classname+") { ");
-        out.writeBytes(classname+" = {};");
+        out.writeBytes("if (!window['"+classname+"']) { ");
+        out.writeBytes("window['"+classname+"'] = {};");
         out.writeBytes(" }\n");
-        out.writeBytes("a="+classname+";\n");
+        out.writeBytes("a=window['"+classname+"'];\n");
     }
     
 	private static void printTail(DataOutputStream out) throws


### PR DESCRIPTION
**Issue:** 
- Currently all zimlets which shows on Admin console has different properties file for supported Locales and the zimlet meta xml contains place holders for  labels and descriptions.

- Initially the modern zimlets does not contain any properties file and the zimlet meta xml contains hardcoded values for label and description. After had a discussion with @silentsakky and as agreed, the modern zimlets will be packaged as legacy zimlets and will contain properties file for default Locale (en_US).
- But the issue is that, the old zimlet name has format of `com_zimbra_xxx` which is a valid variable name in Javascript where as the modern zimlets name is like `zm-x-zimlets-sideloader` which is not a valid variable name in Javascript.

**Approach and Fix:**
When the server gets GetAllZimlets request for the first time, it returns all zimlets and then for each zimlet the client triggers a rest call to the server which gives the conversion of properties file to javascript in response as below
```
// Locale: en_US
 // Basename: /res/zm-x-zimlet-sideloader
 if (!window.zm-x-zimlet-sideloader) { zm-x-zimlet-sideloader = {}; }
 a=zm-x-zimlet-sideloader;
 a.label="For side-loading other zimlets (Modern)";
 a.description="Zimlet for sideloading other zimlets";
 delete a;// properties for zm-x-zimlet-sideloader not found
```

This works fine for old zimlets because the old zimlet name(i.e  `com_zimbra_xxx` ) is a valid javascript variable where as the new zimlet name(i.e `zm-x-zimlet-sideloader`) is not a valid javascript variable.

As suggested by @yashrajpchavda, modified the code which will return valid javascript in response to the rest call which will work for both old and modern zimlets as below
```
if (!window['zm-x-zimlet-sideloader']) { window['zm-x-zimlet-sideloader'] = {}; }
a=window['zm-x-zimlet-sideloader']
```

**Test:**
Tested that the modern zimlet provided by @silentsakky is working fine as well as all old zimlets are properly displayed on admin console.

**Testing to be done by QA:**
- Verify with different modern zimlets that display name and description are correctly shown on admin console.
- change the admin language preference and check that the modern zimlets will be shown on English only.