### PR TITLE
ZCS-9483 rework the fix for ZBUG-903

### DIFF
--- a/store/src/java/com/zimbra/cs/util/AccountUtil.java
+++ b/store/src/java/com/zimbra/cs/util/AccountUtil.java
@@ -43,6 +43,7 @@ import org.apache.commons.codec.binary.Hex;
 
 import com.sun.mail.smtp.SMTPMessage;
 import com.zimbra.common.account.Key;
+import com.zimbra.common.account.Key.AccountBy;
 import com.zimbra.common.account.Key.DomainBy;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.mime.MimeConstants;
@@ -61,7 +62,6 @@ import com.zimbra.common.zmime.ZMimeMultipart;
 import com.zimbra.cs.account.AccessManager;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.AccountServiceException.AuthFailedServiceException;
-import com.zimbra.cs.account.accesscontrol.generated.RightConsts;
 import com.zimbra.cs.account.AuthToken;
 import com.zimbra.cs.account.DataSource;
 import com.zimbra.cs.account.Domain;
@@ -71,6 +71,7 @@ import com.zimbra.cs.account.NamedEntry;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.Server;
 import com.zimbra.cs.account.TokenUtil;
+import com.zimbra.cs.account.accesscontrol.generated.RightConsts;
 import com.zimbra.cs.mailbox.MailItem;
 import com.zimbra.cs.mailbox.MailServiceException;
 import com.zimbra.cs.mailbox.Mailbox;
@@ -862,7 +863,7 @@ public class AccountUtil {
     }
 
     /**
-     * 
+     *
      * @param acct
      * @return SMTPMessage object
      * @throws ServiceException
@@ -918,14 +919,22 @@ public class AccountUtil {
         return false;
     }
 
-    public static boolean isDataSourceAddress(Account account, String fromEmailAddress) throws ServiceException {
-        List<DataSource> dsList = account.getAllDataSources();
-        for (DataSource ds : dsList) {
-            if (ds.getEmailAddress().equals(fromEmailAddress) && (ds.getType().equals(DataSourceType.imap) ||
-                    ds.getType().equals(DataSourceType.pop3))) {
-                return true;
+    /**
+     * @param fromAddress
+     * @param account
+     * @return
+     * @throws ServiceException
+     */
+    public static Account getAccountForFromAddress(String fromAddress, Account account) throws ServiceException {
+        List<Identity> identityList = Provisioning.getInstance().getAllIdentities(account);
+
+        for (Identity identity: identityList) {
+            String idEmailAddress = identity.getAttr("zimbraPrefFromAddress", null);
+            if (idEmailAddress != null && idEmailAddress.equalsIgnoreCase(fromAddress) ) {
+                Account  delgAcct  = Provisioning.getInstance().get(AccountBy.name, fromAddress);
+                return delgAcct
             }
         }
-        return false;
+        return null;
     }
 }

