### PR TITLE
ZCS-10035: Return error code when 2fa is enabled for admin account

### DIFF
--- a/store/src/java/com/zimbra/cs/service/admin/Auth.java
+++ b/store/src/java/com/zimbra/cs/service/admin/Auth.java
@@ -28,6 +28,8 @@ import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.lang.StringUtils;
+
 import com.zimbra.common.account.Key;
 import com.zimbra.common.account.Key.AccountBy;
 import com.zimbra.common.service.ServiceException;
@@ -36,18 +38,28 @@ import com.zimbra.common.soap.AdminConstants;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.HeaderConstants;
 import com.zimbra.common.util.Constants;
+import com.zimbra.common.util.UUIDUtil;
 import com.zimbra.common.util.ZimbraCookie;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.AccountServiceException;
 import com.zimbra.cs.account.AccountServiceException.AuthFailedServiceException;
+import com.zimbra.cs.account.AuthToken.TokenType;
+import com.zimbra.cs.account.AuthToken.Usage;
+import com.zimbra.cs.account.Provisioning.AuthMode;
 import com.zimbra.cs.account.AuthToken;
 import com.zimbra.cs.account.AuthTokenException;
 import com.zimbra.cs.account.Domain;
 import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.TrustedDevice;
+import com.zimbra.cs.account.TrustedDeviceToken;
 import com.zimbra.cs.account.accesscontrol.AdminRight;
 import com.zimbra.cs.account.auth.AuthContext;
 import com.zimbra.cs.account.auth.AuthMechanism.AuthMech;
+import com.zimbra.cs.account.auth.twofactor.AppSpecificPasswords;
+import com.zimbra.cs.account.auth.twofactor.TrustedDevices;
 import com.zimbra.cs.account.auth.twofactor.TwoFactorAuth;
+import com.zimbra.cs.listeners.AuthListener;
 import com.zimbra.cs.service.AuthProvider;
 import com.zimbra.cs.servlet.CsrfFilter;
 import com.zimbra.cs.servlet.util.CsrfUtil;
