### PR TITLE
ZCS-11066: update java identifier check for LDAP enum values to use the first character too for uniqueness

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -956,7 +956,7 @@ public class ZAttrProvisioning {
 
     public static enum MtaNotifyClasses {
         bounce("bounce"),
-        _bounce("2bounce"),
+        _2bounce("2bounce"),
         data("data"),
         delay("delay"),
         policy("policy"),
@@ -973,7 +973,7 @@ public class ZAttrProvisioning {
              throw ServiceException.INVALID_REQUEST("invalid value: "+s+", valid values: "+ Arrays.asList(values()), null);
         }
         public boolean isBounce() { return this == bounce;}
-        public boolean is_bounce() { return this == _bounce;}
+        public boolean is_2bounce() { return this == _2bounce;}
         public boolean isData() { return this == data;}
         public boolean isDelay() { return this == delay;}
         public boolean isPolicy() { return this == policy;}
@@ -1665,9 +1665,9 @@ public class ZAttrProvisioning {
     }
 
     public static enum PrefCalenderScaling {
-        _0("10"),
-        _5("15"),
-        _10("30");
+        _10("10"),
+        _15("15"),
+        _30("30");
         private String mValue;
         private PrefCalenderScaling(String value) { mValue = value; }
         public String toString() { return mValue; }
@@ -1677,9 +1677,9 @@ public class ZAttrProvisioning {
              }
              throw ServiceException.INVALID_REQUEST("invalid value: "+s+", valid values: "+ Arrays.asList(values()), null);
         }
-        public boolean is_0() { return this == _0;}
-        public boolean is_5() { return this == _5;}
         public boolean is_10() { return this == _10;}
+        public boolean is_15() { return this == _15;}
+        public boolean is_30() { return this == _30;}
     }
 
     public static enum PrefClientType {

--- a/common/src/java/com/zimbra/common/util/StringUtil.java
+++ b/common/src/java/com/zimbra/common/util/StringUtil.java
@@ -889,7 +889,7 @@ public class StringUtil {
         for (int i = 0; i < s.length(); i++) {
             char ch = s.charAt(i);
             if (i == 0) {
-                result.append(Character.isJavaIdentifierStart(ch) ? ch : "_");
+                result.append(Character.isJavaIdentifierStart(ch) ? ch : "_" + ch);
             } else {
                 result.append(Character.isJavaIdentifierPart(ch) ? ch : "_");
             }

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -42414,13 +42414,13 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * <p>Valid values: [10, 15, 30]
      *
-     * @return zimbraPrefCalenderScaling, or ZAttrProvisioning.PrefCalenderScaling._0 if unset and/or has invalid value
+     * @return zimbraPrefCalenderScaling, or ZAttrProvisioning.PrefCalenderScaling._30 if unset and/or has invalid value
      *
      * @since ZCS 9.1.0
      */
     @ZAttr(id=4004)
     public ZAttrProvisioning.PrefCalenderScaling getPrefCalenderScaling() {
-        try { String v = getAttr(Provisioning.A_zimbraPrefCalenderScaling, true, true); return v == null ? ZAttrProvisioning.PrefCalenderScaling._0 : ZAttrProvisioning.PrefCalenderScaling.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.PrefCalenderScaling._0; }
+        try { String v = getAttr(Provisioning.A_zimbraPrefCalenderScaling, true, true); return v == null ? ZAttrProvisioning.PrefCalenderScaling._30 : ZAttrProvisioning.PrefCalenderScaling.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.PrefCalenderScaling._30; }
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -32856,13 +32856,13 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * <p>Valid values: [10, 15, 30]
      *
-     * @return zimbraPrefCalenderScaling, or ZAttrProvisioning.PrefCalenderScaling._0 if unset and/or has invalid value
+     * @return zimbraPrefCalenderScaling, or ZAttrProvisioning.PrefCalenderScaling._30 if unset and/or has invalid value
      *
      * @since ZCS 9.1.0
      */
     @ZAttr(id=4004)
     public ZAttrProvisioning.PrefCalenderScaling getPrefCalenderScaling() {
-        try { String v = getAttr(Provisioning.A_zimbraPrefCalenderScaling, true, true); return v == null ? ZAttrProvisioning.PrefCalenderScaling._0 : ZAttrProvisioning.PrefCalenderScaling.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.PrefCalenderScaling._0; }
+        try { String v = getAttr(Provisioning.A_zimbraPrefCalenderScaling, true, true); return v == null ? ZAttrProvisioning.PrefCalenderScaling._30 : ZAttrProvisioning.PrefCalenderScaling.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.PrefCalenderScaling._30; }
     }
 
     /**


### PR DESCRIPTION
**Issue**
LDAP attribute added for type enum with values starting with numeric is leading the compilation errors. For e.g. if the enum is set with values 10, 15, 30 here when generate getters is ran there first character from enum gets removed because for Character.isJavaIdentifierStart first character cannot be numeric and this leads duplicate enum values for '0' as from 10 & 30, 1 & 3 gets removed. This leads to below compilation error.

**Fix**
Java identifier check for enum values requires first character to be non numeric and using numeric enum as list for LDAP attrs enums causes duplicate method errors during compliation. As a fix made identifier check to include the numeric character too for maintaining uniqueness.

```
compile:
 [javac] Compiling 1 source file to /Users/psurana/git/zm-mailbox/common/build/classes
 [javac] /Users/psurana/git/zm-mailbox/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java:1670: error: variable _0 is already defined in enum PrefCalenderScaling
 [javac] _0("30");
 [javac] ^
 [javac] /Users/psurana/git/zm-mailbox/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java:1682: error: method is_0() is already defined in enum PrefCalenderScaling
 [javac] public boolean is_0() { return this == _0;}
 [javac] ^
 [javac] 2 errors

```
