### PR TITLE
ZCS-9159 correct the way of sending error

### DIFF
--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -6149,9 +6149,8 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
         if (getBoolean(acct, cos, entry, Provisioning.A_zimbraPasswordBlockCommonEnabled, false)
                 && commonPasswordFilter.mightContain(password)) {
-                throw AccountServiceException
-                    .INVALID_PASSWORD(Provisioning.A_zimbraPasswordBlockCommonEnabled
-                        + " password is known to be too common");
+            throw AccountServiceException.INVALID_PASSWORD("too common",
+                    new Argument(Provisioning.A_zimbraPasswordBlockCommonEnabled, "", Argument.Type.STR));
         }
 
         int minUpperCase = getInt(acct, cos, entry, Provisioning.A_zimbraPasswordMinUpperCaseChars, 0);


### PR DESCRIPTION
just changed the way of sending the error so that ui does not need any change

**before change**
```
2021-01-29 07:27:17,731 WARN  [qtp366590980-130:https://zdev-vm145.eng.zimbra.com:8443/service/soap/ChangePasswordRequest] [name=bhavin@zdev-vm145.eng.zimbra.com;mid=4;ip=172.16.13.207;port=63908;soapId=520f5928;] SoapEngine - handler exception
com.zimbra.cs.account.AccountServiceException: invalid password: zimbraPasswordBlockCommonEnabled password is known to be too common
ExceptionId:qtp366590980-130:https://zdev-vm145.eng.zimbra.com:8443/service/soap/ChangePasswordRequest:1611923237730:5b4fc290317d42f4
Code:account.INVALID_PASSWORD
```


**after change**
```
2021-01-29 07:41:47,126 WARN  [qtp366590980-127:https://zdev-vm145.eng.zimbra.com:8443/service/soap/ChangePasswordRequest] [name=bhavin@zdev-vm145.eng.zimbra.com;mid=4;ip=172.16.13.207;port=51180;soapId=57818e37;] SoapEngine - handler exception
com.zimbra.cs.account.AccountServiceException: invalid password: too common
ExceptionId:qtp366590980-127:https://zdev-vm145.eng.zimbra.com:8443/service/soap/ChangePasswordRequest:1611924107125:440883ddc2831010
Code:account.INVALID_PASSWORD Arg:(zimbraPasswordBlockCommonEnabled, STR, "")
```
