### PR TITLE
ZCS-10780: move unsubscribe folder enabled check from LC to LDAP attr

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -6899,6 +6899,14 @@ public class ZAttrProvisioning {
     public static final String A_zimbraFeatureResetPasswordSuspensionTime = "zimbraFeatureResetPasswordSuspensionTime";
 
     /**
+     * Creates unsubscribe system folder
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4003)
+    public static final String A_zimbraFeatureSafeUnsubscribeFolderEnabled = "zimbraFeatureSafeUnsubscribeFolderEnabled";
+
+    /**
      * saved search feature
      */
     @ZAttr(id=139)

--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1454,9 +1454,6 @@ public final class LC {
     // imap folder pagination enabled
     public static final KnownKey zimbra_imap_folder_pagination_enabled =  KnownKey.newKey(false);
 
-    // unsubscribe folder creation enabled
-    public static final KnownKey zimbra_feature_safe_unsubscribe_folder_enabled =  KnownKey.newKey(false);
-
     @Supported
     public static final KnownKey zimbra_remote_cmd_channel_timeout_min = KnownKey.newKey(10);
 

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9921,4 +9921,8 @@ TODO: delete them permanently from here
   <defaultCOSValue>FALSE</defaultCOSValue>
   <desc>Whether to permit syncing shared calendar folders</desc>
 </attr>
+<attr id="4003" name="zimbraFeatureSafeUnsubscribeFolderEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="9.1.0">
+  <defaultCOSValue>FALSE</defaultCOSValue>
+  <desc>Creates unsubscribe system folder</desc>
+ </attr>
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -18528,6 +18528,78 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * Creates unsubscribe system folder
+     *
+     * @return zimbraFeatureSafeUnsubscribeFolderEnabled, or false if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4003)
+    public boolean isFeatureSafeUnsubscribeFolderEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureSafeUnsubscribeFolderEnabled, false, true);
+    }
+
+    /**
+     * Creates unsubscribe system folder
+     *
+     * @param zimbraFeatureSafeUnsubscribeFolderEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4003)
+    public void setFeatureSafeUnsubscribeFolderEnabled(boolean zimbraFeatureSafeUnsubscribeFolderEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureSafeUnsubscribeFolderEnabled, zimbraFeatureSafeUnsubscribeFolderEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Creates unsubscribe system folder
+     *
+     * @param zimbraFeatureSafeUnsubscribeFolderEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4003)
+    public Map<String,Object> setFeatureSafeUnsubscribeFolderEnabled(boolean zimbraFeatureSafeUnsubscribeFolderEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureSafeUnsubscribeFolderEnabled, zimbraFeatureSafeUnsubscribeFolderEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Creates unsubscribe system folder
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4003)
+    public void unsetFeatureSafeUnsubscribeFolderEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureSafeUnsubscribeFolderEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Creates unsubscribe system folder
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4003)
+    public Map<String,Object> unsetFeatureSafeUnsubscribeFolderEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureSafeUnsubscribeFolderEnabled, "");
+        return attrs;
+    }
+
+    /**
      * saved search feature
      *
      * @return zimbraFeatureSavedSearchesEnabled, or true if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -13112,6 +13112,78 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * Creates unsubscribe system folder
+     *
+     * @return zimbraFeatureSafeUnsubscribeFolderEnabled, or false if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4003)
+    public boolean isFeatureSafeUnsubscribeFolderEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureSafeUnsubscribeFolderEnabled, false, true);
+    }
+
+    /**
+     * Creates unsubscribe system folder
+     *
+     * @param zimbraFeatureSafeUnsubscribeFolderEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4003)
+    public void setFeatureSafeUnsubscribeFolderEnabled(boolean zimbraFeatureSafeUnsubscribeFolderEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureSafeUnsubscribeFolderEnabled, zimbraFeatureSafeUnsubscribeFolderEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Creates unsubscribe system folder
+     *
+     * @param zimbraFeatureSafeUnsubscribeFolderEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4003)
+    public Map<String,Object> setFeatureSafeUnsubscribeFolderEnabled(boolean zimbraFeatureSafeUnsubscribeFolderEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureSafeUnsubscribeFolderEnabled, zimbraFeatureSafeUnsubscribeFolderEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Creates unsubscribe system folder
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4003)
+    public void unsetFeatureSafeUnsubscribeFolderEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureSafeUnsubscribeFolderEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Creates unsubscribe system folder
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4003)
+    public Map<String,Object> unsetFeatureSafeUnsubscribeFolderEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureSafeUnsubscribeFolderEnabled, "");
+        return attrs;
+    }
+
+    /**
      * saved search feature
      *
      * @return zimbraFeatureSavedSearchesEnabled, or true if unset

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -2255,7 +2255,7 @@ public class Mailbox implements MailboxStore {
             Folder.create(ID_FOLDER_BRIEFCASE, UUIDUtil.generateUUID(), this, userRoot, "Briefcase", system,
                             MailItem.Type.DOCUMENT, 0, MailItem.DEFAULT_COLOR_RGB, null, null, null);
 
-            if (LC.zimbra_feature_safe_unsubscribe_folder_enabled.booleanValue()) {
+            if (this.getAccount().isFeatureSafeUnsubscribeFolderEnabled()) {
                 Folder.create(ID_FOLDER_UNSUBSCRIBE, UUIDUtil.generateUUID(), this, userRoot, "Unsubscribe", system,
                         MailItem.Type.MESSAGE, 0, MailItem.DEFAULT_COLOR_RGB, null, null, null);
             }


### PR DESCRIPTION
Move LC attribute `zimbra_feature_safe_unsubscribe_folder_enabled` to LDAP `zimbraFeatureSafeUnsubscribeFolderEnabled` for checking creation of unsubscribe folder for 9.1.0