### PR TITLE
ZCS-10728: pdf/doc/ppt/xls contents not searchable after switching from tika-app-1.24.1.jar to tika-core-1.24.1.jar

### DIFF
--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -135,6 +135,6 @@
   <dependency org="org.apache.commons" name="commons-collections4" rev="4.4"/>
   <dependency org="com.zaxxer" name="SparseBitSet" rev="1.2"/>
   <dependency org="org.apache.commons" name="commons-math3" rev="3.6.1"/>
-  <dependency org="com.github.veithen.cosmos.bootstrap" name="org.tukaani.xz" rev="0.3"/>
+  <dependency org="org.tukaani" name="xz" rev="1.9"/>
  </dependencies>
 </ivy-module>

--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -121,7 +121,6 @@
   <dependency org="org.owasp.antisamy" name="antisamy" rev="1.5.8"/>
   <dependency org="org.apache.xmlgraphics" name="batik-css" rev="1.7"/>
   <dependency org="org.w3c.css" name="sac" rev="1.3"/>
-  <dependency org="com.github.jtidy" name="jtidy" rev="1.0.2"/>
   <dependency org="org.apache.tika" name="tika-core" rev="1.24.1"/>
   <dependency org="org.apache.tika" name="tika-parsers" rev="1.24.1"/>
   <dependency org="org.apache.pdfbox" name="pdfbox" rev="2.0.24"/>

--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -123,6 +123,10 @@
   <dependency org="org.w3c.css" name="sac" rev="1.3"/>
   <dependency org="com.github.jtidy" name="jtidy" rev="1.0.2"/>
   <dependency org="org.apache.tika" name="tika-core" rev="1.24.1"/>
+  <dependency org="org.apache.tika" name="tika-parsers" rev="1.24.1"/>
+  <dependency org="org.apache.pdfbox" name="pdfbox" rev="2.0.24"/>
+  <dependency org="org.apache.pdfbox" name="jempbox" rev="1.8.16"/>
+  <dependency org="org.apache.pdfbox" name="fontbox" rev="2.0.24"/>
   <dependency org="org.apache.poi" name="poi-ooxml" rev="4.1.2"/>
   <dependency org="org.apache.poi" name="poi-ooxml-schemas" rev="4.1.2"/>
   <dependency org="org.apache.poi" name="poi" rev="4.1.2"/>

--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -134,5 +134,7 @@
   <dependency org="org.apache.xmlbeans" name="xmlbeans" rev="3.1.0"/>
   <dependency org="org.apache.commons" name="commons-collections4" rev="4.4"/>
   <dependency org="com.zaxxer" name="SparseBitSet" rev="1.2"/>
+  <dependency org="org.apache.commons" name="commons-math3" rev="3.6.1"/>
+  <dependency org="com.github.veithen.cosmos.bootstrap" name="org.tukaani.xz" rev="0.3"/>
  </dependencies>
 </ivy-module>


### PR DESCRIPTION
**Problem:**
pdf/doc/docx contents not searchable after switching from tika-app-1.24.1.jar to tika-core-1.24.1.jar

**Fix:**
Added jars which are necessary for the parsing and extraction of the documents which were not working after replacing `tika-app` jar to the `tika-core` jar. Now after adding these required jars like tika-parser and it's dependent jars the content of the search in the e-mail for the documents like `pdf, doc, docx, ppt, pptx, xls, xlsx`.

**Testing Done:**
- Verified on Ubuntu18 build contents of the attachment in e-mail for the above mentioned documents are searchable now.
- Verified on RHEL8 build contents of the attachment in e-mail for the above mentioned documents are searchable now.

**Related PRs:**
[zm-zcs-lib](https://github.com/Zimbra/zm-zcs-lib/pull/82)

**Dependent PRs:**
[zm-mailbox](https://github.com/Zimbra/zm-mailbox/pull/1160)
[zm-zcs-lib](https://github.com/Zimbra/zm-zcs-lib/pull/80)