### PR TITLE
bugfix/ZCS-10425: Throwing particular exception rather

### DIFF
--- a/store/src/java/com/zimbra/cs/service/account/ResetPassword.java
+++ b/store/src/java/com/zimbra/cs/service/account/ResetPassword.java
@@ -51,6 +51,10 @@ public class ResetPassword extends AccountDocumentHandler {
         Element response = zsc.createElement(AccountConstants.E_RESET_PASSWORD_RESPONSE);
 
         AuthToken at = zsc.getAuthToken();
+        if (at == null) {
+            throw ServiceException.AUTH_REQUIRED("Auth Token missing.");
+        }
+
         if(at.getUsage() == Usage.RESET_PASSWORD) {
             AuthProvider.validateAuthToken(prov, at, false, Usage.RESET_PASSWORD);
         } else {

--- a/store/src/java/com/zimbra/cs/service/mail/RecoverAccount.java
+++ b/store/src/java/com/zimbra/cs/service/mail/RecoverAccount.java
@@ -143,9 +143,9 @@ public final class RecoverAccount extends MailDocumentHandler {
                 recoveryCodeMap.put(CodeConstants.RESEND_COUNT.toString(), String.valueOf(resendCount));
             }
             resp.setRecoveryAttemptsLeft(maxAttempts - resendCount);
-        } catch (Exception e) {
+        } catch (ServiceException e) {
             ZimbraLog.account.warn("Error while setting Password Recovery Resend Count : ", e);
-            throw ServiceException.FAILURE("Error while setting Password Recovery Resend Count.", e);
+            throw e;
         }
     }
 


### PR DESCRIPTION
Problem : During Soap Testing, it was found that RecoverAccountRequest throws generic exception rather than MAX_ATTEMPTS_REACHED_SUSPEND_FEATURE

> ExceptionId:qtp103536485-127:https://zqa-225.eng.zimbra.com/service/soap/RecoverAccountRequest:1616657029636:392ec513c12fda53
Code:service.MAX_ATTEMPTS_REACHED_SUSPEND_FEATURE
        at com.zimbra.cs.account.ForgetPasswordException.MAX_ATTEMPTS_REACHED_SUSPEND_FEATURE(ForgetPasswordException.java:68)
        at com.zimbra.cs.service.mail.RecoverAccount.checkVerifiedRecoveryAccAndSetResendCount(RecoverAccount.java:136)
        at com.zimbra.cs.service.mail.RecoverAccount.generatePasswordRecoveryCode(RecoverAccount.java:113)
        at com.zimbra.cs.service.mail.RecoverAccount.handle(RecoverAccount.java:84)
        at com.zimbra.soap.SoapEngine.dispatchRequest(SoapEngine.java:646)
        at com.zimbra.soap.SoapEngine.dispatch(SoapEngine.java:491)
        at com.zimbra.soap.SoapEngine.dispatch(SoapEngine.java:278)
        at com.zimbra.soap.SoapServlet.doWork(SoapServlet.java:308)
        at com.zimbra.soap.SoapServlet.doPost(SoapServlet.java:217)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:707)
        at com.zimbra.cs.servlet.ZimbraServlet.service(ZimbraServlet.java:214)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
        at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:873)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1623)
        at org.eclipse.jetty.websocket.server.WebSocketUpgradeFilter.doFilter(WebSocketUpgradeFilter.java:214)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1610)
        at com.zimbra.cs.servlet.CsrfFilter.doFilter(CsrfFilter.java:175)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1610)
        at com.zimbra.cs.servlet.RequestStringFilter.doFilter(RequestStringFilter.java:54)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1610)
        at com.zimbra.cs.servlet.SetHeaderFilter.doFilter(SetHeaderFilter.java:59)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1610)
        at com.zimbra.cs.servlet.ETagHeaderFilter.doFilter(ETagHeaderFilter.java:47)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1610)
        at com.zimbra.cs.servlet.ContextPathBasedThreadPoolBalancerFilter.doFilter(ContextPathBasedThreadPoolBalancerFilter.java:107)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1610)
        at com.zimbra.cs.servlet.ZimbraQoSFilter.doFilter(ZimbraQoSFilter.java:116)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1610)
        at com.zimbra.cs.servlet.ZimbraInvalidLoginFilter.doFilter(ZimbraInvalidLoginFilter.java:117)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1610)
        at org.eclipse.jetty.servlets.DoSFilter.doFilterChain(DoSFilter.java:482)
        at org.eclipse.jetty.servlets.DoSFilter.doFilter(DoSFilter.java:327)
        at org.eclipse.jetty.servlets.DoSFilter.doFilter(DoSFilter.java:297)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1610)
        at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:540)
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:146)
        at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:524)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:257)
        at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1700)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:255)
        at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1345)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:203)
        at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:480)
        at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1667)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:201)
        at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1247)
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:144)
        at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:220)
        at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:152)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
        at org.eclipse.jetty.rewrite.handler.RewriteHandler.handle(RewriteHandler.java:335)
        at org.eclipse.jetty.server.handler.gzip.GzipHandler.handle(GzipHandler.java:753)
        at org.eclipse.jetty.server.handler.DebugHandler.handle(DebugHandler.java:83)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
        at org.eclipse.jetty.server.Server.handle(Server.java:505)
        at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:370)
        at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:267)
        at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:305)
        at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:103)
        at org.eclipse.jetty.io.ssl.SslConnection$DecryptedEndPoint.onFillable(SslConnection.java:427)
        at org.eclipse.jetty.io.ssl.SslConnection.onFillable(SslConnection.java:321)
        at org.eclipse.jetty.io.ssl.SslConnection$2.succeeded(SslConnection.java:159)
        at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:103)
        at org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:117)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:333)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:310)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:168)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:126)
        at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:366)
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:698)
        at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:804)
        at java.base/java.lang.Thread.run(Thread.java:830)
