### PR TITLE
ZCS-10753: add missing backporting of briefcase folder sharing and send notification for requested item

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -5697,14 +5697,6 @@ public class ZAttrProvisioning {
     public static final String A_zimbraDocumentEditingCallbackPort = "zimbraDocumentEditingCallbackPort";
 
     /**
-     * Host server where the onlyoffice is hosted
-     *
-     * @since ZCS 9.1.0
-     */
-    @ZAttr(id=3098)
-    public static final String A_zimbraDocumentEditingHost = "zimbraDocumentEditingHost";
-
-    /**
      * Document editing JWT secret
      *
      * @since ZCS 9.1.0
@@ -5719,6 +5711,14 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=3101)
     public static final String A_zimbraDocumentRecentlyViewedEnabled = "zimbraDocumentRecentlyViewedEnabled";
+
+    /**
+     * Host server where the onlyoffice is hosted
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3098)
+    public static final String A_zimbraDocumentServerHost = "zimbraDocumentServerHost";
 
     /**
      * maximum amount of mail quota a domain admin can set on a user

--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1440,10 +1440,13 @@ public final class LC {
 
     //allowed file extensions for doc server
     public static final KnownKey doc_editing_supported_document_formats = KnownKey.newKey("doc,docx,docm,dot,dotx,dotm,odt,fodt,ott,rtf,txt,html,htm,mht,pdf,djvu,fb2,epub,xps");
-
     public static final KnownKey doc_editing_supported_spreadsheet_formats = KnownKey.newKey("xls,xlsx,xlsm,xlt,xltx,xltm,ods,fods,ots,csv");
-
     public static final KnownKey doc_editing_supported_presentation_formats = KnownKey.newKey("pps,ppsx,ppsm,ppt,pptx,pptm,pot,potx,potm,odp,fodp,otp");
+
+    // openoffice/onlyoffice path/install identifier for different OS
+    public static final KnownKey oo_mac_install_path = KnownKey.newKey("/Applications/LibreOffice.app/Contents/MacOS/soffice");
+    public static final KnownKey oo_windoze_install_path = KnownKey.newKey("C:\\Program Files\\LibreOffice 3.5\\program\\soffice.exe");
+    public static final KnownKey oo_linux_install_path = KnownKey.newKey("/usr/bin/soffice");
 
     // list file for blocking common passwords
     public static final KnownKey common_passwords_txt = KnownKey.newKey("${zimbra_home}/conf/common-passwords.txt");

--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1439,13 +1439,11 @@ public final class LC {
     public static final KnownKey attachment_extraction_client_class = KnownKey.newKey("com.zimbra.cs.convert.LegacyConverterClient");
 
     //allowed file extensions for doc server
-    public static final KnownKey doc_editing_supported_document_formats = KnownKey.newKey("doc,docx,docm,dot,dotx,dotm,odt,fodt,ott,rtf,txt,html,htm,mht,pdf,djvu,fb2,epub,xps");
+    public static final KnownKey doc_editing_supported_document_formats = KnownKey.newKey("doc,docx,docm,dot,dotx,dotm,odt,fodt,ott,rtf,txt,html,htm,mht,pdf,djvu,fb2,epub,xps,xml");
     public static final KnownKey doc_editing_supported_spreadsheet_formats = KnownKey.newKey("xls,xlsx,xlsm,xlt,xltx,xltm,ods,fods,ots,csv");
     public static final KnownKey doc_editing_supported_presentation_formats = KnownKey.newKey("pps,ppsx,ppsm,ppt,pptx,pptm,pot,potx,potm,odp,fodp,otp");
 
-    // openoffice/onlyoffice path/install identifier for different OS
-    public static final KnownKey oo_mac_install_path = KnownKey.newKey("/Applications/LibreOffice.app/Contents/MacOS/soffice");
-    public static final KnownKey oo_windoze_install_path = KnownKey.newKey("C:\\Program Files\\LibreOffice 3.5\\program\\soffice.exe");
+    // openoffice/onlyoffice path/install identifier
     public static final KnownKey oo_linux_install_path = KnownKey.newKey("/usr/bin/soffice");
 
     // list file for blocking common passwords

--- a/common/src/java/com/zimbra/common/util/HttpUtil.java
+++ b/common/src/java/com/zimbra/common/util/HttpUtil.java
@@ -670,6 +670,15 @@ public final class HttpUtil {
         return URI.create(sb.toString());
     }
 
+    // get the url safe encoded string
+    public static String fetchEncoded(String toEncode) {
+        return java.util.Base64.getUrlEncoder().encodeToString(toEncode.getBytes());
+    }
+
+    public static String fetchDecoded(String toDecode) {
+        return new String(java.util.Base64.getUrlDecoder().decode(toDecode));
+    }
+
     public static void main(String[] args) {
         System.out.println(getURIParams((String) null));
         System.out.println(getURIParams("foo=bar"));

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9893,7 +9893,6 @@ TODO: delete them permanently from here
   <desc>Whether or not document editing feature is enabled within briefcase</desc>
 </attr>
 <attr id="3098" name="zimbraDocumentServerHost" type="string" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="9.1.0">
-  <globalConfigValue>zimbra.com</globalConfigValue>
   <desc>Host server where the onlyoffice is hosted</desc>
 </attr>
 <attr id="3099" name="zimbraDocumentEditingCallbackPort" type="port" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" callback="CheckPortConflict" since="9.1.0">

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9892,7 +9892,7 @@ TODO: delete them permanently from here
   <defaultCOSValue>TRUE</defaultCOSValue>
   <desc>Whether or not document editing feature is enabled within briefcase</desc>
 </attr>
-<attr id="3098" name="zimbraDocumentEditingHost" type="string" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="9.1.0">
+<attr id="3098" name="zimbraDocumentServerHost" type="string" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="9.1.0">
   <globalConfigValue>zimbra.com</globalConfigValue>
   <desc>Host server where the onlyoffice is hosted</desc>
 </attr>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9900,7 +9900,6 @@ TODO: delete them permanently from here
   <desc>Zimbra port on which document editing can request document</desc>
 </attr>
 <attr id="3100" name="zimbraDocumentEditingJwtSecret" type="string" cardinality="single" optionalIn="globalConfig" since="9.1.0">
-  <globalConfigValue>SECRET</globalConfigValue>
   <desc>Document editing JWT secret</desc>
 </attr>
 <attr id="3101" name="zimbraDocumentRecentlyViewedEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="9.1.0">

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9892,7 +9892,7 @@ TODO: delete them permanently from here
   <defaultCOSValue>TRUE</defaultCOSValue>
   <desc>Whether or not document editing feature is enabled within briefcase</desc>
 </attr>
-<attr id="3098" name="zimbraDocumentEditingHost" type="string" cardinality="single" optionalIn="globalConfig" since="9.1.0">
+<attr id="3098" name="zimbraDocumentEditingHost" type="string" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="9.1.0">
   <globalConfigValue>zimbra.com</globalConfigValue>
   <desc>Host server where the onlyoffice is hosted</desc>
 </attr>

--- a/store/src/java/com/zimbra/cs/account/Provisioning.java
+++ b/store/src/java/com/zimbra/cs/account/Provisioning.java
@@ -85,7 +85,7 @@ public abstract class Provisioning extends ZAttrProvisioning {
     public static final String SERVICE_MAILBOX   = "mailbox";
     public static final String SERVICE_PROXY = "proxy";
     public static final String SERVICE_MEMCACHED = "memcached";
-
+    public static final String SERVICE_ONLYOFFICE = "onlyoffice";
     /**
      * generate appts that try to be compatible with exchange
      */

--- a/store/src/java/com/zimbra/cs/account/Server.java
+++ b/store/src/java/com/zimbra/cs/account/Server.java
@@ -127,6 +127,10 @@ public class Server extends ZAttrServer {
         }
     }
 
