### PR TITLE
ZCS-9764: Open Redirect Vulnerability in PreAuthServlet

### DIFF
--- a/store/src/java/com/zimbra/cs/service/PreAuthServlet.java
+++ b/store/src/java/com/zimbra/cs/service/PreAuthServlet.java
@@ -23,6 +23,8 @@ package com.zimbra.cs.service;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -33,6 +35,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.google.common.net.InetAddresses;
 import com.zimbra.common.account.Key;
 import com.zimbra.common.account.Key.AccountBy;
 import com.zimbra.common.account.ZAttrProvisioning.AutoProvAuthMech;
@@ -330,12 +333,39 @@ public class PreAuthServlet extends ZimbraServlet {
     private static final String DEFAULT_MAIL_URL = "/zimbra";
     private static final String DEFAULT_ADMIN_URL = "/zimbraAdmin";
 
+    private static boolean isPrivate172SeriesAddress(String domain) {
+        int address = InetAddresses.coerceToInteger(InetAddresses.forString(domain));
+        return (((address >>> 24) & 0xFF) == 10)
+                || ((((address >>> 24) & 0xFF) == 172)
+                  && ((address >>> 16) & 0xFF) >= 16
+                  && ((address >>> 16) & 0xFF) <= 31)
+                || ((((address >>> 24) & 0xFF) == 192)
+                  && (((address >>> 16) & 0xFF) == 168));
+    }
+
     private void setCookieAndRedirect(HttpServletRequest req, HttpServletResponse resp, AuthToken authToken) throws IOException, ServiceException {
         boolean isAdmin = AuthToken.isAnyAdmin(authToken);
         boolean secureCookie = req.getScheme().equals("https");
         authToken.encode(resp, isAdmin, secureCookie);
 
         String redirectURL = getOptionalParam(req, PARAM_REDIRECT_URL, null);
+        URI uri = null;
+        try {
+            uri = new URI(redirectURL);
+        } catch (URISyntaxException exp) {
+            ZimbraLog.account.debug(String.format("URI %s is a malformed URL", redirectURL), exp);
+        }
+        String domain = uri.getHost();
+        domain = domain.startsWith("www.") ? domain.substring(4) : domain;
+
+        if (domain != null) {
+            if (domain.equals("localhost") || domain.equals("127.0.0.1")
+                    || domain.startsWith("192.168") || domain.startsWith("10.")
+                    || isPrivate172SeriesAddress(domain)) {
+                throw ServiceException.PERM_DENIED("Cannot access internal Ip resources.");
+            }
+        }
+
         if (redirectURL != null) {
             resp.sendRedirect(redirectURL);
         } else {


### PR DESCRIPTION
**Problem:**
As per description in the ticket an authenticated user can recover his `authoken` by simply looking at what URLs are loaded by his browser after authentication. This valid `authtoken` can be used to exploit the insecure redirect in the `PreAuthServlet`.
```
/service/preauth? isredirect=1&authtoken=[VALIDTOKEN]&redirectURL=http://whatever
```

**Fix:**
~~To fix the above exploitation checked the `redirectURL` in the `PreAuthServlet` to look if the domain is `localhost` or `127.0.0.1` or it belongs to the set of private IP addresses then it restricts the user from redirecting it to the local addresses and if it is an external addresses then it allows the redirection.~~

**Update:** There is an insecure redirect in the `PreAuthServlet` which can only be exploited with a valid authtoken as compared to earlier fix this doesn't hold true as a SSRF Vulnerability. This will allow redirect to any external url without checking a whitelist. User can also specify an internal port, which is not specified publicly exposed, which will allow user to probe internal ports.

To fix this, in the redirectURL if it contains the protocol with a domain name and/or a port then that part of the url is stripped
off from the redirectURL and restricting it from getting access to any of the internal domain and ports.

**Testing Done:**
Verified by following the following steps:
- Login to Zimbra Web Mail, grabbed the value of the `ZM_AUTH_TOKEN` cookie.
- Used `OnlyOffice` as a separate service to test the redirection.
- Deleted the cookies related to domain.
- Formed the following URL:
```
https://129.X.X.X/service/preauth?isredirect=1&authtoken=0_2ac9c91aba9d3a6e1f147dfeda66faa648d5c8b5_69643d33363a31653438613761392d363337382d343462632d393231392d6662326636643530306630353b6578703d31333a313632333539363432363836303b747970653d363a7a696d6272613b753d313a613b7469643d31303a323037353132333532353b76657273696f6e3d31333a392e312e305f47415f313436373b637372663d313a313b&redirectURL=https://localhost.webex.com:7080/service/shf/IoHfynD0SAimTzK7M71EAx5Ip6ljeES8khn7L21QDwUAAAJ2Mg==
```
- Verified that the above url strips off the `https://localhost.webex.com:7080` part and redirect to the relative path.
```
/service/preauth?isredirect=1&authtoken=[VALIDTOKEN]&redirectURL=http://127.0.0.1:7080 
/service/preauth?isredirect=1&authtoken=[VALIDTOKEN]&redirectURL=http://localhost.webex.com:7080
```
- Verified that above urls get stripped off and returns `Forbidden` in the browser.
- Verified for `localhost`, `127.0.0.1`, and few other domain names with and without protocol and ports.