### PR TITLE
ZBUG-2316 : Changes to set desc html when missing

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/calendar/Invite.java
+++ b/store/src/java/com/zimbra/cs/mailbox/calendar/Invite.java
@@ -511,6 +511,11 @@ public class Invite {
         String desc = descInMeta ? meta.get(FN_DESC, null) : null;
         String descHtml = descInMeta ? meta.get(FN_DESC_HTML, null) : null;
 
+        // if desc html is missing but desc is present
+        if (desc != null && descHtml == null) {
+            descHtml = Util.textToHtml(desc);
+        }
+
         long completed = meta.getLong(FN_COMPLETED, 0);
 
         ParsedDateTime dtStart = null;

--- a/store/src/java/com/zimbra/cs/mailbox/calendar/Util.java
+++ b/store/src/java/com/zimbra/cs/mailbox/calendar/Util.java
@@ -23,6 +23,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import com.zimbra.common.calendar.Attach;
 import com.zimbra.common.calendar.Geo;
@@ -350,5 +352,57 @@ public class Util {
         meta.put(Util.FN_LATITUDE, geo.getLatitude());
         meta.put(Util.FN_LONGITUDE, geo.getLongitude());
         return meta;
+    }
+
+    /**
+     * Converts text to html.
+     *
+     * @param String containing plain text
+     * @return String Html converted string
+     */
+    public static String textToHtml(String s) {
+        StringBuilder builder = new StringBuilder();
+        boolean previousWasASpace = false;
+        for (char c : s.toCharArray()) {
+            if (c == ' ') {
+                if (previousWasASpace) {
+                    builder.append("&nbsp;");
+                    previousWasASpace = false;
+                    continue;
+                }
+                previousWasASpace = true;
+            } else {
+                previousWasASpace = false;
+            }
+            switch (c) {
+                case '<':
+                    builder.append("&lt;");
+                    break;
+                case '>':
+                    builder.append("&gt;");
+                    break;
+                case '&':
+                    builder.append("&amp;");
+                    break;
+                case '"':
+                    builder.append("&quot;");
+                    break;
+                case '\n':
+                    builder.append("<br>");
+                    break;
+                case '\t':
+                    builder.append("&nbsp; &nbsp; &nbsp;");
+                    break;
+                default:
+                    builder.append(c);
+
+            }
+        }
+        String converted = builder.toString();
+        String str = "(?i)\\b((?:https?://|www\\d{0,3}[.]|[a-z0-9.\\-]+[.][a-z]{2,4}/)(?:[^\\s()<>]+|\\(([^\\s()<>]+|(\\([^\\s()<>]+\\)))*\\))+(?:\\(([^\\s()<>]+|(\\([^\\s()<>]+\\)))*\\)|[^\\s`!()\\[\\]{};:\'\".,<>?«»“”‘’]))";
+        Pattern patt = Pattern.compile(str);
+        Matcher matcher = patt.matcher(converted);
+        converted = matcher.replaceAll("<a href=\"$1\">$1</a>");
+        return converted;
     }
 }


### PR DESCRIPTION
Problem : When sending meeting invites from MS teams Desktop, ALT-DESC param is not being sent. This causes the DescHTML not to be set while creating the invites. When we use EWS to add an account in Outlook, the meeting urls are removed.

Solution: Check if descHtml is missing and desc is present in the request. Convert the desc as html and add it is descHtml.

Test : 
Sent recurring and normal meetings from MS Teams to verify if the URLs are present or not.
