### PR TITLE
Bugfix/zcs 10498

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -5713,6 +5713,14 @@ public class ZAttrProvisioning {
     public static final String A_zimbraDocumentEditingJwtSecret = "zimbraDocumentEditingJwtSecret";
 
     /**
+     * Whether or not to log document accessed time
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3097)
+    public static final String A_zimbraDocumentRecentlyViewedEnabled = "zimbraDocumentRecentlyViewedEnabled";
+
+    /**
      * maximum amount of mail quota a domain admin can set on a user
      */
     @ZAttr(id=398)

--- a/common/src/java/com/zimbra/common/mailbox/ZimbraSortBy.java
+++ b/common/src/java/com/zimbra/common/mailbox/ZimbraSortBy.java
@@ -25,7 +25,7 @@ public enum ZimbraSortBy {
     dateDesc, dateAsc, subjDesc, subjAsc, nameDesc, nameAsc, durDesc, durAsc, none,
     sizeAsc, sizeDesc, attachAsc, attachDesc, flagAsc, flagDesc, priorityAsc, priorityDesc,
     taskDueAsc, taskDueDesc, taskStatusAsc, taskStatusDesc, taskPercCompletedAsc, taskPercCompletedDesc,
-    rcptAsc, rcptDesc, idAsc, idDesc, readAsc, readDesc;
+    rcptAsc, rcptDesc, idAsc, idDesc, readAsc, readDesc, recentlyViewed;
 
     public static ZimbraSortBy fromString(String s)
     throws ServiceException {

--- a/common/src/java/com/zimbra/common/util/L10nUtil.java
+++ b/common/src/java/com/zimbra/common/util/L10nUtil.java
@@ -146,6 +146,7 @@ public class L10nUtil {
         shareNotifBodyGranteeRoleCustom,
 
         shareNotifBodyFolderDesc,
+        shareNotifyFileBodyDesc,
         shareNotifBodyExternalShareText,
         shareNotifBodyExternalShareHtml,
         shareNotifBodyNotesText,

--- a/soap/src/java/com/zimbra/soap/mail/message/DocumentActionResponse.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/DocumentActionResponse.java
@@ -25,7 +25,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 import com.zimbra.common.soap.MailConstants;
 import com.zimbra.common.soap.OctopusXmlConstants;
-import com.zimbra.soap.mail.type.ActionResult;
+import com.zimbra.soap.mail.type.DocumentActionResult;
 import com.zimbra.soap.json.jackson.annotate.ZimbraUniqueElement;
 
 @XmlAccessorType(XmlAccessType.NONE)
@@ -37,22 +37,22 @@ public class DocumentActionResponse {
      */
     @ZimbraUniqueElement
     @XmlElement(name=MailConstants.E_ACTION /* action */, required=true)
-    private ActionResult action;
+    private DocumentActionResult action;
 
     @SuppressWarnings("unused")
     private DocumentActionResponse() {
     }
 
-    public DocumentActionResponse(ActionResult action) {
+    public DocumentActionResponse(DocumentActionResult action) {
         setAction(action);
     }
 
-    public static DocumentActionResponse create (ActionResult action) {
+    public static DocumentActionResponse create (DocumentActionResult action) {
         return new DocumentActionResponse(action);
     }
 
-    public void setAction(ActionResult action) { this.action = action; }
-    public ActionResult getAction() { return action; }
+    public void setAction(DocumentActionResult action) { this.action = action; }
+    public DocumentActionResult getAction() { return action; }
 
     public MoreObjects.ToStringHelper addToStringInfo(MoreObjects.ToStringHelper helper) {
         return helper

--- a/soap/src/java/com/zimbra/soap/mail/type/DocumentActionGrant.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/DocumentActionGrant.java
@@ -25,21 +25,7 @@ import javax.xml.bind.annotation.XmlAttribute;
 import com.zimbra.common.soap.MailConstants;
 
 @XmlAccessorType(XmlAccessType.NONE)
-public class DocumentActionGrant {
-
-    /**
-     * @zm-api-field-tag rights-rwd
-     * @zm-api-field-description Permissions - (r)ead, (w)rite, (d)elete
-     */
-    @XmlAttribute(name=MailConstants.A_RIGHTS /* perm */, required=true)
-    private String rights;
-
-    /**
-     * @zm-api-field-tag grant-type-all|pub
-     * @zm-api-field-description Grant type - <b>all|pub</b>
-     */
-    @XmlAttribute(name=MailConstants.A_GRANT_TYPE /* gt */, required=true)
-    private String grantType;
+public class DocumentActionGrant extends ActionGrantSelector {
 
     /**
      * @zm-api-field-tag expiry-millis
@@ -57,8 +43,7 @@ public class DocumentActionGrant {
     }
 
     private DocumentActionGrant(String rights, String grantType, Long expiry) {
-        setRights(rights);
-        setGrantType(grantType);
+        super(rights, grantType);
         setExpiry(expiry);
     }
 
@@ -70,17 +55,12 @@ public class DocumentActionGrant {
         return new DocumentActionGrant(rights, grantType, expiry);
     }
 
-    public void setRights(String rights) { this.rights = rights; }
-    public void setGrantType(String grantType) { this.grantType = grantType; }
     public void setExpiry(Long expiry) { this.expiry = expiry; }
-    public String getRights() { return rights; }
-    public String getGrantType() { return grantType; }
+
     public Long getExpiry() { return expiry; }
 
     public MoreObjects.ToStringHelper addToStringInfo(MoreObjects.ToStringHelper helper) {
         return helper
-            .add("rights", rights)
-            .add("grantType", grantType)
             .add("expiry", expiry);
     }
 

--- a/soap/src/java/com/zimbra/soap/mail/type/DocumentActionResult.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/DocumentActionResult.java
@@ -1,0 +1,94 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2021 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.mail.type;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+
+import com.google.common.base.MoreObjects;
+import com.zimbra.common.soap.MailConstants;
+
+import io.leangen.graphql.annotations.GraphQLQuery;
+import io.leangen.graphql.annotations.types.GraphQLType;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@GraphQLType(name="DocumentActionResult", description="Document action response")
+public class DocumentActionResult extends ActionResult {
+
+    /**
+     * @zm-api-field-tag grantee-zimbra-id
+     * @zm-api-field-description Grantee Zimbra ID
+     */
+    @XmlAttribute(name=MailConstants.A_ZIMBRA_ID /* zid */, required=false)
+    @GraphQLQuery(name="zimbraId", description="Grantee Zimbra Id")
+    private String zimbraId;
+
+    /**
+     * @zm-api-field-tag display-name
+     * @zm-api-field-description Display name
+     */
+    @XmlAttribute(name=MailConstants.A_DISPLAY /* d */, required=false)
+    @GraphQLQuery(name="displayName", description="Display name")
+    private String displayName;
+
+    /**
+     * @zm-api-field-tag access-key
+     * @zm-api-field-description Access key (Password)
+     */
+    @XmlAttribute(name=MailConstants.A_ACCESSKEY /* key */, required=false)
+    @GraphQLQuery(name="accessKey", description="Access key (password)")
+    private String accessKey;
+
+    /**
+     * no-argument constructor wanted by JAXB
+     */
+    @SuppressWarnings("unused")
+    private DocumentActionResult() {
+        this((String) null, (String) null);
+    }
+
+    public DocumentActionResult(String id, String operation) {
+        super(id, operation);
+    }
+
+
+    public void setZimbraId(String zimbraId) { this.zimbraId = zimbraId; }
+    public void setDisplayName(String displayName) { this.displayName = displayName; }
+    public void setAccessKey(String accessKey) { this.accessKey = accessKey; }
+    @GraphQLQuery(name="zimbraId", description="Grantee Zimbra Id")
+    public String getZimbraId() { return zimbraId; }
+    @GraphQLQuery(name="displayName", description="Display name")
+    public String getDisplayName() { return displayName; }
+    @GraphQLQuery(name="accessKey", description="Access key (password)")
+    public String getAccessKey() { return accessKey; }
+
+    @Override
+    public MoreObjects.ToStringHelper addToStringInfo(MoreObjects.ToStringHelper helper) {
+        helper = super.addToStringInfo(helper);
+        return helper
+            .add("zimbraId", zimbraId)
+            .add("displayName", displayName)
+            .add("accessKey", accessKey);
+    }
+
+    @Override
+    public String toString() {
+        return addToStringInfo(MoreObjects.toStringHelper(this)).toString();
+    }
+}

--- a/store-conf/conf/msgs/ZsMsg.properties
+++ b/store-conf/conf/msgs/ZsMsg.properties
@@ -227,6 +227,7 @@ shareExpireBodyHtml =\
 
 # {0} = share item type
 shareNotifBodyFolderDesc = ({0} Folder)
+shareNotifyFileBodyDesc = ({0} File)
 
 # {0} = URL for accepting share
 # {1) = URL for external user login

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9858,4 +9858,8 @@ TODO: delete them permanently from here
   <globalConfigValue>SECRET</globalConfigValue>
   <desc>Document editing JWT secret</desc>
 </attr>
+<attr id="3097" name="zimbraDocumentRecentlyViewedEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="9.1.0">
+  <defaultCOSValue>TRUE</defaultCOSValue>
+  <desc>Whether or not to log document accessed time</desc>
+</attr>
 </attrs>

--- a/store/src/db/hsqldb/create_database.sql
+++ b/store/src/db/hsqldb/create_database.sql
@@ -250,3 +250,25 @@ CREATE TABLE *{DATABASE_NAME}.data_source_item (
    CONSTRAINT i_remote_id UNIQUE (mailbox_id, data_source_id, remote_id),
    CONSTRAINT fk_data_source_item_mailbox_id FOREIGN KEY (mailbox_id) REFERENCES zimbra.mailbox(id) ON DELETE CASCADE
 );
+
+CREATE TABLE *{DATABASE_NAME}.event (
+   mailbox_id    INTEGER NOT NULL,
+   account_id    VARCHAR(36) NOT NULL,  -- user performing the action (email address or guid)
+   item_id       INTEGER NOT NULL,  -- itemId for the event
+   folder_id     INTEGER NOT NULL,  -- folderId for the item in the event
+   op            TINYINT NOT NULL,  -- operation
+   ts            INTEGER NOT NULL,  -- timestamp
+   version       INTEGER,           -- version of the item
+   user_agent    VARCHAR(128),      -- identifier of device if available
+   arg           VARCHAR(10240),    -- operation specific argument
+
+   CONSTRAINT fk_event_mailbox_id FOREIGN KEY (mailbox_id) REFERENCES zimbra.mailbox(id) ON DELETE CASCADE
+);
+
+CREATE TABLE *{DATABASE_NAME}.watch (
+   mailbox_id   INTEGER NOT NULL,
+   target       VARCHAR(36) NOT NULL,  -- watch target account id
+   item_id      INTEGER NOT NULL,  -- target item id
+
+   CONSTRAINT pk_watch PRIMARY KEY (mailbox_id, target, item_id)
+);

--- a/store/src/java-test/com/zimbra/cs/service/mail/GetShareDetailsTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/mail/GetShareDetailsTest.java
@@ -1,0 +1,215 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2021 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.service.mail;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.google.common.collect.Maps;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.MailConstants;
+import com.zimbra.common.soap.OctopusXmlConstants;
+import com.zimbra.common.soap.SoapFaultException;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.ACL;
+import com.zimbra.cs.mailbox.MailItem;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+
+@Ignore("ZCS-9144 - Please restore when redis is setup on Circleci")
+public class GetShareDetailsTest {
+
+    @BeforeClass
+    public static void init() throws Exception {
+        MailboxTestUtil.initServer();
+        Provisioning prov = Provisioning.getInstance();
+
+        prov.createAccount("test@zimbra.com", "secret", Maps.<String, Object>newHashMap());
+
+        Map<String, Object> attrs = Maps.newHashMap();
+        attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        attrs.put(Provisioning.A_displayName, "Test User 2");
+        prov.createAccount("test2@zimbra.com", "secret", attrs);
+
+        attrs = Maps.newHashMap();
+        attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        attrs.put(Provisioning.A_zimbraIsExternalVirtualAccount, "TRUE");
+        prov.createAccount("virtual@zimbra.com", "secret", attrs);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        MailboxTestUtil.clearData();
+    }
+
+    @Test
+    public void nonexistent() throws Exception {
+        Account acct = Provisioning.getInstance().getAccountByName("test@zimbra.com");
+        Account acct2 = Provisioning.getInstance().getAccountByName("test2@zimbra.com");
+
+        Element request = new Element.XMLElement(OctopusXmlConstants.GET_SHARE_DETAILS_REQUEST);
+        request.addUniqueElement(MailConstants.E_ITEM).addAttribute(MailConstants.A_ID, acct.getId() + ":" + 700);
+        try {
+            new GetShareDetails().handle(request, ServiceTestUtil.getRequestContext(acct2, acct));
+            Assert.fail("did not throw exception on nonexistent item");
+        } catch (ServiceException e) {
+            Assert.assertEquals("nonexistent items should give PERM_DENIED", ServiceException.PERM_DENIED, e.getCode());
+        }
+    }
+
+    @Test
+    public void denied() throws Exception {
+        Account acct = Provisioning.getInstance().getAccountByName("test@zimbra.com");
+        Account acct2 = Provisioning.getInstance().getAccountByName("test2@zimbra.com");
+
+        Element request = new Element.XMLElement(OctopusXmlConstants.GET_SHARE_DETAILS_REQUEST);
+        request.addUniqueElement(MailConstants.E_ITEM).addAttribute(MailConstants.A_ID, acct.getId() + ":" + Mailbox.ID_FOLDER_BRIEFCASE);
+        try {
+            new GetShareDetails().handle(request, ServiceTestUtil.getRequestContext(acct2, acct));
+            Assert.fail("did not throw exception on non-visible item");
+        } catch (ServiceException e) {
+            Assert.assertEquals("nonexistent items should give PERM_DENIED", ServiceException.PERM_DENIED, e.getCode());
+        }
+    }
+
+    @Test
+    public void noacl() throws Exception {
+        Account acct = Provisioning.getInstance().getAccountByName("test@zimbra.com");
+
+        Element request = new Element.XMLElement(OctopusXmlConstants.GET_SHARE_DETAILS_REQUEST);
+        request.addUniqueElement(MailConstants.E_ITEM).addAttribute(MailConstants.A_ID, acct.getId() + ":" + Mailbox.ID_FOLDER_BRIEFCASE);
+        Element response = new GetShareDetails().handle(request, ServiceTestUtil.getRequestContext(acct));
+
+        Element item = response.getElement(MailConstants.E_ITEM);
+        Assert.assertEquals("item ID normalized", "" + Mailbox.ID_FOLDER_BRIEFCASE, item.getAttribute(MailConstants.A_ID));
+        Assert.assertEquals("no grants", 0, item.listElements(MailConstants.E_GRANTEE).size());
+    }
+
+    @Test
+    public void visible() throws Exception {
+        Account acct = Provisioning.getInstance().getAccountByName("test@zimbra.com");
+        Account acct2 = Provisioning.getInstance().getAccountByName("test2@zimbra.com");
+
+        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+        mbox.grantAccess(null, Mailbox.ID_FOLDER_BRIEFCASE, acct2.getId(), ACL.GRANTEE_USER, ACL.RIGHT_READ, null);
+
+        Element request = new Element.XMLElement(OctopusXmlConstants.GET_SHARE_DETAILS_REQUEST);
+        request.addUniqueElement(MailConstants.E_ITEM).addAttribute(MailConstants.A_ID, acct.getId() + ":" + Mailbox.ID_FOLDER_BRIEFCASE);
+        Element response = new GetShareDetails().handle(request, ServiceTestUtil.getRequestContext(acct2, acct));
+
+        List<Element> grants = response.getElement(MailConstants.E_ITEM).listElements(MailConstants.E_GRANTEE);
+        Assert.assertEquals("1 grant", 1, grants.size());
+        Element grant = grants.get(0);
+        Assert.assertEquals("read perm granted", "r", grant.getAttribute(MailConstants.A_RIGHTS));
+        Assert.assertEquals("grant type is user", "usr", grant.getAttribute(MailConstants.A_GRANT_TYPE));
+        Assert.assertEquals("granted to test2", "test2@zimbra.com", grant.getAttribute(MailConstants.A_EMAIL));
+        Assert.assertEquals("granted to Test User 2", "Test User 2", grant.getAttribute(MailConstants.A_NAME));
+    }
+
+    @Test
+    public void pubshare() throws Exception {
+        Account acct = Provisioning.getInstance().getAccountByName("test@zimbra.com");
+        Account acct2 = Provisioning.getInstance().getAccountByName("test2@zimbra.com");
+
+        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+        mbox.grantAccess(null, Mailbox.ID_FOLDER_BRIEFCASE, null, ACL.GRANTEE_PUBLIC, ACL.RIGHT_READ, null);
+
+        Element request = new Element.XMLElement(OctopusXmlConstants.GET_SHARE_DETAILS_REQUEST);
+        request.addUniqueElement(MailConstants.E_ITEM).addAttribute(MailConstants.A_ID, acct.getId() + ":" + Mailbox.ID_FOLDER_BRIEFCASE);
+        Element response = new GetShareDetails().handle(request, ServiceTestUtil.getRequestContext(acct2, acct));
+
+        List<Element> grants = response.getElement(MailConstants.E_ITEM).listElements(MailConstants.E_GRANTEE);
+        Assert.assertEquals("1 grant", 1, grants.size());
+        Element grant = grants.get(0);
+        Assert.assertEquals("read perm granted", "r", grant.getAttribute(MailConstants.A_RIGHTS));
+        Assert.assertEquals("grant type is public", "pub", grant.getAttribute(MailConstants.A_GRANT_TYPE));
+        Assert.assertEquals("no email set", null, grant.getAttribute(MailConstants.A_EMAIL, null));
+        Assert.assertEquals("no name set", null, grant.getAttribute(MailConstants.A_NAME, null));
+    }
+
+    @Test
+    public void external() throws Exception {
+        Account acct = Provisioning.getInstance().getAccountByName("test@zimbra.com");
+
+        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+        mbox.grantAccess(null, Mailbox.ID_FOLDER_BRIEFCASE, null, ACL.GRANTEE_PUBLIC, ACL.RIGHT_READ, null);
+
+        Element request = new Element.XMLElement(OctopusXmlConstants.GET_SHARE_DETAILS_REQUEST);
+        request.addUniqueElement(MailConstants.E_ITEM).addAttribute(MailConstants.A_ID, acct.getId() + ":" + Mailbox.ID_FOLDER_BRIEFCASE);
+        try {
+            new GetShareDetails().handle(request, ServiceTestUtil.getExternalRequestContext("external@domain.com", acct));
+            Assert.fail("did not throw exception on external user");
+        } catch (ServiceException e) {
+            Assert.assertEquals("external users should give PERM_DENIED", ServiceException.PERM_DENIED, e.getCode());
+        }
+    }
+
+    @Test
+    public void mountpoint() throws Exception {
+        Account acct = Provisioning.getInstance().getAccountByName("test@zimbra.com");
+        Account acct2 = Provisioning.getInstance().getAccountByName("test2@zimbra.com");
+
+        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+        mbox.grantAccess(null, Mailbox.ID_FOLDER_BRIEFCASE, acct2.getId(), ACL.GRANTEE_USER, ACL.RIGHT_READ, null);
+
+        Mailbox mbox2 = MailboxManager.getInstance().getMailboxByAccount(acct2);
+        int mptId = mbox2.createMountpoint(null, Mailbox.ID_FOLDER_BRIEFCASE, "link", acct.getId(), Mailbox.ID_FOLDER_BRIEFCASE, null, MailItem.Type.DOCUMENT, 0, (byte) 0, false).getId();
+
+        Element request = new Element.XMLElement(OctopusXmlConstants.GET_SHARE_DETAILS_REQUEST);
+        request.addUniqueElement(MailConstants.E_ITEM).addAttribute(MailConstants.A_ID, mptId);
+        Element response = new GetShareDetails().proxyIfNecessary(request, ServiceTestUtil.getRequestContext(acct2, acct2, new MailService()));
+
+        List<Element> grants = response.getElement(MailConstants.E_ITEM).listElements(MailConstants.E_GRANTEE);
+        Assert.assertEquals("1 grant", 1, grants.size());
+        Element grant = grants.get(0);
+        Assert.assertEquals("read perm granted", "r", grant.getAttribute(MailConstants.A_RIGHTS));
+        Assert.assertEquals("grant type is user", "usr", grant.getAttribute(MailConstants.A_GRANT_TYPE));
+        Assert.assertEquals("granted to test2", "test2@zimbra.com", grant.getAttribute(MailConstants.A_EMAIL));
+        Assert.assertEquals("granted to Test User 2", "Test User 2", grant.getAttribute(MailConstants.A_NAME));
+    }
+
+    @Test
+    public void virtual() throws Exception {
+        Account acct = Provisioning.getInstance().getAccountByName("test@zimbra.com");
+        Account virtual = Provisioning.getInstance().getAccountByName("virtual@zimbra.com");
+
+        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+        mbox.grantAccess(null, Mailbox.ID_FOLDER_BRIEFCASE, virtual.getId(), ACL.GRANTEE_USER, ACL.RIGHT_READ, null);
+
+        Mailbox mbox2 = MailboxManager.getInstance().getMailboxByAccount(virtual);
+        int mptId = mbox2.createMountpoint(null, Mailbox.ID_FOLDER_BRIEFCASE, "link", acct.getId(), Mailbox.ID_FOLDER_BRIEFCASE, null, MailItem.Type.DOCUMENT, 0, (byte) 0, false).getId();
+
+        Element request = new Element.XMLElement(OctopusXmlConstants.GET_SHARE_DETAILS_REQUEST);
+        request.addUniqueElement(MailConstants.E_ITEM).addAttribute(MailConstants.A_ID, mptId);
+        try {
+            new GetShareDetails().proxyIfNecessary(request, ServiceTestUtil.getRequestContext(virtual, virtual, new MailService()));
+            Assert.fail("did not throw exception on external virtual user");
+        } catch (SoapFaultException e) {
+            Assert.assertEquals("external virtual users should give PERM_DENIED", ServiceException.PERM_DENIED, e.getCode());
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/account/ShareInfo.java
+++ b/store/src/java/com/zimbra/cs/account/ShareInfo.java
@@ -574,12 +574,12 @@ public class ShareInfo {
             // TEXT part (add me first!)
             String mimePartText;
             if (action == Action.revoke) {
-                mimePartText = genRevokePart(sid, locale, false);
+                mimePartText = genRevokePart(sid, locale, false, false);
             } else if (action == Action.expire) {
-                mimePartText = genExpirePart(sid, locale, false);
+                mimePartText = genExpirePart(sid, locale, false, false);
             } else {
                 mimePartText = genPart(sid, action == Action.edit, notes, extUserShareAcceptUrl, extUserLoginUrl,
-                        locale, null, false);
+                        locale, null, false, false);
             }
             MimeBodyPart textPart = new ZMimeBodyPart();
             textPart.setText(mimePartText, MimeConstants.P_CHARSET_UTF8);
@@ -587,12 +587,12 @@ public class ShareInfo {
 
             // HTML part
             if (action == Action.revoke) {
-                mimePartText = genRevokePart(sid, locale, true);
+                mimePartText = genRevokePart(sid, locale, true, false);
             } else if (action == Action.expire) {
-                mimePartText = genExpirePart(sid, locale, true);
+                mimePartText = genExpirePart(sid, locale, true, false);
             } else {
                 mimePartText = genPart(sid, action == Action.edit, notes, extUserShareAcceptUrl, extUserLoginUrl,
-                        locale, null, true);
+                        locale, null, true, false);
             }
             MimeBodyPart htmlPart = new ZMimeBodyPart();
             htmlPart.setDataHandler(new DataHandler(new HtmlPartDataSource(mimePartText)));
@@ -610,39 +610,46 @@ public class ShareInfo {
         }
 
         public static String getMimePartHtml(ShareInfoData sid, String notes, Locale locale,
-            Action action, String extUserShareAcceptUrl, String extUserLoginUrl) throws MessagingException, ServiceException {
+                Action action, String extUserShareAcceptUrl, String extUserLoginUrl) throws MessagingException, ServiceException {
+            return getMimePartHtml(sid, notes, locale, action, extUserShareAcceptUrl, extUserLoginUrl, false);
+        }
+
+        public static String getMimePartHtml(ShareInfoData sid, String notes, Locale locale,
+            Action action, String extUserShareAcceptUrl, String extUserLoginUrl, boolean notifyForDocument) throws MessagingException, ServiceException {
 
             String mimePartHtml;
             if (action == Action.revoke) {
-                mimePartHtml = genRevokePart(sid, locale, true);
+                mimePartHtml = genRevokePart(sid, locale, true, notifyForDocument);
             } else if (action == Action.expire) {
-                mimePartHtml = genExpirePart(sid, locale, true);
+                mimePartHtml = genExpirePart(sid, locale, true, notifyForDocument);
             } else {
                 mimePartHtml = genPart(sid, action == Action.edit, notes, extUserShareAcceptUrl,
-                    extUserLoginUrl, locale, null, true);
+                    extUserLoginUrl, locale, null, true, notifyForDocument);
             }
-
             return mimePartHtml;
         }
-        
-        
-        
+
         public static String getMimePartText(ShareInfoData sid, String notes, Locale locale,
-            Action action, String extUserShareAcceptUrl, String extUserLoginUrl) throws MessagingException, ServiceException {
+                Action action, String extUserShareAcceptUrl, String extUserLoginUrl) throws MessagingException, ServiceException {
+            return getMimePartText(sid, notes, locale, action, extUserShareAcceptUrl, extUserLoginUrl, false);
+        }
+
+        public static String getMimePartText(ShareInfoData sid, String notes, Locale locale,
+            Action action, String extUserShareAcceptUrl, String extUserLoginUrl, boolean notifyForDocument) throws MessagingException, ServiceException {
             String mimePartText;
             if (action == Action.revoke) {
-                mimePartText = genRevokePart(sid, locale, false);
+                mimePartText = genRevokePart(sid, locale, false, notifyForDocument);
             } else if (action == Action.expire) {
-                mimePartText = genExpirePart(sid, locale, false);
+                mimePartText = genExpirePart(sid, locale, false, notifyForDocument);
             } else {
                 mimePartText = genPart(sid, action == Action.edit, notes, extUserShareAcceptUrl,
-                    extUserLoginUrl, locale, null, false);
+                    extUserLoginUrl, locale, null, false, notifyForDocument);
             }
             return mimePartText;
         }
 
         private static String genPart(ShareInfoData sid, boolean shareModified, String senderNotes,
-                String extUserShareAcceptUrl, String extUserLoginUrl, Locale locale, StringBuilder sb, boolean html) {
+                String extUserShareAcceptUrl, String extUserLoginUrl, Locale locale, StringBuilder sb, boolean html, boolean notifyForDocument) {
             if (sb == null) {
                 sb = new StringBuilder();
             }
@@ -672,7 +679,7 @@ public class ShareInfo {
             return sb.append(L10nUtil.getMessage(
                     msgKey, locale,
                     sid.getName(),
-                    formatFolderDesc(locale, sid),
+                    formatFolderDesc(locale, sid, notifyForDocument),
                     sid.getOwnerNotifName(),
                     sid.getGranteeNotifName(),
                     getRoleFromRights(sid, locale),
@@ -682,17 +689,17 @@ public class ShareInfo {
                     toString();
         }
 
-        private static String genRevokePart(ShareInfoData sid, Locale locale, boolean html) {
+        private static String genRevokePart(ShareInfoData sid, Locale locale, boolean html, boolean notifyForDocument) {
             return L10nUtil.getMessage(html ? MsgKey.shareRevokeBodyHtml : MsgKey.shareRevokeBodyText,
                     sid.getName(),
-                    formatFolderDesc(locale, sid),
+                    formatFolderDesc(locale, sid, notifyForDocument),
                     sid.getOwnerNotifName());
         }
 
-        private static String genExpirePart(ShareInfoData sid, Locale locale, boolean html) {
+        private static String genExpirePart(ShareInfoData sid, Locale locale, boolean html, boolean notifyForDocument) {
             return L10nUtil.getMessage((html ? MsgKey.shareExpireBodyHtml : MsgKey.shareExpireBodyText),
                     sid.getName(),
-                    formatFolderDesc(locale, sid),
+                    formatFolderDesc(locale, sid, notifyForDocument),
                     sid.getOwnerNotifName());
         }
 
@@ -770,7 +777,7 @@ public class ShareInfo {
             }
         }
 
-        private static String formatFolderDesc(Locale locale, ShareInfoData sid) {
+        private static String formatFolderDesc(Locale locale, ShareInfoData sid, boolean notifyForDocument) {
             MailItem.Type view = sid.getFolderDefaultViewCode();
             String folderView;
             switch (view) {
@@ -792,7 +799,7 @@ public class ShareInfo {
                 default:
                     folderView = sid.getFolderDefaultView();
             }
-            MsgKey key = MsgKey.shareNotifBodyFolderDesc;
+            MsgKey key = notifyForDocument ? MsgKey.shareNotifyFileBodyDesc : MsgKey.shareNotifBodyFolderDesc;
             try {
                 if (Provisioning.getInstance().isOctopus()) {
                     key = MsgKey.octopus_share_notification_email_bodyFolderDesc;
@@ -827,10 +834,10 @@ public class ShareInfo {
 
                 if (idx == null) {
                     for (ShareInfoData sid : mShares) {
-                        genPart(sid, false, null, null, null, locale, sb, false);
+                        genPart(sid, false, null, null, null, locale, sb, false, false);
                     }
                 } else
-                    genPart(mShares.get(idx), false, null, null, null, locale, sb, false);
+                    genPart(mShares.get(idx), false, null, null, null, locale, sb, false, false);
 
                 sb.append("\n\n");
                 return sb.toString();
@@ -848,10 +855,10 @@ public class ShareInfo {
 
                 if (idx == null) {
                     for (ShareInfoData sid : mShares) {
-                        genPart(sid, false, null, null, null, locale, sb, true);
+                        genPart(sid, false, null, null, null, locale, sb, true, false);
                     }
                 } else
-                    genPart(mShares.get(idx), false, null, null, null, locale, sb, true);
+                    genPart(mShares.get(idx), false, null, null, null, locale, sb, true, false);
 
                 return sb.toString();
             }

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -10283,6 +10283,78 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * Whether or not to log document accessed time
+     *
+     * @return zimbraDocumentRecentlyViewedEnabled, or true if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3097)
+    public boolean isDocumentRecentlyViewedEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraDocumentRecentlyViewedEnabled, true, true);
+    }
+
+    /**
+     * Whether or not to log document accessed time
+     *
+     * @param zimbraDocumentRecentlyViewedEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3097)
+    public void setDocumentRecentlyViewedEnabled(boolean zimbraDocumentRecentlyViewedEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDocumentRecentlyViewedEnabled, zimbraDocumentRecentlyViewedEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether or not to log document accessed time
+     *
+     * @param zimbraDocumentRecentlyViewedEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3097)
+    public Map<String,Object> setDocumentRecentlyViewedEnabled(boolean zimbraDocumentRecentlyViewedEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDocumentRecentlyViewedEnabled, zimbraDocumentRecentlyViewedEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether or not to log document accessed time
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3097)
+    public void unsetDocumentRecentlyViewedEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDocumentRecentlyViewedEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether or not to log document accessed time
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3097)
+    public Map<String,Object> unsetDocumentRecentlyViewedEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDocumentRecentlyViewedEnabled, "");
+        return attrs;
+    }
+
+    /**
      * maximum amount of mail quota a domain admin can set on a user
      *
      * @return zimbraDomainAdminMaxMailQuota, or -1 if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -6108,6 +6108,78 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * Whether or not to log document accessed time
+     *
+     * @return zimbraDocumentRecentlyViewedEnabled, or true if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3097)
+    public boolean isDocumentRecentlyViewedEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraDocumentRecentlyViewedEnabled, true, true);
+    }
+
+    /**
+     * Whether or not to log document accessed time
+     *
+     * @param zimbraDocumentRecentlyViewedEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3097)
+    public void setDocumentRecentlyViewedEnabled(boolean zimbraDocumentRecentlyViewedEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDocumentRecentlyViewedEnabled, zimbraDocumentRecentlyViewedEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether or not to log document accessed time
+     *
+     * @param zimbraDocumentRecentlyViewedEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3097)
+    public Map<String,Object> setDocumentRecentlyViewedEnabled(boolean zimbraDocumentRecentlyViewedEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDocumentRecentlyViewedEnabled, zimbraDocumentRecentlyViewedEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether or not to log document accessed time
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3097)
+    public void unsetDocumentRecentlyViewedEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDocumentRecentlyViewedEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether or not to log document accessed time
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3097)
+    public Map<String,Object> unsetDocumentRecentlyViewedEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDocumentRecentlyViewedEnabled, "");
+        return attrs;
+    }
+
+    /**
      * maximum amount of mail quota a domain admin can set on a user
      *
      * @return zimbraDomainAdminMaxMailQuota, or -1 if unset

--- a/store/src/java/com/zimbra/cs/db/DbEvent.java
+++ b/store/src/java/com/zimbra/cs/db/DbEvent.java
@@ -1,0 +1,483 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2021 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.db;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.Pair;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.db.DbPool.DbConnection;
+import com.zimbra.cs.mailbox.MailServiceException;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxOperation;
+import com.zimbra.cs.mailbox.event.MailboxEvent;
+import com.zimbra.cs.mailbox.event.MailboxEvent.EventFilter;
+
+public class DbEvent {
+
+    public static final String TABLE_EVENT = "event";
+    public static final String TABLE_WATCH = "watch";
+
+    private static void commit(DbConnection conn, boolean succeeded) throws ServiceException {
+        try {
+            if (succeeded) {
+                conn.commit();
+            } else {
+                conn.rollback();
+            }
+        } finally {
+            DbPool.quietClose(conn);
+        }
+    }
+
+    public static void logEvent(Mailbox mbox, MailboxEvent ev) throws ServiceException {
+        DbConnection conn = DbPool.getConnection();
+        PreparedStatement stmt = null;
+        boolean succeeded = false;
+        try {
+            stmt = conn.prepareStatement("INSERT INTO " + getEventTableName(mbox) +
+                        "(mailbox_id, account_id, item_id, version, folder_id, op, ts, user_agent, arg) " +
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)");
+            int pos = 1;
+            stmt.setInt(pos++, mbox.getId());
+            stmt.setString(pos++, ev.getAccountId());
+            stmt.setInt(pos++, ev.getItemId().getId());
+            stmt.setInt(pos++, ev.getVersion());
+            stmt.setInt(pos++, ev.getFolderId());
+            stmt.setByte(pos++, (byte)ev.getOperation().getCode());
+            stmt.setInt(pos++, (int)(ev.getTimestamp() / 1000L));
+            stmt.setString(pos++, ev.getUserAgent());
+            stmt.setString(pos++, ev.getArgString());
+
+            if (stmt.executeUpdate() != 1) {
+                throw ServiceException.FAILURE("can't add event", null);
+            }
+            succeeded = true;
+        } catch (SQLException e) {
+            throw ServiceException.FAILURE("can't add event", e);
+        } finally {
+            DbPool.closeStatement(stmt);
+            commit(conn, succeeded);
+        }
+    }
+
+    public static void updateEvent(Mailbox mbox, MailboxEvent ev) throws ServiceException {
+        DbConnection conn = DbPool.getConnection();
+        PreparedStatement stmt = null;
+        boolean succeeded = false;
+        try {
+            stmt = conn.prepareStatement("UPDATE " + getEventTableName(mbox) +
+                        " set ts = ?, version = ?, user_agent = ?, arg = ? " +
+                        "where mailbox_id = ? AND account_id = ? AND item_id = ? AND folder_id = ? AND op = ?");
+            int pos = 1;
+            stmt.setInt(pos++, (int)(ev.getTimestamp() / 1000L));
+            stmt.setInt(pos++, ev.getVersion());
+            stmt.setString(pos++, ev.getUserAgent());
+            stmt.setString(pos++, ev.getArgString());
+
+            stmt.setInt(pos++, mbox.getId());
+            stmt.setString(pos++, ev.getAccountId());
+            stmt.setInt(pos++, ev.getItemId().getId());
+            stmt.setInt(pos++, ev.getFolderId());
+            stmt.setByte(pos++, (byte)ev.getOperation().getCode());
+
+            if (stmt.executeUpdate() != 1) {
+                ZimbraLog.activity.info("Update event failed while updating event table");
+                throw ServiceException.FAILURE("can't update event", null);
+            }
+            succeeded = true;
+        } catch (SQLException e) {
+            ZimbraLog.activity.info("Update event failed while updating event table");
+            throw ServiceException.FAILURE("can't update event", e);
+        } finally {
+            DbPool.closeStatement(stmt);
+            commit(conn, succeeded);
+        }
+    }
+
+    public static Collection<MailboxEvent> getEventsForItem(Mailbox mbox, int itemId, int offset, int count, EventFilter filter) throws ServiceException {
+        return getEvents(mbox, Arrays.asList(itemId), offset, count, filter);
+    }
+
+    private static String listIds(Collection<Integer> itemIds) {
+        StringBuilder ret = new StringBuilder();
+        for (int i = 0; i < itemIds.size(); i++) {
+            if (ret.length() > 0)
+                ret.append(" OR");
+            ret.append(" folder_id = ? OR item_id = ?");
+        }
+        return ret.toString();
+    }
+
+    private static String addLimit(EventFilter filter) {
+        StringBuilder ret = new StringBuilder();
+        if (!filter.ids.isEmpty()) {
+            ret.append(" AND ");
+            ret.append(DbUtil.whereIn("account_id", filter.ids.size()));
+        }
+        if (!filter.ops.isEmpty()) {
+            ret.append(" AND ");
+            ret.append(DbUtil.whereIn("op", filter.ops.size()));
+        }
+        if (filter.since > 0) {
+            ret.append(" AND ");
+            ret.append("ts > ").append(filter.since);
+        }
+        return ret.toString();
+    }
+
+    public static Collection<MailboxEvent> getEvents(Mailbox mbox, Collection<Integer> itemIds, int offset, int count, EventFilter filter) throws ServiceException {
+        ArrayList<MailboxEvent> events = new ArrayList<MailboxEvent>();
+        DbConnection conn = DbPool.getConnection();
+        PreparedStatement stmt = null;
+        ResultSet rs = null;
+        boolean succeeded = false;
+        try {
+            stmt = conn.prepareStatement("SELECT " +
+                    " account_id, op, item_id, version, folder_id, ts, user_agent, arg" +
+                    " FROM " + getEventTableName(mbox) +
+                    " WHERE " + "mailbox_id = ? AND" +
+                    "   (" + listIds(itemIds) + ")" +
+                    addLimit(filter) +
+                    " ORDER BY ts DESC LIMIT " + offset + "," + count);
+            int pos = 1;
+            stmt.setInt(pos++, mbox.getId());
+            for (int itemId : itemIds) {
+                stmt.setInt(pos++, itemId);
+                stmt.setInt(pos++, itemId);
+            }
+            for (String id : filter.ids) {
+                stmt.setString(pos++, id);
+            }
+            for (MailboxOperation op : filter.ops) {
+                stmt.setByte(pos++, (byte)op.getCode());
+            }
+            rs = stmt.executeQuery();
+
+            while (rs.next()) {
+                pos = 1;
+                events.add(new MailboxEvent(rs.getString(pos++), MailboxOperation.fromInt(rs.getByte(pos++)), mbox.getAccountId(), rs.getInt(pos++), rs.getInt(pos++), rs.getInt(pos++), (rs.getInt(pos++) * 1000L), rs.getString(pos++), rs.getString(pos++)));
+            }
+            succeeded = true;
+        } catch (SQLException e) {
+            throw ServiceException.FAILURE("can't fetch events for Mailbox " + mbox.getId(), e);
+        } finally {
+            DbPool.closeResults(rs);
+            DbPool.closeStatement(stmt);
+            commit(conn, succeeded);
+        }
+        return events;
+    }
+
+    public static Collection<MailboxEvent> getEventsBefore(Mailbox mbox, Collection<Integer> itemIds, long timestamp, int count, EventFilter filter) throws ServiceException {
+        ArrayList<MailboxEvent> events = new ArrayList<MailboxEvent>();
+        DbConnection conn = DbPool.getConnection();
+        PreparedStatement stmt = null;
+        ResultSet rs = null;
+        boolean succeeded = false;
+        try {
+            stmt = conn.prepareStatement("SELECT " +
+                    " account_id, op, item_id, version, folder_id, ts, user_agent, arg" +
+                    " FROM " + getEventTableName(mbox) +
+                    " WHERE " + "mailbox_id = ? AND ts < ? AND " +
+                    "   (" + listIds(itemIds) + ")" +
+                    addLimit(filter) +
+                    " ORDER BY ts DESC LIMIT " + count);
+            int pos = 1;
+            stmt.setInt(pos++, mbox.getId());
+            stmt.setInt(pos++, (int)(timestamp / 1000L));
+            for (int itemId : itemIds) {
+                stmt.setInt(pos++, itemId);
+                stmt.setInt(pos++, itemId);
+            }
+            for (String id : filter.ids) {
+                stmt.setString(pos++, id);
+            }
+            for (MailboxOperation op : filter.ops) {
+                stmt.setByte(pos++, (byte)op.getCode());
+            }
+            rs = stmt.executeQuery();
+
+            while (rs.next()) {
+                pos = 1;
+                events.add(new MailboxEvent(rs.getString(pos++), MailboxOperation.fromInt(rs.getByte(pos++)), mbox.getAccountId(), rs.getInt(pos++), rs.getInt(pos++), rs.getInt(pos++), (rs.getInt(pos++) * 1000L), rs.getString(pos++), rs.getString(pos++)));
+            }
+            succeeded = true;
+        } catch (SQLException e) {
+            throw ServiceException.FAILURE("can't fetch events for Mailbox " + mbox.getId(), e);
+        } finally {
+            DbPool.closeResults(rs);
+            DbPool.closeStatement(stmt);
+            commit(conn, succeeded);
+        }
+        return events;
+    }
+
+    public static int getEventCount(Mailbox mbox, Collection<Integer> itemIds, EventFilter filter) throws ServiceException {
+        DbConnection conn = DbPool.getConnection();
+        PreparedStatement stmt = null;
+        ResultSet rs = null;
+        boolean succeeded = false;
+        try {
+            stmt = conn.prepareStatement("SELECT count(*)" +
+                    " FROM " + getEventTableName(mbox) +
+                    " WHERE " + "mailbox_id = ? AND " +
+                    "   (" + listIds(itemIds) + ")" +
+                    addLimit(filter)
+                    );
+            int pos = 1;
+            stmt.setInt(pos++, mbox.getId());
+            for (int itemId : itemIds) {
+                stmt.setInt(pos++, itemId);
+                stmt.setInt(pos++, itemId);
+            }
+            for (String id : filter.ids) {
+                stmt.setString(pos++, id);
+            }
+            for (MailboxOperation op : filter.ops) {
+                stmt.setByte(pos++, (byte)op.getCode());
+            }
+            rs = stmt.executeQuery();
+
+            succeeded = true;
+            if (!rs.next()) {
+                return 0;
+            }
+            return rs.getInt(1);
+        } catch (SQLException e) {
+            throw ServiceException.FAILURE("can't fetch event count for Mailbox " + mbox.getId(), e);
+        } finally {
+            DbPool.closeResults(rs);
+            DbPool.closeStatement(stmt);
+            commit(conn, succeeded);
+        }
+    }
+
+    public static Collection<MailboxOperation> getEventOps(Mailbox mbox, Collection<Integer> itemIds, EventFilter filter) throws ServiceException {
+        EnumSet<MailboxOperation> ops = EnumSet.noneOf(MailboxOperation.class);
+        DbConnection conn = DbPool.getConnection();
+        PreparedStatement stmt = null;
+        ResultSet rs = null;
+        boolean succeeded = false;
+        try {
+            stmt = conn.prepareStatement("SELECT " +
+                    " DISTINCT op" +
+                    " FROM " + getEventTableName(mbox) +
+                    " WHERE " + "mailbox_id = ? AND " +
+                    "   (" + listIds(itemIds) + ")" +
+                    addLimit(filter)
+                    );
+            int pos = 1;
+            stmt.setInt(pos++, mbox.getId());
+            for (int itemId : itemIds) {
+                stmt.setInt(pos++, itemId);
+                stmt.setInt(pos++, itemId);
+            }
+            for (String id : filter.ids) {
+                stmt.setString(pos++, id);
+            }
+            for (MailboxOperation op : filter.ops) {
+                stmt.setByte(pos++, (byte)op.getCode());
+            }
+            rs = stmt.executeQuery();
+
+            while (rs.next()) {
+                pos = 1;
+                ops.add(MailboxOperation.fromInt(rs.getByte(pos++)));
+            }
+            succeeded = true;
+        } catch (SQLException e) {
+            throw ServiceException.FAILURE("can't fetch event operations for Mailbox " + mbox.getId(), e);
+        } finally {
+            DbPool.closeResults(rs);
+            DbPool.closeStatement(stmt);
+            commit(conn, succeeded);
+        }
+        return ops;
+    }
+
+    public static Collection<String> getEventUsers(Mailbox mbox, Collection<Integer> itemIds, EventFilter filter) throws ServiceException {
+        ArrayList<String> users = new ArrayList<String>();
+        DbConnection conn = DbPool.getConnection();
+        PreparedStatement stmt = null;
+        ResultSet rs = null;
+        boolean succeeded = false;
+        try {
+            stmt = conn.prepareStatement("SELECT " +
+                    " DISTINCT account_id" +
+                    " FROM " + getEventTableName(mbox) +
+                    " WHERE " + "mailbox_id = ? AND " +
+                    "   (" + listIds(itemIds) + ")" +
+                    addLimit(filter)
+                    );
+            int pos = 1;
+            stmt.setInt(pos++, mbox.getId());
+            for (int itemId : itemIds) {
+                stmt.setInt(pos++, itemId);
+                stmt.setInt(pos++, itemId);
+            }
+            for (String id : filter.ids) {
+                stmt.setString(pos++, id);
+            }
+            for (MailboxOperation op : filter.ops) {
+                stmt.setByte(pos++, (byte)op.getCode());
+            }
+            rs = stmt.executeQuery();
+
+            while (rs.next()) {
+                pos = 1;
+                users.add(rs.getString(pos++));
+            }
+            succeeded = true;
+        } catch (SQLException e) {
+            throw ServiceException.FAILURE("can't fetch event users for Mailbox " + mbox.getId(), e);
+        } finally {
+            DbPool.closeResults(rs);
+            DbPool.closeStatement(stmt);
+            commit(conn, succeeded);
+        }
+        return users;
+    }
+
+    public static void addWatch(Mailbox mbox, String targetAccountId, int itemId) throws ServiceException {
+        DbConnection conn = DbPool.getConnection();
+        PreparedStatement stmt = null;
+        boolean succeeded = false;
+        try {
+            stmt = conn.prepareStatement("INSERT INTO " + getWatchTableName(mbox) +
+                        " (mailbox_id, target, item_id) " +
+                        " VALUES (?, ?, ?)");
+            int pos = 1;
+            stmt.setInt(pos++, mbox.getId());
+            stmt.setString(pos++, targetAccountId);
+            stmt.setInt(pos++, itemId);
+
+            if (stmt.executeUpdate() != 1) {
+                throw ServiceException.FAILURE("can't add watch mapping", null);
+            }
+            succeeded = true;
+        } catch (SQLException e) {
+            // catch item_id uniqueness constraint violation and return failure
+            if (com.zimbra.cs.db.Db.errorMatches(e, com.zimbra.cs.db.Db.Error.DUPLICATE_ROW)) {
+                throw MailServiceException.ALREADY_EXISTS("watch mapping already exists", e);
+            } else {
+                throw ServiceException.FAILURE("can't add watch mapping", e);
+            }
+        } finally {
+            DbPool.closeStatement(stmt);
+            commit(conn, succeeded);
+        }
+    }
+
+    public static void removeWatch(Mailbox mbox, String targetAccountId, int itemId) throws ServiceException {
+        DbConnection conn = DbPool.getConnection();
+        PreparedStatement stmt = null;
+        boolean succeeded = false;
+        try {
+            stmt = conn.prepareStatement("DELETE FROM " + getWatchTableName(mbox) +
+                        " WHERE mailbox_id = ? AND target = ? AND item_id = ?");
+            int pos = 1;
+            stmt.setInt(pos++, mbox.getId());
+            stmt.setString(pos++, targetAccountId);
+            stmt.setInt(pos++, itemId);
+            stmt.executeUpdate();
+            succeeded = true;
+        } catch (SQLException e) {
+            throw ServiceException.FAILURE("can't delete watch mapping", e);
+        } finally {
+            DbPool.closeStatement(stmt);
+            commit(conn, succeeded);
+        }
+    }
+
+    public static Collection<Pair<String,Integer>> getWatchingItems(Mailbox mbox) throws ServiceException {
+        ArrayList<Pair<String,Integer>> items = new ArrayList<Pair<String,Integer>>();
+        DbConnection conn = DbPool.getConnection();
+        PreparedStatement stmt = null;
+        ResultSet rs = null;
+        boolean succeeded = false;
+        try {
+            stmt = conn.prepareStatement("SELECT target, item_id FROM " + getWatchTableName(mbox) +
+                    " WHERE mailbox_id = ?");
+            int pos = 1;
+            stmt.setInt(pos++, mbox.getId());
+            rs = stmt.executeQuery();
+
+            while (rs.next()) {
+                pos = 1;
+                Pair<String,Integer> item = new Pair<String,Integer>(rs.getString(pos++), rs.getInt(pos++));
+                items.add(item);
+            }
+            succeeded = true;
+        } catch (SQLException e) {
+            throw ServiceException.FAILURE("can't fetch watching items for mailbox " + mbox.getId(), e);
+        } finally {
+            DbPool.closeResults(rs);
+            DbPool.closeStatement(stmt);
+            commit(conn, succeeded);
+        }
+        return items;
+    }
+
+    public static Collection<Integer> getWatchingItems(Mailbox mbox, String targetAccountId) throws ServiceException {
+        ArrayList<Integer> items = new ArrayList<Integer>();
+        DbConnection conn = DbPool.getConnection();
+        PreparedStatement stmt = null;
+        ResultSet rs = null;
+        boolean succeeded = false;
+        try {
+            stmt = conn.prepareStatement("SELECT item_id FROM " + getWatchTableName(mbox) +
+                    " WHERE mailbox_id = ? AND target = ?");
+            int pos = 1;
+            stmt.setInt(pos++, mbox.getId());
+            stmt.setString(pos++, targetAccountId);
+            rs = stmt.executeQuery();
+
+            while (rs.next()) {
+                pos = 1;
+                items.add(rs.getInt(pos++));
+            }
+            succeeded = true;
+        } catch (SQLException e) {
+            throw ServiceException.FAILURE("can't fetch watching items for mailbox " + mbox.getId(), e);
+        } finally {
+            DbPool.closeResults(rs);
+            DbPool.closeStatement(stmt);
+            commit(conn, succeeded);
+        }
+        return items;
+    }
+
+    public static String getEventTableName(Mailbox mbox) {
+        return DbMailbox.qualifyTableName(mbox, TABLE_EVENT);
+    }
+
+    public static String getEventTableName(Mailbox mbox, String alias) {
+        return getEventTableName(mbox) + " AS " + alias;
+    }
+
+    public static String getWatchTableName(Mailbox mbox) {
+        return DbMailbox.qualifyTableName(mbox, TABLE_WATCH);
+    }
+}

--- a/store/src/java/com/zimbra/cs/index/DBQueryOperation.java
+++ b/store/src/java/com/zimbra/cs/index/DBQueryOperation.java
@@ -665,7 +665,7 @@ public class DBQueryOperation extends QueryOperation {
     private void dbSearch(List<DbSearch.Result> results, SortBy sort, int offset, int size) throws ServiceException {
         long start = System.currentTimeMillis();
         results.addAll(context.getMailbox().index.search(constraints, fetch, sort, offset, size,
-                context.getParams().inDumpster()));
+                context.getParams().inDumpster(), authMailbox));
         ZimbraLog.search.debug("DBSearch elapsed=%d", System.currentTimeMillis() - start);
     }
 

--- a/store/src/java/com/zimbra/cs/index/QueryOperation.java
+++ b/store/src/java/com/zimbra/cs/index/QueryOperation.java
@@ -41,6 +41,7 @@ public abstract class QueryOperation implements Cloneable, ZimbraQueryResults {
     static final int MAX_CHUNK_SIZE = 5000;
 
     protected QueryContext context;
+    protected Mailbox authMailbox;
 
     @Override
     public SortBy getSortBy() {

--- a/store/src/java/com/zimbra/cs/index/SortBy.java
+++ b/store/src/java/com/zimbra/cs/index/SortBy.java
@@ -58,6 +58,7 @@ public enum SortBy {
     ID_DESC("idDesc", Key.ID, Direction.DESC, ZimbraSortBy.idDesc),
     READ_DESC("readDesc", Key.UNREAD, Direction.DESC, ZimbraSortBy.readDesc),
     READ_ASC("readAsc", Key.UNREAD, Direction.ASC, ZimbraSortBy.readAsc),
+    RECENTLY_VIEWED("recentlyViewed", Key.RECENTLYVIEWED, Direction.DESC, ZimbraSortBy.recentlyViewed),
 
     // wiki "natural order" sorts are not exposed via SOAP
     NAME_NATURAL_ORDER_ASC(null, Key.NAME_NATURAL_ORDER, Direction.ASC, null),
@@ -80,7 +81,7 @@ public enum SortBy {
     private final ZimbraSortBy zsb;
 
     public enum Key {
-        DATE, SENDER, RCPT, SUBJECT, ID, NONE, NAME, NAME_NATURAL_ORDER, SIZE, ATTACHMENT, FLAG, PRIORITY, UNREAD
+        DATE, SENDER, RCPT, SUBJECT, ID, NONE, NAME, NAME_NATURAL_ORDER, SIZE, ATTACHMENT, FLAG, PRIORITY, UNREAD, RECENTLYVIEWED
     }
 
     public enum Direction {

--- a/store/src/java/com/zimbra/cs/index/ZimbraQuery.java
+++ b/store/src/java/com/zimbra/cs/index/ZimbraQuery.java
@@ -43,6 +43,7 @@ import com.zimbra.cs.mailbox.Folder;
 import com.zimbra.cs.mailbox.MailItem;
 import com.zimbra.cs.mailbox.MailServiceException.NoSuchItemException;
 import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxManager;
 import com.zimbra.cs.mailbox.Mountpoint;
 import com.zimbra.cs.mailbox.OperationContext;
 import com.zimbra.cs.util.IOUtil;
@@ -725,6 +726,7 @@ public final class ZimbraQuery {
         union.add(remoteOps);
         ZimbraLog.search.debug("BEFORE_FINAL_OPT=%s", union);
         operation = union.optimize(mailbox);
+        operation.authMailbox = MailboxManager.getInstance().getMailboxByAccountId(octxt.getAuthenticatedUser().getId());
 
         ZimbraLog.search.debug("COMPILED=%s", operation);
     }

--- a/store/src/java/com/zimbra/cs/iochannel/Message.java
+++ b/store/src/java/com/zimbra/cs/iochannel/Message.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2012, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2012, 2013, 2014, 2016, 2021 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -83,6 +83,7 @@ public abstract class Message {
     static {
         registerMessage(new CrossServerNotification());
         registerMessage(new MailboxNotification());
+        registerMessage(new WatchMessage());
     }
 
     public static void registerMessage(Message m) {

--- a/store/src/java/com/zimbra/cs/iochannel/WatchMessage.java
+++ b/store/src/java/com/zimbra/cs/iochannel/WatchMessage.java
@@ -1,0 +1,124 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2021 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.iochannel;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.cache.WatchCache;
+import com.zimbra.cs.service.util.ItemId;
+
+public class WatchMessage extends Message {
+
+    private static final String AppId = "watch";
+
+    private String accountId;
+    private Op op;
+    private ItemId watchItemId;
+
+    private enum Op {
+        watch, unwatch
+    }
+
+    public WatchMessage() {
+    }
+
+    public WatchMessage(String accountId, Op op, String aid, int iid) {
+        super();
+        this.accountId = accountId;
+        this.op = op;
+        watchItemId = new ItemId(aid, iid);
+    }
+
+    private WatchMessage(ByteBuffer in) throws IOException {
+        super();
+        accountId = readString(in);
+        op = Op.valueOf(readString(in));
+        String aid = readString(in);
+        String iid = readString(in);
+        watchItemId = new ItemId(aid, Integer.parseInt(iid));
+    }
+
+    public static WatchMessage watch(String accountId, String watchAccountId, int itemId) {
+        return new WatchMessage(accountId, Op.watch, watchAccountId, itemId);
+    }
+
+    public static WatchMessage unwatch(String accountId, String watchAccountId, int itemId) {
+        return new WatchMessage(accountId, Op.unwatch, watchAccountId, itemId);
+    }
+
+    @Override
+    public String getAppId() {
+        return AppId;
+    }
+
+    @Override
+    public String getRecipientAccountId() {
+        return accountId;
+    }
+
+    @Override
+    protected int size() {
+        return (accountId.length() + watchItemId.toString().length() + op.name().length()) * 2 + 16;
+    }
+
+    @Override
+    protected void serialize(ByteBuffer out) throws IOException {
+        writeString(out, accountId);
+        writeString(out, op.name());
+        writeString(out, watchItemId.getAccountId());
+        writeString(out, Integer.toString(watchItemId.getId()));
+    }
+
+    @Override
+    protected Message construct(ByteBuffer in) throws IOException {
+        return new WatchMessage(in);
+    }
+
+    @Override
+    public MessageHandler getHandler() {
+        return new MessageHandler() {
+            @Override
+            public void handle(Message m, String clientId) {
+                if (!(m instanceof WatchMessage)) {
+                    return;
+                }
+                try {
+                    WatchMessage message = (WatchMessage)m;
+                    Account account = Provisioning.getInstance().getAccountById(accountId);
+                    WatchCache watchCache = WatchCache.get(account);
+                    switch (message.op) {
+                    case watch:
+                        log.debug("watching item " + watchItemId);
+                        watchCache.watch(watchItemId.getAccountId(), watchItemId.getId());
+                        break;
+                    case unwatch:
+                        log.debug("unwatching item " + watchItemId);
+                        watchCache.unwatch(watchItemId.getAccountId(), watchItemId.getId());
+                        break;
+                    }
+                } catch (ServiceException e) {
+                    log.warn("can't change watch mapping", e);
+                    return;
+                }
+            }
+        };
+    }
+}

--- a/store/src/java/com/zimbra/cs/mailbox/MailboxIndex.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailboxIndex.java
@@ -1062,16 +1062,21 @@ public final class MailboxIndex {
         return compactIndex != null;
     }
 
+    public List<DbSearch.Result> search(DbSearchConstraints constraints, 
+            DbSearch.FetchMode fetch, SortBy sort, int offset, int size, boolean inDumpster) throws ServiceException {
+            return search(constraints, fetch, sort, offset, size, inDumpster, null);
+    }
+    
     /**
      * Executes a DB search in a mailbox transaction.
      */
     public List<DbSearch.Result> search(DbSearchConstraints constraints,
-            DbSearch.FetchMode fetch, SortBy sort, int offset, int size, boolean inDumpster) throws ServiceException {
+            DbSearch.FetchMode fetch, SortBy sort, int offset, int size, boolean inDumpster, Mailbox authMailbox) throws ServiceException {
         List<DbSearch.Result> result;
         boolean success = false;
         try {
             mailbox.beginReadTransaction("search", null);
-            result = new DbSearch(mailbox, inDumpster).search(mailbox.getOperationConnection(),
+            result = new DbSearch(mailbox, inDumpster, authMailbox).search(mailbox.getOperationConnection(),
                     constraints, sort, offset, size, fetch);
             if (fetch == DbSearch.FetchMode.MAIL_ITEM) {
                 // Convert UnderlyingData to MailItem

--- a/store/src/java/com/zimbra/cs/mailbox/MailboxOperation.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailboxOperation.java
@@ -110,7 +110,8 @@ public enum MailboxOperation {
     ExpireAccess(90),
     SetDisableActiveSync(91),
     SetWebOfflineSyncDays(92),
-    DeleteConfig(93);
+    DeleteConfig(93),
+    View(94);
 
     private MailboxOperation(int c) {
         code = c;

--- a/store/src/java/com/zimbra/cs/mailbox/cache/WatchCache.java
+++ b/store/src/java/com/zimbra/cs/mailbox/cache/WatchCache.java
@@ -1,0 +1,217 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2021 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.mailbox.cache;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+import com.zimbra.common.localconfig.LC;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.Element.XMLElement;
+import com.zimbra.common.soap.MailConstants;
+import com.zimbra.common.soap.OctopusXmlConstants;
+import com.zimbra.common.soap.SoapHttpTransport;
+import com.zimbra.common.soap.SoapProtocol;
+import com.zimbra.common.util.Log;
+import com.zimbra.common.util.LogFactory;
+import com.zimbra.common.util.LruMap;
+import com.zimbra.common.util.MapUtil;
+import com.zimbra.common.util.Pair;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.ZimbraAuthToken;
+import com.zimbra.cs.db.DbEvent;
+import com.zimbra.cs.httpclient.URLUtil;
+import com.zimbra.cs.iochannel.MessageChannel;
+import com.zimbra.cs.iochannel.WatchMessage;
+import com.zimbra.cs.mailbox.MailItem;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailbox.OperationContext;
+import com.zimbra.cs.mailbox.OperationContextData;
+import com.zimbra.cs.service.util.ItemId;
+
+public abstract class WatchCache extends OperationContextData {
+
+    public static final String KEY = "WatchCache";
+
+    public static WatchCache get(Account account) {
+        try {
+            if (account.getServer() != null && !Provisioning.onLocalServer(account)) {
+                return new RemoteCache(account);
+            }
+        } catch (ServiceException e) {
+        }
+        return new LocalCache(account);
+    }
+
+    public static WatchCache get(OperationContext octxt) {
+        OperationContextData cache = octxt.getCtxtData(KEY);
+        if (cache != null && cache instanceof WatchCache) {
+            return (WatchCache) cache;
+        }
+        WatchCache watchCache = get(octxt.getAuthenticatedUser());
+        watchCache.addTo(octxt);
+        return watchCache;
+    }
+
+    public abstract void watch(String accountId, int itemId) throws ServiceException;
+    public abstract void unwatch(String accountId, int itemId) throws ServiceException;
+
+    private void addTo(OperationContext octxt) {
+        octxt.setCtxtData(KEY, this);
+    }
+
+    public boolean hasMapping(MailItem item) {
+        try {
+            return hasMapping(item.getAccount().getId(), item.getId());
+        } catch (ServiceException e) {
+            return false;
+        }
+    }
+
+    public boolean hasMapping(String accountId, int itemId) {
+        synchronized (items) {
+            if (items.containsKey(accountId)) {
+                Collection<Integer> itemIds = items.get(accountId);
+                return itemIds.contains(itemId);
+            }
+        }
+        return false;
+    }
+
+    public Multimap<String, Integer> getMap() {
+        return ImmutableMultimap.copyOf(items);
+    }
+
+
+    protected static Log LOG = LogFactory.getLog(WatchCache.class);
+    protected static LruMap<String,HashMultimap<String,Integer>> watchMappings = MapUtil.newLruMap(100);
+    protected HashMultimap<String,Integer> items;
+    protected final Account account;
+    protected ZimbraAuthToken authToken;
+
+    protected WatchCache(Account account) {
+        super(null);
+        this.account = account;
+        synchronized (watchMappings) {
+            items = watchMappings.get(account.getId());
+        }
+        if (items == null) {
+            try {
+                load();
+            } catch (ServiceException e) {
+                LOG.error("can't load watch mapping for account %s", account.getName(), e);
+            }
+        }
+    }
+
+    protected abstract void load() throws ServiceException;
+
+    private static class LocalCache extends WatchCache {
+        LocalCache(Account account) {
+            super(account);
+        }
+
+        @Override
+        public void watch(String accountId, int itemId) throws ServiceException {
+            Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
+            DbEvent.addWatch(mbox, accountId, itemId);
+            synchronized (items) {
+                items.put(accountId, itemId);
+            }
+        }
+
+        @Override
+        public void unwatch(String accountId, int itemId) throws ServiceException {
+            Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
+            DbEvent.removeWatch(mbox, accountId, itemId);
+            synchronized (items) {
+                items.remove(accountId, itemId);
+            }
+        }
+        @Override
+        protected void load() throws ServiceException {
+            items = HashMultimap.create();
+            if (account.getServer() == null) {
+                // system admin accounts have no server or mailbox
+                return;
+            }
+            Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
+            for (Pair<String,Integer> mapping : DbEvent.getWatchingItems(mbox)) {
+                items.put(mapping.getFirst(), mapping.getSecond());
+            }
+
+            synchronized (watchMappings) {
+                watchMappings.put(account.getId(), items);
+            }
+        }
+    }
+
+    private static class RemoteCache extends WatchCache {
+        RemoteCache(Account account) {
+            super(account);
+        }
+
+        @Override
+        public void watch(String accountId, int itemId) throws ServiceException {
+            WatchMessage msg = WatchMessage.watch(account.getId(), accountId, itemId);
+            MessageChannel.getInstance().sendMessage(msg);
+        }
+
+        @Override
+        public void unwatch(String accountId, int itemId) throws ServiceException {
+            WatchMessage msg = WatchMessage.unwatch(account.getId(), accountId, itemId);
+            MessageChannel.getInstance().sendMessage(msg);
+        }
+
+        @Override
+        protected void load() throws ServiceException {
+            items = HashMultimap.create();
+            SoapHttpTransport transport = null;
+            try {
+                if (authToken == null) {
+                    authToken = new ZimbraAuthToken(account);
+                }
+                String url = URLUtil.getSoapURL(account.getServer(), true);
+                transport = new SoapHttpTransport(url);
+                transport.setTargetAcctId(account.getId());
+                transport.setAuthToken(authToken.toZAuthToken());
+                transport.setTimeout(LC.httpclient_soaphttptransport_so_timeout.intValue());
+                transport.setResponseProtocol(SoapProtocol.Soap12);
+                XMLElement req = new XMLElement(OctopusXmlConstants.GET_WATCHING_ITEMS_REQUEST);
+                Element body = transport.invokeWithoutSession(req);
+                for (Element target : body.listElements(MailConstants.E_TARGET)) {
+                    String accountId = target.getAttribute(MailConstants.A_ID);
+                    for (Element item : target.listElements(MailConstants.E_ITEM)) {
+                        ItemId iid = new ItemId(item.getAttribute(MailConstants.A_ID), accountId);
+                        items.put(iid.getAccountId(), iid.getId());
+                    }
+                }
+            } catch (IOException e) {
+                throw ServiceException.PROXY_ERROR(e, account.getName());
+            } finally {
+                if (transport != null)
+                    transport.shutdown();
+            }
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/mailbox/event/DbEventLog.java
+++ b/store/src/java/com/zimbra/cs/mailbox/event/DbEventLog.java
@@ -1,0 +1,132 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2021 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.mailbox.event;
+
+import java.text.SimpleDateFormat;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Map;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.db.DbEvent;
+import com.zimbra.cs.mailbox.MailItem;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailbox.MailboxOperation;
+import com.zimbra.cs.mailbox.event.MailboxEvent.EventFilter;
+
+public class DbEventLog extends ItemEventLog {
+
+    private final Mailbox mbox;
+    private final Collection<Integer> itemIds;
+    private EventFilter filter;
+
+    protected SimpleDateFormat mDateFormat = new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss Z");
+
+    @Override
+    public int getEventCount() throws ServiceException {
+        return DbEvent.getEventCount(mbox, itemIds, filter);
+    }
+
+    @Override
+    public Collection<MailboxEvent> getEvents(int offset, int count) throws ServiceException {
+        return DbEvent.getEvents(mbox, itemIds, offset, count, filter);
+    }
+
+    @Override
+    public Collection<MailboxEvent> getEventsBefore(long timestamp, int count) throws ServiceException {
+        return DbEvent.getEventsBefore(mbox, itemIds, timestamp, count, filter);
+    }
+
+    @Override
+    public Collection<MailboxOperation> getLoggedOps() throws ServiceException {
+        return DbEvent.getEventOps(mbox, itemIds, filter);
+    }
+
+    @Override
+    public Collection<String> getLoggedUsers() throws ServiceException {
+        return DbEvent.getEventUsers(mbox, itemIds, filter);
+    }
+
+    @Override
+    public void addEvent(MailboxEvent event) throws ServiceException {
+        LogEvent(event);
+        Mailbox mboxAccount = MailboxManager.getInstance().getMailboxByAccountId(event.getAccountId());
+        Mailbox targetMbox = mbox;
+        if (mbox.getId() != mboxAccount.getId()) {
+            targetMbox = mboxAccount;
+        }
+
+        if (event.getOperation().getCode() ==  MailboxOperation.View.getCode() &&
+                DbEvent.getEventCount(targetMbox, itemIds, new EventFilter(event.getAccountId(), MailboxOperation.View.toString())) > 0) {
+            DbEvent.updateEvent(targetMbox, event);
+        } else {
+            DbEvent.logEvent(targetMbox, event);
+        }
+    }
+
+    public DbEventLog(MailItem item) throws ServiceException {
+        super();
+        mbox = item.getMailbox();
+        itemIds = new HashSet<Integer>();
+        itemIds.add(item.getId());
+    }
+
+    public DbEventLog(Mailbox mbox, Collection<Integer> itemIds) {
+        super();
+        this.mbox = mbox;
+        this.itemIds = itemIds;
+        this.filter = new EventFilter();
+    }
+
+    public DbEventLog(Mailbox mbox, Collection<Integer> itemIds, EventFilter filter) {
+        this(mbox, itemIds);
+        if (filter != null) {
+            this.filter.ids.addAll(filter.ids);
+            this.filter.ops.addAll(filter.ops);
+            this.filter.since = filter.since;
+        }
+    }
+
+    private void LogEvent(MailboxEvent event) {
+        String Arguments = "";
+        if (event.getArgs() != null) {
+            Arguments += "[";
+            for (Map.Entry<String, String> entry : event.getArgs().entrySet())
+                Arguments += "{\"name\":\"" + entry.getKey() + "\"," + "\"_content\":\"" + entry.getValue() + "\"},";
+
+            if (Arguments.endsWith(","))
+                Arguments = Arguments.substring(0, Arguments.length() - 1);
+
+            Arguments += "]";
+        }
+
+        String Message = "\"cee:{\"Event\":{\"id\":" + "\"" + event.getItemId() + "\"," + "\"time\":\""
+                + mDateFormat.format(new Date(event.getTimestamp())) + "\"," + "\"action\":\"" + event.getOperation()
+                + "\"," + "\"status\":\"" + "success\"," + "\"acct_id\":\"" + event.getAccountId() + "\","
+                + "\"p_prod_id\":\"" + event.getUserAgent() + "\"";
+
+        if (!Arguments.isEmpty())
+            Message += ",\"args\":" + Arguments;
+
+        Message += "}}";
+
+        ZimbraLog.activity.info(Message);
+    }
+}

--- a/store/src/java/com/zimbra/cs/mailbox/event/EventListener.java
+++ b/store/src/java/com/zimbra/cs/mailbox/event/EventListener.java
@@ -1,0 +1,456 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2021 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.mailbox.event;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.mail.MessagingException;
+
+import com.google.common.collect.ImmutableSet;
+import com.zimbra.common.account.Key.DistributionListBy;
+import com.zimbra.common.mailbox.BaseItemInfo;
+import com.zimbra.common.mime.MimeConstants;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.share.ShareNotification;
+import com.zimbra.common.util.Log;
+import com.zimbra.common.util.LogFactory;
+import com.zimbra.common.util.StringUtil;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.NamedEntry;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.ACL;
+import com.zimbra.cs.mailbox.ACL.Grant;
+import com.zimbra.cs.mailbox.Document;
+import com.zimbra.cs.mailbox.Folder;
+import com.zimbra.cs.mailbox.MailItem;
+import com.zimbra.cs.mailbox.MailItem.Type;
+import com.zimbra.cs.mailbox.MailboxListener;
+import com.zimbra.cs.mailbox.MailboxOperation;
+import com.zimbra.cs.mailbox.Message;
+import com.zimbra.cs.mime.MPartInfo;
+import com.zimbra.cs.mime.Mime;
+import com.zimbra.cs.service.util.ItemId;
+import com.zimbra.cs.service.util.ItemIdFormatter;
+import com.zimbra.cs.session.PendingModifications;
+import com.zimbra.cs.session.PendingModifications.ModificationKey;
+
+public class EventListener extends MailboxListener {
+
+    public static final ImmutableSet<MailboxOperation> EVENTS = ImmutableSet.of(
+            MailboxOperation.CreateFolder, MailboxOperation.RenameFolder,
+            MailboxOperation.MoveItem, MailboxOperation.CopyItem,
+            MailboxOperation.DeleteItem, MailboxOperation.EmptyFolder,
+            MailboxOperation.GrantAccess, MailboxOperation.RevokeAccess, MailboxOperation.ExpireAccess,
+            MailboxOperation.SaveDocument, MailboxOperation.AddDocumentRevision,
+            MailboxOperation.RenameItem, MailboxOperation.PurgeRevision,
+            MailboxOperation.RenameItemPath, MailboxOperation.RenameFolderPath,
+            MailboxOperation.AlterItemTag, // for marking notification read
+            MailboxOperation.LockItem, MailboxOperation.UnlockItem,
+            MailboxOperation.CreateComment, MailboxOperation.CreateMountpoint,
+            MailboxOperation.CreateMessage
+    );
+
+    public static final ImmutableSet<MailboxOperation> FOLDER_EVENTS = ImmutableSet.of(
+            MailboxOperation.CreateFolder, MailboxOperation.RenameFolder,
+            MailboxOperation.RenameFolderPath, MailboxOperation.RenameItem,
+            MailboxOperation.MoveItem,
+            MailboxOperation.GrantAccess, MailboxOperation.RevokeAccess, MailboxOperation.ExpireAccess,
+            MailboxOperation.LockItem, MailboxOperation.UnlockItem, MailboxOperation.DeleteItem
+    );
+
+    public static final ImmutableSet<Type> ITEMTYPES = ImmutableSet.of(
+            Type.DOCUMENT, Type.FOLDER, Type.MOUNTPOINT, Type.COMMENT, Type.MESSAGE
+    );
+
+    private final EventLogger logger;
+
+    private static Log LOG = LogFactory.getLog(EventListener.class);
+
+    public EventListener() {
+        logger = EventLogger.getInstance();
+    }
+
+    @Override
+    public void notify(ChangeNotification notification) {
+        if (notification == null)
+            return;
+
+        if ((notification.ctxt != null) && (notification.ctxt.getAuthenticatedUser() == null))
+            return;
+
+        if ((notification.ctxt == null) && (notification.mailboxAccount == null))
+            return;
+
+        String userAgent = (notification.ctxt != null) ? notification.ctxt.getUserAgent() : null;
+
+        String accountId = (notification.ctxt != null) ?
+            notification.ctxt.getAuthenticatedUser().getId() :
+            notification.mailboxAccount.getId();
+
+        ItemIdFormatter ifmt = new ItemIdFormatter(accountId);
+        MailboxOperation op = notification.op;
+        if (notification.mods.modified != null) {
+            for (PendingModifications.Change change : notification.mods.modified.values()) {
+                if (wantThisChange(change, op)) {
+                    handleChange((MailItem)change.what, op, accountId, notification.timestamp, (MailItem)change.preModifyObj, userAgent, getArgs(op, (MailItem)change.what, (MailItem)change.preModifyObj, ifmt));
+                }
+            }
+        }
+        if (notification.mods.created != null) {
+            for (Map.Entry<ModificationKey, BaseItemInfo> entry: notification.mods.created.entrySet()) {
+                if (entry instanceof MailItem) {
+                    MailItem mailItem = (MailItem) entry;
+                    if (!ITEMTYPES.contains(mailItem.getType()))
+                        continue;
+                    handleChange(mailItem, op, accountId, mailItem.getDate(), null, userAgent, getArgs(op, mailItem, null, ifmt));
+                }
+            }
+        }
+        if (notification.mods.deleted != null) {
+            for (PendingModifications.Change change : notification.mods.deleted.values()) {
+                if (wantThisChange(change, op)) {
+                    MailItem item = (MailItem) change.preModifyObj;
+                    if (item != null) {
+                        handleChange(item, op, accountId, notification.timestamp, (MailItem)change.preModifyObj, userAgent, getArgs(op, item, (MailItem)change.preModifyObj, ifmt));
+                    }
+                }
+            }
+        }
+    }
+
+    private static final String ARG_TYPE = "t";
+    private static final String ARG_VER = "ver";
+    private static final String ARG_OLDNAME = "oldName";
+    private static final String ARG_NAME = "filename";
+    private static final String ARG_OLDLOCATION = "oldLocation";
+    private static final String ARG_NEWLOCATION = "newLocation";
+    private static final String ARG_TARGET = "target";
+    private static final String ARG_ROLE = "role";
+    private static final String ARG_PARENTID = "parentId";
+    private static final String ARG_TEXT = "text";
+    private static final String ARG_FROM = "from";
+    private static final String ARG_SUBJECT = "subject";
+    private static final String ARG_SHARED_ITEM_ID = "sharedItemId";
+    private static final String ARG_SHARED_ITEM_NAME = "sharedItemName";
+    private static final String ARG_SHARED_ITEM_VIEW = "sharedItemView";
+    private static final String ARG_SHARE_GRANTEE_ID = "granteeId";
+    private static final String ARG_SHARE_PERMISSIONS = "permissions";
+    private static final String ARG_OLD_FOLDER_ID = "oldFolderId";
+    private static final String ARG_NEW_FOLDER_ID = "newFolderId";
+    private static final String ARG_MESSAGE_READ = "msgRead";  // boolean
+
+    private static final String AUTHUSER = "Authuser";
+    private static final String PUBLIC = "public";
+    private static final String ADMIN = "Admin";
+    private static final String RW = "RW";
+    private static final String READ = "Read";
+
+    public static boolean wantThisChange(PendingModifications.Change change, MailboxOperation op) {
+        if (!EVENTS.contains(op)) {
+            return false;
+        }
+        if (op == MailboxOperation.DeleteItem && change.what instanceof MailItem.Type) {
+            return ITEMTYPES.contains(change.what);
+        }
+        if (!(change.what instanceof MailItem)) {
+            return false;
+        }
+        if (!ITEMTYPES.contains(((MailItem)change.what).getType())) {
+            return false;
+        }
+        if ((change.what instanceof Folder && (change.why & PendingModifications.Change.SIZE) != 0) ||
+            (change.why & PendingModifications.Change.CHILDREN) != 0) {
+            // not interested in change in children, or change in folder size
+            return false;
+        }
+        if (op == MailboxOperation.AlterItemTag &&
+                ((MailItem)change.what).isUnread() == ((MailItem)change.preModifyObj).isUnread()) {
+            // only interested in read state changes
+            return false;
+        }
+        return true;
+    }
+
+    public static Map<String,String> getArgs(MailboxOperation op, MailItem mailitem, MailItem originalitem, ItemIdFormatter ifmt) {
+        HashMap<String,String> args = new HashMap<String,String>();
+        switch (op) {
+        case CreateFolder:
+            args.put(ARG_NAME, mailitem.getName());
+            break;
+        case SaveDocument:
+        case AddDocumentRevision:
+            if (mailitem instanceof Document) {
+                Document doc = (Document) mailitem;
+                args.put(ARG_VER, "" + doc.getVersion());
+            }
+            args.put(ARG_NAME, mailitem.getName());
+            break;
+        case MoveItem:
+            if (originalitem != null) {
+                int originalFolderId = originalitem.getFolderId();
+                try {
+                    Folder f1 = mailitem.getMailbox().getFolderById(null, originalFolderId);
+                    if (f1 != null) {
+                        args.put(ARG_OLDLOCATION, f1.getName());
+                        args.put(ARG_OLD_FOLDER_ID, "" + f1.getId());
+                    }
+                } catch (ServiceException e) {
+                }
+            }
+            try {
+                Folder f2 = mailitem.getMailbox().getFolderById(null, mailitem.getFolderId());
+                if (f2 != null) {
+                    args.put(ARG_NEWLOCATION, f2.getName());
+                    args.put(ARG_NEW_FOLDER_ID, "" + f2.getId());
+                }
+            } catch (ServiceException e) {
+            }
+            args.put(ARG_NAME, mailitem.getName());
+            break;
+        case RenameItem:
+            if (originalitem != null) {
+                args.put(ARG_OLDNAME, originalitem.getName());
+            }
+            args.put(ARG_NAME, mailitem.getName());
+            break;
+        case GrantAccess:
+            if (originalitem != null) {
+                ACL acl = originalitem.getACL();
+                ACL newAcl = mailitem.getACL();
+                for (Grant g : newAcl.getGrants()) {
+                    if (acl == null || !containsGrant(acl, g)) {
+                        getGrantArgs(g, args);
+                    }
+                }
+            }
+            args.put(ARG_NAME, mailitem.getName());
+            break;
+        case RevokeAccess:
+        case ExpireAccess:
+            if (originalitem != null) {
+                ACL acl = originalitem.getACL();
+                ACL newAcl = mailitem.getACL();
+                for (Grant g : acl.getGrants()) {
+                    if (!containsGrant(newAcl, g)) {
+                        getGrantArgs(g, args);
+                    }
+                }
+            }
+            args.put(ARG_NAME, mailitem.getName());
+            break;
+        case CreateComment:
+            try {
+                ItemId parentId = new ItemId(mailitem.getMailbox(), mailitem.getParentId());
+                args.put(ARG_PARENTID, ifmt.formatItemId(parentId));
+                args.put(ARG_TEXT, mailitem.getSubject());
+                MailItem parent = mailitem.getMailbox().getItemById(null, mailitem.getParentId(), MailItem.Type.UNKNOWN);
+                args.put(ARG_NAME, parent.getName());
+            } catch (ServiceException se) {
+                LOG.debug(se.getMessage(), se.getCause());
+            }
+            break;
+        case CreateMessage:
+            if (!(mailitem instanceof Message))
+                break;
+            Message msg = (Message) mailitem;
+            // return the activity stream args only for share notifications.
+            try {
+                for (MPartInfo part : Mime.getParts(msg.getMimeMessage())) {
+                    String ctype = StringUtil.stripControlCharacters(part.getContentType());
+                    if (MimeConstants.CT_XML_ZIMBRA_SHARE.equals(ctype)) {
+                        ShareNotification sn = ShareNotification.fromMimePart(part.getMimePart());
+                        ItemId iid = new ItemId(sn.getGrantorId(), sn.getItemId());
+                        args.put(ARG_SHARED_ITEM_ID, iid.toString());
+                        args.put(ARG_SHARED_ITEM_NAME, sn.getItemName());
+                        args.put(ARG_SHARED_ITEM_VIEW, sn.getView());
+                        args.put(ARG_SHARE_GRANTEE_ID, sn.getGranteeId());
+                        args.put(ARG_SHARE_PERMISSIONS, sn.getPermissions());
+                        args.put(ARG_FROM, msg.getSender());
+                        args.put(ARG_SUBJECT, msg.getSubject());
+                        break;
+                    }
+                }
+            } catch (IOException e) {
+                ZimbraLog.misc.warn("can't parse share notification", e);
+            } catch (MessagingException e) {
+                ZimbraLog.misc.warn("can't parse share notification", e);
+            } catch (ServiceException e) {
+                ZimbraLog.misc.warn("can't parse share notification", e);
+            }
+            break;
+        case Watch:
+        case Unwatch:
+            args.put(ARG_NAME, mailitem.getName());
+            break;
+        case AlterItemTag:
+            args.put(ARG_MESSAGE_READ, "" + !mailitem.isUnread());
+            break;
+        case DeleteItem:
+            if (originalitem != null) {
+                int originalFolderId = originalitem.getFolderId();
+                try {
+                    Folder f1 = mailitem.getMailbox().getFolderById(null, originalFolderId);
+                    if (f1 != null) {
+                        args.put(ARG_OLDLOCATION, f1.getName());
+                        args.put(ARG_OLD_FOLDER_ID, "" + f1.getId());
+                    }
+                } catch (ServiceException e) {
+                }
+            }
+            args.put(ARG_NAME, mailitem.getName());
+            break;
+        }
+        args.put(ARG_TYPE, mailitem.getType().toString());
+        return args;
+    }
+
+    private static void getGrantArgs(Grant g, Map<String,String> args) {
+        String role = READ;
+        if ((g.getGrantedRights() & ACL.RIGHT_ADMIN) > 0)
+            role = ADMIN;
+        else if ((g.getGrantedRights() & ACL.RIGHT_WRITE) > 0)
+            role = RW;
+        Provisioning prov = Provisioning.getInstance();
+        NamedEntry entry = null;
+        try {
+            String granteeId = null;
+            if (g.hasGrantee())
+                granteeId = g.getGranteeId();
+            switch (g.getGranteeType()) {
+            case ACL.GRANTEE_USER:     entry = prov.getAccountById(granteeId); break;
+            case ACL.GRANTEE_COS:      entry = prov.getCosById(granteeId); break;
+            case ACL.GRANTEE_DOMAIN:   entry = prov.getDomainById(granteeId); break;
+            case ACL.GRANTEE_GROUP:    entry = prov.get(DistributionListBy.id, granteeId); break;
+            case ACL.GRANTEE_KEY:      break;
+            case ACL.GRANTEE_GUEST:    args.put(ARG_TARGET, granteeId); break;
+            case ACL.GRANTEE_AUTHUSER: args.put(ARG_TARGET, AUTHUSER); break;
+            case ACL.GRANTEE_PUBLIC:   args.put(ARG_TARGET, PUBLIC); break;
+            }
+        } catch (ServiceException e) {
+        }
+        if (entry != null) {
+            args.put(ARG_TARGET, entry.getName());
+        }
+        args.put(ARG_ROLE, role);
+    }
+
+    public static MailboxOperation guessCreateOperation(MailItem item) {
+        switch (item.getType()) {
+        case DOCUMENT:
+            return MailboxOperation.SaveDocument;
+        case TAG:
+            return MailboxOperation.CreateTag;
+        case MESSAGE:
+            return MailboxOperation.CreateMessage;
+        case APPOINTMENT:
+        case TASK:
+            return MailboxOperation.SetCalendarItem;
+        case FOLDER:
+            return MailboxOperation.CreateFolder;
+        case COMMENT:
+            return MailboxOperation.CreateComment;
+        case MOUNTPOINT:
+            return MailboxOperation.CreateMountpoint;
+        default:
+            return MailboxOperation.SaveDocument;
+        }
+    }
+
+    private static boolean containsGrant(ACL acl, Grant grant) {
+        if (acl == null)
+            return false;
+        if (grant.hasGrantee()) {
+            String principal = grant.getGranteeId();
+            for (Grant g : acl.getGrants()) {
+                if (g.hasGrantee() && g.getGranteeId().equals(principal)) {
+                    if (grant.getGrantedRights() == g.getGrantedRights())
+                        return true;
+                    else
+                        return false;
+                }
+            }
+        } else {
+            byte granteeType = grant.getGranteeType();
+            for (Grant g : acl.getGrants()) {
+                if (g.getGranteeType() == granteeType) {
+                    if (grant.getGrantedRights() == g.getGrantedRights())
+                        return true;
+                    else
+                        return false;
+                }
+            }
+        }
+        return false;
+    }
+
+    private int getFolderId(MailItem item, MailItem preModifyObj, MailboxOperation op) {
+        if (item.getType() == MailItem.Type.COMMENT) {
+            return item.getParentId();
+        } else if (op == MailboxOperation.MoveItem && preModifyObj != null) {
+            return preModifyObj.getFolderId();
+        }
+        return item.getFolderId();
+    }
+
+    private void handleChange(MailItem item, MailboxOperation op, String accountId, long ts, MailItem preModifyObj, String userAgent, Map<String,String> args) {
+        try {
+            ItemEventLog log = logger.getLog(item);
+            /*
+             * We need to normalize the userAgent, otherwise there isn't enough space both in UI and DB to log the raw userAgent
+             * Following are some examples of userAgents, regex used and normalizedUserAgents logged in DB
+             * Octopus ZimbraWebClient - FF4 (Mac)/prototype     --- "(.*)ZimbraWebClient(.*)"  --- Web UI
+             * VMware Octopus (iPad Simulator/iPhone OS/5.1)     --- "(.*)iPad(.*)"             --- ipad
+             * Horizon Data (Mac)                                --- "(.*)\\((.*)\\)$"          --- Mac
+             */
+            String normalizedUserAgent = null;
+            if (userAgent != null) {
+                String[] userAgentRegex = Provisioning.getInstance().getConfig().getClientTypeRegex();
+                for(String regex : userAgentRegex) {
+                    Pattern pattern = Pattern.compile(regex.substring(regex.indexOf(":")+1));
+                    if (pattern.matcher(userAgent).matches()) {
+                        String clientType = regex.substring(0, regex.indexOf(":"));
+
+                        if (StringUtil.equal(clientType, "SyncClient")) {
+                            Matcher m = pattern.matcher(userAgent);
+                            if (m.find()) {
+                                normalizedUserAgent = m.group(2);
+                            }
+                        } else {
+                            normalizedUserAgent = clientType;
+                        }
+                        break;
+                    }
+                }
+                if (normalizedUserAgent == null)
+                    normalizedUserAgent = "Other Client";
+            }
+            log.addEvent(new MailboxEvent(accountId, op, item.getId(), item.getVersion(), getFolderId(item, preModifyObj, op), ts, normalizedUserAgent, args));
+        } catch (ServiceException e) {
+            LOG.error("can't add event", e);
+        }
+    }
+
+    @Override
+    public Set<Type> registerForItemTypes() {
+        return ITEMTYPES;
+    }
+}

--- a/store/src/java/com/zimbra/cs/mailbox/event/EventLogger.java
+++ b/store/src/java/com/zimbra/cs/mailbox/event/EventLogger.java
@@ -1,0 +1,105 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2020 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.mailbox.event;
+
+import java.util.Collection;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.LruMap;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.MailItem;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailbox.Mountpoint;
+import com.zimbra.cs.mailbox.event.MailboxEvent.EventFilter;
+
+public class EventLogger {
+
+    private static EventLogger instance;
+    public synchronized static EventLogger getInstance() {
+        if (instance == null) {
+            instance = new EventLogger();
+        }
+        return instance;
+    }
+
+    public ItemEventLog getLog(MailItem item) throws ServiceException {
+        return new DbEventLog(item);
+    }
+
+    public ItemEventLog getLog(String sessionId) {
+        synchronized (logs) {
+            return logs.get(sessionId);
+        }
+    }
+
+    public ItemEventLog getLog(String accountId, int mailboxId, Collection<Integer> itemIds, EventFilter filter) throws ServiceException {
+        DbEventLog log = null;
+        Mailbox mbox = MailboxManager.getInstance().getMailboxById(mailboxId);
+        log = new DbEventLog(mbox, itemIds, filter);
+        synchronized (logs) {
+            logs.put(log.getId(), log);
+        }
+        return log;
+    }
+
+    public ItemEventLog getLog(String accountId, Mountpoint mp, EventFilter filter) {
+        String owner = mp.getOwnerId();
+        int folderId = mp.getRemoteId();
+        Provisioning prov = Provisioning.getInstance();
+        try {
+            Account authAccount = prov.getAccountById(accountId);
+            Account ownerAccount = prov.getAccountById(owner);
+            return getRemoteItemLog(authAccount, ownerAccount, folderId);
+        } catch (ServiceException se) {
+            // skip this log if it is unavailable (stale mountpoint, etc)
+            return null;
+        }
+    }
+
+    public ItemEventLog getLog(String accountId, String ownerAccountId, Collection<Integer> itemIds, EventFilter filter) throws ServiceException {
+        MergedEventLog log = new MergedEventLog();
+        Provisioning prov = Provisioning.getInstance();
+        Account ownerAccount = prov.getAccountById(ownerAccountId);
+        if (ownerAccount == null) {
+            return log;
+        }
+        if (Provisioning.onLocalServer(ownerAccount)) {
+            Mailbox ownerMbox = MailboxManager.getInstance().getMailboxByAccount(ownerAccount);
+            return getLog(accountId, ownerMbox.getId(), itemIds, filter);
+        }
+        Account authAccount = prov.getAccountById(accountId);
+        if (itemIds.size() == 1) {
+            return getRemoteItemLog(authAccount, ownerAccount, itemIds.iterator().next());
+        }
+        for (int itemId : itemIds) {
+            log.merge(getRemoteItemLog(authAccount, ownerAccount, itemId));
+        }
+        return log;
+    }
+
+    private ItemEventLog getRemoteItemLog(Account authAccount, Account targetAccount, int itemId) throws ServiceException {
+        return new RemoteEventLog(authAccount, targetAccount, itemId);
+    }
+
+    private final LruMap<String,DbEventLog> logs;
+
+    public EventLogger() {
+        logs = new LruMap<String,DbEventLog>(1024);
+    }
+}

--- a/store/src/java/com/zimbra/cs/mailbox/event/ItemEventLog.java
+++ b/store/src/java/com/zimbra/cs/mailbox/event/ItemEventLog.java
@@ -1,0 +1,43 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2021 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.mailbox.event;
+
+import java.util.Collection;
+import java.util.UUID;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.mailbox.MailboxOperation;
+
+public abstract class ItemEventLog {
+
+    public abstract int getEventCount() throws ServiceException;
+    public abstract Collection<MailboxEvent> getEvents(int offset, int count) throws ServiceException;
+    public abstract Collection<MailboxEvent> getEventsBefore(long timestamp, int count) throws ServiceException;
+    public abstract Collection<MailboxOperation> getLoggedOps() throws ServiceException;
+    public abstract Collection<String> getLoggedUsers() throws ServiceException;
+    public abstract void addEvent(MailboxEvent event) throws ServiceException;
+
+    public String getId() {
+        return id;
+    }
+
+    public ItemEventLog() {
+        id = UUID.randomUUID().toString();
+    }
+
+    private String id;
+}

--- a/store/src/java/com/zimbra/cs/mailbox/event/MailboxEvent.java
+++ b/store/src/java/com/zimbra/cs/mailbox/event/MailboxEvent.java
@@ -1,0 +1,157 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2021 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.mailbox.event;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+import com.zimbra.common.util.BEncoding;
+import com.zimbra.common.util.BEncoding.BEncodingException;
+import com.zimbra.cs.mailbox.MailboxOperation;
+import com.zimbra.cs.service.util.ItemId;
+
+public class MailboxEvent implements Comparable<MailboxEvent> {
+
+    public static class EventFilter {
+        public ArrayList<String> ids;
+        public ArrayList<MailboxOperation> ops;
+        public long since;
+        public EventFilter() {
+            ids = new ArrayList<String>();
+            ops = new ArrayList<MailboxOperation>();
+        }
+        public EventFilter(String idsStr, String opsStr) {
+            this();
+            if (idsStr != null) {
+                for (String id : idsStr.split(",")) {
+                    ids.add(id.trim());
+                }
+            }
+            if (opsStr != null) {
+                for (String op : opsStr.split(",")) {
+                    try {
+                        ops.add(MailboxOperation.valueOf(op.trim()));
+                    } catch (IllegalArgumentException e) {
+                        // client is sending invalid op
+                    }
+                }
+            }
+        }
+    }
+
+    private final String accountId;
+    private final MailboxOperation op;
+    private final String userAgent;
+    private String ownerId;
+    private final int itemId;
+    private final int version;
+    private final int folderId;
+    private final long timestamp;
+    private Map<String,String> args;
+
+    public MailboxEvent(String accountId, MailboxOperation op, int itemId, int version, int folderId, long timestamp, String userAgent, String encodedArgs) {
+        this(accountId, op, null, itemId, version, folderId, timestamp, userAgent, encodedArgs);
+    }
+
+    public MailboxEvent(String accountId, MailboxOperation op, String ownerId, int itemId, int version, int folderId, long timestamp, String userAgent, String encodedArgs) {
+        this.accountId = accountId;
+        this.op = op;
+        this.ownerId = ownerId;
+        this.itemId = itemId;
+        this.version = version;
+        this.folderId = folderId;
+        this.timestamp = timestamp;
+        this.userAgent = userAgent;
+        try {
+            this.args = BEncoding.decode(encodedArgs);
+        } catch (BEncodingException e) {
+        }
+    }
+    public MailboxEvent(String accountId, MailboxOperation op, int itemId, int version, int folderId, long timestamp, String userAgent, Map<String,String> args) {
+        this.accountId = accountId;
+        this.op = op;
+        this.itemId = itemId;
+        this.version = version;
+        this.folderId = folderId;
+        this.timestamp = timestamp;
+        this.userAgent = userAgent;
+        this.args = args;
+    }
+
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public String getUserAgent() {
+        return userAgent;
+    }
+
+    public MailboxOperation getOperation() {
+        return op;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public ItemId getItemId() {
+        return new ItemId(ownerId, itemId);
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public int getFolderId() {
+        return folderId;
+    }
+
+    public Map<String,String> getArgs() {
+        return args;
+    }
+
+    public String getArgString() {
+        return BEncoding.encode(args);
+    }
+
+    @Override
+    public String toString() {
+        ToStringBuilder sb =  new ToStringBuilder(this)
+                .append(accountId)
+                .append(op)
+                .append(itemId)
+                .append(userAgent);
+        if (args != null)
+            sb.append(args);
+        sb.append(timestamp);
+        return sb.toString();
+    }
+
+    @Override
+    public int compareTo(MailboxEvent that) {
+        // sort descending order from latest to oldest
+        int diff = (int)(that.timestamp - this.timestamp);
+        if (diff != 0) {
+            return diff;
+        } else if (this.itemId != that.itemId) {
+            return that.itemId - this.itemId;
+        }
+        return toString().compareTo(that.toString());
+    }
+}

--- a/store/src/java/com/zimbra/cs/mailbox/event/MergedEventLog.java
+++ b/store/src/java/com/zimbra/cs/mailbox/event/MergedEventLog.java
@@ -1,0 +1,158 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2021 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.mailbox.event;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.TreeSet;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.mailbox.MailboxOperation;
+
+public class MergedEventLog extends ItemEventLog {
+
+    private static final int chunkSize = 100;
+    private final HashSet<ItemEventLog> logs;
+    private final ArrayList<MailboxEvent> mergedEvents;
+
+    @Override
+    public int getEventCount() throws ServiceException {
+        int count = 0;
+        for (ItemEventLog log : logs) {
+            count += log.getEventCount();
+        }
+        return count;
+    }
+
+    @Override
+    public Collection<MailboxEvent> getEvents(int offset, int count) throws ServiceException {
+        ArrayList<MailboxEvent> ret = new ArrayList<MailboxEvent>();
+        int chunk = chunkSize;
+        if (mergedEvents.size() == 0) {
+            if (chunk < offset + count) {
+                chunk = offset + count;
+            }
+            fetchInitialEvents(chunk);
+        }
+
+        if (mergedEvents.size() == 0) {
+            return ret;
+        }
+        int end = offset + count;
+        if (end < mergedEvents.size()) {
+            // we already have the data in mergedEvents
+            for (int i = 0; i < count; i++) {
+                ret.add(mergedEvents.get(offset + i));
+            }
+        } else {
+            // we need to fill mergedEvents
+            if (end - mergedEvents.size() > chunk) {
+                chunk = end - mergedEvents.size();
+            }
+            fetchNextEvents(chunk);
+            if (mergedEvents.size() < offset + count) {
+                count = mergedEvents.size() - offset;
+            }
+            for (int i = 0; i < count; i++) {
+                ret.add(mergedEvents.get(offset + i));
+            }
+        }
+        return ret;
+    }
+
+    @Override
+    public Collection<MailboxEvent> getEventsBefore(long timestamp, int count)
+            throws ServiceException {
+        ArrayList<MailboxEvent> ret = new ArrayList<MailboxEvent>();
+        Iterator<MailboxEvent> iter = fetchEventsBefore(timestamp, count).iterator();
+        while (iter.hasNext()) {
+            ret.add(iter.next());
+        }
+        return ret;
+    }
+
+    @Override
+    public Collection<MailboxOperation> getLoggedOps() throws ServiceException {
+        HashSet<MailboxOperation> ops = new HashSet<MailboxOperation>();
+        for (ItemEventLog log : logs) {
+            ops.addAll(log.getLoggedOps());
+        }
+        return ops;
+    }
+
+    @Override
+    public Collection<String> getLoggedUsers() throws ServiceException {
+        HashSet<String> users = new HashSet<String>();
+        for (ItemEventLog log : logs) {
+            users.addAll(log.getLoggedUsers());
+        }
+        return users;
+    }
+
+    @Override
+    public void addEvent(MailboxEvent event) throws ServiceException {
+        throw ServiceException.UNSUPPORTED();
+    }
+
+    public void merge(ItemEventLog log) throws ServiceException {
+        logs.add(log);
+        mergedEvents.clear();
+    }
+
+    private void fetchInitialEvents(int count) throws ServiceException {
+        // fetch the events from each logs, sort, then trim
+        TreeSet<MailboxEvent> sortedEvents = new TreeSet<MailboxEvent>();
+        for (ItemEventLog log : logs) {
+            sortedEvents.addAll(log.getEvents(0, count));
+        }
+        Iterator<MailboxEvent> iter = sortedEvents.iterator();
+        for (int i = 0; i < count && iter.hasNext(); i++) {
+            mergedEvents.add(iter.next());
+        }
+    }
+
+    private void fetchNextEvents(int count) throws ServiceException {
+        // fetch the next set of events from each logs
+        long ts = mergedEvents.get(mergedEvents.size() - 1).getTimestamp();
+        Iterator<MailboxEvent> iter = fetchEventsBefore(ts, count).iterator();
+        for (int i = 0; i < count && iter.hasNext(); i++) {
+            mergedEvents.add(iter.next());
+        }
+    }
+
+    private Collection<MailboxEvent> fetchEventsBefore(long ts, int count) throws ServiceException {
+        TreeSet<MailboxEvent> sortedEvents = new TreeSet<MailboxEvent>();
+        for (ItemEventLog log : logs) {
+            sortedEvents.addAll(log.getEventsBefore(ts, count));
+        }
+        if (sortedEvents.size() > count) {
+            Iterator<MailboxEvent> iter = sortedEvents.iterator();
+            for (int i = 0; i < count; i++) {
+                iter.next();
+            }
+            return sortedEvents.headSet(iter.next());
+        }
+        return sortedEvents;
+    }
+
+    public MergedEventLog() {
+        logs = new HashSet<ItemEventLog>();
+        mergedEvents = new ArrayList<MailboxEvent>();
+    }
+}

--- a/store/src/java/com/zimbra/cs/mailbox/event/NewNotifications.java
+++ b/store/src/java/com/zimbra/cs/mailbox/event/NewNotifications.java
@@ -1,0 +1,136 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2021 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.mailbox.event;
+
+import java.util.Collections;
+
+import com.google.common.collect.Multimap;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.OctopusXmlConstants;
+import com.zimbra.common.util.Log;
+import com.zimbra.common.util.LogFactory;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailbox.MailboxOperation;
+import com.zimbra.cs.mailbox.Metadata;
+import com.zimbra.cs.mailbox.OperationContext;
+import com.zimbra.cs.mailbox.cache.WatchCache;
+import com.zimbra.cs.mailbox.event.MailboxEvent.EventFilter;
+import com.zimbra.cs.service.account.GetInfo.GetInfoExt;
+import com.zimbra.soap.ZimbraSoapContext;
+
+public class NewNotifications {
+
+    private static Log LOG = LogFactory.getLog(NewNotifications.class);
+    private static final String CONFIG_KEY = "notifications";
+    private static final String LAST_SEEN = "lastSeen";
+
+    private final Mailbox mbox;
+    private final OperationContext octxt;
+
+    public static class GetInfoExtension implements GetInfoExt {
+        @Override
+        public void handle(ZimbraSoapContext zsc, Element getInfoResponse) {
+            try {
+                Provisioning prov = Provisioning.getInstance();
+                Account authAccount = prov.getAccountById(zsc.getAuthtokenAccountId());
+                Account targetAccount = prov.getAccountById(zsc.getRequestedAccountId());
+                NewNotifications notif = new NewNotifications(authAccount, targetAccount);
+                int count = notif.getNewNotificationCount();
+                getInfoResponse.addUniqueElement(OctopusXmlConstants.E_NOTIFICATIONS).setText("" + count);
+            } catch (ServiceException e) {
+                LOG.warn("can't add to GetInfo", e);
+            }
+        }
+    }
+
+    public NewNotifications(Account authAccount, Account targetAccount) throws ServiceException {
+        octxt = new OperationContext(authAccount);
+        mbox = MailboxManager.getInstance().getMailboxByAccount(targetAccount);
+    }
+
+    /**
+     * Updates lastSeen time stamp to now.
+     *
+     * @throws ServiceException
+     */
+    public void markSeen() throws ServiceException {
+        Metadata config = mbox.getConfig(octxt, CONFIG_KEY);
+        if (config == null) {
+            config = new Metadata();
+        }
+        config.put(LAST_SEEN, System.currentTimeMillis() / 1000);  // store second since epoch
+        mbox.setConfig(octxt, CONFIG_KEY, config);
+    }
+
+    /**
+     * Returns the time stamp of last time the notifications were seen by the user.
+     *
+     * @return seconds since epoch
+     * @throws ServiceException
+     */
+    public long getLastSeen() throws ServiceException {
+        Metadata config = mbox.getConfig(octxt, CONFIG_KEY);
+        if (config == null) {
+            config = new Metadata();
+        }
+        return config.getLong(LAST_SEEN, 0);
+    }
+
+    /**
+     * Returns the number of new notifications since last seen.
+     *
+     * @return number of unseen notifications
+     * @throws ServiceException
+     */
+    public int getNewNotificationCount() throws ServiceException {
+        return getLog().getEventCount();
+    }
+
+    /**
+     * Returns the event log containing new notifications
+     * the user has received since last seen.
+     *
+     * @return event log containing notifications
+     * @throws ServiceException
+     */
+    public ItemEventLog getLog() throws ServiceException {
+        long lastSeen = getLastSeen();
+        EventFilter filter = new EventFilter();
+        filter.ops.add(MailboxOperation.CreateMessage);
+        filter.since = lastSeen;
+        EventLogger logger = EventLogger.getInstance();
+
+        // events for share notifications
+        ItemEventLog shareEvents = logger.getLog(octxt.getAuthenticatedUser().getId(), mbox.getId(), Collections.singletonList(Mailbox.ID_FOLDER_INBOX), filter);
+
+        MergedEventLog log = new MergedEventLog();
+        log.merge(shareEvents);
+
+        // events for watched items
+        filter.ops.clear();
+        Multimap<String,Integer> watchCache = WatchCache.get(octxt).getMap();
+        for (String ownerAccountId : watchCache.keySet()) {
+            ItemEventLog watchLog = logger.getLog(octxt.getAuthenticatedUser().getId(), ownerAccountId, watchCache.get(ownerAccountId), filter);
+            log.merge(watchLog);
+        }
+        return log;
+    }
+}

--- a/store/src/java/com/zimbra/cs/mailbox/event/RemoteEventLog.java
+++ b/store/src/java/com/zimbra/cs/mailbox/event/RemoteEventLog.java
@@ -1,0 +1,205 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2021 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.mailbox.event;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.Element.XMLElement;
+import com.zimbra.common.soap.MailConstants;
+import com.zimbra.common.soap.OctopusXmlConstants;
+import com.zimbra.common.soap.SoapHttpTransport;
+import com.zimbra.common.soap.SoapProtocol;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.ZimbraAuthToken;
+import com.zimbra.cs.httpclient.URLUtil;
+import com.zimbra.cs.mailbox.MailboxOperation;
+import com.zimbra.cs.service.util.ItemId;
+import com.zimbra.soap.JaxbUtil;
+import com.zimbra.soap.mail.message.GetActivityStreamResponse;
+import com.zimbra.soap.mail.type.ActivityInfo;
+import com.zimbra.soap.mail.type.IdEmailName;
+import com.zimbra.soap.type.NamedElement;
+import com.zimbra.soap.type.NamedValue;
+
+public class RemoteEventLog extends ItemEventLog {
+
+    private static final int batchSize = 100;
+
+    private final int itemId;
+    private final Account authAccount;
+    private final Account targetAccount;
+    private final HashSet<MailboxOperation> operations;
+    private final HashMap<String,String> users;
+    private final ArrayList<MailboxEvent> activities;
+
+    private int total;
+    private String sessionId;
+    private ZimbraAuthToken authToken;
+
+    @Override
+    public int getEventCount() throws ServiceException {
+        return total;
+    }
+
+    @Override
+    public Collection<MailboxEvent> getEvents(int offset, int count)
+            throws ServiceException {
+        while (activities.size() < offset + count) {
+            int num = load();
+            if (num == 0) {
+                break;
+            }
+        }
+        if (offset > activities.size()) {
+            return Collections.emptyList();
+        }
+        int limit = offset + count;
+        if (limit > activities.size()) {
+            limit = activities.size();
+        }
+        return activities.subList(offset, limit);
+    }
+
+    @Override
+    public Collection<MailboxEvent> getEventsBefore(long timestamp, int count)
+            throws ServiceException {
+        int end = activities.size() - 1;
+        // check if we need to load additional events
+        while (count < end && activities.get(end).getTimestamp() >= timestamp) {
+            int num = load();
+            if (num == 0) {
+                break;
+            }
+        }
+        int start = 0;
+        int mid = (end - start) / 2;
+        while (activities.get(mid).getTimestamp() != timestamp) {
+            if (activities.get(mid).getTimestamp() > timestamp) {
+                start = mid;
+            } else {
+                end = mid;
+            }
+            if ((end - start) < 3) {
+                mid = start;
+                break;
+            }
+            mid = start + (end - start) / 2;
+        }
+        // roll forward to the first item with timestamp - 1 or less
+        while (mid < end && activities.get(mid).getTimestamp() >= timestamp) {
+            mid++;
+        }
+        int limit = mid + count;
+        if (limit > activities.size()) {
+            limit = activities.size();
+        }
+        return activities.subList(mid, limit);
+    }
+
+    @Override
+    public Collection<MailboxOperation> getLoggedOps() throws ServiceException {
+        return operations;
+    }
+
+    @Override
+    public Collection<String> getLoggedUsers() throws ServiceException {
+        return users.values();
+    }
+
+    @Override
+    public void addEvent(MailboxEvent event) throws ServiceException {
+        throw ServiceException.UNSUPPORTED();
+    }
+
+    public RemoteEventLog(Account authAccount, Account targetAccount, int itemId) throws ServiceException {
+        this.authAccount = authAccount;
+        this.targetAccount = targetAccount;
+        this.itemId = itemId;
+        operations = new HashSet<MailboxOperation>();
+        users = new HashMap<String,String>();
+        activities = new ArrayList<MailboxEvent>();
+        load();
+    }
+
+    private synchronized int load() throws ServiceException {
+        int offset = activities.size();
+        SoapHttpTransport transport = null;
+        try {
+            if (authToken == null) {
+                authToken = new ZimbraAuthToken(authAccount);
+            }
+            String url = URLUtil.getSoapURL(targetAccount.getServer(), true);
+            transport = new SoapHttpTransport(url);
+            transport.setTargetAcctId(targetAccount.getId());
+            transport.setAuthToken(authToken.toZAuthToken());
+            transport.setTimeout(10000);
+            transport.setResponseProtocol(SoapProtocol.Soap12);
+            XMLElement req = new XMLElement(OctopusXmlConstants.GET_ACTIVITY_STREAM_REQUEST);
+            req.addAttribute(MailConstants.A_ID, itemId);
+            req.addAttribute(MailConstants.A_QUERY_OFFSET, offset);
+            req.addAttribute(MailConstants.A_QUERY_LIMIT, batchSize);
+            if (sessionId != null) {
+                Element filter = req.addElement(MailConstants.E_FILTER);
+                filter.addAttribute(MailConstants.A_SESSION, sessionId);
+            }
+            GetActivityStreamResponse resp = JaxbUtil.elementToJaxb(transport.invokeWithoutSession(req));
+            sessionId = resp.getSession();
+            total = Integer.parseInt(resp.getCount());
+            for (NamedElement op : resp.getOperations()) {
+                operations.add(MailboxOperation.valueOf(op.getName()));
+            }
+            for (IdEmailName user : resp.getUsers()) {
+                users.put(user.getEmail(), user.getId());
+            }
+            for (ActivityInfo activity : resp.getActivities()) {
+                ItemId iid = new ItemId(activity.getItemId(), targetAccount.getId());
+                HashMap<String,String> arg = new HashMap<String,String>();
+                for (NamedValue nv : activity.getArgs()) {
+                    arg.put(nv.getName(), nv.getValue());
+                }
+                MailboxOperation op = MailboxOperation.valueOf(activity.getOperation());
+                String accountId = users.get(activity.getEmail());
+                int version = activity.getVersion() == null ? 0 : activity.getVersion();
+                activities.add(
+                    new MailboxEvent(
+                        accountId,
+                        op,
+                        iid.getId(),
+                        version,
+                        0, // folderId
+                        activity.getTimeStamp(),
+                        null, // user agent
+                        arg // arg
+                        )
+                    );
+            }
+            return resp.getActivities().size();
+        } catch (IOException e) {
+            throw ServiceException.PROXY_ERROR(e, targetAccount.getName());
+        } finally {
+            if (transport != null)
+                transport.shutdown();
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/service/SharedFileServlet.java
+++ b/store/src/java/com/zimbra/cs/service/SharedFileServlet.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2020 Synacor, Inc.
+ * Copyright (C) 2021 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,

--- a/store/src/java/com/zimbra/cs/service/UserServlet.java
+++ b/store/src/java/com/zimbra/cs/service/UserServlet.java
@@ -1,18 +1,18 @@
 /*
- * ***** BEGIN LICENSE BLOCK *****
- * Zimbra Collaboration Suite Server
- * Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016 Synacor, Inc.
+ * ***** BEGIN LICENSE BLOCK ***** Zimbra Collaboration Suite Server Copyright
+ * (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016
+ * Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software Foundation,
- * version 2 of the License.
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 2 of the License.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU General Public License for more details.
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <https://www.gnu.org/licenses/>.
- * ***** END LICENSE BLOCK *****
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>. *****
+ * END LICENSE BLOCK *****
  */
 
 package com.zimbra.cs.service;
@@ -145,7 +145,8 @@ public class UserServlet extends ZimbraServlet {
 
     public static final String QP_FMT = "fmt"; // format query param
 
-    public static final String QP_NOHIERARCHY = "nohierarchy"; // nohierarchy query param
+    public static final String QP_NOHIERARCHY = "nohierarchy"; // nohierarchy
+                                                               // query param
 
     public static final String QP_ZLV = "zlv"; // zip level query param
 
@@ -158,19 +159,21 @@ public class UserServlet extends ZimbraServlet {
     public static final String QP_PART = "part"; // part query param
 
     /**
-     * Body query param.  Also used by {@link ZipFormatter} and {@link TarFormatter} to specify whether
-     * the entire message should be returned (<tt>body=1</tt>), or just the headers (<tt>body=0</tt>).
-     * The default is <tt>1</tt>.
+     * Body query param. Also used by {@link ZipFormatter} and
+     * {@link TarFormatter} to specify whether the entire message should be
+     * returned (<tt>body=1</tt>), or just the headers (<tt>body=0</tt>). The
+     * default is <tt>1</tt>.
      */
     public static final String QP_BODY = "body"; // body query param
 
     public static final String BODY_TEXT = "text"; // return text body
 
-    public static final String BODY_HTML = "html"; // return html body if possible
+    public static final String BODY_HTML = "html"; // return html body if
+                                                   // possible
 
     public static final String QP_QUERY = "query"; // query query param
 
-    public static final String QP_SORT = "sort"; //sort query param
+    public static final String QP_SORT = "sort"; // sort query param
 
     public static final String QP_VIEW = "view"; // view query param
 
@@ -180,11 +183,21 @@ public class UserServlet extends ZimbraServlet {
 
     public static final String QP_END = "end"; // end time
 
-    public static final String QP_FREEBUSY_CALENDAR = "fbcal";  // calendar folder to run free/busy search on
+    public static final String QP_FREEBUSY_CALENDAR = "fbcal"; // calendar
+                                                               // folder to run
+                                                               // free/busy
+                                                               // search on
 
-    public static final String QP_IGNORE_ERROR = "ignore";  // ignore and continue on error during ics import
+    public static final String QP_IGNORE_ERROR = "ignore"; // ignore and
+                                                           // continue on error
+                                                           // during ics import
 
-    public static final String QP_PRESERVE_ALARMS = "preserveAlarms";  // preserve existing alarms during ics import
+    public static final String QP_PRESERVE_ALARMS = "preserveAlarms"; // preserve
+                                                                      // existing
+                                                                      // alarms
+                                                                      // during
+                                                                      // ics
+                                                                      // import
 
     public static final String QP_OFFSET = "offset"; // offset into results
 
@@ -192,19 +205,26 @@ public class UserServlet extends ZimbraServlet {
 
     public static final String QP_AUTH = "auth"; // auth types
 
-    public static final String QP_DISP = "disp"; // disposition (a = attachment, i = inline)
+    public static final String QP_DISP = "disp"; // disposition (a = attachment,
+                                                 // i = inline)
 
-    public static final String QP_NAME = "name"; // filename/path segments, added to pathInfo
+    public static final String QP_NAME = "name"; // filename/path segments,
+                                                 // added to pathInfo
 
-    public static final String QP_CSVFORMAT = "csvfmt"; // csv type (outlook-2003-csv, yahoo-csv, ...)
+    public static final String QP_CSVFORMAT = "csvfmt"; // csv type
+                                                        // (outlook-2003-csv,
+                                                        // yahoo-csv, ...)
 
-    public static final String QP_CSVLOCALE = "csvlocale"; // refining locale for csvfmt - e.g. zh-CN
+    public static final String QP_CSVLOCALE = "csvlocale"; // refining locale
+                                                           // for csvfmt - e.g.
+                                                           // zh-CN
 
     public static final String QP_CSVSEPARATOR = "csvsep"; // separator
 
-    public static final String QP_VERSION = "ver";  // version for WikiItem and Document
+    public static final String QP_VERSION = "ver"; // version for WikiItem and
+                                                   // Document
 
-    public static final String QP_HISTORY = "history";  // history for WikiItem
+    public static final String QP_HISTORY = "history"; // history for WikiItem
 
     public static final String QP_LANGUAGE = "language"; // all three
 
@@ -214,26 +234,32 @@ public class UserServlet extends ZimbraServlet {
 
     public static final String UPLOAD_NAME = "uploadName"; // upload filename
 
-    public static final String UPLOAD_TYPE = "uploadType"; // upload content type
+    public static final String UPLOAD_TYPE = "uploadType"; // upload content
+                                                           // type
 
-    public static final String QP_FBFORMAT = "fbfmt"; // free/busy format - "fb" (default) or "event"
+    public static final String QP_FBFORMAT = "fbfmt"; // free/busy format - "fb"
+                                                      // (default) or "event"
 
     /**
      * Used by {@link OctopusPatchFormatter}
      */
-    public static final String QP_MANIFEST = "manifest"; // selects whether server returns patch manifest or not
+    public static final String QP_MANIFEST = "manifest"; // selects whether
+                                                         // server returns patch
+                                                         // manifest or not
 
-    public static final String QP_DUMPSTER = "dumpster"; // whether search in dumpster
+    public static final String QP_DUMPSTER = "dumpster"; // whether search in
+                                                         // dumpster
 
     /**
-     * Used by {@link TarFormatter} to specify whether the <tt>.meta</tt>
-     * files should be added to the tarball (<tt>meta=1</tt>) or not (<tt>meta=0</tt>).
-     * The default is <tt>1</tt>.
+     * Used by {@link TarFormatter} to specify whether the <tt>.meta</tt> files
+     * should be added to the tarball (<tt>meta=1</tt>) or not
+     * (<tt>meta=0</tt>). The default is <tt>1</tt>.
      */
     public static final String QP_META = "meta";
 
     /**
-     * Used by {@link IfbFormatter} to specify the UID of calendar item to exclude when computing free/busy.
+     * Used by {@link IfbFormatter} to specify the UID of calendar item to
+     * exclude when computing free/busy.
      */
     public static final String QP_EXUID = "exuid";
 
@@ -243,13 +269,17 @@ public class UserServlet extends ZimbraServlet {
 
     public static final String AUTH_QUERYPARAM = "qp"; // query parameter
 
-    public static final String AUTH_NO_SET_COOKIE = "nsc"; // don't set auth token cookie after basic auth
-                                                           // same as ba after bug 42782
+    public static final String AUTH_NO_SET_COOKIE = "nsc"; // don't set auth
+                                                           // token cookie after
+                                                           // basic auth
+                                                           // same as ba after
+                                                           // bug 42782
 
     public static final String AUTH_JWT = "jwt"; // auth by jwt
 
     // see https://bugzilla.zimbra.com/show_bug.cgi?id=42782#c11
-    public static final String AUTH_SET_COOKIE = "sc"; // set auth token cookie after basic auth
+    public static final String AUTH_SET_COOKIE = "sc"; // set auth token cookie
+                                                       // after basic auth
 
     public static final String AUTH_DEFAULT = "co,jwt,nsc,qp"; // all four
 
@@ -303,23 +333,24 @@ public class UserServlet extends ZimbraServlet {
         return FormatterFactory.mFormatters.get(type);
     }
 
-    private void sendError(UserServletContext ctxt, HttpServletRequest req, HttpServletResponse resp, String message) throws IOException {
-        if(resp.isCommitted()) {
+    private void sendError(UserServletContext ctxt, HttpServletRequest req, HttpServletResponse resp, String message)
+            throws IOException {
+        if (resp.isCommitted()) {
             log.info("Response already committed. Skipping sending error code for response");
             return;
         }
-        if (ctxt != null &&!ctxt.cookieAuthHappened && ctxt.basicAuthAllowed() && !ctxt.basicAuthHappened) {
+        if (ctxt != null && !ctxt.cookieAuthHappened && ctxt.basicAuthAllowed() && !ctxt.basicAuthHappened) {
             resp.addHeader(AuthUtil.WWW_AUTHENTICATE_HEADER, getRealmHeader(req, null));
             resp.sendError(HttpServletResponse.SC_UNAUTHORIZED, L10nUtil.getMessage(MsgKey.errMustAuthenticate, req));
         } else if (ctxt != null && ctxt.cookieAuthHappened && !ctxt.isCsrfAuthSucceeded()
-            && (req.getMethod().equalsIgnoreCase("POST") || req.getMethod().equalsIgnoreCase("PUT"))) {
+                && (req.getMethod().equalsIgnoreCase("POST") || req.getMethod().equalsIgnoreCase("PUT"))) {
             resp.sendError(HttpServletResponse.SC_UNAUTHORIZED, L10nUtil.getMessage(MsgKey.errMustAuthenticate, req));
-        } else if (ctxt != null && ctxt.getAuthAccount() instanceof GuestAccount && ctxt.basicAuthAllowed() ) {
+        } else if (ctxt != null && ctxt.getAuthAccount() instanceof GuestAccount && ctxt.basicAuthAllowed()) {
             resp.addHeader(AuthUtil.WWW_AUTHENTICATE_HEADER, getRealmHeader(req, null));
-                resp.sendError(HttpServletResponse.SC_UNAUTHORIZED, L10nUtil.getMessage(MsgKey.errMustAuthenticate, req));
-         } else {
-                resp.sendError(HttpServletResponse.SC_NOT_FOUND, message);
-         }
+            resp.sendError(HttpServletResponse.SC_UNAUTHORIZED, L10nUtil.getMessage(MsgKey.errMustAuthenticate, req));
+        } else {
+            resp.sendError(HttpServletResponse.SC_NOT_FOUND, message);
+        }
     }
 
     protected UserServletContext createContext(HttpServletRequest req, HttpServletResponse resp, UserServlet servlet)
@@ -345,7 +376,8 @@ public class UserServlet extends ZimbraServlet {
                 return;
             }
             // at this point context.authAccount is set either from the Cookie,
-            // or from basic auth.  if there was no credential in either the Cookie
+            // or from basic auth. if there was no credential in either the
+            // Cookie
             // or basic auth, authAccount is set to anonymous account.
             if (context.getAuthAccount() != null) {
                 ZimbraLog.addAccountNameToContext(context.getAuthAccount().getName());
@@ -354,11 +386,10 @@ public class UserServlet extends ZimbraServlet {
             doAuthGet(req, resp, context);
 
         } catch (ServiceException se) {
-            if (se.getCode() == ServiceException.PERM_DENIED ||
-                se instanceof NoSuchItemException)
+            if (se.getCode() == ServiceException.PERM_DENIED || se instanceof NoSuchItemException)
                 sendError(context, req, resp, L10nUtil.getMessage(MsgKey.errNoSuchItem, req));
-            else if (se.getCode() == AccountServiceException.MAINTENANCE_MODE ||
-                     se.getCode() == AccountServiceException.ACCOUNT_INACTIVE)
+            else if (se.getCode() == AccountServiceException.MAINTENANCE_MODE
+                    || se.getCode() == AccountServiceException.ACCOUNT_INACTIVE)
                 sendError(context, req, resp, se.getMessage());
             else
                 throw new ServletException(se);
@@ -371,7 +402,7 @@ public class UserServlet extends ZimbraServlet {
     }
 
     private boolean checkAuthentication(UserServletContext context)
-        throws IOException, ServletException, UserServletException {
+            throws IOException, ServletException, UserServletException {
 
         // if they specify /~/, we must auth
         if (context.targetAccount == null && context.accountPath != null && context.accountPath.equals("~")) {
@@ -382,7 +413,8 @@ public class UserServlet extends ZimbraServlet {
             context.targetAccount = context.getAuthAccount();
         }
 
-        // need this before proxy if we want to support sending cookie from a basic-auth
+        // need this before proxy if we want to support sending cookie from a
+        // basic-auth
         UserServletUtil.getAccount(context);
         if (context.getAuthAccount() == null) {
             context.setAnonymousRequest();
@@ -399,9 +431,9 @@ public class UserServlet extends ZimbraServlet {
                 throw AccountServiceException.MAINTENANCE_MODE();
 
             // allow only admin access if the account is not active
-            if (!Provisioning.ACCOUNT_STATUS_ACTIVE.equals(acctStatus) && !(context.authToken != null &&
-                    (context.authToken.isDelegatedAuth() ||
-                            AdminAccessControl.isAdequateAdminAccount(context.getAuthAccount())))) {
+            if (!Provisioning.ACCOUNT_STATUS_ACTIVE.equals(acctStatus)
+                    && !(context.authToken != null && (context.authToken.isDelegatedAuth()
+                            || AdminAccessControl.isAdequateAdminAccount(context.getAuthAccount())))) {
                 throw AccountServiceException.ACCOUNT_INACTIVE(context.targetAccount.getName());
             }
         }
@@ -418,14 +450,15 @@ public class UserServlet extends ZimbraServlet {
         }
     }
 
-    protected boolean proxyIfRemoteTargetAccount(HttpServletRequest req, HttpServletResponse resp, UserServletContext context)
-            throws IOException, ServiceException {
+    protected boolean proxyIfRemoteTargetAccount(HttpServletRequest req, HttpServletResponse resp,
+            UserServletContext context) throws IOException, ServiceException {
         // this should handle both explicit /user/user-on-other-server/ and
         // /user/~/?id={account-id-on-other-server}:id
 
         if (context.targetAccount != null && !Provisioning.onLocalServer(context.targetAccount)) {
             try {
-                proxyServletRequest(req, resp, Provisioning.getInstance().getServer(context.targetAccount), getProxyAuthToken(context));
+                proxyServletRequest(req, resp, Provisioning.getInstance().getServer(context.targetAccount),
+                        getProxyAuthToken(context));
             } catch (HttpException e) {
                 throw new IOException("Unknown error", e);
             }
@@ -436,17 +469,21 @@ public class UserServlet extends ZimbraServlet {
     }
 
     /**
-     * Constructs the exteral url for a mount point. This gets the link back to the correct server without need for proxying it
+     * Constructs the exteral url for a mount point. This gets the link back to
+     * the correct server without need for proxying it
+     * 
      * @param authToken
-     * @param mpt The mount point to create the url for
-     * @return The url for the mountpoint/share that goes back to the original user/share/server
+     * @param mpt
+     *            The mount point to create the url for
+     * @return The url for the mountpoint/share that goes back to the original
+     *         user/share/server
      * @throws ServiceException
      */
     public static String getExternalRestUrl(OperationContext octxt, Mountpoint mpt) throws ServiceException {
         AuthToken authToken = AuthToken.getCsrfUnsecuredAuthToken(octxt.getAuthToken());
         // check to see if it is a local mount point, if it is there's
         // no need to do anything
-        if(mpt.isLocal()) {
+        if (mpt.isLocal()) {
             return null;
         }
 
@@ -462,50 +499,56 @@ public class UserServlet extends ZimbraServlet {
         }
         Server targetServer = prov.getServer(targetAccount);
 
-
         // Avoid the soap call if its a local mailbox
         if (Provisioning.onLocalServer(targetAccount)) {
             Mailbox mailbox = MailboxManager.getInstance().getMailboxByAccountId(targetAccount.getId());
-            if(mailbox == null){
+            if (mailbox == null) {
                 // no mailbox (shouldn't happen normally)
                 return null;
             }
             // Get the folder from the mailbox
             Folder folder = mailbox.getFolderById(octxt, mpt.getRemoteId());
-            if(folder == null) {
+            if (folder == null) {
                 return null;
             }
             folderPath = folder.getPath();
         } else {
             // The remote server case
             // Get the target user's mailbox..
-            ZMailbox.Options zoptions = new ZMailbox.Options(authToken.toZAuthToken(), AccountUtil.getSoapUri(targetAccount));
+            ZMailbox.Options zoptions = new ZMailbox.Options(authToken.toZAuthToken(),
+                    AccountUtil.getSoapUri(targetAccount));
             zoptions.setTargetAccount(mpt.getOwnerId());
             zoptions.setTargetAccountBy(AccountBy.id);
             zoptions.setNoSession(true);
             ZMailbox zmbx = ZMailbox.getMailbox(zoptions);
-            if(zmbx == null) {
+            if (zmbx == null) {
                 // we didn't manage to get a mailbox
                 return null;
             }
 
-            // Get an instance of their folder so we can build the path correctly
-             ZFolder folder = zmbx.getFolderById(mpt.getTarget().toString(authToken.getAccount().getId()));
+            // Get an instance of their folder so we can build the path
+            // correctly
+            ZFolder folder = zmbx.getFolderById(mpt.getTarget().toString(authToken.getAccount().getId()));
             // if for some reason we can't find the folder, return null
-            if(folder == null){
+            if (folder == null) {
                 return null;
             }
             folderPath = folder.getPath();
         }
         // For now we'll always use SSL
-        return URLUtil.getServiceURL(targetServer, SERVLET_PATH + HttpUtil.urlEscape(getAccountPath(targetAccount) +folderPath) , true);
+        return URLUtil.getServiceURL(targetServer,
+                SERVLET_PATH + HttpUtil.urlEscape(getAccountPath(targetAccount) + folderPath), true);
     }
 
     /**
-     * Constructs the exteral url for a mount point. This gets the link back to the correct server without need for proxying it
+     * Constructs the exteral url for a mount point. This gets the link back to
+     * the correct server without need for proxying it
+     * 
      * @param authToken
-     * @param mpt The mount point to create the url for
-     * @return The url for the mountpoint/share that goes back to the original user/share/server
+     * @param mpt
+     *            The mount point to create the url for
+     * @return The url for the mountpoint/share that goes back to the original
+     *         user/share/server
      * @throws ServiceException
      */
     public static String getExternalRestUrl(Folder folder) throws ServiceException {
@@ -517,7 +560,8 @@ public class UserServlet extends ZimbraServlet {
         Server targetServer = prov.getServer(targetAccount);
 
         // For now we'll always use SSL
-        return URLUtil.getServiceURL(targetServer, SERVLET_PATH + HttpUtil.urlEscape(getAccountPath(targetAccount) +folder.getPath()) , true);
+        return URLUtil.getServiceURL(targetServer,
+                SERVLET_PATH + HttpUtil.urlEscape(getAccountPath(targetAccount) + folder.getPath()), true);
     }
 
     protected void resolveItems(UserServletContext context) throws ServiceException, IOException {
@@ -529,11 +573,12 @@ public class UserServlet extends ZimbraServlet {
     }
 
     private void doAuthGet(HttpServletRequest req, HttpServletResponse resp, UserServletContext context)
-    throws ServletException, IOException, ServiceException, UserServletException {
+            throws ServletException, IOException, ServiceException, UserServletException {
         if (log.isDebugEnabled()) {
             StringBuffer reqURL = context.req.getRequestURL();
             String queryParam = context.req.getQueryString();
-            if (queryParam != null) reqURL.append('?').append(queryParam);
+            if (queryParam != null)
+                reqURL.append('?').append(queryParam);
             log.debug("UserServlet: " + reqURL.toString());
         }
 
@@ -546,26 +591,33 @@ public class UserServlet extends ZimbraServlet {
             } else {
                 MailItem item = resolveItem(context);
                 if (proxyIfMountpoint(req, resp, context, item)) {
-                    // if the target is a mountpoint, the request was already proxied to the resolved target
+                    // if the target is a mountpoint, the request was already
+                    // proxied to the resolved target
                     return;
                 }
-                context.target = item;  /* imap_id resolution needs this. */
+                context.target = item; /* imap_id resolution needs this. */
             }
         }
 
         if (FormatType.FREE_BUSY.equals(context.format)) {
-            /* Always reference Calendar.  This is the fallback for non-existent paths, thus, could harvest
-             * emails by asking for freebusy against, say the Drafts folder.  Without this change, the returned
-             * HTML would reference Drafts for valid emails and Calendar for invalid ones.
+            /*
+             * Always reference Calendar. This is the fallback for non-existent
+             * paths, thus, could harvest emails by asking for freebusy against,
+             * say the Drafts folder. Without this change, the returned HTML
+             * would reference Drafts for valid emails and Calendar for invalid
+             * ones.
              */
             context.fakeTarget = new UserServletContext.FakeFolder(context.accountPath, "/Calendar", "Calendar");
         }
 
         resolveFormatter(context);
 
-        // Prevent harvest attacks.  If mailbox doesn't exist for a request requiring authentication,
-        // return auth error instead of "no such mailbox".  If request/formatter doesn't require
-        // authentication, call the formatter and let it deal with preventing harvest attacks.
+        // Prevent harvest attacks. If mailbox doesn't exist for a request
+        // requiring authentication,
+        // return auth error instead of "no such mailbox". If request/formatter
+        // doesn't require
+        // authentication, call the formatter and let it deal with preventing
+        // harvest attacks.
         if (mbox == null && context.formatter.requiresAuth())
             throw ServiceException.PERM_DENIED(L10nUtil.getMessage(MsgKey.errPermissionDenied, req));
 
@@ -582,7 +634,8 @@ public class UserServlet extends ZimbraServlet {
     }
 
     /**
-     * Adds an item to a folder specified in the URI.  The item content is provided in the PUT request's body.
+     * Adds an item to a folder specified in the URI. The item content is
+     * provided in the PUT request's body.
      */
     @Override
     public void doPut(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
@@ -590,7 +643,8 @@ public class UserServlet extends ZimbraServlet {
     }
 
     /**
-     * Adds an item to a folder specified in the URI.  The item content is provided in the POST request's body.
+     * Adds an item to a folder specified in the URI. The item content is
+     * provided in the POST request's body.
      */
     @Override
     public void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
@@ -614,26 +668,25 @@ public class UserServlet extends ZimbraServlet {
 
             boolean doCsrfCheck = false;
             if (req.getAttribute(CsrfFilter.CSRF_TOKEN_CHECK) != null) {
-                doCsrfCheck =  (Boolean) req.getAttribute(CsrfFilter.CSRF_TOKEN_CHECK);
+                doCsrfCheck = (Boolean) req.getAttribute(CsrfFilter.CSRF_TOKEN_CHECK);
             }
 
             if (doCsrfCheck) {
                 String csrfToken = req.getHeader(Constants.CSRF_TOKEN);
                 if (log.isDebugEnabled()) {
                     String paramValue = req.getParameter(QP_AUTH);
-                    log.debug(
-                        "CSRF check is: %s, CSRF token is: %s, Authentication recd with request is: %s",
-                        doCsrfCheck, csrfToken, paramValue);
+                    log.debug("CSRF check is: %s, CSRF token is: %s, Authentication recd with request is: %s",
+                            doCsrfCheck, csrfToken, paramValue);
                 }
 
                 if (!StringUtil.isNullOrEmpty(csrfToken)) {
                     if (!CsrfUtil.isValidCsrfToken(csrfToken, context.authToken)) {
                         context.setCsrfAuthSucceeded(Boolean.FALSE);
-                        log.debug("CSRF token validation failed for account: %s"
-                            + ", Auth token is CSRF enabled:  %s" + "CSRF token is: %s",
-                            context.authToken, context.authToken.isCsrfTokenEnabled(), csrfToken);
-                        sendError(context, req, resp,
-                            L10nUtil.getMessage(MsgKey.errMustAuthenticate, req));
+                        log.debug(
+                                "CSRF token validation failed for account: %s" + ", Auth token is CSRF enabled:  %s"
+                                        + "CSRF token is: %s",
+                                context.authToken, context.authToken.isCsrfTokenEnabled(), csrfToken);
+                        sendError(context, req, resp, L10nUtil.getMessage(MsgKey.errMustAuthenticate, req));
                         return;
                     } else {
                         context.setCsrfAuthSucceeded(Boolean.TRUE);
@@ -653,7 +706,8 @@ public class UserServlet extends ZimbraServlet {
                 try {
                     context.target = UserServletUtil.resolveItem(context, false);
                 } catch (NoSuchItemException nsie) {
-                    // perhaps it's a POST to "Notebook/new-file-name" -- find the parent folder and proceed from there
+                    // perhaps it's a POST to "Notebook/new-file-name" -- find
+                    // the parent folder and proceed from there
                     if (context.itemPath == null)
                         throw nsie;
                     int separator = context.itemPath.lastIndexOf('/');
@@ -665,18 +719,21 @@ public class UserServlet extends ZimbraServlet {
                     context.extraPath = filename;
                 }
 
-                folder = (context.target instanceof Folder ? (Folder) context.target : mbox.getFolderById(context.opContext, context.target.getFolderId()));
+                folder = (context.target instanceof Folder ? (Folder) context.target
+                        : mbox.getFolderById(context.opContext, context.target.getFolderId()));
 
                 if (context.target != folder) {
                     if (filename == null)
                         filename = context.target.getName();
                     else
-                        // need to fail on POST to "Notebook/existing-file/random-cruft"
+                        // need to fail on POST to
+                        // "Notebook/existing-file/random-cruft"
                         throw MailServiceException.NO_SUCH_FOLDER(context.itemPath);
                 }
 
                 if (proxyIfMountpoint(req, resp, context, folder)) {
-                    // if the target is a mountpoint, the request was already proxied to the resolved target
+                    // if the target is a mountpoint, the request was already
+                    // proxied to the resolved target
                     return;
                 }
             }
@@ -687,7 +744,8 @@ public class UserServlet extends ZimbraServlet {
 
             String ctype = context.req.getContentType();
 
-            // if no format explicitly specified, try to guess it from the Content-Type header
+            // if no format explicitly specified, try to guess it from the
+            // Content-Type header
             if (context.format == null && ctype != null) {
                 String normalizedType = new com.zimbra.common.mime.ContentType(ctype).getContentType();
                 Formatter fmt = FormatterFactory.mDefaultFormatters.get(normalizedType);
@@ -700,9 +758,12 @@ public class UserServlet extends ZimbraServlet {
             if (!context.formatter.supportsSave())
                 sendError(context, req, resp, L10nUtil.getMessage(MsgKey.errUnsupportedFormat, req));
 
-            // Prevent harvest attacks.  If mailbox doesn't exist for a request requiring authentication,
-            // return auth error instead of "no such mailbox".  If request/formatter doesn't require
-            // authentication, call the formatter and let it deal with preventing harvest attacks.
+            // Prevent harvest attacks. If mailbox doesn't exist for a request
+            // requiring authentication,
+            // return auth error instead of "no such mailbox". If
+            // request/formatter doesn't require
+            // authentication, call the formatter and let it deal with
+            // preventing harvest attacks.
             if (mbox == null && context.formatter.requiresAuth())
                 throw ServiceException.PERM_DENIED(L10nUtil.getMessage(MsgKey.errPermissionDenied, req));
 
@@ -710,8 +771,8 @@ public class UserServlet extends ZimbraServlet {
         } catch (ServiceException se) {
             if (se.getCode() == ServiceException.PERM_DENIED || se instanceof NoSuchItemException) {
                 sendError(context, req, resp, L10nUtil.getMessage(MsgKey.errNoSuchItem, req));
-            } else if (se.getCode() == AccountServiceException.MAINTENANCE_MODE ||
-                     se.getCode() == AccountServiceException.ACCOUNT_INACTIVE) {
+            } else if (se.getCode() == AccountServiceException.MAINTENANCE_MODE
+                    || se.getCode() == AccountServiceException.ACCOUNT_INACTIVE) {
                 sendError(context, req, resp, se.getMessage());
             } else if (se.getCode() == ServiceException.INVALID_REQUEST) {
                 if (log.isDebugEnabled()) {
@@ -731,8 +792,7 @@ public class UserServlet extends ZimbraServlet {
         } catch (UserServletException e) {
             // add check for ServiceException root cause?
             if (e.getHttpStatusCode() == HttpServletResponse.SC_UNAUTHORIZED) {
-                sendError(context, req, resp,
-                    L10nUtil.getMessage(MsgKey.errMustAuthenticate, req));
+                sendError(context, req, resp, L10nUtil.getMessage(MsgKey.errMustAuthenticate, req));
             } else {
                 resp.sendError(e.getHttpStatusCode(), e.getMessage());
             }
@@ -743,14 +803,16 @@ public class UserServlet extends ZimbraServlet {
         }
     }
 
-    /** Determines the <code>format</code> and <code>formatter<code> for the
-     *  request, if not already set. */
+    /**
+     * Determines the <code>format</code> and <code>formatter<code> for the
+     * request, if not already set.
+     */
     private void resolveFormatter(UserServletContext context) throws UserServletException {
         if (context.format == null) {
             context.format = defaultFormat(context);
             if (context.format == null) {
                 throw new UserServletException(HttpServletResponse.SC_BAD_REQUEST,
-                                                L10nUtil.getMessage(MsgKey.errUnsupportedFormat, context.req));
+                        L10nUtil.getMessage(MsgKey.errUnsupportedFormat, context.req));
             }
         }
 
@@ -758,21 +820,22 @@ public class UserServlet extends ZimbraServlet {
             context.formatter = FormatterFactory.mFormatters.get(context.format);
             if (context.formatter == null) {
                 throw new UserServletException(HttpServletResponse.SC_BAD_REQUEST,
-                                                L10nUtil.getMessage(MsgKey.errUnsupportedFormat, context.req));
+                        L10nUtil.getMessage(MsgKey.errUnsupportedFormat, context.req));
             }
         }
         context.formatter.validateParams(context);
     }
 
-    protected boolean proxyIfMountpoint(HttpServletRequest req, HttpServletResponse resp, UserServletContext context, MailItem item)
-    throws IOException, ServiceException, UserServletException {
+    protected boolean proxyIfMountpoint(HttpServletRequest req, HttpServletResponse resp, UserServletContext context,
+            MailItem item) throws IOException, ServiceException, UserServletException {
         if (!(item instanceof Mountpoint))
             return false;
         if (context.format != null && context.format.equals("html"))
             return false;
         Mountpoint mpt = (Mountpoint) item;
 
-        String uri = SERVLET_PATH + "/~/?" + QP_ID + '=' + HttpUtil.urlEscape(mpt.getOwnerId()) + "%3A" + mpt.getRemoteId();
+        String uri = SERVLET_PATH + "/~/?" + QP_ID + '=' + HttpUtil.urlEscape(mpt.getOwnerId()) + "%3A"
+                + mpt.getRemoteId();
         if (context.format != null)
             uri += '&' + QP_FMT + '=' + HttpUtil.urlEscape(context.format.toString());
         if (context.extraPath != null)
@@ -786,7 +849,8 @@ public class UserServlet extends ZimbraServlet {
         Provisioning prov = Provisioning.getInstance();
         Account targetAccount = prov.get(AccountBy.id, mpt.getOwnerId());
         if (targetAccount == null)
-            throw new UserServletException(HttpServletResponse.SC_BAD_REQUEST, L10nUtil.getMessage(MsgKey.errNoSuchAccount, req));
+            throw new UserServletException(HttpServletResponse.SC_BAD_REQUEST,
+                    L10nUtil.getMessage(MsgKey.errNoSuchAccount, req));
         try {
             proxyServletRequest(req, resp, prov.getServer(targetAccount), uri, getProxyAuthToken(context));
         } catch (HttpException e) {
@@ -813,23 +877,23 @@ public class UserServlet extends ZimbraServlet {
             type = context.target.getType();
 
         switch (type) {
-        case APPOINTMENT:
-        case TASK:
-            return FormatType.ICS;
-        case CONTACT:
-            return context.target instanceof Folder? FormatType.CSV : FormatType.VCF;
-        case DOCUMENT:
-            // Zimbra docs and folder rendering should use html formatter.
-            if (context.target instanceof Folder)
-                return FormatType.HTML;
-            String contentType = ((Document)context.target).getContentType();
-            if (contentType != null && contentType.indexOf(';') > 0)
-                contentType = contentType.substring(0, contentType.indexOf(';')).toLowerCase();
-            if (ZIMBRA_DOC_CONTENT_TYPE.contains(contentType))
-                return FormatType.HTML;
-            return FormatType.HTML_CONVERTED;
-        default:
-            return FormatType.HTML_CONVERTED;
+            case APPOINTMENT:
+            case TASK:
+                return FormatType.ICS;
+            case CONTACT:
+                return context.target instanceof Folder ? FormatType.CSV : FormatType.VCF;
+            case DOCUMENT:
+                // Zimbra docs and folder rendering should use html formatter.
+                if (context.target instanceof Folder)
+                    return FormatType.HTML;
+                String contentType = ((Document) context.target).getContentType();
+                if (contentType != null && contentType.indexOf(';') > 0)
+                    contentType = contentType.substring(0, contentType.indexOf(';')).toLowerCase();
+                if (ZIMBRA_DOC_CONTENT_TYPE.contains(contentType))
+                    return FormatType.HTML;
+                return FormatType.HTML_CONVERTED;
+            default:
+                return FormatType.HTML_CONVERTED;
         }
     }
 
@@ -845,14 +909,16 @@ public class UserServlet extends ZimbraServlet {
         super.destroy();
     }
 
-    public static byte[] getRemoteContent(AuthToken authToken, ItemId iid, Map<String, String> params) throws ServiceException {
+    public static byte[] getRemoteContent(AuthToken authToken, ItemId iid, Map<String, String> params)
+            throws ServiceException {
         Account target = Provisioning.getInstance().get(AccountBy.id, iid.getAccountId(), authToken);
         Map<String, String> pcopy = new HashMap<String, String>(params);
         pcopy.put(QP_ID, iid.toString());
-        return getRemoteContent(authToken, target, (String)null, pcopy);
+        return getRemoteContent(authToken, target, (String) null, pcopy);
     }
 
-    public static byte[] getRemoteContent(AuthToken authToken, Account target, String folder, Map<String,String> params) throws ServiceException {
+    public static byte[] getRemoteContent(AuthToken authToken, Account target, String folder,
+            Map<String, String> params) throws ServiceException {
         return getRemoteContent(authToken.toZAuthToken(), getRemoteUrl(target, folder, params));
     }
 
@@ -860,12 +926,14 @@ public class UserServlet extends ZimbraServlet {
         return getRemoteResource(authToken, url).getSecond();
     }
 
-    public static HttpInputStream getRemoteContentAsStream(AuthToken authToken, Account target, String folder, Map<String,String> params) throws ServiceException, IOException {
+    public static HttpInputStream getRemoteContentAsStream(AuthToken authToken, Account target, String folder,
+            Map<String, String> params) throws ServiceException, IOException {
         String url = getRemoteUrl(target, folder, params);
         return getRemoteResourceAsStream(authToken.toZAuthToken(), url).getSecond();
     }
 
-    private static String getRemoteUrl(Account target, String folder, Map<String, String> params) throws ServiceException {
+    private static String getRemoteUrl(Account target, String folder, Map<String, String> params)
+            throws ServiceException {
         if (folder == null) {
             folder = "";
         } else {
@@ -882,7 +950,8 @@ public class UserServlet extends ZimbraServlet {
         url.append("/?").append(QP_AUTH).append('=').append(AUTH_COOKIE);
         if (params != null) {
             for (Map.Entry<String, String> param : params.entrySet())
-                url.append('&').append(HttpUtil.urlEscape(param.getKey())).append('=').append(HttpUtil.urlEscape(param.getValue()));
+                url.append('&').append(HttpUtil.urlEscape(param.getKey())).append('=')
+                        .append(HttpUtil.urlEscape(param.getValue()));
         }
         return url.toString();
     }
@@ -902,8 +971,8 @@ public class UserServlet extends ZimbraServlet {
         }
     }
 
-    public static FileUploadServlet.Upload getRemoteResourceAsUpload(AuthToken at, ItemId iid, Map<String,String> params)
-    throws ServiceException, IOException {
+    public static FileUploadServlet.Upload getRemoteResourceAsUpload(AuthToken at, ItemId iid,
+            Map<String, String> params) throws ServiceException, IOException {
         Map<String, String> pcopy = new HashMap<String, String>(params);
         pcopy.put(QP_ID, iid.toString());
 
@@ -930,7 +999,6 @@ public class UserServlet extends ZimbraServlet {
         return FileUploadServlet.saveUpload(response.getSecond(), filename, ctype, at.getAccountId());
     }
 
-
     /** Helper class so that we can close connection upon stream close */
     public static class HttpInputStream extends FilterInputStream {
         private final HttpResponse response;
@@ -939,29 +1007,34 @@ public class UserServlet extends ZimbraServlet {
             super(r.getEntity().getContent());
             this.response = r;
         }
+
         public int getContentLength() {
             String cl = getHeader("Content-Length");
             if (cl != null)
                 return Integer.parseInt(cl);
             return -1;
         }
+
         public String getHeader(String headerName) {
             Header cl = response.getFirstHeader(headerName);
             if (cl != null)
                 return cl.getValue();
             return null;
         }
+
         public int getStatusCode() {
             return response.getStatusLine().getStatusCode();
         }
-        @Override public void close() {
+
+        @Override
+        public void close() {
             EntityUtils.consumeQuietly(response.getEntity());
         }
     }
 
-    public static Pair<Header[], HttpInputStream> getRemoteResourceAsStream(ZAuthToken authToken, ItemId iid, String extraPath)
-            throws ServiceException, IOException {
-        Map<String,String> params = new HashMap<String,String>();
+    public static Pair<Header[], HttpInputStream> getRemoteResourceAsStream(ZAuthToken authToken, ItemId iid,
+            String extraPath) throws ServiceException, IOException {
+        Map<String, String> params = new HashMap<String, String>();
         params.put(QP_ID, iid.toString());
         if (extraPath != null)
             params.put(QP_NAME, extraPath);
@@ -970,19 +1043,20 @@ public class UserServlet extends ZimbraServlet {
         return getRemoteResourceAsStream(authToken, url);
     }
 
-    public static Pair<Integer, InputStream> getRemoteResourceAsStreamWithLength(ZAuthToken authToken, String url) throws ServiceException, IOException {
+    public static Pair<Integer, InputStream> getRemoteResourceAsStreamWithLength(ZAuthToken authToken, String url)
+            throws ServiceException, IOException {
         HttpInputStream his = getRemoteResourceAsStream(authToken, url).getSecond();
         return new Pair<Integer, InputStream>(his.getContentLength(), his);
     }
 
     public static Pair<Header[], HttpInputStream> getRemoteResourceAsStream(ZAuthToken authToken, String url)
-    throws ServiceException, IOException {
+            throws ServiceException, IOException {
         Pair<Header[], HttpResponse> pair = doHttpOp(authToken, new HttpGet(url));
         return new Pair<Header[], HttpInputStream>(pair.getFirst(), new HttpInputStream(pair.getSecond()));
     }
 
     public static Pair<Header[], HttpInputStream> putMailItem(ZAuthToken authToken, String url, MailItem item)
-    throws ServiceException, IOException {
+            throws ServiceException, IOException {
         if (item instanceof Document) {
             Document doc = (Document) item;
             StringBuilder u = new StringBuilder(url);
@@ -993,24 +1067,25 @@ public class UserServlet extends ZimbraServlet {
             HttpPut method = new HttpPut(u.toString());
             String contentType = doc.getContentType();
             method.addHeader("Content-Type", contentType);
-            method.setEntity(new InputStreamEntity(doc.getContentStream(), doc.getSize(), ContentType.create(contentType)));
-            
+            method.setEntity(
+                    new InputStreamEntity(doc.getContentStream(), doc.getSize(), ContentType.create(contentType)));
+
             method.addHeader("X-Zimbra-Description", doc.getDescription());
-            method.setEntity(new InputStreamEntity(doc.getContentStream(), doc.getSize(), ContentType.create(contentType)));
+            method.setEntity(
+                    new InputStreamEntity(doc.getContentStream(), doc.getSize(), ContentType.create(contentType)));
             Pair<Header[], HttpResponse> pair = doHttpOp(authToken, method);
             return new Pair<Header[], HttpInputStream>(pair.getFirst(), new HttpInputStream(pair.getSecond()));
         }
         return putRemoteResource(authToken, url, item.getContentStream(), null);
     }
 
-    public static Pair<Header[], HttpInputStream> putRemoteResource(
-            AuthToken authToken, String url, InputStream req, Header[] headers)
-            throws ServiceException, IOException {
+    public static Pair<Header[], HttpInputStream> putRemoteResource(AuthToken authToken, String url, InputStream req,
+            Header[] headers) throws ServiceException, IOException {
         return putRemoteResource(authToken.toZAuthToken(), url, req, headers);
     }
 
-    public static Pair<Header[], HttpInputStream> putRemoteResource(ZAuthToken authToken, String url, InputStream req, Header[] headers)
-    throws ServiceException, IOException {
+    public static Pair<Header[], HttpInputStream> putRemoteResource(ZAuthToken authToken, String url, InputStream req,
+            Header[] headers) throws ServiceException, IOException {
         StringBuilder u = new StringBuilder(url);
         u.append("?").append(QP_AUTH).append('=').append(AUTH_COOKIE);
         HttpPut method = new HttpPut(u.toString());
@@ -1029,7 +1104,7 @@ public class UserServlet extends ZimbraServlet {
     }
 
     private static Pair<Header[], HttpResponse> doHttpOp(ZAuthToken authToken, HttpRequestBase method)
-    throws ServiceException {
+            throws ServiceException {
         // create an HTTP client with the same cookies
         String url = "";
         String hostname = "";
@@ -1041,7 +1116,7 @@ public class UserServlet extends ZimbraServlet {
         if (cookieMap != null) {
             BasicCookieStore cookieStore = new BasicCookieStore();
             for (Map.Entry<String, String> ck : cookieMap.entrySet()) {
-                
+
                 BasicClientCookie cookie = new BasicClientCookie(ck.getKey(), ck.getValue());
                 cookie.setDomain(hostname);
                 cookie.setPath("/");
@@ -1049,9 +1124,9 @@ public class UserServlet extends ZimbraServlet {
                 cookieStore.addCookie(cookie);
             }
             clientBuilder.setDefaultCookieStore(cookieStore);
-            RequestConfig reqConfig = RequestConfig.copy(
-                ZimbraHttpConnectionManager.getInternalHttpConnMgr().getZimbraConnMgrParams().getReqConfig())
-                .setCookieSpec(CookieSpecs.BROWSER_COMPATIBILITY).build();
+            RequestConfig reqConfig = RequestConfig
+                    .copy(ZimbraHttpConnectionManager.getInternalHttpConnMgr().getZimbraConnMgrParams().getReqConfig())
+                    .setCookieSpec(CookieSpecs.BROWSER_COMPATIBILITY).build();
 
             clientBuilder.setDefaultRequestConfig(reqConfig);
             if (method.getMethod().equalsIgnoreCase("PUT")) {
@@ -1061,13 +1136,18 @@ public class UserServlet extends ZimbraServlet {
         }
 
         if (method instanceof HttpPut) {
-            long contentLength = ((HttpPut)method).getEntity().getContentLength();
+            long contentLength = ((HttpPut) method).getEntity().getContentLength();
             if (contentLength > 0) {
-                int timeEstimate = Math.max(10000, (int)(contentLength / 100));  // 100kbps in millis
-                // cannot set connection time using our ZimbrahttpConnectionManager,
+                int timeEstimate = Math.max(10000, (int) (contentLength / 100)); // 100kbps
+                                                                                 // in
+                                                                                 // millis
+                // cannot set connection time using our
+                // ZimbrahttpConnectionManager,
                 // see comments in ZimbrahttpConnectionManager.
-                // actually, length of the content to Put should not be a factor for
-                // establishing a connection, only read time out matter, which we set
+                // actually, length of the content to Put should not be a factor
+                // for
+                // establishing a connection, only read time out matter, which
+                // we set
                 // client.getHttpConnectionManager().getParams().setConnectionTimeout(timeEstimate);
                 SocketConfig config = SocketConfig.custom().setSoTimeout(timeEstimate).build();
                 clientBuilder.setDefaultSocketConfig(config);
@@ -1080,15 +1160,15 @@ public class UserServlet extends ZimbraServlet {
             int statusCode = response.getStatusLine().getStatusCode();
             if (statusCode == HttpStatus.SC_NOT_FOUND || statusCode == HttpStatus.SC_FORBIDDEN)
                 throw MailServiceException.NO_SUCH_ITEM(-1);
-            else if (statusCode != HttpStatus.SC_OK &&
-                    statusCode != HttpStatus.SC_CREATED &&
-                    statusCode != HttpStatus.SC_NO_CONTENT)
+            else if (statusCode != HttpStatus.SC_OK && statusCode != HttpStatus.SC_CREATED
+                    && statusCode != HttpStatus.SC_NO_CONTENT)
                 throw ServiceException.RESOURCE_UNREACHABLE(response.getStatusLine().getReasonPhrase(), null,
                         new ServiceException.InternalArgument(HTTP_URL, url, ServiceException.Argument.Type.STR),
-                        new ServiceException.InternalArgument(HTTP_STATUS_CODE, statusCode, ServiceException.Argument.Type.NUM));
+                        new ServiceException.InternalArgument(HTTP_STATUS_CODE, statusCode,
+                                ServiceException.Argument.Type.NUM));
 
             List<Header> headers = new ArrayList<Header>(Arrays.asList(response.getAllHeaders()));
-            headers.add(new BasicHeader("X-Zimbra-Http-Status", ""+statusCode));
+            headers.add(new BasicHeader("X-Zimbra-Http-Status", "" + statusCode));
             return new Pair<Header[], HttpResponse>(headers.toArray(new Header[0]), response);
         } catch (HttpException e) {
             throw ServiceException.RESOURCE_UNREACHABLE("HttpException while fetching " + url, e);

--- a/store/src/java/com/zimbra/cs/service/mail/DocumentAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/DocumentAction.java
@@ -1,0 +1,217 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2021 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.service.mail;
+
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.MailConstants;
+import com.zimbra.common.soap.OctopusXmlConstants;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Domain;
+import com.zimbra.cs.account.GuestAccount;
+import com.zimbra.cs.account.MailTarget;
+import com.zimbra.cs.account.NamedEntry;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.ACL;
+import com.zimbra.cs.mailbox.Document;
+import com.zimbra.cs.mailbox.MailItem;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxOperation;
+import com.zimbra.cs.mailbox.OperationContext;
+import com.zimbra.cs.mailbox.cache.WatchCache;
+import com.zimbra.cs.mailbox.event.EventLogger;
+import com.zimbra.cs.mailbox.event.ItemEventLog;
+import com.zimbra.cs.service.util.ItemId;
+import com.zimbra.cs.service.util.ItemIdFormatter;
+import com.zimbra.cs.session.Session;
+import com.zimbra.cs.session.Session.Type;
+import com.zimbra.cs.session.WatchNotification;
+import com.zimbra.soap.ZimbraSoapContext;
+
+public class DocumentAction extends ItemAction {
+
+    public static final String OP_WATCH = "watch";
+    public static final String OP_UNWATCH = "!watch";
+    public static final String OP_GRANT = "grant";
+    public static final String OP_REVOKE = "!grant";
+    public static final String OP_VIEW = "view";
+    private static final Set<String> OPS = ImmutableSet.of(OP_WATCH, OP_UNWATCH, OP_GRANT, OP_REVOKE, OP_VIEW);
+
+    @Override
+    protected String[] getProxiedIdPath(Element request) { return TARGET_ITEM_PATH; }
+
+    @Override
+    public Element handle(Element request, Map<String, Object> context) throws ServiceException {
+        ZimbraSoapContext zsc = getZimbraSoapContext(context);
+
+        Element action = request.getElement(MailConstants.E_ACTION);
+        String operation = action.getAttribute(MailConstants.A_OPERATION).toLowerCase();
+
+        Element response = zsc.createElement(OctopusXmlConstants.DOCUMENT_ACTION_RESPONSE);
+        Element result = response.addUniqueElement(MailConstants.E_ACTION);
+
+        String successes = null;
+        if (OPS.contains(operation)) {
+            successes = handleDocument(context, request, operation, result);
+        } else {
+            successes = Joiner.on(",").join(handleCommon(context, request, MailItem.Type.DOCUMENT).getSuccessIds());
+        }
+
+        result.addAttribute(MailConstants.A_ID, successes);
+        result.addAttribute(MailConstants.A_OPERATION, operation);
+        return response;
+    }
+
+    private String handleDocument(Map<String,Object> context, Element request, String operation, Element result) throws ServiceException {
+        Element action = request.getElement(MailConstants.E_ACTION);
+
+        ZimbraSoapContext zsc = getZimbraSoapContext(context);
+        Mailbox mbox = getRequestedMailbox(zsc);
+        OperationContext octxt = getOperationContext(zsc, context);
+        ItemIdFormatter ifmt = new ItemIdFormatter(zsc);
+        ItemId iid = new ItemId(action.getAttribute(MailConstants.A_ID), zsc);
+        WatchNotification notification = null;
+        long timestamp = System.currentTimeMillis();
+        Account authAccount = Provisioning.getInstance().getAccountById(zsc.getAuthtokenAccountId());
+
+        // check the access and make sure the item exists and the authUser has access to it
+        MailItem watchedItem = mbox.getItemById(octxt, iid.getId(), MailItem.Type.DOCUMENT);
+        Document doc = (Document) watchedItem;
+
+        if (operation.equals(OP_WATCH)) {
+            // add the watch mapping
+            WatchCache.get(authAccount).watch(iid.getAccountId(), iid.getId());
+            notification = new WatchNotification(MailboxOperation.Watch, octxt.getAuthenticatedUser(), octxt.getUserAgent(), timestamp, watchedItem);
+            mbox.markMetadataChanged(octxt, iid.getId());
+        } else if (operation.equals(OP_UNWATCH)) {
+            // remove the watch mapping
+            WatchCache.get(authAccount).unwatch(iid.getAccountId(), iid.getId());
+            notification = new WatchNotification(MailboxOperation.Unwatch, octxt.getAuthenticatedUser(), octxt.getUserAgent(), timestamp, watchedItem);
+            mbox.markMetadataChanged(octxt, iid.getId());
+        } else if (operation.equals(OP_REVOKE)) {
+            String zid = action.getAttribute(MailConstants.A_ZIMBRA_ID);
+            mbox.revokeAccess(octxt, iid.getId(), zid);
+        } else if (operation.equals(OP_GRANT)) {
+            // file level shares can be granted to all users, public or specific users
+            Element grant = action.getElement(MailConstants.E_GRANT);
+            short rights = ACL.stringToRights(grant.getAttribute(MailConstants.A_RIGHTS));
+            String gtype = grant.getAttribute(MailConstants.A_GRANT_TYPE);
+            String zid = null;
+            String secret = null;
+            long expiry = grant.getAttributeLong(MailConstants.A_EXPIRY, 0);
+            byte gtypeByte = ACL.stringToType(gtype);
+            switch (gtypeByte) {
+            case ACL.GRANTEE_AUTHUSER:
+                zid = GuestAccount.GUID_AUTHUSER;
+                break;
+            case ACL.GRANTEE_PUBLIC:
+                zid = GuestAccount.GUID_PUBLIC;
+                expiry = validateGrantExpiry(grant.getAttribute(MailConstants.A_EXPIRY, null),
+                        mbox.getAccount().getFilePublicShareLifetime());
+                break;
+            case ACL.GRANTEE_USER:
+                zid = getZimbraId(grant, zsc, mbox, result);
+                break;
+            default:
+                throw ServiceException.INVALID_REQUEST("unsupported gt: " + gtype, null);
+            }
+
+            ZimbraLog.soap.debug("The user: %s has been granted: %s for item:  %s", zid, ACL.rightsToString(rights),
+                iid.getId());
+            mbox.grantAccess(octxt, iid.getId(), zid, gtypeByte, rights, secret, expiry);
+        } else if (operation.equals(OP_VIEW) && allowDocumentAccessedTimeLogging(octxt)) {
+                notification = new WatchNotification(MailboxOperation.View, octxt.getAuthenticatedUser(), octxt.getUserAgent(), timestamp, watchedItem, doc.getVersion());
+        } else {
+            throw ServiceException.INVALID_REQUEST("unknown operation: " + operation, null);
+        }
+
+        if (notification != null) {
+//            for (Session s : mbox.getNotificationPubSub().getSubscriber().getListeners(Type.SOAP)) {
+//                s.notifyExternalEvent(notification);
+//            }
+            for (Session s : mbox.getListeners(Type.SOAP)) {
+                s.notifyExternalEvent(notification);
+            }
+
+            EventLogger logger = EventLogger.getInstance();
+            ItemEventLog log = logger.getLog(watchedItem);
+            log.addEvent(notification.toActivity());
+        }
+
+        return ifmt.formatItemId(iid);
+    }
+
+    private boolean allowDocumentAccessedTimeLogging(OperationContext octxt) {
+        if (octxt != null) {
+            Account account = octxt.getAuthenticatedUser();
+            if (account != null && !account.getId().equals(GuestAccount.GUID_PUBLIC)
+                    && !account.getId().equals(GuestAccount.GUID_AUTHUSER)
+                    && account.isDocumentRecentlyViewedEnabled()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @param grant Required grant
+     * @param zsc ZimbraSoapContext
+     * @param mbox mailbox
+     * @return zid
+     * @throws ServiceException
+     */
+    private String getZimbraId(Element grant, ZimbraSoapContext zsc, Mailbox mbox, Element result) throws ServiceException {
+        String zid = grant.getAttribute(MailConstants.A_ZIMBRA_ID, null);
+        NamedEntry nentry = null;
+        if (zid == null) {
+            // if zid == null, check if email exist in the request and try to get the account using the email
+            String email = grant.getAttribute(MailConstants.A_DISPLAY, null);
+            if (email == null || email == "") {
+                throw ServiceException.FAILURE("Either zid or email is missing", null);
+            } else if (email.indexOf('@') < 0) {
+                throw ServiceException.INVALID_REQUEST("invalid email id", null);
+            } else {
+                try {
+                    nentry = FolderAction.lookupGranteeByName(email, ACL.GRANTEE_USER, zsc);
+                    if (nentry instanceof MailTarget) {
+                        Domain domain = Provisioning.getInstance().getDomain(mbox.getAccount());
+                        String granteeDomainName = ((MailTarget) nentry).getDomainName();
+                        if (domain.isInternalSharingCrossDomainEnabled() ||
+                                domain.getName().equals(granteeDomainName) ||
+                                Sets.newHashSet(domain.getInternalSharingDomain()).contains(granteeDomainName)) {
+                            zid = nentry.getId();
+                            result.addAttribute(MailConstants.A_ZIMBRA_ID, zid);
+                            result.addAttribute(MailConstants.A_DISPLAY, nentry.getName());
+                        }
+                    }
+                } catch (ServiceException se) {
+                    // this is the normal path, where lookupGranteeByName throws account.NO_SUCH_USER
+                    ZimbraLog.soap.debug("Exception while lookupGranteeByName : %s", se);
+                    throw se;
+                }
+            }
+        }
+        return zid;
+    }
+}

--- a/store/src/java/com/zimbra/cs/service/mail/GetDocumentShareURL.java
+++ b/store/src/java/com/zimbra/cs/service/mail/GetDocumentShareURL.java
@@ -59,7 +59,7 @@ public class GetDocumentShareURL extends MailDocumentHandler {
     private String getPublicShareURL(Document doc) throws ServiceException {
         Account account = doc.getAccount();
         Folder share = doc.getShare();
-        String path = "/service" + SharedFileServlet.getSharedFileURLPath(doc.getUuid(), account.getId(), share != null ?  account.getId() : null);
+        String path = "/service" + SharedFileServlet.getSharedFileURLPath(doc.getUuid(), account.getId(), share != null ? account.getId() : null);
         return URLUtil.getPublicURLForDomain(account.getServer(), Provisioning.getInstance().getDomain(account), path, true);
     }
 }

--- a/store/src/java/com/zimbra/cs/service/mail/GetNotifications.java
+++ b/store/src/java/com/zimbra/cs/service/mail/GetNotifications.java
@@ -1,0 +1,106 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2020 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.service.mail;
+
+import java.util.Map;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.MailboxOperation;
+import com.zimbra.cs.mailbox.event.ItemEventLog;
+import com.zimbra.cs.mailbox.event.MailboxEvent;
+import com.zimbra.cs.mailbox.event.NewNotifications;
+import com.zimbra.cs.service.util.ItemIdFormatter;
+import com.zimbra.soap.JaxbUtil;
+import com.zimbra.soap.ZimbraSoapContext;
+import com.zimbra.soap.mail.message.GetNotificationsRequest;
+import com.zimbra.soap.mail.message.GetNotificationsResponse;
+import com.zimbra.soap.mail.type.IdEmailName;
+import com.zimbra.soap.type.NamedElement;
+
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2020 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+public class GetNotifications extends MailDocumentHandler {
+
+    @Override
+    public Element handle(Element request, Map<String, Object> context)
+            throws ServiceException {
+        ZimbraSoapContext zsc = getZimbraSoapContext(context);
+
+        GetNotificationsRequest req = JaxbUtil.elementToJaxb(request);
+
+        Account account = getRequestedAccount(zsc);
+        Account authAccount = getAuthenticatedAccount(zsc);
+        NewNotifications notif = new NewNotifications(authAccount, account);
+        ItemEventLog log = notif.getLog();
+
+        GetNotificationsResponse resp = new GetNotificationsResponse();
+        resp.setlastSeen(notif.getLastSeen() * 1000);  // return millis in order to be consistent with the rest of ts in activities
+        for (MailboxOperation op : log.getLoggedOps()) {
+            resp.addOperation(new NamedElement(op.name()));
+        }
+        ItemIdFormatter fmt = new ItemIdFormatter(zsc);
+        Provisioning prov = Provisioning.getInstance();
+        for (String user : log.getLoggedUsers()) {
+            IdEmailName userInfo = IdEmailName.fromId(user);
+            resp.addUser(userInfo);
+            Account a = prov.getAccountById(user);
+            if (a != null) {
+                userInfo.setEmail(a.getName());
+                userInfo.setName(a.getDisplayName());
+            }
+        }
+        writeEntries(resp, log, fmt);
+        if (req.isMarkSeen()) {
+            notif.markSeen();
+        }
+
+        return zsc.jaxbToElement(resp);
+    }
+
+    private void writeEntries(GetNotificationsResponse resp, ItemEventLog log, ItemIdFormatter fmt)
+    throws ServiceException {
+        Provisioning prov = Provisioning.getInstance();
+        for (MailboxEvent ev : log.getEvents(0, 100)) {
+            Account acct = null;
+            try {
+                acct = prov.getAccountById(ev.getAccountId());
+            } catch (ServiceException e) {
+                
+            }
+            resp.addActivity(ToXML.toActivityInfo(acct, ev.getOperation(),
+                    ev.getTimestamp(), fmt.formatItemId(ev.getItemId()), ev.getVersion(),
+                    ev.getUserAgent(), ev.getArgs()));
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/service/mail/GetShareDetails.java
+++ b/store/src/java/com/zimbra/cs/service/mail/GetShareDetails.java
@@ -1,0 +1,113 @@
+package com.zimbra.cs.service.mail;
+
+import java.util.Map;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.MailConstants;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Group;
+import com.zimbra.cs.account.NamedEntry;
+import com.zimbra.cs.mailbox.ACL;
+import com.zimbra.cs.mailbox.MailItem;
+import com.zimbra.cs.mailbox.MailServiceException.NoSuchItemException;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.OperationContext;
+import com.zimbra.cs.service.util.ItemId;
+import com.zimbra.soap.JaxbUtil;
+import com.zimbra.soap.ZimbraSoapContext;
+import com.zimbra.soap.mail.message.GetShareDetailsRequest;
+import com.zimbra.soap.mail.message.GetShareDetailsResponse;
+import com.zimbra.soap.mail.type.ShareDetails;
+import com.zimbra.soap.mail.type.ShareGrantee;
+import com.zimbra.soap.type.GrantGranteeType;
+
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2020 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+public class GetShareDetails extends MailDocumentHandler {
+
+    protected static final String[] TARGET_ITEM_PATH = new String[] { MailConstants.E_ITEM, MailConstants.A_ID };
+
+    @Override
+    protected String[] getProxiedIdPath(Element request) {
+        return TARGET_ITEM_PATH;
+    }
+
+    @Override
+    protected String[] getResponseItemPath() {
+        return TARGET_ITEM_PATH;
+    }
+
+    @Override
+    protected boolean checkMountpointProxy(Element request) {
+        return true;
+    }
+
+    @VisibleForTesting
+    @Override
+    protected Element proxyIfNecessary(Element request, Map<String, Object> context) throws ServiceException {
+        return super.proxyIfNecessary(request, context);
+    }
+
+    @Override
+    public Element handle(Element request, Map<String, Object> context) throws ServiceException {
+        ZimbraSoapContext zsc = getZimbraSoapContext(context);
+        Account acct = getAuthenticatedAccount(zsc);
+        if (acct.isAccountExternal() || acct.isIsExternalVirtualAccount()) {
+            throw ServiceException.PERM_DENIED("you do not have permission to view share details");
+        }
+        Mailbox mbox = getRequestedMailbox(zsc);
+        OperationContext octxt = getOperationContext(zsc, context);
+
+        GetShareDetailsRequest req = JaxbUtil.elementToJaxb(request);
+        ItemId iid = new ItemId(req.getItem().getId(), zsc);
+        ACL acl = null;
+        try {
+            acl = mbox.getItemById(octxt, iid.getId(), MailItem.Type.UNKNOWN).getACL();
+        } catch (NoSuchItemException nsie) {
+            // mask nonexistent item as permission denied
+            throw ServiceException.PERM_DENIED("you do not have sufficient permissions");
+        }
+
+        GetShareDetailsResponse resp = new GetShareDetailsResponse(iid.toString(acct));
+        ShareDetails details = resp.getShareDetails();
+        if (acl != null) {
+            for (ACL.Grant grant : acl.getGrants()) {
+                byte granteeType = grant.getGranteeType();
+                NamedEntry nentry = FolderAction.lookupGranteeByZimbraId(grant.getGranteeId(), granteeType);
+
+                ShareGrantee grantee = new ShareGrantee();
+                grantee.setPerm(ACL.rightsToString(grant.getGrantedRights()));
+                grantee.setGranteeType(GrantGranteeType.fromString(ACL.typeToString(granteeType)));
+                if (nentry != null) {
+                    if (nentry instanceof Account) {
+                        grantee.setGranteeName(((Account) nentry).getDisplayName());
+                        grantee.setGranteeEmail(nentry.getName());
+                    } else if (nentry instanceof Group) {
+                        grantee.setGranteeName(((Group) nentry).getDisplayName());
+                        grantee.setGranteeEmail(nentry.getName());
+                    } else {
+                        grantee.setGranteeName(nentry.getName());
+                    }
+                }
+                details.addGrantee(grantee);
+            }
+        }
+        return zsc.jaxbToElement(resp);
+    }
+}

--- a/store/src/java/com/zimbra/cs/service/mail/GetWatchingItems.java
+++ b/store/src/java/com/zimbra/cs/service/mail/GetWatchingItems.java
@@ -1,0 +1,58 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2020 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.service.mail;
+
+import java.util.Map;
+
+import com.google.common.collect.Multimap;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.MailConstants;
+import com.zimbra.common.soap.OctopusXmlConstants;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.cache.WatchCache;
+import com.zimbra.cs.service.util.ItemId;
+import com.zimbra.cs.service.util.ItemIdFormatter;
+import com.zimbra.soap.ZimbraSoapContext;
+
+public class GetWatchingItems extends MailDocumentHandler {
+
+    @Override
+    public Element handle(Element request, Map<String, Object> context) throws ServiceException {
+        ZimbraSoapContext zsc = getZimbraSoapContext(context);
+        Element response = zsc.createElement(OctopusXmlConstants.GET_WATCHING_ITEMS_RESPONSE);
+        Provisioning prov = Provisioning.getInstance();
+        ItemIdFormatter fmt = new ItemIdFormatter(zsc);
+        Account account = prov.getAccountById(zsc.getRequestedAccountId());
+        Multimap<String,Integer> cache = WatchCache.get(account).getMap();
+        for (String key : cache.keySet()) {
+            Element target = response.addNonUniqueElement(MailConstants.E_TARGET);
+            Account a = prov.getAccountById(key);
+            target.addAttribute(MailConstants.A_ID, a.getId());
+            target.addAttribute(MailConstants.A_EMAIL, a.getName());
+            target.addAttribute(MailConstants.A_NAME, a.getDisplayName());
+            for (Integer itemId : cache.get(key)) {
+                Element i = target.addNonUniqueElement(MailConstants.E_ITEM);
+                ItemId iid = new ItemId(key, itemId);
+                i.addAttribute(MailConstants.A_ID, fmt.formatItemId(iid));
+            }
+        }
+        return response;
+    }
+
+}

--- a/store/src/java/com/zimbra/cs/service/mail/MailService.java
+++ b/store/src/java/com/zimbra/cs/service/mail/MailService.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016 Synacor, Inc.
+ * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2021 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -246,5 +246,12 @@ public final class MailService implements DocumentService {
         dispatcher.registerHandler(MailConstants.SET_RECOVERY_EMAIL_REQUEST, new SetRecoveryAccount());
 
         dispatcher.registerHandler(OctopusXmlConstants.GET_DOCUMENT_SHARE_URL_REQUEST, new GetDocumentShareURL());
+
+        //Document action API
+        dispatcher.registerHandler(OctopusXmlConstants.DOCUMENT_ACTION_REQUEST, new DocumentAction());
+        dispatcher.registerHandler(OctopusXmlConstants.GET_WATCHING_ITEMS_REQUEST, new GetWatchingItems());
+        dispatcher.registerHandler(OctopusXmlConstants.GET_NOTIFICATIONS_REQUEST, new GetNotifications());
+        dispatcher.registerHandler(OctopusXmlConstants.GET_DOCUMENT_SHARE_URL_REQUEST, new GetDocumentShareURL());
+        dispatcher.registerHandler(OctopusXmlConstants.GET_SHARE_DETAILS_REQUEST, new GetShareDetails());
     }
 }

--- a/store/src/java/com/zimbra/cs/session/WatchNotification.java
+++ b/store/src/java/com/zimbra/cs/session/WatchNotification.java
@@ -1,0 +1,91 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2021 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.session;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.MailConstants;
+import com.zimbra.common.soap.ZimbraNamespace;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.mailbox.MailItem;
+import com.zimbra.cs.mailbox.MailboxOperation;
+import com.zimbra.cs.mailbox.OperationContext;
+import com.zimbra.cs.mailbox.event.EventListener;
+import com.zimbra.cs.mailbox.event.MailboxEvent;
+import com.zimbra.cs.service.mail.ToXML;
+import com.zimbra.cs.service.util.ItemId;
+import com.zimbra.cs.service.util.ItemIdFormatter;
+import com.zimbra.cs.session.Session.ExternalEventNotification;
+
+public class WatchNotification extends ExternalEventNotification {
+
+    private final MailboxOperation op;
+    private final Account account;
+    private final String userAgent;
+    private final long timestamp;
+    private final ItemId itemId;
+    private final MailItem item;
+    private final int version;
+
+    public WatchNotification(MailboxOperation op, Account account, String userAgent, long timestamp, MailItem item) throws ServiceException {
+        this.op = op;
+        this.account = account;
+        this.userAgent = userAgent;
+        this.timestamp = timestamp;
+        this.item = item;
+        this.itemId = new ItemId(item.getMailbox().getAccountId(), item.getId());
+        this.version = 1;
+    }
+
+    public WatchNotification(MailboxOperation op, Account account, String userAgent, long timestamp, MailItem item, int version) throws ServiceException {
+        this.op = op;
+        this.account = account;
+        this.userAgent = userAgent;
+        this.timestamp = timestamp;
+        this.item = item;
+        this.itemId = new ItemId(item.getMailbox().getAccountId(), item.getId());
+        this.version = version;
+    }
+
+    @Override
+    public boolean canAccess(Account account) {
+        boolean visible = false;
+        try {
+            item.getMailbox().getItemById(new OperationContext(account), item.getId(), MailItem.Type.UNKNOWN);
+            visible = true;
+        } catch (ServiceException e) {
+        }
+        return visible;
+    }
+
+    @Override
+    public void addElement(Element notify) {
+        ToXML.addWatchActivity(notify, account, op.toString(), timestamp, itemId.toString(), userAgent, EventListener.getArgs(op, item, null, null));
+        Element modified = notify.getOptionalElement(ZimbraNamespace.E_MODIFIED);
+        if (modified == null) {
+            modified = notify.addUniqueElement(ZimbraNamespace.E_MODIFIED);
+            Element doc = modified.addElement(MailConstants.E_DOC);
+            ItemIdFormatter fmt = new ItemIdFormatter(account.getId());
+            doc.addAttribute(MailConstants.A_ID, fmt.formatItemId(itemId));
+            ToXML.encodeDocumentWatchAttribute(doc, op == MailboxOperation.Watch);
+        }
+    }
+
+    public MailboxEvent toActivity() {
+        return new MailboxEvent(account.getId(), op, item.getId(), version, item.getFolderId(), timestamp, userAgent, EventListener.getArgs(op, item, null, null));
+    }
+}


### PR DESCRIPTION
Back port changes from ZimbraX to Zimbra9 for Briefcase APIs and update recently viewed documents.
This includes changes back ported from  ZCS-9144, ZCS-9445, ZCS-9933, ZCS-9807, ZCS-10002

Testing done
Verified the changes from above tickets are available on Zimbra9 and Briefcase operations work as expected.
Folder & Document sharing works with required share notifications
Recently viewed documents are updated to DB

https://github.com/Zimbra/zm-db-conf/pull/18
https://github.com/Zimbra/zm-doc-server-ext/pull/1