### PR TITLE
ZCS-9569 Return  empty response for success  and dryrun=1

### DIFF
--- a/store/src/java/com/zimbra/cs/service/account/ChangePassword.java
+++ b/store/src/java/com/zimbra/cs/service/account/ChangePassword.java
@@ -109,8 +109,10 @@ public class ChangePassword extends AccountDocumentHandler {
         AuthToken at = AuthProvider.getAuthToken(acct);
 
         Element response = zsc.createElement(AccountConstants.CHANGE_PASSWORD_RESPONSE);
-        at.encodeAuthResp(response, false);
-        response.addAttribute(AccountConstants.E_LIFETIME, at.getExpires() - System.currentTimeMillis(), Element.Disposition.CONTENT);
+        if (!dryRun) { 
+           at.encodeAuthResp(response, false);
+           response.addAttribute(AccountConstants.E_LIFETIME, at.getExpires() - System.currentTimeMillis(), Element.Disposition.CONTENT);
+        }
         return response;
 	}
 

--- a/store/src/java/com/zimbra/cs/service/account/ChangePassword.java
+++ b/store/src/java/com/zimbra/cs/service/account/ChangePassword.java
@@ -106,10 +106,10 @@ public class ChangePassword extends AccountDocumentHandler {
         } else {
 		    prov.changePassword(acct, oldPassword, newPassword, dryRun);
         }
-        AuthToken at = AuthProvider.getAuthToken(acct);
 
         Element response = zsc.createElement(AccountConstants.CHANGE_PASSWORD_RESPONSE);
         if (!dryRun) { 
+           AuthToken at = AuthProvider.getAuthToken(acct);
            at.encodeAuthResp(response, false);
            response.addAttribute(AccountConstants.E_LIFETIME, at.getExpires() - System.currentTimeMillis(), Element.Disposition.CONTENT);
         }


### PR DESCRIPTION
When dryrun is true and new password is valid and satisfy the rules return an empty response.
Tested with dryrun true and dryrun  false