### PR TITLE
ZCS-10603: fetch authenticated user mailbox skipping check of is on local server

### DIFF
--- a/store/src/java/com/zimbra/cs/index/ZimbraQuery.java
+++ b/store/src/java/com/zimbra/cs/index/ZimbraQuery.java
@@ -42,6 +42,7 @@ import com.zimbra.cs.mailbox.CalendarItem;
 import com.zimbra.cs.mailbox.Folder;
 import com.zimbra.cs.mailbox.MailItem;
 import com.zimbra.cs.mailbox.MailServiceException.NoSuchItemException;
+import com.zimbra.cs.mailbox.MailboxManager.FetchMode;
 import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.MailboxManager;
 import com.zimbra.cs.mailbox.Mountpoint;
@@ -726,7 +727,8 @@ public final class ZimbraQuery {
         union.add(remoteOps);
         ZimbraLog.search.debug("BEFORE_FINAL_OPT=%s", union);
         operation = union.optimize(mailbox);
-        operation.authMailbox = MailboxManager.getInstance().getMailboxByAccountId(octxt.getAuthenticatedUser().getId());
+        // fetch authenticated user mailbox skipping the check of is on local server
+        operation.authMailbox = MailboxManager.getInstance().getMailboxByAccountId(octxt.getAuthenticatedUser().getId(), FetchMode.DO_NOT_AUTOCREATE, true);
 
         ZimbraLog.search.debug("COMPILED=%s", operation);
     }


### PR DESCRIPTION
Issue
Sharing briefcase folder on multi node environment across the mailbox servers between 2 users resulting into WRONG_HOST exception when fetching the mailbox account of authenticated user. Resulting into no files list for shared folders for sharee user.

Fix
Added flag to skip the check of is on local server and get the mailbox of authenticated user using account id.

Testing done
Verified folder shared across mailbox server on multi node environment between user, sharee user is able to get the files list.
