### PR TITLE
TSS-18300: Fix for emails displaying as blank

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -319,7 +319,6 @@
                     <exclude name="**/cs/redolog/op/CreateMessageTest.java"/>
                     <exclude name="**/cs/service/mail/SearchActionTest.java"/>
                     <exclude name="**/cs/filter/RuleManagerWithCustomActionFilterTest.java"/>
-                    <exclude name="**/html/owasp/OwaspHtmlSanitizerTest.java"/>
                 </fileset>
             </batchtest>
           </junit>

--- a/store/src/java-test/com/zimbra/cs/html/owasp/OwaspHtmlSanitizerTest.java
+++ b/store/src/java-test/com/zimbra/cs/html/owasp/OwaspHtmlSanitizerTest.java
@@ -705,4 +705,21 @@ public class OwaspHtmlSanitizerTest {
         // check that the id and class attributes are not removed
         Assert.assertTrue(result.equals(html));
     }
+
+    @Test
+    public void testBugTSS18004() throws Exception {
+        String malformedHtml = "<HTML><BODY><p dir=\"ltr\" style=\"-webkit-text-size-adjust:auto;line-height:1.38;margin-top:0pt;margin-bottom:0pt;\">"
+                + "<span style=\"font-family:Arial;font-size:14.666666984558105px-webkit-text-size-adjust:auto;\"\">Hello h</span>"
+                + "<span style=\"font-size:11pt;font-family:Arial;font-variant-ligatures:normal;font-variant-east-asian:normal;font-variant-position:normal;vertical-align:baseline\"\">ave a nice day.</span>"
+                + "</p></BODY></HTML>";
+        String result = new OwaspHtmlSanitizer(malformedHtml, true, null).cleanMalformedHtml(malformedHtml, true);
+        String output = "<p dir=\"ltr\"\n"
+                + "style=\"-webkit-text-size-adjust:auto;line-height:1.38;margin-top:0pt;margin-bottom:0pt;\"><span\n"
+                + " style=\"font-family:Arial;font-size:14.666666984558105px-webkit-text-size-adjust:auto;\">Hello\n"
+                + "h</span><span\n"
+                + "style=\"font-size:11pt;font-family:Arial;font-variant-ligatures:normal;font-variant-east-asian:normal;font-variant-position:normal;vertical-align:baseline\">ave\n"
+                + "a nice day.</span></p>";
+        // check that the extra double quotes are removed
+        Assert.assertTrue(output.equals(result.trim()));
+    }
 }

--- a/store/src/java-test/com/zimbra/cs/html/owasp/OwaspHtmlSanitizerTest.java
+++ b/store/src/java-test/com/zimbra/cs/html/owasp/OwaspHtmlSanitizerTest.java
@@ -34,6 +34,7 @@ import org.junit.rules.TestName;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.CharStreams;
+import com.zimbra.common.localconfig.DebugConfig;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.util.ByteUtil;
 import com.zimbra.cs.mailbox.MailboxTestUtil;
