### PR TITLE
ZCS-10805 : Set limit to expansion based on timezone

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/calendar/ZRecur.java
+++ b/store/src/java/com/zimbra/cs/mailbox/calendar/ZRecur.java
@@ -689,7 +689,8 @@ public class ZRecur implements Cloneable {
         int numInstancesExpanded = 1;  // initially 1 rather than 0 because DTSTART is always included
 
         // Set hard limit of expansion time range.  (bug 21989)
-        ParsedDateTime earliestDateTime = ParsedDateTime.fromUTCTime(earliestDate.getTime());
+        //changes made it handle TimeZone for ZCS-10805
+        ParsedDateTime earliestDateTime = ParsedDateTime.fromUTCTime(earliestDate.getTime(), dtStart.getTimeZone());
         Date hardEndDate = getEstimatedEndTime(earliestDateTime);
         if (hardEndDate.before(rangeEndDate))
             rangeEndDate = hardEndDate;


### PR DESCRIPTION
Problem : When `zimbraCalendarRecurrenceMonthlyMaxMonths` is `3` the instance for the appointment are not created correctly. The last instance is not being genarted.

Reason : The logic to create instances checks for the last instance date till which the appointments can be expanded to. The last instance date calculation was wrong.

Try this:
```
        Calendar calendar = Calendar.getInstance();
        calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
//        calendar.setTimeZone(TimeZone.getTimeZone("Asia/Tokyo"));
//        calendar.setTime(new Date());
        calendar.setTimeInMillis(1638284400000l); //1st dec
//        calendar.setTimeInMillis(1646060400000l);// 1st march 
//        calendar.setTimeInMillis(1638370800000l);//2nd dec 1638370800000 
//        calendar.setTimeInMillis(1646146800000l);// 2nd march 1646146800000
        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss z");

        //Here you say to java the initial timezone. This is the secret
//        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
        sdf.setTimeZone(TimeZone.getTimeZone("America/New_York"));
//      sdf.setTimeZone(TimeZone.getTimeZone("Asia/Tokyo"));
        //Will print in UTC
        System.out.println(sdf.format(calendar.getTime()));   
        
        calendar.add(Calendar.MONTH, 2);
        
        //Will print in UTC
        System.out.println(sdf.format(calendar.getTime()));   

        //Here you set to your timezone
//        sdf.setTimeZone(TimeZone.getDefault());
//        //Will print on your default Timezone
//        System.out.println(sdf.format(calendar.getTime()));
        
        
        Date d = calendar.getTime();
        System.out.println(d);
```

Tests : 
Tested scenarios as mentioned in ZCS-10732 and ZCS-10805.
Ran Soap test cases.
