### PR TITLE
ZCS-8993: making the mailbox listener unergister method accessible from extension

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/MailboxListener.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailboxListener.java
@@ -111,7 +111,7 @@ public abstract class MailboxListener {
     }
 
     @VisibleForTesting
-    static void unregister(MailboxListener listener) {
+    public static void unregister(MailboxListener listener) {
         synchronized (sListeners) {
             sListeners.remove(listener);
         }


### PR DESCRIPTION
Issue:
Mailboxlistener unregister() method is not accessible like register method() is for classes. So the listeners registered cannot be de-registered.

Fix: make unregister() public to de-register listener.