2021-03-25 03:23:49,638 WARN  [qtp103536485-127:https://zqa-225.eng.zimbra.com/service/soap/RecoverAccountRequest] [ip=10.139.244.225;port=56016;ua=ZimbraWebClient - GC89 (Win);soapId=6061d90e;] SoapEngine - handler exception
com.zimbra.common.service.ServiceException: system failure: Error while setting Password Recovery Resend Count.
ExceptionId:qtp103536485-127:https://zqa-225.eng.zimbra.com/service/soap/RecoverAccountRequest:1616657029638:392ec513c12fda53
Code:service.FAILURE
        at com.zimbra.common.service.ServiceException.FAILURE(ServiceException.java:288)
        at com.zimbra.cs.service.mail.RecoverAccount.checkVerifiedRecoveryAccAndSetResendCount(RecoverAccount.java:148)
        at com.zimbra.cs.service.mail.RecoverAccount.generatePasswordRecoveryCode(RecoverAccount.java:113)
        at com.zimbra.cs.service.mail.RecoverAccount.handle(RecoverAccount.java:84)
        at com.zimbra.soap.SoapEngine.dispatchRequest(SoapEngine.java:646)
        at com.zimbra.soap.SoapEngine.dispatch(SoapEngine.java:491)
        at com.zimbra.soap.SoapEngine.dispatch(SoapEngine.java:278)
        at com.zimbra.soap.SoapServlet.doWork(SoapServlet.java:308)
        at com.zimbra.soap.SoapServlet.doPost(SoapServlet.java:217)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:707)
        at com.zimbra.cs.servlet.ZimbraServlet.service(ZimbraServlet.java:214)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
        at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:873)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1623)
        at org.eclipse.jetty.websocket.server.WebSocketUpgradeFilter.doFilter(WebSocketUpgradeFilter.java:214)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1610)
        at com.zimbra.cs.servlet.CsrfFilter.doFilter(CsrfFilter.java:175)


Solution : 
Rather than catching Exception, we should catch ServiceExceptions only.

Tests: 
Keep re-sending password recovery code until it reaches the max limit. The response should be 

> <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
  <soap:Header>
    <context xmlns="urn:zimbra">
      <change token="4"></change>
    </context>
  </soap:Header>
  <soap:Body>
    <soap:Fault>
      <soap:Code>
        <soap:Value>soap:Sender</soap:Value>
      </soap:Code>
      <soap:Reason>
        <soap:Text>service exception: Max re-send attempts reached, feature is suspended.</soap:Text>
      </soap:Reason>
      <soap:Detail>
        <Error xmlns="urn:zimbra">
          <Code>service.MAX_ATTEMPTS_REACHED_SUSPEND_FEATURE</Code>
          <Trace>qtp366590980-7213:1591131401294:6cfdd488048519c9</Trace>
        </Error>
      </soap:Detail>
    </soap:Fault>
  </soap:Body>
</soap:Envelope>