### PR TITLE
ZCS-9829:Invalid attribute fix

### DIFF
--- a/store/src/java/com/zimbra/cs/service/account/ChangePassword.java
+++ b/store/src/java/com/zimbra/cs/service/account/ChangePassword.java
@@ -42,10 +42,10 @@ import com.zimbra.soap.ZimbraSoapContext;
  */
 public class ChangePassword extends AccountDocumentHandler {
 
-	@Override
+    @Override
     public Element handle(Element request, Map<String, Object> context) throws ServiceException {
 
-	    if (!checkPasswordSecurity(context))
+        if (!checkPasswordSecurity(context))
             throw ServiceException.INVALID_REQUEST("clear text password is not allowed", null);
 
         ZimbraSoapContext zsc = getZimbraSoapContext(context);
@@ -63,7 +63,7 @@ public class ChangePassword extends AccountDocumentHandler {
                 name = name + "@" + d.getName();
         }
 
-        String text =  request.getAttribute(AccountConstants.E_DRYRUN);
+        String text =  request.getAttribute(AccountConstants.E_DRYRUN, null);
 
         boolean dryRun   = false;
         if (!StringUtil.isNullOrEmpty(text)) {
@@ -93,8 +93,8 @@ public class ChangePassword extends AccountDocumentHandler {
             }
         }
 
-		String oldPassword = request.getAttribute(AccountConstants.E_OLD_PASSWORD);
-		String newPassword = request.getAttribute(AccountConstants.E_PASSWORD);
+        String oldPassword = request.getAttribute(AccountConstants.E_OLD_PASSWORD);
+        String newPassword = request.getAttribute(AccountConstants.E_PASSWORD);
         if (acct.isIsExternalVirtualAccount() && StringUtil.isNullOrEmpty(oldPassword)
                 && !acct.isVirtualAccountInitialPasswordSet() && acct.getId().equals(zsc.getAuthtokenAccountId())) {
             // need a valid auth token in this case
@@ -102,7 +102,7 @@ public class ChangePassword extends AccountDocumentHandler {
             prov.setPassword(acct, newPassword, true);
             acct.setVirtualAccountInitialPasswordSet(true);
         } else {
-		    prov.changePassword(acct, oldPassword, newPassword, dryRun);
+            prov.changePassword(acct, oldPassword, newPassword, dryRun);
         }
 
         Element response = zsc.createElement(AccountConstants.CHANGE_PASSWORD_RESPONSE);


### PR DESCRIPTION
Issue: After the [ZCS-9735](https://jira.corp.synacor.com/browse/ZCS-9735) fix for json request, server throws below exception
```
(Windows)/9.0.0_GA_3031;soapId=3407aeab;] SoapEngine - handler exception
com.zimbra.common.service.ServiceException: invalid request: missing required attribute: dryRun
ExceptionId:qtp366590980-151:https://zqa-402.eng.zimbra.com/service/soap/ChangePasswordRequest:1600244644227:31b28a3714bd72b5
Code:service.INVALID_REQUEST
        at com.zimbra.common.service.ServiceException.INVALID_REQUEST(ServiceException.java:295)
        at com.zimbra.common.soap.Element.checkNull(Element.java:412)
        at com.zimbra.common.soap.Element.getAttribute(Element.java:347)
        at com.zimbra.cs.service.account.ChangePassword.handle(ChangePassword.java:66)
        at com.zimbra.soap.SoapEngine.dispatchRequest(SoapEngine.java:646)
        at com.zimbra.soap.SoapEngine.dispatch(SoapEngine.java:491)
        at com.zimbra.soap.SoapEngine.dispatch(SoapEngine.java:278)
```
because of this `request.getAttribute(AccountConstants.E_DRYRUN);` it always expects that this attr should come as part of the request.

Fix:
using `request.getAttribute(AccountConstants.E_DRYRUN, null); returns null if it is not present in the request.


Test:
- Tested from modern UI that changes password works fine.
- Tested from soap UI with `dryRun` it is working and does not generate any new auth token.
- Tested from soap UI without `dryRun`, it does not throw any exception and we get proper response with new authToken.