### PR TITLE
ZCS-10761: remove default value of zimbra.com from zimbraZulipBaseHost

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -17736,7 +17736,8 @@ public class ZAttrProvisioning {
     public static final String A_zimbraZookeeperClientServerList = "zimbraZookeeperClientServerList";
 
     /**
-     * Zulip server base host
+     * Zulip server base host. Requires server restart if updating from empty
+     * value.
      *
      * @since ZCS 9.1.0
      */

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9885,7 +9885,7 @@ TODO: delete them permanently from here
   <desc>Zulip JWT secret</desc>
 </attr>
 <attr id="3096" name="zimbraZulipBaseHost" type="string" cardinality="single" optionalIn="globalConfig" since="9.1.0">
-  <globalConfigValue>zimbra.com</globalConfigValue>
+  <globalConfigValue></globalConfigValue>
   <desc>Zulip server base host</desc>
 </attr>
 <attr id="3097" name="zimbraFeatureDocumentEditingEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="9.1.0">

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9884,9 +9884,10 @@ TODO: delete them permanently from here
   <globalConfigValue>SECRET</globalConfigValue>
   <desc>Zulip JWT secret</desc>
 </attr>
-<attr id="3096" name="zimbraZulipBaseHost" type="string" cardinality="single" optionalIn="globalConfig" since="9.1.0">
-  <globalConfigValue></globalConfigValue>
-  <desc>Zulip server base host</desc>
+<attr id="3096" name="zimbraZulipBaseHost" type="string" cardinality="single" optionalIn="globalConfig" since="9.1.0" requiresRestart="mailbox">
+  <desc>Zulip server base host.
+        Requires server restart if updating from empty value.
+  </desc>
 </attr>
 <attr id="3097" name="zimbraFeatureDocumentEditingEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="9.1.0">
   <defaultCOSValue>TRUE</defaultCOSValue>

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -31972,6 +31972,21 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Blocked mobile device list for ActiveSync/ABQ
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.9.0
+     */
+    @ZAttr(id=3090)
+    public Map<String,Object> unsetMobileBlockedDevices(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMobileBlockedDevices, "");
+        return attrs;
+    }
+
+    /**
      * id of the doamin under which (hidden) accounts for apps would be
      * created
      *
@@ -76753,13 +76768,13 @@ public abstract class ZAttrConfig extends Entry {
     /**
      * Zulip server base host
      *
-     * @return zimbraZulipBaseHost, or "zimbra.com" if unset
+     * @return zimbraZulipBaseHost, or "" if unset
      *
      * @since ZCS 9.1.0
      */
     @ZAttr(id=3096)
     public String getZulipBaseHost() {
-        return getAttr(Provisioning.A_zimbraZulipBaseHost, "zimbra.com", true);
+        return getAttr(Provisioning.A_zimbraZulipBaseHost, "", true);
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -76766,19 +76766,21 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Zulip server base host
+     * Zulip server base host. Requires server restart if updating from empty
+     * value.
      *
-     * @return zimbraZulipBaseHost, or "" if unset
+     * @return zimbraZulipBaseHost, or null if unset
      *
      * @since ZCS 9.1.0
      */
     @ZAttr(id=3096)
     public String getZulipBaseHost() {
-        return getAttr(Provisioning.A_zimbraZulipBaseHost, "", true);
+        return getAttr(Provisioning.A_zimbraZulipBaseHost, null, true);
     }
 
     /**
-     * Zulip server base host
+     * Zulip server base host. Requires server restart if updating from empty
+     * value.
      *
      * @param zimbraZulipBaseHost new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -76793,7 +76795,8 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Zulip server base host
+     * Zulip server base host. Requires server restart if updating from empty
+     * value.
      *
      * @param zimbraZulipBaseHost new value
      * @param attrs existing map to populate, or null to create a new map
@@ -76809,7 +76812,8 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Zulip server base host
+     * Zulip server base host. Requires server restart if updating from empty
+     * value.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -76823,7 +76827,8 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Zulip server base host
+     * Zulip server base host. Requires server restart if updating from empty
+     * value.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs


### PR DESCRIPTION
**Issue**
There is default value of zimbra.com set for zimbraZulipBaseHost LDAP attr. Once the extension loads on every domain creation there is zulip realm creation request gets fired.

**Fix**
Removed the default value of zimbra.com from zimbraZulipBaseHost. Zulip extension will check for this value first before initializing the extension, if its set domain listeners will register. If not set extension won't initialize and listeners won't get called for realm creation.

https://github.com/Zimbra/zm-zulip-proxy-ext/pull/2