### PR TITLE
Bugfix/zbug 1694

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1441,6 +1441,8 @@ public final class LC {
 
     // enable blocking common passwords
     public static final KnownKey zimbra_block_common_passwords_enabled = KnownKey.newKey(false);
+ // enable blocking common passwords
+    public static final KnownKey zimbra_imap_folder_pagination_size =  KnownKey.newKey(2000);
 
     static {
         // Automatically set the key name with the variable name.

--- a/store/src/java/com/zimbra/cs/imap/ImapHandler.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapHandler.java
@@ -52,6 +52,7 @@ import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.zimbra.client.ZFolder;
 import com.zimbra.client.ZSharedFolder;
@@ -2152,17 +2153,20 @@ public abstract class ImapHandler {
 
         boolean selectRecursive = (selectOptions & SELECT_RECURSIVE) != 0;
 
+        int paginationSize = LC.zimbra_imap_folder_pagination_size.intValue();
         Map<ImapPath, Object> ownerMatches = new TreeMap<ImapPath, Object>();
         Map<ImapPath, Object> mountMatches = new TreeMap<ImapPath, Object>();
+        Map<ImapPath, ItemId> ownerPaths = new HashMap<ImapPath, ItemId>();
+        Map<ImapPath, ItemId> mountPaths = new HashMap<ImapPath, ItemId>();
+        Set<ImapPath> ownerSelected = new HashSet<ImapPath>();
+        Set<ImapPath> mountSelected = new HashSet<ImapPath>();
+        List<Pattern> patterns = new ArrayList<Pattern>(mailboxNames.size());
         try {
             if (returnSubscribed) {
                 remoteSubscriptions = credentials.listSubscriptions();
             }
-            Map<ImapPath, ItemId> ownerPaths = new HashMap<ImapPath, ItemId>();
-            Map<ImapPath, ItemId> mountPaths = new HashMap<ImapPath, ItemId>();
-            Set<ImapPath> ownerSelected = new HashSet<ImapPath>();
-            Set<ImapPath> mountSelected = new HashSet<ImapPath>();
-            List<Pattern> patterns = new ArrayList<Pattern>(mailboxNames.size());
+
+
 
             for (String mailboxName : mailboxNames) {
                 // RFC 5258 3: "In particular, if an extended LIST command has multiple mailbox
@@ -2229,41 +2233,84 @@ public abstract class ImapHandler {
                 }
             }
 
-            // return only the selected folders (and perhaps their parents) matching the pattern
-            // for owner folders
-            populateFoldersList(ownerPaths, ownerSelected, ownerMatches, returnOptions, remoteSubscriptions, patterns, command, status, selectRecursive, false);
-            // for shared(mounted) folders
-            populateFoldersList(mountPaths, mountSelected, mountMatches, returnOptions, remoteSubscriptions, patterns, command, status, selectRecursive, true);
+            if (ownerSelected.size() <= paginationSize) {
+                ZimbraLog.imap.info("Total folder count is less than folder pagination size.");
+                // return only the selected folders (and perhaps their parents) matching the pattern
+                // for owner folders
+                populateFoldersList(ownerPaths, ownerSelected, ownerMatches, returnOptions, remoteSubscriptions, patterns, command, status, selectRecursive, false);
+                // for shared(mounted) folders
+                populateFoldersList(mountPaths, mountSelected, mountMatches, returnOptions, remoteSubscriptions, patterns, command, status, selectRecursive, true);
+            }
         } catch (ServiceException e) {
             ZimbraLog.imap.warn(command + " failed", e);
             sendNO(tag, command + " failed");
             return canContinue(e);
         }
 
-        // send owners list first
-        if (!ownerMatches.isEmpty()) {
-            for (Object match : ownerMatches.values()) {
-                if (match instanceof String[]) {
-                    for (String response : (String[]) match) {
-                        sendUntagged(response);
-                    }
-                } else {
-                    sendUntagged((String) match);
-                }
-            }
-        }
+        if (ownerSelected.size() > paginationSize) {
+            try {
+              Iterable<List<ImapPath>> lists = Iterables.partition(ownerSelected, paginationSize);
+              for (List<ImapPath> listChunk: lists) {
 
-        // send shared(mounted) folders list
-        if (!mountMatches.isEmpty()) {
-            for (Object match : mountMatches.values()) {
-                if (match instanceof String[]) {
-                    for (String response : (String[]) match) {
-                        sendUntagged(response);
-                    }
-                } else {
-                    sendUntagged((String) match);
-                }
-            }
+                  Set<ImapPath> ownerSelectedChunk = new HashSet<ImapPath>();
+                  ownerSelectedChunk.addAll(listChunk);
+                  populateFoldersList(ownerPaths, ownerSelectedChunk, ownerMatches, returnOptions, remoteSubscriptions, patterns, command, status, selectRecursive, false);
+                  // send owners list first
+                  if (!ownerMatches.isEmpty()) {
+                      for (Object match : ownerMatches.values()) {
+                          if (match instanceof String[]) {
+                              for (String response : (String[]) match) {
+                                  sendUntagged(response);
+                              }
+                          } else {
+                              sendUntagged((String) match);
+                          }
+                      }
+                  }
+
+                  ownerSelectedChunk.clear();
+                  ownerMatches.clear();
+                  ownerSelectedChunk = null;
+                  ownerMatches = new TreeMap<ImapPath, Object>();
+              }
+          }  catch  (ServiceException e) {
+              ZimbraLog.imap.warn(command + " failed", e);
+              sendNO(tag, command + " failed");
+              return canContinue(e);
+          }
+
+          // send shared(mounted) folders list
+          try {
+              Iterable<List<ImapPath>> lists = Iterables.partition(mountSelected, paginationSize);
+
+              // send owners list first
+              for (List<ImapPath> listChunk: lists) {
+                  Set<ImapPath> mountSelectedChunk = new HashSet<ImapPath>();
+                  mountSelectedChunk.addAll(listChunk);
+                  populateFoldersList(mountPaths, mountSelectedChunk, mountMatches, returnOptions, remoteSubscriptions, patterns, command, status, selectRecursive, true);
+
+              // send shared(mounted) folders list
+                  if (!mountMatches.isEmpty()) {
+                      for (Object match : mountMatches.values()) {
+                          if (match instanceof String[]) {
+                              for (String response : (String[]) match) {
+                                  sendUntagged(response);
+                              }
+                          } else {
+                              sendUntagged((String) match);
+                          }
+                      }
+                  }
+                  mountSelected.clear();
+                  mountMatches.clear();
+                  mountSelected = null;
+                  mountMatches = new TreeMap<ImapPath, Object>();
+              }
+          }  catch (ServiceException e) {
+              ZimbraLog.imap.warn(command + " failed", e);
+              sendNO(tag, command + " failed");
+              return canContinue(e);
+          }
         }
 
         sendNotifications(true, false);

--- a/store/src/java/com/zimbra/cs/imap/ImapMailboxStore.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapMailboxStore.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import com.google.common.collect.Lists;
 import com.zimbra.client.ZMailbox;
 import com.zimbra.client.ZSharedFolder;
 import com.zimbra.common.mailbox.FolderStore;
@@ -40,10 +39,9 @@ import com.zimbra.cs.mailbox.OperationContext;
 
 public abstract class ImapMailboxStore {
 
-    protected transient ImapFlagCache flags;
+    protected final static transient ImapFlagCache flags = ImapFlagCache.getSystemFlags();
 
     protected ImapMailboxStore() {
-        this.flags = ImapFlagCache.getSystemFlags();
     }
 
     public static ImapMailboxStore get(MailboxStore mbox) throws ServiceException {


### PR DESCRIPTION
Added code to split up processing of folders for IMAP LIST command into chunks.
Tested with  different chunk size and defaulted to 2000.
No errors seen on the backend

Observation: Thunderbird takes  a  long time  to process the received response.
Tried  with command line, verified all folders and subfolders are received and no  exception  in the logs