### PR TITLE
ZBUG-1456

### DIFF
--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -985,7 +985,7 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
      * @throws ServiceException If there are issues parsing or handling the request
      */
     @SuppressWarnings("unchecked")
-    public <T> T invokeJaxb(Object jaxbObject, Consumer<Element> bodyHandler) throws ServiceException {
+    private <T> T invokeJaxb(Object jaxbObject, Consumer<Element> bodyHandler) throws ServiceException {
         Element res = invoke(JaxbUtil.jaxbToElement(jaxbObject), null, bodyHandler);
         return (T) JaxbUtil.elementToJaxb(res);
     }
@@ -1024,7 +1024,7 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
         return invoke(request, requestedAccountId, null);
     }
 
-    public Element invoke(Element request, String requestedAccountId, Consumer<Element> bodyHandler) throws ServiceException {
+    private Element invoke(Element request, String requestedAccountId, Consumer<Element> bodyHandler) throws ServiceException {
         lock();
         try {
             try {
@@ -1398,13 +1398,21 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
                 }
             } else if (event instanceof ZModifyFolderEvent) {
                 ZModifyFolderEvent mfe = (ZModifyFolderEvent) event;
-                ZFolder f = getFolderById(mfe.getId());
-                if (f != null) {
-                    String newParentId = mfe.getParentId(null);
-                    if (newParentId != null && !newParentId.equals(f.getParentId())) {
-                        reparent(f, newParentId);
+                // don't allow modify events to force refresh folders
+                // this will prevent overflow if a lot of modification events are happening
+                boolean backupAlwaysRefreshFolders = alwaysRefreshFolders;
+                try {
+                    alwaysRefreshFolders = false;
+                    ZFolder f = getFolderById(mfe.getId());
+                    if (f != null) {
+                        String newParentId = mfe.getParentId(null);
+                        if (newParentId != null && !newParentId.equals(f.getParentId())) {
+                            reparent(f, newParentId);
+                        }
+                        f.modifyNotification(event);
                     }
-                    f.modifyNotification(event);
+                } finally {
+                    alwaysRefreshFolders = backupAlwaysRefreshFolders;
                 }
             } else if (event instanceof ZModifyMailboxEvent) {
                 ZModifyMailboxEvent mme = (ZModifyMailboxEvent) event;

--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -1255,6 +1255,7 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
             mTransport.setMaxNotifySeq(0);
             mSize = event.getSize();
             if (root != null) {
+                mUserRoot = root;
                 try {
                     // skip the cache update if invalid auth/zmailbox instance
                     mailbox.getAccountId();
@@ -1262,7 +1263,6 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
                     ZimbraLog.cache.error("Unable to refresh mailbox item id mappings due to missing auth info.");
                     return;
                 }
-                mUserRoot = root;
                 addIdMappings(mUserRoot);
             }
             if (tags != null) {

--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -1108,8 +1108,10 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
         if (ZimbraNamespace.E_BATCH_REQUEST.equals(originalRequestName)) {
             return res;
         }
-        // return the first non-getinfo response (there should only be 1 child element at this point)
+        // return the first non-getinfo response (there should only be 1 child element if no errors)
         for (Element e : res.listElements()) {
+            // always check for errors in order
+            ensureNotSoapFault(e);
             if (!AccountConstants.GET_INFO_RESPONSE.equals(e.getQName())) {
                 return e;
             }
@@ -1119,6 +1121,17 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
         // wrapRequest should only be wrapping things if accountId and mGetInfoResult are null
         ZimbraLog.mailbox.error("Batch response was missing the primary request.");
         throw ServiceException.FAILURE("Batch response was missing the primary request.", null);
+    }
+
+    private void ensureNotSoapFault(Element e) throws ServiceException {
+        final SoapProtocol proto = mTransport.getRequestProtocol();
+        if (e != null && proto.isFault(e)) {
+            // make sure the target account id is properly set
+            if (mTransport.getTargetAcctId() != null) {
+                proto.updateArgumentsForRemoteFault(e, mTransport.getTargetAcctId());
+            }
+            throw proto.soapFault(e);
+        }
     }
 
     private void doConnectionAndSSLFailures(Exception e) throws RemoteServiceException {

--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -1305,11 +1305,10 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
                 try {
                     // skip the cache update if invalid auth/zmailbox instance
                     mailbox.getAccountId();
+                    addIdMappings(mUserRoot);
                 } catch (ServiceException e) {
                     ZimbraLog.cache.error("Unable to refresh mailbox item id mappings due to missing auth info.");
-                    return;
                 }
-                addIdMappings(mUserRoot);
             }
             if (tags != null) {
                 if (mNameToTag == null) {

--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -1004,7 +1004,7 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
                 } else {
                     response = mTransport.invoke(wrapRequest(request, uuid), nosession, requestedAccountId, this.mNotificationFormat, this.mCurWaitSetID);
                 }
-                return unwrapResponse(response, request.getQName(), uuid);
+                return unwrapAndHandleResponse(response, request.getQName(), uuid);
             } catch (SoapFaultException e) {
                 throw e; // for now, later, try to map to more specific exception
             } catch (IOException e) {
@@ -1048,14 +1048,30 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
         return batchRequest;
     }
 
-    private Element unwrapResponse(Element res, QName originalRequestName, String uuid) throws ServiceException {
+    private Element unwrapAndHandleResponse(Element res, QName originalRequestName, String uuid) throws ServiceException {
         // nothing to unwrap if this isn't a batch response with child elements
         if (res == null || !ZimbraNamespace.E_BATCH_RESPONSE.equals(res.getQName()) || !res.hasChildren()) {
             return res;
         }
         ZimbraLog.mailbox.debug("Unwrapping response: %s.", res.getName());
+        // if not already cached, cache any auth result so context notification handling has immediate access
+        final Element authElement = res.getOptionalElement(AccountConstants.AUTH_RESPONSE);
+        if (authElement != null && mAuthResult == null) {
+            final AuthResponse authResponse = JaxbUtil.elementToJaxb(authElement);
+            mAuthResult = new ZAuthResult(authResponse);
+            mAuthResult.setSessionId(mTransport.getSessionId());
+            initCsrfToken(mAuthResult.getCsrfToken());
+            initAuthToken(mAuthResult.getAuthToken());
+            initTrustedToken(mAuthResult.getTrustedToken());
+            // attempt to match whatever AccountBy was originally being used
+            if (name != null) {
+                initTargetAccountForTransport(name, AccountBy.name);
+            } else if (accountId != null) {
+                initTargetAccountForTransport(accountId, AccountBy.id);
+            }
+        }
         // if not already cached, cache any info response so subsequent requests don't need to fetch it
-        final Element infoElement = res.getOptionalElement(AccountConstants.E_GET_INFO_RESPONSE);
+        final Element infoElement = res.getOptionalElement(AccountConstants.GET_INFO_RESPONSE);
         if (infoElement != null && mGetInfoResult == null) {
             GetInfoResponse infoResponse = JaxbUtil.elementToJaxb(infoElement);
             mGetInfoResult = new ZGetInfoResult(infoResponse);
@@ -1076,8 +1092,8 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
             }
         }
         // we shouldn't get here as long as this method is only used to unwrap responses from requests created
-        // by wrapResponse. if we do get here, check wrapResponse's elements and where it is being used.
-        // wrapResponse should only be wrapping things if accountId and mGetInfoResult are null
+        // by wrapRequest. if we do get here, check wrapRequest's elements and where it is being used.
+        // wrapRequest should only be wrapping things if accountId and mGetInfoResult are null
         ZimbraLog.mailbox.error("Batch response was missing the primary request.");
         throw ServiceException.FAILURE("Batch response was missing the primary request.", null);
     }

--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -996,13 +997,14 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
         try {
             try {
                 boolean nosession = mNotifyPreference == SessionPreference.nosession;
+                final String uuid = UUID.randomUUID().toString();
                 Element response = null;
                 if (nosession) {
-                    response = mTransport.invoke(wrapRequest(request), false, nosession, requestedAccountId);
+                    response = mTransport.invoke(wrapRequest(request, uuid), false, nosession, requestedAccountId);
                 } else {
-                    response = mTransport.invoke(wrapRequest(request), nosession, requestedAccountId, this.mNotificationFormat, this.mCurWaitSetID);
+                    response = mTransport.invoke(wrapRequest(request, uuid), nosession, requestedAccountId, this.mNotificationFormat, this.mCurWaitSetID);
                 }
-                return unwrapResponse(response, request.getQName());
+                return unwrapResponse(response, request.getQName(), uuid);
             } catch (SoapFaultException e) {
                 throw e; // for now, later, try to map to more specific exception
             } catch (IOException e) {
@@ -1021,46 +1023,61 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
         }
     }
 
-    private Element wrapRequest(Element req) throws ServiceException {
-        // business as usual if accountId is present, getInfo has already been retrieved, this is getInfo, or batch request
+    private Element wrapRequest(Element req, String uuid) throws ServiceException {
+        // business as usual if accountId is present, getInfo has already been retrieved, or this is getInfo
         if (accountId != null || mGetInfoResult != null
-            || AccountConstants.GET_INFO_REQUEST.equals(req.getQName())
-            || ZimbraNamespace.E_BATCH_REQUEST.equals(req.getQName())) {
+            || AccountConstants.GET_INFO_REQUEST.equals(req.getQName())) {
             return req;
         }
-        ZimbraLog.mailbox.debug("Wrapping request with info request: %s.", req.getName());
         // batch for the account info after the outgoing request.
         // this works even if the first request is an auth request
-        Element infoRequest = JaxbUtil.jaxbToElement(new GetInfoRequest(NOT_ZIMLETS));
-        Element batchRequest = Element.create(SoapProtocol.Soap12, ZimbraNamespace.E_BATCH_REQUEST);
-        batchRequest.addNonUniqueElement(req);
-        batchRequest.addNonUniqueElement(infoRequest);
+        ZimbraLog.mailbox.debug("Adding info request to: %s.", req.getName());
+        // make sure we have a batch request or create one and add the original
+        Element batchRequest = req;
+        if (!ZimbraNamespace.E_BATCH_REQUEST.equals(req.getQName())) {
+            batchRequest = Element.create(SoapProtocol.Soap12, ZimbraNamespace.E_BATCH_REQUEST);
+            batchRequest.addNonUniqueElement(req);
+        }
+        // create and add the info request with a correlator if not already present
+        Element infoRequest = batchRequest.getOptionalElement(AccountConstants.GET_INFO_REQUEST);
+        if (infoRequest == null) {
+            infoRequest = JaxbUtil.jaxbToElement(new GetInfoRequest(NOT_ZIMLETS));
+            infoRequest.addAttribute(ZimbraNamespace.A_REQUEST_ID, uuid);
+            batchRequest.addNonUniqueElement(infoRequest);
+        }
         return batchRequest;
     }
 
-    private Element unwrapResponse(Element res, QName originalRequestName) throws ServiceException {
+    private Element unwrapResponse(Element res, QName originalRequestName, String uuid) throws ServiceException {
         // nothing to unwrap if this isn't a batch response with child elements
-        if (res == null || !ZimbraNamespace.E_BATCH_RESPONSE.equals(res.getQName()) || !res.hasChildren()
-            // or if the original request was already a batch request
-            || ZimbraNamespace.E_BATCH_REQUEST.equals(originalRequestName)) {
+        if (res == null || !ZimbraNamespace.E_BATCH_RESPONSE.equals(res.getQName()) || !res.hasChildren()) {
             return res;
         }
         ZimbraLog.mailbox.debug("Unwrapping response: %s.", res.getName());
-        // cache any info response so subsequent requests don't need to fetch it
+        // if not already cached, cache any info response so subsequent requests don't need to fetch it
         final Element infoElement = res.getOptionalElement(AccountConstants.E_GET_INFO_RESPONSE);
-        if (infoElement != null) {
+        if (infoElement != null && mGetInfoResult == null) {
             GetInfoResponse infoResponse = JaxbUtil.elementToJaxb(infoElement);
             mGetInfoResult = new ZGetInfoResult(infoResponse);
             accountId = mGetInfoResult.getId();
+            // remove the info response if we added it to the request in wrapRequest
+            if (uuid.equals(infoElement.getAttribute(ZimbraNamespace.A_REQUEST_ID, ""))) {
+                infoElement.detach();
+            }
         }
-        // return the first non-getinfo response (there should only be 2 elements)
+        // if the original request was a batch request we're done
+        if (ZimbraNamespace.E_BATCH_REQUEST.equals(originalRequestName)) {
+            return res;
+        }
+        // return the first non-getinfo response (there should only be 1 child element at this point)
         for (Element e: res.listElements()) {
             if (!AccountConstants.GET_INFO_RESPONSE.equals(e.getQName())) {
                 return e;
             }
         }
         // we shouldn't get here as long as this method is only used to unwrap responses from requests created
-        // by wrapResponse. if we do get here, check wrapResponse's elements and where it is being used
+        // by wrapResponse. if we do get here, check wrapResponse's elements and where it is being used.
+        // wrapResponse should only be wrapping things if accountId and mGetInfoResult are null
         ZimbraLog.mailbox.error("Batch response was missing the primary request.");
         throw ServiceException.FAILURE("Batch response was missing the primary request.", null);
     }


### PR DESCRIPTION
**Problem**
* Notification cycling due to a combination of the following issues resulting in a stackoverflow on the client and/or potentially a connection pool shutdown from too many noop/getInfo requests.
* Early request auth failures when using ZMailbox without explicitly specified auth token at creation
* accountId is unset if not explicitly specified, and may remain unset due to:
  * invalid auth in early requests preventing the requests from retrieving the accountId for a period of time
  * notification cycling if many events are happening on the server, preventing the getAccountInfo invoke finally block from returning.

**Solution**
* Prevent notification cycle by disabling forced noop invoke when handling notifications. The other fixes mask the need for invokes during response context handling.
* Fix missing auth on early requests for non-delegated auth ZMailboxes by saving auth token before processing response context
* Fix missing accountId by batching a getInfo request into first soap request if necessary - saves an extra request and prevents receiving more notifications during a second request that will be handled out of order to the current set being handled.

**Testing**
* Reproduced issue prior to fix by triggering moderate amount of modify events on several threads (mark as read 50-100k messages, move 50-100k messages between folders, add 6 messages per second to inbox), while requesting a new mailbox along with all folders, etc on another. See ticket for details.
* Verified issue could not be reproduced in specified fashion after fix.

**Testing to be done by QA**
* Reproduce issue before fix. Steps to reproduce are given on ticket by Prashant.
* Verify issue cannot be reproduced after fix. Steps to reproduce are given on ticket by Prashant.
* Verify shared folder syncing on IMAP client. (sharee and sharer should be on different mailbox nodes)
* Test zmmailbox cli utility with direct auth (-m, -p flags), admin auth (-a, or -z flags) for impact. Use -d flag for soap request/response inspection.
* Test classic webclient in a variety of use-cases.
* Make sure nothing is broken.

See #1103.


Side note: the notification handling is/was problematic as mailbox#invoke handles them in `try { transport.invoke } finally { handleResponseContext ... }` fashion. Since they're processed on the stack, if `handleResponseContext` invokes and receives more notifications, the newer notifications would be handled before the previous stack layer finishes handling theirs. This probably needs a queue on the client side if invokes are eventually unavoidable again while handling notifications