### PR TITLE
ZBUG-1948: Fix for Problems viewing mail with owasp_html_sanitizer enabled

### DIFF
--- a/store/src/java/com/zimbra/cs/html/owasp/OwaspDefang.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/OwaspDefang.java
@@ -44,6 +44,9 @@ public class OwaspDefang extends AbstractDefang {
     @Override
     public void defang(InputStream is, boolean neuterImages, Writer out) throws IOException {
         String html = CharStreams.toString(new InputStreamReader(is, Charsets.UTF_8));
+        if (html == null || html.isEmpty()) {
+            html = "<html><body></body></html>";
+        }
         String sanitizedHtml = runSanitizer(html, neuterImages);
         out.write(sanitizedHtml);
         out.close();

--- a/store/src/java/com/zimbra/cs/html/owasp/policies/BackgroundPolicy.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/policies/BackgroundPolicy.java
@@ -20,6 +20,8 @@ import java.util.List;
 
 import org.owasp.html.ElementPolicy;
 
+import com.zimbra.common.util.ZimbraLog;
+
 public class BackgroundPolicy implements ElementPolicy {
 
     @Override
@@ -28,6 +30,11 @@ public class BackgroundPolicy implements ElementPolicy {
         if (bgIndex == -1) {
             return elementName;
         }
+        if (bgIndex%2 != 0) {
+            ZimbraLog.mailbox.debug("Keyword 'background' found as attribute value instead of attribute name, so ignoring.");
+            return elementName;
+        }
+
         String bgValue = attrs.get(bgIndex + 1);
         attrs.remove(bgIndex);
         attrs.remove(bgIndex);// value
@@ -35,5 +42,4 @@ public class BackgroundPolicy implements ElementPolicy {
         attrs.add(bgValue);
         return elementName;
     }
-
 }


### PR DESCRIPTION
**Problem:**
Problems viewing mail with `owasp_html_sanitizer` enabled.

**Approach and Fix:**
**[1]** Mime `427353-1804751.msg` attached in [ZBUG-1948](https://jira.corp.synacor.com/browse/ZBUG-1948) causes `java.lang.IndexOutOfBoundsException`

Fix: The root cause of this problem is that the attribute value in itself is `background` instead of attribute itself, so while
`BackgroundPolicy` tries to seek the `attrs.indexOf("background")` resulting in wrong index of the attribute and resulting in the `java.lang.IndexOutOfBoundsException`.

To fix this another condition is implemented which checks for that if the keyword `background` is coming at odd index or not,
if the index of `background` keyword is found at the odd index position then we are ignoring it as we are only interested in the attribute key if it is `background` or not.

-------

**[2]** Mime `ProblematiEmail.eml`  attached in [ZBUG-1948](https://jira.corp.synacor.com/browse/ZBUG-1948) causes the `NullPointerException` exception:

The root cause of this problem is that in this particular MIME there was no dummy html tags were present, verified by creating a empty mail body without having any contents with attachment that the dummy `<html><body></body></html>` are present, so the html was evaluating to `null` and we were getting the `NullPointerException` exception.

To fix this issue if the html is null or empty then the dummy html tags are added.

-------

**[3]** Mime `01106177.eml`  attached in [ZBUG-1948](https://jira.corp.synacor.com/browse/ZBUG-1948) is not getting parsed properly which we were facing in the [TSS-18004](https://jira.corp.synacor.com/browse/TSS-18004) because of extra double quotes.

The original message body which contains a lot of unclosed double quotes which was escaping large chunks of the real
message. Looking inside the owasp java sanitizer code turns out that the `OWASP` uses `HtmlLexer` for the sanitization process which traverses element by element so before sanitizing the html it takes the value of the attribute and strips of any of the vulnerable kinds of stuff based on what policies we have applied. In this particular case because of the malformed double quotes which were present inside the tag it thinks of it as the new attribute has started and intercepts whatever is there as its value before the next double-quotes.

To fix this issue extended the earlier work of fixing the double quotes issue addressed in the [TSS-18004](https://jira.corp.synacor.com/browse/TSS-18004), but in that particular issue double-quotes was handled if it was present at the very end of the tag near to `>` but in this case the the duplicate quotes were present not at the very end resulting in failing of the issue as it was addressed in the earlier attempt, to address this issue added another condition to handle the duplicate quotes if they are present not at the very end of the tag but in the middle for an attribute.
[Reference PR](https://github.com/Zimbra/java-html-sanitizer-release-20190610.1/pull/5)

-------

**[4]** Mime `Activación_de_usuarios_en_SEFLOGIC-Producción_HANA_-_LGONALM.eml `  attached in [ZBUG-1948](https://jira.corp.synacor.com/browse/ZBUG-1948) is not getting parsed properly because of there are too many nested div elements due to a corrupt HTML file.

Here, in the owasp sanitizer there is the restriction implemented how deep down a nested tag can be allowed. If it crosses that limit then the e-mail body is not displayed.

To fix that above issue the limit is now increased to `Integer.MAX_VALUE.`
[Reference PR](https://github.com/Zimbra/java-html-sanitizer-release-20190610.1/pull/5)

**Testing Done:**
- Verified all the above e-mails are displaying properly.