### PR TITLE
ZCS-10789: remove duplicate method for zimbraMobileBlockedDevices ldap attr

### DIFF
--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -32016,21 +32016,6 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Blocked mobile device list for ActiveSync/ABQ
-     *
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 8.9.0
-     */
-    @ZAttr(id=3090)
-    public Map<String,Object> unsetMobileBlockedDevices(Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraMobileBlockedDevices, "");
-        return attrs;
-    }
-
-    /**
      * id of the doamin under which (hidden) accounts for apps would be
      * created
      *


### PR DESCRIPTION
**Issue**
LDAP attr `zimbraMobileBlockedDevices` has `unsetMobileBlockedDevices` method which seems to have been added manually causing below error during compilation.

**Fix**
Remove the method that was added manually and keep the one created from running `ant generate-getters`

`generate-buildinfo:
    [mkdir] Created dir: /Users/yogesh.dasi/zimbra/zcs/zm-mailbox/store/build/buildinfo/com/zimbra/cs/util
    [javac] Compiling 1 source file to /Users/yogesh.dasi/zimbra/zcs/zm-mailbox/store/build/classes
compile:
    [javac] Compiling 2481 source files to /Users/yogesh.dasi/zimbra/zcs/zm-mailbox/store/build/classes
    [javac] /Users/yogesh.dasi/zimbra/zcs/zm-mailbox/store/src/java/com/zimbra/cs/account/ZAttrConfig.java:32027: error: method unsetMobileBlockedDevices(Map<String,Object>) is already defined in class ZAttrConfig
    [javac]     public Map<String,Object> unsetMobileBlockedDevices(Map<String,Object> attrs) {
    [javac]                               ^`