### PR TITLE
ZBUG-2289: zmmboxmove broken with rsync timeout

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1453,6 +1453,9 @@ public final class LC {
     // imap folder pagination enabled
     public static final KnownKey zimbra_imap_folder_pagination_enabled =  KnownKey.newKey(false);
 
+    @Supported
+    public static final KnownKey zimbra_remote_cmd_channel_timeout_min = KnownKey.newKey(10);
+
     static {
         // Automatically set the key name with the variable name.
         for (Field field : LC.class.getFields()) {

--- a/store/src/java/com/zimbra/cs/rmgmt/RemoteManager.java
+++ b/store/src/java/com/zimbra/cs/rmgmt/RemoteManager.java
@@ -37,6 +37,7 @@ import org.apache.sshd.client.session.ClientSession;
 import org.apache.sshd.common.util.security.SecurityUtils;
 
 import com.zimbra.common.account.Key;
+import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ByteUtil;
 import com.zimbra.common.util.CliUtil;
@@ -179,7 +180,7 @@ public class RemoteManager {
 				channel.open().await();
 				try {
 					channel.waitFor(EnumSet.of(ClientChannelEvent.CLOSED),
-							TimeUnit.SECONDS.toMillis(defaultTimeoutSeconds));
+							TimeUnit.MINUTES.toMillis(LC.zimbra_remote_cmd_channel_timeout_min.intValue()));
 					session.close(false);
 					RemoteResult result = new RemoteResult();
 					ClientChannel.validateCommandExitStatusCode(mShimCommand, channel.getExitStatus());
@@ -203,6 +204,7 @@ public class RemoteManager {
 			client.stop();
 		}
 	}
+
 	public static KeyPair loadKeypair(String privateKeyPath) throws IOException, GeneralSecurityException {
         try (InputStream privateKeyStream = new FileInputStream(privateKeyPath)) {
             Iterable<KeyPair> keyPairIterable =


### PR DESCRIPTION
**Problem**
- zmmboxmove and moveMailboxRequest was broken, invalid exception thrown and rsync timeout

**Approach and Fix**
- Increase the default timeout.
- Introduce configurable timeout.

**Testing done**
- Tested the mailbox move in the machine where issue was reproducing.