### PR TITLE
ZBUG-1694 Fixing OOM error for large no.  of folders

### DIFF
--- a/store/src/java/com/zimbra/cs/imap/ImapMailboxStore.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapMailboxStore.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import com.google.common.collect.Lists;
 import com.zimbra.client.ZMailbox;
 import com.zimbra.client.ZSharedFolder;
 import com.zimbra.common.mailbox.FolderStore;
@@ -40,10 +39,9 @@ import com.zimbra.cs.mailbox.OperationContext;
 
 public abstract class ImapMailboxStore {
 
-    protected transient ImapFlagCache flags;
+    protected final static transient ImapFlagCache flags = ImapFlagCache.getSystemFlags();
 
     protected ImapMailboxStore() {
-        this.flags = ImapFlagCache.getSystemFlags();
     }
 
     public static ImapMailboxStore get(MailboxStore mbox) throws ServiceException {


### PR DESCRIPTION
When syncing large number of folders to Thunderbird, OutOfMemory error was observed.  Simulated the issue by reducing the heap space.
The SystemFlags variable was being initialized when loading each folder,  this is a static data and can be initialized only once. Made system flags a static variable. Tested with the same reduced heap space, no OOO memory error was observed.

