### PR TITLE
 ZBUG-1456 Connection pool shut down 3.0

### DIFF
--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -1255,6 +1255,7 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
             mTransport.setMaxNotifySeq(0);
             mSize = event.getSize();
             if (root != null) {
+                mUserRoot = root;
                 try {
                     // skip the cache update if invalid auth/zmailbox instance
                     mailbox.getAccountId();
@@ -1262,7 +1263,6 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
                     ZimbraLog.cache.error("Unable to refresh mailbox item id mappings due to missing auth info.");
                     return;
                 }
-                mUserRoot = root;
                 addIdMappings(mUserRoot);
             }
             if (tags != null) {


### PR DESCRIPTION
**Problem:** `InternalEventHandler.handleRefresh()` and `InternalEventHandler.handleModify()` stuck in loop calling each other resulting `StackOverflowError`.

**Approach and Fix:**
- This is side effect of fix for [ZBUG-527](https://jira.corp.synacor.com/browse/ZBUG-527) and was missed in [ZBUG-1080](https://jira.corp.synacor.com/browse/ZBUG-1080)
- Issue not reproducible locally or in lab.
- `ZMailbox.populateFolderCache()` method creates refresh event and calls `handleRefresh()` method on handlers since `mUserRoot` is not set and the loop starts.
- So set `mUserRoot` before calling `mailbox.getAccountId()`

**Testing to be done by QA:**
- Reproduce issue before fix, if possible. Steps to reproduce are given on ticket by Mukesh.
- Verify shared folder syncing on IMAP client.(sharee and sharer should be on different mailbox nodes)
- Make sure nothing is broken.