@@ -90,7 +91,7 @@ public class OwaspHtmlSanitizerTest {
         + "            )";
 
     private void defangHtmlString(String html, String expected) throws IOException {
-        String result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        String result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertEquals("Defanged HTML result", expected, result);
     }
 
@@ -158,39 +159,39 @@ public class OwaspHtmlSanitizerTest {
     @Test
     public void testBug98215() throws Exception {
         String html = "<a href=\"vbscript:alert(parent.csrfToken)\">CLICK</a>";
-        String result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        String result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertEquals(result, "CLICK"); // a tag removed
 
         html = "<a href=\"Vbscr&amp;#0009;ip&#009;t:alert(parent.csrfToken)\">CLICK</a>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertTrue(!result.contains("Vbscript:alert(parent.csrfToken)"));
 
         html = "<a href=\"java&amp;Tab;script:alert(parent.csrfToken)\">CLICK</a>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertEquals(result, "CLICK"); // a tag removed
 
         html = "<a href=\"&amp;Tab;javascript:alert(parent.csrfToken)\">CLICK</a>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertEquals(result, "CLICK"); // a tag removed
 
         html = "<a href=\"javascr&amp;#09;ipt:alert(parent.csrfToken)\">CLICK</a>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertTrue(!result.contains("javascript:alert(parent.csrfToken)"));
 
         html = "<form id=\"test\" action=\"javascript:alert(1)\"><p>test</p>"
             + "<button form=\"test\">Test</button></form>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         // action attribute removed
         Assert.assertEquals(result, "<form id=\"test\"><p>test</p><button>Test</button></form>");
 
         html = "<form id=\"test\" action=\"ja&amp;Tab;vascript:alert(1)\"><p>test</p>"
             + "<button form=\"test\">Test</button></form>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         // action attribute removed
         Assert.assertEquals(result, "<form id=\"test\"><p>test</p><button>Test</button></form>");
 
         html = "<a href=\"&amp;#009;java&#00009;scr&amp;#09;i\t\tpt:alert(parent.csrfToken)\">CLICK</a>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertTrue(!result.contains("javascript:alert(parent.csrfToken)"));
     }
 
@@ -204,36 +205,35 @@ public class OwaspHtmlSanitizerTest {
     public void testBug105001() throws Exception {
         String html = "<html><body><div> <a href=\"javascript\n: alert('XSS')\">XSS LINK</a>"
             + "<br data-mce-bogus=\"1\"></div></div></body></html>";
-        String result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        String result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertEquals(result, "<html><body><div> XSS LINK<br /></div></body></html>");
 
         html = "<a href=\"vbscript\n\n:alert(parent.csrfToken)\">CLICK</a>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         // a tag removed
         Assert.assertEquals(result, "CLICK");
 
         html = "<a href=\"Vbscr&amp;#0009;ip&#009;t\n\n:alert(parent.csrfToken)\">CLICK</a>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertTrue(!result.contains("Vbscript:alert(parent.csrfToken)"));
 
         html = "<a href=\"Vbscr&amp;#0009;ip&#009;t\r\n:alert(parent.csrfToken)\">CLICK</a>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertTrue(!result.contains("Vbscript:alert(parent.csrfToken)"));
 
         html = "<a href=\"Vbscr&amp;#0009;ip&#009;t\r&#009\n:alert(parent.csrfToken)\">CLICK</a>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertTrue(!result.contains("Vbscript:alert(parent.csrfToken)"));
 
         html = "<html>" + " <body>\n" + " <a href=\"j\n" + " av\n" + " ascript\n" + " :\n"
             + "alert(1)\n" + "\"\n" + ">XSS(1)</a>\n" + "</body>\n" + "</html>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertEquals(result, "<html><body>\n XSS(1)\n</body></html>");
 
         html = "<a href=j&#97;v&#97;script&#x3A;&#97;lert(document.domain)>ClickMe</a>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         // a tag removed
         Assert.assertEquals(result, "ClickMe");
-
     }
 
     @Test
@@ -241,72 +241,71 @@ public class OwaspHtmlSanitizerTest {
         String html = "<a href=\"http://ebobby.org/2013/05/18/"
             + "Fun-with-Javascript-and-function-tracing.html\" "
             + "style=\"color: #187AAB; text-decoration: none\" target=\"_blank\">";
-        String result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        String result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertTrue(result.contains("Fun-with-Javascript-and-function-tracing.html"));
 
         html = "<a href=\"javascript-and-function-tracing.html\" "
             + "style=\"color: #187AAB; text-decoration: none\" target=\"_blank\">";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertTrue(result.contains("javascript-and-function-tracing.html"));
 
         html = "<a href=\"javascript:myJsFunc()\">Link Text</a>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertFalse(result.contains("javascript"));
 
         html = "<a href=\"javascriptlessDestination.html\" onclick=\"myJSFunc(); "
             + "return false;\">Link text</a>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertTrue(result.contains("javascriptlessDestination.html"));
 
         html = "<a href=\"javascript:alert('Hello');\"></a>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertFalse(result.contains("javascript"));
 
         html = "<a href=\"http://ebobby.org/2013/05/18/" + "javascript/Lessonsinjavascript.html\" "
             + "style=\"color: #187AAB; text-decoration: none\" target=\"_blank\">";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertTrue(result.contains("javascript/Lessonsinjavascript.html"));
 
         html = "<a href='javascript:myFunction()'> Click Me! <a/>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertFalse(result.contains("javascript"));
 
         html = " <a href=\"javascript:void(0)\" onclick=\"loadProducts(<?php echo $categoryId ?>)\"> ";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertFalse(result.contains("javascript"));
 
         html = "<a href=\"#\" onclick=\"someFunction();\" return false;\">LINK</a>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertTrue(result.equals("<a href=\"#\" rel=\"nofollow\">LINK</a>"));
 
         html = "<a href='javascript:my_Function()'> Click Me! <a/>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertFalse(result.contains("javascript"));
 
         html = "<a href='javascript:myFunction(field1, field2)'> Click Me! <a/>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertFalse(result.contains("javascript"));
 
         html = "<a href='javaScript:document.f1.findString(this.t1.value)'>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertFalse(result.contains("javascript"));
 
         html = "<a href='javaScript:document.f1.findString(this.t1.value)'>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertFalse(result.contains("javascript"));
 
         html = "<a href=\"#\" onclick=\"findString(document.getElementById('t1').value); return false;\">Click Me</a>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertTrue(result.contains("<a href=\"#\" rel=\"nofollow\">Click Me</a>"));
 
         html = "<a href=\"javascript:alert('0');\">Click Me</a>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertFalse(result.contains("javascript"));
 
         html = "<a href=\"  javascript:alert('0');\">Click Me</a>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertFalse(result.contains("javascript"));
