### PR TITLE
ZCS-10443: File upload size restrictions per user

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -8887,6 +8887,14 @@ public class ZAttrProvisioning {
     public static final String A_zimbraMailAllowReceiveButNotSendWhenOverQuota = "zimbraMailAllowReceiveButNotSendWhenOverQuota";
 
     /**
+     * Maximum size in bytes for e-mail attachment.
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3093)
+    public static final String A_zimbraMailAttachmentMaxSize = "zimbraMailAttachmentMaxSize";
+
+    /**
      * interface address on which HTTP server should listen; if empty, binds
      * to all interfaces
      *

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -8893,7 +8893,7 @@ public class ZAttrProvisioning {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=3093)
+    @ZAttr(id=4000)
     public static final String A_zimbraMailAttachmentMaxSize = "zimbraMailAttachmentMaxSize";
 
     /**

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -7264,13 +7264,15 @@ public class ZAttrProvisioning {
     public static final String A_zimbraFileUploadBlockedFileTypes = "zimbraFileUploadBlockedFileTypes";
 
     /**
-     * Maximum size in bytes for file uploads
+     * Maximum size in bytes for file uploads.
      */
     @ZAttr(id=227)
     public static final String A_zimbraFileUploadMaxSize = "zimbraFileUploadMaxSize";
 
     /**
-     * Maximum size in bytes for each attachment.
+     * Maximum size in bytes for each attachment for the file uploads. If the
+     * default value is not set then upload size is limited by
+     * zimbraFileUploadMaxSize.
      *
      * @since ZCS 8.0.0
      */

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -8891,7 +8891,7 @@ public class ZAttrProvisioning {
     /**
      * Maximum size in bytes for e-mail attachment.
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3093)
     public static final String A_zimbraMailAttachmentMaxSize = "zimbraMailAttachmentMaxSize";

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -1349,7 +1349,7 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
 
 <attr id="227" name="zimbraFileUploadMaxSize" type="long" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited,accountInfo">
   <globalConfigValue>10485760</globalConfigValue>
-  <desc>Maximum size in bytes for file uploads</desc>
+  <desc>Maximum size in bytes for file uploads.</desc>
 </attr>
 
 <attr id="229" name="zimbraTimeZoneStandardDtStart" type="string" max="256" cardinality="multi" requiredIn="timeZone" deprecatedSince="5.0">
@@ -6786,7 +6786,10 @@ TODO: delete them permanently from here
 <attr id="1350" name="zimbraFileUploadMaxSizePerFile" type="long" cardinality="single" optionalIn="account,cos,domain,globalConfig" flags="accountCosDomainInherited,domainInherited,accountInfo" since="8.0.0">
   <globalConfigValue>2147483648</globalConfigValue>
   <defaultCOSValue>0</defaultCOSValue>
-  <desc>Maximum size in bytes for each attachment.</desc>
+  <desc>
+    Maximum size in bytes for each attachment for the file uploads.
+    If the default value is not set then upload size is limited by zimbraFileUploadMaxSize.
+  </desc>
 </attr>
 
 <attr id="1351" name="zimbraPublicSharingEnabled" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountInfo,accountCosDomainInherited,domainAdminModifiable" since="8.0.0">

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9825,6 +9825,7 @@ TODO: delete them permanently from here
   <defaultCOSValue>TRUE</defaultCOSValue>
   <desc>whether to use Web Client feature</desc>
 </attr>
+
 <attr id="3091" name="zimbraFileUploadBlockedFileTypes" type="string" cardinality="multi" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="9.1.0">
   <defaultCOSValue>asd</defaultCOSValue>
   <defaultCOSValue>bat</defaultCOSValue>
@@ -9858,7 +9859,7 @@ TODO: delete them permanently from here
   <desc>Commonly blocked file types for uploading</desc>
  </attr>
 
-<attr id="3092" name="zimbraFeatureFileTypeUploadRestrictionsEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="9.1.0">
+ <attr id="3092" name="zimbraFeatureFileTypeUploadRestrictionsEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="9.1.0">
   <defaultCOSValue>TRUE</defaultCOSValue>
   <desc>Enable/Disable blocked file types set in zimbraFileUploadBlockedFileTypes for uploading</desc>
  </attr>
@@ -9902,8 +9903,8 @@ TODO: delete them permanently from here
   <defaultCOSValue>TRUE</defaultCOSValue>
   <desc>Whether or not to log document accessed time</desc>
  
-<attr id="4000" name="zimbraMailAttachmentMaxSize" type="long" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="9.1.0">
+ <attr id="4000" name="zimbraMailAttachmentMaxSize" type="long" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="9.1.0">
   <defaultCOSValue>0</defaultCOSValue>
   <desc>Maximum size in bytes for e-mail attachment.</desc>
-</attr>
+ </attr>
 </attrs>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -6783,9 +6783,9 @@ TODO: delete them permanently from here
   </desc>
 </attr>
 
-<attr id="1350" name="zimbraFileUploadMaxSizePerFile" type="long" cardinality="single" optionalIn="account,cos,domain,globalConfig" flags="accountCosDomainInherited,domainInherited" since="8.0.0">
+<attr id="1350" name="zimbraFileUploadMaxSizePerFile" type="long" cardinality="single" optionalIn="account,cos,domain,globalConfig" flags="accountCosDomainInherited,domainInherited,accountInfo" since="8.0.0">
   <globalConfigValue>2147483648</globalConfigValue>
-  <defaultCOSValue>2147483648</defaultCOSValue>
+  <defaultCOSValue>0</defaultCOSValue>
   <desc>Maximum size in bytes for each attachment.</desc>
 </attr>
 
@@ -9854,6 +9854,7 @@ TODO: delete them permanently from here
   <defaultCOSValue>application/x-dosexec</defaultCOSValue>
   <desc>Commonly blocked file types for uploading</desc>
  </attr>
+
 <attr id="3092" name="zimbraFeatureFileTypeUploadRestrictionsEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="9.1.0">
   <defaultCOSValue>TRUE</defaultCOSValue>
   <desc>Enable/Disable blocked file types set in zimbraFileUploadBlockedFileTypes for uploading</desc>
@@ -9897,5 +9898,9 @@ TODO: delete them permanently from here
 <attr id="3101" name="zimbraDocumentRecentlyViewedEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="9.1.0">
   <defaultCOSValue>TRUE</defaultCOSValue>
   <desc>Whether or not to log document accessed time</desc>
+ 
+<attr id="4000" name="zimbraMailAttachmentMaxSize" type="long" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="9.1.0">
+  <defaultCOSValue>0</defaultCOSValue>
+  <desc>Maximum size in bytes for e-mail attachment.</desc>
 </attr>
 </attrs>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9902,9 +9902,10 @@ TODO: delete them permanently from here
 <attr id="3101" name="zimbraDocumentRecentlyViewedEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="9.1.0">
   <defaultCOSValue>TRUE</defaultCOSValue>
   <desc>Whether or not to log document accessed time</desc>
- 
- <attr id="4000" name="zimbraMailAttachmentMaxSize" type="long" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="9.1.0">
+</attr>
+
+<attr id="4000" name="zimbraMailAttachmentMaxSize" type="long" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="9.1.0">
   <defaultCOSValue>0</defaultCOSValue>
   <desc>Maximum size in bytes for e-mail attachment.</desc>
- </attr>
+</attr>
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -26164,7 +26164,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @return zimbraMailAttachmentMaxSize, or 0 if unset
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3093)
     public long getMailAttachmentMaxSize() {
@@ -26177,7 +26177,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param zimbraMailAttachmentMaxSize new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3093)
     public void setMailAttachmentMaxSize(long zimbraMailAttachmentMaxSize) throws com.zimbra.common.service.ServiceException {
@@ -26193,7 +26193,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3093)
     public Map<String,Object> setMailAttachmentMaxSize(long zimbraMailAttachmentMaxSize, Map<String,Object> attrs) {
@@ -26207,7 +26207,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3093)
     public void unsetMailAttachmentMaxSize() throws com.zimbra.common.service.ServiceException {
@@ -26222,7 +26222,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3093)
     public Map<String,Object> unsetMailAttachmentMaxSize(Map<String,Object> attrs) {

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -21862,19 +21862,23 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * Maximum size in bytes for each attachment for the file uploads. If the
+     * default value is not set then upload size is limited by
+     * zimbraFileUploadMaxSize.
      *
-     * @return zimbraFileUploadMaxSizePerFile, or 2147483648 if unset
+     * @return zimbraFileUploadMaxSizePerFile, or 0 if unset
      *
      * @since ZCS 8.0.0
      */
     @ZAttr(id=1350)
     public long getFileUploadMaxSizePerFile() {
-        return getLongAttr(Provisioning.A_zimbraFileUploadMaxSizePerFile, 2147483648L, true);
+        return getLongAttr(Provisioning.A_zimbraFileUploadMaxSizePerFile, 0L, true);
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * Maximum size in bytes for each attachment for the file uploads. If the
+     * default value is not set then upload size is limited by
+     * zimbraFileUploadMaxSize.
      *
      * @param zimbraFileUploadMaxSizePerFile new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -21889,7 +21893,9 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * Maximum size in bytes for each attachment for the file uploads. If the
+     * default value is not set then upload size is limited by
+     * zimbraFileUploadMaxSize.
      *
      * @param zimbraFileUploadMaxSizePerFile new value
      * @param attrs existing map to populate, or null to create a new map
@@ -21905,7 +21911,9 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * Maximum size in bytes for each attachment for the file uploads. If the
+     * default value is not set then upload size is limited by
+     * zimbraFileUploadMaxSize.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -21919,7 +21927,9 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * Maximum size in bytes for each attachment for the file uploads. If the
+     * default value is not set then upload size is limited by
+     * zimbraFileUploadMaxSize.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -26152,13 +26152,13 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * Maximum size in bytes for e-mail attachment.
      *
-     * @return zimbraMailAttachmentMaxSize, or 6815744 if unset
+     * @return zimbraMailAttachmentMaxSize, or 0 if unset
      *
      * @since ZCS 9.0.0
      */
     @ZAttr(id=3093)
     public long getMailAttachmentMaxSize() {
-        return getLongAttr(Provisioning.A_zimbraMailAttachmentMaxSize, 6815744L, true);
+        return getLongAttr(Provisioning.A_zimbraMailAttachmentMaxSize, 0L, true);
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -26166,7 +26166,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=3093)
+    @ZAttr(id=4000)
     public long getMailAttachmentMaxSize() {
         return getLongAttr(Provisioning.A_zimbraMailAttachmentMaxSize, 0L, true);
     }
@@ -26179,7 +26179,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=3093)
+    @ZAttr(id=4000)
     public void setMailAttachmentMaxSize(long zimbraMailAttachmentMaxSize) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraMailAttachmentMaxSize, Long.toString(zimbraMailAttachmentMaxSize));
@@ -26195,7 +26195,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=3093)
+    @ZAttr(id=4000)
     public Map<String,Object> setMailAttachmentMaxSize(long zimbraMailAttachmentMaxSize, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraMailAttachmentMaxSize, Long.toString(zimbraMailAttachmentMaxSize));
