### PR TITLE
ZCS-8658: Changed error messages when customer is not able to send mail.

### DIFF
--- a/common/src/java/com/zimbra/common/service/ServiceException.java
+++ b/common/src/java/com/zimbra/common/service/ServiceException.java
@@ -60,9 +60,9 @@ public class ServiceException extends Exception {
     public static final String FORBIDDEN = "service.FORBIDDEN";
     // generic "not found" error for objects other than mail items
     public static final String NOT_FOUND = "service.NOT_FOUND";
-    public static final String WRONG_DATASOURCE_ID = "service.WRONG_DATASOURCE_ID";
+    public static final String INTERNAL_ERROR = "service.INTERNAL_ERROR";
+    public static final String INVALID_DATASOURCE_ID = "service.INVALID_DATASOURCE_ID";
     public static final String DATASOURCE_SMTP_DISABLED = "service.DATASOURCE_SMTP_DISABLED";
-    public static final String SENTBY_PARSE_ERROR = "service.FIXING_SENDMSG_FOR_SENTBY_PARSE_ERROR";
     public static final String ERROR_WHILE_PARSING_UPLOAD = "service.IOEXCEPTION_WHILE_PARSING_UPLOAD";
 
     //smime
@@ -306,8 +306,8 @@ public class ServiceException extends Exception {
     /**
      * The request was invalid as datasource with the specified Id is not present.
      */
-    public static ServiceException WRONG_DATASOURCE_ID(String message, Throwable cause) {
-        return new ServiceException("wrong datasource id: "+message, WRONG_DATASOURCE_ID, SENDERS_FAULT, cause);
+    public static ServiceException INVALID_DATASOURCE_ID(String message, Throwable cause) {
+        return new ServiceException("wrong datasource id: "+message, INVALID_DATASOURCE_ID, SENDERS_FAULT, cause);
     }
 
     /**
@@ -329,7 +329,7 @@ public class ServiceException extends Exception {
     }
 
     public static ServiceException FIXING_SENDMSG_FOR_SENTBY_PARSE_ERROR(String message, Throwable cause) {
-        return new ServiceException("parse error for SENT-BY: "+message, SENTBY_PARSE_ERROR, SENDERS_FAULT, cause);
+        return new ServiceException("parse error for SENT-BY: "+message, INTERNAL_ERROR, SENDERS_FAULT, cause);
     }
 
     public static ServiceException RESOURCE_UNREACHABLE(String message, Throwable cause, Argument... arguments) {

--- a/common/src/java/com/zimbra/common/service/ServiceException.java
+++ b/common/src/java/com/zimbra/common/service/ServiceException.java
@@ -60,6 +60,10 @@ public class ServiceException extends Exception {
     public static final String FORBIDDEN = "service.FORBIDDEN";
     // generic "not found" error for objects other than mail items
     public static final String NOT_FOUND = "service.NOT_FOUND";
+    public static final String WRONG_DATASOURCE_ID = "service.WRONG_DATASOURCE_ID";
+    public static final String DATASOURCE_SMTP_DISABLED = "service.DATASOURCE_SMTP_DISABLED";
+    public static final String SENTBY_PARSE_ERROR = "service.FIXING_SENDMSG_FOR_SENTBY_PARSE_ERROR";
+    public static final String ERROR_WHILE_PARSING_UPLOAD = "service.IOEXCEPTION_WHILE_PARSING_UPLOAD";
 
     //smime
     public static final String LOAD_CERTIFICATE_FAILED = "smime.LOAD_CERTIFICATE_FAILED";
@@ -288,11 +292,29 @@ public class ServiceException extends Exception {
         return new ServiceException("system failure: "+message, FAILURE, RECEIVERS_FAULT, cause);
     }
 
+    public static ServiceException ERROR_WHILE_PARSING_UPLOAD(String message, Throwable cause) {
+        return new ServiceException("ioexception during upload: "+message, ERROR_WHILE_PARSING_UPLOAD, RECEIVERS_FAULT, cause);
+    }
+
     /**
      * The request was somehow invalid (wrong parameter, wrong target, etc)
      */
     public static ServiceException INVALID_REQUEST(String message, Throwable cause) {
         return new ServiceException("invalid request: "+message, INVALID_REQUEST, SENDERS_FAULT, cause);
+    }
+
+    /**
+     * The request was invalid as datasource with the specified Id is not present.
+     */
+    public static ServiceException WRONG_DATASOURCE_ID(String message, Throwable cause) {
+        return new ServiceException("wrong datasource id: "+message, WRONG_DATASOURCE_ID, SENDERS_FAULT, cause);
+    }
+
+    /**
+     * The request was invalid as datasource datasource SMTP is not enabled.
+     */
+    public static ServiceException DATASOURCE_SMTP_DISABLED(String message, Throwable cause) {
+        return new ServiceException("datasource smtp not enabled: "+message, DATASOURCE_SMTP_DISABLED, SENDERS_FAULT, cause);
     }
 
     /**
@@ -304,6 +326,10 @@ public class ServiceException extends Exception {
 
     public static ServiceException PARSE_ERROR(String message, Throwable cause) {
         return new ServiceException("parse error: "+message, PARSE_ERROR, SENDERS_FAULT, cause);
+    }
+
+    public static ServiceException FIXING_SENDMSG_FOR_SENTBY_PARSE_ERROR(String message, Throwable cause) {
+        return new ServiceException("parse error for SENT-BY: "+message, SENTBY_PARSE_ERROR, SENDERS_FAULT, cause);
     }
 
     public static ServiceException RESOURCE_UNREACHABLE(String message, Throwable cause, Argument... arguments) {

--- a/common/src/java/com/zimbra/common/service/ServiceException.java
+++ b/common/src/java/com/zimbra/common/service/ServiceException.java
@@ -64,6 +64,7 @@ public class ServiceException extends Exception {
     public static final String INVALID_DATASOURCE_ID = "service.INVALID_DATASOURCE_ID";
     public static final String DATASOURCE_SMTP_DISABLED = "service.DATASOURCE_SMTP_DISABLED";
     public static final String ERROR_WHILE_PARSING_UPLOAD = "service.IOEXCEPTION_WHILE_PARSING_UPLOAD";
+    public static final String ACCT_BLOCKED_FAILURE = "service.ACCT_BLOCKED_FAILURE";
 
     //smime
     public static final String LOAD_CERTIFICATE_FAILED = "smime.LOAD_CERTIFICATE_FAILED";
@@ -290,6 +291,10 @@ public class ServiceException extends Exception {
      */
     public static ServiceException FAILURE(String message, Throwable cause) {
         return new ServiceException("system failure: "+message, FAILURE, RECEIVERS_FAULT, cause);
+    }
+
+    public static ServiceException ACCT_BLOCKED_FAILURE(String message) {
+        return new ServiceException("system failure: "+message, ACCT_BLOCKED_FAILURE, RECEIVERS_FAULT);
     }
 
     public static ServiceException ERROR_WHILE_PARSING_UPLOAD(String message, Throwable cause) {

--- a/store/src/java/com/zimbra/cs/mailbox/MailSender.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailSender.java
@@ -511,6 +511,11 @@ public class MailSender {
             }
 
             Account acct = mbox.getAccount();
+            if (acct.getAccountStatusAsString().equals(Provisioning.ACCOUNT_STATUS_LOCKED) || 
+                    acct.getAccountStatusAsString().equals(Provisioning.ACCOUNT_STATUS_CLOSED)) {
+                throw ServiceException.ACCT_BLOCKED_FAILURE("Sending not possible as the account is blocked.");
+            }
+
             Account authuser = octxt == null ? null : octxt.getAuthenticatedUser();
             boolean isAdminRequest = octxt == null ? false : octxt.isUsingAdminPrivileges();
             if (authuser == null) {

--- a/store/src/java/com/zimbra/cs/mailbox/MailServiceException.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailServiceException.java
@@ -72,7 +72,7 @@ public class MailServiceException extends ServiceException {
     public static final String CANNOT_UNLOCK   = "mail.CANNOT_UNLOCK";
     public static final String LOCKED          = "mail.LOCKED";
     public static final String MUST_RESYNC     = "mail.MUST_RESYNC";
-    public static final String SENDMSG_IN_PROGRESS_TRY_AGAIN = "mail.SENDING_MESSAGE_IN_PROGRESS_TRY_AGAIN";
+    public static final String SENDMSG_IN_PENDING_STATE_TRY_AGAIN = "mail.SENDING_MESSAGE_IN_PENDING_STATE_TRY_AGAIN";
 
     public static final String SCAN_ERROR      = "mail.SCAN_ERROR";
     public static final String UPLOAD_REJECTED = "mail.UPLOAD_REJECTED";
@@ -574,8 +574,8 @@ public class MailServiceException extends ServiceException {
         return new MailServiceException("try again: " + msg, TRY_AGAIN, RECEIVERS_FAULT, e);
     }
 
-    public static MailServiceException SENDMSG_IN_PROGRESS_TRY_AGAIN(String msg) {
-        return new MailServiceException("try again: " + msg, SENDMSG_IN_PROGRESS_TRY_AGAIN, RECEIVERS_FAULT);
+    public static MailServiceException SENDMSG_IN_PENDING_STATE_TRY_AGAIN(String msg) {
+        return new MailServiceException("try again: " + msg, SENDMSG_IN_PENDING_STATE_TRY_AGAIN, RECEIVERS_FAULT);
     }
 
     public static MailServiceException TOO_MANY_QUERY_TERMS_EXPANDED(String msg, String token, int max) {

--- a/store/src/java/com/zimbra/cs/mailbox/MailServiceException.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailServiceException.java
@@ -72,6 +72,7 @@ public class MailServiceException extends ServiceException {
     public static final String CANNOT_UNLOCK   = "mail.CANNOT_UNLOCK";
     public static final String LOCKED          = "mail.LOCKED";
     public static final String MUST_RESYNC     = "mail.MUST_RESYNC";
+    public static final String SENDMSG_IN_PROGRESS_TRY_AGAIN = "mail.SENDING_MESSAGE_IN_PROGRESS_TRY_AGAIN";
 
     public static final String SCAN_ERROR      = "mail.SCAN_ERROR";
     public static final String UPLOAD_REJECTED = "mail.UPLOAD_REJECTED";
@@ -571,6 +572,10 @@ public class MailServiceException extends ServiceException {
 
     public static MailServiceException TRY_AGAIN(String msg, Exception e) {
         return new MailServiceException("try again: " + msg, TRY_AGAIN, RECEIVERS_FAULT, e);
+    }
+
+    public static MailServiceException SENDMSG_IN_PROGRESS_TRY_AGAIN(String msg) {
+        return new MailServiceException("try again: " + msg, SENDMSG_IN_PROGRESS_TRY_AGAIN, RECEIVERS_FAULT);
     }
 
     public static MailServiceException TOO_MANY_QUERY_TERMS_EXPANDED(String msg, String token, int max) {

--- a/store/src/java/com/zimbra/cs/service/mail/SendMsg.java
+++ b/store/src/java/com/zimbra/cs/service/mail/SendMsg.java
@@ -202,7 +202,7 @@ public class SendMsg extends MailDocumentHandler {
                    savedMsgId = sendRecord.getSecond();
                } else if (state == SendState.PENDING) {
                    // tired of waiting for another thread to complete the send
-                   throw MailServiceException.TRY_AGAIN("message send already in progress: " + sendUid);
+                   throw MailServiceException.SENDMSG_IN_PROGRESS_TRY_AGAIN("message send already in progress: " + sendUid);
                } else if (state == SendState.NEW) {
                    MimeMessageData mimeData = new MimeMessageData();
                    try {
@@ -292,7 +292,7 @@ public class SendMsg extends MailDocumentHandler {
             try {
                 mv.accept(mm);
             } catch (MessagingException e) {
-                throw ServiceException.PARSE_ERROR("Error while fixing up SendMsg for SENT-BY", e);
+                throw ServiceException.FIXING_SENDMSG_FOR_SENTBY_PARSE_ERROR("Error while fixing up SendMsg for SENT-BY", e);
             }
             isCalendarMessage = mv.isCalendarMessage();
         }
@@ -308,10 +308,10 @@ public class SendMsg extends MailDocumentHandler {
         } else {
             com.zimbra.cs.account.DataSource dataSource = mbox.getAccount().getDataSourceById(dataSourceId);
             if (dataSource == null) {
-                throw ServiceException.INVALID_REQUEST("No data source with id " + dataSourceId, null);
+                throw ServiceException.WRONG_DATASOURCE_ID("No data source with id " + dataSourceId, null);
             }
             if (!dataSource.isSmtpEnabled()) {
-                throw ServiceException.INVALID_REQUEST("Data source SMTP is not enabled", null);
+                throw ServiceException.DATASOURCE_SMTP_DISABLED("Data source SMTP is not enabled", null);
             }
             sender = mbox.getDataSourceMailSender(dataSource, isCalendarMessage);
             id = sender.sendDataSourceMimeMessage(oc, mbox, mm, uploads, origMsgId, replyType);
@@ -381,7 +381,7 @@ public class SendMsg extends MailDocumentHandler {
         } catch (MessagingException e) {
             throw MailServiceException.MESSAGE_PARSE_ERROR(e);
         } catch (IOException e) {
-            throw ServiceException.FAILURE("IOException when parsing upload", e);
+            throw ServiceException.ERROR_WHILE_PARSING_UPLOAD("IOException when parsing upload", e);
         }
     }
 

--- a/store/src/java/com/zimbra/cs/service/mail/SendMsg.java
+++ b/store/src/java/com/zimbra/cs/service/mail/SendMsg.java
@@ -202,7 +202,7 @@ public class SendMsg extends MailDocumentHandler {
                    savedMsgId = sendRecord.getSecond();
                } else if (state == SendState.PENDING) {
                    // tired of waiting for another thread to complete the send
-                   throw MailServiceException.SENDMSG_IN_PROGRESS_TRY_AGAIN("message send already in progress: " + sendUid);
+                   throw MailServiceException.SENDMSG_IN_PENDING_STATE_TRY_AGAIN("message send in pending state: " + sendUid);
                } else if (state == SendState.NEW) {
                    MimeMessageData mimeData = new MimeMessageData();
                    try {
@@ -292,7 +292,7 @@ public class SendMsg extends MailDocumentHandler {
             try {
                 mv.accept(mm);
             } catch (MessagingException e) {
-                throw ServiceException.FIXING_SENDMSG_FOR_SENTBY_PARSE_ERROR("Error while fixing up SendMsg for SENT-BY", e);
+                throw ServiceException.FIXING_SENDMSG_FOR_SENTBY_PARSE_ERROR("Error while sending the message during fixup for SENT-BY of ICalendar on behalf of other user.", e);
             }
             isCalendarMessage = mv.isCalendarMessage();
         }
@@ -308,7 +308,7 @@ public class SendMsg extends MailDocumentHandler {
         } else {
             com.zimbra.cs.account.DataSource dataSource = mbox.getAccount().getDataSourceById(dataSourceId);
             if (dataSource == null) {
-                throw ServiceException.WRONG_DATASOURCE_ID("No data source with id " + dataSourceId, null);
+                throw ServiceException.INVALID_DATASOURCE_ID("No data source with id " + dataSourceId, null);
             }
             if (!dataSource.isSmtpEnabled()) {
                 throw ServiceException.DATASOURCE_SMTP_DISABLED("Data source SMTP is not enabled", null);


### PR DESCRIPTION
**Problem:**
Change error messages when the customer is not able to send mail.

**Approach and Fix:**
To support RFE [ZCS-7256](https://jira.corp.synacor.com/browse/ZCS-7256), clients need the summary information to explain the reason for the email send failures, which is been updated as per the following messages codes:
```
* FAILURE             -> ERROR_WHILE_PARSING_UPLOAD                 : For the error while parsing the upload.
* TRY_AGAIN           -> SENDING_MESSAGE_IN_PENDING_STATE_TRY_AGAIN : For waiting for another thread to complete the send.
* PARSE_ERROR         -> INTERNAL_ERROR                             : Error while sending the message during fixup for SENT-BY of ICalendar on behalf of other user.
* INVALID_REQUEST     -> INVALID_DATASOURCE_ID                      : For sending failed if datasource with the specified Id is not present. 
* INVALID_REQUEST     -> DATASOURCE_SMTP_DISABLED                   : For sending failed if the datasource SMTP is not enabled.
* MESSAGE_PARSE_ERROR -> No Change.
* FAILURE             -> ACCT_BLOCKED_FAILURE                       : For sending failed if the account is Blocked/Closed.
```
**Testing Done:**
- Verified that the new codes are now being updated in the sending failures using `SendMsgRequest` soap API.

_Example_:
```
<SendMsgRequest xmlns='urn:zimbraMail'>
  <m did="fcb89995-db50-4e01-a8da-2cbd062deda2">
    <e t='t' a='akshat@apps-automation1.synacor.tk'/>
    <su>'Test for SendMsgRequest'</su>
    <mp ct='text/plain'>
      <content>'Hello, how are you ?'</content>
    </mp>
  </m>
</SendMsgRequest>
```
```
zimbra@apps-automation1:~$ zmsoap -m aks@apps-automation1.synacor.tk -p Test123 -f /tmp/SendMsg.xml
ERROR: service.WRONG_DATASOURCE_ID (wrong datasource id: No data source with id fcb89995-db50-4e01-a8da-2cbd062deda2)
```
_Logs:_
```
2021-02-10 14:52:30,149 INFO  [qtp1027591600-138://localhost:8080/service/soap/SendMsgRequest] [name=aks@apps-automation1.synacor.tk;mid=13;ua=zmsoap;soapId=9d3e934;] soap - SendMsgRequest elapsed=4
2021-02-10 14:52:30,149 TRACE [qtp1027591600-138://localhost:8080/service/soap/SendMsgRequest] [name=aks@apps-automation1.synacor.tk;mid=13;ua=zmsoap;soapId=9d3e934;] soap - S:
<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
  <soap:Header>
    <context xmlns="urn:zimbra">
      <change token="5099"/>
    </context>
  </soap:Header>
  <soap:Body>
    <soap:Fault>
      <soap:Code>
        <soap:Value>soap:Sender</soap:Value>
      </soap:Code>
      <soap:Reason>
        <soap:Text>wrong datasource id: No data source with id fcb89995-db50-4e01-a8da-2cbd062deda2</soap:Text>
      </soap:Reason>
      <soap:Detail>
        <Error xmlns="urn:zimbra">
          <Code>service.WRONG_DATASOURCE_ID</Code>
          <Trace>qtp1027591600-138:1612968750148:22d143c41d44b518</Trace>
        </Error>
      </soap:Detail>
    </soap:Fault>
  </soap:Body>
</soap:Envelope>
```


_Example 2: If the account is Blocked_

```
<SendMsgRequest xmlns='urn:zimbraMail'>
  <m>
    <e t='t' a='aks@apps-automation1.synacor.tk'/>
    <e t='c' a='aks@apps-automation1.synacor.tk'/>
    <su>'Test for SendMsgRequest'</su>
    <mp ct='text/plain'>
      <content>'Hello Test body..'</content>
    </mp>
  </m>
</SendMsgRequest>
```
```
zmc-mailbox-0:~$ zmsoap -z -m t1@apps-automation1.synacor.tk -f /tmp/SMsg.xml
ERROR: service.ACCT_BLOCKED_FAILURE (system failure: Sending not possible as the account is blocked.)
```

_Logs:_
```
2021-03-02 09:22:06,072 TRACE [qtp2138564891-219] [name=t1@apps-automation1.synacor.tk;aname=zimbra;mid=5;ip=172.17.0.14;port=43908;ua=zmsoap;soapId=3780c964;] soap - S:
<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
  <soap:Header>
    <context xmlns="urn:zimbra">
      <change token="18259"/>
    </context>
  </soap:Header>
  <soap:Body>
    <soap:Fault>
      <soap:Code>
        <soap:Value>soap:Receiver</soap:Value>
      </soap:Code>
      <soap:Reason>
        <soap:Text>system failure: Sending not possible as the account is blocked.</soap:Text>
      </soap:Reason>
      <soap:Detail>
        <Error xmlns="urn:zimbra">
          <Code>service.ACCT_BLOCKED_FAILURE</Code>
          <Trace>qtp2138564891-219:1614676926070:c84ac9e4d32d2e6c</Trace>
        </Error>
      </soap:Detail>
    </soap:Fault>
  </soap:Body>
</soap:Envelope>
```