### PR TITLE
ZBUG-2316: store text/html from message to calendar invite metadata

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/CalendarItem.java
+++ b/store/src/java/com/zimbra/cs/mailbox/CalendarItem.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2016, 2021 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -462,6 +462,13 @@ public abstract class CalendarItem extends MailItem {
         }
         Mailbox mbox = folder.getMailbox();
 
+        if (firstInvite.getXZimbraDescriptionHtml() == null) {
+            String htmlDesc = mbox.getMsgHtmlDesc(pm);
+            if (!StringUtil.isNullOrEmpty(htmlDesc)) {
+                firstInvite.setXZimbraDescriptionHtml(htmlDesc);
+            }
+        }
+
         if (pm != null && pm.hasAttachments()) {
             firstInvite.setHasAttachment(true);
             flags |= Flag.BITMASK_ATTACHED;
@@ -549,6 +556,9 @@ public abstract class CalendarItem extends MailItem {
         CalendarItem item = type == Type.APPOINTMENT ? new Appointment(mbox, data) : new Task(mbox, data);
         Invite defInvite = item.getDefaultInviteOrNull();
         if (defInvite != null) {
+            if (firstInvite.getXZimbraDescriptionHtml() != null) {
+                defInvite.setXZimbraDescriptionHtml(firstInvite.getXZimbraDescriptionHtml());
+            }
             Collection<Instance> instances =
                     item.expandInstances(CalendarUtils.MICROSOFT_EPOC_START_MS_SINCE_EPOC, Long.MAX_VALUE, false);
             if (instances.isEmpty()) {

--- a/store/src/java/com/zimbra/cs/mailbox/Message.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Message.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016 Synacor, Inc.
+ * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2021 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -879,7 +879,6 @@ public class Message extends MailItem {
             if (!cur.isPublic()) {
                 publicInvites = false;
             }
-
             // Bug 38550/41239: If ORGANIZER is missing, set it to email sender.  If that sender
             // is the same user as the recipient, don't set organizer and clear attendees instead.
             // We don't want to set organizer to receiving user unless we're absolutely certain
@@ -1111,6 +1110,13 @@ public class Message extends MailItem {
         boolean calItemIsNew = false;
         boolean modifiedCalItem = false;
         boolean success = false;
+
+        if (cur.getXZimbraDescriptionHtml() == null) {
+            String htmlDesc = this.getMailbox().getMsgHtmlDesc(pm);
+            if (!StringUtil.isNullOrEmpty(htmlDesc)) {
+                cur.setXZimbraDescriptionHtml(htmlDesc);
+            }
+        }
         try {
             InviteChanges invChanges = null;
             // Look for organizer-provided change list.

--- a/store/src/java/com/zimbra/cs/mailbox/calendar/Invite.java
+++ b/store/src/java/com/zimbra/cs/mailbox/calendar/Invite.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016 Synacor, Inc.
+ * Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2021 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -264,6 +264,7 @@ public class Invite {
     private static final String FN_CONTACT         = "contact";
     private static final String FN_DESC            = "desc";
     private static final String FN_DESC_HTML       = "descH";
+    private static final String FN_X_ZIMBRA_DESC_HTML = "xDescH";
     private static final String FN_DESC_IN_META    = "dinM";  // whether description is stored in metadata
     private static final String FN_FRAGMENT        = "frag";
     private static final String FN_DTSTAMP         = "dts";
@@ -347,6 +348,8 @@ public class Invite {
                 meta.put(FN_DESC, inv.mDescription);
             if (inv.mDescHtml != null)
                 meta.put(FN_DESC_HTML, inv.mDescHtml);
+            if (inv.xZimbraDescHtml != null)
+                meta.put(FN_X_ZIMBRA_DESC_HTML, inv.xZimbraDescHtml);
         }
 
         if (inv.mRecurrence != null) {
@@ -510,6 +513,7 @@ public class Invite {
         boolean descInMeta = meta.getBool(FN_DESC_IN_META, false);  // default to false for backward compat
         String desc = descInMeta ? meta.get(FN_DESC, null) : null;
         String descHtml = descInMeta ? meta.get(FN_DESC_HTML, null) : null;
+        String xDescHtml = descInMeta ? meta.get(FN_X_ZIMBRA_DESC_HTML, null) : null;
 
         // if desc html is missing but desc is present
         if (desc != null && descHtml == null) {
@@ -664,7 +668,7 @@ public class Invite {
                 seqno, lastFullSeqno, mailboxId, mailItemId, componentNum, sentByMe,
                 desc, descHtml, fragment, comments, categories, contacts, geo, url);
         invite.mDescInMeta = descInMeta;  // a little hacky, but necessary
-
+        invite.setXZimbraDescriptionHtml(xDescHtml);
         invite.setClassPropSetByMe(classPropSetByMe);
 
         long numAlarms = meta.getLong(FN_NUM_ALARMS, 0);
@@ -713,6 +717,7 @@ public class Invite {
 
     private String mDescription;
     private String mDescHtml;
+    private String xZimbraDescHtml;
     private boolean mDescInMeta = true;  // assume description is in metadata unless someone sets a large value
 
     /**
@@ -757,6 +762,22 @@ public class Invite {
         if (!mDescInMeta && mDescription == null)
             loadDescFromBlob();
         return mDescription;
+    }
+
+    /**
+     * Returns the invite email text/html part.
+     *
+     * @return null if notes is not found
+     * @throws ServiceException
+     */
+    public synchronized String getXZimbraDescriptionHtml() throws ServiceException {
+        return xZimbraDescHtml;
+    }
+
+    public synchronized void setXZimbraDescriptionHtml(String html) throws ServiceException {
+        if (html != null) {
+            xZimbraDescHtml = html;
+        }
     }
 
     public synchronized String getDescriptionHtml() throws ServiceException {


### PR DESCRIPTION
**Issue**
Invite sent from MS Teams does not shows up the links from the invite since it uses x-alt-desc or html description from invite.

**Fix**
Since MS Team sent the invites text part with links enclosed in <> , this content is sent in the EWS response is sent as text type and EWS ignores this link. As a fix the email invite which is received contains html body within the multipart we can send this html content in EWS response so the content type is sent as HTML and the links display fine in the invite, for this storing the text/html description into invite metadata as `xDescH`.
If `xDescH` is missing as fallback sending text/plain description in EWS response with converting the text links to anchor tags.

**Testing done**
Verfied by injecting the test MIME can see the links fine in the invite after accepting the invite and message is moved the trash.