@@ -26209,7 +26209,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=3093)
+    @ZAttr(id=4000)
     public void unsetMailAttachmentMaxSize() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraMailAttachmentMaxSize, "");
@@ -26224,7 +26224,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=3093)
+    @ZAttr(id=4000)
     public Map<String,Object> unsetMailAttachmentMaxSize(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraMailAttachmentMaxSize, "");

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -26150,6 +26150,78 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * Maximum size in bytes for e-mail attachment.
+     *
+     * @return zimbraMailAttachmentMaxSize, or 6815744 if unset
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3093)
+    public long getMailAttachmentMaxSize() {
+        return getLongAttr(Provisioning.A_zimbraMailAttachmentMaxSize, 6815744L, true);
+    }
+
+    /**
+     * Maximum size in bytes for e-mail attachment.
+     *
+     * @param zimbraMailAttachmentMaxSize new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3093)
+    public void setMailAttachmentMaxSize(long zimbraMailAttachmentMaxSize) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailAttachmentMaxSize, Long.toString(zimbraMailAttachmentMaxSize));
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Maximum size in bytes for e-mail attachment.
+     *
+     * @param zimbraMailAttachmentMaxSize new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3093)
+    public Map<String,Object> setMailAttachmentMaxSize(long zimbraMailAttachmentMaxSize, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailAttachmentMaxSize, Long.toString(zimbraMailAttachmentMaxSize));
+        return attrs;
+    }
+
+    /**
+     * Maximum size in bytes for e-mail attachment.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3093)
+    public void unsetMailAttachmentMaxSize() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailAttachmentMaxSize, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Maximum size in bytes for e-mail attachment.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3093)
+    public Map<String,Object> unsetMailAttachmentMaxSize(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailAttachmentMaxSize, "");
+        return attrs;
+    }
+
+    /**
      * Maximum number of entries for per user black list. This restricts the
      * number of values that can be set on the amavisBlacklistSender
      * attribute of an account. If set to 0, the per user white list feature

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -16355,7 +16355,7 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Maximum size in bytes for file uploads
+     * Maximum size in bytes for file uploads.
      *
      * @return zimbraFileUploadMaxSize, or 10485760 if unset
      */
