### PR TITLE
ZCS-10834: Add an attribute to SendMsgRequest for request delivery notification on successful delivery

### DIFF
--- a/common/src/java/com/zimbra/common/soap/MailConstants.java
+++ b/common/src/java/com/zimbra/common/soap/MailConstants.java
@@ -892,6 +892,7 @@ public final class MailConstants {
     public static final String A_NO_SAVE_TO_SENT = "noSave";
     public static final String A_FETCH_SAVED_MSG = "fetchSavedMsg";
     public static final String A_SEND_UID = "suid";
+    public static final String A_DELIVERY_RECEIPT_NOTIFICATION ="deliveryReport";
     public static final String A_FOR_ACCOUNT = "forAcct";
     public static final String A_AUTO_SEND_TIME = "autoSendTime";
 

--- a/soap/src/java/com/zimbra/soap/mail/message/SendMsgRequest.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/SendMsgRequest.java
@@ -17,15 +17,14 @@
 
 package com.zimbra.soap.mail.message;
 
-import com.google.common.base.MoreObjects;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import com.google.common.base.MoreObjects;
 import com.zimbra.common.soap.MailConstants;
-import com.zimbra.soap.mail.type.Msg;
 import com.zimbra.soap.mail.type.MsgToSend;
 import com.zimbra.soap.type.ZmBoolean;
 
@@ -106,6 +105,13 @@ public class SendMsgRequest {
     @XmlElement(name=MailConstants.E_MSG /* m */, required=false)
     private MsgToSend msg;
 
+    /**
+     * @zm-api-field-tag delivery-receipt-notification
+     * @zm-api-field-description If set, delivery receipt notification will be sent.
+     */
+    @XmlAttribute(name=MailConstants.A_DELIVERY_RECEIPT_NOTIFICATION /* deliveryReport */, required=false)
+    private ZmBoolean deliveryReport;
+
     public SendMsgRequest() {
     }
 
@@ -125,6 +131,10 @@ public class SendMsgRequest {
         this.fetchSavedMsg = ZmBoolean.fromBool(fetchSavedMsg);
     }
 
+    public void setDeliveryReport(Boolean deliveryReport) {
+        this.deliveryReport = ZmBoolean.fromBool(deliveryReport);
+    }
+
     public void setSendUid(String sendUid) { this.sendUid = sendUid; }
     public void setMsg(MsgToSend msg) { this.msg = msg; }
 
@@ -133,6 +143,7 @@ public class SendMsgRequest {
     public Boolean getNoSaveToSent() { return ZmBoolean.toBool(noSaveToSent); }
     public Boolean getFetchSavedMsg() { return ZmBoolean.toBool(fetchSavedMsg); }
     public String getSendUid() { return sendUid; }
+    public Boolean getDeliveryReport() { return ZmBoolean.toBool(deliveryReport); }
     public MsgToSend getMsg() { return msg; }
 
     public MoreObjects.ToStringHelper addToStringInfo(MoreObjects.ToStringHelper helper) {
@@ -142,6 +153,7 @@ public class SendMsgRequest {
             .add("noSaveToSent", noSaveToSent)
             .add("fetchSavedMsg", fetchSavedMsg)
             .add("sendUid", sendUid)
+            .add("deliveryReport", deliveryReport)
             .add("msg", msg);
     }
 


### PR DESCRIPTION
**Problem:**
Add an attribute to SendMsgRequest for request delivery notification on successful delivery.

**Approach and Implementation:**
- Added a new SendMsgRequest attribute `deliveryReport` to request for the delivery notification on successful delivery.
- Refactored the code to use the attribute `deliveryReport` if passed with the `SendMsgRequest` to request delivery notification on the successful delivery of the e-mail.
- Updated the NOTIFY parameter of `RCPT` command to inform `MTA` to send the delivery report on successful delivery OR failure to deliver OR delayed delivery. To achieve this used the `DsnNotifyOption` enums and set it to `NOTIFY=SUCCESS, FAILURE, DELAY` if the newly introduced option `deliveryReport` in the `SendMsgRequest` is set to `true`.

**Testing Done:**
- Verified with the following `SendMsgRequest` that the newly introduced attribute `deliveryReport`.
```
<SendMsgRequest deliveryReport='1' xmlns='urn:zimbraMail'>
  <m>
    <e t='t' a='aks@dev-akshat.synacor.tk'/>
    <su>Test executed for SendMsgRequest</su>
    <mp ct='text/plain'>
      <content>Hello, how are you... ?</content>
    </mp>
  </m>
</SendMsgRequest>
```
```
zmsoap -m akshat@dev-akshat.synacor.tk -p test123 -f /tmp/SMsg.xml
```
- Verified all the status of the accounts with Delivery Report Requested:
**a.** `Active` - Delivery Report Requested -> Successful Mail Delivery Report
**b.** `Closed` - Delivery Report Requested -> Undelivered Mail Returned to Sender [E-mail will not be delivered]
**c.** `Pending` - Delivery Report Requested -> Undelivered Mail Returned to Sender [E-mail will not be delivered]
**d.** `Locked` - Delivery Report Requested -> Successful Mail Delivery Report
**e.** `Maintenance` - Delivery Report Requested -> [Mail will not be delivered until the account is in Maintenance mode] for maintenance the sender shouldn't get a bounce since maintenance is supposed to be only for a short time. -> Successful Mail Delivery Report when the account is reset to `Active` mode.
- Verified all the status of the accounts with Delivery Report **NOT** Requested: Didn’t receive any delivery report e-mail.
- `Out of Office Delivery:` E-mail will be triggered for the Out of Office (only once) and if the Delivery Report Requested -> Successful Mail Delivery Report.
- `Invalid account:` Delivery Report Requested -> Undelivered Mail Returned to Sender [E-mail will not be delivered]
- `Gmail Account:`E-mail will be triggered for the Delivery Report Requested -> Successful Mail Delivery Report