### PR TITLE
zcs-9810:Fixing IMAP regression caused by ZBUG-1694

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1441,8 +1441,11 @@ public final class LC {
 
     // enable blocking common passwords
     public static final KnownKey zimbra_block_common_passwords_enabled = KnownKey.newKey(false);
- // enable blocking common passwords
+    // imap folder pagination size
     public static final KnownKey zimbra_imap_folder_pagination_size =  KnownKey.newKey(2000);
+
+    // imap folder pagination enabled
+    public static final KnownKey zimbra_imap_folder_pagination_enabled =  KnownKey.newKey(false);
 
     static {
         // Automatically set the key name with the variable name.

--- a/store/src/java/com/zimbra/cs/imap/ImapHandler.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapHandler.java
@@ -2154,6 +2154,7 @@ public abstract class ImapHandler {
         boolean selectRecursive = (selectOptions & SELECT_RECURSIVE) != 0;
 
         int paginationSize = LC.zimbra_imap_folder_pagination_size.intValue();
+        boolean imapFolderPaginationEnabled = LC.zimbra_imap_folder_pagination_enabled.booleanValue();
         Map<ImapPath, Object> ownerMatches = new TreeMap<ImapPath, Object>();
         Map<ImapPath, Object> mountMatches = new TreeMap<ImapPath, Object>();
         Map<ImapPath, ItemId> ownerPaths = new HashMap<ImapPath, ItemId>();
@@ -2231,8 +2232,9 @@ public abstract class ImapHandler {
                 }
             }
 
-            if (ownerSelected.size() <= paginationSize) {
-                ZimbraLog.imap.info("Total folder count - %s is less than folder pagination size - %s ", ownerSelected.size(), paginationSize);
+            if (!imapFolderPaginationEnabled) {
+                ZimbraLog.imap.info("Imap folder pagination not enabled");
+                ZimbraLog.imap.info("Total folder count - %s", ownerSelected.size());
                 // return only the selected folders (and perhaps their parents) matching the pattern
                 // for owner folders
                 populateFoldersList(ownerPaths, ownerSelected, ownerMatches, returnOptions, remoteSubscriptions, patterns, command, status, selectRecursive, false);
@@ -2266,14 +2268,14 @@ public abstract class ImapHandler {
                 ownerSelected = null;
                 mountMatches = null;
                 mountSelected = null;
-            } else if (ownerSelected.size() > paginationSize) {
+            } else {
+                ZimbraLog.imap.info("Imap folder pagination is enabled");
                 ZimbraLog.imap.info("Total folder count - %s is greater than folder pagination size - %s", ownerSelected.size(), paginationSize);
                 // send owners list first
                 Iterable<List<ImapPath>> ownerLists = Iterables.partition(ownerSelected, paginationSize);
                 for (List<ImapPath> listChunk: ownerLists) {
                     Set<ImapPath> ownerSelectedChunk = new HashSet<ImapPath>();
                     ownerSelectedChunk.addAll(listChunk);
-                    ZimbraLog.imap.info("Populate selected folder list : %s", ownerSelectedChunk.size());
                     populateFoldersList(ownerPaths, ownerSelectedChunk, ownerMatches, returnOptions, remoteSubscriptions, patterns, command, status, selectRecursive, false);
 
                     if (!ownerMatches.isEmpty()) {

--- a/store/src/java/com/zimbra/cs/imap/ImapHandler.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapHandler.java
@@ -2166,8 +2166,6 @@ public abstract class ImapHandler {
                 remoteSubscriptions = credentials.listSubscriptions();
             }
 
-
-
             for (String mailboxName : mailboxNames) {
                 // RFC 5258 3: "In particular, if an extended LIST command has multiple mailbox
                 //              names and one (or more) of them is the empty string, the empty
@@ -2234,7 +2232,7 @@ public abstract class ImapHandler {
             }
 
             if (ownerSelected.size() <= paginationSize) {
-                ZimbraLog.imap.info("Total folder count is less than folder pagination size.");
+                ZimbraLog.imap.info("Total folder count - %s is less than folder pagination size - %s ", ownerSelected.size(), paginationSize);
                 // return only the selected folders (and perhaps their parents) matching the pattern
                 // for owner folders
                 populateFoldersList(ownerPaths, ownerSelected, ownerMatches, returnOptions, remoteSubscriptions, patterns, command, status, selectRecursive, false);
@@ -2272,12 +2270,14 @@ public abstract class ImapHandler {
         }
 
         if (ownerSelected.size() > paginationSize) {
+            ZimbraLog.imap.info("Total folder count - %s is greater than folder pagination size - %s", ownerSelected.size(), paginationSize);
             try {
               Iterable<List<ImapPath>> lists = Iterables.partition(ownerSelected, paginationSize);
               for (List<ImapPath> listChunk: lists) {
 
                   Set<ImapPath> ownerSelectedChunk = new HashSet<ImapPath>();
                   ownerSelectedChunk.addAll(listChunk);
+                  ZimbraLog.imap.debug("Populate folder list : %s", ownerSelectedChunk.size());
                   populateFoldersList(ownerPaths, ownerSelectedChunk, ownerMatches, returnOptions, remoteSubscriptions, patterns, command, status, selectRecursive, false);
                   // send owners list first
                   if (!ownerMatches.isEmpty()) {
@@ -2292,9 +2292,8 @@ public abstract class ImapHandler {
                       }
                   }
 
-                  ownerSelectedChunk.clear();
                   ownerMatches.clear();
-                  ownerSelectedChunk = null;
+                  ownerMatches = null;
                   ownerMatches = new TreeMap<ImapPath, Object>();
               }
           }  catch  (ServiceException e) {
@@ -2324,9 +2323,8 @@ public abstract class ImapHandler {
                           }
                       }
                   }
-                  mountSelected.clear();
                   mountMatches.clear();
-                  mountSelected = null;
+                  mountMatches = null;
                   mountMatches = new TreeMap<ImapPath, Object>();
               }
           }  catch (ServiceException e) {

--- a/store/src/java/com/zimbra/cs/imap/ImapHandler.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapHandler.java
@@ -2240,6 +2240,30 @@ public abstract class ImapHandler {
                 populateFoldersList(ownerPaths, ownerSelected, ownerMatches, returnOptions, remoteSubscriptions, patterns, command, status, selectRecursive, false);
                 // for shared(mounted) folders
                 populateFoldersList(mountPaths, mountSelected, mountMatches, returnOptions, remoteSubscriptions, patterns, command, status, selectRecursive, true);
+                // send owners list first
+                if (!ownerMatches.isEmpty()) {
+                    for (Object match : ownerMatches.values()) {
+                        if (match instanceof String[]) {
+                            for (String response : (String[]) match) {
+                                sendUntagged(response);
+                            }
+                        } else {
+                            sendUntagged((String) match);
+                        }
+                    }
+                }
+                // send shared(mounted) folders list
+                if (!mountMatches.isEmpty()) {
+                    for (Object match : mountMatches.values()) {
+                        if (match instanceof String[]) {
+                            for (String response : (String[]) match) {
+                                sendUntagged(response);
+                            }
+                        } else {
+                            sendUntagged((String) match);
+                        }
+                    }
+                }
             }
         } catch (ServiceException e) {
             ZimbraLog.imap.warn(command + " failed", e);
@@ -2283,7 +2307,6 @@ public abstract class ImapHandler {
           try {
               Iterable<List<ImapPath>> lists = Iterables.partition(mountSelected, paginationSize);
 
-              // send owners list first
               for (List<ImapPath> listChunk: lists) {
                   Set<ImapPath> mountSelectedChunk = new HashSet<ImapPath>();
                   mountSelectedChunk.addAll(listChunk);


### PR DESCRIPTION
Fixing ZBUG-1694 regression. As part of ZBUG-1694, a new LC was added to fix the pagination issue when there are huge number of folders present on an account. So the block 
```
if (ownerSelected.size() <= paginationSize) {
```
was causing the issue because when the size is less then pagination size server was not able to send the folder list which caused the regression [ZCS-9810](https://jira.corp.synacor.com/browse/ZCS-9810) and [ZCS-9820](https://jira.corp.synacor.com/browse/ZCS-9820).
- Done some code refactoring. There was multiple try-catch blocks. so removed those as the exception is already handled in single try block. Moved those codes into same try block
- There was high memory usage when connecting from multiple IMAP sessions. so externally nullifying all the objects so that those objects could be immediately garbage collected.
- Added the fix, so that in both the cases it will send the folder list to the client.