-
     }
 
     /**
@@ -323,7 +322,7 @@ public class OwaspHtmlSanitizerTest {
     @Test
     public void testBug76500() throws Exception {
         String html = "<blockquote style=\"border-left:2px solid rgb(16, 16, 255);\">";
-        String result = new OwaspHtmlSanitizer(html,true,null).sanitize();
+        String result = new OwaspHtmlSanitizer(html,true,null).sanitize(false);
         Assert.assertTrue(result.contains("rgb( 16 , 16 , 255 )"));
     }
 
@@ -332,7 +331,7 @@ public class OwaspHtmlSanitizerTest {
         String html = "<html><head></head><body><table><tr><td><B>javascript-blocked test </B></td>"
             + "</tr><tr><td><a href=\"javascript:alert('Hello!');\">alert</a>"
             + "</td></tr></table></body></html>";
-        String result = new OwaspHtmlSanitizer(html,true,null).sanitize();
+        String result = new OwaspHtmlSanitizer(html,true,null).sanitize(false);
         Assert.assertTrue(result
             .contains("<body><table><tbody><tr><td><b>javascript-blocked test </b></td></tr><tr><td>alert</td></tr></tbody></table></body>"));
 
@@ -340,16 +339,15 @@ public class OwaspHtmlSanitizerTest {
             + "<table><tr><td><B>javascript-blocked test</B></td></tr><tr><td>"
             + "<a href=\"javascript:alert('Hello!');\">alert</a></td></tr></table>"
             + "</body></html>";
-        result = new OwaspHtmlSanitizer(html,true,null).sanitize();
+        result = new OwaspHtmlSanitizer(html,true,null).sanitize(false);
         Assert.assertTrue(result
                 .contains("<body><table><tbody><tr><td><b>javascript-blocked test</b></td></tr><tr><td>alert</td></tr></tbody></table></body>"));
     }
     
     @Test
     public void testBug78902() throws Exception {
-
         String html = "<html><head></head><body><a target=\"_blank\" href=\"Neptune.gif\"></a></body></html>";
-        String result = new OwaspHtmlSanitizer(html,true,null).sanitize();
+        String result = new OwaspHtmlSanitizer(html,true,null).sanitize(false);
         Assert.assertTrue(result
                 .contains("<a href=\"Neptune.gif\" target=\"_blank\" rel=\"nofollow noopener noreferrer\"></a>"));
 
@@ -357,22 +355,22 @@ public class OwaspHtmlSanitizerTest {
         html = "<html><body>My pictures <a href=\"javascript:document.write('%3C%61%20%68%72%65%66%3D%22%6A%61%76%"
             + "61%73%63%72%69%70%74%3A%61%6C%65%72%74%28%31%29%22%20%6F%6E%4D%6F%75%73%65%4F%76%65%72%3D%61%6C%65%"
             + "72%74%28%5C%22%70%30%77%6E%5C%22%29%3E%4D%6F%75%73%65%20%6F%76%65%72%20%68%65%72%65%3C%2F%61%3E')\">here</a></body></html>";
-        result = new OwaspHtmlSanitizer(html,true,null).sanitize();
+        result = new OwaspHtmlSanitizer(html,true,null).sanitize(false);
         Assert.assertEquals(result,
                 "<html><body>My pictures here</body></html>");
 
         html =  "<html><head></head><body><a target=\"_blank\" href=\"Neptune.txt\"></a></body></html>";
-        result = new OwaspHtmlSanitizer(html,true,null).sanitize();
+        result = new OwaspHtmlSanitizer(html,true,null).sanitize(false);
         Assert.assertEquals(result,
                 "<html><head></head><body><a href=\"Neptune.txt\" target=\"_blank\" rel=\"nofollow noopener noreferrer\"></a></body></html>");
 
         html =  "<html><head></head><body><a target=\"_blank\" href=\"Neptune.pptx\"></a></body></html>";
-        result = new OwaspHtmlSanitizer(html,true,null).sanitize();
+        result = new OwaspHtmlSanitizer(html,true,null).sanitize(false);
         Assert.assertEquals(result,
                 "<html><head></head><body><a href=\"Neptune.pptx\" target=\"_blank\" rel=\"nofollow noopener noreferrer\"></a></body></html>");
 
         html = "<li><a href=\"poc.zip?view=html&archseq=0\">\"/><script>alert(1);</script>AAAAAAAAAA</a></li>";
-        result = new OwaspHtmlSanitizer(html,true,null).sanitize();
+        result = new OwaspHtmlSanitizer(html,true,null).sanitize(false);
         Assert.assertTrue(!result
                 .contains("<script>"));
     }
@@ -380,16 +378,16 @@ public class OwaspHtmlSanitizerTest {
     @Test
     public void testBug101813() throws Exception {
         String html = "<textarea><img title=\"</<!-- -->textarea><img src=x onerror=alert(1)></img>";
-        String result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        String result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         // make sure that the javascript content is escaped
         Assert.assertTrue(result.contains("onerror&#61;alert(1)&gt;"));
 
         html = "<textarea><IMG title=\"</<!-- -->textarea><img src=x onerror=alert(1)></img>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertTrue(result.contains("onerror&#61;alert(1)&gt;"));
 
         html = "<textarea><   img title=\"</<!-- -->textarea><img src=x onerror=alert(1)></img>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertTrue(result.contains("onerror&#61;alert(1)&gt;"));
     }
 
@@ -451,7 +449,7 @@ public class OwaspHtmlSanitizerTest {
     @Test
     public void testBug64974() throws Exception {
         String html = "<html><body><![CDATA[--><a href=\"data:text/html;base64,PHNjcmlwdD4KYWxlcnQoZG9jdW1lbnQuY29va2llKQo8L3NjcmlwdD4=\">click</a]]></body></html>";
-        String result = new OwaspHtmlSanitizer(html,true,null).sanitize();
+        String result = new OwaspHtmlSanitizer(html,true,null).sanitize(false);
         Assert.assertTrue(result.equals("<html><body>click</body></html>"));
     }
 
@@ -463,12 +461,12 @@ public class OwaspHtmlSanitizerTest {
     public void testBug104666() throws Exception {
         String html = "<div></div><div></div><div id=\"5589f382-9e9b-47cd-ab09-3ea973fd4f6a\" data-marker=\"__SIG_PRE__\">"
             + "<div>LIne 1</div>" + "</div>" + "<div>Line 2</div>" + "</div>";
-        String result = new OwaspHtmlSanitizer(html,true,null).sanitize();
+        String result = new OwaspHtmlSanitizer(html,true,null).sanitize(false);
         Assert.assertTrue(result.contains("<div>LIne 1</div></div><div>Line 2</div>"));
 
         html = "<div>Thanks</div><div><img src=\"/home/ews01@zdev-vm002.eng.zimbra.com/Briefcase/rupali.jpeg\" "
                 + "data-mce-src=\"/home/ews01@zdev-vm002.eng.zimbra.com/Briefcase/rupali.jpeg\"></div>";
-        result = new OwaspHtmlSanitizer(html,true,null).sanitize();
+        result = new OwaspHtmlSanitizer(html,true,null).sanitize(false);
         Assert.assertTrue(result.contains("data-mce-src=\"/home/ews01"));
     }
 
@@ -489,54 +487,53 @@ public class OwaspHtmlSanitizerTest {
     public void testBug85478() throws Exception {
         String html = "<a href=\"data:text/html;base64,PHNjcmlwdD5hbGVydCgiSGVsbG8hIik7PC9zY3JpcHQ+\" "
             + "data-mce-href=\"data:text/html;base64,PHNjcmlwdD5hbGVydCgiSGVsbG8hIik7PC9zY3JpcHQ+\">Bug</a>";
-        String result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        String result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         // make sure that it removed the href link with 'data' URI
         Assert.assertEquals(result, "Bug");
 
         html = "<a href=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAErkJggg==\" />Bug</a>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertEquals(result, "Bug");
 
         html = "<a target=_blank href=\"data:text/html,<script>alert(opener.document.body.innerHTML)</script>\">"
             + " clickme in Opera/FF</a>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertEquals(result, "<a target=\"_blank\"> clickme in Opera/FF</a>");
 
         html = "<a target=_blank href=\"data.html\"> Data fIle</a>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertTrue(result.contains("data.html"));
 
         html = "<a href=\"data:;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAErkJggg==\" />Bug</a>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertEquals(result, "Bug");
 
         // make sure that it doesn't remove the img src with 'data' URI
         html = "<img src=\"data:image/jpeg;base64,/9j/4AAAAAxITGlubwIQAABtbnRyUkdCI\"><br>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertTrue(
             result.contains("data:image/jpeg;base64,/9j/4AAAAAxITGlubwIQAABtbnRyUkdCI"));
 
         html = "<img src=\"DaTa:image/jpeg;base64,/9j/4AAAAAxITGlubwIQAABtbnRyUkdCI\"><br>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertTrue(
             result.contains("DaTa:image/jpeg;base64,/9j/4AAAAAxITGlubwIQAABtbnRyUkdCI"));
 
         html = "<a href=\"DATA:;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAErkJggg==\" />Bug</a>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertEquals(result, "Bug");
 
         html = "<a href=\"data\n\n:\n\ntext/html;base64,PHNjcmlwdD5hbGVydCgiSGVsbG8hIik7PC9zY3JpcHQ+\">Bug</a>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertEquals(result, "Bug");
 
         html = "<a href=\"data\r\n:text/html;base64,PHNjcmlwdD5hbGVydCgiSGVsbG8hIik7PC9zY3JpcHQ+\">Bug</a>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertEquals(result, "Bug");
 
         html = "<a href=\"data:text/html;base64,PHNjcmlwdD5hbGVydCgiSGVsbG8hIik7PC9zY3JpcHQ+\">Bug</a>";
-        result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertEquals(result, "Bug");
-
     }
 
     @Test
@@ -689,7 +686,7 @@ public class OwaspHtmlSanitizerTest {
     @Test
     public void testZCS7621() throws Exception {
         String html = "<div class=\"gmail\" style=\"display:none; width:0; overflow:hidden; float:left; max-height:0;\" align=\"center\">";
-        String result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        String result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertTrue(result.contains("display"));
         Assert.assertTrue(result.contains("float"));
     }
@@ -697,14 +694,14 @@ public class OwaspHtmlSanitizerTest {
     @Test
     public void testZCS7784() throws Exception {
         String html = "<img class=\"gmail\" style=\"display:none; width:0; overflow:hidden;\" src=\"https://localhost:8443/service/home/~/?auth=co&loc=en_US&id=285&part=2.2\" >";
-        String result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        String result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         Assert.assertTrue(result.contains("style"));
     }
 
     @Test
     public void testZBUG1215() throws Exception {
         String html = "<div id=\"noticias\"><div class=\"bloque\">BLOQUESSS</div></div>";
-        String result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        String result = new OwaspHtmlSanitizer(html, true, null).sanitize(false);
         // check that the id and class attributes are not removed
         Assert.assertTrue(result.equals(html));
     }

--- a/store/src/java-test/com/zimbra/cs/html/owasp/OwaspHtmlSanitizerTest.java
+++ b/store/src/java-test/com/zimbra/cs/html/owasp/OwaspHtmlSanitizerTest.java
@@ -720,6 +720,6 @@ public class OwaspHtmlSanitizerTest {
                 + "style=\"font-size:11pt;font-family:Arial;font-variant-ligatures:normal;font-variant-east-asian:normal;font-variant-position:normal;vertical-align:baseline\">ave\n"
                 + "a nice day.</span></p>";
         // check that the extra double quotes are removed
-        Assert.assertTrue(output.equals(result.trim()));
+        Assert.assertTrue("Verification failed: Failed to remove extra double quotes.", output.equals(result.trim()));
     }
 }

--- a/store/src/java-test/com/zimbra/cs/html/owasp/OwaspHtmlSanitizerTest.java
+++ b/store/src/java-test/com/zimbra/cs/html/owasp/OwaspHtmlSanitizerTest.java
@@ -34,7 +34,6 @@ import org.junit.rules.TestName;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.CharStreams;
-import com.zimbra.common.localconfig.DebugConfig;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.util.ByteUtil;
 import com.zimbra.cs.mailbox.MailboxTestUtil;

--- a/store/src/java/com/zimbra/cs/html/owasp/OwaspHtmlSanitizer.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/OwaspHtmlSanitizer.java
@@ -103,8 +103,8 @@ public class OwaspHtmlSanitizer implements Callable<String> {
             ByteArrayInputStream inputStream = new ByteArrayInputStream(str.getBytes("UTF-8"));
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             tidy.parseDOM(inputStream, outputStream);
-            String outStream = outputStream.toString("UTF-8").trim();
-            if (outStream.isEmpty() || outStream == null) {
+            String outStream = outputStream.toString("UTF-8");
+            if (outStream == null || outStream.trim().isEmpty()) {
                 return str;
             }
             ZimbraLog.mailbox.debug("End - Using JTidy library for cleaning the markup. Taken %d milliseconds.",

--- a/store/src/java/com/zimbra/cs/html/owasp/OwaspHtmlSanitizer.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/OwaspHtmlSanitizer.java
@@ -66,11 +66,11 @@ public class OwaspHtmlSanitizer implements Callable<String> {
         return processSanitization(true).toString();
     }
 
-    public String sanitize(boolean cleanData) throws UnsupportedEncodingException {
-        return processSanitization(cleanData).toString();
+    public String sanitize(boolean cleanMalformedHtml) throws UnsupportedEncodingException {
+        return processSanitization(cleanMalformedHtml).toString();
     }
 
-    private StringBuilder processSanitization(boolean cleanData) throws UnsupportedEncodingException {
+    private StringBuilder processSanitization(boolean cleanMalformedHtml) throws UnsupportedEncodingException {
         OwaspThreadLocal threadLocalInstance = new OwaspThreadLocal();
         threadLocalInstance.setVHost(vHost);
         OwaspHtmlSanitizer.zThreadLocal.set(threadLocalInstance);
@@ -93,14 +93,14 @@ public class OwaspHtmlSanitizer implements Callable<String> {
         instantiatePolicy();
         final Policy policy = POLICY_DEFINITION.apply(new StyleTagReceiver(renderer));
         // run the html through the sanitizer
-        runSanitizer(html, policy, cleanData);
+        runSanitizer(html, policy, cleanMalformedHtml);
         // return the resulting HTML from the builder
         OwaspHtmlSanitizer.zThreadLocal.remove();
         return htmlBuilder;
     }
 
-    private void runSanitizer(String str, Policy policy, boolean cleanData) throws UnsupportedEncodingException {
-        if (cleanData) {
+    private void runSanitizer(String str, Policy policy, boolean cleanMalformedHtml) throws UnsupportedEncodingException {
+        if (cleanMalformedHtml) {
             HtmlSanitizer.sanitize(cleanMalformedHtml(str, false), policy);
         } else {
             HtmlSanitizer.sanitize(str, policy);

--- a/store/src/java/com/zimbra/cs/html/owasp/OwaspHtmlSanitizer.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/OwaspHtmlSanitizer.java
@@ -98,12 +98,12 @@ public class OwaspHtmlSanitizer implements Callable<String> {
             Tidy tidy = new Tidy();
             tidy.setInputEncoding("UTF-8");
             tidy.setOutputEncoding("UTF-8");
-            tidy.setPrintBodyOnly(true);
+            tidy.setPrintBodyOnly(false);
             tidy.setXHTML(true);
             ByteArrayInputStream inputStream = new ByteArrayInputStream(str.getBytes("UTF-8"));
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             tidy.parseDOM(inputStream, outputStream);
-            String outStream = outputStream.toString("UTF-8");
+            String outStream = outputStream.toString("UTF-8").trim();
             if (outStream.isEmpty() || outStream == null) {
                 return str;
             }

--- a/store/src/java/com/zimbra/cs/html/owasp/OwaspHtmlSanitizer.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/OwaspHtmlSanitizer.java
@@ -63,6 +63,14 @@ public class OwaspHtmlSanitizer implements Callable<String> {
      * @throws UnsupportedEncodingException
      */
     public String sanitize() throws UnsupportedEncodingException {
+        return processSanitization(true).toString();
+    }
+
+    public String sanitize(boolean cleanData) throws UnsupportedEncodingException {
+        return processSanitization(cleanData).toString();
+    }
+
+    private StringBuilder processSanitization(boolean cleanData) throws UnsupportedEncodingException {
         OwaspThreadLocal threadLocalInstance = new OwaspThreadLocal();
         threadLocalInstance.setVHost(vHost);
         OwaspHtmlSanitizer.zThreadLocal.set(threadLocalInstance);
@@ -73,32 +81,40 @@ public class OwaspHtmlSanitizer implements Callable<String> {
         final StringBuilder htmlBuilder = new StringBuilder(html.length());
         // create the renderer that will write the sanitized HTML to the builder
         final HtmlStreamRenderer renderer = HtmlStreamRenderer.create(htmlBuilder,
-            Handler.PROPAGATE,
-            // log errors resulting from exceptionally bizarre inputs
-            new Handler<String>() {
+                Handler.PROPAGATE,
+                // log errors resulting from exceptionally bizarre inputs
+                new Handler<String>() {
 
-                public void handle(final String x) {
-                    throw new AssertionError(x);
-                }
-            });
+            public void handle(final String x) {
+                throw new AssertionError(x);
+            }
+        });
         // create a thread-specific policy
         instantiatePolicy();
         final Policy policy = POLICY_DEFINITION.apply(new StyleTagReceiver(renderer));
         // run the html through the sanitizer
-        HtmlSanitizer.sanitize(cleanMalformedHtml(html), policy);
+        runSanitizer(html, policy, cleanData);
         // return the resulting HTML from the builder
         OwaspHtmlSanitizer.zThreadLocal.remove();
-        return htmlBuilder.toString();
+        return htmlBuilder;
     }
 
