### PR TITLE
ZCS-10972: Localconfig to enable/disable DSN with SendMsgRequest

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1460,6 +1460,9 @@ public final class LC {
     @Supported
     public static final KnownKey zimbra_remote_cmd_channel_timeout_min = KnownKey.newKey(10);
 
+    @Supported
+    public static final KnownKey delivery_report_enabled = KnownKey.newKey(true);
+
     static {
         // Automatically set the key name with the variable name.
         for (Field field : LC.class.getFields()) {

--- a/store/src/java/com/zimbra/cs/service/mail/SendMsg.java
+++ b/store/src/java/com/zimbra/cs/service/mail/SendMsg.java
@@ -131,7 +131,10 @@ public class SendMsg extends MailDocumentHandler {
                boolean isCalendarForward = request.getAttributeBool(MailConstants.A_IS_CALENDAR_FORWARD, false);
                boolean noSaveToSent = request.getAttributeBool(MailConstants.A_NO_SAVE_TO_SENT, false);
                boolean fetchSavedMsg = request.getAttributeBool(MailConstants.A_FETCH_SAVED_MSG, false);
-               boolean deliveryReport = request.getAttributeBool(MailConstants.A_DELIVERY_RECEIPT_NOTIFICATION, false);
+               boolean deliveryReport = false;
+               if (LC.delivery_report_enabled.booleanValue()) {
+                   deliveryReport = request.getAttributeBool(MailConstants.A_DELIVERY_RECEIPT_NOTIFICATION, false);
+               }
 
                String origId = msgElem.getAttribute(MailConstants.A_ORIG_ID, null);
                ItemId iidOrigId = origId == null ? null : new ItemId(origId, zsc);


### PR DESCRIPTION
**Problem:**
Introduce a local config to enable/disable `DSN` with `SendMsgRequest`.

**Approach and Implementation:**
Introduced a new LC `delivery_report_enabled` with default value as `true`.
If the LC value is `true`, then the `SendMsgRequest` with the `DSN` feature is enabled.
If the LC value is `false`, then the `SendMsgRequest` with the `DSN` feature is disabled.

**Testing Done:**
- Set the LC value as `true` with `deliveryReport` attribute of `SendMsgRequest` set as `true` :: **Result**-> Successful Mail Delivery Report.
- Set the LC value as `true` with `deliveryReport` attribute of `SendMsgRequest` set as `false` :: **Result**-> No Mail Delivery Report.
- Set the LC value as `true` with **NO** `deliveryReport` attribute in `SendMsgRequest` :: **Result**-> No Mail Delivery Report.
- Set the LC value as `false` with `deliveryReport` attribute of `SendMsgRequest` set as `true` :: **Result**-> No Mail Delivery Report.
- Set the LC value as `false` with `deliveryReport` attribute of `SendMsgRequest` set as `false` :: **Result**-> No Mail Delivery Report.
- Set the LC value as `false` with **NO** `deliveryReport` attribute in `SendMsgRequest` :: **Result**-> No Mail Delivery Report.
- All the testing which is done for [ZCS-10834](https://jira.corp.synacor.com/browse/ZCS-10834)

**Related** [PR](https://github.com/Zimbra/zm-mailbox/pull/1200)