### PR TITLE
ZCS-10418 Admin is not able to open admin console from web client

### DIFF
--- a/store/src/java/com/zimbra/cs/httpclient/URLUtil.java
+++ b/store/src/java/com/zimbra/cs/httpclient/URLUtil.java
@@ -206,22 +206,22 @@ public class URLUtil {
     }
 
     public static String getPublicAdminConsoleURLForDomain(Server server, Domain domain) throws ServiceException {
-        String publicAdminUrl = getAdminConsoleProxyUrl(server, domain);
+        String publicAdminUrl = getAdminConsoleProxyUrl(server, domain, false);
         if (publicAdminUrl == null) {
             publicAdminUrl = URLUtil.getAdminURL(server, server.getAdminURL());
         }
         return publicAdminUrl;
     }
 
-    public static String getPublicAdminConsoleSoapURLForDomain(Server server, Domain domain) throws ServiceException {
-        String publicAdminUrl = getAdminConsoleProxyUrl(server, domain);
+    public static String getPublicAdminSoapURLForDomain(Server server, Domain domain) throws ServiceException {
+        String publicAdminUrl = getAdminConsoleProxyUrl(server, domain, true);
         if (publicAdminUrl == null) {
             publicAdminUrl = URLUtil.getAdminURL(server, AdminConstants.ADMIN_SERVICE_URI);
         }
         return publicAdminUrl;
     }
 
-    private static String getAdminConsoleProxyUrl(Server server, Domain domain) throws ServiceException {
+    private static String getAdminConsoleProxyUrl(Server server, Domain domain, boolean isAdminSoapURL) throws ServiceException {
         if (domain == null) {
             return null;
         }
@@ -252,7 +252,11 @@ public class URLUtil {
         if (printPort) {
             buf.append(":").append(port);
         }
-        buf.append(AdminConstants.ADMIN_SERVICE_URI);
+        if (isAdminSoapURL) {
+            buf.append(AdminConstants.ADMIN_SERVICE_URI);
+        } else {
+            buf.append(server.getAdminURL());
+        }
         return buf.toString();
 
     }

--- a/store/src/java/com/zimbra/cs/httpclient/URLUtil.java
+++ b/store/src/java/com/zimbra/cs/httpclient/URLUtil.java
@@ -213,7 +213,7 @@ public class URLUtil {
         return publicAdminUrl;
     }
 
-    public static String getSoapPublicAdminConsoleURLForDomain(Server server, Domain domain) throws ServiceException {
+    public static String getPublicAdminConsoleSoapURLForDomain(Server server, Domain domain) throws ServiceException {
         String publicAdminUrl = getAdminConsoleProxyUrl(server, domain);
         if (publicAdminUrl == null) {
             publicAdminUrl = URLUtil.getAdminURL(server, AdminConstants.ADMIN_SERVICE_URI);

--- a/store/src/java/com/zimbra/cs/httpclient/URLUtil.java
+++ b/store/src/java/com/zimbra/cs/httpclient/URLUtil.java
@@ -208,6 +208,14 @@ public class URLUtil {
     public static String getPublicAdminConsoleURLForDomain(Server server, Domain domain) throws ServiceException {
         String publicAdminUrl = getAdminConsoleProxyUrl(server, domain);
         if (publicAdminUrl == null) {
+            publicAdminUrl = URLUtil.getAdminURL(server, server.getAdminURL());
+        }
+        return publicAdminUrl;
+    }
+
+    public static String getSoapPublicAdminConsoleURLForDomain(Server server, Domain domain) throws ServiceException {
+        String publicAdminUrl = getAdminConsoleProxyUrl(server, domain);
+        if (publicAdminUrl == null) {
             publicAdminUrl = URLUtil.getAdminURL(server, AdminConstants.ADMIN_SERVICE_URI);
         }
         return publicAdminUrl;

--- a/store/src/java/com/zimbra/soap/WsdlServlet.java
+++ b/store/src/java/com/zimbra/soap/WsdlServlet.java
@@ -127,7 +127,7 @@ public class WsdlServlet extends ZimbraServlet {
 
     private static String getSoapAdminURL(Domain domain) {
         try {
-            return URLUtil.getPublicAdminConsoleSoapURLForDomain(Provisioning.getInstance().getLocalServer(), domain);
+            return URLUtil.getPublicAdminSoapURLForDomain(Provisioning.getInstance().getLocalServer(), domain);
         } catch (ServiceException e) {
             return WsdlServiceInfo.localhostSoapAdminHttpsURL;
         }

--- a/store/src/java/com/zimbra/soap/WsdlServlet.java
+++ b/store/src/java/com/zimbra/soap/WsdlServlet.java
@@ -127,7 +127,7 @@ public class WsdlServlet extends ZimbraServlet {
 
     private static String getSoapAdminURL(Domain domain) {
         try {
-            return URLUtil.getSoapPublicAdminConsoleURLForDomain(Provisioning.getInstance().getLocalServer(), domain);
+            return URLUtil.getPublicAdminConsoleSoapURLForDomain(Provisioning.getInstance().getLocalServer(), domain);
         } catch (ServiceException e) {
             return WsdlServiceInfo.localhostSoapAdminHttpsURL;
         }

--- a/store/src/java/com/zimbra/soap/WsdlServlet.java
+++ b/store/src/java/com/zimbra/soap/WsdlServlet.java
@@ -127,7 +127,7 @@ public class WsdlServlet extends ZimbraServlet {
 
     private static String getSoapAdminURL(Domain domain) {
         try {
-            return URLUtil.getPublicAdminConsoleURLForDomain(Provisioning.getInstance().getLocalServer(), domain);
+            return URLUtil.getSoapPublicAdminConsoleURLForDomain(Provisioning.getInstance().getLocalServer(), domain);
         } catch (ServiceException e) {
             return WsdlServiceInfo.localhostSoapAdminHttpsURL;
         }


### PR DESCRIPTION
**Problem:** Admin is not able to open admin console from web client

**Fix:** 
- Added `URLUtil.getSoapPublicAdminConsoleURLForDomain()` to be used in WsdlServlet class
- Updated `URLUtil.getPublicAdminConsoleURLForDomain()` to use `server.getAdminURL()` to fetch correct admin console url

**Testing done:**
- testing done on local vm by replacing jars
- Admin is able to open admin console from web client
- Verified wsdl behaviour as given by Gren on https://github.com/Zimbra/zm-mailbox/commit/bff882def9f8ba086366e1adad99661864bc6671

**Testing to be done by QA:**
- verify both of the given scenarios
- make sure nothing else is broken related to wsdl and admin console url