### PR TITLE
ZBUG-2283: Do not allow to explicitly set the Host header

### DIFF
--- a/store/src/java/com/zimbra/cs/zimlet/ProxyServlet.java
+++ b/store/src/java/com/zimbra/cs/zimlet/ProxyServlet.java
@@ -286,13 +286,10 @@ public class ProxyServlet extends ZimbraServlet {
             Enumeration headers = req.getHeaderNames();
             while (headers.hasMoreElements()) {
                 String hdr = (String) headers.nextElement();
-            	ZimbraLog.zimlet.debug("incoming: " + hdr + ": " + req.getHeader(hdr));
+                ZimbraLog.zimlet.debug("incoming: " + hdr + ": " + req.getHeader(hdr));
                 if (canProxyHeader(hdr)) {
-                	ZimbraLog.zimlet.debug("outgoing: " + hdr + ": " + req.getHeader(hdr));
-                	if (hdr.equalsIgnoreCase("x-host"))
-                	    method.setHeader("Host", req.getHeader(hdr));
-                	else
-                		method.addHeader(hdr, req.getHeader(hdr));
+                    ZimbraLog.zimlet.debug("outgoing: " + hdr + ": " + req.getHeader(hdr));
+                    method.addHeader(hdr, req.getHeader(hdr));
                 }
             }
 


### PR DESCRIPTION
**Issue**
- Proxy SSRF: An attacker in control of any user-account regardless of their privileges on a targeted Zimbra
instance can forge arbitrary requests on the server the Zimbra instance is hosted on. This could
lead to disclosure of sensitive information and access control bypasses.

**Solution:**
- Do not take into consideration the Host header setting.

**Test:**
- Tested the scenario where a user should not be able to redirect to any service with the Help of X-host. 