### PR TITLE
TSS-18004: Fix for PTD - Message not displaying correctly

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/DebugConfig.java
+++ b/common/src/java/com/zimbra/common/localconfig/DebugConfig.java
@@ -352,6 +352,13 @@ public final class DebugConfig {
      */
     public static final int owasp_html_sanitizer_timeout = value ("owasp_html_sanitizer_timeout", 15);
 
+    /**
+     *
+     * enabling/disabling the jtidy library for cleaning  the
+     * malformed markup.
+     */
+    public static final boolean jtidyEnabled = value("jtidy_enabled", true);
+
     private static boolean value(String key, boolean defaultValue) {
         String value = LC.get(key);
         return value.isEmpty() ? defaultValue : Boolean.parseBoolean(value);

--- a/store/build.xml
+++ b/store/build.xml
@@ -338,6 +338,7 @@
     <ivy:install organisation="org.eclipse.jetty" module="jetty-servlet" revision="9.4.18.v20190429" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.tukaani" module="xz" revision="1.8" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.apache.commons" module="commons-compress" revision="1.20" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
+    <ivy:install organisation="com.github.jtidy" module="jtidy" revision="1.0.2" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     
     <war warfile="${warfile}" webxml="${war.web.xml}">
       <fileset dir="WebRoot"/>

--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -123,5 +123,6 @@
   <dependency org="org.owasp.antisamy" name="antisamy" rev="1.5.8"/>
   <dependency org="org.apache.xmlgraphics" name="batik-css" rev="1.7"/>
   <dependency org="org.w3c.css" name="sac" rev="1.3"/>
+  <dependency org="com.github.jtidy" name="jtidy" rev="1.0.2"/>
  </dependencies>
 </ivy-module>

--- a/store/src/java/com/zimbra/cs/html/owasp/OwaspHtmlSanitizer.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/OwaspHtmlSanitizer.java
@@ -103,12 +103,13 @@ public class OwaspHtmlSanitizer implements Callable<String> {
             ByteArrayInputStream inputStream = new ByteArrayInputStream(str.getBytes("UTF-8"));
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             tidy.parseDOM(inputStream, outputStream);
-            if (outputStream.toString("UTF-8").isEmpty()) {
+            String outStream = outputStream.toString("UTF-8");
+            if (outStream.isEmpty() || outStream == null) {
                 return str;
             }
-            long endTime = System.currentTimeMillis();
-            ZimbraLog.mailbox.debug("End - Using JTidy library for cleaning the markup. Taken %d milliseconds.", (endTime - startTime));
-            return outputStream.toString("UTF-8");
+            ZimbraLog.mailbox.debug("End - Using JTidy library for cleaning the markup. Taken %d milliseconds.",
+                    (System.currentTimeMillis() - startTime));
+            return outStream;
         }
         return str;
     }


### PR DESCRIPTION
**Problem:** 
PTD - Message not displaying correctly. [[TSS-18004](https://jira.corp.synacor.com/browse/TSS-18004)]

**Analysis:**
It was reported that some of the messages were not getting displayed correctly. On further analysis, it was found that
the particular attached message was having a lot of malformed inline styling in the original message body which contains a
lot of unclosed double quotes which was escaping large chunks of the real message. The mailer which the customer has used seems like `sendgrid` which has malformed the html.

Looking through the Antisamy policy which we are using turned out that it cannot be fixed through that the reason is that the
`antisamy` policy which we are using with `owasp` can able to handle various operations like validate, truncate, filter, remove based on the element types, tag names, tag values, attributes, and the `css` rules but not with the malformed `qoutes`.

Looking inside the `owasp` java sanitizer code turns out that the `owasp` uses `HtmlLexer` for the sanitization process which traverses element by element so before sanitizing the html it takes the value of the attribute and strips of any vulnerable kinds of stuff based on what policies we have applied. But in our case, the problem is not that `OWASP` html filter is strict with the quotes rather it is skipping the texts because it is considering the text as the attribute name because of the malformed double quotes which were present inside the span tag and it thinks of it as the new attribute has started and intercepts whatever is there as its value before the next double-quotes.

For example in case of the following html:
```
<span style="font-size:11pt;font-family:Arial;font-variant-ligatures:normal;font-variant-east-asian:normal;font-variant-position:normal;vertical-align:baseline"">Dear Member,</span></p><br style="-webkit-text-size-adjust:auto;" />
```
The attribute style is properly interpreted then the next malformed double  quote it has interpreted as the `!attrsReadyForName` and it has interpreted the key as: `">Dear Member,</span></p><br style="` and detected its value as `-webkit-text-size-adjust:auto;"` and since the value parts look vulnerable to `owasp` so it has quietly dropped.

And as per comments from the `owasp` community _`Unfortunately we cannot throw compilation errors for invalid HTML markup.`_

On analyzing the already reported issues of `antisamy` and `owasp` it is found that the user has to handle the invalid HTML markup.

**Fix:**
Looked at some libraries that can fix the malformed html for that tried using `jsoup` which is used for parsing, cleaning, extract, manipulate and make the output tidy. Used its `Cleaner` class and got the expected results. Later it is realized that `jsoup` is also capable of doing the sanitization so to remove any future collision between the two `jsoup` is dropped.

Finally, used the java port of the old `HTML Tidy` which is originally written in C and is a command-line utility that is widely used for cleaning the malformed markup. So, used the java port `JTidy` which is updated to work with HTML5 new tags. Used its `Tidy` class with other options for cleaning the malformed html. The advantage of using this library is that it only fixes the markup but does not do any other process of sanitization or manipulation as `jsoup` does. The cleaned
html is now passed to the `sanitize()` method for further sanitization process using `antisamy` and `owasp`.

Also, added debug config for enabling and disabling the `JTidy` library.

**Testing Done:**
- Injected the malformed html mime, attached in the ticket and verified it is displaying properly.
- Injected the old problematic mimes attached in the [ZCS-6512](https://jira.corp.synacor.com/browse/ZCS-6512) that are displaying properly.