### PR TITLE
ZBUG-1948: Bumped the version of owasp-java-html-sanitizer

### DIFF
--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -44,7 +44,7 @@
   <dependency org="com.101tec" name="zkclient" rev="0.1.0"/>
   <dependency org="xerces" name="xercesImpl" rev="2.9.1-patch-01"/>
   <dependency org="net.sourceforge.nekohtml" name="nekohtml" rev="1.9.13.1z"/>
-  <dependency org="com.googlecode.owasp-java-html-sanitizer" name="owasp-java-html-sanitizer" rev="20190610.2z"/>
+  <dependency org="com.googlecode.owasp-java-html-sanitizer" name="owasp-java-html-sanitizer" rev="20190610.3z"/>
   <dependency org="org.ehcache" name="ehcache" rev="3.1.2"/>
   <dependency org="ant-1.7.0-ziputil-patched" name="ant-1.7.0-ziputil-patched" rev="1.0"/>
   <dependency org="org.eclipse.jetty" name="jetty-continuation" rev="${jetty.version}"/>


### PR DESCRIPTION
Bumped the version of owasp-java-html-sanitizer

**Reference PRs:**
[zm-mailbox](https://github.com/Zimbra/zm-mailbox/pull/1145)
[zm-zcs-lib](https://github.com/Zimbra/zm-zcs-lib/pull/81)
[owasp-java-html-sanitizer](https://github.com/Zimbra/java-html-sanitizer-release-20190610.1/pull/5)