### PR TITLE
zbug-903:Problem with 'send as' delegate rights and 'Save a copy of sent messages to my Sent folder

### DIFF
--- a/store/src/java/com/zimbra/cs/service/mail/SendMsg.java
+++ b/store/src/java/com/zimbra/cs/service/mail/SendMsg.java
@@ -142,7 +142,7 @@ public class SendMsg extends MailDocumentHandler {
                // As the draft is always part of authUser's context, append the authUser accountId with draftId
                // so that the draft will be deleted when message will be sent successfully in case of persona.
                // Because in case of sendAs and sendOnBehalfOf the draftId pattern is accountId:itemId.
-               if (AccountUtil.isMessageSentUsingPersona(identityId, authAcct, authToken)) {
+               if (AccountUtil.isMessageSentUsingOwnersPersona(identityId, authAcct, authToken)) {
                    if(draftId != null && draftId.indexOf(ItemIdentifier.ACCOUNT_DELIMITER) == -1) {
                        draftId = authAcct.getId() + ItemIdentifier.ACCOUNT_DELIMITER + draftId;
                    }

--- a/store/src/java/com/zimbra/cs/util/AccountUtil.java
+++ b/store/src/java/com/zimbra/cs/util/AccountUtil.java
@@ -899,16 +899,18 @@ public class AccountUtil {
      * @return true/false
      * @throws ServiceException s
      */
-    public static boolean isMessageSentUsingPersona(String identityId, Account authAcct, AuthToken authToken) throws ServiceException {
+    public static boolean isMessageSentUsingOwnersPersona(String identityId, Account authAcct, AuthToken authToken) throws ServiceException {
         if (identityId != null) {
             Identity identity = Provisioning.getInstance().get(authAcct, Key.IdentityBy.id, identityId);
-            if (identity != null) {
-                String fromAddrPrefType =  identity.getAccount().getPrefFromAddressTypeAsString();
-                String fromAddrPrefValue   = identity.getAccount().getPrefFromAddress();
-                if (!StringUtil.isNullOrEmpty(fromAddrPrefType) && !authToken.isAdmin()
-                        && !authAcct.isAllowAnyFromAddress()
-                        && (fromAddrPrefType.equals(RightConsts.RT_sendAs) || fromAddrPrefType.equals(RightConsts.RT_sendOnBehalfOf))
-                        && !StringUtil.isNullOrEmpty(fromAddrPrefValue) && !authAcct.getMail().equals(fromAddrPrefValue)) {
+            Identity defaultIdentity = Provisioning.getInstance().getDefaultIdentity(authAcct);
+            if (identity != null && defaultIdentity != null && !defaultIdentity.getId().equals(identity.getId())) {
+                String fromAddrPrefType = identity.getAttr(Provisioning.A_zimbraPrefFromAddressType, null);
+                String fromAddrPrefValue = identity.getAttr(Provisioning.A_zimbraPrefFromAddress, null);
+                if (!StringUtil.isNullOrEmpty(fromAddrPrefType) && !StringUtil.isNullOrEmpty(fromAddrPrefValue)
+                        && !authToken.isAdmin() && !authAcct.isAllowAnyFromAddress()
+                        && !authAcct.getMail().equals(fromAddrPrefValue)
+                        && (fromAddrPrefType.equals(RightConsts.RT_sendAs)
+                                || fromAddrPrefType.equals(RightConsts.RT_sendOnBehalfOf))) {
                     return true;
                 }
             }

--- a/store/src/java/com/zimbra/soap/ZimbraSoapContext.java
+++ b/store/src/java/com/zimbra/soap/ZimbraSoapContext.java
@@ -415,6 +415,30 @@ public final class ZimbraSoapContext {
             }
 
             mMountpointTraversed = eAccount.getAttributeBool(HeaderConstants.A_MOUNTPOINT, false);
+        } else if (body != null && requestName.equals(MailConstants.SEND_MSG_REQUEST)) {
+            // To handle SendMsgRequest sent using zmsoap command where header does not exists.
+            // Check if from Address is not equal to auth user email address then set `mRequestedAccountId`
+            // as the from address accountId.
+            if (mAuthToken == null) {
+                throw ServiceException.AUTH_REQUIRED();
+            }
+            Account authAccount = mAuthToken.getAccount();
+            String fromAddress = AccountUtil.extractFromAddress(body);
+            String identityId = body.getElement(MailConstants.E_MSG).getAttribute(MailConstants.A_IDENTITY_ID, null);
+            if (!StringUtil.isNullOrEmpty(fromAddress) && AccountUtil.isMessageSentUsingOwnersPersona(identityId, authAccount, mAuthToken)) {
+                Account account = prov.get(AccountBy.name, fromAddress, mAuthToken);
+                if (account == null) {
+                    if (!mAuthToken.isAdmin()) {
+                        throw ServiceException.DEFEND_ACCOUNT_HARVEST(fromAddress);
+                    } else {
+                        throw AccountServiceException.NO_SUCH_ACCOUNT(fromAddress);
+                    }
+                }
+                if (!account.getId().equals(authAccount.getId())) {
+                    mRequestedAccountId = account.getId();
+                    validateDelegatedAccess(account, handler, requestName, fromAddress);
+                }
+            }
         } else {
             mRequestedAccountId = null;
         }


### PR DESCRIPTION
Issue:
Draft is not getting deleted when message is send using persona account and draft folder is count is getting increased.

Fix:
- renamed method `isMessageSentUsingPersona` to `isMessageSentUsingOwnersPersona`.
- `AccountUtil.isMessageSentUsingOwnersPersona()` method was always returning false because `fromAddrPrefType` and `fromAddrPrefValue` value is always null as these are the properties set on identity. updated the method to get the values from identity.
- The above modification is required because in case of `sendAs and SOB` sendMsg request contains draft id which is always appended with auth user account id but in case of persona it is only the item id because of which it was not getting deleted.

Test:
Tested that all functionality is working fine and drafts are getting deleted after message is successfully sent.