@@ -64,6 +76,7 @@ public class Auth extends AdminDocumentHandler {
         ZimbraSoapContext zsc = getZimbraSoapContext(context);
         AuthToken at = null;
         Account acct = null;
+        String acctValuePassedIn = null;
 
         Provisioning prov = Provisioning.getInstance();
         boolean csrfSupport = request.getAttributeBool(AccountConstants.A_CSRF_SUPPORT, false);
@@ -119,6 +132,7 @@ public class Auth extends AdminDocumentHandler {
                 throw ServiceException.INVALID_REQUEST("missing <name> or <account>", null);
 
             String password = request.getAttribute(AdminConstants.E_PASSWORD, null);
+            String recoveryCode = request.getAttribute(AccountConstants.E_RECOVERY_CODE, null);
             String twoFactorCode = request.getAttribute(AccountConstants.E_TWO_FACTOR_CODE, null);
             Element virtualHostEl = request.getOptionalElement(AccountConstants.E_VIRTUAL_HOST);
             String virtualHost = virtualHostEl == null ? null : virtualHostEl.getText().toLowerCase();
@@ -169,13 +183,135 @@ public class Auth extends AdminDocumentHandler {
                 authCtxt.put(AuthContext.AC_REMOTE_IP, context.get(SoapEngine.SOAP_REQUEST_IP));
                 authCtxt.put(AuthContext.AC_ACCOUNT_NAME_PASSEDIN, valuePassedIn);
                 authCtxt.put(AuthContext.AC_USER_AGENT, zsc.getUserAgent());
-                authCtxt.put(AuthContext.AC_AS_ADMIN, Boolean.TRUE);
-                prov.authAccount(acct, password, AuthContext.Protocol.soap, authCtxt);
-                TwoFactorAuth twoFactorAuth = TwoFactorAuth.getFactory().getTwoFactorAuth(acct);
-                boolean usingTwoFactorAuth = twoFactorAuth.twoFactorAuthEnabled();
-                if (usingTwoFactorAuth) {
-                    if (twoFactorCode != null) {
-                        twoFactorAuth.authenticate(twoFactorCode);
+                authCtxt.put(AuthContext.AC_AS_ADMIN, Boolean.TRUE);          
+                
+                String deviceId = request.getAttribute(AccountConstants.E_DEVICE_ID, null);
+                Element authTokenEl = request.getOptionalElement(AccountConstants.E_AUTH_TOKEN);
+                String reqTokenType = request.getAttribute(AccountConstants.A_TOKEN_TYPE, "");
+                TokenType tokenType = TokenType.fromCode(reqTokenType);
+                boolean generateDeviceId = request.getAttributeBool(AccountConstants.A_GENERATE_DEVICE_ID, false);
+                String newDeviceId = generateDeviceId? UUIDUtil.generateUUID(): null;
+                
+                AuthMode mode = AuthMode.PASSWORD;
+                String code = password;
+                if (StringUtils.isEmpty(password) && StringUtils.isNotEmpty(recoveryCode)) {
+                    mode = AuthMode.RECOVERY_CODE;
+                    code = recoveryCode;
+                }
+                authCtxt.put(Provisioning.AUTH_MODE_KEY, mode);
+                
+                TrustedDeviceToken trustedToken = null;
+                if (acct != null) {
+                	if(acctEl != null) {
+                		acctValuePassedIn = acctEl.getText();
+                	}
+                    TrustedDevices trustedDeviceManager = TwoFactorAuth.getFactory().getTrustedDevices(acct);
+                    if (trustedDeviceManager != null) {
+                        trustedToken = trustedDeviceManager.getTokenFromRequest(request, context);
+                        if (trustedToken != null && trustedToken.isExpired()) {
+                            TrustedDevice device = trustedDeviceManager.getTrustedDeviceByTrustedToken(trustedToken);
+                            if (device != null) {
+                                device.revoke();
+                            }
+                        }
+                    }
+                }
+                
+                Boolean registerTrustedDevice = false;
+                TwoFactorAuth twoFactorManager = TwoFactorAuth.getFactory().getTwoFactorAuth(acct);
+                if (twoFactorManager.twoFactorAuthEnabled()) {
+                    registerTrustedDevice = trustedToken == null && request.getAttributeBool(AccountConstants.A_TRUSTED_DEVICE, false);
+                }
+                
+                boolean trustedDeviceOverride = false;
+                if (trustedToken != null && acct.isFeatureTrustedDevicesEnabled()) {
+                    if (trustedToken.isExpired()) {
+                        ZimbraLog.account.debug("trusted token is expired");
+                        registerTrustedDevice = false;
+                    } else {
+                        Map<String, Object> attrs = getTrustedDeviceAttrs(zsc, deviceId);
+                        try {
+                            verifyTrustedDevice(acct, trustedToken, attrs);
+                            trustedDeviceOverride = true;
+                        } catch (AuthFailedServiceException e) {
+                            AuthListener.invokeOnException(e);
+                            ZimbraLog.account.info("trusted device not verified");
+                        }
+                    }
+                }
+                boolean usingTwoFactorAuth = acct != null && twoFactorManager.twoFactorAuthRequired() && !trustedDeviceOverride;
+                boolean twoFactorAuthWithToken = usingTwoFactorAuth && authTokenEl != null;
+                if (password != null || recoveryCode != null || twoFactorAuthWithToken) {
+                    // authentication logic can be reached with either a password, or a 2FA auth token
+                    if (usingTwoFactorAuth && twoFactorCode == null && (password != null || recoveryCode != null)) {
+                        int mtaAuthPort = acct.getServer().getMtaAuthPort();
+                        boolean supportsAppSpecificPaswords =  acct.isFeatureAppSpecificPasswordsEnabled() && zsc.getPort() == mtaAuthPort;
+                        if (supportsAppSpecificPaswords && password != null) {
+                            // if we are here, it means we are authenticating SMTP,
+                            // so app-specific passwords are accepted. Other protocols (pop, imap)
+                            // doesn't touch this code, so their authentication happens in ZimbraAuth.
+                            AppSpecificPasswords appPasswords = TwoFactorAuth.getFactory().getAppSpecificPasswords(acct, acctValuePassedIn);
+                            appPasswords.authenticate(password);
+                        } else {
+                            prov.authAccount(acct, code, AuthContext.Protocol.soap, authCtxt);
+                            return needTwoFactorAuth(acct, twoFactorManager, zsc, tokenType);
+                        }
+                    } else {
+                        if (password != null || recoveryCode != null) {
+                            prov.authAccount(acct, code, AuthContext.Protocol.soap, authCtxt);
+                        } else {
+                            // it's ok to not have a password if the client is using a 2FA auth token for the 2nd step of 2FA
+                            if (!twoFactorAuthWithToken) {
+                                throw ServiceException.AUTH_REQUIRED();
+                            }
+                        }
+                        if (usingTwoFactorAuth) {
+                            // check that 2FA has been enabled, in case the client is passing in a twoFactorCode prior to setting up 2FA
+                            if (!twoFactorManager.twoFactorAuthEnabled()) {
+                                throw AccountServiceException.TWO_FACTOR_SETUP_REQUIRED();
+                            }
+                            AuthToken twoFactorToken = null;
+                            if (password == null) {
+                                try {
+                                    twoFactorToken = AuthProvider.getAuthToken(authTokenEl, acct);
+                                    Account twoFactorTokenAcct = AuthProvider.validateAuthToken(prov, twoFactorToken, false, Usage.TWO_FACTOR_AUTH);
+                                    boolean verifyAccount = authTokenEl.getAttributeBool(AccountConstants.A_VERIFY_ACCOUNT, false);
+                                    if (verifyAccount && !twoFactorTokenAcct.getId().equalsIgnoreCase(acct.getId())) {
+                                        throw new AuthTokenException("two-factor auth token doesn't match the named account");
+                                    }
+                                } catch (AuthTokenException e) {
+                                    AuthFailedServiceException exception = AuthFailedServiceException
+                                        .AUTH_FAILED("bad auth token");
+                                    AuthListener.invokeOnException(exception);
+                                    throw exception;
+                                }
+                            }
+                            TwoFactorAuth manager = TwoFactorAuth.getFactory().getTwoFactorAuth(acct);
+                            if (twoFactorCode != null) {
+                                manager.authenticate(twoFactorCode);
+                            } else {
+                                AuthFailedServiceException e = AuthFailedServiceException
+                                    .AUTH_FAILED("no two-factor code provided");
+                                AuthListener.invokeOnException(e);
+                                throw e;
+                            }
+                            if (twoFactorToken != null) {
+                                try {
+                                    twoFactorToken.deRegister();
+                                } catch (AuthTokenException e) {
+                                    throw ServiceException.FAILURE("cannot de-register two-factor auth token", e);
+                                }
+                            }
+                        }
+                    }
+                } 
+
+                if (registerTrustedDevice && (trustedToken == null || trustedToken.isExpired())) {
+                    //generate a new trusted device token if there is no existing one or if the current one is no longer valid
+                    Map<String, Object> attrs = getTrustedDeviceAttrs(zsc, newDeviceId == null? deviceId: newDeviceId);
+                    TrustedDevices trustedDeviceManager = TwoFactorAuth.getFactory().getTrustedDevices(acct);
+                    if (trustedDeviceManager != null) {
+                        trustedToken = trustedDeviceManager.registerTrustedDevice(attrs);
                     }
                 }
                 checkAdmin(acct);
@@ -193,6 +329,39 @@ public class Auth extends AdminDocumentHandler {
         ServletRequest httpReq = (ServletRequest) context.get(SoapServlet.SERVLET_REQUEST);
         httpReq.setAttribute(CsrfFilter.AUTH_TOKEN, at);
         return doResponse(request, at, zsc, context, acct, csrfSupport);
+    }
+    
+    private Map<String, Object> getTrustedDeviceAttrs(ZimbraSoapContext zsc, String deviceId) {
+        Map<String, Object> deviceAttrs = new HashMap<String, Object>();
+        deviceAttrs.put(AuthContext.AC_DEVICE_ID, deviceId);
+        deviceAttrs.put(AuthContext.AC_USER_AGENT, zsc.getUserAgent());
+        return deviceAttrs;
+    }
+    
+    private void verifyTrustedDevice(Account account, TrustedDeviceToken td, Map<String, Object> attrs) throws ServiceException {
+        TrustedDevices trustedDeviceManager = TwoFactorAuth.getFactory().getTrustedDevices(account);
+        trustedDeviceManager.verifyTrustedDevice(td, attrs);
+    }
+
+    private Element needTwoFactorAuth(Account account, TwoFactorAuth auth, ZimbraSoapContext zsc, TokenType tokenType) throws ServiceException {
+        /* two cases here:
+         * 1) the user needs to provide a two-factor code.
+         *    in this case, the server returns a two-factor auth token in the response header that the client
+         *    must send back, along with the code, in order to finish the authentication process.
+         * 2) the user needs to set up two-factor auth.
+         *    this can happen if it's required for the account but the user hasn't received a secret yet.
+         */
+        if (!auth.twoFactorAuthEnabled()) {
+            throw AccountServiceException.TWO_FACTOR_SETUP_REQUIRED();
+        } else {
+            Element response = zsc.createElement(AccountConstants.AUTH_RESPONSE);
+            AuthToken twoFactorToken = AuthProvider.getAuthToken(account, Usage.TWO_FACTOR_AUTH, tokenType);
+            response.addUniqueElement(AccountConstants.E_TWO_FACTOR_AUTH_REQUIRED).setText("true");
+            response.addAttribute(AccountConstants.E_LIFETIME, twoFactorToken.getExpires() - System.currentTimeMillis(), Element.Disposition.CONTENT);
+            twoFactorToken.encodeAuthResp(response, false);
+            response.addUniqueElement(AccountConstants.E_TRUSTED_DEVICES_ENABLED).setText(account.isFeatureTrustedDevicesEnabled() ? "true" : "false");
+            return response;
+        }
     }
 
     private void checkAdmin(Account acct) throws ServiceException {


### PR DESCRIPTION
**Problem:** For admin auth, no exception was returned to client indicating that two-factor setup is required.

**Fix:** Added necessary code to return exception indicating that two-factor setup is required.

**Testing to be done by QA:** 

1. Check if proper exception is returned when two factor is enabled for admin auth indicating that two-factor setup is required.
2. Check if auth is working as before if 2fa is not enabled for the admin account. 