### PR TITLE
ZCS-10705 - Workaround for android outlook sending 25-character dates

### DIFF
--- a/store/src/java/com/zimbra/cs/imap/ImapRequest.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapRequest.java
@@ -796,7 +796,13 @@ public abstract class ImapRequest {
     protected Date readDate(boolean datetime, boolean checkRange) throws ImapParseException {
         String dateStr = (peekChar() == '"' ? readQuoted() : readAtom());
         if (dateStr.length() < (datetime ? 26 : 10)) {
-            throw new ImapParseException(tag, "invalid date format");
+            if (dateStr.length() == 25) {
+                // Outlook on Android will send dates "7-Feb-1994 22:43:04 -0800", where " 7-Feb-1994 22:43:04 -0800" is expected in APPEND.
+                // See: https://datatracker.ietf.org/doc/html/rfc3502
+                dateStr = " " + dateStr;
+            } else {
+                throw new ImapParseException(tag, "invalid date format");
+            }
         }
         Calendar cal = new GregorianCalendar();
         cal.clear();


### PR DESCRIPTION
Workaround for android outlook sending 25-character dates in append commands, which was causing a loop of "Failed to add recipient" "Failed to remove recipient" error messages in Android Outlook.

Android outlook will send APPEND commands with dates that look like this:
```
A2374 APPEND "Drafts" (\Seen) "3-May-2021 20:38:39 +0000" {570}
```
Where date is expected to be:
```
A2374 APPEND "Drafts" (\Seen) " 3-May-2021 20:38:39 +0000" {570}
```

Example in: https://datatracker.ietf.org/doc/html/rfc3502
```

   Example: C: A003 APPEND saved-messages (\Seen) {329}
            S: + Ready for literal data
            C: Date: Mon, 7 Feb 1994 21:52:25 -0800 (PST)
            C: From: Fred Foobar <foobar@Blurdybloop.example.COM>
            C: Subject: afternoon meeting
            C: To: mooch@owatagu.example.net
            C: Message-Id: <B27397-0100000@Blurdybloop.example.COM>
            C: MIME-Version: 1.0
            C: Content-Type: TEXT/PLAIN; CHARSET=US-ASCII
            C:
            C: Hello Joe, do you think we can meet at 3:30 tomorrow?
            C:  (\Seen) " 7-Feb-1994 22:43:04 -0800" {295}
            S: + Ready for literal data
            C: Date: Mon, 7 Feb 1994 22:43:04 -0800 (PST)
            C: From: Joe Mooch <mooch@OWaTaGu.example.net>
            C: Subject: Re: afternoon meeting
            C: To: foobar@blurdybloop.example.com
            C: Message-Id: <a0434793874930@OWaTaGu.example.net>
            C: MIME-Version: 1.0
            C: Content-Type: TEXT/PLAIN; CHARSET=US-ASCII
```