### PR TITLE
ZCS-10801: add custom mime type for xml detection

### DIFF
--- a/store-conf/conf/custom-mimetypes.xml
+++ b/store-conf/conf/custom-mimetypes.xml
@@ -19,4 +19,33 @@
             <match value="MZ" type="string" offset="0"/>
         </magic>
     </mime-type>
+
+    <mime-type type="application/xml">
+	    <acronym>XML</acronym>
+	    <_comment>Extensible Markup Language</_comment>
+	    <tika:link>http://en.wikipedia.org/wiki/Xml</tika:link>
+	    <tika:uti>public.xml</tika:uti>
+	    <alias type="text/xml"/>
+	    <alias type="application/x-xml"/>
+	    <magic priority="50">
+		      <match value="&lt;?xml" type="string" offset="0"/>
+		      <match value="&lt;?XML" type="string" offset="0"/>
+		      <!-- UTF-8 BOM -->
+		      <match value="0xEFBBBF3C3F786D6C" type="string" offset="0"/>
+		      <!-- UTF-16 LE/BE -->
+		      <match value="0xFFFE3C003F0078006D006C00" type="string" offset="0"/>
+		      <match value="0xFEFF003C003F0078006D006C" type="string" offset="0"/>
+		      <!-- TODO: Add matches for the other possible XML encoding schemes -->
+	    </magic>
+	    <!-- XML files can start with a comment but then must not contain processing instructions.
+	         This should be rare so we assign lower priority here. Priority is also lower than text/html magics
+	         for them to be preferred for HTML starting with comment.-->
+	    <magic priority="30">
+	        <match value="&lt;!--" type="string" offset="0"/>
+	    </magic>
+	    <glob pattern="*.xml"/>
+	    <glob pattern="*.xsl"/>
+	    <glob pattern="*.xsd"/>
+	    <sub-class-of type="text/plain" />
+    </mime-type>
 </mime-info>


### PR DESCRIPTION
**Issue**
CalDav configuration fails due to user not found as the xml file mime type is not getting detected as application/xml instead its showing as text/plain

**Fix**
Add support to custom mime types for XML to detect the mime type of xml as application/xml