--- a/store/src/java/com/zimbra/soap/ZimbraSoapContext.java
+++ b/store/src/java/com/zimbra/soap/ZimbraSoapContext.java
@@ -294,7 +294,7 @@ public final class ZimbraSoapContext {
     public ZimbraSoapContext(Element ctxt, QName requestName, DocumentHandler handler, Map<String, Object> context,
             SoapProtocol requestProtocol, Element body) throws ServiceException {
 
-        if (ctxt != null && !ctxt.getQName().equals(HeaderConstants.CONTEXT))
+       if (ctxt != null && !ctxt.getQName().equals(HeaderConstants.CONTEXT))
             throw new IllegalArgumentException("expected ctxt, got: " + ctxt.getQualifiedName());
 
         Provisioning prov = Provisioning.getInstance();
@@ -363,45 +363,35 @@ public final class ZimbraSoapContext {
                     throw ServiceException.AUTH_REQUIRED();
                 }
                 Account account = prov.get(AccountBy.name, value, mAuthToken);
+                if (account == null) {
+                    if (!mAuthToken.isAdmin()) {
+                        throw ServiceException.DEFEND_ACCOUNT_HARVEST(value);
+                    } else {
+                        throw AccountServiceException.NO_SUCH_ACCOUNT(value);
+                    }
+                }
+
                 // Overriding the value for sendMsgRequest if the account in header is not equal to the from address.
                 // Because in case of Persona(added for the owner's account), the account passed in header is not equal to from address.
                 // if zimbraAllowAnyFromAddress = TRUE for delegate's account then we can create Persona with any email address and the
                 // from address could be different in this case.
                 if (body != null && requestName.equals(MailConstants.SEND_MSG_REQUEST)) {
+                   Account delegatedAccount = null;
                    String fromAddress = AccountUtil.extractFromAddress(body);
-                   if (!StringUtil.isNullOrEmpty(fromAddress) && !AccountUtil.isDataSourceAddress(account, fromAddress)) {
-                       if (!value.equals(fromAddress) && !account.getBooleanAttr(Provisioning.A_zimbraAllowAnyFromAddress, false)) {
-                           value = fromAddress;
-                           account = prov.get(AccountBy.name, value, mAuthToken);
-                       }
+                   delegatedAccount = AccountUtil.getAccountForFromAddress(fromAddress, account);
+                   if (delegatedAccount != null) {
+                       account  = delegatedAccount;
+                       value  = fromAddress;
                    }
                 }
-                if (account == null) {
-                    if (!mAuthToken.isAdmin()) {
-                        throw ServiceException.DEFEND_ACCOUNT_HARVEST(value);
-                    } else {
-                        throw AccountServiceException.NO_SUCH_ACCOUNT(value);
-                    }
-                }
-
-                mRequestedAccountId = account.getId();
                 validateDelegatedAccess(account, handler, requestName, value);
+                mRequestedAccountId = account.getId();
+
             } else if (key.equals(HeaderConstants.BY_ID)) {
                 if (mAuthToken == null) {
                     throw ServiceException.AUTH_REQUIRED();
                 }
                 Account account = prov.get(AccountBy.id, value, mAuthToken);
-                if (body != null && requestName.equals(MailConstants.SEND_MSG_REQUEST)) {
-                    String fromAddress = AccountUtil.extractFromAddress(body);
-                    if (!StringUtil.isNullOrEmpty(fromAddress) && !AccountUtil.isDataSourceAddress(account, fromAddress) &&
-                            !account.getBooleanAttr(Provisioning.A_zimbraAllowAnyFromAddress, false)) {
-                        Account fromAccount = prov.get(AccountBy.name, fromAddress, mAuthToken);
-                        if(!value.equals(fromAccount.getId())) {
-                            value = fromAccount.getId();
-                            account = prov.get(AccountBy.id, value, mAuthToken);
-                        }
-                    }
-                }
                 if (account == null) {
                     if (!mAuthToken.isAdmin()) {
                         throw ServiceException.DEFEND_ACCOUNT_HARVEST(value);
@@ -409,8 +399,17 @@ public final class ZimbraSoapContext {
                         throw AccountServiceException.NO_SUCH_ACCOUNT(value);
                     }
                 }
+                if (body != null && requestName.equals(MailConstants.SEND_MSG_REQUEST)) {
+                    Account delegatedAccount = null;
+                    String fromAddress = AccountUtil.extractFromAddress(body);
+                    delegatedAccount = AccountUtil.getAccountForFromAddress(fromAddress, account);
+                    if (delegatedAccount != null) {
+                        account  = delegatedAccount;
+                        value  = fromAddress;
+                    }
+                }
 
-                mRequestedAccountId = value;
+                mRequestedAccountId = account.getId();
                 validateDelegatedAccess(account, handler, requestName, value);
             } else {
                 throw ServiceException.INVALID_REQUEST("unknown value for by: " + key, null);
@@ -428,7 +427,7 @@ public final class ZimbraSoapContext {
             mRequestedAccountId = authAccount.getId();
             String fromAddress = AccountUtil.extractFromAddress(body);
             String identityId = body.getElement(MailConstants.E_MSG).getAttribute(MailConstants.A_IDENTITY_ID, null);
-            if (!StringUtil.isNullOrEmpty(fromAddress) && !AccountUtil.isDataSourceAddress(authAccount, fromAddress) &&
+            if (!StringUtil.isNullOrEmpty(fromAddress) &&
                     AccountUtil.isMessageSentUsingOwnersPersona(identityId, authAccount, mAuthToken)) {
                 Account account = prov.get(AccountBy.name, fromAddress, mAuthToken);
                 if (account == null) {


### PR DESCRIPTION
reworked the fix for 903.
If the from address is an external account or a delegated  DL the account is going to be null.
Hence iterate through the identities  for the  account and if we find the from address  in  the Identity, try to  get the account.
If the account is non null then assign the requested Account to this.

removed the datasource code
Tested all the scenarios in 903, ZBUG-1659, 9483
