### PR TITLE
ZBUG-2026: display cos id from domain if unset on account

### DIFF
--- a/store/src/java/com/zimbra/cs/account/Account.java
+++ b/store/src/java/com/zimbra/cs/account/Account.java
@@ -409,8 +409,12 @@ public class Account extends ZAttrAccount implements GroupedEntry, AliasedEntry 
         Cos cos = getProvisioning().getCOS(this); // will set cos if not set yet
 
         Map<String, Object> defaults = null;
-        if (cos != null)
+        if (cos != null) {
             defaults = cos.getAccountDefaults();
+            if (cos.getId() != null && this.getCOSId() == null) {
+                defaults.put(Provisioning.A_zimbraCOSId, cos.getId());
+            }
+        }
 
         if (!setSecondaryDefaults) {
             // set only primary defaults


### PR DESCRIPTION
**Issue**
**zimbraCosId** if not set on account but set on domain as **zimbraDomainDefaultCosId** does not shows for account in `zmprov ga <account> zimbraCosId`

**Fix**
Add the cos Id from domain to list of account defaults in display of the zmprov get account request.