@@ -16365,7 +16365,7 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Maximum size in bytes for file uploads
+     * Maximum size in bytes for file uploads.
      *
      * @param zimbraFileUploadMaxSize new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -16378,7 +16378,7 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Maximum size in bytes for file uploads
+     * Maximum size in bytes for file uploads.
      *
      * @param zimbraFileUploadMaxSize new value
      * @param attrs existing map to populate, or null to create a new map
@@ -16392,7 +16392,7 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Maximum size in bytes for file uploads
+     * Maximum size in bytes for file uploads.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      */
@@ -16404,7 +16404,7 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Maximum size in bytes for file uploads
+     * Maximum size in bytes for file uploads.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
@@ -16417,7 +16417,9 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * Maximum size in bytes for each attachment for the file uploads. If the
+     * default value is not set then upload size is limited by
+     * zimbraFileUploadMaxSize.
      *
      * @return zimbraFileUploadMaxSizePerFile, or 2147483648 if unset
      *
@@ -16429,7 +16431,9 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * Maximum size in bytes for each attachment for the file uploads. If the
+     * default value is not set then upload size is limited by
+     * zimbraFileUploadMaxSize.
      *
      * @param zimbraFileUploadMaxSizePerFile new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -16444,7 +16448,9 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * Maximum size in bytes for each attachment for the file uploads. If the