+    public boolean hasOnlyOfficeService() {
+        return getMultiAttrSet(Provisioning.A_zimbraServiceEnabled).contains(Provisioning.SERVICE_ONLYOFFICE);
+    }
+
     public boolean isLocalServer() throws ServiceException {
         Server localServer = getProvisioning().getLocalServer();
         return getId() != null && getId().equals(localServer.getId());

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -13885,13 +13885,13 @@ public abstract class ZAttrConfig extends Entry {
     /**
      * Host server where the onlyoffice is hosted
      *
-     * @return zimbraDocumentServerHost, or "zimbra.com" if unset
+     * @return zimbraDocumentServerHost, or null if unset
      *
      * @since ZCS 9.1.0
      */
     @ZAttr(id=3098)
     public String getDocumentServerHost() {
-        return getAttr(Provisioning.A_zimbraDocumentServerHost, "zimbra.com", true);
+        return getAttr(Provisioning.A_zimbraDocumentServerHost, null, true);
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -13811,78 +13811,6 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Host server where the onlyoffice is hosted
-     *
-     * @return zimbraDocumentEditingHost, or "zimbra.com" if unset
-     *
-     * @since ZCS 9.1.0
-     */
-    @ZAttr(id=3098)
-    public String getDocumentEditingHost() {
-        return getAttr(Provisioning.A_zimbraDocumentEditingHost, "zimbra.com", true);
-    }
-
-    /**
-     * Host server where the onlyoffice is hosted
-     *
-     * @param zimbraDocumentEditingHost new value
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 9.1.0
-     */
-    @ZAttr(id=3098)
-    public void setDocumentEditingHost(String zimbraDocumentEditingHost) throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraDocumentEditingHost, zimbraDocumentEditingHost);
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Host server where the onlyoffice is hosted
-     *
-     * @param zimbraDocumentEditingHost new value
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 9.1.0
-     */
-    @ZAttr(id=3098)
-    public Map<String,Object> setDocumentEditingHost(String zimbraDocumentEditingHost, Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraDocumentEditingHost, zimbraDocumentEditingHost);
-        return attrs;
-    }
-
-    /**
-     * Host server where the onlyoffice is hosted
-     *
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 9.1.0
-     */
-    @ZAttr(id=3098)
-    public void unsetDocumentEditingHost() throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraDocumentEditingHost, "");
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Host server where the onlyoffice is hosted
-     *
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 9.1.0
-     */
-    @ZAttr(id=3098)
-    public Map<String,Object> unsetDocumentEditingHost(Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraDocumentEditingHost, "");
-        return attrs;
-    }
-
-    /**
      * Document editing JWT secret
      *
      * @return zimbraDocumentEditingJwtSecret, or "SECRET" if unset
@@ -13951,6 +13879,78 @@ public abstract class ZAttrConfig extends Entry {
     public Map<String,Object> unsetDocumentEditingJwtSecret(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraDocumentEditingJwtSecret, "");
+        return attrs;
+    }
+
+    /**
+     * Host server where the onlyoffice is hosted
+     *
+     * @return zimbraDocumentServerHost, or "zimbra.com" if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3098)
+    public String getDocumentServerHost() {
+        return getAttr(Provisioning.A_zimbraDocumentServerHost, "zimbra.com", true);
+    }
+
+    /**
+     * Host server where the onlyoffice is hosted
+     *
+     * @param zimbraDocumentServerHost new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3098)
+    public void setDocumentServerHost(String zimbraDocumentServerHost) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDocumentServerHost, zimbraDocumentServerHost);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Host server where the onlyoffice is hosted
+     *
+     * @param zimbraDocumentServerHost new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3098)
+    public Map<String,Object> setDocumentServerHost(String zimbraDocumentServerHost, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDocumentServerHost, zimbraDocumentServerHost);
+        return attrs;
+    }
+
+    /**
+     * Host server where the onlyoffice is hosted
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3098)
+    public void unsetDocumentServerHost() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDocumentServerHost, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Host server where the onlyoffice is hosted
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3098)
+    public Map<String,Object> unsetDocumentServerHost(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDocumentServerHost, "");
         return attrs;
     }
 
@@ -31969,6 +31969,21 @@ public abstract class ZAttrConfig extends Entry {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraMobileBlockedDevices, "");
         getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Blocked mobile device list for ActiveSync/ABQ
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3090)
+    public Map<String,Object> unsetMobileBlockedDevices(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMobileBlockedDevices, "");
+        return attrs;
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -13813,13 +13813,13 @@ public abstract class ZAttrConfig extends Entry {
     /**
      * Document editing JWT secret
      *
-     * @return zimbraDocumentEditingJwtSecret, or "SECRET" if unset
+     * @return zimbraDocumentEditingJwtSecret, or null if unset
      *
      * @since ZCS 9.1.0
      */
     @ZAttr(id=3100)
     public String getDocumentEditingJwtSecret() {
-        return getAttr(Provisioning.A_zimbraDocumentEditingJwtSecret, "SECRET", true);
+        return getAttr(Provisioning.A_zimbraDocumentEditingJwtSecret, null, true);
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -8490,43 +8490,43 @@ public abstract class ZAttrServer extends NamedEntry {
     /**
      * Host server where the onlyoffice is hosted
      *
-     * @return zimbraDocumentEditingHost, or "zimbra.com" if unset
+     * @return zimbraDocumentServerHost, or "zimbra.com" if unset
      *
      * @since ZCS 9.1.0
      */
     @ZAttr(id=3098)
-    public String getDocumentEditingHost() {
-        return getAttr(Provisioning.A_zimbraDocumentEditingHost, "zimbra.com", true);
+    public String getDocumentServerHost() {
+        return getAttr(Provisioning.A_zimbraDocumentServerHost, "zimbra.com", true);
     }
 
     /**
      * Host server where the onlyoffice is hosted
      *
-     * @param zimbraDocumentEditingHost new value
+     * @param zimbraDocumentServerHost new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
      * @since ZCS 9.1.0
      */
     @ZAttr(id=3098)
-    public void setDocumentEditingHost(String zimbraDocumentEditingHost) throws com.zimbra.common.service.ServiceException {
+    public void setDocumentServerHost(String zimbraDocumentServerHost) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraDocumentEditingHost, zimbraDocumentEditingHost);
+        attrs.put(Provisioning.A_zimbraDocumentServerHost, zimbraDocumentServerHost);
         getProvisioning().modifyAttrs(this, attrs);
     }
 
     /**
      * Host server where the onlyoffice is hosted
      *
-     * @param zimbraDocumentEditingHost new value
+     * @param zimbraDocumentServerHost new value
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
      * @since ZCS 9.1.0
      */
     @ZAttr(id=3098)
-    public Map<String,Object> setDocumentEditingHost(String zimbraDocumentEditingHost, Map<String,Object> attrs) {
+    public Map<String,Object> setDocumentServerHost(String zimbraDocumentServerHost, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraDocumentEditingHost, zimbraDocumentEditingHost);
+        attrs.put(Provisioning.A_zimbraDocumentServerHost, zimbraDocumentServerHost);
         return attrs;
     }
 
@@ -8538,9 +8538,9 @@ public abstract class ZAttrServer extends NamedEntry {
      * @since ZCS 9.1.0
      */
     @ZAttr(id=3098)
-    public void unsetDocumentEditingHost() throws com.zimbra.common.service.ServiceException {
+    public void unsetDocumentServerHost() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraDocumentEditingHost, "");
+        attrs.put(Provisioning.A_zimbraDocumentServerHost, "");
         getProvisioning().modifyAttrs(this, attrs);
     }
 
@@ -8553,9 +8553,9 @@ public abstract class ZAttrServer extends NamedEntry {
      * @since ZCS 9.1.0
      */
     @ZAttr(id=3098)
-    public Map<String,Object> unsetDocumentEditingHost(Map<String,Object> attrs) {
+    public Map<String,Object> unsetDocumentServerHost(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraDocumentEditingHost, "");
+        attrs.put(Provisioning.A_zimbraDocumentServerHost, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -8490,13 +8490,13 @@ public abstract class ZAttrServer extends NamedEntry {
     /**
      * Host server where the onlyoffice is hosted
      *
-     * @return zimbraDocumentServerHost, or "zimbra.com" if unset
+     * @return zimbraDocumentServerHost, or null if unset
      *
      * @since ZCS 9.1.0
      */
     @ZAttr(id=3098)
     public String getDocumentServerHost() {
-        return getAttr(Provisioning.A_zimbraDocumentServerHost, "zimbra.com", true);
+        return getAttr(Provisioning.A_zimbraDocumentServerHost, null, true);
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -8488,6 +8488,78 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
+     * Host server where the onlyoffice is hosted
+     *
+     * @return zimbraDocumentEditingHost, or "zimbra.com" if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3098)
+    public String getDocumentEditingHost() {
+        return getAttr(Provisioning.A_zimbraDocumentEditingHost, "zimbra.com", true);
+    }
+
+    /**
+     * Host server where the onlyoffice is hosted
+     *
+     * @param zimbraDocumentEditingHost new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3098)
+    public void setDocumentEditingHost(String zimbraDocumentEditingHost) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDocumentEditingHost, zimbraDocumentEditingHost);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Host server where the onlyoffice is hosted
+     *
+     * @param zimbraDocumentEditingHost new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3098)
+    public Map<String,Object> setDocumentEditingHost(String zimbraDocumentEditingHost, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDocumentEditingHost, zimbraDocumentEditingHost);
+        return attrs;
+    }
+
+    /**
+     * Host server where the onlyoffice is hosted
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3098)
+    public void unsetDocumentEditingHost() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDocumentEditingHost, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Host server where the onlyoffice is hosted
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=3098)
+    public Map<String,Object> unsetDocumentEditingHost(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDocumentEditingHost, "");
+        return attrs;
+    }
+
+    /**
      * EmptyFolderOpTimeout is the time in seconds for which empty folder
      * operation will wait for the current empty folder operation to complete
      *

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -10194,7 +10194,7 @@ public class Mailbox implements MailboxStore {
         if (isCachedType(type)) {
             return;
         }
-        ZimbraLog.cache.debug("Cache hit for %s %d in mailbox %d", type, key, getId());
+        ZimbraLog.cache.debug("Cache hit for %s %s in mailbox %d", type, String.valueOf(key), getId());
     }
 
     public MailItem lock(OperationContext octxt, int itemId, MailItem.Type type, String accountId)

--- a/store/src/java/com/zimbra/cs/service/SharedFileServletContext.java
+++ b/store/src/java/com/zimbra/cs/service/SharedFileServletContext.java
@@ -27,7 +27,6 @@ import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import com.zimbra.common.account.Key;
 import com.zimbra.common.account.Key.AccountBy;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ByteUtil;
@@ -35,7 +34,6 @@ import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.AuthToken;
 import com.zimbra.cs.account.Provisioning;
-import com.zimbra.cs.account.Server;
 import com.zimbra.cs.account.ShareLocator;
 
 public class SharedFileServletContext extends UserServletContext {
@@ -177,12 +175,4 @@ public class SharedFileServletContext extends UserServletContext {
         }
     }
 
-    // get the url safe encoded string
-    public static String fetchEncoded(String toEncode) {
-        return java.util.Base64.getUrlEncoder().encodeToString(toEncode.getBytes());
-    }
-
-    public static String fetchDecoded(String toDecode) {
-        return new String(java.util.Base64.getUrlDecoder().decode(toDecode));
-    }
 }

--- a/store/src/java/com/zimbra/cs/service/SharedFileServletContext.java
+++ b/store/src/java/com/zimbra/cs/service/SharedFileServletContext.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.zimbra.common.account.Key;
 import com.zimbra.common.account.Key.AccountBy;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ByteUtil;
@@ -34,6 +35,7 @@ import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.AuthToken;
 import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.Server;
 import com.zimbra.cs.account.ShareLocator;
 
 public class SharedFileServletContext extends UserServletContext {
@@ -173,5 +175,22 @@ public class SharedFileServletContext extends UserServletContext {
                 ByteUtil.closeStream(dis);
             }
         }
+    }
+
+    // get the url safe encoded string
+    public static String fetchEncoded(String toEncode) {
+        return java.util.Base64.getUrlEncoder().encodeToString(toEncode.getBytes());
+    }
+
+    public static String fetchDecoded(String toDecode) {
+        return new String(java.util.Base64.getUrlDecoder().decode(toDecode));
+    }
+
+    public static Server fetchServerFromZimbraId(String zimbraId) throws ServiceException {
+        return Provisioning.getInstance().get(Key.ServerBy.id, zimbraId);
+    }
+
+    public static Server fetchServerFromName(String serverName) throws ServiceException {
+        return Provisioning.getInstance().get(Key.ServerBy.name, serverName);
     }
 }

--- a/store/src/java/com/zimbra/cs/service/SharedFileServletContext.java
+++ b/store/src/java/com/zimbra/cs/service/SharedFileServletContext.java
@@ -185,12 +185,4 @@ public class SharedFileServletContext extends UserServletContext {
     public static String fetchDecoded(String toDecode) {
         return new String(java.util.Base64.getUrlDecoder().decode(toDecode));
     }
-
-    public static Server fetchServerFromZimbraId(String zimbraId) throws ServiceException {
-        return Provisioning.getInstance().get(Key.ServerBy.id, zimbraId);
-    }
-
-    public static Server fetchServerFromName(String serverName) throws ServiceException {
-        return Provisioning.getInstance().get(Key.ServerBy.name, serverName);
-    }
 }

--- a/store/src/java/com/zimbra/cs/util/ProxyConfGen.java
+++ b/store/src/java/com/zimbra/cs/util/ProxyConfGen.java
@@ -1124,8 +1124,6 @@ class OnlyOfficeDocServiceServersVar extends ProxyConfVar {
         // if it is set, it means onlyoffice is to be deployed on a single
         // server
         String onlyofficeServer = mProv.getConfig().getDocumentEditingHost();
-        mLog.info(String.format(" --- Inside OnlyOfficeDocServiceServersVar update; onlyofficeServer : %s",
-                onlyofficeServer));
         if (onlyofficeServer != null && onlyofficeServer.trim().length() > 0 && !defaultHost.equals(onlyofficeServer)) {
             Server server = mProv.get(Key.ServerBy.name, onlyofficeServer);
             sb.append(generateUpstreamBlock(server.getId(), onlyofficeServer));
@@ -1147,9 +1145,6 @@ class OnlyOfficeDocServiceServersVar extends ProxyConfVar {
     }
 
     public String generateUpstreamBlock(String zimbraId, String serverName) {
-        mLog.info(String.format(" --- Inside generateUpstreamBlock"));
-        mLog.info(String.format(" --- generating upstream block for server name : %s and server id : %s", serverName,
-                zimbraId));
         int timeout = 0;
         int maxFails = 0;
         // form the docservice upstream block

--- a/store/src/java/com/zimbra/cs/util/ProxyConfGen.java
+++ b/store/src/java/com/zimbra/cs/util/ProxyConfGen.java
@@ -1130,10 +1130,11 @@ class OnlyOfficeDocServiceServersVar extends ProxyConfVar {
                     " Setting Docservice upstream for servername : %s , zimbraId : %s , docServerHost in config : %s ",
                     serverName, zimbraId, docServerHost));
             // if docServerHost is present, get the zimbraId of that host
+            // zimbraDocumentServerHost is always defined at either server or global level
             if (docServerHost != null && docServerHost.trim().length() > 0
                     && !docServerHost.trim().equals(DEFAULT_DOC_HOST)
                     && !serverName.trim().equals(docServerHost.trim())) {
-                mLog.info(String.format(" Setting Docservice upstream, Document Server set to : %s in config",
+                mLog.debug(String.format(" Setting Docservice upstream, Document Server set to : %s in config",
                         docServerHost));
                 Server docServer = mProv.get(Key.ServerBy.name, docServerHost);
                 zimbraId = docServer.getId();

--- a/store/src/java/com/zimbra/cs/util/ProxyConfGen.java
+++ b/store/src/java/com/zimbra/cs/util/ProxyConfGen.java
@@ -1135,7 +1135,7 @@ class OnlyOfficeDocServiceServersVar extends ProxyConfVar {
                 serverName = docServerHost;
             }
 
-            if (isValidUpstream(server, serverName) && !upstreamsCreatedForZimbraId.contains(zimbraId)) {
+            if (!upstreamsCreatedForZimbraId.contains(zimbraId)) {
                 sb.append(generateUpstreamBlock(zimbraId, serverName));
                 sb.append("\n");
                 upstreamsCreatedForZimbraId.add(zimbraId);
@@ -1188,9 +1188,8 @@ class OnlyOfficeSpellCheckerServersVar extends ProxyConfVar {
                 zimbraId = docServer.getId();
                 serverName = docServerHost;
             }
-            if (isValidUpstream(server, serverName) && !upstreamsCreatedForZimbraId.contains(zimbraId)) {
-                sb.append(generateUpstreamBlock(zimbraId,
-                        docServerHost != null && docServerHost.length() > 0 ? docServerHost : serverName));
+            if (!upstreamsCreatedForZimbraId.contains(zimbraId)) {
+                sb.append(generateUpstreamBlock(zimbraId, serverName));
                 sb.append("\n");
                 upstreamsCreatedForZimbraId.add(zimbraId);
                 mLog.debug("Added spellchecker upstream for onlyoffice server " + serverName);

--- a/store/src/java/com/zimbra/cs/util/ProxyConfGen.java
+++ b/store/src/java/com/zimbra/cs/util/ProxyConfGen.java
@@ -1106,6 +1106,64 @@ class WebLoginSSLUpstreamServersVar extends ServersVar {
     }
 }
 
+class OnlyOfficeDocServiceServersVar extends ServersVar {
+    
+    public OnlyOfficeDocServiceServersVar() {
+        super("web.upstream.onlyoffice.docservice.:servers", null,
+              "List of upstream HTTP servers towards docservice port used by Web Proxy (i.e. servers " +
+                "for which zimbraReverseProxyLookupTarget is true, and whose " +
+                "mail mode is http|https|mixed|both)");
+    }
+
+    @Override
+    public void update() throws ServiceException {
+        ArrayList<String> directives = new ArrayList<String>();
+
+        List<Server> mailclientservers = mProv.getAllMailClientServers();
+        for (Server server : mailclientservers) {
+            String serverName = server.getAttr( Provisioning.A_zimbraServiceHostname, "");
+
+            if (isValidUpstream(server, serverName)) {
+                int timeout = 0;
+                int maxFails = 0;
+                directives.add(String.format("%s:%d fail_timeout=%ds max_fails=%d", serverName, ProxyConfGen.ZIMBRA_UPSTREAM_ONLYOFFICE_DOCSERVICE_PORT,
+                        timeout, maxFails));
+                mLog.debug("Added server to HTTPS docservice upstream: " + serverName);
+            }
+        }
+        mValue = directives;
+    }
+}
+
+class OnlyOfficeSpellCheckerServersVar extends ServersVar {
+
+    public OnlyOfficeSpellCheckerServersVar() {
+        super("web.upstream.onlyoffice.spellchecker.:servers", null,
+              "List of upstream HTTP servers towards spellchecker port used by Web Proxy (i.e. servers " +
+                "for which zimbraReverseProxyLookupTarget is true, and whose " +
+                "mail mode is http|https|mixed|both)");
+    }
+
+    @Override
+    public void update() throws ServiceException {
+        ArrayList<String> directives = new ArrayList<String>();
+
+        List<Server> mailclientservers = mProv.getAllMailClientServers();
+        for (Server server : mailclientservers) {
+            String serverName = server.getAttr( Provisioning.A_zimbraServiceHostname, "");
+
+            if (isValidUpstream(server, serverName)) {
+                int timeout = 0;
+                int maxFails = 0;
+                directives.add(String.format("%s:%d", serverName, ProxyConfGen.ZIMBRA_UPSTREAM_ONLYOFFICE_SPELLCHECKER_PORT,
+                        timeout, maxFails));
+                mLog.debug("Added server to HTTPS spellchecker upstream: " + serverName);
+            }
+        }
+        mValue = directives;
+    }
+}
+
 class AddHeadersVar extends ProxyConfVar {
     private final ArrayList<String> rhdr;
     private final String key;
@@ -2092,6 +2150,8 @@ public class ProxyConfGen
     static final String ZIMBRA_SSL_UPSTREAM_ZX_NAME = "zx_ssl";
     static final int    ZIMBRA_UPSTREAM_ZX_PORT = 8742;
     static final int    ZIMBRA_UPSTREAM_SSL_ZX_PORT = 8743;
+    static final int    ZIMBRA_UPSTREAM_ONLYOFFICE_DOCSERVICE_PORT = 7084;
+    static final int    ZIMBRA_UPSTREAM_ONLYOFFICE_SPELLCHECKER_PORT = 7085;
 
     /** the pattern for custom header cmd, such as "!{explode domain} */
     private static Pattern cmdPattern = Pattern.compile("(.*)\\!\\{([^\\}]+)\\}(.*)", Pattern.DOTALL);
@@ -2966,6 +3026,9 @@ public class ProxyConfGen
         mConfVars.put("web.ssl.upstream.zx.name", new ProxyConfVar("web.ssl.upstream.zx.name", null, ZIMBRA_SSL_UPSTREAM_ZX_NAME, ProxyConfValueType.STRING, ProxyConfOverride.CONFIG,"Symbolic name for HTTPS zx upstream"));
         mConfVars.put("web.upstream.zx.:servers", new WebUpstreamZxServersVar());
         mConfVars.put("web.ssl.upstream.zx.:servers", new WebSslUpstreamZxServersVar());
+        
+        mConfVars.put("web.upstream.onlyoffice.docservice.:servers", new OnlyOfficeDocServiceServersVar());
+        mConfVars.put("web.upstream.onlyoffice.spellchecker.:servers", new OnlyOfficeSpellCheckerServersVar());
 
         //Get the response headers list from globalconfig
         String[] rspHeaders = ProxyConfVar.configSource.getMultiAttr(Provisioning.A_zimbraReverseProxyResponseHeaders);

--- a/store/src/java/com/zimbra/cs/util/ProxyConfGen.java
+++ b/store/src/java/com/zimbra/cs/util/ProxyConfGen.java
@@ -1135,7 +1135,6 @@ class OnlyOfficeDocServiceServersVar extends ProxyConfVar {
                 serverName = docServerHost;
             }
 
-            mLog.info("doc editing server : " + docServerHost);
             if (isValidUpstream(server, serverName) && !upstreamsCreatedForZimbraId.contains(zimbraId)) {
                 sb.append(generateUpstreamBlock(zimbraId, serverName));
                 sb.append("\n");
@@ -1189,7 +1188,6 @@ class OnlyOfficeSpellCheckerServersVar extends ProxyConfVar {
                 zimbraId = docServer.getId();
                 serverName = docServerHost;
             }
-            mLog.info("spellchecker doc editing server : " + docServerHost);
             if (isValidUpstream(server, serverName) && !upstreamsCreatedForZimbraId.contains(zimbraId)) {
                 sb.append(generateUpstreamBlock(zimbraId,
                         docServerHost != null && docServerHost.length() > 0 ? docServerHost : serverName));


### PR DESCRIPTION
Issue
Sharing a shared folder from briefcase causes exception of no such item as below.

Fix
Briefcase folder sharing changes had a missing code of from Zimbrax in the backporting which was checking for requested item in the request for sharing. Updated the check for requested item.

`.1.0_GA_3032;soapId=5475f5d6;] SoapEngine - handler exception
com.zimbra.cs.mailbox.MailServiceException$NoSuchItemException: no such item: 283
ExceptionId:qtp1794717576-844:https://zdev-vm003.eng.zimbra.com/service/soap/SendShareNotificationRequest:1625832182006:0cbb3f70f83c4667
Code:mail.NO_SUCH_ITEM Arg:(itemId, IID, "283")
 at com.zimbra.cs.mailbox.MailServiceException.NO_SUCH_ITEM(MailServiceException.java:204)
 at com.zimbra.cs.mailbox.MailItem.noSuchItem(MailItem.java:1774)
 at com.zimbra.cs.db.DbMailItem.getBy(DbMailItem.java:2531)
 at com.zimbra.cs.db.DbMailItem.getById(DbMailItem.java:2495)
 at com.zimbra.cs.mailbox.MailItem.getById(MailItem.java:1680)
 at com.zimbra.cs.mailbox.MailItem.getById(MailItem.java:1676)
 at com.zimbra.cs.mailbox.Mailbox.getItemById(Mailbox.java:2990)
 at com.zimbra.cs.mailbox.Mailbox.getItemById(Mailbox.java:2904)
 at com.zimbra.cs.mailbox.Mailbox.getItemById(Mailbox.java:2895)
 at com.zimbra.cs.service.mail.SendShareNotification.sendNotificationEmail(SendShareNotification.java:641)
 at com.zimbra.cs.service.mail.SendShareNotification.handle(SendShareNotification.java:108)
 at com.zimbra.soap.SoapEngine.dispatchRequest(SoapEngine.java:646)
 at com.zimbra.soap.SoapEngine.dispatch(SoapEngine.java:491)
 at com.zimbra.soap.SoapEngine.dispatch(SoapEngine.java:278)
 at com.zimbra.soap.SoapServlet.doWork(SoapServlet.java:308)
 at com.zimbra.soap.SoapServlet.doPost(SoapServlet.java:217)
 at javax.servlet.http.HttpServlet.service(HttpServlet.java:707)
 at com.zimbra.cs.servlet.ZimbraServlet.service(ZimbraServlet.java:214)
 at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
 at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:873)
 at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1623)
 at org.eclipse.jetty.websocket.server.WebSocketUpgradeFilter.doFilter(WebSocketUpgradeFilter.java:214)
 at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1610)
 at com.zimbra.cs.servlet.CsrfFilter.doFilter(CsrfFilter.java:175)`