### PR TITLE
ZCS-9842: Add support for dry run in ResetPassword

### DIFF
--- a/soap/src/java/com/zimbra/soap/admin/message/SetPasswordRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/SetPasswordRequest.java
@@ -20,9 +20,11 @@ package com.zimbra.soap.admin.message;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
+import com.zimbra.common.soap.AccountConstants;
 import com.zimbra.common.soap.AdminConstants;
 
 /**
@@ -52,6 +54,9 @@ public class SetPasswordRequest {
     @XmlAttribute(name=AdminConstants.E_NEW_PASSWORD, required=true)
     private final String newPassword;
 
+    @XmlElement(name=AccountConstants.E_DRYRUN, required=false)
+    private boolean dryRun;
+
     /**
      * no-argument constructor wanted by JAXB
      */
@@ -64,7 +69,21 @@ public class SetPasswordRequest {
         this.newPassword = newPassword;
     }
 
+    public SetPasswordRequest(String id, String newPassword, boolean dryRun) {
+        this.id = id;
+        this.newPassword = newPassword;
+        setDryRun(dryRun);
+    }
+
     public String getId() { return id; }
     public String getNewPassword() { return newPassword; }
+
+    public boolean isDryRun() {
+        return dryRun;
+    }
+
+    public void setDryRun(boolean dryRun) {
+        this.dryRun = dryRun;
+    }
 
 }

--- a/store/src/java-test/com/zimbra/cs/account/MockProvisioning.java
+++ b/store/src/java-test/com/zimbra/cs/account/MockProvisioning.java
@@ -951,4 +951,11 @@ public final class MockProvisioning extends Provisioning {
         // TODO Auto-generated method stub
 
     }
+
+	@Override
+	public SetPasswordResult resetPassword(Account acct, String newPassword, boolean dryRun) throws ServiceException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
 }

--- a/store/src/java-test/com/zimbra/cs/service/ResetPasswordTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/ResetPasswordTest.java
@@ -201,7 +201,7 @@ public class ResetPasswordTest {
 
 class TestResetPassword extends ResetPassword {
     @Override
-    protected void setPasswordAndPurgeAuthTokens(Provisioning prov, Account acct, String newPassword)
+    protected void setPasswordAndPurgeAuthTokens(Provisioning prov, Account acct, String newPassword, boolean dryRun)
             throws ServiceException {
         // do nothing
     }

--- a/store/src/java/com/zimbra/cs/account/Provisioning.java
+++ b/store/src/java/com/zimbra/cs/account/Provisioning.java
@@ -1278,7 +1278,7 @@ public abstract class Provisioning extends ZAttrProvisioning {
     throws ServiceException;
 
     public abstract void changePassword(Account acct, String currentPassword, String newPassword) throws ServiceException;
-    public abstract void changePassword(Account acct, String currentPassword, String newPassword,  boolean dryRun) throws ServiceException;
+    public abstract void changePassword(Account acct, String currentPassword, String newPassword, boolean dryRun) throws ServiceException;
 
     public static class SetPasswordResult {
         private String msg;
@@ -1309,6 +1309,8 @@ public abstract class Provisioning extends ZAttrProvisioning {
     throws ServiceException {
         throw ServiceException.UNSUPPORTED();
     }
+
+    public abstract SetPasswordResult resetPassword(Account acct, String newPassword, boolean dryRun) throws ServiceException;
 
     public abstract void checkPasswordStrength(Account acct, String password) throws ServiceException;
 

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -6032,6 +6032,12 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
         return setPassword(acct, newPassword, false);
     }
 
+	@Override
+	public SetPasswordResult resetPassword(Account acct, String newPassword, boolean dryRun) 
+	throws ServiceException {
+		return setPassword(acct, newPassword, dryRun);
+	}
+
     @Override
     public SetPasswordResult setPassword(Account acct, String newPassword,
             boolean enforcePasswordPolicy)

--- a/store/src/java/com/zimbra/cs/account/soap/SoapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/soap/SoapProvisioning.java
@@ -113,6 +113,7 @@ import com.zimbra.soap.account.message.GetDistributionListMembersResponse;
 import com.zimbra.soap.account.message.GetIdentitiesRequest;
 import com.zimbra.soap.account.message.GetIdentitiesResponse;
 import com.zimbra.soap.account.message.ModifyIdentityRequest;
+import com.zimbra.soap.account.message.ResetPasswordRequest;
 import com.zimbra.soap.account.type.HABGroupMember;
 import com.zimbra.soap.account.type.NameId;
 import com.zimbra.soap.admin.message.AddAccountAliasRequest;
@@ -870,6 +871,16 @@ public class SoapProvisioning extends Provisioning {
         com.zimbra.soap.type.AccountSelector jaxbAcct =
             new com.zimbra.soap.type.AccountSelector(com.zimbra.soap.type.AccountBy.name, acct.getName());
         invokeJaxb(new ChangePasswordRequest(jaxbAcct, currentPassword, newPassword, dryRun));
+    }
+
+    public SetPasswordResult resetPassword(Account acct, String newPassword, boolean dryRun) throws ServiceException {
+    		SetPasswordResponse resp =
+                invokeJaxb(new SetPasswordRequest(acct.getId(), newPassword, dryRun));
+	    	SetPasswordResult result = new SetPasswordResult();
+	    	String eMsg = resp.getMessage();
+	    	if (eMsg != null)
+	    		result.setMessage(eMsg);
+	    	return result;
     }
 
     @Override
@@ -3218,5 +3229,4 @@ public class SoapProvisioning extends Provisioning {
         GetDistributionListMembersResponse resp = invokeJaxb(new GetDistributionListMembersRequest(0, 0, group.getName()));
         return resp.getHABGroupMembers();
     }
-
 }


### PR DESCRIPTION
**Problem:**
Add support for `dryRun` in `ResetPasswordRequest`

**Approach:**
Added support for `dryRun` in `ResetPasswordRequest` in the API.

**Testing Done:**
Verified valid failure message is returned when the password rule is not followed when COS settings are changed.