### PR TITLE
feature/ZCS-10060 : Upgraded SSH client library

### DIFF
--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -88,7 +88,8 @@
   <dependency org="org.bouncycastle" name="bcpkix-jdk15on" rev="1.64"/>
   <dependency org="com.googlecode.concurrentlinkedhashmap" name="concurrentlinkedhashmap-lru" rev="1.3.1" />
   <dependency org="org.apache.commons" name="commons-csv" rev="1.2"/>
-  <dependency org="ch.ethz.ganymed" name="ganymed-ssh2" rev="build210" />
+  <dependency org="org.jenkins-ci" name="trilead-ssh2" rev="build-217-jenkins-27" />
+  <dependency org="net.i2p.crypto" name="eddsa" rev="0.3.0" />
   <dependency org="ant-tar-patched" name="ant-tar-patched" rev="1.0" />
   <dependency org="com.yahoo.platform.yui" name="yuicompressor" rev="2.4.2-zimbra" />
   <dependency org="org.hsqldb" name="hsqldb" rev="2.2.9" />

--- a/store/src/java/com/zimbra/cs/rmgmt/RemoteManager.java
+++ b/store/src/java/com/zimbra/cs/rmgmt/RemoteManager.java
@@ -31,9 +31,9 @@ import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.Server;
 import com.zimbra.cs.util.Zimbra;
 
-import ch.ethz.ssh2.Connection;
-import ch.ethz.ssh2.Session;
-import ch.ethz.ssh2.StreamGobbler;
+import com.trilead.ssh2.Connection;
+import com.trilead.ssh2.Session;
+import com.trilead.ssh2.StreamGobbler;
 
 public class RemoteManager {
 


### PR DESCRIPTION
**Problem**: RemoteManager calls are failing with FIPS enabled.
https://jira.corp.synacor.com/browse/ZCS-10060?focusedCommentId=1419982&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1419982

Ganymed SSH-2 offering KexAlgorithms: `diffie-hellman-group-exchange-sha1`, `diffie-hellman-group14-sha1`, `diffie-hellman-group1-sha1` , which are not allowed in FIPS mode.

**Solution** : Replaced Ganymed SSH-2 with Trilead SSH-2 , which supports KexAlgorithms allowed in FIPS mode.