### PR TITLE
ZCS-9850: Add placeholder LDAP attributes to Z9.1

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -6806,6 +6806,14 @@ public class ZAttrProvisioning {
     public static final String A_zimbraFeaturePortalEnabled = "zimbraFeaturePortalEnabled";
 
     /**
+     * Whether Powerpaste functionality is enabled or not.
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3084)
+    public static final String A_zimbraFeaturePowerPasteEnabled = "zimbraFeaturePowerPasteEnabled";
+
+    /**
      * whether priority inbox feature is enabled
      *
      * @since ZCS 8.0.0

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -6806,7 +6806,7 @@ public class ZAttrProvisioning {
     public static final String A_zimbraFeaturePortalEnabled = "zimbraFeaturePortalEnabled";
 
     /**
-     * Whether Powerpaste functionality is enabled or not.
+     * Whether Powerpaste Feature is enabled or not
      *
      * @since ZCS 9.1.0
      */
@@ -13841,6 +13841,14 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=1166)
     public static final String A_zimbraPrefPop3IncludeSpam = "zimbraPrefPop3IncludeSpam";
+
+    /**
+     * Whether Powerpaste preference is enabled by user or admin
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3085)
+    public static final String A_zimbraPrefPowerPasteEnabled = "zimbraPrefPowerPasteEnabled";
 
     /**
      * quick command encoded by the client

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9793,8 +9793,13 @@ TODO: delete them permanently from here
     <desc>Account Suspension reason. It describes the actual cause for account suspension if any and it must be updated with account status.</desc>
 </attr>
 
-<attr id="3084" name="zimbraFeaturePowerPasteEnabled" type="boolean" cardinality="single" flags="accountInfo,accountInherited" optionalIn="account,cos" since="9.1.0">
+<attr id="3084" name="zimbraFeaturePowerPasteEnabled" type="boolean" cardinality="single" flags="accountInfo,accountInherited,domainAdminModifiable" optionalIn="account,cos" since="9.1.0">
     <defaultCOSValue>TRUE</defaultCOSValue>
-    <desc>Whether Powerpaste functionality is enabled or not.</desc>
+    <desc>Whether Powerpaste Feature is enabled or not</desc>
+</attr>
+
+<attr id="3085" name="zimbraPrefPowerPasteEnabled" type="boolean" cardinality="single" flags="accountInfo,accountInherited" optionalIn="account,cos" since="9.1.0">
+    <defaultCOSValue>TRUE</defaultCOSValue>
+    <desc>Whether Powerpaste preference is enabled by user or admin</desc>
 </attr>
 </attrs>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9792,4 +9792,9 @@ TODO: delete them permanently from here
 <attr id="3078" name="zimbraAccountSuspensionReason" type="string" cardinality="single" flags="domainAdminModifiable" optionalIn="account" since="8.9.0">
     <desc>Account Suspension reason. It describes the actual cause for account suspension if any and it must be updated with account status.</desc>
 </attr>
+
+<attr id="3084" name="zimbraFeaturePowerPasteEnabled" type="boolean" cardinality="single" flags="accountInfo,accountInherited" optionalIn="account,cos" since="9.1.0">
+    <defaultCOSValue>TRUE</defaultCOSValue>
+    <desc>Whether Powerpaste functionality is enabled or not.</desc>
+</attr>
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -17771,6 +17771,78 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * Whether Powerpaste functionality is enabled or not.
+     *
+     * @return zimbraFeaturePowerPasteEnabled, or true if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3084)
+    public boolean isFeaturePowerPasteEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeaturePowerPasteEnabled, true, true);
+    }
+
+    /**
+     * Whether Powerpaste functionality is enabled or not.
+     *
+     * @param zimbraFeaturePowerPasteEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3084)
+    public void setFeaturePowerPasteEnabled(boolean zimbraFeaturePowerPasteEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeaturePowerPasteEnabled, zimbraFeaturePowerPasteEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether Powerpaste functionality is enabled or not.
+     *
+     * @param zimbraFeaturePowerPasteEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3084)
+    public Map<String,Object> setFeaturePowerPasteEnabled(boolean zimbraFeaturePowerPasteEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeaturePowerPasteEnabled, zimbraFeaturePowerPasteEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether Powerpaste functionality is enabled or not.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3084)
+    public void unsetFeaturePowerPasteEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeaturePowerPasteEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether Powerpaste functionality is enabled or not.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3084)
+    public Map<String,Object> unsetFeaturePowerPasteEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeaturePowerPasteEnabled, "");
+        return attrs;
+    }
+
+    /**
      * whether priority inbox feature is enabled
      *
      * @return zimbraFeaturePriorityInboxEnabled, or true if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -17771,7 +17771,7 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * Whether Powerpaste functionality is enabled or not.
+     * Whether Powerpaste Feature is enabled or not
      *
      * @return zimbraFeaturePowerPasteEnabled, or true if unset
      *
@@ -17783,7 +17783,7 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * Whether Powerpaste functionality is enabled or not.
+     * Whether Powerpaste Feature is enabled or not
      *
      * @param zimbraFeaturePowerPasteEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -17798,7 +17798,7 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * Whether Powerpaste functionality is enabled or not.
+     * Whether Powerpaste Feature is enabled or not
      *
      * @param zimbraFeaturePowerPasteEnabled new value
      * @param attrs existing map to populate, or null to create a new map
@@ -17814,7 +17814,7 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * Whether Powerpaste functionality is enabled or not.
+     * Whether Powerpaste Feature is enabled or not
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -17828,7 +17828,7 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * Whether Powerpaste functionality is enabled or not.
+     * Whether Powerpaste Feature is enabled or not
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
@@ -52267,6 +52267,78 @@ public abstract class ZAttrAccount  extends MailTarget {
     public Map<String,Object> unsetPrefPop3IncludeSpam(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraPrefPop3IncludeSpam, "");
+        return attrs;
+    }
+
+    /**
+     * Whether Powerpaste preference is enabled by user or admin
+     *
+     * @return zimbraPrefPowerPasteEnabled, or true if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3085)
+    public boolean isPrefPowerPasteEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraPrefPowerPasteEnabled, true, true);
+    }
+
+    /**
+     * Whether Powerpaste preference is enabled by user or admin
+     *
+     * @param zimbraPrefPowerPasteEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3085)
+    public void setPrefPowerPasteEnabled(boolean zimbraPrefPowerPasteEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefPowerPasteEnabled, zimbraPrefPowerPasteEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether Powerpaste preference is enabled by user or admin
+     *
+     * @param zimbraPrefPowerPasteEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3085)
+    public Map<String,Object> setPrefPowerPasteEnabled(boolean zimbraPrefPowerPasteEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefPowerPasteEnabled, zimbraPrefPowerPasteEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether Powerpaste preference is enabled by user or admin
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3085)
+    public void unsetPrefPowerPasteEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefPowerPasteEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether Powerpaste preference is enabled by user or admin
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3085)
+    public Map<String,Object> unsetPrefPowerPasteEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefPowerPasteEnabled, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -12355,6 +12355,78 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * Whether Powerpaste functionality is enabled or not.
+     *
+     * @return zimbraFeaturePowerPasteEnabled, or true if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3084)
+    public boolean isFeaturePowerPasteEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeaturePowerPasteEnabled, true, true);
+    }
+
+    /**
+     * Whether Powerpaste functionality is enabled or not.
+     *
+     * @param zimbraFeaturePowerPasteEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3084)
+    public void setFeaturePowerPasteEnabled(boolean zimbraFeaturePowerPasteEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeaturePowerPasteEnabled, zimbraFeaturePowerPasteEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether Powerpaste functionality is enabled or not.
+     *
+     * @param zimbraFeaturePowerPasteEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3084)
+    public Map<String,Object> setFeaturePowerPasteEnabled(boolean zimbraFeaturePowerPasteEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeaturePowerPasteEnabled, zimbraFeaturePowerPasteEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether Powerpaste functionality is enabled or not.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3084)
+    public void unsetFeaturePowerPasteEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeaturePowerPasteEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether Powerpaste functionality is enabled or not.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3084)
+    public Map<String,Object> unsetFeaturePowerPasteEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeaturePowerPasteEnabled, "");
+        return attrs;
+    }
+
+    /**
      * whether priority inbox feature is enabled
      *
      * @return zimbraFeaturePriorityInboxEnabled, or true if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -12355,7 +12355,7 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Whether Powerpaste functionality is enabled or not.
+     * Whether Powerpaste Feature is enabled or not
      *
      * @return zimbraFeaturePowerPasteEnabled, or true if unset
      *
@@ -12367,7 +12367,7 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Whether Powerpaste functionality is enabled or not.
+     * Whether Powerpaste Feature is enabled or not
      *
      * @param zimbraFeaturePowerPasteEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -12382,7 +12382,7 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Whether Powerpaste functionality is enabled or not.
+     * Whether Powerpaste Feature is enabled or not
      *
      * @param zimbraFeaturePowerPasteEnabled new value
      * @param attrs existing map to populate, or null to create a new map
@@ -12398,7 +12398,7 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Whether Powerpaste functionality is enabled or not.
+     * Whether Powerpaste Feature is enabled or not
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -12412,7 +12412,7 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Whether Powerpaste functionality is enabled or not.
+     * Whether Powerpaste Feature is enabled or not
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
@@ -40135,6 +40135,78 @@ public abstract class ZAttrCos extends NamedEntry {
     public Map<String,Object> unsetPrefPop3IncludeSpam(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraPrefPop3IncludeSpam, "");
+        return attrs;
+    }
+
+    /**
+     * Whether Powerpaste preference is enabled by user or admin
+     *
+     * @return zimbraPrefPowerPasteEnabled, or true if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3085)
+    public boolean isPrefPowerPasteEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraPrefPowerPasteEnabled, true, true);
+    }
+
+    /**
+     * Whether Powerpaste preference is enabled by user or admin
+     *
+     * @param zimbraPrefPowerPasteEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3085)
+    public void setPrefPowerPasteEnabled(boolean zimbraPrefPowerPasteEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefPowerPasteEnabled, zimbraPrefPowerPasteEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether Powerpaste preference is enabled by user or admin
+     *
+     * @param zimbraPrefPowerPasteEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3085)
+    public Map<String,Object> setPrefPowerPasteEnabled(boolean zimbraPrefPowerPasteEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefPowerPasteEnabled, zimbraPrefPowerPasteEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether Powerpaste preference is enabled by user or admin
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3085)
+    public void unsetPrefPowerPasteEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefPowerPasteEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether Powerpaste preference is enabled by user or admin
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3085)
+    public Map<String,Object> unsetPrefPowerPasteEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefPowerPasteEnabled, "");
         return attrs;
     }
 


### PR DESCRIPTION
Adding placeholder attribute for 9.1 release.

- Added below two attribute 
  - `zimbraFeaturePowerPasteEnabled`
      - default COS value `TRUE`
  - `zimbraPrefPowerPasteEnabled`
       - default COS value `TRUE`
- Generated getters and setters
- This feature and pref attribute will be returned as part of GetInfo Response.
