### PR TITLE
ZCS-10870: adding check to display unsubscribe folder on local config

### DIFF
--- a/store/src/java/com/zimbra/cs/imap/ImapHandler.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapHandler.java
@@ -63,6 +63,7 @@ import com.zimbra.common.localconfig.ConfigException;
 import com.zimbra.common.localconfig.DebugConfig;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.mailbox.ACLGrant;
+import com.zimbra.common.mailbox.FolderConstants;
 import com.zimbra.common.mailbox.FolderStore;
 import com.zimbra.common.mailbox.GrantGranteeType;
 import com.zimbra.common.mailbox.ItemIdentifier;
@@ -2442,6 +2443,10 @@ public abstract class ImapHandler {
         // TODO - This probably needs to be the setting for the server for IMAP session's main mailbox
         boolean isMailFolders =  Provisioning.getInstance().getLocalServer().isImapDisplayMailFoldersOnly();
         for (FolderStore folderStore : visibleFolders) {
+            if (!LC.zimbra_feature_safe_unsubscribe_folder_enabled.booleanValue() && folderStore.getFolderIdAsString().equals(Integer.toString(FolderConstants.ID_FOLDER_UNSUBSCRIBE))) {
+                continue;
+            }
+
             //bug 6418 ..filter out folders which are contacts and chat for LIST command.
             //  chat has item type of message.  hence ignoring the chat folder by name.
             if (isMailFolders && (folderStore.isChatsFolder() || (folderStore.getName().equals ("Chats")))) {

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -4449,6 +4449,9 @@ public class Mailbox implements MailboxStore {
         }
         // write the subfolders' data to the response
         for (Folder subfolder : subfolders) {
+            if (!LC.zimbra_feature_safe_unsubscribe_folder_enabled.booleanValue() && subfolder.getId() == FolderConstants.ID_FOLDER_UNSUBSCRIBE) {
+                continue;
+            }
             FolderNode child = handleFolder(subfolder, visible, returnAllVisibleFolders);
             if (child != null) {
                 node.mSubfolders.add(child);


### PR DESCRIPTION
**Issue**
LC **zimbra_feature_safe_unsubscribe_folder_enabled** when set to false still shows the Unsubscribe folder

**Fix**
Added check to getFolder & IMAP to hide the folder from list if **zimbra_feature_safe_unsubscribe_folder_enabled** is set to false