### PR TITLE
ZCS-10060 :  Replaced Ganymed SSH-2 with Apache MINA SSHD

### DIFF
--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -88,7 +88,8 @@
   <dependency org="org.bouncycastle" name="bcpkix-jdk15on" rev="1.64"/>
   <dependency org="com.googlecode.concurrentlinkedhashmap" name="concurrentlinkedhashmap-lru" rev="1.3.1" />
   <dependency org="org.apache.commons" name="commons-csv" rev="1.2"/>
-  <dependency org="ch.ethz.ganymed" name="ganymed-ssh2" rev="build210" />
+  <dependency org="org.apache.sshd" name="sshd-common" rev="2.5.1"/>
+  <dependency org="org.apache.sshd" name="sshd-core" rev="2.5.1"/>
   <dependency org="ant-tar-patched" name="ant-tar-patched" rev="1.0" />
   <dependency org="com.yahoo.platform.yui" name="yuicompressor" rev="2.4.2-zimbra" />
   <dependency org="org.hsqldb" name="hsqldb" rev="2.2.9" />

--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -88,8 +88,8 @@
   <dependency org="org.bouncycastle" name="bcpkix-jdk15on" rev="1.64"/>
   <dependency org="com.googlecode.concurrentlinkedhashmap" name="concurrentlinkedhashmap-lru" rev="1.3.1" />
   <dependency org="org.apache.commons" name="commons-csv" rev="1.2"/>
-  <dependency org="org.apache.sshd" name="sshd-common" rev="2.5.1"/>
-  <dependency org="org.apache.sshd" name="sshd-core" rev="2.5.1"/>
+  <dependency org="org.apache.sshd" name="sshd-common" rev="2.6.0"/>
+  <dependency org="org.apache.sshd" name="sshd-core" rev="2.6.0"/>
   <dependency org="ant-tar-patched" name="ant-tar-patched" rev="1.0" />
   <dependency org="com.yahoo.platform.yui" name="yuicompressor" rev="2.4.2-zimbra" />
   <dependency org="org.hsqldb" name="hsqldb" rev="2.2.9" />

--- a/store/src/java/com/zimbra/cs/rmgmt/RemoteManager.java
+++ b/store/src/java/com/zimbra/cs/rmgmt/RemoteManager.java
@@ -16,11 +16,24 @@
  */
 package com.zimbra.cs.rmgmt;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.util.EnumSet;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.sshd.client.SshClient;
+import org.apache.sshd.client.channel.ClientChannel;
+import org.apache.sshd.client.channel.ClientChannelEvent;
+import org.apache.sshd.client.session.ClientSession;
+import org.apache.sshd.common.util.security.SecurityUtils;
 
 import com.zimbra.common.account.Key;
 import com.zimbra.common.service.ServiceException;
@@ -31,9 +44,7 @@ import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.Server;
 import com.zimbra.cs.util.Zimbra;
 
