### PR TITLE
ZCS-10589: update db version for adding watch & event tables for briefcase api

### DIFF
--- a/store/src/java/com/zimbra/cs/db/Versions.java
+++ b/store/src/java/com/zimbra/cs/db/Versions.java
@@ -41,7 +41,7 @@ public final class Versions {
      *
      * UPDATE THESE TO REQUIRE RESET-WORLD TO BE RUN
      */
-    public static final int DB_VERSION = 111;
+    public static final int DB_VERSION = 112;
 
     /**
      * The INDEX_VERSION is stored into the config table of the DB when the DB is created.


### PR DESCRIPTION
Updating database version for feature addition of document editing with Briefcase APIs. Database has been updated with new tables of watch & event in mailbox groups.

Also adding support for ZCS upgrade with supported scripts in below PRs

https://github.com/Zimbra/zm-db-conf/pull/19
https://github.com/Zimbra/zm-build/pull/182