### PR TITLE
ZBUG-2316: add LC to ignore x-alt-desc with x-microsoft header presence check and update desc to html encoding

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1463,6 +1463,9 @@ public final class LC {
     @Supported
     public static final KnownKey delivery_report_enabled = KnownKey.newKey(true);
 
+    // ignore X-ALT-DESC and use invite description to create html description
+    public static final KnownKey invite_ignore_x_alt_description = KnownKey.newKey(false);
+
     static {
         // Automatically set the key name with the variable name.
         for (Field field : LC.class.getFields()) {

--- a/store/src/java/com/zimbra/cs/mailbox/calendar/Invite.java
+++ b/store/src/java/com/zimbra/cs/mailbox/calendar/Invite.java
@@ -511,8 +511,17 @@ public class Invite {
         String desc = descInMeta ? meta.get(FN_DESC, null) : null;
         String descHtml = descInMeta ? meta.get(FN_DESC_HTML, null) : null;
 
-        // if desc html is missing but desc is present
-        if (desc != null && descHtml == null) {
+        boolean hasXMicrosoftHeader = false;
+        for (Map.Entry<String, ?> entry : meta.asMap().entrySet()) {
+            if (entry.getValue().toString().contains("X-MICROSOFT")) {
+                hasXMicrosoftHeader = true;
+                break;
+            }
+        }
+
+        // generate HTML description if invite_ignore_x_alt_description is true
+        // and contains X-MICROSOFT headers
+        if (desc != null && LC.invite_ignore_x_alt_description.booleanValue() && hasXMicrosoftHeader) {
             descHtml = Util.textToHtml(desc);
         }
 

--- a/store/src/java/com/zimbra/cs/mailbox/calendar/Util.java
+++ b/store/src/java/com/zimbra/cs/mailbox/calendar/Util.java
@@ -375,12 +375,6 @@ public class Util {
                 previousWasASpace = false;
             }
             switch (c) {
-                case '<':
-                    builder.append("&lt;");
-                    break;
-                case '>':
-                    builder.append("&gt;");
-                    break;
                 case '&':
                     builder.append("&amp;");
                     break;


### PR DESCRIPTION
**Issue**
Invite sent from MS Teams having X-ALT-DESC has missing links in the invite causing no links after accepting the invite.

**Fix**
Added LC **invite_ignore_x_alt_description** and check X-MICROSOFT header presence check to ignore the X-ALT-DESC and generate HTML description from description with HTML encoding and create HTML links from plain link text.
