### PR TITLE
ZCS-10798: deprecate zimbraNetworkModulesNGEnabled ldap attr with default value to false

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -11917,6 +11917,7 @@ public class ZAttrProvisioning {
     public static final String A_zimbraNetworkMobileNGEnabled = "zimbraNetworkMobileNGEnabled";
 
     /**
+     * Deprecated since: 9.1.0. Deprecated and defaulted to false. Orig desc:
      * Whether to enable zimbra network new generation modules.
      *
      * @since ZCS 8.8.0

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9375,9 +9375,10 @@ TODO: delete them permanently from here
 <desc>outgoing sieve script defined by admin (not able to edit and view from the end user) applied after the end user filter rule</desc>
 </attr>
 
-<attr id="2117" name="zimbraNetworkModulesNGEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mailbox" since="8.8.0">
-  <globalConfigValue>TRUE</globalConfigValue>
+<attr id="2117" name="zimbraNetworkModulesNGEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mailbox" since="8.8.0" deprecatedSince="9.1.0">
+  <globalConfigValue>FALSE</globalConfigValue>
   <desc>Whether to enable zimbra network new generation modules.</desc>
+  <deprecateDesc>Deprecated and defaulted to false</deprecateDesc>
 </attr>
 
 <attr id="2118" name="zimbraNetworkMobileNGEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mailbox" since="8.8.0" >

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -48477,18 +48477,20 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Deprecated since: 9.1.0. Deprecated and defaulted to false. Orig desc:
      * Whether to enable zimbra network new generation modules.
      *
-     * @return zimbraNetworkModulesNGEnabled, or true if unset
+     * @return zimbraNetworkModulesNGEnabled, or false if unset
      *
      * @since ZCS 8.8.0
      */
     @ZAttr(id=2117)
     public boolean isNetworkModulesNGEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraNetworkModulesNGEnabled, true, true);
+        return getBooleanAttr(Provisioning.A_zimbraNetworkModulesNGEnabled, false, true);
     }
 
     /**
+     * Deprecated since: 9.1.0. Deprecated and defaulted to false. Orig desc:
      * Whether to enable zimbra network new generation modules.
      *
      * @param zimbraNetworkModulesNGEnabled new value
@@ -48504,6 +48506,7 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Deprecated since: 9.1.0. Deprecated and defaulted to false. Orig desc:
      * Whether to enable zimbra network new generation modules.
      *
      * @param zimbraNetworkModulesNGEnabled new value
@@ -48520,6 +48523,7 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Deprecated since: 9.1.0. Deprecated and defaulted to false. Orig desc:
      * Whether to enable zimbra network new generation modules.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -48534,6 +48538,7 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Deprecated since: 9.1.0. Deprecated and defaulted to false. Orig desc:
      * Whether to enable zimbra network new generation modules.
      *
      * @param attrs existing map to populate, or null to create a new map

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -35887,18 +35887,20 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
+     * Deprecated since: 9.1.0. Deprecated and defaulted to false. Orig desc:
      * Whether to enable zimbra network new generation modules.
      *
-     * @return zimbraNetworkModulesNGEnabled, or true if unset
+     * @return zimbraNetworkModulesNGEnabled, or false if unset
      *
      * @since ZCS 8.8.0
      */
     @ZAttr(id=2117)
     public boolean isNetworkModulesNGEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraNetworkModulesNGEnabled, true, true);
+        return getBooleanAttr(Provisioning.A_zimbraNetworkModulesNGEnabled, false, true);
     }
 
     /**
+     * Deprecated since: 9.1.0. Deprecated and defaulted to false. Orig desc:
      * Whether to enable zimbra network new generation modules.
      *
      * @param zimbraNetworkModulesNGEnabled new value
@@ -35914,6 +35916,7 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
+     * Deprecated since: 9.1.0. Deprecated and defaulted to false. Orig desc:
      * Whether to enable zimbra network new generation modules.
      *
      * @param zimbraNetworkModulesNGEnabled new value
@@ -35930,6 +35933,7 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
+     * Deprecated since: 9.1.0. Deprecated and defaulted to false. Orig desc:
      * Whether to enable zimbra network new generation modules.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -35944,6 +35948,7 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
+     * Deprecated since: 9.1.0. Deprecated and defaulted to false. Orig desc:
      * Whether to enable zimbra network new generation modules.
      *
      * @param attrs existing map to populate, or null to create a new map


### PR DESCRIPTION
Deprecate **zimbraNetworkModulesNGEnabled** LDAP attr and default its value to false since 9.1.0