### PR TITLE
ZCS-10383: Integrating zulip with zimbra 9

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -7055,6 +7055,18 @@ public class ZAttrProvisioning {
     public static final String A_zimbraFeatureZimbraAssistantEnabled = "zimbraFeatureZimbraAssistantEnabled";
 
     /**
+     * Whether or not zulip chat is enabled. If false at domain level,
+     * feature not available at domain, cos &amp; account. If true at domain
+     * and false at cos, feature not available at cos &amp; account. If true
+     * at domain &amp; cos and false at account, feature not available at
+     * account.
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3089)
+    public static final String A_zimbraFeatureZulipChatEnabled = "zimbraFeatureZulipChatEnabled";
+
+    /**
      * Deprecated since: 8.9.0. deprecated with attribute
      * zimbraFeatureModernDesktopEnabled. Orig desc: Whether to allow a user
      * to access Zimbra X desktop
@@ -17623,6 +17635,14 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=1447)
     public static final String A_zimbraZookeeperClientServerList = "zimbraZookeeperClientServerList";
+
+    /**
+     * Zulip chat domain ID
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3090)
+    public static final String A_zimbraZulipChatDomainId = "zimbraZulipChatDomainId";
 
     ///// END-AUTO-GEN-REPLACE
 }

--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1372,7 +1372,7 @@ public final class LC {
 
     public static final KnownKey conversation_ignore_maillist_prefix = KnownKey.newKey(true);
 
- // base host for zulip
+    // base host for zulip
     public static final KnownKey zulip_base_host = KnownKey.newKey("https://%s.zimbracloud.com");
 
     // zulip jwt secret

--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1372,6 +1372,11 @@ public final class LC {
 
     public static final KnownKey conversation_ignore_maillist_prefix = KnownKey.newKey(true);
 
+ // base host for zulip
+    public static final KnownKey zulip_base_host = KnownKey.newKey("https://%s.zimbracloud.com");
+
+    // zulip jwt secret
+    public static final KnownKey zulip_jwt_secret = KnownKey.newKey("MOVE_ME_TO_A_SECRET");
 
 
     //EWS web service

--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016 Synacor, Inc.
+ * Copyright (C) 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2021 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -89,6 +89,9 @@ public final class AdminConstants {
     public static final String E_DELETE_DOMAIN_RESPONSE = "DeleteDomainResponse";
     public static final String E_GET_ALL_DOMAINS_REQUEST = "GetAllDomainsRequest";
     public static final String E_GET_ALL_DOMAINS_RESPONSE = "GetAllDomainsResponse";
+
+    public static final String E_CREATE_ZULIP_REALM_REQUEST = "CreateZulipRealmRequest";
+    public static final String E_CREATE_ZULIP_REALM_RESPONSE = "CreateZulipRealmResponse";
 
     public static final String E_CREATE_COS_REQUEST = "CreateCosRequest";
     public static final String E_CREATE_COS_RESPONSE = "CreateCosResponse";
@@ -596,6 +599,9 @@ public final class AdminConstants {
     public static final QName DELETE_DOMAIN_RESPONSE = QName.get(E_DELETE_DOMAIN_RESPONSE, NAMESPACE);
     public static final QName GET_ALL_DOMAINS_REQUEST = QName.get(E_GET_ALL_DOMAINS_REQUEST, NAMESPACE);
     public static final QName GET_ALL_DOMAINS_RESPONSE = QName.get(E_GET_ALL_DOMAINS_RESPONSE, NAMESPACE);
+
+    public static final QName CREATE_ZULIP_REALM_REQUEST = QName.get(E_CREATE_ZULIP_REALM_REQUEST, NAMESPACE);
+    public static final QName CREATE_ZULIP_REALM_RESPONSE = QName.get(E_CREATE_ZULIP_REALM_RESPONSE, NAMESPACE);
 
     public static final QName CREATE_COS_REQUEST = QName.get(E_CREATE_COS_REQUEST, NAMESPACE);
     public static final QName CREATE_COS_RESPONSE = QName.get(E_CREATE_COS_RESPONSE, NAMESPACE);
@@ -1551,4 +1557,6 @@ public final class AdminConstants {
     public static final String E_GAL_FILTER = "galFilter";
     public static final String E_LDAP_FILTER = "ldapFilter";
     public static final String A_CLEAR_FILTER = "clearFilter";
+
+    public static final String A_ZULIP_DOMAIN = "zulipDomain";
 }

--- a/soap/src/java/com/zimbra/soap/JaxbUtil.java
+++ b/soap/src/java/com/zimbra/soap/JaxbUtil.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2018 Synacor, Inc.
+ * Copyright (C) 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2018, 2021 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -304,6 +304,8 @@ public final class JaxbUtil {
             com.zimbra.soap.admin.message.CreateHABGroupResponse.class,
             com.zimbra.soap.admin.message.CreateDomainRequest.class,
             com.zimbra.soap.admin.message.CreateDomainResponse.class,
+            com.zimbra.soap.admin.message.CreateZulipRealmRequest.class,
+            com.zimbra.soap.admin.message.CreateZulipRealmResponse.class,
             com.zimbra.soap.admin.message.CreateGalSyncAccountRequest.class,
             com.zimbra.soap.admin.message.CreateGalSyncAccountResponse.class,
             com.zimbra.soap.admin.message.CreateLDAPEntryRequest.class,

--- a/soap/src/java/com/zimbra/soap/admin/message/CreateZulipRealmRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/CreateZulipRealmRequest.java
@@ -1,0 +1,93 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2021 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.soap.admin.type.AdminAttrsImpl;
+import com.zimbra.soap.admin.type.DomainSelector;
+
+@XmlRootElement(name=AdminConstants.E_CREATE_ZULIP_REALM_REQUEST)
+public class CreateZulipRealmRequest  extends AdminAttrsImpl {
+    /**
+     * @zm-api-field-tag domainId
+     * @zm-api-field-description domain id, id of sub domain
+     */
+    @XmlAttribute(name=AdminConstants.A_ID /* domain Id(sub domain) */, required=true)
+    private String domainId;
+
+    /**
+     * @zm-api-field-tag domainName
+     * @zm-api-field-description zulip domain name
+     */
+    @XmlAttribute(name=AdminConstants.A_ZULIP_DOMAIN /* full domain name */, required=true)
+    private String domainName;
+
+    /**
+     * @zm-api-field-description Account
+     */
+    @XmlElement(name=AdminConstants.E_DOMAIN /* zimbra domin */, required=true)
+    private final DomainSelector domain;
+
+    /**
+     * no-argument constructor wanted by JAXB
+     */
+    @SuppressWarnings("unused")
+    private CreateZulipRealmRequest() {
+        this((DomainSelector) null);
+    }
+
+    public CreateZulipRealmRequest(DomainSelector domain) {
+        this.domain = domain;
+    }
+
+    public DomainSelector getDomain() {
+        return domain;
+    }
+
+    /**
+     * @return the domainId
+     */
+    public String getDomainId() {
+        return domainId;
+    }
+
+    /**
+     * @param domainId the domainId to set
+     */
+    public void setDomainId(String domainId) {
+        this.domainId = domainId;
+    }
+
+    /**
+     * @return the domainName
+     */
+    public String getDomainName() {
+        return domainName;
+    }
+
+    /**
+     * @param domainName the domainName to set
+     */
+    public void setDomainName(String domainName) {
+        this.domainName = domainName;
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/CreateZulipRealmResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/CreateZulipRealmResponse.java
@@ -1,0 +1,71 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2021 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.AdminConstants;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name=AdminConstants.E_CREATE_ZULIP_REALM_RESPONSE)
+public class CreateZulipRealmResponse {
+    /**
+     * @zm-api-field-tag domainId
+     * @zm-api-field-description zulip domain id
+     */
+    @XmlElement(name=AdminConstants.A_ID /* domain id */, required=true)
+    private String domainId;
+
+    /**
+     * @zm-api-field-tag domainName
+     * @zm-api-field-description zulip domain name
+     */
+    @XmlElement(name=AdminConstants.A_DOMAIN /* domain name */, required=true)
+    private String domainName;
+
+    /**
+     * @return the domainId
+     */
+    public String getDomainId() {
+        return domainId;
+    }
+
+    /**
+     * @param domainId the domainId to set
+     */
+    public void setDomainId(String domainId) {
+        this.domainId = domainId;
+    }
+
+    /**
+     * @return the domainName
+     */
+    public String getDomainName() {
+        return domainName;
+    }
+
+    /**
+     * @param domainName the domainName to set
+     */
+    public void setDomainName(String domainName) {
+        this.domainName = domainName;
+    }
+}

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9822,4 +9822,16 @@ TODO: delete them permanently from here
   <defaultCOSValue>TRUE</defaultCOSValue>
   <desc>whether to use Web Client feature</desc>
 </attr>
+
+<attr id="3089" name="zimbraFeatureZulipChatEnabled" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountInfo,accountInherited,domainAdminModifiable" since="9.0.0">
+  <defaultCOSValue>TRUE</defaultCOSValue>
+  <desc>Whether or not zulip chat is enabled.
+        If false at domain level, feature not available at domain, cos &amp; account.
+        If true at domain and false at cos, feature not available at cos &amp; account.
+        If true at domain &amp; cos and false at account, feature not available at account.
+  </desc>
+</attr>
+<attr id="3090" name="zimbraZulipChatDomainId" type="string" cardinality="single" optionalIn="domain" flags="domainInfo" since="9.0.0">
+  <desc>Zulip chat domain ID</desc>
+</attr>
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -20318,6 +20318,98 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * Whether or not zulip chat is enabled. If false at domain level,
+     * feature not available at domain, cos &amp; account. If true at domain
+     * and false at cos, feature not available at cos &amp; account. If true
+     * at domain &amp; cos and false at account, feature not available at
+     * account.
+     *
+     * @return zimbraFeatureZulipChatEnabled, or true if unset
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3089)
+    public boolean isFeatureZulipChatEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureZulipChatEnabled, true, true);
+    }
+
+    /**
+     * Whether or not zulip chat is enabled. If false at domain level,
+     * feature not available at domain, cos &amp; account. If true at domain
+     * and false at cos, feature not available at cos &amp; account. If true
+     * at domain &amp; cos and false at account, feature not available at
+     * account.
+     *
+     * @param zimbraFeatureZulipChatEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3089)
+    public void setFeatureZulipChatEnabled(boolean zimbraFeatureZulipChatEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureZulipChatEnabled, zimbraFeatureZulipChatEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether or not zulip chat is enabled. If false at domain level,
+     * feature not available at domain, cos &amp; account. If true at domain
+     * and false at cos, feature not available at cos &amp; account. If true
+     * at domain &amp; cos and false at account, feature not available at
+     * account.
+     *
+     * @param zimbraFeatureZulipChatEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3089)
+    public Map<String,Object> setFeatureZulipChatEnabled(boolean zimbraFeatureZulipChatEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureZulipChatEnabled, zimbraFeatureZulipChatEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether or not zulip chat is enabled. If false at domain level,
+     * feature not available at domain, cos &amp; account. If true at domain
+     * and false at cos, feature not available at cos &amp; account. If true
+     * at domain &amp; cos and false at account, feature not available at
+     * account.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3089)
+    public void unsetFeatureZulipChatEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureZulipChatEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether or not zulip chat is enabled. If false at domain level,
+     * feature not available at domain, cos &amp; account. If true at domain
+     * and false at cos, feature not available at cos &amp; account. If true
+     * at domain &amp; cos and false at account, feature not available at
+     * account.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3089)
+    public Map<String,Object> unsetFeatureZulipChatEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureZulipChatEnabled, "");
+        return attrs;
+    }
+
+    /**
      * whether crash reporting is enabled in the Android client
      *
      * @return zimbraFileAndroidCrashReportingEnabled, or true if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -14902,6 +14902,98 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * Whether or not zulip chat is enabled. If false at domain level,
+     * feature not available at domain, cos &amp; account. If true at domain
+     * and false at cos, feature not available at cos &amp; account. If true
+     * at domain &amp; cos and false at account, feature not available at
+     * account.
+     *
+     * @return zimbraFeatureZulipChatEnabled, or true if unset
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3089)
+    public boolean isFeatureZulipChatEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureZulipChatEnabled, true, true);
+    }
+
+    /**
+     * Whether or not zulip chat is enabled. If false at domain level,
+     * feature not available at domain, cos &amp; account. If true at domain
+     * and false at cos, feature not available at cos &amp; account. If true
+     * at domain &amp; cos and false at account, feature not available at
+     * account.
+     *
+     * @param zimbraFeatureZulipChatEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3089)
+    public void setFeatureZulipChatEnabled(boolean zimbraFeatureZulipChatEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureZulipChatEnabled, zimbraFeatureZulipChatEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether or not zulip chat is enabled. If false at domain level,
+     * feature not available at domain, cos &amp; account. If true at domain
+     * and false at cos, feature not available at cos &amp; account. If true
+     * at domain &amp; cos and false at account, feature not available at
+     * account.
+     *
+     * @param zimbraFeatureZulipChatEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3089)
+    public Map<String,Object> setFeatureZulipChatEnabled(boolean zimbraFeatureZulipChatEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureZulipChatEnabled, zimbraFeatureZulipChatEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether or not zulip chat is enabled. If false at domain level,
+     * feature not available at domain, cos &amp; account. If true at domain
+     * and false at cos, feature not available at cos &amp; account. If true
+     * at domain &amp; cos and false at account, feature not available at
+     * account.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3089)
+    public void unsetFeatureZulipChatEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureZulipChatEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether or not zulip chat is enabled. If false at domain level,
+     * feature not available at domain, cos &amp; account. If true at domain
+     * and false at cos, feature not available at cos &amp; account. If true
+     * at domain &amp; cos and false at account, feature not available at
+     * account.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3089)
+    public Map<String,Object> unsetFeatureZulipChatEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureZulipChatEnabled, "");
+        return attrs;
+    }
+
+    /**
      * whether crash reporting is enabled in the Android client
      *
      * @return zimbraFileAndroidCrashReportingEnabled, or true if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -9471,6 +9471,98 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
+     * Whether or not zulip chat is enabled. If false at domain level,
+     * feature not available at domain, cos &amp; account. If true at domain
+     * and false at cos, feature not available at cos &amp; account. If true
+     * at domain &amp; cos and false at account, feature not available at
+     * account.
+     *
+     * @return zimbraFeatureZulipChatEnabled, or false if unset
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3089)
+    public boolean isFeatureZulipChatEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureZulipChatEnabled, false, true);
+    }
+
+    /**
+     * Whether or not zulip chat is enabled. If false at domain level,
+     * feature not available at domain, cos &amp; account. If true at domain
+     * and false at cos, feature not available at cos &amp; account. If true
+     * at domain &amp; cos and false at account, feature not available at
+     * account.
+     *
+     * @param zimbraFeatureZulipChatEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3089)
+    public void setFeatureZulipChatEnabled(boolean zimbraFeatureZulipChatEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureZulipChatEnabled, zimbraFeatureZulipChatEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether or not zulip chat is enabled. If false at domain level,
+     * feature not available at domain, cos &amp; account. If true at domain
+     * and false at cos, feature not available at cos &amp; account. If true
+     * at domain &amp; cos and false at account, feature not available at
+     * account.
+     *
+     * @param zimbraFeatureZulipChatEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3089)
+    public Map<String,Object> setFeatureZulipChatEnabled(boolean zimbraFeatureZulipChatEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureZulipChatEnabled, zimbraFeatureZulipChatEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether or not zulip chat is enabled. If false at domain level,
+     * feature not available at domain, cos &amp; account. If true at domain
+     * and false at cos, feature not available at cos &amp; account. If true
+     * at domain &amp; cos and false at account, feature not available at
+     * account.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3089)
+    public void unsetFeatureZulipChatEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureZulipChatEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether or not zulip chat is enabled. If false at domain level,
+     * feature not available at domain, cos &amp; account. If true at domain
+     * and false at cos, feature not available at cos &amp; account. If true
+     * at domain &amp; cos and false at account, feature not available at
+     * account.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3089)
+    public Map<String,Object> unsetFeatureZulipChatEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureZulipChatEnabled, "");
+        return attrs;
+    }
+
+    /**
      * Maximum size in bytes for each attachment.
      *
      * @return zimbraFileUploadMaxSizePerFile, or 2147483648 if unset
@@ -24635,6 +24727,78 @@ public abstract class ZAttrDomain extends NamedEntry {
     public Map<String,Object> unsetZimletUserPropertiesMaxNumEntries(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraZimletUserPropertiesMaxNumEntries, "");
+        return attrs;
+    }
+
+    /**
+     * Zulip chat domain ID
+     *
+     * @return zimbraZulipChatDomainId, or null if unset
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3090)
+    public String getZulipChatDomainId() {
+        return getAttr(Provisioning.A_zimbraZulipChatDomainId, null, true);
+    }
+
+    /**
+     * Zulip chat domain ID
+     *
+     * @param zimbraZulipChatDomainId new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3090)
+    public void setZulipChatDomainId(String zimbraZulipChatDomainId) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraZulipChatDomainId, zimbraZulipChatDomainId);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Zulip chat domain ID
+     *
+     * @param zimbraZulipChatDomainId new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3090)
+    public Map<String,Object> setZulipChatDomainId(String zimbraZulipChatDomainId, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraZulipChatDomainId, zimbraZulipChatDomainId);
+        return attrs;
+    }
+
+    /**
+     * Zulip chat domain ID
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3090)
+    public void unsetZulipChatDomainId() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraZulipChatDomainId, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Zulip chat domain ID
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3090)
+    public Map<String,Object> unsetZulipChatDomainId(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraZulipChatDomainId, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ldap/RenameDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/RenameDomain.java
@@ -50,6 +50,7 @@ import com.zimbra.cs.account.soap.SoapProvisioning;
 import com.zimbra.cs.httpclient.URLUtil;
 import com.zimbra.cs.ldap.ILdapContext;
 import com.zimbra.cs.ldap.ZLdapFilterFactory.FilterId;
+import com.zimbra.cs.listeners.DomainListener;
 import com.zimbra.soap.admin.type.CacheEntryType;
 
 
@@ -210,6 +211,8 @@ public class RenameDomain {
          * 7. flush account cache on all servers
          */
         flushCacheOnAllServers(CacheEntryType.account);
