### PR TITLE
ZCS-10158 user api GetDeviceStatusRequest returns removed devices too

### DIFF
--- a/common/src/java/com/zimbra/common/soap/SyncConstants.java
+++ b/common/src/java/com/zimbra/common/soap/SyncConstants.java
@@ -106,6 +106,7 @@ public final class SyncConstants {
     public static final String A_FILTERDEVICESBYAND = "filterDevicesByAnd";
     public static final String A_ADMIN = "Admin";
     public static final String A_USER = "User";
+    public static final String A_INCLUDE_REMOVED_DEVICES = "includeRemovedDevices";
 
     // Sync command response statuses
     // Reference - https://msdn.microsoft.com/en-us/library/gg675457(v=exchg.80).aspx

--- a/soap/src/java/com/zimbra/soap/sync/message/GetDeviceStatusRequest.java
+++ b/soap/src/java/com/zimbra/soap/sync/message/GetDeviceStatusRequest.java
@@ -17,6 +17,7 @@
 
 package com.zimbra.soap.sync.message;
 
+import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import com.zimbra.common.soap.SyncConstants;
@@ -29,4 +30,36 @@ import com.zimbra.common.soap.SyncConstants;
  */
 @XmlRootElement(name=SyncConstants.E_GET_DEVICE_STATUS_REQUEST)
 public class GetDeviceStatusRequest {
+
+    /**
+     * @zm-api-field-tag offset
+     * @zm-api-field-description Offset for the resultant list of the devices. Offset and Limit both should be sent together in request.
+     */
+    @XmlAttribute(name=SyncConstants.A_INCLUDE_REMOVED_DEVICES /* includeRemovedDevices */, required=false)
+    private Boolean includeRemovedDevices = false;
+
+    public GetDeviceStatusRequest() {
+        this(false);
+    }
+
+    /**
+     * @param includeRemovedDevices
+     */
+    public GetDeviceStatusRequest(Boolean includeRemovedDevices) {
+        this.includeRemovedDevices = includeRemovedDevices;
+    }
+
+    /**
+     * @return the includeRemovedDevices
+     */
+    public Boolean getIncludeRemovedDevices() {
+        return includeRemovedDevices;
+    }
+
+    /**
+     * @param includeRemovedDevices the includeRemovedDevices to set
+     */
+    public void setIncludeRemovedDevices(Boolean includeRemovedDevices) {
+        this.includeRemovedDevices = includeRemovedDevices;
+    }
 }

--- a/soap/src/java/com/zimbra/soap/sync/message/GetDeviceStatusRequest.java
+++ b/soap/src/java/com/zimbra/soap/sync/message/GetDeviceStatusRequest.java
@@ -32,8 +32,8 @@ import com.zimbra.common.soap.SyncConstants;
 public class GetDeviceStatusRequest {
 
     /**
-     * @zm-api-field-tag offset
-     * @zm-api-field-description Offset for the resultant list of the devices. Offset and Limit both should be sent together in request.
+     * @zm-api-field-tag includeRemovedDevices
+     * @zm-api-field-description Whether to include devices removed by user or not. Default is FALSE, which will not include removed devices.
      */
     @XmlAttribute(name=SyncConstants.A_INCLUDE_REMOVED_DEVICES /* includeRemovedDevices */, required=false)
     private Boolean includeRemovedDevices = false;


### PR DESCRIPTION
**Problem:**
- device removed by user immediately gets re-provisioned and continues syncing and gets listed in the syncing device list on UI
- user api `GetDeviceStatusRequest` returns removed devices too

**Approach and Fix:**
- once device is removed by user, do not allow it to re-provision on it's own. user should be able to allow it using `AllowDeviceRequest`. This stops devices syncing after removal by user.
- added optional attribute `includeRemovedDevices` in user api `GetDeviceStatusRequest` with default value as `false`. this will give control on api level whether removed devices should be returned in response or not.

**Testing done:**
- once device is removed by user, it does not get re-provisioned and stops syncing new items.
- user can allow re-provision of removed device using `AllowDeviceRequest`
- `GetDeviceStatusRequest` returns list of devices as per `includeRemovedDevices` attribute value, default is `false`, which means, it does not include removed devices.

**Testing to be done by QA:**
- verify given scenarios
- make sure nothing is broken in user api `AllowDeviceRequest`, `GetDeviceStatusRequest`, `RemoveDeviceRequest`

**Linked PR:**
https://github.com/Zimbra/zm-sync-store/pull/31