### PR TITLE
ZCS-10801: adding mime type support for text/calendar detection

### DIFF
--- a/store-conf/conf/custom-mimetypes.xml
+++ b/store-conf/conf/custom-mimetypes.xml
@@ -48,4 +48,16 @@
 	    <glob pattern="*.xsd"/>
 	    <sub-class-of type="text/plain" />
     </mime-type>
+
+    <mime-type type="text/calendar">
+        <magic priority="50">
+            <match value="BEGIN:VCALENDAR" type="stringignorecase" offset="0">
+                <match value="(?s).*\\nVERSION\\s*:2\\.0" type="regex" offset="15" />
+            </match>
+        </magic>
+        <glob pattern="*.ics"/>
+        <glob pattern="*.ifb"/>
+        <sub-class-of type="text/plain"/>
+    </mime-type>
+
 </mime-info>


### PR DESCRIPTION
**Issue**
Mime type detection for text/calendar is failing causing the event creation failure for caldav throwing below exception

**Fix**
Added text/calendar mime type to custom mime types list for detection

**Exception**
`2021-08-04 05:37:04,868 DEBUG [qtp393040818-106:https://zqa-410.eng.zimbra.com/dav/sk1%40zqa-410.eng.zimbra.com/Calendar/12231ef7-825a-4f37-888b-d11b674b40b0.ics] [aname=sk1@zqa-410.eng.zimbra.com;ip=10.139.245.155;port=60086;ua=Mozilla/5.0 (Windows NT 10.0;; Win64;; x64;; rv:78.0) Gecko/20100101 Thunderbird/78.12.0;] dav - getResource at user='sk1@zqa-410.eng.zimbra.com' path='/Calendar'
2021-08-04 05:37:04,872 DEBUG [qtp393040818-106:https://zqa-410.eng.zimbra.com/dav/sk1%40zqa-410.eng.zimbra.com/Calendar/12231ef7-825a-4f37-888b-d11b674b40b0.ics] [aname=sk1@zqa-410.eng.zimbra.com;ip=10.139.245.155;port=60086;ua=Mozilla/5.0 (Windows NT 10.0;; Win64;; x64;; rv:78.0) Gecko/20100101 Thunderbird/78.12.0;] dav - ERROR RESPONSE
<?xml version="1.0" encoding="UTF-8"?>
<D:error xmlns:D="DAV:"><C:supported-calendar-data xmlns:C="urn:ietf:params:xml:ns:caldav"/></D:error>
2021-08-04 05:37:04,872 INFO  [qtp393040818-106:https://zqa-410.eng.zimbra.com/dav/sk1%40zqa-410.eng.zimbra.com/Calendar/12231ef7-825a-4f37-888b-d11b674b40b0.ics] [aname=sk1@zqa-410.eng.zimbra.com;ip=10.139.245.155;port=60086;ua=Mozilla/5.0 (Windows NT 10.0;; Win64;; x64;; rv:78.0) Gecko/20100101 Thunderbird/78.12.0;] dav - sending http error 403 because: Incorrect Content-Type 'text/plain', expected 'text/calendar'
com.zimbra.cs.dav.DavException$InvalidData: Incorrect Content-Type 'text/plain', expected 'text/calendar'
        at com.zimbra.cs.dav.resource.CalendarCollection.uploadToInvites(CalendarCollection.java:684)
        at com.zimbra.cs.dav.resource.CalendarCollection.createItem(CalendarCollection.java:428)
        at com.zimbra.cs.dav.service.method.Put.handle(Put.java:49)
        at com.zimbra.cs.dav.service.DavServlet.service(DavServlet.java:400)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
        at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:873)`