### PR TITLE
ZCS-9569 Add support for dry runn in ChangePassword

### DIFF
--- a/common/src/java-test/com/zimbra/common/util/UnmodifiableBloomFilterTest.java
+++ b/common/src/java-test/com/zimbra/common/util/UnmodifiableBloomFilterTest.java
@@ -20,12 +20,20 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.MethodRule;
+import org.junit.rules.TestName;
+
+import com.zimbra.cs.util.ZTestWatchman;
 
 public class UnmodifiableBloomFilterTest {
 
-    protected UnmodifiableBloomFilter<String> bloomFilter = UnmodifiableBloomFilter
-        .createFilterFromFile("src/java-test/common-passwords.txt");
+    @Rule public TestName testName = new TestName();
+    @Rule public MethodRule watchman = new ZTestWatchman();
+    protected static UnmodifiableBloomFilter<String> bloomFilter  =  UnmodifiableBloomFilter
+        .createFilterFromFile("common/src/java-test/common-passwords.txt");
+
 
     @Before
     public void setUp() {
@@ -79,7 +87,7 @@ public class UnmodifiableBloomFilterTest {
     @Test
     public void testMightContainLazyLoad() {
         UnmodifiableBloomFilter<String> lazyFilter = UnmodifiableBloomFilter
-            .createLazyFilterFromFile("src/java-test/common-passwords.txt");
+            .createLazyFilterFromFile("common/src/java-test/common-passwords.txt");
         // expect to initialize on demand
         assertFalse(lazyFilter.isInitialized());
         assertFalse(lazyFilter.isDisabled());

--- a/common/src/java/com/zimbra/common/soap/AccountConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AccountConstants.java
@@ -324,13 +324,13 @@ public class AccountConstants {
     public static final QName GET_OAUTH_CONSUMERS_RESPONSE = QName.get(E_GET_OAUTH_CONSUMERS_RESPONSE, NAMESPACE);
     public static final QName REVOKE_OAUTH_CONSUMER_REQUEST = QName.get(E_REVOKE_OAUTH_CONSUMER_REQUEST, NAMESPACE);
     public static final QName REVOKE_OAUTH_CONSUMER_RESPONSE = QName.get(E_REVOKE_OAUTH_CONSUMER_RESPONSE, NAMESPACE);
-    
+
     //HAB
     public static final String E_GET_HAB_REQUEST = "GetHABRequest";
     public static final String E_GET_HAB_RESPONSE = "GetHABResponse";
     public static final QName GET_HAB_REQUEST = QName.get( E_GET_HAB_REQUEST, NAMESPACE);
     public static final QName GET_HAB_RESPONSE = QName.get(E_GET_HAB_RESPONSE, NAMESPACE);
-    
+
     public static final QName GET_ADDRESS_LIST_MEMBERS_REQUEST = QName.get(E_GET_ADDRESS_LIST_MEMBERS_REQUEST, NAMESPACE);
     public static final QName GET_ADDRESS_LIST_MEMBERS_RESPONSE = QName.get(E_GET_ADDRESS_LIST_MEMBERS_RESPONSE, NAMESPACE);
 
@@ -421,6 +421,7 @@ public class AccountConstants {
     public static final String E_BOSH_URL = "boshURL";
     public static final String E_SUBSCRIPTION = "sub";
     public static final String E_IS_TRACKING_IMAP = "isTrackingIMAP";
+    public static final String E_DRYRUN = "dryRun";
 
     public static final String A_ACTIVE = "active";
     public static final String A_ATTRS = "attrs";
@@ -594,7 +595,7 @@ public class AccountConstants {
     public static final String A_CONSUMER_APP_NAME = "appName";
     public static final String A_APPROVED_ON = "approvedOn";
     public static final String A_CONSUMER_DEVICE = "device";
-    
+
     //ext user prov URL metadata constants
     public static final String P_ACCOUNT_ID = "aid";
     public static final String P_FOLDER_ID = "fid";

--- a/soap/src/java/com/zimbra/soap/account/message/ChangePasswordRequest.java
+++ b/soap/src/java/com/zimbra/soap/account/message/ChangePasswordRequest.java
@@ -64,37 +64,59 @@ public class ChangePasswordRequest {
     @XmlElement(name=AccountConstants.E_VIRTUAL_HOST, required=false)
     private String virtualHost;
 
+    @XmlElement(name=AccountConstants.E_DRYRUN, required=false)
+    private boolean dryRun;
+
     public ChangePasswordRequest() {
     }
-    
+
     public ChangePasswordRequest(AccountSelector account, String oldPassword, String newPassword) {
         setAccount(account);
         setOldPassword(oldPassword);
         setPassword(newPassword);
     }
-    
+
+    public ChangePasswordRequest(AccountSelector account, String oldPassword, String newPassword, boolean dryRun) {
+        setAccount(account);
+        setOldPassword(oldPassword);
+        setPassword(newPassword);
+        setDryRun(dryRun);
+    }
+
     public AccountSelector getAccount() { return account; }
     public String oldPassword() { return oldPassword; }
     public String getPassword() { return password; }
     public String getVirtualHost() { return virtualHost; }
-    
+
     public ChangePasswordRequest setAccount(AccountSelector account) {
         this.account = account;
         return this;
     }
-    
+
     public ChangePasswordRequest setOldPassword(String oldPassword) {
         this.oldPassword = oldPassword;
         return this;
     }
-    
+
     public ChangePasswordRequest setPassword(String password) {
         this.password = password;
         return this;
     }
-    
+
     public ChangePasswordRequest setVirtualHost(String host) {
         virtualHost = host;
         return this;
     }
+
+
+    public boolean isDryRun() {
+        return dryRun;
+    }
+
+
+    public void setDryRun(boolean dryRun) {
+        this.dryRun = dryRun;
+    }
+
+
 }

--- a/store/src/java-test/com/zimbra/cs/account/MockProvisioning.java
+++ b/store/src/java-test/com/zimbra/cs/account/MockProvisioning.java
@@ -32,8 +32,8 @@ import com.zimbra.common.account.Key.AccountBy;
 import com.zimbra.common.account.Key.AlwaysOnClusterBy;
 import com.zimbra.common.account.Key.ShareLocatorBy;
 import com.zimbra.common.account.Key.UCServiceBy;
-import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.account.ProvisioningConstants;
+import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.mime.MimeConstants;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.StringUtil;
@@ -931,7 +931,7 @@ public final class MockProvisioning extends Provisioning {
     @Override
     public void deleteHabOrgUnit(Domain domain, String habOrgUnitName) throws ServiceException {
         // TODO Auto-generated method stub
-        
+
     }
 
     @Override
@@ -943,5 +943,12 @@ public final class MockProvisioning extends Provisioning {
     public Set<String> listHabOrgUnit(Domain domain) throws ServiceException {
         // TODO Auto-generated method stub
         return null;
+    }
+
+    @Override
+    public void changePassword(Account acct, String currentPassword, String newPassword,
+        boolean dryRun) throws ServiceException {
+        // TODO Auto-generated method stub
+
     }
 }

--- a/store/src/java/com/zimbra/cs/account/Provisioning.java
+++ b/store/src/java/com/zimbra/cs/account/Provisioning.java
@@ -56,8 +56,8 @@ import com.zimbra.cs.ldap.ZLdapFilterFactory.FilterId;
 import com.zimbra.cs.mime.MimeTypeInfo;
 import com.zimbra.cs.util.AccountUtil;
 import com.zimbra.cs.util.Zimbra;
-import com.zimbra.soap.account.type.HABGroupMember;
 import com.zimbra.soap.account.type.AddressListInfo;
+import com.zimbra.soap.account.type.HABGroupMember;
 import com.zimbra.soap.admin.type.CacheEntryType;
 import com.zimbra.soap.admin.type.CmdRightsInfo;
 import com.zimbra.soap.admin.type.CountObjectsType;
@@ -279,7 +279,7 @@ public abstract class Provisioning extends ZAttrProvisioning {
 
     /** do not fixup return attrs for searchObject, onlt used from LdapUpgrade */
     public static final int SO_NO_FIXUP_RETURNATTRS = 0x400;
-    
+
     /** return distribution lists from searchAccounts/searchDirectory */
     public static final int SD_HAB_FLAG = 0x12;
 
@@ -1278,6 +1278,7 @@ public abstract class Provisioning extends ZAttrProvisioning {
     throws ServiceException;
 
     public abstract void changePassword(Account acct, String currentPassword, String newPassword) throws ServiceException;
+    public abstract void changePassword(Account acct, String currentPassword, String newPassword,  boolean dryRun) throws ServiceException;
 
     public static class SetPasswordResult {
         private String msg;
@@ -2373,7 +2374,7 @@ public abstract class Provisioning extends ZAttrProvisioning {
     public abstract List<XMPPComponent> getAllXMPPComponents() throws ServiceException;
 
     public abstract void deleteXMPPComponent(XMPPComponent comp) throws ServiceException;
-    
+
     public abstract Set<String> createHabOrgUnit(Domain domain, String habOrgUnitName) throws ServiceException;
     public abstract Set<String> listHabOrgUnit(Domain domain) throws ServiceException;
     public abstract Set<String> renameHabOrgUnit(Domain domain, String habOrgUnitName, String newHabOrgUnitName) throws ServiceException;
@@ -2709,7 +2710,7 @@ public abstract class Provisioning extends ZAttrProvisioning {
     public void removeConfigSMIMEConfig(String configName) throws ServiceException {
         throw ServiceException.UNSUPPORTED();
     }
-    
+
     public AddressList getAddressList(String id) throws ServiceException {
         throw ServiceException.UNSUPPORTED();
     }
@@ -2717,7 +2718,7 @@ public abstract class Provisioning extends ZAttrProvisioning {
     public AddressListInfo getAddressListByName(String name, Domain domain) throws ServiceException {
         throw ServiceException.UNSUPPORTED();
     }
-    
+
 
     public List<AddressListInfo> getAllAddressLists(Domain domain, boolean activeOnly) throws ServiceException {
         throw ServiceException.UNSUPPORTED();
@@ -2757,7 +2758,7 @@ public abstract class Provisioning extends ZAttrProvisioning {
 
     /**
      * @param domain
-     * @param rootDn 
+     * @param rootDn
      * @return
      */
     public List<LdapDistributionList> getAllHabGroups(Domain domain, String rootDn) throws ServiceException {

--- a/store/src/java/com/zimbra/cs/account/soap/SoapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/soap/SoapProvisioning.java
@@ -865,6 +865,14 @@ public class SoapProvisioning extends Provisioning {
     }
 
     @Override
+    public void changePassword(Account acct, String currentPassword,
+        String newPassword, boolean dryRun) throws ServiceException {
+        com.zimbra.soap.type.AccountSelector jaxbAcct =
+            new com.zimbra.soap.type.AccountSelector(com.zimbra.soap.type.AccountBy.name, acct.getName());
+        invokeJaxb(new ChangePasswordRequest(jaxbAcct, currentPassword, newPassword, dryRun));
+    }
+
+    @Override
     public Account createAccount(String emailAddress, String password, Map<String, Object> attrs)
         throws ServiceException
     {
@@ -3160,7 +3168,7 @@ public class SoapProvisioning extends Provisioning {
     }
 
     /**
-     * 
+     *
      * @param rootHabGroupId the group for which HAB is required
      * @return GetHabResponse object
      * @throws ServiceException if an error occurs while fetching hierarchy from ldap
@@ -3173,7 +3181,7 @@ public class SoapProvisioning extends Provisioning {
     }
 
     /**
-     * 
+     *
      * @param habGroupId HAB group to be moved
      * @param currentParentGroupId current HAB parent id
      * @param targetParentGroupId target parent id
@@ -3187,7 +3195,7 @@ public class SoapProvisioning extends Provisioning {
     }
 
     /**
-     * 
+     *
      * @param habGroupId HAB group to be modified
      * @param seniorityIndex seniority index
      * @throws ServiceException if an error occurs while modifying the HAB group
@@ -3201,10 +3209,11 @@ public class SoapProvisioning extends Provisioning {
     }
 
     /**
-     * 
+     *
      * @param group HAB group whose members will be returned
      * @throws ServiceException if an error occurs while getting the HAB group members
      */
+    @Override
     public List<HABGroupMember> getHABGroupMembers(Group group) throws ServiceException {
         GetDistributionListMembersResponse resp = invokeJaxb(new GetDistributionListMembersRequest(0, 0, group.getName()));
         return resp.getHABGroupMembers();

--- a/store/src/java/com/zimbra/cs/service/account/ChangePassword.java
+++ b/store/src/java/com/zimbra/cs/service/account/ChangePassword.java
@@ -20,6 +20,10 @@
  */
 package com.zimbra.cs.service.account;
 
+import java.util.Map;
+
+import com.zimbra.common.account.Key;
+import com.zimbra.common.account.Key.AccountBy;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AccountConstants;
 import com.zimbra.common.soap.Element;
@@ -30,44 +34,52 @@ import com.zimbra.cs.account.AccountServiceException.AuthFailedServiceException;
 import com.zimbra.cs.account.AuthToken;
 import com.zimbra.cs.account.Domain;
 import com.zimbra.cs.account.Provisioning;
-import com.zimbra.common.account.Key;
-import com.zimbra.common.account.Key.AccountBy;
 import com.zimbra.cs.service.AuthProvider;
 import com.zimbra.soap.ZimbraSoapContext;
-
-import java.util.Map;
 
 /**
  * @author dkarp
  */
 public class ChangePassword extends AccountDocumentHandler {
 
-	public Element handle(Element request, Map<String, Object> context) throws ServiceException {
-	    
+	@Override
+    public Element handle(Element request, Map<String, Object> context) throws ServiceException {
+
 	    if (!checkPasswordSecurity(context))
             throw ServiceException.INVALID_REQUEST("clear text password is not allowed", null);
-	    
+
         ZimbraSoapContext zsc = getZimbraSoapContext(context);
         Provisioning prov = Provisioning.getInstance();
-        
+
         String namePassedIn = request.getAttribute(AccountConstants.E_ACCOUNT);
         String name = namePassedIn;
-        
+
         Element virtualHostEl = request.getOptionalElement(AccountConstants.E_VIRTUAL_HOST);
         String virtualHost = virtualHostEl == null ? null : virtualHostEl.getText().toLowerCase();
-        
+
         if (virtualHost != null && name.indexOf('@') == -1) {
             Domain d = prov.get(Key.DomainBy.virtualHostname, virtualHost);
             if (d != null)
                 name = name + "@" + d.getName();
         }
-        
+
+        Element dryRunEl = request.getOptionalElement(AccountConstants.E_DRYRUN);
+        String text =  dryRunEl == null ? null : dryRunEl.getText();
+
+        boolean dryRun   = false;
+        if (!StringUtil.isNullOrEmpty(text)) {
+            if (text.equals("1") || text.equalsIgnoreCase("true")) {
+                dryRun = true;
+            }
+        }
+
+
         Account acct = prov.get(AccountBy.name, name, zsc.getAuthToken());
         if (acct == null)
             throw AuthFailedServiceException.AUTH_FAILED(name, namePassedIn, "account not found");
-        
-        // proxyIfNecessary is called by the SOAP framework only for 
-        // requests that require auth.  ChangePassword does not require 
+
+        // proxyIfNecessary is called by the SOAP framework only for
+        // requests that require auth.  ChangePassword does not require
         // an auth token.  Proxy here if this is not the home server of the account.
         if (!Provisioning.onLocalServer(acct)) {
             try {
@@ -82,7 +94,7 @@ public class ChangePassword extends AccountDocumentHandler {
                 }
             }
         }
-        
+
 		String oldPassword = request.getAttribute(AccountConstants.E_OLD_PASSWORD);
 		String newPassword = request.getAttribute(AccountConstants.E_PASSWORD);
         if (acct.isIsExternalVirtualAccount() && StringUtil.isNullOrEmpty(oldPassword)
@@ -92,7 +104,7 @@ public class ChangePassword extends AccountDocumentHandler {
             prov.setPassword(acct, newPassword, true);
             acct.setVirtualAccountInitialPasswordSet(true);
         } else {
-		    prov.changePassword(acct, oldPassword, newPassword);
+		    prov.changePassword(acct, oldPassword, newPassword, dryRun);
         }
         AuthToken at = AuthProvider.getAuthToken(acct);
 
@@ -102,6 +114,7 @@ public class ChangePassword extends AccountDocumentHandler {
         return response;
 	}
 
+    @Override
     public boolean needsAuth(Map<String, Object> context) {
         // This command can be sent before authenticating, so this method
         // should return false.  The Account.changePassword() method called

--- a/store/src/java/com/zimbra/cs/service/admin/ModifyCos.java
+++ b/store/src/java/com/zimbra/cs/service/admin/ModifyCos.java
@@ -40,34 +40,37 @@ import com.zimbra.soap.ZimbraSoapContext;
  */
 public class ModifyCos extends AdminDocumentHandler {
 
-	public Element handle(Element request, Map<String, Object> context) throws ServiceException {
+	@Override
+    public Element handle(Element request, Map<String, Object> context) throws ServiceException {
 
         ZimbraSoapContext zsc = getZimbraSoapContext(context);
 	    Provisioning prov = Provisioning.getInstance();
 
 	    String id = request.getElement(AdminConstants.E_ID).getText();
 	    Map<String, Object> attrs = AdminService.getAttrs(request);
-	    
+
+	    attrs.remove("zimbraPasswordBlockCommonEnabled", attrs.get("zimbraPasswordBlockCommonEnabled"));
+
 	    Cos cos = prov.get(Key.CosBy.id, id);
         if (cos == null)
             throw AccountServiceException.NO_SUCH_COS(id);
-        
+
         checkRight(zsc, context, cos, attrs);
-        
+
         // pass in true to checkImmutable
         prov.modifyAttrs(cos, attrs, true);
 
         ZimbraLog.security.info(ZimbraLog.encodeAttrs(
                 new String[] {"cmd", "ModifyCos","name", cos.getName()}, attrs));
-        
+
 	    Element response = zsc.createElement(AdminConstants.MODIFY_COS_RESPONSE);
 	    GetCos.encodeCos(response, cos);
 	    return response;
 	}
-	
+
     @Override
     public void docRights(List<AdminRight> relatedRights, List<String> notes) {
-        notes.add(String.format(AdminRightCheckPoint.Notes.MODIFY_ENTRY, 
+        notes.add(String.format(AdminRightCheckPoint.Notes.MODIFY_ENTRY,
                 Admin.R_modifyCos.getName(), "cos"));
     }
 


### PR DESCRIPTION
Added support for dryrun in ChangePasswordRequest. Please  refer to the Jira ticket for req/resp.
Tested by setting up password rules and then try  to change password.
Checked valid failure message is returned when password rule is not followed or a common password is used.

Had to modify ModifyCos as the the Admin console  sends request with attribute zimbraPasswordBlockCommonEnabled but this is not supported in Zimbra 9.0 only in ZimbraX. Thisc  change  should have been made  when CommonPassword block code was ported from Zimbrax