### PR TITLE
TSS-18349/ZCS-10544: Fix for emails displaying as blank [2]

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/DebugConfig.java
+++ b/common/src/java/com/zimbra/common/localconfig/DebugConfig.java
@@ -359,6 +359,8 @@ public final class DebugConfig {
      */
     public static final boolean jtidyEnabled = value("jtidy_enabled", true);
 
+    public static final boolean hideJtidyWarnings = value("hide_jtidy_warnings", true);
+
     private static boolean value(String key, boolean defaultValue) {
         String value = LC.get(key);
         return value.isEmpty() ? defaultValue : Boolean.parseBoolean(value);

--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1455,6 +1455,9 @@ public final class LC {
     // imap folder pagination enabled
     public static final KnownKey zimbra_imap_folder_pagination_enabled =  KnownKey.newKey(false);
 
+    // For disabling the printing of jtidy warnings in zmmailboxd.out
+    public static final KnownKey hide_jtidy_warnings = KnownKey.newKey(true);
+
     static {
         // Automatically set the key name with the variable name.
         for (Field field : LC.class.getFields()) {

--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1455,9 +1455,6 @@ public final class LC {
     // imap folder pagination enabled
     public static final KnownKey zimbra_imap_folder_pagination_enabled =  KnownKey.newKey(false);
 
-    // For disabling the printing of jtidy warnings in zmmailboxd.out
-    public static final KnownKey hide_jtidy_warnings = KnownKey.newKey(true);
-
     static {
         // Automatically set the key name with the variable name.
         for (Field field : LC.class.getFields()) {

--- a/store/src/java-test/com/zimbra/cs/html/owasp/OwaspHtmlSanitizerTest.java
+++ b/store/src/java-test/com/zimbra/cs/html/owasp/OwaspHtmlSanitizerTest.java
@@ -712,12 +712,9 @@ public class OwaspHtmlSanitizerTest {
                 + "<span style=\"font-size:11pt;font-family:Arial;font-variant-ligatures:normal;font-variant-east-asian:normal;font-variant-position:normal;vertical-align:baseline\"\">ave a nice day.</span>"
                 + "</p></BODY></HTML>";
         String result = new OwaspHtmlSanitizer(malformedHtml, true, null).cleanMalformedHtml(malformedHtml, true);
-        String output = "<p dir=\"ltr\"\n"
-                + "style=\"-webkit-text-size-adjust:auto;line-height:1.38;margin-top:0pt;margin-bottom:0pt;\"><span\n"
-                + " style=\"font-family:Arial;font-size:14.666666984558105px-webkit-text-size-adjust:auto;\">Hello\n"
-                + "h</span><span\n"
-                + "style=\"font-size:11pt;font-family:Arial;font-variant-ligatures:normal;font-variant-east-asian:normal;font-variant-position:normal;vertical-align:baseline\">ave\n"
-                + "a nice day.</span></p>";
+        String output = "<p dir=\"ltr\" style=\"-webkit-text-size-adjust:auto;line-height:1.38;margin-top:0pt;margin-bottom:0pt;\">"
+                + "<span style=\"font-family:Arial;font-size:14.666666984558105px-webkit-text-size-adjust:auto;\">Hello h</span>"
+                + "<span style=\"font-size:11pt;font-family:Arial;font-variant-ligatures:normal;font-variant-east-asian:normal;font-variant-position:normal;vertical-align:baseline\">ave a nice day.</span></p>";
         // check that the extra double quotes are removed
         Assert.assertTrue("Verification failed: Failed to remove extra double quotes.", output.equals(result.trim()));
     }

--- a/store/src/java/com/zimbra/cs/html/owasp/OwaspHtmlSanitizer.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/OwaspHtmlSanitizer.java
@@ -123,6 +123,9 @@ public class OwaspHtmlSanitizer implements Callable<String> {
             if (outStream == null || outStream.trim().isEmpty()) {
                 return str;
             }
+            if (outStream.contains("<\n/")) {
+                outStream = outStream.replaceAll("<\n/","</");
+            }
             ZimbraLog.mailbox.debug("End - Using JTidy library for cleaning the markup. Taken %d milliseconds.",
                     (System.currentTimeMillis() - startTime));
             return outStream;

--- a/store/src/java/com/zimbra/cs/html/owasp/OwaspHtmlSanitizer.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/OwaspHtmlSanitizer.java
@@ -29,7 +29,6 @@ import org.owasp.html.PolicyFactory;
 import org.w3c.tidy.Tidy;
 
 import com.zimbra.common.localconfig.DebugConfig;
-import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.html.owasp.policies.StyleTagReceiver;
@@ -119,7 +118,7 @@ public class OwaspHtmlSanitizer implements Callable<String> {
             tidy.setTidyMark(false);
             tidy.setHideEndTags(true);
             tidy.setWraplen(0);
-            if (LC.hide_jtidy_warnings.booleanValue()) {
+            if (DebugConfig.hideJtidyWarnings) {
                 tidy.setQuiet(true);
                 tidy.setShowWarnings(false);
             }

--- a/store/src/java/com/zimbra/cs/html/owasp/OwaspHtmlSanitizer.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/OwaspHtmlSanitizer.java
@@ -118,6 +118,7 @@ public class OwaspHtmlSanitizer implements Callable<String> {
             tidy.setDocType("omit");
             tidy.setTidyMark(false);
             tidy.setHideEndTags(true);
+            tidy.setWraplen(0);
             if (LC.hide_jtidy_warnings.booleanValue()) {
                 tidy.setQuiet(true);
                 tidy.setShowWarnings(false);
@@ -130,9 +131,6 @@ public class OwaspHtmlSanitizer implements Callable<String> {
             String outStream = outputStream.toString("UTF-8");
             if (outStream == null || outStream.trim().isEmpty()) {
                 return str;
-            }
-            if (outStream.contains("<\n/")) {
-                outStream = outStream.replaceAll("<\n/","</");
             }
             ZimbraLog.mailbox.debug("End - Using JTidy library for cleaning the markup. Taken %d milliseconds.",
                     (System.currentTimeMillis() - startTime));

--- a/store/src/java/com/zimbra/cs/html/owasp/OwaspHtmlSanitizer.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/OwaspHtmlSanitizer.java
@@ -29,6 +29,7 @@ import org.owasp.html.PolicyFactory;
 import org.w3c.tidy.Tidy;
 
 import com.zimbra.common.localconfig.DebugConfig;
+import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.html.owasp.policies.StyleTagReceiver;
@@ -114,6 +115,13 @@ public class OwaspHtmlSanitizer implements Callable<String> {
             Tidy tidy = new Tidy();
             tidy.setInputEncoding("UTF-8");
             tidy.setOutputEncoding("UTF-8");
+            tidy.setDocType("omit");
+            tidy.setTidyMark(false);
+            tidy.setHideEndTags(true);
+            if (LC.hide_jtidy_warnings.booleanValue()) {
+                tidy.setQuiet(true);
+                tidy.setShowWarnings(false);
+            }
             tidy.setPrintBodyOnly(printBodyOnly);
             tidy.setXHTML(true);
             ByteArrayInputStream inputStream = new ByteArrayInputStream(str.getBytes("UTF-8"));


### PR DESCRIPTION
**Problem:**
Some of the emails displaying as blank.

**Analysis and Fix:**
It was observed that certain e-mails were displaying as blank. On analysing the input mime it was found that there was issue
with the input html after getting parsed div tag was containing a new line between `<` and `/div>`. ~~To fix this issue a new
condition is introduced to handle if any of the end tag contains this situation then newline is removed from that tag and it
should constitute a well-formed end tag.~~
**Update:** Handled the newline condition using the `JTidy` library option `setWraplen(0)` as earlier `JTidy` was wrapping the html at 68th character. So, setting this option to set the wrapping to `0` which in removes any chances of having the unnecessary newline in the html.

Also, added `localconfig` `hide_jtidy_warnings` to disable the printing of warnings and messages in the `zmmailboxd.out` log.
Also, added the following configs:
- Set to omit the doctype to not have unnecessary jtidy generated doctype in the parsed html.
- Set the tidy mark to false so that tidy should not add meta element indicating tidied doc.
- Set the hide end tags to true so that it suppress optional end tags.

**Testing Done:**
- Imported few e-mails from the account mentioned in the [TSS-18349](https://jira.corp.synacor.com/browse/TSS-18349) and verified they are displaying properly.
- Imported few e-mails from the account mentioned in the [TSS-18300](https://jira.corp.synacor.com/browse/TSS-18300) and verified they are displaying properly.
- Verified the older malformed html mime, attached in the [TSS-18004](https://jira.corp.synacor.com/browse/TSS-18004) and verified it is displaying properly.
- Injected the old problematic mimes attached in the [ZCS-6512](https://jira.corp.synacor.com/browse/ZCS-6512) that are displaying properly.

**Related PRs:**
[TSS-18004](https://github.com/Zimbra/zm-mailbox/pull/1128)
[TSS-18300](https://github.com/ZimbraOS/zm-mailbox/pull/1139)