+
+        DomainListener.invokeOnRenameDomain(mOldDomain, mOldDomain.getName(), newDomain.getName());
     }
 
     public static enum RenamePhase {

--- a/store/src/java/com/zimbra/cs/listeners/AccountListener.java
+++ b/store/src/java/com/zimbra/cs/listeners/AccountListener.java
@@ -249,6 +249,17 @@ public abstract class AccountListener {
     public abstract void onAccountCreation(Account acct) throws ServiceException;
 
     /**
+     * called after a successful account rename.
+     *
+     * @param USER_ACCOUNT user account renamed
+     * @param OLD_NAME old name of user account
+     * @param NEW_NAME new name of user account
+     */
+    public void onAccountRename(Account acct, String oldName, String newName) throws ServiceException {
+        // TODO: Empty body for existing implementation, override if needed.
+    }
+
+    /**
      * called after an account status change.
      *
      * @param USER_ACCOUNT user account whose status is changed

--- a/store/src/java/com/zimbra/cs/listeners/AccountListener.java
+++ b/store/src/java/com/zimbra/cs/listeners/AccountListener.java
@@ -211,6 +211,14 @@ public abstract class AccountListener {
         }
     }
 
+    public static void invokeOnAdminPrivilegesUpdate(Account acct) throws ServiceException {
+        Map<String, AccountListenerEntry> sortedListeners = ListenerUtil.sortByPriority(mListeners);
+        for (Map.Entry<String, AccountListenerEntry> listener : sortedListeners.entrySet()) {
+            AccountListenerEntry listenerInstance = listener.getValue();
+            listenerInstance.getAccountListener().onAdminPrivilegesUpdate(acct);
+        }
+    }
+
     public static void invokeOnException(ServiceException exceptionThrown) {
         ZimbraLog.account.debug("Error occurred during account creation: %s",
             exceptionThrown.getMessage());
@@ -247,6 +255,15 @@ public abstract class AccountListener {
      * @param USER_ACCOUNT user account created
      */
     public abstract void onAccountCreation(Account acct) throws ServiceException;
+
+    /**
+     * called on change of admin privileges on account update request
+     *
+     * @param USER_ACCOUNT user account whose admin privileges have been modified
+     */
+    public void onAdminPrivilegesUpdate(Account acct) throws ServiceException {
+        // TODO: Empty body for existing implementation, override if needed.
+    };
 
     /**
      * called after a successful account rename.

--- a/store/src/java/com/zimbra/cs/listeners/DomainListener.java
+++ b/store/src/java/com/zimbra/cs/listeners/DomainListener.java
@@ -1,0 +1,91 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2019, 2021 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.listeners;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.zimbra.common.localconfig.LC;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.Domain;
+import com.zimbra.cs.listeners.ListenerUtil.Priority;
+
+public abstract class DomainListener {
+
+    private static final Map<String, DomainListenerEntry> mListeners = Collections
+            .synchronizedMap(new HashMap<String, DomainListenerEntry>());
+
+    public static void registerListener(final String listenerName, final Priority priority, DomainListener listener)
+            throws ServiceException {
+        if (mListeners.size() == LC.zimbra_listeners_maxsize.intValue()) {
+            ZimbraLog.store.warn("Domain listener limit reached, registering of %s is ignored", listenerName);
+            throw ServiceException.FORBIDDEN("Domain listener limit reached");
+        }
+        final DomainListenerEntry listenerEntry = mListeners.get(listenerName);
+        if (listenerEntry != null) {
+            ZimbraLog.store.warn("Listener %s is already registered, registering of %s is ignored", listenerName,
+                    listenerEntry.getDomainListener().getClass().getCanonicalName());
+            throw ServiceException.FORBIDDEN("Domain listener with this name is already registered");
+        }
+        ZimbraLog.store.info("Registering domain listener: %s", listenerName);
+        final DomainListenerEntry entry = new DomainListenerEntry(listenerName, priority, listener);
+
+        mListeners.put(listenerName, entry);
+    }
+
+    public static void deregisterListner(final String listenerName) {
+        ZimbraLog.store.info("De-registering domain listener: %s", listenerName);
+        mListeners.remove(listenerName);
+    }
+
+    public static void invokeOnDomainCreation(final Domain newDomain) {
+        ZimbraLog.store.debug("Domain creation successful for user: %s", newDomain.getName());
+        // invoke listeners
+        final Map<String, DomainListenerEntry> sortedListeners = ListenerUtil.sortByPriority(mListeners);
+        for (Map.Entry<String, DomainListenerEntry> listener : sortedListeners.entrySet()) {
+            final DomainListenerEntry listenerInstance = listener.getValue();
+            try {
+                listenerInstance.getDomainListener().onDomainCreation(newDomain);
+            } catch (ServiceException ex) {
+                ZimbraLog.store.warn("Unable to invoke domain creation listener: " + listenerInstance.getListenerName(),
+                        ex);
+            }
+        }
+    }
+
+    public static void invokeOnRenameDomain(final Domain domain, final String oldName, final String newName) {
+        ZimbraLog.account.debug("Domain %s renamed from '%s' to '%s'", domain.getName(), oldName, newName);
+
+        final Map<String, DomainListenerEntry> sortedListeners = ListenerUtil.sortByPriority(mListeners);
+        for (Map.Entry<String, DomainListenerEntry> listener : sortedListeners.entrySet()) {
+            final DomainListenerEntry listenerInstance = listener.getValue();
+            try {
+                listenerInstance.getDomainListener().onDomainRename(domain, oldName, newName);
+            } catch (ServiceException ex) {
+                ZimbraLog.store.warn("Unable to invoke domain rename listener: " + listenerInstance.getListenerName(),
+                        ex);
+            }
+        }
+    }
+
+    public abstract void onDomainCreation(final Domain newDomain) throws ServiceException;
+
+    public abstract void onDomainRename(final Domain domain, final String oldName, final String newName)
+            throws ServiceException;
+}

--- a/store/src/java/com/zimbra/cs/listeners/DomainListener.java
+++ b/store/src/java/com/zimbra/cs/listeners/DomainListener.java
@@ -84,8 +84,24 @@ public abstract class DomainListener {
         }
     }
 
+    public static void invokeOnDeleteDomain(final Domain domain) {
+        ZimbraLog.account.debug("Domain %s is getting deleted ", domain.getName());
+        final Map<String, DomainListenerEntry> sortedListeners = ListenerUtil.sortByPriority(mListeners);
+        for (Map.Entry<String, DomainListenerEntry> listener : sortedListeners.entrySet()) {
+            final DomainListenerEntry listenerInstance = listener.getValue();
+            try {
+                listenerInstance.getDomainListener().onDomainDelete(domain);
+            } catch (ServiceException ex) {
+                ZimbraLog.store.warn("Unable to invoke domain delete listener: " + listenerInstance.getListenerName(),
+                        ex);
+            }
+        }
+    }
+
     public abstract void onDomainCreation(final Domain newDomain) throws ServiceException;
 
     public abstract void onDomainRename(final Domain domain, final String oldName, final String newName)
             throws ServiceException;
+
+    public abstract void onDomainDelete(final Domain domain) throws ServiceException;
 }

--- a/store/src/java/com/zimbra/cs/listeners/DomainListenerEntry.java
+++ b/store/src/java/com/zimbra/cs/listeners/DomainListenerEntry.java
@@ -14,6 +14,8 @@
  * If not, see <https://www.gnu.org/licenses/>.
  * ***** END LICENSE BLOCK *****
  */
+package com.zimbra.cs.listeners;
+
 import com.zimbra.cs.listeners.ListenerUtil.Priority;
 
 public class DomainListenerEntry implements Comparable<DomainListenerEntry> {

--- a/store/src/java/com/zimbra/cs/listeners/DomainListenerEntry.java
+++ b/store/src/java/com/zimbra/cs/listeners/DomainListenerEntry.java
@@ -1,0 +1,56 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2019, 2021 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+import com.zimbra.cs.listeners.ListenerUtil.Priority;
+
+public class DomainListenerEntry implements Comparable<DomainListenerEntry> {
+    private String listenerName;
+    private Priority priority;
+    private DomainListener domainListener;
+
+    public DomainListenerEntry(String listenerName, Priority priority, DomainListener domainListener) {
+        this.listenerName = listenerName;
+        this.priority = priority;
+        this.domainListener = domainListener;
+    }
+
+    @Override
+    public int compareTo(DomainListenerEntry other) {
+        if (this.priority.ordinal() < other.priority.ordinal()) {
+            return -1;
+        } else if (this.priority.ordinal() > other.priority.ordinal()) {
+            return 1;
+        } else {
+            return 0;
+        }
+    }
+
+    public String getListenerName() {
+        return this.listenerName;
+    }
+
+    public void setListenerName(String listenerName) {
+        this.listenerName = listenerName;
+    }
+
+    public DomainListener getDomainListener() {
+        return this.domainListener;
+    }
+
+    public void setDomainListener(DomainListener domainListener) {
+        this.domainListener = domainListener;
+    }
+}

--- a/store/src/java/com/zimbra/cs/service/account/GetInfo.java
+++ b/store/src/java/com/zimbra/cs/service/account/GetInfo.java
@@ -68,6 +68,7 @@ import com.zimbra.cs.service.admin.AdminAccessControl;
 import com.zimbra.cs.service.mail.ModifyProfileImage;
 import com.zimbra.cs.session.Session;
 import com.zimbra.cs.session.SoapSession;
+import com.zimbra.cs.util.AccountUtil;
 import com.zimbra.cs.util.BuildInfo;
 import com.zimbra.cs.zimlet.ZimletPresence;
 import com.zimbra.cs.zimlet.ZimletUserProperties;
@@ -329,6 +330,9 @@ public class GetInfo extends AccountDocumentHandler  {
             } else if (Provisioning.A_zimbraAttachmentsBlocked.equals(key)) {
                 // leave this a special case for now, until we have enough incidences to make it a pattern
                 value = config.isAttachmentsBlocked() || acct.isAttachmentsBlocked() ?
+                        ProvisioningConstants.TRUE : ProvisioningConstants.FALSE;
+            } else if (Provisioning.A_zimbraFeatureZulipChatEnabled.equals(key)) {
+                value = AccountUtil.isZulipChatEnabled(acct) ?
                         ProvisioningConstants.TRUE : ProvisioningConstants.FALSE;
             } else {
                 value = attrsMap.get(key);

--- a/store/src/java/com/zimbra/cs/service/admin/CreateDomain.java
+++ b/store/src/java/com/zimbra/cs/service/admin/CreateDomain.java
@@ -35,6 +35,7 @@ import com.zimbra.cs.account.accesscontrol.Rights.Admin;
 import com.zimbra.cs.account.accesscontrol.AdminRight;
 import com.zimbra.cs.account.accesscontrol.PseudoTarget;
 import com.zimbra.cs.account.accesscontrol.TargetType;
+import com.zimbra.cs.listeners.DomainListener;
 import com.zimbra.soap.ZimbraSoapContext;
 
 /**
@@ -89,6 +90,8 @@ public class CreateDomain extends AdminDocumentHandler {
 
 	    Element response = zsc.createElement(AdminConstants.CREATE_DOMAIN_RESPONSE);
 	    GetDomain.encodeDomain(response, domain);
+
+	    DomainListener.invokeOnDomainCreation(domain);
 
 	    return response;
 	}

--- a/store/src/java/com/zimbra/cs/service/admin/DeleteDomain.java
+++ b/store/src/java/com/zimbra/cs/service/admin/DeleteDomain.java
@@ -28,6 +28,7 @@ import com.zimbra.cs.account.Domain;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.accesscontrol.AdminRight;
 import com.zimbra.cs.account.accesscontrol.Rights.Admin;
+import com.zimbra.cs.listeners.DomainListener;
 import com.zimbra.common.account.Key;
 import com.zimbra.common.account.Key.DomainBy;
 import com.zimbra.common.service.ServiceException;
@@ -64,6 +65,9 @@ public class DeleteDomain extends AdminDocumentHandler {
         ZimbraLog.security.info(ZimbraLog.encodeAttrs(new String[] {"cmd", "DeleteDomain","name", name, "id", id }));
 
 	    Element response = zsc.createElement(AdminConstants.DELETE_DOMAIN_RESPONSE);
+
+	    DomainListener.invokeOnDeleteDomain(domain);
+
 	    return response;
 	}
 	

--- a/store/src/java/com/zimbra/cs/service/admin/ModifyAccount.java
+++ b/store/src/java/com/zimbra/cs/service/admin/ModifyAccount.java
@@ -241,6 +241,11 @@ public class ModifyAccount extends AdminDocumentHandler {
                     }
                 }
             }
+
+            if (attrs.containsKey(Provisioning.A_zimbraIsAdminAccount) || attrs.containsKey(Provisioning.A_zimbraIsDelegatedAdminAccount)
+                    || attrs.containsKey(Provisioning.A_zimbraIsDomainAdminAccount)) {
+                AccountListener.invokeOnAdminPrivilegesUpdate(account);
+            }
         } catch (ServiceException se) {
             if (rollbackOnFailure) {
                 ZimbraLog.account.debug("Exception occured while modifying account in zimbra for %s, roll back listener updates.", account.getMail());

--- a/store/src/java/com/zimbra/cs/util/AccountUtil.java
+++ b/store/src/java/com/zimbra/cs/util/AccountUtil.java
@@ -45,6 +45,7 @@ import com.sun.mail.smtp.SMTPMessage;
 import com.zimbra.common.account.Key;
 import com.zimbra.common.account.Key.AccountBy;
 import com.zimbra.common.account.Key.DomainBy;
+import com.zimbra.common.account.ProvisioningConstants;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.mime.MimeConstants;
 import com.zimbra.common.mime.shim.JavaMailInternetAddress;
@@ -884,5 +885,28 @@ public class AccountUtil {
             }
         }
         return null;
+    }
+
+    public static boolean isZulipChatEnabled(Account account) {
+        boolean isEnabled = false;
+        if (account == null) {
+            return isEnabled;
+        }
+        isEnabled = account.isFeatureZulipChatEnabled();
+
+        if (isEnabled) {
+            Provisioning prov = Provisioning.getInstance();
+            try {
+                Domain domain = prov.getDomainById(account.getDomainId());
+                if (domain != null && !Boolean.valueOf(domain.getAttr(Provisioning.A_zimbraFeatureZulipChatEnabled, ProvisioningConstants.TRUE))) {
+                    ZimbraLog.account.debug("Zulip: chat is disabled on domain, won't be available for user '%s'", account.getName());
+                    isEnabled = false;
+                }
+            } catch (ServiceException e) {
+                ZimbraLog.account.debug(String.format("Zulip: failed to get zulip chat enabled status on domain '%s' for user '%s'. "
+                        + "User account level zulip chat enabled status will be used.", account.getDomainName(), account.getName()), e);
+            }
+        }
+        return isEnabled;
     }
 }


### PR DESCRIPTION
Integrating Zulip with Zimbra9. 
Porting the required code from ZimbraX to Zimbra 9 to get zulip working with Z9.