### PR TITLE
ZCS-10585: zulip base host & jwt secret attrs moved to ldap removing from lc

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1374,13 +1374,6 @@ public final class LC {
 
     public static final KnownKey conversation_ignore_maillist_prefix = KnownKey.newKey(true);
 
-    // base host for zulip
-    public static final KnownKey zulip_base_host = KnownKey.newKey("https://%s.zimbracloud.com");
-
-    // zulip jwt secret
-    public static final KnownKey zulip_jwt_secret = KnownKey.newKey("MOVE_ME_TO_A_SECRET");
-
-
     //EWS web service
     public static final KnownKey ews_service_wsdl_location =
         KnownKey.newKey("/opt/zimbra/lib/ext/zimbraews/");


### PR DESCRIPTION
Zulip base host & jwt secret attrs have been moved to LDAP removing them from localconfig.