### PR TITLE
ZCS-10870: adding check for LDAP attr unsubscribe folder enabled to display unsubscribe folder

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -4450,6 +4450,9 @@ public class Mailbox implements MailboxStore {
         }
         // write the subfolders' data to the response
         for (Folder subfolder : subfolders) {
+            if (!this.getAccount().isFeatureSafeUnsubscribeFolderEnabled() && subfolder.getId() == FolderConstants.ID_FOLDER_UNSUBSCRIBE) {
+                continue;
+            }
             FolderNode child = handleFolder(subfolder, visible, returnAllVisibleFolders);
             if (child != null) {
                 node.mSubfolders.add(child);


### PR DESCRIPTION
**Issue**
Unsubscribe folder display even if the **zimbraFeatureSafeUnsubscribeFolderEnabled** is FALSE

**Fix**
Added check to display Unsubsribe folder if **zimbraFeatureSafeUnsubscribeFolderEnabled** is TRUE for getFolder request & IMAP folder list