### PR TITLE
ZCS-10766: Briefcase contents not searchable

### DIFF
--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -136,7 +136,7 @@
   <dependency org="com.zaxxer" name="SparseBitSet" rev="1.2"/>
   <dependency org="org.apache.commons" name="commons-math3" rev="3.6.1"/>
   <dependency org="org.tukaani" name="xz" rev="1.9"/>
-  <dependency org="org.apache.commons" name="commons-csv" rev="1.8"/>
-  <dependency org="com.github.veithen.cosmos.bootstrap" name="org.tukaani.xz" rev="0.3"/>
+  <dependency org="com.drewnoakes" name="metadata-extractor" rev="2.16.0"/>
+  <dependency org="com.adobe.xmp" name="xmpcore" rev="6.1.11"/>
  </dependencies>
 </ivy-module>

--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -136,5 +136,7 @@
   <dependency org="com.zaxxer" name="SparseBitSet" rev="1.2"/>
   <dependency org="org.apache.commons" name="commons-math3" rev="3.6.1"/>
   <dependency org="org.tukaani" name="xz" rev="1.9"/>
+  <dependency org="org.apache.commons" name="commons-csv" rev="1.8"/>
+  <dependency org="com.github.veithen.cosmos.bootstrap" name="org.tukaani.xz" rev="0.3"/>
  </dependencies>
 </ivy-module>


### PR DESCRIPTION
**Problem:**
Briefcase uploads were not searchable

**Fix:**
While working on this found that while trying to create or edit the presentation following exception were getting observed:
- `java.lang.NoClassDefFoundError: Could not initialize class com.drew.imaging.jpeg.JpegMetadataReader`
- `java.lang.NoClassDefFoundError: com/adobe/internal/xmp/XMPException`

To fix these issues added the following dependencies to create and edit pptx presentation while using `TikaExtractorClient`:
- `metadata-extractor-2.16.0.jar`
- `xmpcore-6.1.11.jar`

**Testing Done:**
- Now, search is working in Briefcase.
- Verified now able to create and edit a presentation.

**Related PRs:**
[zm-zcs-lib](https://github.com/Zimbra/zm-zcs-lib/pull/84)
[zm-convertd-store](https://github.com/Zimbra/zm-convertd-store/pull/16)

**Dependent PRs:**
- ZCS-10598: [zm-mailbox](https://github.com/Zimbra/zm-mailbox/pull/1160)
- ZCS-10598: [zm-zcs-lib](https://github.com/Zimbra/zm-zcs-lib/pull/80)
- ZCS-10728: [zm-mailbox](https://github.com/Zimbra/zm-mailbox/pull/1173)
- ZCS-10728: [zm-zcs-lib](https://github.com/Zimbra/zm-zcs-lib/pull/82)