### PR TITLE
Fixing ResetPasswordResponse that started sending  authtoken in soap response

### DIFF
--- a/store/src/java-test/com/zimbra/cs/account/MockProvisioning.java
+++ b/store/src/java-test/com/zimbra/cs/account/MockProvisioning.java
@@ -949,12 +949,11 @@ public final class MockProvisioning extends Provisioning {
     public void changePassword(Account acct, String currentPassword, String newPassword,
         boolean dryRun) throws ServiceException {
         // TODO Auto-generated method stub
-
     }
 
-	@Override
-	public void resetPassword(Account acct, String newPassword, boolean dryRun) throws ServiceException {
-		// TODO Auto-generated method stub
-	}
+    @Override
+    public void resetPassword(Account acct, String newPassword, boolean dryRun) throws ServiceException {
+        throw ServiceException.UNSUPPORTED();
+    }
 
 }

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -6261,6 +6261,11 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
             (ch >=123 && ch <= 126);  // { | } ~
     }
 
+    public void resetPassword(Account acct, String newPassword, boolean dryRun) 
+            throws ServiceException {
+        setPassword(acct, newPassword, true, dryRun);
+    }
+
     void setPassword(Account acct, String newPassword, boolean enforcePolicy, boolean dryRun)
     throws ServiceException {
 
@@ -6285,7 +6290,6 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
         }
 
         Map<String, Object> attrs = new HashMap<String, Object>();
-
         int enforceHistory = acct.getIntAttr(Provisioning.A_zimbraPasswordEnforceHistory, 0);
         if (enforceHistory > 0) {
             String[] newHistory = updateHistory(
@@ -6294,8 +6298,9 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
                     enforceHistory);
             attrs.put(Provisioning.A_zimbraPasswordHistory, newHistory);
 
-            if (enforcePolicy || dryRun)
+            if (enforcePolicy || dryRun) {
                 checkHistory(newPassword, newHistory);
+            }
         }
 
         if (dryRun) {
@@ -11576,10 +11581,5 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
             LdapClient.closeContext(zlc);
         }
     }
-
-	@Override
-	public void resetPassword(Account acct, String newPassword, boolean dryRun) throws ServiceException {
-		// TODO Auto-generated method stub	
-	}
 
 }

--- a/store/src/java/com/zimbra/cs/account/soap/SoapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/soap/SoapProvisioning.java
@@ -873,11 +873,6 @@ public class SoapProvisioning extends Provisioning {
         invokeJaxb(new ChangePasswordRequest(jaxbAcct, currentPassword, newPassword, dryRun));
     }
 
-    public void resetPassword(Account acct, String newPassword, boolean dryRun) throws ServiceException {
-    		SetPasswordResponse resp =
-                invokeJaxb(new SetPasswordRequest(acct.getId(), newPassword, dryRun));
-    }
-
     @Override
     public Account createAccount(String emailAddress, String password, Map<String, Object> attrs)
         throws ServiceException
@@ -3224,4 +3219,10 @@ public class SoapProvisioning extends Provisioning {
         GetDistributionListMembersResponse resp = invokeJaxb(new GetDistributionListMembersRequest(0, 0, group.getName()));
         return resp.getHABGroupMembers();
     }
+
+    @Override
+    public void resetPassword(Account acct, String newPassword, boolean dryRun) throws ServiceException {
+        throw ServiceException.UNSUPPORTED();
+    }
+
 }

--- a/store/src/java/com/zimbra/cs/service/account/ResetPassword.java
+++ b/store/src/java/com/zimbra/cs/service/account/ResetPassword.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AccountConstants;
 import com.zimbra.common.soap.Element;
-import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.AccountServiceException;
@@ -58,7 +57,6 @@ public class ResetPassword extends AccountDocumentHandler {
         }
         ResetPasswordUtil.validateFeatureResetPasswordStatus(acct);
         String newPassword = req.getPassword();
