### PR TITLE
ZCS-10914: Introduce calendar resolution preference backed by LDAP attribute

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -1667,7 +1667,7 @@ public class ZAttrProvisioning {
     public static enum PrefCalenderScaling {
         _0("10"),
         _5("15"),
-        _0("30");
+        _10("30");
         private String mValue;
         private PrefCalenderScaling(String value) { mValue = value; }
         public String toString() { return mValue; }
@@ -1679,7 +1679,7 @@ public class ZAttrProvisioning {
         }
         public boolean is_0() { return this == _0;}
         public boolean is_5() { return this == _5;}
-        public boolean is_0() { return this == _0;}
+        public boolean is_10() { return this == _10;}
     }
 
     public static enum PrefClientType {

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -1664,6 +1664,24 @@ public class ZAttrProvisioning {
         public boolean isYear() { return this == year;}
     }
 
+    public static enum PrefCalenderScaling {
+        _0("10"),
+        _5("15"),
+        _0("30");
+        private String mValue;
+        private PrefCalenderScaling(String value) { mValue = value; }
+        public String toString() { return mValue; }
+        public static PrefCalenderScaling fromString(String s) throws ServiceException {
+            for (PrefCalenderScaling value : values()) {
+                if (value.mValue.equals(s)) return value;
+             }
+             throw ServiceException.INVALID_REQUEST("invalid value: "+s+", valid values: "+ Arrays.asList(values()), null);
+        }
+        public boolean is_0() { return this == _0;}
+        public boolean is_5() { return this == _5;}
+        public boolean is_0() { return this == _0;}
+    }
+
     public static enum PrefClientType {
         standard("standard"),
         advanced("advanced"),
@@ -12985,6 +13003,14 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=1103)
     public static final String A_zimbraPrefCalendarWorkingHours = "zimbraPrefCalendarWorkingHours";
+
+    /**
+     * Default calendar resolution preference
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4004)
+    public static final String A_zimbraPrefCalenderScaling = "zimbraPrefCalenderScaling";
 
     /**
      * If FALSE, chat features are disabled in the client and user presence

--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -663,7 +663,6 @@ public final class LC {
     public static final KnownKey calendar_cache_max_stale_items = KnownKey.newKey(10);
     public static final KnownKey calendar_exchange_form_auth_url = KnownKey.newKey("/exchweb/bin/auth/owaauth.dll");
     public static final KnownKey calendar_item_get_max_retries = KnownKey.newKey(100);
-    public static final KnownKey zimbraPrefCalenderScaling = KnownKey.newKey(false);
 
     public static final KnownKey spnego_java_options =  KnownKey.newKey(
             "-Djava.security.krb5.conf=${mailboxd_directory}/etc/krb5.ini " +

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9924,4 +9924,8 @@ TODO: delete them permanently from here
   <defaultCOSValue>FALSE</defaultCOSValue>
   <desc>Creates unsubscribe system folder</desc>
  </attr>
+ <attr id="4004" name="zimbraPrefCalenderScaling" type="enum" value="10,15,30" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="9.1.0">
+  <defaultCOSValue>30</defaultCOSValue>
+  <desc>Default calendar resolution preference</desc>
+</attr>
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -42410,6 +42410,137 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * Default calendar resolution preference
+     *
+     * <p>Valid values: [10, 15, 30]
+     *
+     * @return zimbraPrefCalenderScaling, or ZAttrProvisioning.PrefCalenderScaling._0 if unset and/or has invalid value
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4004)
+    public ZAttrProvisioning.PrefCalenderScaling getPrefCalenderScaling() {
+        try { String v = getAttr(Provisioning.A_zimbraPrefCalenderScaling, true, true); return v == null ? ZAttrProvisioning.PrefCalenderScaling._0 : ZAttrProvisioning.PrefCalenderScaling.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.PrefCalenderScaling._0; }
+    }
+
+    /**
+     * Default calendar resolution preference
+     *
+     * <p>Valid values: [10, 15, 30]
+     *
+     * @return zimbraPrefCalenderScaling, or "30" if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4004)
+    public String getPrefCalenderScalingAsString() {
+        return getAttr(Provisioning.A_zimbraPrefCalenderScaling, "30", true);
+    }
+
+    /**
+     * Default calendar resolution preference
+     *
+     * <p>Valid values: [10, 15, 30]
+     *
+     * @param zimbraPrefCalenderScaling new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4004)
+    public void setPrefCalenderScaling(ZAttrProvisioning.PrefCalenderScaling zimbraPrefCalenderScaling) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefCalenderScaling, zimbraPrefCalenderScaling.toString());
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Default calendar resolution preference
+     *
+     * <p>Valid values: [10, 15, 30]
+     *
+     * @param zimbraPrefCalenderScaling new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4004)
+    public Map<String,Object> setPrefCalenderScaling(ZAttrProvisioning.PrefCalenderScaling zimbraPrefCalenderScaling, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefCalenderScaling, zimbraPrefCalenderScaling.toString());
+        return attrs;
+    }
+
+    /**
+     * Default calendar resolution preference
+     *
+     * <p>Valid values: [10, 15, 30]
+     *
+     * @param zimbraPrefCalenderScaling new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4004)
+    public void setPrefCalenderScalingAsString(String zimbraPrefCalenderScaling) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefCalenderScaling, zimbraPrefCalenderScaling);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Default calendar resolution preference
+     *
+     * <p>Valid values: [10, 15, 30]
+     *
+     * @param zimbraPrefCalenderScaling new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4004)
+    public Map<String,Object> setPrefCalenderScalingAsString(String zimbraPrefCalenderScaling, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefCalenderScaling, zimbraPrefCalenderScaling);
+        return attrs;
+    }
+
+    /**
+     * Default calendar resolution preference
+     *
+     * <p>Valid values: [10, 15, 30]
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4004)
+    public void unsetPrefCalenderScaling() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefCalenderScaling, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Default calendar resolution preference
+     *
+     * <p>Valid values: [10, 15, 30]
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4004)
+    public Map<String,Object> unsetPrefCalenderScaling(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefCalenderScaling, "");
+        return attrs;
+    }
+
+    /**
      * If FALSE, chat features are disabled in the client and user presence
      * is shown as offline to all other users.
      *

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -32852,6 +32852,137 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * Default calendar resolution preference
+     *
+     * <p>Valid values: [10, 15, 30]
+     *
+     * @return zimbraPrefCalenderScaling, or ZAttrProvisioning.PrefCalenderScaling._0 if unset and/or has invalid value
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4004)
+    public ZAttrProvisioning.PrefCalenderScaling getPrefCalenderScaling() {
+        try { String v = getAttr(Provisioning.A_zimbraPrefCalenderScaling, true, true); return v == null ? ZAttrProvisioning.PrefCalenderScaling._0 : ZAttrProvisioning.PrefCalenderScaling.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.PrefCalenderScaling._0; }
+    }
+
+    /**
+     * Default calendar resolution preference
+     *
+     * <p>Valid values: [10, 15, 30]
+     *
+     * @return zimbraPrefCalenderScaling, or "30" if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4004)
+    public String getPrefCalenderScalingAsString() {
+        return getAttr(Provisioning.A_zimbraPrefCalenderScaling, "30", true);
+    }
+
+    /**
+     * Default calendar resolution preference
+     *
+     * <p>Valid values: [10, 15, 30]
+     *
+     * @param zimbraPrefCalenderScaling new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4004)
+    public void setPrefCalenderScaling(ZAttrProvisioning.PrefCalenderScaling zimbraPrefCalenderScaling) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefCalenderScaling, zimbraPrefCalenderScaling.toString());
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Default calendar resolution preference
+     *
+     * <p>Valid values: [10, 15, 30]
+     *
+     * @param zimbraPrefCalenderScaling new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4004)
+    public Map<String,Object> setPrefCalenderScaling(ZAttrProvisioning.PrefCalenderScaling zimbraPrefCalenderScaling, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefCalenderScaling, zimbraPrefCalenderScaling.toString());
+        return attrs;
+    }
+
+    /**
+     * Default calendar resolution preference
+     *
+     * <p>Valid values: [10, 15, 30]
+     *
+     * @param zimbraPrefCalenderScaling new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4004)
+    public void setPrefCalenderScalingAsString(String zimbraPrefCalenderScaling) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefCalenderScaling, zimbraPrefCalenderScaling);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Default calendar resolution preference
+     *
+     * <p>Valid values: [10, 15, 30]
+     *
+     * @param zimbraPrefCalenderScaling new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4004)
+    public Map<String,Object> setPrefCalenderScalingAsString(String zimbraPrefCalenderScaling, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefCalenderScaling, zimbraPrefCalenderScaling);
+        return attrs;
+    }
+
+    /**
+     * Default calendar resolution preference
+     *
+     * <p>Valid values: [10, 15, 30]
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4004)
+    public void unsetPrefCalenderScaling() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefCalenderScaling, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Default calendar resolution preference
+     *
+     * <p>Valid values: [10, 15, 30]
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4004)
+    public Map<String,Object> unsetPrefCalenderScaling(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefCalenderScaling, "");
+        return attrs;
+    }
+
+    /**
      * If FALSE, chat features are disabled in the client and user presence
      * is shown as offline to all other users.
      *

--- a/store/src/java/com/zimbra/cs/service/account/GetPrefs.java
+++ b/store/src/java/com/zimbra/cs/service/account/GetPrefs.java
@@ -24,7 +24,6 @@ import java.util.HashSet;
 import java.util.Map;
 
 import com.zimbra.common.calendar.TZIDMapper;
-import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AccountConstants;
 import com.zimbra.common.soap.Element;
@@ -99,15 +98,6 @@ public class GetPrefs extends AccountDocumentHandler  {
                 prefs.addKeyValuePair(key, (String) value, AccountConstants.E_PREF, AccountConstants.A_NAME);
             }
         }
-
-        String calenderScalingMinutes = null;
-        if (LC.zimbraPrefCalenderScaling.booleanValue()) {
-            calenderScalingMinutes = "15";
-        } else {
-            calenderScalingMinutes = "30";
-        }
-        prefs.addKeyValuePair(LC.zimbraPrefCalenderScaling.key(), calenderScalingMinutes,
-                AccountConstants.E_PREF, AccountConstants.A_NAME);
     }
 
 }


### PR DESCRIPTION
**Problem:**
Introduce calendar resolution preference backed by the LDAP attribute.

**Approach:**
- Introduced a new LDAP attribute `zimbraPrefCalenderScaling` on the `account` and `COS` level to have the calendar resolution preference for `10, 15, 30` minutes keeping the default value as `30 minutes`.
- Reverted the [ZCS-10883](https://jira.corp.synacor.com/browse/ZCS-10883) changes for the temporary boolean `local-config` for `15 minutes` calendar resolution.

**Testing Done:**
- Created a new build with these changes and verified that the newly introduced LDAP attribute `zimbraPrefCalenderScaling`  is available at the `account` and `COS` levels.
- Verified with the following `GetPrefsRequest` that the newly introduced LDAP attribute `zimbraPrefCalenderScaling` is now available as `GetPrefsResponse`.
```                                                                                                                                                               
<GetPrefsRequest xmlns="urn:zimbraAccount">
</GetPrefsRequest>
```

```
<GetPrefsResponse xmlns="urn:zimbraAccount">
  <pref name="zimbraPrefCalendarReminderMobile">FALSE</pref>
....
....
   <pref name="zimbraPrefOpenMailInNewWindow">FALSE</pref>
  <pref name="zimbraPrefMailSignatureStyle">outlook</pref>
  <pref name="zimbraPrefCalenderScaling">15</pref>
  <pref name="zimbraPrefAdminConsoleWarnOnExit">TRUE</pref>
....
....
</GetPrefsResponse>
```
- Verified that the newly introduced LDAP attribute `zimbraPrefCalenderScaling` default value is `30 minutes`.
- Verified that the newly introduced LDAP attribute `zimbraPrefCalenderScaling` accepts the ENUM (10 mins, 15 mins, 30 mins) by changing them.
 ```
zimbra@dev-akshat:~$ zmprov -l mc default zimbraPrefCalenderScaling 15
zimbra@dev-akshat:~$ zmprov -l gc default zimbraPrefCalenderScaling
# name default
zimbraPrefCalenderScaling: 15
```
- Verified that the newly introduced LDAP attribute `zimbraPrefCalenderScaling` accepts only the valid ENUM values.
```
zimbra@dev-akshat:~$ zmprov -l mc default zimbraPrefCalenderScaling 100
ERROR: account.INVALID_ATTR_VALUE (zimbraPrefCalenderScaling must be one of: 10,15,30)
```

Related [PR](https://github.com/Zimbra/zm-mailbox/pull/1192) of [ZCS-10883](https://jira.corp.synacor.com/browse/ZCS-10883)