### PR TITLE
ZCS-10537: moving open office path local configs to mailbox

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1440,10 +1440,13 @@ public final class LC {
 
     //allowed file extensions for doc server
     public static final KnownKey doc_editing_supported_document_formats = KnownKey.newKey("doc,docx,docm,dot,dotx,dotm,odt,fodt,ott,rtf,txt,html,htm,mht,pdf,djvu,fb2,epub,xps");
-
     public static final KnownKey doc_editing_supported_spreadsheet_formats = KnownKey.newKey("xls,xlsx,xlsm,xlt,xltx,xltm,ods,fods,ots,csv");
-
     public static final KnownKey doc_editing_supported_presentation_formats = KnownKey.newKey("pps,ppsx,ppsm,ppt,pptx,pptm,pot,potx,potm,odp,fodp,otp");
+
+    // openoffice/onlyoffice path/install identifier for different OS
+    public static final KnownKey oo_mac_install_path = KnownKey.newKey("/Applications/LibreOffice.app/Contents/MacOS/soffice");
+    public static final KnownKey oo_windoze_install_path = KnownKey.newKey("C:\\Program Files\\LibreOffice 3.5\\program\\soffice.exe");
+    public static final KnownKey oo_linux_install_path = KnownKey.newKey("/usr/bin/soffice");
 
     // list file for blocking common passwords
     public static final KnownKey common_passwords_txt = KnownKey.newKey("${zimbra_home}/conf/common-passwords.txt");

--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1439,13 +1439,11 @@ public final class LC {
     public static final KnownKey attachment_extraction_client_class = KnownKey.newKey("com.zimbra.cs.convert.LegacyConverterClient");
 
     //allowed file extensions for doc server
-    public static final KnownKey doc_editing_supported_document_formats = KnownKey.newKey("doc,docx,docm,dot,dotx,dotm,odt,fodt,ott,rtf,txt,html,htm,mht,pdf,djvu,fb2,epub,xps");
+    public static final KnownKey doc_editing_supported_document_formats = KnownKey.newKey("doc,docx,docm,dot,dotx,dotm,odt,fodt,ott,rtf,txt,html,htm,mht,pdf,djvu,fb2,epub,xps,xml");
     public static final KnownKey doc_editing_supported_spreadsheet_formats = KnownKey.newKey("xls,xlsx,xlsm,xlt,xltx,xltm,ods,fods,ots,csv");
     public static final KnownKey doc_editing_supported_presentation_formats = KnownKey.newKey("pps,ppsx,ppsm,ppt,pptx,pptm,pot,potx,potm,odp,fodp,otp");
 
-    // openoffice/onlyoffice path/install identifier for different OS
-    public static final KnownKey oo_mac_install_path = KnownKey.newKey("/Applications/LibreOffice.app/Contents/MacOS/soffice");
-    public static final KnownKey oo_windoze_install_path = KnownKey.newKey("C:\\Program Files\\LibreOffice 3.5\\program\\soffice.exe");
+    // openoffice/onlyoffice path/install identifier
     public static final KnownKey oo_linux_install_path = KnownKey.newKey("/usr/bin/soffice");
 
     // list file for blocking common passwords


### PR DESCRIPTION
Added Onlyoffice as an option for document preview.
Moving open office path local configs to mailbox for switching the preview between onlyoffice & openoffice.

https://github.com/Zimbra/zm-openoffice-store/pull/9
https://github.com/Zimbra/zm-doc-server-ext/pull/5