### PR TITLE
ZBUG-1555:Can not reset the Two factor setup (zimbraTwoFactorAuthSecret) from trusted device clients

### DIFF
--- a/store/src/java/com/zimbra/cs/service/admin/ModifyAccount.java
+++ b/store/src/java/com/zimbra/cs/service/admin/ModifyAccount.java
@@ -227,6 +227,20 @@ public class ModifyAccount extends AdminDocumentHandler {
         try {
             // pass in true to checkImmutable
             prov.modifyAttrs(account, attrs, true);
+
+            // If request is for `zimbraTwoFactorAuthEnabled = FALSE` and both zimbraFeatureTwoFactorAuthAvailable and zimbraFeatureTwoFactorAuthRequired is set to TRUE
+            // for the user, clear all the trusted devices so that the user would re-setup 2FA in the next login after LDAP updation is successful.
+            if (attrs.containsKey(Provisioning.A_zimbraTwoFactorAuthEnabled)) {
+                String value = (String) attrs.get(Provisioning.A_zimbraTwoFactorAuthEnabled);
+                if (!StringUtil.isNullOrEmpty(value) && value.equalsIgnoreCase("false") && account.isFeatureTwoFactorAuthAvailable() && account.isFeatureTwoFactorAuthRequired()) {
+                    String []trustedDevices = account.getTwoFactorAuthTrustedDevices();
+                    if (trustedDevices != null && trustedDevices.length > 0) {
+                        for (String encoded : trustedDevices) {
+                            account.removeTwoFactorAuthTrustedDevices(encoded);
+                        }
+                    }
+                }
+            }
         } catch (ServiceException se) {
             if (rollbackOnFailure) {
                 ZimbraLog.account.debug("Exception occured while modifying account in zimbra for %s, roll back listener updates.", account.getMail());


### PR DESCRIPTION
**Issue:**
Can not reset the Two factor setup from trusted device clients even though `zimbraTwoFactorAuthEnabled` is set to `FALSE`. For detailed information refer [ZBUG-1555](https://jira.corp.synacor.com/browse/ZBUG-1555). It is because the user has already added the client in to his/her trusted devices list and logging in from that same client.

**Approach & Fix:**
As a fix, tried existing functionality how it works and looking into all possibilities added the code in ModifyAccount.java. The newly added code block would look for the attribute `zimbraTwoFactorAuthEnabled` in the request and its value. If the attribute value is `false` and the value for other two attributes `zimbraFeatureTwoFactorAuthAvailable` and `zimbraFeatureTwoFactorAuthRequired` is set to `true`, it will reset all the values for  `zimbraTwoFactorAuthTrustedDevices` so that the user should re-setup 2fa in the next login.
So when the user will login next time he/she will be asked to re-setup the 2fa for his/her account.

**Test:**
- Tested all the existing 2fa functionality.
- Created account with `zimbraFeatureTwoFactorAuthAvailable` and `zimbraFeatureTwoFactorAuthRequired` is set to `true`. It asks for 2fa setup in the 1st login which is working as expected.
- After 2fa setup logged in with username and password and it asks for the TOTP, enter the TOTP and the user logs in without any issue.
- Log out the user and login again with selecting the checkbox which adds the client as a trusted devices. Then log out and login with username and password, it wont ask for the TOTP because the user is logging in from the trusted devices.
- When the user has already set up the 2fa for his/her account, the attribute `zimbraTwoFactorAuthEnabled` is already set to `TRUE` automatically.
- Now try to set the attribute `zimbraTwoFactorAuthEnabled` value to `FALSE` either from `zmprov` command or from the `Admin Console`. Logout the user and Login with username and password and it will ask for re-setup the 2fa. (this is the fix done for zbug-1555 which was not working before).
- Generated app specific password and configured account via IMAP in Thunderbird and via EWS in Outlook. Account are configured properly.

**Testing to be done by QA:**
Build and test from this bugfix branch.

- Test that nothing is broken after this change except the know bugs.
- Test that 2fa functionality is working as expected.
- Test that this fix is working as per the requirement.