### PR TITLE
ZCS-8901 - IMAP: Shared folder does not visible properly as well as can't see emails in shared folder in Thunderbird client

### DIFF
--- a/store/src/java/com/zimbra/cs/imap/ImapHandler.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapHandler.java
@@ -2400,10 +2400,11 @@ public abstract class ImapHandler {
                     // IMAP datasource connections
                     continue;
                 }
-                //boolean alreadyTraversed = paths.put(path, path.asItemId()) != null;
+                if (folderStore instanceof MountpointStore) {
+                    isMountPath = true;
+                }
                 boolean alreadyTraversed = (!isMountPath) ? paths.put(path, path.asItemId()) != null : mountPaths.put(path, path.asItemId()) != null;
                 if (folderStore instanceof MountpointStore && !alreadyTraversed) {
-//                    mountPaths.put(path, path.asItemId());
                     accumulatePaths(path.getOwnerImapMailboxStore(), owner, path, paths, mountPaths, true);
                 }
             }


### PR DESCRIPTION
Issue: 
When an account is configured in IMAP with shared folders, the shared folder is not correctly displayed as well as the emails inside the folder is not visible where as the subfolders email are visible.

Fix:
After ZBUG-1096 change, For the logged in account, there was separate collection for owner account folders and separate collection for shared folder(Mountpoint). Though the Folder structure is correctly displayed on Thunderbird client but the shared folder was getting added to the owner's folder collection which was causing the problem and the mail inside the folder is not correctly displayed.

So put a check for shared folder so that it will add to the shared folder collection and maintain correct hierarchy.

Test:
- Tested that the issue with ZBUG-1096 is working where the whole mailbox was shared.
- Tested by sharing individual folders.
- Tested that all folders email are getting displayed correctly on Thunderbird client.