### PR TITLE
ZCS-9767 Zimbra9 - Update GetInfoResponse to report zimbraPasswordBlockCommonEnabled password rule

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -1667,7 +1667,7 @@ public class ZAttrProvisioning {
     public static enum PrefClientType {
         standard("standard"),
         advanced("advanced"),
-        zimbrax("zimbrax");
+        modern("modern");
         private String mValue;
         private PrefClientType(String value) { mValue = value; }
         public String toString() { return mValue; }
@@ -1679,7 +1679,7 @@ public class ZAttrProvisioning {
         }
         public boolean isStandard() { return this == standard;}
         public boolean isAdvanced() { return this == advanced;}
-        public boolean isZimbrax() { return this == zimbrax;}
+        public boolean isModern() { return this == modern;}
     }
 
     public static enum PrefComposeDirection {
@@ -12051,6 +12051,14 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=1256)
     public static final String A_zimbraPasswordAllowedPunctuationChars = "zimbraPasswordAllowedPunctuationChars";
+
+    /**
+     * whether or not blocking common passwords is enabled
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public static final String A_zimbraPasswordBlockCommonEnabled = "zimbraPasswordBlockCommonEnabled";
 
     /**
      * registered change password listener name

--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1439,9 +1439,6 @@ public final class LC {
     // list file for blocking common passwords
     public static final KnownKey common_passwords_txt = KnownKey.newKey("${zimbra_home}/conf/common-passwords.txt");
 
-    // enable blocking common passwords
-    public static final KnownKey zimbra_block_common_passwords_enabled = KnownKey.newKey(false);
-    // imap folder pagination size
     public static final KnownKey zimbra_imap_folder_pagination_size =  KnownKey.newKey(2000);
 
     // imap folder pagination enabled

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9770,7 +9770,7 @@ TODO: delete them permanently from here
   <deprecateDesc>deprecated with attribute zimbraFeatureModernDesktopEnabled</deprecateDesc>
 </attr>
 
-<attr id="3081" name="zimbraPasswordBlockCommonEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="8.9.0">
+<attr id="3081" name="zimbraPasswordBlockCommonEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="9.1.0">
   <defaultCOSValue>FALSE</defaultCOSValue>
   <desc>whether or not blocking common passwords is enabled</desc>
 </attr>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9770,6 +9770,11 @@ TODO: delete them permanently from here
   <deprecateDesc>deprecated with attribute zimbraFeatureModernDesktopEnabled</deprecateDesc>
 </attr>
 
+<attr id="3081" name="zimbraPasswordBlockCommonEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="8.9.0">
+  <defaultCOSValue>FALSE</defaultCOSValue>
+  <desc>whether or not blocking common passwords is enabled</desc>
+</attr>
+
 <attr id="3082" name="zimbraFeatureModernDesktopEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited" since="8.9.0">
   <defaultCOSValue>FALSE</defaultCOSValue>
   <desc>Whether to allow a user to access Zimbra modern desktop</desc>

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -34872,6 +34872,78 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * whether or not blocking common passwords is enabled
+     *
+     * @return zimbraPasswordBlockCommonEnabled, or false if unset
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public boolean isPasswordBlockCommonEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraPasswordBlockCommonEnabled, false, true);
+    }
+
+    /**
+     * whether or not blocking common passwords is enabled
+     *
+     * @param zimbraPasswordBlockCommonEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public void setPasswordBlockCommonEnabled(boolean zimbraPasswordBlockCommonEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPasswordBlockCommonEnabled, zimbraPasswordBlockCommonEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * whether or not blocking common passwords is enabled
+     *
+     * @param zimbraPasswordBlockCommonEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public Map<String,Object> setPasswordBlockCommonEnabled(boolean zimbraPasswordBlockCommonEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPasswordBlockCommonEnabled, zimbraPasswordBlockCommonEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * whether or not blocking common passwords is enabled
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public void unsetPasswordBlockCommonEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPasswordBlockCommonEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * whether or not blocking common passwords is enabled
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public Map<String,Object> unsetPasswordBlockCommonEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPasswordBlockCommonEnabled, "");
+        return attrs;
+    }
+
+    /**
      * whether or not to enforce password history. Number of unique passwords
      * a user must have before being allowed to re-use an old one. A value of
      * 0 means no password history.
@@ -41743,31 +41815,31 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * user preference of client type
      *
-     * <p>Valid values: [standard, advanced, zimbrax]
+     * <p>Valid values: [standard, advanced, modern]
      *
-     * @return zimbraPrefClientType, or ZAttrProvisioning.PrefClientType.advanced if unset and/or has invalid value
+     * @return zimbraPrefClientType, or ZAttrProvisioning.PrefClientType.modern if unset and/or has invalid value
      */
     @ZAttr(id=453)
     public ZAttrProvisioning.PrefClientType getPrefClientType() {
-        try { String v = getAttr(Provisioning.A_zimbraPrefClientType, true, true); return v == null ? ZAttrProvisioning.PrefClientType.advanced : ZAttrProvisioning.PrefClientType.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.PrefClientType.advanced; }
+        try { String v = getAttr(Provisioning.A_zimbraPrefClientType, true, true); return v == null ? ZAttrProvisioning.PrefClientType.modern : ZAttrProvisioning.PrefClientType.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.PrefClientType.modern; }
     }
 
     /**
      * user preference of client type
      *
-     * <p>Valid values: [standard, advanced, zimbrax]
+     * <p>Valid values: [standard, advanced, modern]
      *
-     * @return zimbraPrefClientType, or "advanced" if unset
+     * @return zimbraPrefClientType, or "modern" if unset
      */
     @ZAttr(id=453)
     public String getPrefClientTypeAsString() {
-        return getAttr(Provisioning.A_zimbraPrefClientType, "advanced", true);
+        return getAttr(Provisioning.A_zimbraPrefClientType, "modern", true);
     }
 
     /**
      * user preference of client type
      *
-     * <p>Valid values: [standard, advanced, zimbrax]
+     * <p>Valid values: [standard, advanced, modern]
      *
      * @param zimbraPrefClientType new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -41782,7 +41854,7 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * user preference of client type
      *
-     * <p>Valid values: [standard, advanced, zimbrax]
+     * <p>Valid values: [standard, advanced, modern]
      *
      * @param zimbraPrefClientType new value
      * @param attrs existing map to populate, or null to create a new map
@@ -41798,7 +41870,7 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * user preference of client type
      *
-     * <p>Valid values: [standard, advanced, zimbrax]
+     * <p>Valid values: [standard, advanced, modern]
      *
      * @param zimbraPrefClientType new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -41813,7 +41885,7 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * user preference of client type
      *
-     * <p>Valid values: [standard, advanced, zimbrax]
+     * <p>Valid values: [standard, advanced, modern]
      *
      * @param zimbraPrefClientType new value
      * @param attrs existing map to populate, or null to create a new map
@@ -41829,7 +41901,7 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * user preference of client type
      *
-     * <p>Valid values: [standard, advanced, zimbrax]
+     * <p>Valid values: [standard, advanced, modern]
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      */
@@ -41843,7 +41915,7 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * user preference of client type
      *
-     * <p>Valid values: [standard, advanced, zimbrax]
+     * <p>Valid values: [standard, advanced, modern]
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -27094,6 +27094,78 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * whether or not blocking common passwords is enabled
+     *
+     * @return zimbraPasswordBlockCommonEnabled, or false if unset
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public boolean isPasswordBlockCommonEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraPasswordBlockCommonEnabled, false, true);
+    }
+
+    /**
+     * whether or not blocking common passwords is enabled
+     *
+     * @param zimbraPasswordBlockCommonEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public void setPasswordBlockCommonEnabled(boolean zimbraPasswordBlockCommonEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPasswordBlockCommonEnabled, zimbraPasswordBlockCommonEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * whether or not blocking common passwords is enabled
+     *
+     * @param zimbraPasswordBlockCommonEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public Map<String,Object> setPasswordBlockCommonEnabled(boolean zimbraPasswordBlockCommonEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPasswordBlockCommonEnabled, zimbraPasswordBlockCommonEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * whether or not blocking common passwords is enabled
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public void unsetPasswordBlockCommonEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPasswordBlockCommonEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * whether or not blocking common passwords is enabled
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3081)
+    public Map<String,Object> unsetPasswordBlockCommonEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPasswordBlockCommonEnabled, "");
+        return attrs;
+    }
+
+    /**
      * whether or not to enforce password history. Number of unique passwords
      * a user must have before being allowed to re-use an old one. A value of
      * 0 means no password history.
@@ -32042,31 +32114,31 @@ public abstract class ZAttrCos extends NamedEntry {
     /**
      * user preference of client type
      *
-     * <p>Valid values: [standard, advanced, zimbrax]
+     * <p>Valid values: [standard, advanced, modern]
      *
-     * @return zimbraPrefClientType, or ZAttrProvisioning.PrefClientType.advanced if unset and/or has invalid value
+     * @return zimbraPrefClientType, or ZAttrProvisioning.PrefClientType.modern if unset and/or has invalid value
      */
     @ZAttr(id=453)
     public ZAttrProvisioning.PrefClientType getPrefClientType() {
-        try { String v = getAttr(Provisioning.A_zimbraPrefClientType, true, true); return v == null ? ZAttrProvisioning.PrefClientType.advanced : ZAttrProvisioning.PrefClientType.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.PrefClientType.advanced; }
+        try { String v = getAttr(Provisioning.A_zimbraPrefClientType, true, true); return v == null ? ZAttrProvisioning.PrefClientType.modern : ZAttrProvisioning.PrefClientType.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.PrefClientType.modern; }
     }
 
     /**
      * user preference of client type
      *
-     * <p>Valid values: [standard, advanced, zimbrax]
+     * <p>Valid values: [standard, advanced, modern]
      *
-     * @return zimbraPrefClientType, or "advanced" if unset
+     * @return zimbraPrefClientType, or "modern" if unset
      */
     @ZAttr(id=453)
     public String getPrefClientTypeAsString() {
-        return getAttr(Provisioning.A_zimbraPrefClientType, "advanced", true);
+        return getAttr(Provisioning.A_zimbraPrefClientType, "modern", true);
     }
 
     /**
      * user preference of client type
      *
-     * <p>Valid values: [standard, advanced, zimbrax]
+     * <p>Valid values: [standard, advanced, modern]
      *
      * @param zimbraPrefClientType new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -32081,7 +32153,7 @@ public abstract class ZAttrCos extends NamedEntry {
     /**
      * user preference of client type
      *
-     * <p>Valid values: [standard, advanced, zimbrax]
+     * <p>Valid values: [standard, advanced, modern]
      *
      * @param zimbraPrefClientType new value
      * @param attrs existing map to populate, or null to create a new map
@@ -32097,7 +32169,7 @@ public abstract class ZAttrCos extends NamedEntry {
     /**
      * user preference of client type
      *
-     * <p>Valid values: [standard, advanced, zimbrax]
+     * <p>Valid values: [standard, advanced, modern]
      *
      * @param zimbraPrefClientType new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -32112,7 +32184,7 @@ public abstract class ZAttrCos extends NamedEntry {
     /**
      * user preference of client type
      *
-     * <p>Valid values: [standard, advanced, zimbrax]
+     * <p>Valid values: [standard, advanced, modern]
      *
      * @param zimbraPrefClientType new value
      * @param attrs existing map to populate, or null to create a new map
@@ -32128,7 +32200,7 @@ public abstract class ZAttrCos extends NamedEntry {
     /**
      * user preference of client type
      *
-     * <p>Valid values: [standard, advanced, zimbrax]
+     * <p>Valid values: [standard, advanced, modern]
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      */
@@ -32142,7 +32214,7 @@ public abstract class ZAttrCos extends NamedEntry {
     /**
      * user preference of client type
      *
-     * <p>Valid values: [standard, advanced, zimbrax]
+     * <p>Valid values: [standard, advanced, modern]
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -266,7 +266,6 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     private final INamedEntryCache<LdapZimlet> zimletCache;
 
     private final UnmodifiableBloomFilter<String> commonPasswordFilter;
-    private boolean blockCommonPasswordsEnabled;
 
     private LdapConfig cachedGlobalConfig = null;
     private GlobalGrant cachedGlobalGrant = null;
@@ -321,7 +320,6 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
         commonPasswordFilter = UnmodifiableBloomFilter
             .createLazyFilterFromFile(LC.common_passwords_txt.value());
-        blockCommonPasswordsEnabled = LC.zimbra_block_common_passwords_enabled.booleanValue();
 
         setDIT();
         setHelper(new ZLdapHelper(this));
@@ -6104,6 +6102,28 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
         return cos.getAttr(name);
     }
 
+    private boolean getBoolean(Account acct, Cos cos, ZMutableEntry entry, String name,
+        boolean defaultValue) throws ServiceException {
+        if (acct != null) {
+            return acct.getBooleanAttr(name, defaultValue);
+        }
+
+        try {
+            String v = entry.getAttrString(name);
+            if (v != null) {
+                try {
+                    return Boolean.parseBoolean(v);
+                } catch (NumberFormatException e) {
+                    return defaultValue;
+                }
+            }
+        } catch (ServiceException ne) {
+            throw ServiceException.FAILURE(ne.getMessage(), ne);
+        }
+
+        return cos.getBooleanAttr(name, defaultValue);
+    }
+
     /**
      * called to check password strength. Should pass in either an Account, or Cos/Attributes (during creation).
      *
@@ -6127,8 +6147,11 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
                     new Argument(Provisioning.A_zimbraPasswordMaxLength, maxLength, Argument.Type.NUM));
         }
 
-        if (blockCommonPasswordsEnabled && commonPasswordFilter.mightContain(password)) {
-            throw AccountServiceException.INVALID_PASSWORD("password is known to be too common");
+        if (getBoolean(acct, cos, entry, Provisioning.A_zimbraPasswordBlockCommonEnabled, false)
+                && commonPasswordFilter.mightContain(password)) {
+                throw AccountServiceException
+                    .INVALID_PASSWORD(Provisioning.A_zimbraPasswordBlockCommonEnabled
+                        + " password is known to be too common");
         }
 
         int minUpperCase = getInt(acct, cos, entry, Provisioning.A_zimbraPasswordMinUpperCaseChars, 0);

--- a/store/src/java/com/zimbra/cs/service/admin/ModifyCos.java
+++ b/store/src/java/com/zimbra/cs/service/admin/ModifyCos.java
@@ -40,16 +40,16 @@ import com.zimbra.soap.ZimbraSoapContext;
  */
 public class ModifyCos extends AdminDocumentHandler {
 
-	@Override
+    @Override
     public Element handle(Element request, Map<String, Object> context) throws ServiceException {
 
         ZimbraSoapContext zsc = getZimbraSoapContext(context);
-	    Provisioning prov = Provisioning.getInstance();
+        Provisioning prov = Provisioning.getInstance();
 
-	    String id = request.getElement(AdminConstants.E_ID).getText();
-	    Map<String, Object> attrs = AdminService.getAttrs(request);
+        String id = request.getElement(AdminConstants.E_ID).getText();
+        Map<String, Object> attrs = AdminService.getAttrs(request);
 
-	    Cos cos = prov.get(Key.CosBy.id, id);
+        Cos cos = prov.get(Key.CosBy.id, id);
         if (cos == null)
             throw AccountServiceException.NO_SUCH_COS(id);
 
@@ -61,15 +61,14 @@ public class ModifyCos extends AdminDocumentHandler {
         ZimbraLog.security.info(ZimbraLog.encodeAttrs(
                 new String[] {"cmd", "ModifyCos","name", cos.getName()}, attrs));
 
-	    Element response = zsc.createElement(AdminConstants.MODIFY_COS_RESPONSE);
-	    GetCos.encodeCos(response, cos);
-	    return response;
-	}
+        Element response = zsc.createElement(AdminConstants.MODIFY_COS_RESPONSE);
+        GetCos.encodeCos(response, cos);
+        return response;
+    }
 
     @Override
     public void docRights(List<AdminRight> relatedRights, List<String> notes) {
         notes.add(String.format(AdminRightCheckPoint.Notes.MODIFY_ENTRY,
                 Admin.R_modifyCos.getName(), "cos"));
     }
-
 }

--- a/store/src/java/com/zimbra/cs/service/admin/ModifyCos.java
+++ b/store/src/java/com/zimbra/cs/service/admin/ModifyCos.java
@@ -49,8 +49,6 @@ public class ModifyCos extends AdminDocumentHandler {
 	    String id = request.getElement(AdminConstants.E_ID).getText();
 	    Map<String, Object> attrs = AdminService.getAttrs(request);
 
-	    attrs.remove("zimbraPasswordBlockCommonEnabled", attrs.get("zimbraPasswordBlockCommonEnabled"));
-
 	    Cos cos = prov.get(Key.CosBy.id, id);
         if (cos == null)
             throw AccountServiceException.NO_SUCH_COS(id);


### PR DESCRIPTION
**Problem:** `zimbraPasswordBlockCommonEnabled` should be returned in the `GetInfoResponse`

**Fix:**
- Removed LC with name `zimbra_block_common_passwords_enabled` and created ldap attribute with name `zimbraPasswordBlockCommonEnabled` with `accountInfo` flag.
- After doing `generate-getters` found that value for `zimbraPrefClientType` was changed in PREAPPS-4182 but `ZAttrProvisioning.java` did not have the new value i.e. `modern`. So kept it in the PR.

**Testing to be done by QA:**
- Verify that value for `zimbraPasswordBlockCommonEnabled` is returned in the `GetInfoResponse` and same is used while checking password strength.