+     * default value is not set then upload size is limited by
+     * zimbraFileUploadMaxSize.
      *
      * @param zimbraFileUploadMaxSizePerFile new value
      * @param attrs existing map to populate, or null to create a new map
@@ -16460,7 +16466,9 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * Maximum size in bytes for each attachment for the file uploads. If the
+     * default value is not set then upload size is limited by
+     * zimbraFileUploadMaxSize.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -16474,7 +16482,9 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * Maximum size in bytes for each attachment for the file uploads. If the
+     * default value is not set then upload size is limited by
+     * zimbraFileUploadMaxSize.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -19470,6 +19470,78 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * Maximum size in bytes for e-mail attachment.
+     *
+     * @return zimbraMailAttachmentMaxSize, or 6815744 if unset
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3093)
+    public long getMailAttachmentMaxSize() {
+        return getLongAttr(Provisioning.A_zimbraMailAttachmentMaxSize, 6815744L, true);
+    }
+
+    /**
+     * Maximum size in bytes for e-mail attachment.
+     *
+     * @param zimbraMailAttachmentMaxSize new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3093)
+    public void setMailAttachmentMaxSize(long zimbraMailAttachmentMaxSize) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailAttachmentMaxSize, Long.toString(zimbraMailAttachmentMaxSize));
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Maximum size in bytes for e-mail attachment.
+     *
+     * @param zimbraMailAttachmentMaxSize new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3093)
+    public Map<String,Object> setMailAttachmentMaxSize(long zimbraMailAttachmentMaxSize, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailAttachmentMaxSize, Long.toString(zimbraMailAttachmentMaxSize));
+        return attrs;
+    }
+
+    /**
+     * Maximum size in bytes for e-mail attachment.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3093)
+    public void unsetMailAttachmentMaxSize() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailAttachmentMaxSize, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Maximum size in bytes for e-mail attachment.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.0.0
+     */
+    @ZAttr(id=3093)
+    public Map<String,Object> unsetMailAttachmentMaxSize(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailAttachmentMaxSize, "");
+        return attrs;
+    }
+
+    /**
      * Maximum number of entries for per user black list. This restricts the
      * number of values that can be set on the amavisBlacklistSender
      * attribute of an account. If set to 0, the per user white list feature

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -16446,19 +16446,23 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * Maximum size in bytes for each attachment for the file uploads. If the
+     * default value is not set then upload size is limited by
+     * zimbraFileUploadMaxSize.
      *
-     * @return zimbraFileUploadMaxSizePerFile, or 2147483648 if unset
+     * @return zimbraFileUploadMaxSizePerFile, or 0 if unset
      *
      * @since ZCS 8.0.0
      */
     @ZAttr(id=1350)
     public long getFileUploadMaxSizePerFile() {
-        return getLongAttr(Provisioning.A_zimbraFileUploadMaxSizePerFile, 2147483648L, true);
+        return getLongAttr(Provisioning.A_zimbraFileUploadMaxSizePerFile, 0L, true);
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * Maximum size in bytes for each attachment for the file uploads. If the
+     * default value is not set then upload size is limited by
+     * zimbraFileUploadMaxSize.
      *
      * @param zimbraFileUploadMaxSizePerFile new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -16473,7 +16477,9 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * Maximum size in bytes for each attachment for the file uploads. If the
+     * default value is not set then upload size is limited by
+     * zimbraFileUploadMaxSize.
      *
      * @param zimbraFileUploadMaxSizePerFile new value
      * @param attrs existing map to populate, or null to create a new map
@@ -16489,7 +16495,9 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * Maximum size in bytes for each attachment for the file uploads. If the
+     * default value is not set then upload size is limited by
+     * zimbraFileUploadMaxSize.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -16503,7 +16511,9 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * Maximum size in bytes for each attachment for the file uploads. If the
+     * default value is not set then upload size is limited by
+     * zimbraFileUploadMaxSize.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -19472,13 +19472,13 @@ public abstract class ZAttrCos extends NamedEntry {
     /**
      * Maximum size in bytes for e-mail attachment.
      *
-     * @return zimbraMailAttachmentMaxSize, or 6815744 if unset
+     * @return zimbraMailAttachmentMaxSize, or 0 if unset
      *
      * @since ZCS 9.0.0
      */
     @ZAttr(id=3093)
     public long getMailAttachmentMaxSize() {
-        return getLongAttr(Provisioning.A_zimbraMailAttachmentMaxSize, 6815744L, true);
+        return getLongAttr(Provisioning.A_zimbraMailAttachmentMaxSize, 0L, true);
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -19484,7 +19484,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @return zimbraMailAttachmentMaxSize, or 0 if unset
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3093)
     public long getMailAttachmentMaxSize() {
@@ -19497,7 +19497,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param zimbraMailAttachmentMaxSize new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3093)
     public void setMailAttachmentMaxSize(long zimbraMailAttachmentMaxSize) throws com.zimbra.common.service.ServiceException {
@@ -19513,7 +19513,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3093)
     public Map<String,Object> setMailAttachmentMaxSize(long zimbraMailAttachmentMaxSize, Map<String,Object> attrs) {
@@ -19527,7 +19527,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3093)
     public void unsetMailAttachmentMaxSize() throws com.zimbra.common.service.ServiceException {
@@ -19542,7 +19542,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.0.0
+     * @since ZCS 9.1.0
      */
     @ZAttr(id=3093)
     public Map<String,Object> unsetMailAttachmentMaxSize(Map<String,Object> attrs) {

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -19486,7 +19486,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=3093)
+    @ZAttr(id=4000)
     public long getMailAttachmentMaxSize() {
         return getLongAttr(Provisioning.A_zimbraMailAttachmentMaxSize, 0L, true);
     }
@@ -19499,7 +19499,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=3093)
+    @ZAttr(id=4000)
     public void setMailAttachmentMaxSize(long zimbraMailAttachmentMaxSize) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraMailAttachmentMaxSize, Long.toString(zimbraMailAttachmentMaxSize));
@@ -19515,7 +19515,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=3093)
+    @ZAttr(id=4000)
     public Map<String,Object> setMailAttachmentMaxSize(long zimbraMailAttachmentMaxSize, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraMailAttachmentMaxSize, Long.toString(zimbraMailAttachmentMaxSize));
