### PR TITLE
ZCS-10883: Create a boolean local-config for fifteen minutes calendar resolution

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -663,7 +663,7 @@ public final class LC {
     public static final KnownKey calendar_cache_max_stale_items = KnownKey.newKey(10);
     public static final KnownKey calendar_exchange_form_auth_url = KnownKey.newKey("/exchweb/bin/auth/owaauth.dll");
     public static final KnownKey calendar_item_get_max_retries = KnownKey.newKey(100);
-    public static final KnownKey zimbraPrefCalenderScaling = KnownKey.newKey(true);
+    public static final KnownKey zimbraPrefCalenderScaling = KnownKey.newKey(false);
 
     public static final KnownKey spnego_java_options =  KnownKey.newKey(
             "-Djava.security.krb5.conf=${mailboxd_directory}/etc/krb5.ini " +

--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -663,6 +663,7 @@ public final class LC {
     public static final KnownKey calendar_cache_max_stale_items = KnownKey.newKey(10);
     public static final KnownKey calendar_exchange_form_auth_url = KnownKey.newKey("/exchweb/bin/auth/owaauth.dll");
     public static final KnownKey calendar_item_get_max_retries = KnownKey.newKey(100);
+    public static final KnownKey zimbraPref15MinutesCalenderScaling = KnownKey.newKey(false);
 
     public static final KnownKey spnego_java_options =  KnownKey.newKey(
             "-Djava.security.krb5.conf=${mailboxd_directory}/etc/krb5.ini " +

--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -663,7 +663,7 @@ public final class LC {
     public static final KnownKey calendar_cache_max_stale_items = KnownKey.newKey(10);
     public static final KnownKey calendar_exchange_form_auth_url = KnownKey.newKey("/exchweb/bin/auth/owaauth.dll");
     public static final KnownKey calendar_item_get_max_retries = KnownKey.newKey(100);
-    public static final KnownKey zimbraPref15MinutesCalenderScaling = KnownKey.newKey(false);
+    public static final KnownKey zimbraPrefCalenderScaling = KnownKey.newKey(true);
 
     public static final KnownKey spnego_java_options =  KnownKey.newKey(
             "-Djava.security.krb5.conf=${mailboxd_directory}/etc/krb5.ini " +

--- a/store/src/java/com/zimbra/cs/service/account/GetPrefs.java
+++ b/store/src/java/com/zimbra/cs/service/account/GetPrefs.java
@@ -99,8 +99,17 @@ public class GetPrefs extends AccountDocumentHandler  {
                 prefs.addKeyValuePair(key, (String) value, AccountConstants.E_PREF, AccountConstants.A_NAME);
             }
         }
-        prefs.addKeyValuePair(LC.zimbraPref15MinutesCalenderScaling.key(), String.valueOf(LC.zimbraPref15MinutesCalenderScaling.booleanValue()),
-                AccountConstants.E_PREF, AccountConstants.A_NAME);
+
+        String CalenderScalingMinutes = null;
+        if (LC.zimbraPrefCalenderScaling.booleanValue()) {
+            CalenderScalingMinutes = "15";
+        } else {
+            CalenderScalingMinutes = "30";
+        }
+        if (CalenderScalingMinutes != null) {
+            prefs.addKeyValuePair(LC.zimbraPrefCalenderScaling.key(), CalenderScalingMinutes,
+                    AccountConstants.E_PREF, AccountConstants.A_NAME);
+        }
     }
 
 }

--- a/store/src/java/com/zimbra/cs/service/account/GetPrefs.java
+++ b/store/src/java/com/zimbra/cs/service/account/GetPrefs.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.Map;
 
 import com.zimbra.common.calendar.TZIDMapper;
+import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AccountConstants;
 import com.zimbra.common.soap.Element;
@@ -98,6 +99,8 @@ public class GetPrefs extends AccountDocumentHandler  {
                 prefs.addKeyValuePair(key, (String) value, AccountConstants.E_PREF, AccountConstants.A_NAME);
             }
         }
-    }   
+        prefs.addKeyValuePair(LC.zimbraPref15MinutesCalenderScaling.key(), String.valueOf(LC.zimbraPref15MinutesCalenderScaling.booleanValue()),
+                AccountConstants.E_PREF, AccountConstants.A_NAME);
+    }
 
 }

--- a/store/src/java/com/zimbra/cs/service/account/GetPrefs.java
+++ b/store/src/java/com/zimbra/cs/service/account/GetPrefs.java
@@ -100,16 +100,14 @@ public class GetPrefs extends AccountDocumentHandler  {
             }
         }
 
-        String CalenderScalingMinutes = null;
+        String calenderScalingMinutes = null;
         if (LC.zimbraPrefCalenderScaling.booleanValue()) {
-            CalenderScalingMinutes = "15";
+            calenderScalingMinutes = "15";
         } else {
-            CalenderScalingMinutes = "30";
+            calenderScalingMinutes = "30";
         }
-        if (CalenderScalingMinutes != null) {
-            prefs.addKeyValuePair(LC.zimbraPrefCalenderScaling.key(), CalenderScalingMinutes,
-                    AccountConstants.E_PREF, AccountConstants.A_NAME);
-        }
+        prefs.addKeyValuePair(LC.zimbraPrefCalenderScaling.key(), calenderScalingMinutes,
+                AccountConstants.E_PREF, AccountConstants.A_NAME);
     }
 
 }


### PR DESCRIPTION
**Problem:**
Create a boolean local-config for fifteen minutes calendar resolution.

**Approach and Fix:**
- Added local config `zimbraPrefCalenderScaling` for fifteen minutes calendar resolution.
- Made the LC value available as pref on the front-end side based on the boolean condition of the value of `zimbraPrefCalenderScaling`.

**Testing Done:**
- Verified with the following `GetPrefsRequest` that the local-config value `zimbraPrefCalenderScaling` is now available as `GetPrefsResponse`.
```                                                                                                                                                               
<GetPrefsRequest xmlns="urn:zimbraAccount">
</GetPrefsRequest>
```

```
<GetPrefsResponse xmlns="urn:zimbraAccount">
  <pref name="zimbraPrefCalendarReminderMobile">FALSE</pref>
....
....
  <pref name="zimbraPrefCalendarReminderSendEmail">FALSE</pref>
  <pref name="zimbraPrefCalendarSendInviteDeniedAutoReply">FALSE</pref>
  <pref name="zimbraPrefIMIdleTimeout">10</pref>
  <pref name="zimbraPrefCalenderScaling">15</pref>
</GetPrefsResponse>
```