### PR TITLE
ZBUG-2360: adding LC to toggle the behaviour as earlier that was updated in ZCS-10403

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1457,6 +1457,9 @@ public final class LC {
     // unsubscribe folder creation enabled
     public static final KnownKey zimbra_feature_safe_unsubscribe_folder_enabled =  KnownKey.newKey(false);
 
+    // wsdl use public service hostname
+    public static final KnownKey wsdl_use_public_service_hostname =  KnownKey.newKey(true);
+
     @Supported
     public static final KnownKey zimbra_remote_cmd_channel_timeout_min = KnownKey.newKey(10);
 

--- a/store/src/java/com/zimbra/soap/WsdlServlet.java
+++ b/store/src/java/com/zimbra/soap/WsdlServlet.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 
+import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.mime.MimeConstants;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AccountConstants;
@@ -127,7 +128,10 @@ public class WsdlServlet extends ZimbraServlet {
 
     private static String getSoapAdminURL(Domain domain) {
         try {
-            return URLUtil.getPublicAdminSoapURLForDomain(Provisioning.getInstance().getLocalServer(), domain);
+            if (LC.wsdl_use_public_service_hostname.booleanValue()) {
+                return URLUtil.getPublicAdminSoapURLForDomain(Provisioning.getInstance().getLocalServer(), domain);
+            }
+            return URLUtil.getAdminURL(Provisioning.getInstance().getLocalServer());
         } catch (ServiceException e) {
             return WsdlServiceInfo.localhostSoapAdminHttpsURL;
         }
@@ -135,8 +139,10 @@ public class WsdlServlet extends ZimbraServlet {
 
     private static String getSoapURL(Domain domain) {
         try {
-            return URLUtil.getPublicURLForDomain(Provisioning.getInstance().getLocalServer(),
-                    domain, AccountConstants.USER_SERVICE_URI, true);
+            if (LC.wsdl_use_public_service_hostname.booleanValue()) {
+                return URLUtil.getPublicURLForDomain(Provisioning.getInstance().getLocalServer(), domain, AccountConstants.USER_SERVICE_URI, true);
+            }
+            return URLUtil.getServiceURL(Provisioning.getInstance().getLocalServer(), AccountConstants.USER_SERVICE_URI, true);
         } catch (ServiceException e) {
             return WsdlServiceInfo.localhostSoapHttpURL;
         }


### PR DESCRIPTION
**Issue**
In ZCS-10403 wsdl behavior was updated to honor `zimbraPublicServiceHostname zimbraPublicServiceProtocol zimbraPublicServicePort zimbraAdminProxyPort ` and use them in wsdl. There is no option to go back to old behavior.

**Fix**
Added LC switch `wsdl_use_public_service_hostname` to toggle this behavior. If its **true** it is using the above global configs to set the hostname, port and so on. If set to **false** it use old default behavior.