@@ -19529,7 +19529,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=3093)
+    @ZAttr(id=4000)
     public void unsetMailAttachmentMaxSize() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraMailAttachmentMaxSize, "");
@@ -19544,7 +19544,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=3093)
+    @ZAttr(id=4000)
     public Map<String,Object> unsetMailAttachmentMaxSize(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraMailAttachmentMaxSize, "");

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -9563,7 +9563,9 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * Maximum size in bytes for each attachment for the file uploads. If the
+     * default value is not set then upload size is limited by
+     * zimbraFileUploadMaxSize.
      *
      * @return zimbraFileUploadMaxSizePerFile, or 2147483648 if unset
      *
@@ -9575,7 +9577,9 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * Maximum size in bytes for each attachment for the file uploads. If the
+     * default value is not set then upload size is limited by
+     * zimbraFileUploadMaxSize.
      *
      * @param zimbraFileUploadMaxSizePerFile new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -9590,7 +9594,9 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * Maximum size in bytes for each attachment for the file uploads. If the
+     * default value is not set then upload size is limited by
+     * zimbraFileUploadMaxSize.
      *
      * @param zimbraFileUploadMaxSizePerFile new value
      * @param attrs existing map to populate, or null to create a new map
@@ -9606,7 +9612,9 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * Maximum size in bytes for each attachment for the file uploads. If the
+     * default value is not set then upload size is limited by
+     * zimbraFileUploadMaxSize.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -9620,7 +9628,9 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * Maximum size in bytes for each attachment for the file uploads. If the
+     * default value is not set then upload size is limited by
+     * zimbraFileUploadMaxSize.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -9121,7 +9121,7 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Maximum size in bytes for file uploads
+     * Maximum size in bytes for file uploads.
      *
      * @return zimbraFileUploadMaxSize, or 10485760 if unset
      */