-        checkPasswordStrength(prov, acct, newPassword);
 
         // proxy if required
         if (!Provisioning.onLocalServer(acct)) {
@@ -76,25 +74,21 @@ public class ResetPassword extends AccountDocumentHandler {
         }
 
         setPasswordAndPurgeAuthTokens(prov, acct, newPassword, dryRun);
-
         Element response = zsc.createElement(AccountConstants.E_RESET_PASSWORD_RESPONSE);
-        if (!dryRun) { 
-            at.encodeAuthResp(response, false);
-            response.addAttribute(AccountConstants.E_LIFETIME, at.getExpires() - System.currentTimeMillis(), Element.Disposition.CONTENT);
-         }
         return response;
     }
 
-    protected void setPasswordAndPurgeAuthTokens(Provisioning prov, Account acct, String newPassword, boolean dryRun) throws ServiceException {
-        // set new password
-    	    if (dryRun) {
-    	    		prov.resetPassword(acct, newPassword, dryRun);
-    	    } else {
-    	    		prov.setPassword(acct, newPassword);
-    	    }
-        // purge old auth tokens to invalidate existing sessions
-        acct.purgeAuthTokens();
-    }
+	protected void setPasswordAndPurgeAuthTokens(Provisioning prov, Account acct, String newPassword, 
+	        boolean dryRun) throws ServiceException {
+	    if (dryRun) {
+	        prov.resetPassword(acct, newPassword, dryRun);
+	    } else {
+	        // set new password
+	        prov.setPassword(acct, newPassword, true);
+	        // purge old auth tokens to invalidate existing sessions
+	        acct.purgeAuthTokens();
+	    }
+	}
 
     protected void checkPasswordStrength(Provisioning prov, Account acct, String newPassword) throws ServiceException {
         prov.checkPasswordStrength(acct, newPassword);


### PR DESCRIPTION
Fixing ResetPasswordResponse that started sending `authtoken` in soap response in `dryRun` support implementation.

**Testing Done:**
- Verified after enabling the following conditions from the admin console for at least 2 Uppercase letters, at least one lowercase letter, at least one numeric value, and password history not to repeat for 5 times.
- Verification done for both XML as well as JSON.
- Verified all the above scenarios.
- Verified if the password was recently used with both XML as well as JSON formats with and without `dryRun` flag:
***XML***
```
zimbra@apps-automation1:~$ zmsoap -vv -m akshat@apps-automation1.synacor.tk -p Akshat123A -f /tmp/ResetPassword.xml
Sending auth request to http://localhost:8080/service/soap
.....
  <soap:Body>
    <soap:Fault>
      <soap:Code>
        <soap:Value>soap:Sender</soap:Value>
      </soap:Code>
      <soap:Reason>
        <soap:Text>password was recently used</soap:Text>
      </soap:Reason>
      <soap:Detail>
        <Error xmlns="urn:zimbra">
          <Code>account.PASSWORD_RECENTLY_USED</Code>
          <Trace>qtp1027591600-30:1610383289287:e7783aa1d856f87d</Trace>
        </Error>
      </soap:Detail>
    </soap:Fault>
  </soap:Body>
</soap:Envelope>
ERROR: account.PASSWORD_RECENTLY_USED (password was recently used)
```
***JSON***
```zimbra@apps-automation1:~$ zmsoap -vv -m akshat@apps-automation1.synacor.tk -p Akshat123A -f /tmp/resetPassword.json --json
Sending auth request to http://localhost:8080/service/soap
{
  "Header": {
 ....
  "Body": {
    "Fault": {
      "Code": {
        "Value": "soap:Sender"
      },
      "Reason": {
        "Text": "password was recently used"
      },
      "Detail": {
        "Error": {
          "Code": "account.PASSWORD_RECENTLY_USED",
          "Trace": "qtp1027591600-135:1610383979636:e7783aa1d856f87d",
          "_jsns": "urn:zimbra"
        }
      }
    }
  },
  "_jsns": "urn:zimbraSoap"
}
ERROR: account.PASSWORD_RECENTLY_USED (password was recently used)
```