### PR TITLE
ZCS-9842: Fixed when request has dryRun=true password should not be changed.

### DIFF
--- a/store/src/java-test/com/zimbra/cs/account/MockProvisioning.java
+++ b/store/src/java-test/com/zimbra/cs/account/MockProvisioning.java
@@ -953,9 +953,8 @@ public final class MockProvisioning extends Provisioning {
     }
 
 	@Override
-	public SetPasswordResult resetPassword(Account acct, String newPassword, boolean dryRun) throws ServiceException {
+	public void resetPassword(Account acct, String newPassword, boolean dryRun) throws ServiceException {
 		// TODO Auto-generated method stub
-		return null;
 	}
 
 }

--- a/store/src/java/com/zimbra/cs/account/Provisioning.java
+++ b/store/src/java/com/zimbra/cs/account/Provisioning.java
@@ -1310,7 +1310,7 @@ public abstract class Provisioning extends ZAttrProvisioning {
         throw ServiceException.UNSUPPORTED();
     }
 
-    public abstract SetPasswordResult resetPassword(Account acct, String newPassword, boolean dryRun) throws ServiceException;
+    public abstract void resetPassword(Account acct, String newPassword, boolean dryRun) throws ServiceException;
 
     public abstract void checkPasswordStrength(Account acct, String password) throws ServiceException;
 

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -6032,12 +6032,6 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
         return setPassword(acct, newPassword, false);
     }
 
-	@Override
-	public SetPasswordResult resetPassword(Account acct, String newPassword, boolean dryRun) 
-	throws ServiceException {
-		return setPassword(acct, newPassword, dryRun);
-	}
-
     @Override
     public SetPasswordResult setPassword(Account acct, String newPassword,
             boolean enforcePasswordPolicy)
@@ -11559,5 +11553,10 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
             LdapClient.closeContext(zlc);
         }
     }
+
+	@Override
+	public void resetPassword(Account acct, String newPassword, boolean dryRun) throws ServiceException {
+		// TODO Auto-generated method stub	
+	}
 
 }

--- a/store/src/java/com/zimbra/cs/account/soap/SoapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/soap/SoapProvisioning.java
@@ -873,14 +873,9 @@ public class SoapProvisioning extends Provisioning {
         invokeJaxb(new ChangePasswordRequest(jaxbAcct, currentPassword, newPassword, dryRun));
     }
 
-    public SetPasswordResult resetPassword(Account acct, String newPassword, boolean dryRun) throws ServiceException {
+    public void resetPassword(Account acct, String newPassword, boolean dryRun) throws ServiceException {
     		SetPasswordResponse resp =
                 invokeJaxb(new SetPasswordRequest(acct.getId(), newPassword, dryRun));
-	    	SetPasswordResult result = new SetPasswordResult();
-	    	String eMsg = resp.getMessage();
-	    	if (eMsg != null)
-	    		result.setMessage(eMsg);
-	    	return result;
     }
 
     @Override


### PR DESCRIPTION
**Problem:**
When the `ResetPassword` request has `dryRun=true` password is also getting changed.

**Fix:**
Fixed when the request has `dryRun=true` password is not getting changed now.

**Testing Done:**
- Tested when `dryRun` option is provided it satisfies the password rule when `COS` settings are changed and is **NOT** changing the password.
- Tested when the `dryRun` option is not provided then in that case only password is getting changed.