### PR TITLE
ZBUG-903: Problem with 'sendAs' delegate rights and 'Save a copy of sent messages to my Sent folder

### DIFF
--- a/store/src/java/com/zimbra/cs/service/mail/ParseMimeMessage.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ParseMimeMessage.java
@@ -42,6 +42,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.zimbra.common.calendar.ZCalendar;
 import com.zimbra.common.localconfig.LC;
+import com.zimbra.common.mailbox.ItemIdentifier;
 import com.zimbra.common.mime.ContentDisposition;
 import com.zimbra.common.mime.ContentType;
 import com.zimbra.common.mime.MimeConstants;
@@ -490,7 +491,11 @@ public final class ParseMimeMessage {
             boolean optional = elem.getAttributeBool(MailConstants.A_OPTIONAL, false);
             try {
                 if (attachType.equals(MailConstants.E_MIMEPART)) {
-                    ItemId iid = new ItemId(elem.getAttribute(MailConstants.A_MESSAGE_ID), ctxt.zsc);
+                    String mid = elem.getAttribute(MailConstants.A_MESSAGE_ID);
+                    if (mid.indexOf(ItemIdentifier.ACCOUNT_DELIMITER) == -1) {
+                        mid = ctxt.zsc.getAuthToken().getAccount().getId() + ItemIdentifier.ACCOUNT_DELIMITER + mid;
+                    }
+                    ItemId iid = new ItemId(mid, ctxt.zsc);
                     String part = elem.getAttribute(MailConstants.A_PART);
                     attachPart(mmp, iid, part, contentID, ctxt, contentDisposition);
                 } else if (attachType.equals(MailConstants.E_MSG)) {

--- a/store/src/java/com/zimbra/cs/util/AccountUtil.java
+++ b/store/src/java/com/zimbra/cs/util/AccountUtil.java
@@ -49,6 +49,7 @@ import com.zimbra.common.mime.MimeConstants;
 import com.zimbra.common.mime.shim.JavaMailInternetAddress;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AccountConstants;
+import com.zimbra.common.soap.Element;
 import com.zimbra.common.util.BlobMetaData;
 import com.zimbra.common.util.CharsetUtil;
 import com.zimbra.common.util.EmailUtil;
@@ -60,10 +61,12 @@ import com.zimbra.common.zmime.ZMimeMultipart;
 import com.zimbra.cs.account.AccessManager;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.AccountServiceException.AuthFailedServiceException;
+import com.zimbra.cs.account.accesscontrol.generated.RightConsts;
 import com.zimbra.cs.account.AuthToken;
 import com.zimbra.cs.account.DataSource;
 import com.zimbra.cs.account.Domain;
 import com.zimbra.cs.account.ExtAuthTokenKey;
+import com.zimbra.cs.account.Identity;
 import com.zimbra.cs.account.NamedEntry;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.Server;
@@ -74,8 +77,12 @@ import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.Metadata;
 import com.zimbra.cs.mailbox.MetadataList;
 import com.zimbra.cs.mime.Mime;
+import com.zimbra.cs.service.mail.ToXML.EmailType;
 import com.zimbra.cs.servlet.ZimbraServlet;
+import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.admin.type.DataSourceType;
+import com.zimbra.soap.mail.message.SendMsgRequest;
+import com.zimbra.soap.mail.type.EmailAddrInfo;
 
 public class AccountUtil {
     public static final String FN_SUBSCRIPTIONS = "subs";
@@ -864,5 +871,48 @@ public class AccountUtil {
     public static SMTPMessage getSmtpMessageObj(Account acct) throws ServiceException, MessagingException {
         return new SMTPMessage(JMSession.getSmtpSession(Provisioning.getInstance().getDomain(acct)));
     }
+
+    /**
+     * Extract (f)rom address from sendMsg SOAP Request.
+     * @param body SOAP request body.
+     * @return from address
+     * @throws ServiceException
+     */
+    public static String extractFromAddress(Element body) throws ServiceException {
+        String fromAddress = null;
+        SendMsgRequest req = JaxbUtil.elementToJaxb(body, SendMsgRequest.class);
+        for (EmailAddrInfo addr : req.getMsg().getEmailAddresses()) {
+            if (addr.getAddressType().equals(EmailType.FROM.toString())) {
+                fromAddress = addr.getAddress();
+                break;
+            }
+        }
+        return fromAddress;
+    }
+
+    /**
+     * This method will check if the mail has sent using persona of owner account or not.
+     * If <b>zimbraAllowAnyFromAddress</b> is set to true on auth user account, then this method will return false.
+     * @param identityId persona id.
+     * @param authAcct authUser account
+     * @param authTokenn authToken.
+     * @return true/false
+     * @throws ServiceException s
+     */
+    public static boolean isMessageSentUsingPersona(String identityId, Account authAcct, AuthToken authToken) throws ServiceException {
+        if (identityId != null) {
+            Identity identity = Provisioning.getInstance().get(authAcct, Key.IdentityBy.id, identityId);
+            if (identity != null) {
+                String fromAddrPrefType =  identity.getAccount().getPrefFromAddressTypeAsString();
+                String fromAddrPrefValue   = identity.getAccount().getPrefFromAddress();
+                if (!StringUtil.isNullOrEmpty(fromAddrPrefType) && !authToken.isAdmin()
+                        && !authAcct.isAllowAnyFromAddress()
+                        && (fromAddrPrefType.equals(RightConsts.RT_sendAs) || fromAddrPrefType.equals(RightConsts.RT_sendOnBehalfOf))
+                        && !StringUtil.isNullOrEmpty(fromAddrPrefValue) && !authAcct.getMail().equals(fromAddrPrefValue)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 }
-    

--- a/store/src/java/com/zimbra/soap/SoapEngine.java
+++ b/store/src/java/com/zimbra/soap/SoapEngine.java
@@ -326,7 +326,11 @@ public class SoapEngine {
         ZimbraSoapContext zsc = null;
         Element ectxt = soapProto.getHeader(envelope, HeaderConstants.CONTEXT);
         try {
-            zsc = new ZimbraSoapContext(ectxt, doc.getQName(), handler, context, soapProto);
+            if (doc.getName().equals(MailConstants.E_SEND_MSG_REQUEST)) {
+                zsc = new ZimbraSoapContext(ectxt, doc.getQName(), handler, context, soapProto, doc);
+            } else {
+                zsc = new ZimbraSoapContext(ectxt, doc.getQName(), handler, context, soapProto);
+            }
         } catch (ServiceException e) {
             return soapFaultEnv(soapProto, "unable to construct SOAP context", e);
         }


### PR DESCRIPTION
**Issue:**
- user A has given sendAs and SOB delegate rights to userB and userA has set the preference to `save Copy of sent messages to  my sent folder `. userB added a persona for userA and sends message using userA but the sent message is not saved to userA's sent folder.

- Problem here is that in case fo sendAs and SOB the context header always contains userA and the server identifies the target account and mailbox and process accordingly. But in case of Persona the context header contains userB and  the server identifies that it has to perform on userB's account and mailbox for which it always stores the sent message to userB's sent folder.

- Also the there is difference in request for sendAs, SOB and persona.

**Approach and Fix:**
- added an overloaded constructor for ZimbraSoapContext which will accept soap request body and in case of sendMsgRequest it will call the overloaded constructor and parse the request from body to get the from address.
- check if from address is different from the context header email address and based on this set the target account.
- In case of sendAs and SOB the draftId always contains authuser account id appended with item id but in case of persona it only contains the item id. So added a check for that and append the auth user account id with draft item id.
- the behaviour is same in case of attachments so added the check to prevent errors.

**Test:**
- Tested email send is working and with attachments as well with persona and the sent message is saved to userA's sent folder based on the userA's preference. there are below 4 options
    - save copy of sent messages to my sent folder
    - save copy of sent messages to delegate's sent folder.
    - save copy of sent messages to delegate's sent folder and my Sent folder
    - Don't save a copy of sent messages.
- Tested forward, reply, replyAll is working and with attachments as well using persona account.
- Tested by setting `zimbraAllowFromAnyAddress = TRUE` on userB's account.
- Tested email send is working from draft.

**Testing to be done by QA:**
- Sanity test of send Message request.
- Test send message with attachments.
- Test forward, reply, replyAll with attachments as well.
- Test send message from draft.
- Test by setting `zimbraAllowFromAnyAddress = TRUE` on userB's account.
- Test that nothing is broken.
- Ensure that there is no regression.

Test all the scenario by sending from primary account, sendAs, SOB and by using persona account.