### PR TITLE
ZBUG-1577  getting service.INVALID_REQUEST while checking grants of a domain admin using getAllEffectiveRights

### DIFF
--- a/store/src/java/com/zimbra/cs/account/accesscontrol/CollectAllEffectiveRights.java
+++ b/store/src/java/com/zimbra/cs/account/accesscontrol/CollectAllEffectiveRights.java
@@ -396,6 +396,15 @@ public class CollectAllEffectiveRights {
                 processedGroups.add(groupName);
             }
 
+            if (group.isDynamic()) {
+                DynamicGroup dg = (DynamicGroup)group;
+                if (dg.isMembershipDefinedByCustomURL()) {
+                    // cannot search members of dynamic group with custom memberURL, so do not process this group.
+                    ZimbraLog.acl.debug("Dynamic group with custom memberURL found '%s', ignoring further process on same.", dg.getName());
+                    continue;
+                }
+            }
+
             AllGroupMembers allMembers = getAllGroupMembers(group);
             GroupShape.shapeMembers(TargetType.account, accountShapes, allMembers);
             GroupShape.shapeMembers(TargetType.calresource, calendarResourceShapes, allMembers);


### PR DESCRIPTION
**Problem:** If a delegated admin is given grants on dynamic distribution list created with custom member url, gets `service.INVALID_REQUEST` when trying to do getAllEffectiveRights.

**Fix:**
- in getAllEffectiveRights, all the groups are iterated for searching the member items. and members for dynamic dls with custom member url, can not be fetched. so LdapProvisioning is throwing invalid request service exception.
- so to avoid this situation, if a dynamic dl with custom member url is found, it is ignored and members of that dynamic dl are not searched.

**Testing done:**
- testing done on local vm with latest develop branch changes
- no more invalid request exception for getAllEffectiveRights. Sample command request and response [zbug-1577_sample.txt](https://github.com/Zimbra/zm-mailbox/files/5187964/zbug-1577_sample.txt)

**Testing to be done by QA:**
- verify given scenario in the ticket.
- do sanity around dynamic dl and get rights
- make sure nothing is broken
- if possible add automation