### PR TITLE
ZBUG-1967 Problem synchronizing shared calendar via caldav when a '+' character is present on the EVENT

### DIFF
--- a/store/src/java/com/zimbra/cs/dav/service/DavServlet.java
+++ b/store/src/java/com/zimbra/cs/dav/service/DavServlet.java
@@ -20,7 +20,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -52,6 +52,7 @@ import com.zimbra.client.ZMailbox;
 import com.zimbra.common.account.Key;
 import com.zimbra.common.account.Key.AccountBy;
 import com.zimbra.common.httpclient.HttpClientUtil;
+import com.zimbra.common.mime.MimeConstants;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.W3cDomUtil;
 import com.zimbra.common.soap.XmlParseException;
@@ -818,8 +819,8 @@ public class DavServlet extends ZimbraServlet {
                             }
                             Element href = ((Element)responseObj).element(DavElements.E_HREF);
                             String v = href.getText();
-                            v = URLDecoder.decode(v);
                             // Bug:106438, because v contains URL encoded value(%40) for '@' the comparison fails
+                            newPrefix = newPrefix.replace("@", URLEncoder.encode("@", MimeConstants.P_CHARSET_UTF8));
                             if (v.startsWith(newPrefix)) {
                                 href.setText(prefix + v.substring(newPrefix.length()+1));
                             }


### PR DESCRIPTION
**Problem:** when  a '+' character is present in UID in shared appointment, it breaks caldav syncing.

**Fix and Approach:**
- when '+' character is present in uid, the url created to get ics gets broken.
- url is decoded after getting proxy response and before sending it to client.
- removed code which was decoding href after getting response from proxy request
- added encoding of '@' to fix bugzilla bug#106438

**Testing done:**
- Tested on mac calendar client and thunderbird, both do sync all appointments in shared calendar including appointment with '+' character in UID and `+`, `@` in calendar name.

**Testing to be done by QA:**
- verify given scenario
- verify nothing is broken