-import ch.ethz.ssh2.Connection;
-import ch.ethz.ssh2.Session;
-import ch.ethz.ssh2.StreamGobbler;
+
 
 public class RemoteManager {
 
@@ -95,27 +106,25 @@ public class RemoteManager {
     }
 
     private synchronized void executeBackground0(String command, RemoteBackgroundHandler handler) {
-        Session s = null;
+        RemoteResult result = new RemoteResult();
         try {
-            s = getSession();
-            if (ZimbraLog.rmgmt.isDebugEnabled()) ZimbraLog.rmgmt.debug("(bg) executing shim command  '" + mShimCommand + "' on " + this);
-            s.execCommand(mShimCommand);
-            OutputStream os = s.getStdin();
-            String send = "HOST:" + mHost + " " + command;
-            if (ZimbraLog.rmgmt.isDebugEnabled()) ZimbraLog.rmgmt.debug("(bg) sending mgmt command '" + send + "' on " + this);
-            os.write(send.getBytes());
-            os.close();
-            InputStream stdout = new StreamGobbler(s.getStdout());
-            InputStream stderr = new StreamGobbler(s.getStderr());
-            handler.read(stdout, stderr);
-        } catch (OutOfMemoryError e) {
+            result = executeRemoteCommand(mUser,mHost,mPort,mPrivateKey,mShimCommand,command);
+            if (ZimbraLog.rmgmt.isTraceEnabled()) {
+                try {
+                    ZimbraLog.rmgmt.trace("stdout content for cmd:\n%s", new String(result.mStdout, "UTF-8"));
+                    ZimbraLog.rmgmt.trace("stderr content for cmd:\n%s", new String(result.mStderr, "UTF-8"));
+                } catch (Exception ex) {
+                    ZimbraLog.rmgmt.trace("Problem logging stdout or stderr for cmd - probably not UTF-8");
+                }
+            }
+            InputStream stdout = new ByteArrayInputStream(result.mStdout);
+            InputStream stderr = new ByteArrayInputStream(result.mStderr);
+            handler.read(stdout,stderr);
+        }
+        catch (OutOfMemoryError e) {
             Zimbra.halt("out of memory", e);
         } catch (Throwable t) {
             handler.error(t);
-        } finally {
-            if (s != null) {
-                releaseSession(s);
-            }
         }
     }
 
@@ -133,26 +142,10 @@ public class RemoteManager {
         t.start();
     }
 
-    public synchronized RemoteResult execute(String command) throws ServiceException {
-        Session s = null;
+    public synchronized RemoteResult execute(String command) throws ServiceException{
+        RemoteResult result = new RemoteResult();
         try {
-            s = getSession();
-            if (ZimbraLog.rmgmt.isDebugEnabled()) ZimbraLog.rmgmt.debug("executing shim command  '" + mShimCommand + "' on " + this);
-            s.execCommand(mShimCommand);
-            OutputStream os = s.getStdin();
-            String send = "HOST:" + mHost + " " + command;
-            if (ZimbraLog.rmgmt.isDebugEnabled()) {
-                ZimbraLog.rmgmt.debug("sending mgmt command '%s' on %s", send, this);
-            }
-            os.write(send.getBytes());
-            os.close();
-
-            RemoteResult result = new RemoteResult();
-
-            InputStream stdout = new StreamGobbler(s.getStdout());
-            InputStream stderr = new StreamGobbler(s.getStderr());
-            result.mStdout = ByteUtil.getContent(stdout, -1);
-            result.mStderr = ByteUtil.getContent(stderr, -1);
+            result = executeRemoteCommand(mUser,mHost,mPort,mPrivateKey,mShimCommand,command);
             if (ZimbraLog.rmgmt.isTraceEnabled()) {
                 try {
                     ZimbraLog.rmgmt.trace("stdout content for cmd:\n%s", new String(result.mStdout, "UTF-8"));
@@ -161,54 +154,72 @@ public class RemoteManager {
                     ZimbraLog.rmgmt.trace("Problem logging stdout or stderr for cmd - probably not UTF-8");
                 }
             }
-            try {
-                result.mExitStatus = s.getExitStatus();
-            } catch (NullPointerException npe) {
-                // wow this is strange - on hold command we hit NPE here.  TODO file a bug against ganymed
-            }
-            if (result.mExitStatus != 0) {
-                throw new IOException(
-                        "command failed: exit status=" + result.mExitStatus +
-                        ", stdout=" + new String(result.mStdout) +
-                        ", stderr=" + new String(result.mStderr));
-            }
-            result.mExitSignal = s.getExitSignal();
-            return result;
-        } catch (IOException ioe) {
-            throw ServiceException.FAILURE("exception executing command: " + command + " with " + this, ioe);
-        } finally {
-            if (s != null) {
-                releaseSession(s);
-            }
+        } catch (Exception ioe) {
+             throw ServiceException.FAILURE("exception executing command: " + command + " with " + this, ioe);
         }
+        return result;
     }
 
-    private Connection mConnection;
-
-    private void releaseSession(Session sess) {
-        try {
-            sess.close();
-        } finally {
-            mConnection.close();
-            mConnection = null;
+    public static RemoteResult executeRemoteCommand(String username, String host, int port, File privateKey,
+			String mShimCommand, String command) throws Exception {
+		long defaultTimeoutSeconds = 10l;
+		SshClient client = SshClient.setUpDefaultClient();
+		client.start();
+		String send = "HOST:" + host + " " + command;
+		InputStream inputStream = new ByteArrayInputStream(send.getBytes());
+		try (ClientSession session = client.connect(username, host, port)
+				.verify(defaultTimeoutSeconds, TimeUnit.SECONDS).getSession()) {
+			session.addPublicKeyIdentity(loadKeypair(privateKey.getAbsolutePath()));
+			session.auth().verify(defaultTimeoutSeconds, TimeUnit.SECONDS);
+			if (ZimbraLog.rmgmt.isDebugEnabled()) {
+				ZimbraLog.rmgmt.debug("executing shim command '%s'", mShimCommand);
+			}
+			try (ByteArrayOutputStream responseStream = new ByteArrayOutputStream();
+					ByteArrayOutputStream errorResponseStream = new ByteArrayOutputStream();
+					ClientChannel channel = session.createChannel("exec", mShimCommand + "\n")) {
+				if (ZimbraLog.rmgmt.isDebugEnabled()) {
+					ZimbraLog.rmgmt.debug("sending mgmt command '%s'", send);
+				}
+				channel.setIn(inputStream);
+				channel.setOut(responseStream);
+				channel.setErr(errorResponseStream);
+				channel.open();
+				try {
+					channel.waitFor(EnumSet.of(ClientChannelEvent.CLOSED),
+							TimeUnit.SECONDS.toMillis(defaultTimeoutSeconds));
+					RemoteResult result = new RemoteResult();
+					InputStream stdout = new ByteArrayInputStream(responseStream.toByteArray());
+					InputStream stderr = new ByteArrayInputStream(errorResponseStream.toByteArray());
+					result.mStdout = ByteUtil.getContent(stdout, -1);
+					result.mStderr = ByteUtil.getContent(stderr, -1);
+					result.mExitStatus = channel.getExitStatus();
+					if (result.mExitStatus != 0) {
+						throw new IOException("command failed: exit status=" + result.mExitStatus + ", stdout="
+								+ new String(result.mStdout) + ", stderr=" + new String(result.mStderr));
+					}
+					result.mExitSignal = channel.getExitSignal();
+					String errorString = new String(errorResponseStream.toByteArray());
+					if (!errorString.isEmpty()) {
+						throw new Exception(errorString);
+					}
+					return result;
+				} finally {
+					channel.close(false);
+					session.close();
+				}
+			}
+		} finally {
+			client.stop();
+		}
+	}
+	public static KeyPair loadKeypair(String privateKeyPath) throws IOException, GeneralSecurityException {
+        try (InputStream privateKeyStream = new FileInputStream(privateKeyPath)) {
+            Iterable<KeyPair> keyPairIterable =
+                    SecurityUtils.loadKeyPairIdentities(null, null, privateKeyStream, null);
+            KeyPair keyPair = keyPairIterable.iterator().next();
+            return keyPair;
         }
-    }
-
-    private Session getSession() throws ServiceException {
-        try {
-            mConnection = new Connection(mHost, mPort);
-            mConnection.connect();
-            if (!mConnection.authenticateWithPublicKey(mUser, mPrivateKey, null)) {
-                throw new IOException("auth failed");
-            }
-            return mConnection.openSession();
-        } catch (IOException ioe) {
-            if (mConnection != null) {
-                mConnection.close();
-            }
-            throw ServiceException.FAILURE("exception during auth " + this, ioe);
-        }
-    }
+	}
 
     public static RemoteManager getRemoteManager(Server server) throws ServiceException {
         return new RemoteManager(server);

--- a/store/src/java/com/zimbra/cs/rmgmt/RemoteManager.java
+++ b/store/src/java/com/zimbra/cs/rmgmt/RemoteManager.java
@@ -181,22 +181,18 @@ public class RemoteManager {
 					channel.waitFor(EnumSet.of(ClientChannelEvent.CLOSED),
 							TimeUnit.SECONDS.toMillis(defaultTimeoutSeconds));
 					session.close(false);
-					String errorString = new String(errorResponseStream.toByteArray());
-					if (!errorString.isEmpty()) {
-						throw ServiceException.FAILURE("Error occurred while executing command " + send + errorString, null);
-					}
 					RemoteResult result = new RemoteResult();
 					ClientChannel.validateCommandExitStatusCode(mShimCommand, channel.getExitStatus());
+					InputStream stdout = new ByteArrayInputStream(responseStream.toByteArray());
+					InputStream stderr = new ByteArrayInputStream(errorResponseStream.toByteArray());
+					result.mStdout = ByteUtil.getContent(stdout, -1);
+					result.mStderr = ByteUtil.getContent(stderr, -1);
 					result.mExitStatus = channel.getExitStatus();
 					if (result.mExitStatus != 0) {
 						throw new IOException("command failed: exit status=" + result.mExitStatus + ", stdout="
 								+ new String(result.mStdout) + ", stderr=" + new String(result.mStderr));
 					}
 					result.mExitSignal = channel.getExitSignal();
-					InputStream stdout = new ByteArrayInputStream(responseStream.toByteArray());
-					InputStream stderr = new ByteArrayInputStream(errorResponseStream.toByteArray());
-					result.mStdout = ByteUtil.getContent(stdout, -1);
-					result.mStderr = ByteUtil.getContent(stderr, -1);
 					return result;
 				} finally {
 					channel.close(false);

--- a/store/src/java/com/zimbra/cs/rmgmt/RemoteManager.java
+++ b/store/src/java/com/zimbra/cs/rmgmt/RemoteManager.java
@@ -22,7 +22,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.util.EnumSet;
@@ -109,14 +108,12 @@ public class RemoteManager {
         RemoteResult result = new RemoteResult();
         try {
             result = executeRemoteCommand(mUser,mHost,mPort,mPrivateKey,mShimCommand,command);
-            if (ZimbraLog.rmgmt.isTraceEnabled()) {
                 try {
                     ZimbraLog.rmgmt.trace("stdout content for cmd:\n%s", new String(result.mStdout, "UTF-8"));
                     ZimbraLog.rmgmt.trace("stderr content for cmd:\n%s", new String(result.mStderr, "UTF-8"));
                 } catch (Exception ex) {
                     ZimbraLog.rmgmt.trace("Problem logging stdout or stderr for cmd - probably not UTF-8");
                 }
-            }
             InputStream stdout = new ByteArrayInputStream(result.mStdout);
             InputStream stderr = new ByteArrayInputStream(result.mStderr);
             handler.read(stdout,stderr);
@@ -146,14 +143,12 @@ public class RemoteManager {
         RemoteResult result = new RemoteResult();
         try {
             result = executeRemoteCommand(mUser,mHost,mPort,mPrivateKey,mShimCommand,command);
-            if (ZimbraLog.rmgmt.isTraceEnabled()) {
                 try {
                     ZimbraLog.rmgmt.trace("stdout content for cmd:\n%s", new String(result.mStdout, "UTF-8"));
                     ZimbraLog.rmgmt.trace("stderr content for cmd:\n%s", new String(result.mStderr, "UTF-8"));
                 } catch (Exception ex) {
                     ZimbraLog.rmgmt.trace("Problem logging stdout or stderr for cmd - probably not UTF-8");
                 }
-            }
         } catch (Exception ioe) {
              throw ServiceException.FAILURE("exception executing command: " + command + " with " + this, ioe);
         }
@@ -171,15 +166,11 @@ public class RemoteManager {
 				.verify(defaultTimeoutSeconds, TimeUnit.SECONDS).getSession()) {
 			session.addPublicKeyIdentity(loadKeypair(privateKey.getAbsolutePath()));
 			session.auth().verify(defaultTimeoutSeconds, TimeUnit.SECONDS);
-			if (ZimbraLog.rmgmt.isDebugEnabled()) {
-				ZimbraLog.rmgmt.debug("executing shim command '%s'", mShimCommand);
-			}
+			ZimbraLog.rmgmt.debug("executing shim command '%s'", mShimCommand);
 			try (ByteArrayOutputStream responseStream = new ByteArrayOutputStream();
 					ByteArrayOutputStream errorResponseStream = new ByteArrayOutputStream();
 					ClientChannel channel = session.createChannel("exec", mShimCommand + "\n")) {
-				if (ZimbraLog.rmgmt.isDebugEnabled()) {
 					ZimbraLog.rmgmt.debug("sending mgmt command '%s'", send);
-				}
 				channel.setIn(inputStream);
 				channel.setOut(responseStream);
 				channel.setErr(errorResponseStream);
@@ -200,7 +191,7 @@ public class RemoteManager {
 					result.mExitSignal = channel.getExitSignal();
 					String errorString = new String(errorResponseStream.toByteArray());
 					if (!errorString.isEmpty()) {
-						throw new Exception(errorString);
+						throw ServiceException.FAILURE("Error occurred while executing command " + send + errorString, null);
 					}
 					return result;
 				} finally {


### PR DESCRIPTION
Problem: RemoteManager calls are failing with FIPS enabled.
https://jira.corp.synacor.com/browse/ZCS-10060?focusedCommentId=1419982&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1419982

Ganymed SSH-2 offering KexAlgorithms: diffie-hellman-group-exchange-sha1, diffie-hellman-group14-sha1, diffie-hellman-group1-sha1 , which are not allowed in FIPS mode.

Solution : Replaced Ganymed SSH-2 with Apache MINA SSHD , which supports KexAlgorithms allowed in FIPS mode.