### PR TITLE
ZBUG-2191: Updated Apache MINA and it's dependent jar's

### DIFF
--- a/store/build.xml
+++ b/store/build.xml
@@ -269,8 +269,8 @@
   <target name="war" depends="jar,set-dev-version">
     <delete dir="${build.tmp.dir}"/>
     <!-- delete anything that may have been left over, e.g.: older versions of same libs -->
-    <ivy:install organisation="org.slf4j" module="slf4j-api" revision="1.6.4" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
-    <ivy:install organisation="org.slf4j" module="slf4j-log4j12" revision="1.6.4" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
+    <ivy:install organisation="org.slf4j" module="slf4j-api" revision="1.7.30" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
+    <ivy:install organisation="org.slf4j" module="slf4j-log4j12" revision="1.7.30" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.apache.james" module="apache-jsieve-core" revision="0.5" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.apache.lucene" module="lucene-core" revision="3.5.0" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.apache.lucene" module="lucene-analyzers" revision="3.5.0" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>

--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -15,8 +15,8 @@
   <dependency org="org.powermock" name="powermock-api-mockito-common" rev="1.6.5"/>
   <dependency org="org.mockito" name="mockito-all" rev="1.10.19" />
   <dependency org="org.javassist" name="javassist" rev="3.18.2-GA" />
-  <dependency org="org.slf4j" name="slf4j-api" rev="1.6.4"/>
-  <dependency org="org.slf4j" name="slf4j-log4j12" rev="1.6.4"/>
+  <dependency org="org.slf4j" name="slf4j-api" rev="1.7.30"/>
+  <dependency org="org.slf4j" name="slf4j-log4j12" rev="1.7.30"/>
   <dependency org="junit" name="junit" rev="4.8.2" />
   <dependency org="javax.mail" name="mail" rev="1.4.5" />
   <dependency org="jaxen" name="jaxen" rev="1.1-beta-10"/>
@@ -88,8 +88,8 @@
   <dependency org="org.bouncycastle" name="bcpkix-jdk15on" rev="1.64"/>
   <dependency org="com.googlecode.concurrentlinkedhashmap" name="concurrentlinkedhashmap-lru" rev="1.3.1" />
   <dependency org="org.apache.commons" name="commons-csv" rev="1.2"/>
-  <dependency org="org.apache.sshd" name="sshd-common" rev="2.6.0"/>
-  <dependency org="org.apache.sshd" name="sshd-core" rev="2.6.0"/>
+  <dependency org="org.apache.sshd" name="sshd-common" rev="2.6.1"/>
+  <dependency org="org.apache.sshd" name="sshd-core" rev="2.6.1"/>
   <dependency org="ant-tar-patched" name="ant-tar-patched" rev="1.0" />
   <dependency org="com.yahoo.platform.yui" name="yuicompressor" rev="2.4.2-zimbra" />
   <dependency org="org.hsqldb" name="hsqldb" rev="2.2.9" />


### PR DESCRIPTION
**Problem:**
Apache MINA SSHD Client 2.6.0 not compatible with lower version of OpenSSH(<7).

**Fix:**
Update Apache MINA SSHD Client to latest version 2.6.1, and updated it's dependent jar's