### PR TITLE
Update ZimbraHttpClientManager

### DIFF
--- a/common/src/java/com/zimbra/common/httpclient/ZimbraHttpClientManager.java
+++ b/common/src/java/com/zimbra/common/httpclient/ZimbraHttpClientManager.java
@@ -33,7 +33,7 @@ public class ZimbraHttpClientManager {
     private final CloseableHttpAsyncClient internalAsyncClient;
     private final CloseableHttpClient internalClient;
     private final CloseableHttpClient externalClient;
-    public ZimbraHttpClientManager() {
+    private ZimbraHttpClientManager() {
         PoolingHttpClientConnectionManager internalConnectionMgr;
         PoolingHttpClientConnectionManager externallConnectionMgr;
         RequestConfig internalRequestConfig;


### PR DESCRIPTION
Switch the constructor from public to private, as this class is supposed to be a singleton (at least it is used as one).