-    private String cleanMalformedHtml(String str) throws UnsupportedEncodingException {
+    private void runSanitizer(String str, Policy policy, boolean cleanData) throws UnsupportedEncodingException {
+        if (cleanData) {
+            HtmlSanitizer.sanitize(cleanMalformedHtml(str, false), policy);
+        } else {
+            HtmlSanitizer.sanitize(str, policy);
+        }
+    }
+
+    public String cleanMalformedHtml(String str, boolean printBodyOnly) throws UnsupportedEncodingException {
         if (DebugConfig.jtidyEnabled) {
             long startTime = System.currentTimeMillis();
             ZimbraLog.mailbox.debug("Start - Using JTidy library for cleaning the markup.");
             Tidy tidy = new Tidy();
             tidy.setInputEncoding("UTF-8");
             tidy.setOutputEncoding("UTF-8");
-            tidy.setPrintBodyOnly(false);
+            tidy.setPrintBodyOnly(printBodyOnly);
             tidy.setXHTML(true);
             ByteArrayInputStream inputStream = new ByteArrayInputStream(str.getBytes("UTF-8"));
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();


### PR DESCRIPTION
**Problem:**
Some of the emails displaying as blank.

**Analysis and Fix:**
It was observed that certain e-mails were displaying as blank. On analysing the input mime it was found that there was issue with the input html that there was no closing `style` tag. Here, there are 2 issues:

1. In the `JTidy` configuration `setPrintBodyOnly()` was earlier set to true so it was processing only the body part and skipping the style tags.

2. Earlier in the code skipped the trimming of the parsed string which was getting null value as it was not handling the head of the html because of `setPrintBodyOnly()` was set to true but the code  was written to handle these situation earlier and fallback to the `OWASP` if the output from the `JTidy` was `null`. In this particular case it was not able to handle because
the parsed string was having a whitespace character and it was not null so it skipped the string trimming which is causing not getting fallback to `OWASP` directly.

**Testing Done:**
- Imported few e-mails from the account mentioned in the [TSS-18300](https://jira.corp.synacor.com/browse/TSS-18300) and verified they are displaying properly.
- Verified the older malformed html mime, attached in the [TSS-18004](https://jira.corp.synacor.com/browse/TSS-18004) and verified it is displaying properly.
- Injected the old problematic mimes attached in the [ZCS-6512](https://jira.corp.synacor.com/browse/ZCS-6512) that are displaying properly.