### PR TITLE
ZCS-10322: LDAP Attribute for supporting Attachment Type Restrictions

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -6495,6 +6495,15 @@ public class ZAttrProvisioning {
     public static final String A_zimbraFeatureExternalFeedbackEnabled = "zimbraFeatureExternalFeedbackEnabled";
 
     /**
+     * Enable/Disable blocked file types set in
+     * zimbraFileUploadBlockedFileTypes for uploading
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3092)
+    public static final String A_zimbraFeatureFileTypeUploadRestrictionsEnabled = "zimbraFeatureFileTypeUploadRestrictionsEnabled";
+
+    /**
      * filter prefs enabled
      */
     @ZAttr(id=143)
@@ -7193,6 +7202,14 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=1362)
     public static final String A_zimbraFileShareLifetime = "zimbraFileShareLifetime";
+
+    /**
+     * Commonly blocked file types for uploading
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3091)
+    public static final String A_zimbraFileUploadBlockedFileTypes = "zimbraFileUploadBlockedFileTypes";
 
     /**
      * Maximum size in bytes for file uploads

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -6498,7 +6498,7 @@ public class ZAttrProvisioning {
      * Enable/Disable blocked file types set in
      * zimbraFileUploadBlockedFileTypes for uploading
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3092)
     public static final String A_zimbraFeatureFileTypeUploadRestrictionsEnabled = "zimbraFeatureFileTypeUploadRestrictionsEnabled";
@@ -7206,7 +7206,7 @@ public class ZAttrProvisioning {
     /**
      * Commonly blocked file types for uploading
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3091)
     public static final String A_zimbraFileUploadBlockedFileTypes = "zimbraFileUploadBlockedFileTypes";

--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -701,6 +701,8 @@ public final class LC {
     @Supported
     public static final KnownKey imapd_keystore = KnownKey.newKey("/opt/zimbra/conf/imapd.keystore");
     @Supported
+    public static final KnownKey custom_mimetypes = KnownKey.newKey("/opt/zimbra/conf/custom-mimetypes.xml");
+    @Supported
     public static final KnownKey imapd_keystore_password = KnownKey.newKey("${mailboxd_keystore_password}");
     @Supported
     public static final KnownKey imapd_java_options = KnownKey.newKey("");

--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1400,9 +1400,6 @@ public final class LC {
     // owasp handler
     public static final KnownKey zimbra_use_owasp_html_sanitizer = KnownKey.newKey(true);
 
-    // file content type blacklist
-    public static final KnownKey zimbra_file_content_type_blacklist = KnownKey.newKey("application/x-ms*");
-
     public static final KnownKey enable_delegated_admin_ldap_access = KnownKey.newKey(true);
 
     // OAuth2 Social

--- a/common/src/java/com/zimbra/common/service/ServiceException.java
+++ b/common/src/java/com/zimbra/common/service/ServiceException.java
@@ -64,6 +64,7 @@ public class ServiceException extends Exception {
     public static final String INVALID_DATASOURCE_ID = "service.INVALID_DATASOURCE_ID";
     public static final String DATASOURCE_SMTP_DISABLED = "service.DATASOURCE_SMTP_DISABLED";
     public static final String ERROR_WHILE_PARSING_UPLOAD = "service.IOEXCEPTION_WHILE_PARSING_UPLOAD";
+    public static final String BLOCKED_FILE_TYPE_UPLOAD = "service.BLOCKED_FILE_TYPE_UPLOAD";
 
     //smime
     public static final String LOAD_CERTIFICATE_FAILED = "smime.LOAD_CERTIFICATE_FAILED";
@@ -295,6 +296,11 @@ public class ServiceException extends Exception {
     public static ServiceException ERROR_WHILE_PARSING_UPLOAD(String message, Throwable cause) {
         return new ServiceException(
                 String.format("ioexception during upload: %s", message), ERROR_WHILE_PARSING_UPLOAD, RECEIVERS_FAULT, cause);
+    }
+
+    public static ServiceException BLOCKED_FILE_TYPE_UPLOAD(String message, Throwable cause) {
+        return new ServiceException(
+                String.format("blocked file type upload: %s", message), BLOCKED_FILE_TYPE_UPLOAD, RECEIVERS_FAULT, cause);
     }
 
     /**

--- a/store-conf/conf/custom-mimetypes.xml
+++ b/store-conf/conf/custom-mimetypes.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor
+	license agreements. See the NOTICE file distributed with this work for additional
+	information regarding copyright ownership. The ASF licenses this file to
+	You under the Apache License, Version 2.0 (the "License"); you may not use
+	this file except in compliance with the License. You may obtain a copy of
+	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required
+	by applicable law or agreed to in writing, software distributed under the
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+	OF ANY KIND, either express or implied. See the License for the specific
+	language governing permissions and limitations under the License. -->
+<mime-info>
+    <mime-type type="application/x-dosexec">
+    <_comment>Mapping application/x-dosexec content-type to microsoft executables.</_comment>
+        <glob pattern="*.exe" />
+        <glob pattern="*.dll" />
+        <glob pattern="*.com" />
+        <magic priority="65">
+            <match value="MZ" type="string" offset="0"/>
+        </magic>
+    </mime-type>
+</mime-info>

--- a/store/build.xml
+++ b/store/build.xml
@@ -101,6 +101,7 @@
     <mkdir dir="${build.dir}/zimbra/conf"/>
     <copy file="${zm-mailbox.basedir}/store-conf/conf/antisamy.xml" todir="${build.dir}/zimbra/conf/"/>
     <copy file="${zm-mailbox.basedir}/store-conf/conf/owasp_policy.xml" todir="${build.dir}/zimbra/conf/"/>
+    <copy file="${zm-mailbox.basedir}/store-conf/conf/custom-mimetypes.xml" todir="${build.dir}/zimbra/conf/"/>
     <antcall target="make-dirs">
       <param name="base.dir" value="${dist.dir}"/>
     </antcall>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9850,6 +9850,7 @@ TODO: delete them permanently from here
   <defaultCOSValue>wsf</defaultCOSValue>
   <defaultCOSValue>wsh</defaultCOSValue>
   <defaultCOSValue>xl</defaultCOSValue>
+  <defaultCOSValue>application/x-ms*</defaultCOSValue>
   <desc>Commonly blocked file types for uploading</desc>
  </attr>
 <attr id="3092" name="zimbraFeatureFileTypeUploadRestrictionsEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="9.0.0">

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9851,6 +9851,7 @@ TODO: delete them permanently from here
   <defaultCOSValue>wsh</defaultCOSValue>
   <defaultCOSValue>xl</defaultCOSValue>
   <defaultCOSValue>application/x-ms*</defaultCOSValue>
+  <defaultCOSValue>application/x-dosexec</defaultCOSValue>
   <desc>Commonly blocked file types for uploading</desc>
  </attr>
 <attr id="3092" name="zimbraFeatureFileTypeUploadRestrictionsEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="9.0.0">

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9822,4 +9822,38 @@ TODO: delete them permanently from here
   <defaultCOSValue>TRUE</defaultCOSValue>
   <desc>whether to use Web Client feature</desc>
 </attr>
+<attr id="3091" name="zimbraFileUploadBlockedFileTypes" type="string" cardinality="multi" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="9.0.0">
+  <defaultCOSValue>asd</defaultCOSValue>
+  <defaultCOSValue>bat</defaultCOSValue>
+  <defaultCOSValue>chm</defaultCOSValue>
+  <defaultCOSValue>cmd</defaultCOSValue>
+  <defaultCOSValue>com</defaultCOSValue>
+  <defaultCOSValue>dll</defaultCOSValue>
+  <defaultCOSValue>do</defaultCOSValue>
+  <defaultCOSValue>exe</defaultCOSValue>
+  <defaultCOSValue>hlp</defaultCOSValue>
+  <defaultCOSValue>hta</defaultCOSValue>
+  <defaultCOSValue>js</defaultCOSValue>
+  <defaultCOSValue>jse</defaultCOSValue>
+  <defaultCOSValue>lnk</defaultCOSValue>
+  <defaultCOSValue>ocx</defaultCOSValue>
+  <defaultCOSValue>pif</defaultCOSValue>
+  <defaultCOSValue>reg</defaultCOSValue>
+  <defaultCOSValue>scr</defaultCOSValue>
+  <defaultCOSValue>shb</defaultCOSValue>
+  <defaultCOSValue>shm</defaultCOSValue>
+  <defaultCOSValue>shs</defaultCOSValue>
+  <defaultCOSValue>vbe</defaultCOSValue>
+  <defaultCOSValue>vbs</defaultCOSValue>
+  <defaultCOSValue>vbx</defaultCOSValue>
+  <defaultCOSValue>vxd</defaultCOSValue>
+  <defaultCOSValue>wsf</defaultCOSValue>
+  <defaultCOSValue>wsh</defaultCOSValue>
+  <defaultCOSValue>xl</defaultCOSValue>
+  <desc>Commonly blocked file types for uploading</desc>
+ </attr>
+<attr id="3092" name="zimbraFeatureFileTypeUploadRestrictionsEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="9.0.0">
+  <defaultCOSValue>TRUE</defaultCOSValue>
+  <desc>Enable/Disable blocked file types set in zimbraFileUploadBlockedFileTypes for uploading</desc>
+ </attr>
 </attrs>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9822,7 +9822,7 @@ TODO: delete them permanently from here
   <defaultCOSValue>TRUE</defaultCOSValue>
   <desc>whether to use Web Client feature</desc>
 </attr>
-<attr id="3091" name="zimbraFileUploadBlockedFileTypes" type="string" cardinality="multi" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="9.0.0">
+<attr id="3091" name="zimbraFileUploadBlockedFileTypes" type="string" cardinality="multi" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="9.1.0">
   <defaultCOSValue>asd</defaultCOSValue>
   <defaultCOSValue>bat</defaultCOSValue>
   <defaultCOSValue>chm</defaultCOSValue>
@@ -9854,7 +9854,7 @@ TODO: delete them permanently from here
   <defaultCOSValue>application/x-dosexec</defaultCOSValue>
   <desc>Commonly blocked file types for uploading</desc>
  </attr>
-<attr id="3092" name="zimbraFeatureFileTypeUploadRestrictionsEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="9.0.0">
+<attr id="3092" name="zimbraFeatureFileTypeUploadRestrictionsEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="9.1.0">
   <defaultCOSValue>TRUE</defaultCOSValue>
   <desc>Enable/Disable blocked file types set in zimbraFileUploadBlockedFileTypes for uploading</desc>
  </attr>

--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -124,5 +124,6 @@
   <dependency org="org.apache.xmlgraphics" name="batik-css" rev="1.7"/>
   <dependency org="org.w3c.css" name="sac" rev="1.3"/>
   <dependency org="com.github.jtidy" name="jtidy" rev="1.0.2"/>
+  <dependency org="org.apache.tika" name="tika-core" rev="1.24"/>
  </dependencies>
 </ivy-module>

--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -124,6 +124,6 @@
   <dependency org="org.apache.xmlgraphics" name="batik-css" rev="1.7"/>
   <dependency org="org.w3c.css" name="sac" rev="1.3"/>
   <dependency org="com.github.jtidy" name="jtidy" rev="1.0.2"/>
-  <dependency org="org.apache.tika" name="tika-core" rev="1.24"/>
+  <dependency org="org.apache.tika" name="tika-app" rev="1.24.1"/>
  </dependencies>
 </ivy-module>

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -21500,7 +21500,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      */
     @ZAttr(id=3091)
     public String[] getFileUploadBlockedFileTypes() {
-        String[] value = getMultiAttr(Provisioning.A_zimbraFileUploadBlockedFileTypes, true, true); return value.length > 0 ? value : new String[] {"asd","bat","chm","cmd","com","dll","do","exe","hlp","hta","js","jse","lnk","ocx","pif","reg","scr","shb","shm","shs","vbe","vbs","vbx","vxd","wsf","wsh","xl","application/x-ms*"};
+        String[] value = getMultiAttr(Provisioning.A_zimbraFileUploadBlockedFileTypes, true, true); return value.length > 0 ? value : new String[] {"asd","bat","chm","cmd","com","dll","do","exe","hlp","hta","js","jse","lnk","ocx","pif","reg","scr","shb","shm","shs","vbe","vbs","vbx","vxd","wsf","wsh","xl","application/x-ms*","application/x-dosexec"};
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -14872,6 +14872,83 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * Enable/Disable blocked file types set in
+     * zimbraFileUploadBlockedFileTypes for uploading
+     *
+     * @return zimbraFeatureFileTypeUploadRestrictionsEnabled, or true if unset
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3092)
+    public boolean isFeatureFileTypeUploadRestrictionsEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureFileTypeUploadRestrictionsEnabled, true, true);
+    }
+
+    /**
+     * Enable/Disable blocked file types set in
+     * zimbraFileUploadBlockedFileTypes for uploading
+     *
+     * @param zimbraFeatureFileTypeUploadRestrictionsEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3092)
+    public void setFeatureFileTypeUploadRestrictionsEnabled(boolean zimbraFeatureFileTypeUploadRestrictionsEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureFileTypeUploadRestrictionsEnabled, zimbraFeatureFileTypeUploadRestrictionsEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Enable/Disable blocked file types set in
+     * zimbraFileUploadBlockedFileTypes for uploading
+     *
+     * @param zimbraFeatureFileTypeUploadRestrictionsEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3092)
+    public Map<String,Object> setFeatureFileTypeUploadRestrictionsEnabled(boolean zimbraFeatureFileTypeUploadRestrictionsEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureFileTypeUploadRestrictionsEnabled, zimbraFeatureFileTypeUploadRestrictionsEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Enable/Disable blocked file types set in
+     * zimbraFileUploadBlockedFileTypes for uploading
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3092)
+    public void unsetFeatureFileTypeUploadRestrictionsEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureFileTypeUploadRestrictionsEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Enable/Disable blocked file types set in
+     * zimbraFileUploadBlockedFileTypes for uploading
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3092)
+    public Map<String,Object> unsetFeatureFileTypeUploadRestrictionsEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureFileTypeUploadRestrictionsEnabled, "");
+        return attrs;
+    }
+
+    /**
      * filter prefs enabled
      *
      * @return zimbraFeatureFiltersEnabled, or true if unset
@@ -21411,6 +21488,140 @@ public abstract class ZAttrAccount  extends MailTarget {
     public Map<String,Object> unsetFileShareLifetime(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFileShareLifetime, "");
+        return attrs;
+    }
+
+    /**
+     * Commonly blocked file types for uploading
+     *
+     * @return zimbraFileUploadBlockedFileTypes, or empty array if unset
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3091)
+    public String[] getFileUploadBlockedFileTypes() {
+        String[] value = getMultiAttr(Provisioning.A_zimbraFileUploadBlockedFileTypes, true, true); return value.length > 0 ? value : new String[] {"asd","bat","chm","cmd","com","dll","do","exe","hlp","hta","js","jse","lnk","ocx","pif","reg","scr","shb","shm","shs","vbe","vbs","vbx","vxd","wsf","wsh","xl"};
+    }
+
+    /**
+     * Commonly blocked file types for uploading
+     *
+     * @param zimbraFileUploadBlockedFileTypes new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3091)
+    public void setFileUploadBlockedFileTypes(String[] zimbraFileUploadBlockedFileTypes) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFileUploadBlockedFileTypes, zimbraFileUploadBlockedFileTypes);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Commonly blocked file types for uploading
+     *
+     * @param zimbraFileUploadBlockedFileTypes new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3091)
+    public Map<String,Object> setFileUploadBlockedFileTypes(String[] zimbraFileUploadBlockedFileTypes, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFileUploadBlockedFileTypes, zimbraFileUploadBlockedFileTypes);
+        return attrs;
+    }
+
+    /**
+     * Commonly blocked file types for uploading
+     *
+     * @param zimbraFileUploadBlockedFileTypes new to add to existing values
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3091)
+    public void addFileUploadBlockedFileTypes(String zimbraFileUploadBlockedFileTypes) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraFileUploadBlockedFileTypes, zimbraFileUploadBlockedFileTypes);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Commonly blocked file types for uploading
+     *
+     * @param zimbraFileUploadBlockedFileTypes new to add to existing values
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3091)
+    public Map<String,Object> addFileUploadBlockedFileTypes(String zimbraFileUploadBlockedFileTypes, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraFileUploadBlockedFileTypes, zimbraFileUploadBlockedFileTypes);
+        return attrs;
+    }
+
+    /**
+     * Commonly blocked file types for uploading
+     *
+     * @param zimbraFileUploadBlockedFileTypes existing value to remove
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3091)
+    public void removeFileUploadBlockedFileTypes(String zimbraFileUploadBlockedFileTypes) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraFileUploadBlockedFileTypes, zimbraFileUploadBlockedFileTypes);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Commonly blocked file types for uploading
+     *
+     * @param zimbraFileUploadBlockedFileTypes existing value to remove
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3091)
+    public Map<String,Object> removeFileUploadBlockedFileTypes(String zimbraFileUploadBlockedFileTypes, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraFileUploadBlockedFileTypes, zimbraFileUploadBlockedFileTypes);
+        return attrs;
+    }
+
+    /**
+     * Commonly blocked file types for uploading
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3091)
+    public void unsetFileUploadBlockedFileTypes() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFileUploadBlockedFileTypes, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Commonly blocked file types for uploading
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3091)
+    public Map<String,Object> unsetFileUploadBlockedFileTypes(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFileUploadBlockedFileTypes, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -21500,7 +21500,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      */
     @ZAttr(id=3091)
     public String[] getFileUploadBlockedFileTypes() {
-        String[] value = getMultiAttr(Provisioning.A_zimbraFileUploadBlockedFileTypes, true, true); return value.length > 0 ? value : new String[] {"asd","bat","chm","cmd","com","dll","do","exe","hlp","hta","js","jse","lnk","ocx","pif","reg","scr","shb","shm","shs","vbe","vbs","vbx","vxd","wsf","wsh","xl"};
+        String[] value = getMultiAttr(Provisioning.A_zimbraFileUploadBlockedFileTypes, true, true); return value.length > 0 ? value : new String[] {"asd","bat","chm","cmd","com","dll","do","exe","hlp","hta","js","jse","lnk","ocx","pif","reg","scr","shb","shm","shs","vbe","vbs","vbx","vxd","wsf","wsh","xl","application/x-ms*"};
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -14877,7 +14877,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @return zimbraFeatureFileTypeUploadRestrictionsEnabled, or true if unset
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3092)
     public boolean isFeatureFileTypeUploadRestrictionsEnabled() {
@@ -14891,7 +14891,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param zimbraFeatureFileTypeUploadRestrictionsEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3092)
     public void setFeatureFileTypeUploadRestrictionsEnabled(boolean zimbraFeatureFileTypeUploadRestrictionsEnabled) throws com.zimbra.common.service.ServiceException {
@@ -14908,7 +14908,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3092)
     public Map<String,Object> setFeatureFileTypeUploadRestrictionsEnabled(boolean zimbraFeatureFileTypeUploadRestrictionsEnabled, Map<String,Object> attrs) {
@@ -14923,7 +14923,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3092)
     public void unsetFeatureFileTypeUploadRestrictionsEnabled() throws com.zimbra.common.service.ServiceException {
@@ -14939,7 +14939,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3092)
     public Map<String,Object> unsetFeatureFileTypeUploadRestrictionsEnabled(Map<String,Object> attrs) {
@@ -21496,7 +21496,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @return zimbraFileUploadBlockedFileTypes, or empty array if unset
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3091)
     public String[] getFileUploadBlockedFileTypes() {
@@ -21509,7 +21509,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param zimbraFileUploadBlockedFileTypes new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3091)
     public void setFileUploadBlockedFileTypes(String[] zimbraFileUploadBlockedFileTypes) throws com.zimbra.common.service.ServiceException {
@@ -21525,7 +21525,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3091)
     public Map<String,Object> setFileUploadBlockedFileTypes(String[] zimbraFileUploadBlockedFileTypes, Map<String,Object> attrs) {
@@ -21540,7 +21540,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param zimbraFileUploadBlockedFileTypes new to add to existing values
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3091)
     public void addFileUploadBlockedFileTypes(String zimbraFileUploadBlockedFileTypes) throws com.zimbra.common.service.ServiceException {
@@ -21556,7 +21556,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3091)
     public Map<String,Object> addFileUploadBlockedFileTypes(String zimbraFileUploadBlockedFileTypes, Map<String,Object> attrs) {
@@ -21571,7 +21571,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param zimbraFileUploadBlockedFileTypes existing value to remove
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3091)
     public void removeFileUploadBlockedFileTypes(String zimbraFileUploadBlockedFileTypes) throws com.zimbra.common.service.ServiceException {
@@ -21587,7 +21587,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3091)
     public Map<String,Object> removeFileUploadBlockedFileTypes(String zimbraFileUploadBlockedFileTypes, Map<String,Object> attrs) {
@@ -21601,7 +21601,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3091)
     public void unsetFileUploadBlockedFileTypes() throws com.zimbra.common.service.ServiceException {
@@ -21616,7 +21616,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3091)
     public Map<String,Object> unsetFileUploadBlockedFileTypes(Map<String,Object> attrs) {

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -16084,7 +16084,7 @@ public abstract class ZAttrCos extends NamedEntry {
      */
     @ZAttr(id=3091)
     public String[] getFileUploadBlockedFileTypes() {
-        String[] value = getMultiAttr(Provisioning.A_zimbraFileUploadBlockedFileTypes, true, true); return value.length > 0 ? value : new String[] {"asd","bat","chm","cmd","com","dll","do","exe","hlp","hta","js","jse","lnk","ocx","pif","reg","scr","shb","shm","shs","vbe","vbs","vbx","vxd","wsf","wsh","xl","application/x-ms*"};
+        String[] value = getMultiAttr(Provisioning.A_zimbraFileUploadBlockedFileTypes, true, true); return value.length > 0 ? value : new String[] {"asd","bat","chm","cmd","com","dll","do","exe","hlp","hta","js","jse","lnk","ocx","pif","reg","scr","shb","shm","shs","vbe","vbs","vbx","vxd","wsf","wsh","xl","application/x-ms*","application/x-dosexec"};
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -9456,6 +9456,83 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * Enable/Disable blocked file types set in
+     * zimbraFileUploadBlockedFileTypes for uploading
+     *
+     * @return zimbraFeatureFileTypeUploadRestrictionsEnabled, or true if unset
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3092)
+    public boolean isFeatureFileTypeUploadRestrictionsEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureFileTypeUploadRestrictionsEnabled, true, true);
+    }
+
+    /**
+     * Enable/Disable blocked file types set in
+     * zimbraFileUploadBlockedFileTypes for uploading
+     *
+     * @param zimbraFeatureFileTypeUploadRestrictionsEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3092)
+    public void setFeatureFileTypeUploadRestrictionsEnabled(boolean zimbraFeatureFileTypeUploadRestrictionsEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureFileTypeUploadRestrictionsEnabled, zimbraFeatureFileTypeUploadRestrictionsEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Enable/Disable blocked file types set in
+     * zimbraFileUploadBlockedFileTypes for uploading
+     *
+     * @param zimbraFeatureFileTypeUploadRestrictionsEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3092)
+    public Map<String,Object> setFeatureFileTypeUploadRestrictionsEnabled(boolean zimbraFeatureFileTypeUploadRestrictionsEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureFileTypeUploadRestrictionsEnabled, zimbraFeatureFileTypeUploadRestrictionsEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Enable/Disable blocked file types set in
+     * zimbraFileUploadBlockedFileTypes for uploading
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3092)
+    public void unsetFeatureFileTypeUploadRestrictionsEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureFileTypeUploadRestrictionsEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Enable/Disable blocked file types set in
+     * zimbraFileUploadBlockedFileTypes for uploading
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3092)
+    public Map<String,Object> unsetFeatureFileTypeUploadRestrictionsEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureFileTypeUploadRestrictionsEnabled, "");
+        return attrs;
+    }
+
+    /**
      * filter prefs enabled
      *
      * @return zimbraFeatureFiltersEnabled, or true if unset
@@ -15995,6 +16072,140 @@ public abstract class ZAttrCos extends NamedEntry {
     public Map<String,Object> unsetFileShareLifetime(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFileShareLifetime, "");
+        return attrs;
+    }
+
+    /**
+     * Commonly blocked file types for uploading
+     *
+     * @return zimbraFileUploadBlockedFileTypes, or empty array if unset
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3091)
+    public String[] getFileUploadBlockedFileTypes() {
+        String[] value = getMultiAttr(Provisioning.A_zimbraFileUploadBlockedFileTypes, true, true); return value.length > 0 ? value : new String[] {"asd","bat","chm","cmd","com","dll","do","exe","hlp","hta","js","jse","lnk","ocx","pif","reg","scr","shb","shm","shs","vbe","vbs","vbx","vxd","wsf","wsh","xl"};
+    }
+
+    /**
+     * Commonly blocked file types for uploading
+     *
+     * @param zimbraFileUploadBlockedFileTypes new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3091)
+    public void setFileUploadBlockedFileTypes(String[] zimbraFileUploadBlockedFileTypes) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFileUploadBlockedFileTypes, zimbraFileUploadBlockedFileTypes);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Commonly blocked file types for uploading
+     *
+     * @param zimbraFileUploadBlockedFileTypes new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3091)
+    public Map<String,Object> setFileUploadBlockedFileTypes(String[] zimbraFileUploadBlockedFileTypes, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFileUploadBlockedFileTypes, zimbraFileUploadBlockedFileTypes);
+        return attrs;
+    }
+
+    /**
+     * Commonly blocked file types for uploading
+     *
+     * @param zimbraFileUploadBlockedFileTypes new to add to existing values
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3091)
+    public void addFileUploadBlockedFileTypes(String zimbraFileUploadBlockedFileTypes) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraFileUploadBlockedFileTypes, zimbraFileUploadBlockedFileTypes);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Commonly blocked file types for uploading
+     *
+     * @param zimbraFileUploadBlockedFileTypes new to add to existing values
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3091)
+    public Map<String,Object> addFileUploadBlockedFileTypes(String zimbraFileUploadBlockedFileTypes, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraFileUploadBlockedFileTypes, zimbraFileUploadBlockedFileTypes);
+        return attrs;
+    }
+
+    /**
+     * Commonly blocked file types for uploading
+     *
+     * @param zimbraFileUploadBlockedFileTypes existing value to remove
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3091)
+    public void removeFileUploadBlockedFileTypes(String zimbraFileUploadBlockedFileTypes) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraFileUploadBlockedFileTypes, zimbraFileUploadBlockedFileTypes);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Commonly blocked file types for uploading
+     *
+     * @param zimbraFileUploadBlockedFileTypes existing value to remove
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3091)
+    public Map<String,Object> removeFileUploadBlockedFileTypes(String zimbraFileUploadBlockedFileTypes, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraFileUploadBlockedFileTypes, zimbraFileUploadBlockedFileTypes);
+        return attrs;
+    }
+
+    /**
+     * Commonly blocked file types for uploading
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3091)
+    public void unsetFileUploadBlockedFileTypes() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFileUploadBlockedFileTypes, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Commonly blocked file types for uploading
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3091)
+    public Map<String,Object> unsetFileUploadBlockedFileTypes(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFileUploadBlockedFileTypes, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -16084,7 +16084,7 @@ public abstract class ZAttrCos extends NamedEntry {
      */
     @ZAttr(id=3091)
     public String[] getFileUploadBlockedFileTypes() {
-        String[] value = getMultiAttr(Provisioning.A_zimbraFileUploadBlockedFileTypes, true, true); return value.length > 0 ? value : new String[] {"asd","bat","chm","cmd","com","dll","do","exe","hlp","hta","js","jse","lnk","ocx","pif","reg","scr","shb","shm","shs","vbe","vbs","vbx","vxd","wsf","wsh","xl"};
+        String[] value = getMultiAttr(Provisioning.A_zimbraFileUploadBlockedFileTypes, true, true); return value.length > 0 ? value : new String[] {"asd","bat","chm","cmd","com","dll","do","exe","hlp","hta","js","jse","lnk","ocx","pif","reg","scr","shb","shm","shs","vbe","vbs","vbx","vxd","wsf","wsh","xl","application/x-ms*"};
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -9461,7 +9461,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @return zimbraFeatureFileTypeUploadRestrictionsEnabled, or true if unset
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3092)
     public boolean isFeatureFileTypeUploadRestrictionsEnabled() {
@@ -9475,7 +9475,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param zimbraFeatureFileTypeUploadRestrictionsEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3092)
     public void setFeatureFileTypeUploadRestrictionsEnabled(boolean zimbraFeatureFileTypeUploadRestrictionsEnabled) throws com.zimbra.common.service.ServiceException {
@@ -9492,7 +9492,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3092)
     public Map<String,Object> setFeatureFileTypeUploadRestrictionsEnabled(boolean zimbraFeatureFileTypeUploadRestrictionsEnabled, Map<String,Object> attrs) {
@@ -9507,7 +9507,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3092)
     public void unsetFeatureFileTypeUploadRestrictionsEnabled() throws com.zimbra.common.service.ServiceException {
@@ -9523,7 +9523,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3092)
     public Map<String,Object> unsetFeatureFileTypeUploadRestrictionsEnabled(Map<String,Object> attrs) {
@@ -16080,7 +16080,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @return zimbraFileUploadBlockedFileTypes, or empty array if unset
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3091)
     public String[] getFileUploadBlockedFileTypes() {
@@ -16093,7 +16093,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param zimbraFileUploadBlockedFileTypes new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3091)
     public void setFileUploadBlockedFileTypes(String[] zimbraFileUploadBlockedFileTypes) throws com.zimbra.common.service.ServiceException {
@@ -16109,7 +16109,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3091)
     public Map<String,Object> setFileUploadBlockedFileTypes(String[] zimbraFileUploadBlockedFileTypes, Map<String,Object> attrs) {
@@ -16124,7 +16124,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param zimbraFileUploadBlockedFileTypes new to add to existing values
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3091)
     public void addFileUploadBlockedFileTypes(String zimbraFileUploadBlockedFileTypes) throws com.zimbra.common.service.ServiceException {
@@ -16140,7 +16140,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3091)
     public Map<String,Object> addFileUploadBlockedFileTypes(String zimbraFileUploadBlockedFileTypes, Map<String,Object> attrs) {
@@ -16155,7 +16155,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param zimbraFileUploadBlockedFileTypes existing value to remove
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3091)
     public void removeFileUploadBlockedFileTypes(String zimbraFileUploadBlockedFileTypes) throws com.zimbra.common.service.ServiceException {
@@ -16171,7 +16171,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3091)
     public Map<String,Object> removeFileUploadBlockedFileTypes(String zimbraFileUploadBlockedFileTypes, Map<String,Object> attrs) {
@@ -16185,7 +16185,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3091)
     public void unsetFileUploadBlockedFileTypes() throws com.zimbra.common.service.ServiceException {
@@ -16200,7 +16200,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3091)
     public Map<String,Object> unsetFileUploadBlockedFileTypes(Map<String,Object> attrs) {

--- a/store/src/java/com/zimbra/cs/service/FileUploadServlet.java
+++ b/store/src/java/com/zimbra/cs/service/FileUploadServlet.java
@@ -206,9 +206,9 @@ public class FileUploadServlet extends ZimbraServlet {
                     }
 
                     MimeType mimeType = getMimeType(file);
-                    if (blockedExtensionList.stream().anyMatch((blacklistedContentType) -> {
-                        if (blacklistedContentType.contains("/")) {
-                            Pattern p = Pattern.compile(blacklistedContentType);
+                    if (blockedExtensionList.stream().anyMatch((blockedContentType) -> {
+                        if (blockedContentType.contains("/")) {
+                            Pattern p = Pattern.compile(blockedContentType);
                             Matcher m = p.matcher(mimeType.toString());
                             return m.find();
                         } else {

--- a/store/src/java/com/zimbra/cs/service/FileUploadServlet.java
+++ b/store/src/java/com/zimbra/cs/service/FileUploadServlet.java
@@ -231,6 +231,7 @@ public class FileUploadServlet extends ZimbraServlet {
                 metadata.add(Metadata.RESOURCE_NAME_KEY, fileItem.getName());
                 MediaType mediaType = detector.detect(stream, metadata);
                 mimeType = tikaConfig.getMimeRepository().forName(mediaType.toString());
+                mLog.debug("Content type detected by tika: %s.", mimeType.toString());
             } catch (MimeTypeException mexp) {
                 mLog.warn("Failed to detect file content type", mexp);
             } catch (IOException exp) {
@@ -243,6 +244,7 @@ public class FileUploadServlet extends ZimbraServlet {
             String fileExtension = null;
             MimeType mimeType = getMimeType(fileItem);
             fileExtension = mimeType == null ? "" : StringUtils.strip(mimeType.getExtension(), ".");
+            mLog.debug("File extension detected by tika: %s.", fileExtension);
             return fileExtension;
         }
 

--- a/store/src/java/com/zimbra/cs/service/FileUploadServlet.java
+++ b/store/src/java/com/zimbra/cs/service/FileUploadServlet.java
@@ -193,8 +193,8 @@ public class FileUploadServlet extends ZimbraServlet {
             String extension = FilenameUtils.getExtension(filename).trim();
             String [] blockedFileTypes = null;
 
-            if (acct.getCOS().isFeatureFileTypeUploadRestrictionsEnabled()) {
-                blockedFileTypes = acct.getCOS().getMultiAttr(Provisioning.A_zimbraFileUploadBlockedFileTypes);
+            if (acct.isFeatureFileTypeUploadRestrictionsEnabled()) {
+                blockedFileTypes = acct.getMultiAttr(Provisioning.A_zimbraFileUploadBlockedFileTypes);
                 for(String blockedExt : blockedFileTypes){
                     if(blockedExt.equalsIgnoreCase(extension)) {
                         throw ServiceException.BLOCKED_FILE_TYPE_UPLOAD(


### PR DESCRIPTION
**Problem:**
LDAP Attribute for supporting Attachment Type Restrictions.

**Approach for Implementation:**
Added new ldap attributes at account and cos levels.
`zimbraFileUploadBlockedFileTypes` - Commonly blocked file types for uploading.
`zimbraFeatureFileTypeUploadRestrictionsEnabled` - Enable/Disable blocked file types set in `zimbraFileUploadBlockedFileTypes` for uploading.

Added ldap attribute `zimbraFeatureFileTypeUploadRestrictionsEnabled` for enabling and disabling the blocked file types set in the `zimbraFileUploadBlockedFileTypes` for uploading. If this ldap attribute is disabled then the atachment is uploaded without scanning the ldap attribute `zimbraFileUploadBlockedFileTypes` and the any type of the attachments are allowed to be uploaded.

If the ldap attribute `zimbraFeatureFileTypeUploadRestrictionsEnabled` is enabled then the file extensions mentioned in the ldap attribute are scanned one by one and if any of the matching blocked extensions are found during attachement upload then `BLOCKED_FILE_TYPE_UPLOAD` service exception is thrown and the attachment is disallowed from uploading. And suppose in case while uploading the attachment the extension is not found in the blocked ldap attribute `zimbraFileUploadBlockedFileTypes` then after that it's `content-type` is detected using the `tika-core` library and based on it's content type the file extension is detected and matched from the already fetched list of the blocked extension and if a match is found then `BLOCKED_FILE_TYPE_UPLOAD` service exception is thrown and the attachment is disallowed from uploading. 

This is also helpful in the situation when the user tries to upload an attachment after removing the extension.

**Updates:**
- Removed alreday blacklisted `application/x-ms*`from `zmlocalconfig` and fixed the issue of `.har` file content-type was not able to get detected from the mime type, used tika to get the content-type of the har file.
- Added debug statements for detected content-types and file extension.
- Added logic for handling the content-types specified in the `zimbraFileUploadBlockedFileTypes` ldap attribute.
- Added `custom-mimetypes.xml` in `store-conf` which will be copied over to the `/opt/zimbra/conf` directory where we can be able override the existing mimetypes and can be able to map the `content-type` to any of the extensions with a higher magic priority. So, in this change we are using `compositeDetector` which comprises of the default detector as well as the custom detector. If the `custom-mimetype.xml` is missing then in that case the `mediaType` will fallback to the default detector and will use the default `tika-mimetypes.xml` file.
- Removed the older way of `contentType` detection using the `MimeDetect` class and removed the unnecessary code for handling the `.har` file as it was based upon only the extension. As, if we remove the extension of the `.har` file [ZBUG-711](https://jira.corp.synacor.com/browse/ZBUG-711) still exist and making the web-client unresponsive and also in CPU spike. While it is correctly handled by the `tika` with it's `content-type` detected as `application/pdf` contrary to earlier where it is getting detected as `application/octet-stream` but the file actually contains `html` content and the `convertd` is trying to convert the document based on `application/octet-stream` and failing.
- 30-April-2021: Bumped the version of newly introduced `LDAP` attributes zimbraFeatureFileTypeUploadRestrictionsEnabled` and `zimbraFileUploadBlockedFileTypes` from `9.0.0` to `9.1.0`.

**Testing Done:**
- Tested when the ldap attribute `zimbraFeatureFileTypeUploadRestrictionsEnabled` is set to `FALSE` and verified that  any type of the attachments are allowed to be uploaded.
- Tested when the ldap attribute `zimbraFeatureFileTypeUploadRestrictionsEnabled` is set to `TRUE` and verified that the  file extensions mentioned it are blocked during the attachment upload and throws `BLOCKED_FILE_TYPE_UPLOAD` service exception.
- Verified that on removing the file extension from the blocked file type user is not able to upload the attachment.
- Verified by changing the extension of an `exe` file to `pdf` and and verified that the attachment upload throws `BLOCKED_FILE_TYPE_UPLOAD` service exception and is disallowed from uploading.
- Verified all the above scenarios for the uploads to the `e-mail` as well as for the `briefcase`.
- Verified no content types based on `application/x-ms*` are getting uploaded with or without the extensions.
- Verified `custom-mimetypes.xml` content-types are getting override to the default mime types.
- Verified that on uploading `.har` file with or without extension is not making the web-client unresponsive and is able to properly index and search the contents of the `.har` file.

**Related PR:**
[zm-zcs-lib](https://github.com/Zimbra/zm-zcs-lib/pull/72)
[zm-build](https://github.com/Zimbra/zm-build/pull/180)