@@ -9131,7 +9131,7 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Maximum size in bytes for file uploads
+     * Maximum size in bytes for file uploads.
      *
      * @param zimbraFileUploadMaxSize new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -9144,7 +9144,7 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Maximum size in bytes for file uploads
+     * Maximum size in bytes for file uploads.
      *
      * @param zimbraFileUploadMaxSize new value
      * @param attrs existing map to populate, or null to create a new map
@@ -9158,7 +9158,7 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Maximum size in bytes for file uploads
+     * Maximum size in bytes for file uploads.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      */
@@ -9170,7 +9170,7 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Maximum size in bytes for file uploads
+     * Maximum size in bytes for file uploads.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/service/FileUploadServlet.java
+++ b/store/src/java/com/zimbra/cs/service/FileUploadServlet.java
@@ -908,6 +908,9 @@ public class FileUploadServlet extends ZimbraServlet {
                     attributeUsed = Provisioning.A_zimbraMailAttachmentMaxSize;
                 }
                 if (maxSize == 0) {
+                    /* 0 means "no limit". The return value from this function gets used
+                     * by FileUploadBase "sizeMax" where "-1" means "no limit"
+                     */
                     maxSize = -1;
                 }
             } else {

--- a/store/src/java/com/zimbra/cs/service/FileUploadServlet.java
+++ b/store/src/java/com/zimbra/cs/service/FileUploadServlet.java
@@ -883,6 +883,7 @@ public class FileUploadServlet extends ZimbraServlet {
 
     private static long getFileUploadMaxSize(boolean limitByFileUploadMaxSize, Account acct) {
         long maxSize = DEFAULT_MAX_SIZE;
+        String attributeUsed = null;
         if (acct.getMailAttachmentMaxSize() >= 0 || acct.getFileUploadMaxSizePerFile() >= 0) {
             try {
                 if (limitByFileUploadMaxSize) {
@@ -891,8 +892,10 @@ public class FileUploadServlet extends ZimbraServlet {
                             Provisioning.A_zimbraFileUploadMaxSize, DEFAULT_MAX_SIZE);
                     if (fileUploadSizePerFile >= fileUploadSize) {
                         maxSize = fileUploadSize;
+                        attributeUsed = Provisioning.A_zimbraFileUploadMaxSize;
                     } else {
                         maxSize = fileUploadSizePerFile;
+                        attributeUsed = Provisioning.A_zimbraFileUploadMaxSizePerFile;
                     }
                 } else {
                     long mailAttachmentMaxSize = acct.getMailAttachmentMaxSize();
@@ -900,16 +903,17 @@ public class FileUploadServlet extends ZimbraServlet {
                             Provisioning.A_zimbraMtaMaxMessageSize, DEFAULT_MAX_SIZE);
                     if (mailAttachmentMaxSize > mtaMaxMsgSize) {
                         maxSize = mtaMaxMsgSize;
+                        attributeUsed = Provisioning.A_zimbraMtaMaxMessageSize;
                     } else {
                         maxSize = mailAttachmentMaxSize;
+                        attributeUsed = Provisioning.A_zimbraMailAttachmentMaxSize;
                     }
                     if (maxSize == 0) {
                         maxSize = -1;
                     }
                 }
-            } catch (ServiceException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
+            } catch (ServiceException exp) {
+                mLog.error(String.format("Unable to read %s attribute.", attributeUsed), exp);
             }
         } else {
             maxSize = getFileUploadMaxSize(limitByFileUploadMaxSize);


### PR DESCRIPTION
**Problem:** 
File upload size restrictions per user.

**Description:**
- Added new `LDAP` attribute `zimbraMailAttachmentMaxSize` at `account` and `cos` level for restricting the maximum size in bytes for e-mail attachment.
- Set the `defaultCOSValue` for the `LDAP` attribute `zimbraMailAttachmentMaxSize` as `0`.
- Modified `zimbraFileUploadMaxSizePerFile` `LDAP` attribute to be used for file uploads restrictions other than e-mail. Now, the old `defaultCOSValue` is removed as its value should be less than the `LDAP` attribute `zimbraFileUploadMaxSize`. If the default value is not set then upload size is limited by `zimbraFileUploadMaxSize` which is global. Also, added accountInfo flag to `zimbraFileUploadMaxSizePerFile`.
- Added new ldap attributes for restricting  the maximum size in bytes for e-mail attachment `zimbraMailAttachmentMaxSize`
and the for file uploads restrictions `zimbraFileUploadMaxSizePerFile` other than e-mail. The default value for both the new ldap attributes is set to `0`. So, the provided file upload size limit to `account` and `COS` levels. As we are using the `zimbraMailAttachmentMaxSize` ldap attribute for e-mail attachments file size restriction and  `zimbraFileUploadMaxSizePerFile` for the briefcase and other file size restrictions. And if these new ldap attributes are not set then it falls back to the original ldap values `zimbraMtaMaxMessageSize` in case of e-mail attachment file size restriction else `zimbraFileUploadMaxSize`. The values of these new attributes are lower than the older global level ldap attributes (`zimbraMtaMaxMessageSize`, `zimbraFileUploadMaxSize`). If the value of (`zimbraMailAttachmentMaxSize`, `zimbraFileUploadMaxSizePerFile`) is set higher than the (`zimbraMtaMaxMessageSize`, `zimbraFileUploadMaxSize`) then the global value is overridden.

**Updates:**
- Bumped the version of newly introduced  `LDAP` attribute `zimbraMailAttachmentMaxSize` from `9.0.0` to `9.1.0`
- Added code for handling the error in the  catch block of the method `getFileUploadMaxSize`.
- 05May2021
-- Fixed the scenario when the user was able to attach more than 1 files after crossing the size restrictions imposed by the new ldap attributes but with single attachment it was working fine.
-- Also fixed when the new ldap attributes on the account level was set to `0`  files were getting uploaded as zero bytes now when the `zimbraMailAttachmentMaxSize` and `zimbraFileUploadMaxSizePerFile` is set to the default values then the values of `zimbraMtaMaxMessageSize` and `zimbraFileUploadMaxSize` will be used.

**Note:**
UI performs a check of base64 encoding on the size of the upload
```
$ zmprov -l gcf zimbraMtaMaxMessageSize
zimbraMtaMaxMessageSize: 10240000

$ zmprov -l gcf zimbraFileUploadMaxSize
zimbraFileUploadMaxSize: 10485760
```
uses `attSizeLimit` and `docSizeLimit` returned in `GetInfo` call:
```
<GetInfoResponse docSizeLimit="10485760" requestId="418fb075-dec3-49a6-9b75-6ad96a484a6b" attSizeLimit="10240000" xmlns="urn:zimbraAccount">
=> attSizeLimit :: zimbraMtaMaxMessageSize :: 10240000 (9.7656MB)
=> docSizeLimit :: zimbraFileUploadMaxSize :: 10485760 (10MB)
```
But UI is restricting to `7MB` limit, details are in the following bug.
```
Attachment file size check should be before encoding
The admin sets the limit based on the base64 encoded size. (The actual size sent over the network). And since 1.3333 * originalSize = base64Size, this means that:
If the admin sets the limit (for either attSizeLimit or docSizeLimit) to some value (m), then as far as the client (and end-user) is concerned the limit is actually m / 1.34. (1.34 is approximation of 1.333333....)
```
[Bug 76919](https://bugzilla.zimbra.com/show_bug.cgi?id=76919) - [PR](https://github.com/Zimbra/zm-web-client/commit/78f82dedfd70da53ac87556712787230d4bd89e3)


**Testing Done:**
- Verified the new ldap attributes are present.
- Verified that if zimbraMailAttachmentMaxSize is set to a lower value than `zimbraMtaMaxMessageSize` for e-mail attachment then `zimbraMailAttachmentMaxSize` value is used and if `zimbraMailAttachmentMaxSize` is set to a higher value than `zimbraMtaMaxMessageSize` for e-mail attachment then the value of `zimbraMtaMaxMessageSize` is used.
- Verified that if `zimbraFileUploadMaxSizePerFile` is set to a lower value than `zimbraFileUploadMaxSize` for e-mail attachment then `zimbraFileUploadMaxSizePerFile` value is used and if `zimbraFileUploadMaxSizePerFile` is set to a higher value than `zimbraFileUploadMaxSize` for e-mail attachment then the value of `zimbraFileUploadMaxSize` is used.
- Verified now the whole attachment upload is also now limited by the `zimbraMailAttachmentMaxSize` and `zimbraFileUploadMaxSizePerFile` ldap attributes.
- Verified that when the new ldap attributes on the account level was set to `0`  files are not getting uploaded as zero bytes.