### PR TITLE
ZCS-10691: Need attachment restrictions attributes in GetInfoResponse for ZCO client

### DIFF
--- a/common/src/java-test/com/zimbra/common/soap/GetInfoResponseSOAP.xml
+++ b/common/src/java-test/com/zimbra/common/soap/GetInfoResponseSOAP.xml
@@ -338,6 +338,7 @@
         <attr name="displayName">Demo User One</attr>
         <attr name="zimbraPasswordMinLength">6</attr>
         <attr name="zimbraFeatureComposeInNewWindowEnabled">TRUE</attr>
+        <attr name="zimbraFeatureFileTypeUploadRestrictionsEnabled">TRUE</attr>
       </attrs>
       <zimlets>
         <zimlet>

--- a/soap/src/java-test/com/zimbra/soap/account/GetInfoResponse.json
+++ b/soap/src/java-test/com/zimbra/soap/account/GetInfoResponse.json
@@ -324,7 +324,8 @@
       "zimbraFeatureNewAddrBookEnabled": "TRUE",
       "displayName": "Demo User One",
       "zimbraPasswordMinLength": "6",
-      "zimbraFeatureComposeInNewWindowEnabled": "TRUE"
+      "zimbraFeatureComposeInNewWindowEnabled": "TRUE",
+      "zimbraFeatureFileTypeUploadRestrictionsEnabled": "TRUE"
     }
   },
   "zimlets": {

--- a/soap/src/java-test/com/zimbra/soap/account/GetInfoResponse.xml
+++ b/soap/src/java-test/com/zimbra/soap/account/GetInfoResponse.xml
@@ -334,6 +334,7 @@
     <attr name="displayName">Demo User One</attr>
     <attr name="zimbraPasswordMinLength">6</attr>
     <attr name="zimbraFeatureComposeInNewWindowEnabled">TRUE</attr>
+    <attr name="zimbraFeatureFileTypeUploadRestrictionsEnabled">TRUE</attr>
   </attrs>
   <zimlets>
     <zimlet>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9831,7 +9831,7 @@ TODO: delete them permanently from here
 <attr id="3090" name="zimbraMobileBlockedDevices" type="cstring" cardinality="multi" flags="domainInherited" optionalIn="globalConfig,domain" since="8.9.0">
     <desc>Blocked mobile device list for ActiveSync/ABQ</desc>
 </attr>
-<attr id="3091" name="zimbraFileUploadBlockedFileTypes" type="string" cardinality="multi" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="9.1.0">
+<attr id="3091" name="zimbraFileUploadBlockedFileTypes" type="string" cardinality="multi" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="9.1.0">
   <defaultCOSValue>asd</defaultCOSValue>
   <defaultCOSValue>bat</defaultCOSValue>
   <defaultCOSValue>chm</defaultCOSValue>
@@ -9864,7 +9864,7 @@ TODO: delete them permanently from here
   <desc>Commonly blocked file types for uploading</desc>
  </attr>
 
- <attr id="3092" name="zimbraFeatureFileTypeUploadRestrictionsEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="9.1.0">
+ <attr id="3092" name="zimbraFeatureFileTypeUploadRestrictionsEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="9.1.0">
   <defaultCOSValue>TRUE</defaultCOSValue>
   <desc>Enable/Disable blocked file types set in zimbraFileUploadBlockedFileTypes for uploading</desc>
  </attr>


### PR DESCRIPTION
**Problem Statement:** 
Pass attachment restrictions attributes in GetInfoResponse.

**Fix:** 
Added accountInfo tag in the following Zimbra attributes
- zimbraFeatureFileTypeUploadRestrictionsEnabled
- zimbraFileUploadBlockedFileTypes

**Testing:**
Able to get zimbraFeatureFileTypeUploadRestrictionsEnabled, zimbraFileUploadBlockedFileTypes attributes in getInfoResponse