### PR TITLE
ZCS-9578 Recurring appointment is shown over zimbraCalendarRecurrenceDailyMaxDays/Weeks

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/calendar/ZRecur.java
+++ b/store/src/java/com/zimbra/cs/mailbox/calendar/ZRecur.java
@@ -113,7 +113,58 @@ public class ZRecur implements Cloneable {
         }
     }
 
-    private Date estimateEndTimeByUntilAndHardLimits(ParsedDateTime dtStart) throws ServiceException {
+    private int estimateMaxCountByCountAndHardLimits() {
+        Frequency freq = mFreq;
+        if (freq == null) {
+            freq = Frequency.WEEKLY;
+        }
+        switch (freq) {
+        case WEEKLY:
+            int weeks = sExpansionLimits.maxWeeks;
+            if (weeks <= 0) {
+                return mCount;
+            } else {
+                return Math.min(weeks, mCount);
+            }
+        case MONTHLY:
+            int months = sExpansionLimits.maxMonths;
+            if (months <= 0) {
+                return mCount;
+            } else {
+                return Math.min(months, mCount);
+            }
+        case YEARLY:
+            int years = sExpansionLimits.maxYears;
+            if (years <= 0) {
+                return mCount;
+            } else {
+                return Math.min(years, mCount);
+            }
+        case DAILY:
+            int days = sExpansionLimits.maxDays;
+            if (days <= 0) {
+                return mCount;
+            } else {
+                return Math.min(days, mCount);
+            }
+        default:
+            int others = sExpansionLimits.maxInstances;
+            if (others <= 0) {
+                return mCount;
+            } else {
+                return Math.min(others, mCount);
+            }
+        }
+    }
+
+    public int getEstimatedCount(ParsedDateTime dtStart) throws ServiceException {
+        if (dtStart == null)
+            return 0;
+        return estimateMaxCountByCountAndHardLimits();
+    }
+
+    // deduct 1 from all values for mUntil calculation when appointment is not all day because it picks the next X occurrences
+    private Date estimateEndTimeByUntilAndHardLimits(ParsedDateTime dtStart, boolean allDay) throws ServiceException {
         boolean forever = false;
         Calendar hardEnd = dtStart.getCalendarCopy();
         Frequency freq = mFreq;
@@ -122,31 +173,47 @@ public class ZRecur implements Cloneable {
         switch (freq) {
         case WEEKLY:
             int weeks = sExpansionLimits.maxWeeks;
-            if (weeks <= 0)
+            if (weeks <= 0) {
                 forever = true;
-            else
+            } else {
+                if (!allDay) {
+                    weeks--;
+                }
                 hardEnd.add(Calendar.WEEK_OF_YEAR, weeks);
+            }
             break;
         case MONTHLY:
             int months = sExpansionLimits.maxMonths;
-            if (months <= 0)
+            if (months <= 0) {
                 forever = true;
-            else
+            } else {
+                if (!allDay) {
+                    months--;
+                }
                 hardEnd.add(Calendar.MONTH, months);
+            }
             break;
         case YEARLY:
             int years = sExpansionLimits.maxYears;
-            if (years <= 0)
+            if (years <= 0) {
                 forever = true;
-            else
+            } else {
+                if (!allDay) {
+                    years--;
+                }
                 hardEnd.add(Calendar.YEAR, years);
+            }
             break;
         case DAILY:
             int days = sExpansionLimits.maxDays;
-            if (days <= 0)
+            if (days <= 0) {
                 forever = true;
-            else
+            } else {
+                if (!allDay) {
+                    days--;
+                }
                 hardEnd.add(Calendar.DAY_OF_YEAR, days);
+            }
             break;
         default:
             int otherFreqYears = Math.max(sExpansionLimits.maxYearsOtherFreqs, 1);
@@ -166,9 +233,12 @@ public class ZRecur implements Cloneable {
     }
 
     public Date getEstimatedEndTime(ParsedDateTime dtStart) throws ServiceException {
+        return getEstimatedEndTime(dtStart, false);
+    }
+    public Date getEstimatedEndTime(ParsedDateTime dtStart, boolean allDay) throws ServiceException {
         if (dtStart == null)
             return null;
-        return estimateEndTimeByUntilAndHardLimits(dtStart);
+        return estimateEndTimeByUntilAndHardLimits(dtStart, allDay);
         // We can't estimate by COUNT because BYxxx rule parts yield too many possibilities.
     }
 


### PR DESCRIPTION
**Problem:** Recurring appointments do not honor max limits set by below attributes.
```
zimbraCalendarRecurrenceMaxInstances
zimbraCalendarRecurrenceDailyMaxDays
zimbraCalendarRecurrenceWeeklyMaxWeeks
zimbraCalendarRecurrenceMonthlyMaxMonths
zimbraCalendarRecurrenceYearlyMaxYears
zimbraCalendarRecurrenceOtherFrequencyMaxYears
```

**Fix & Approach:**
-  When recurring appointment is created/modified, verify it's `count` or `until` with above attribute values and calculate correct `count` or `until` and update in the invite.
- Do above in all 3 cases, when `count` is provided in the invite, when `until` is provided in the invite or invite is created/modifed with never ending recurrence.

**Testing done:**
- Testing done with new zimbra web client.
- All above attribute value changes require mailbox restart.
- Tested daily/weekly/monthly/yearly recurring appointment with all 3 cases.(count, until, never ending)
- Tested all day appointments with daily recurrence with all 3 cases.(count, until, never ending)
- Verified unit test on local. [Here](https://jira.corp.synacor.com/secure/attachment/187821/report_zcs-9578.zip) is the result. The failures are either existing or environment related.

**Testing to be done by QA:**
- Verify create/modify, daily/weekly/monthly/yearly recurring appointment with all 3 cases.(count, until, never ending)
- Verify all above cases with all day appointments.
- Verify other clients like, imap, eas, zco, and if they fail, file new ticket for them.
- Verify case where recurring appointment was created before zcs upgrade with no end date and try to modify same appointment after zcs upgrade with this fix, and it should apply the hard limit set in the attribute.
- Check existing SOAP automation and correct if any automation needs changes or write new automation if possible.