### PR TITLE
ZCS-10637: fix cache logging string formatter as per the value of string or integer

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -10194,7 +10194,7 @@ public class Mailbox implements MailboxStore {
         if (isCachedType(type)) {
             return;
         }
-        ZimbraLog.cache.debug("Cache hit for %s %d in mailbox %d", type, key, getId());
+        ZimbraLog.cache.debug("Cache hit for %s %s in mailbox %d", type, (key instanceof String) ? key : String.valueOf(key), getId());
     }
 
     public MailItem lock(OperationContext octxt, int itemId, MailItem.Type type, String accountId)

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -10194,7 +10194,7 @@ public class Mailbox implements MailboxStore {
         if (isCachedType(type)) {
             return;
         }
-        ZimbraLog.cache.debug("Cache hit for %s %s in mailbox %d", type, (key instanceof String) ? key : String.valueOf(key), getId());
+        ZimbraLog.cache.debug("Cache hit for %s %s in mailbox %d", type, String.valueOf(key), getId());
     }
 
     public MailItem lock(OperationContext octxt, int itemId, MailItem.Type type, String accountId)


### PR DESCRIPTION
**Issue**
While getting mail item from cache there is logging done, if the logging is set to debug mode there is logging tried and it fails with exception as below. Since the cache item is being retrieved by integer or string key string formatter uses %d and fails for string key.

**Fix**
Changed logging formatter to use %s and added to check to see if its int or string and convert the key accordingly for logging.

**Exception**
`2021-06-04 03:30:22,898 WARN  [qtp1052245076-22] [] HttpChannel - /service/shf/jy01LHkIS+eD,3vdsQNZpjCJco3IEUcpnJnHN,Js1sQAAAJ2Mg==
java.util.IllegalFormatConversionException: d != java.lang.String
        at java.base/java.util.Formatter$FormatSpecifier.failConversion(Formatter.java:4426)
        at java.base/java.util.Formatter$FormatSpecifier.printInteger(Formatter.java:2938)
        at java.base/java.util.Formatter$FormatSpecifier.print(Formatter.java:2892)
        at java.base/java.util.Formatter.format(Formatter.java:2673)
        at java.base/java.util.Formatter.format(Formatter.java:2609)
        at java.base/java.lang.String.format(String.java:3274)
        at com.zimbra.common.util.Log.debug(Log.java:202)
        at com.zimbra.cs.mailbox.Mailbox.logCacheActivity(Mailbox.java:10148)
        at com.zimbra.cs.mailbox.Mailbox.getCachedItemByUuid(Mailbox.java:3296)
        at com.zimbra.cs.mailbox.Mailbox.getCachedItemByUuid(Mailbox.java:3304)
        at com.zimbra.cs.mailbox.Mailbox.getItemByUuid(Mailbox.java:3045)
        at com.zimbra.cs.mailbox.Mailbox.getItemByUuid(Mailbox.java:3012)
        at com.zimbra.cs.service.SharedFileServlet.resolveItem(SharedFileServlet.java:109)
        at com.zimbra.cs.service.UserServlet.doAuthGet(UserServlet.java:653)
        at com.zimbra.cs.service.UserServlet.doGet(UserServlet.java:395)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:687)
        at com.zimbra.cs.servlet.ZimbraServlet.service(ZimbraServlet.java:214)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
        at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:865)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1623)
        at org.eclipse.jetty.websocket.server.WebSocketUpgradeFilter.doFilter(WebSocketUpgradeFilter.java:214)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1610)
        at com.zimbra.cs.servlet.RequestStringFilter.doFilter(RequestStringFilter.java:54)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1610)
        at com.zimbra.cs.servlet.SetHeaderFilter.doFilter(SetHeaderFilter.java:59)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1610)
        at com.zimbra.cs.servlet.ETagHeaderFilter.doFilter(ETagHeaderFilter.java:47)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1610)
`