### PR TITLE
ZCS-9288:Incorrect content type is displaying for xls and xlsx file type

### DIFF
--- a/store/src/java/com/zimbra/cs/service/FileUploadServlet.java
+++ b/store/src/java/com/zimbra/cs/service/FileUploadServlet.java
@@ -156,7 +156,11 @@ public class FileUploadServlet extends ZimbraServlet {
                 }
 
                 // 2. detect by file extension
-                if (contentType == null) {
+                // .xls and .docx files can contain beginning characters
+                // resembling to x-ole-storage/zip. Hence,
+                // check by file extension
+                if (contentType == null || contentType.equals("application/x-ole-storage")
+                    || contentType.equals("application/zip")) {
                     contentType = MimeDetect.getMimeDetect().detect(name);
                 }
 


### PR DESCRIPTION
Issue:
When uploading .xls file, the content type of uploaded file was incorrectly being set to application/x-ole-storage

Cause:
The beginning characters of .xls and .docx files resemble to files with content type application/x-ole-storage and application/zip

Fix:
If mime magic returns these content types check by the file extension 

Testing done:
Tested with following file types:
zip, zipx, xls, xlsx, doc, docx, ppt, pptx, 7z, rar, tar, tar.gz