### PR TITLE
Zbug-1280 added isSpellCheckEnabled attribute to the GetInfoResponse

### DIFF
--- a/client/src/java/com/zimbra/client/ZGetInfoResult.java
+++ b/client/src/java/com/zimbra/client/ZGetInfoResult.java
@@ -154,8 +154,8 @@ public class ZGetInfoResult implements ToZJSONObject {
         return data.getDocumentSizeLimit();
     }
 
-    public Boolean getIsSpellCheckEnabled() {
-        return data.getSpellCheckEnabled();
+    public Boolean getIsSpellCheckAvailable() {
+        return data.getSpellCheckAvailable();
     }
 
     public String getRecent() {

--- a/client/src/java/com/zimbra/client/ZGetInfoResult.java
+++ b/client/src/java/com/zimbra/client/ZGetInfoResult.java
@@ -154,6 +154,10 @@ public class ZGetInfoResult implements ToZJSONObject {
         return data.getDocumentSizeLimit();
     }
 
+    public Boolean getIsSpellCheckEnabled() {
+        return data.getSpellCheckEnabled();
+    }
+
     public String getRecent() {
         return SystemUtil.coalesce(data.getRecentMessageCount(), 0).toString();
     }

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -16656,7 +16656,8 @@ public class ZAttrProvisioning {
      * URL of the server running the spell checking service. Multi-valued
      * attribute that allows multiple spell check servers to be specified. If
      * the request to the first server fails, a request to the second server
-     * is sent and so on.
+     * is sent and so on. Spell check service is available only when this
+     * value is non-empty
      */
     @ZAttr(id=267)
     public static final String A_zimbraSpellCheckURL = "zimbraSpellCheckURL";

--- a/common/src/java/com/zimbra/common/gql/GqlConstants.java
+++ b/common/src/java/com/zimbra/common/gql/GqlConstants.java
@@ -317,6 +317,7 @@ public class GqlConstants {
     public static final String RIGHTS = "rights";
     public static final String ATTACHMENT_SIZE_LIMIT = "attachmentSizeLimit";
     public static final String DOCUMENT_SIZE_LIMIT = "documentSizeLimit";
+    public static final String IS_SPELL_CHECK_ENABLED = "isSpellCheckEnabled";
     public static final String VERSION = "version";
     public static final String ACCOUNT_ID = "accountId";
     public static final String PROFILE_IMAGE_ID = "profileImageId";

--- a/common/src/java/com/zimbra/common/gql/GqlConstants.java
+++ b/common/src/java/com/zimbra/common/gql/GqlConstants.java
@@ -317,7 +317,7 @@ public class GqlConstants {
     public static final String RIGHTS = "rights";
     public static final String ATTACHMENT_SIZE_LIMIT = "attachmentSizeLimit";
     public static final String DOCUMENT_SIZE_LIMIT = "documentSizeLimit";
-    public static final String IS_SPELL_CHECK_ENABLED = "isSpellCheckEnabled";
+    public static final String IS_SPELL_CHECK_AVAILABLE = "isSpellCheckAvailable";
     public static final String VERSION = "version";
     public static final String ACCOUNT_ID = "accountId";
     public static final String PROFILE_IMAGE_ID = "profileImageId";

--- a/common/src/java/com/zimbra/common/soap/AccountConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AccountConstants.java
@@ -553,8 +553,8 @@ public class AccountConstants {
     public static final String A_ATTACHMENT_SIZE_LIMIT = "attSizeLimit";
     public static final String A_DOCUMENT_SIZE_LIMIT = "docSizeLimit";
 
-    //Checks if spell check is enabled
-    public static final String A_IS_SPELL_CHECK_ENABLED = "isSpellCheckEnabled";
+    //zimbra spellcheck
+    public static final String A_IS_SPELL_CHECK_AVAILABLE = "isSpellCheckAvailable";
 
     //end session
     public static final String A_LOG_OFF = "logoff";

--- a/common/src/java/com/zimbra/common/soap/AccountConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AccountConstants.java
@@ -553,6 +553,9 @@ public class AccountConstants {
     public static final String A_ATTACHMENT_SIZE_LIMIT = "attSizeLimit";
     public static final String A_DOCUMENT_SIZE_LIMIT = "docSizeLimit";
 
+    //Checks if spell check is enabled
+    public static final String A_IS_SPELL_CHECK_ENABLED = "isSpellCheckEnabled";
+
     //end session
     public static final String A_LOG_OFF = "logoff";
     public static final String A_CLEAR_ALL_SOAP_SESSIONS = "all";

--- a/soap/src/java/com/zimbra/soap/account/message/GetInfoResponse.java
+++ b/soap/src/java/com/zimbra/soap/account/message/GetInfoResponse.java
@@ -77,8 +77,8 @@ import io.leangen.graphql.annotations.types.GraphQLType;
 @XmlType(propOrder = {"version", "accountId", "profileImageId", "accountName", "crumb", "lifetime", "adminDelegated", "restUrl",
         "quotaUsed", "isTrackingIMAP", "previousSessionTime", "lastWriteAccessTime", "recentMessageCount", "cos", "prefs", "attrs",
         "zimlets", "props", "identities", "signatures", "dataSources", "childAccounts", "discoveredRights",
-        "soapURL", "publicURL", "changePasswordURL", "license", "adminURL", "boshURL"})
-@JsonPropertyOrder({"version", "id", "profileImageId", "name", "crumb", "lifetime", "adminDelegated", "docSizeLimit", "attSizeLimit",
+        "soapURL", "publicURL", "changePasswordURL", "license", "adminURL", "boshURL", "spellCheckEnabled"})
+@JsonPropertyOrder({"version", "id", "profileImageId", "name", "crumb", "lifetime", "adminDelegated", "docSizeLimit", "spellCheckEnabled", "attSizeLimit",
         "rest", "used", "isTrackingIMAP", "prevSession", "accessed", "recent", "cos", "prefs", "attrs", "zimlets", "props", "identities",
         "signatures", "dataSources", "childAccounts", "discoveredRights", "soapURL", "publicURL", "license", "adminURL", "boshURL"})
 public final class GetInfoResponse {
@@ -96,6 +96,14 @@ public final class GetInfoResponse {
      */
     @XmlAttribute(name=AccountConstants.A_DOCUMENT_SIZE_LIMIT /* docSizeLimit */, required=false)
     private Long documentSizeLimit;
+
+    /**
+     * @zm-api-field-tag spell-check-enabled
+     * @zm-api-field-description returns true if the spell check is enabled on the server
+     */
+    @XmlElement(name=AccountConstants.A_IS_SPELL_CHECK_ENABLED /* isSpellCheckEnabled */, required=false)
+    @ZimbraJsonAttribute
+    private ZmBoolean spellCheckEnabled;
 
     /**
      * @zm-api-field-description Server version:
@@ -580,6 +588,14 @@ public final class GetInfoResponse {
         this.isTrackingIMAP = ZmBoolean.fromBool(trackingEnabled);
     }
 
+    @GraphQLQuery(name=GqlConstants.IS_SPELL_CHECK_ENABLED, description="Boolean value denoting if spell check is enabled on a server")
+    public Boolean getSpellCheckEnabled() {
+        return ZmBoolean.toBool(spellCheckEnabled, Boolean.FALSE);
+    }
+    public void setSpellCheckEnabled(Boolean spellCheckEnabled) {
+        this.spellCheckEnabled = ZmBoolean.fromBool(spellCheckEnabled);
+    }
+
     public MoreObjects.ToStringHelper addToStringInfo(
                 MoreObjects.ToStringHelper helper) {
         return helper
@@ -610,6 +626,7 @@ public final class GetInfoResponse {
             .add("boshURL", boshURL)
             .add("changePasswordURL", changePasswordURL)
             .add("license", license)
+            .add("isSpellCheckEnabled", spellCheckEnabled)
             .add("isTrackingIMAP", ZmBoolean.toBool(isTrackingIMAP) ? "1": "0");
 
     }

--- a/soap/src/java/com/zimbra/soap/account/message/GetInfoResponse.java
+++ b/soap/src/java/com/zimbra/soap/account/message/GetInfoResponse.java
@@ -98,8 +98,8 @@ public final class GetInfoResponse {
     private Long documentSizeLimit;
 
     /**
-     * @zm-api-field-tag spell-check-enabled
-     * @zm-api-field-description returns true if the spell check is enabled on the server
+     * @zm-api-field-tag spell-check-available
+     * @zm-api-field-description returns true if the spell check is available on the server
      */
     @XmlElement(name=AccountConstants.A_IS_SPELL_CHECK_AVAILABLE /* isSpellCheckAvailable */, required=false)
     @ZimbraJsonAttribute

--- a/soap/src/java/com/zimbra/soap/account/message/GetInfoResponse.java
+++ b/soap/src/java/com/zimbra/soap/account/message/GetInfoResponse.java
@@ -77,8 +77,8 @@ import io.leangen.graphql.annotations.types.GraphQLType;
 @XmlType(propOrder = {"version", "accountId", "profileImageId", "accountName", "crumb", "lifetime", "adminDelegated", "restUrl",
         "quotaUsed", "isTrackingIMAP", "previousSessionTime", "lastWriteAccessTime", "recentMessageCount", "cos", "prefs", "attrs",
         "zimlets", "props", "identities", "signatures", "dataSources", "childAccounts", "discoveredRights",
-        "soapURL", "publicURL", "changePasswordURL", "license", "adminURL", "boshURL", "spellCheckEnabled"})
-@JsonPropertyOrder({"version", "id", "profileImageId", "name", "crumb", "lifetime", "adminDelegated", "docSizeLimit", "spellCheckEnabled", "attSizeLimit",
+        "soapURL", "publicURL", "changePasswordURL", "license", "adminURL", "boshURL", "spellCheckAvailable"})
+@JsonPropertyOrder({"version", "id", "profileImageId", "name", "crumb", "lifetime", "adminDelegated", "docSizeLimit", "spellCheckAvailable", "attSizeLimit",
         "rest", "used", "isTrackingIMAP", "prevSession", "accessed", "recent", "cos", "prefs", "attrs", "zimlets", "props", "identities",
         "signatures", "dataSources", "childAccounts", "discoveredRights", "soapURL", "publicURL", "license", "adminURL", "boshURL"})
 public final class GetInfoResponse {
@@ -101,9 +101,9 @@ public final class GetInfoResponse {
      * @zm-api-field-tag spell-check-enabled
      * @zm-api-field-description returns true if the spell check is enabled on the server
      */
-    @XmlElement(name=AccountConstants.A_IS_SPELL_CHECK_ENABLED /* isSpellCheckEnabled */, required=false)
+    @XmlElement(name=AccountConstants.A_IS_SPELL_CHECK_AVAILABLE /* isSpellCheckAvailable */, required=false)
     @ZimbraJsonAttribute
-    private ZmBoolean spellCheckEnabled;
+    private ZmBoolean spellCheckAvailable;
 
     /**
      * @zm-api-field-description Server version:
@@ -588,12 +588,12 @@ public final class GetInfoResponse {
         this.isTrackingIMAP = ZmBoolean.fromBool(trackingEnabled);
     }
 
-    @GraphQLQuery(name=GqlConstants.IS_SPELL_CHECK_ENABLED, description="Boolean value denoting if spell check is enabled on a server")
-    public Boolean getSpellCheckEnabled() {
-        return ZmBoolean.toBool(spellCheckEnabled, Boolean.FALSE);
+    @GraphQLQuery(name=GqlConstants.IS_SPELL_CHECK_AVAILABLE, description="Boolean value denoting if spell check is available on a server")
+    public Boolean getSpellCheckAvailable() {
+        return ZmBoolean.toBool(spellCheckAvailable, Boolean.FALSE);
     }
-    public void setSpellCheckEnabled(Boolean spellCheckEnabled) {
-        this.spellCheckEnabled = ZmBoolean.fromBool(spellCheckEnabled);
+    public void setSpellCheckAvailable(Boolean spellCheckAvailable) {
+        this.spellCheckAvailable = ZmBoolean.fromBool(spellCheckAvailable);
     }
 
     public MoreObjects.ToStringHelper addToStringInfo(
@@ -626,7 +626,7 @@ public final class GetInfoResponse {
             .add("boshURL", boshURL)
             .add("changePasswordURL", changePasswordURL)
             .add("license", license)
-            .add("isSpellCheckEnabled", spellCheckEnabled)
+            .add("isSpellCheckAvailable", spellCheckAvailable)
             .add("isTrackingIMAP", ZmBoolean.toBool(isTrackingIMAP) ? "1": "0");
 
     }

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -1510,7 +1510,7 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
 </attr>
 
 <attr id="267" name="zimbraSpellCheckURL" type="astring" max="256" cardinality="multi" optionalIn="globalConfig,server" flags="serverInherited">
-  <desc>URL of the server running the spell checking service.  Multi-valued attribute that allows multiple spell check servers to be specified.  If the request to the first server fails, a request to the second server is sent and so on.</desc>
+  <desc>URL of the server running the spell checking service.  Multi-valued attribute that allows multiple spell check servers to be specified.  If the request to the first server fails, a request to the second server is sent and so on. Spell check service is available only when this value is non-empty </desc>
 </attr>
 
 <attr id="268" name="zimbraImapBindOnStartup" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mailbox">

--- a/store/src/java-test/com/zimbra/cs/service/account/GetInfoTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/account/GetInfoTest.java
@@ -69,7 +69,7 @@ public class GetInfoTest {
      * zimbraServiceInstalled and zimbraServiceEnabled shouldn't impact the return value of this method when "spell" service is not available on current server.
      */
     @Test
-    public void trueWhenZimbraSpellCheckURLReturnsNonEmptyListWhenEnabled() {
+    public void trueWhenZimbraSpellCheckURLReturnsNonEmptyListWhenDisabled() {
         String[] spellCheckUrls = {"http://zcs.example.one:7780/aspell.php", " http://zcs.example.two:7780/aspell.php", "http://zcs.example.three:7780/aspell.php"};
         String[] servicesEnabled = { "amavis", "antivirus", "opendkim", "stats", "mailbox", "proxy"};
         String[] servicesInstalled = {"amavis", "antivirus", "opendkim", "stats", "mailbox", "proxy"};

--- a/store/src/java-test/com/zimbra/cs/service/account/GetInfoTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/account/GetInfoTest.java
@@ -1,0 +1,104 @@
+package com.zimbra.cs.service.account;
+
+import com.zimbra.cs.account.MockProvisioning;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.Server;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class GetInfoTest {
+
+    private static Server server = null;
+
+    @BeforeClass
+    public static void init() throws Exception {
+        MailboxTestUtil.initServer();
+        MockProvisioning prov = new MockProvisioning();
+        Provisioning.setInstance(prov);
+        server = Provisioning.getInstance().getLocalServer();
+    }
+
+    /**
+     * spellcheck should return true when zimbraSpellCheckURL on the current server returns non-empty list of urls.
+     */
+    @Test
+    public void trueWhenZimbraSpellCheckURLReturnsNonEmptyList() {
+        String[] spellCheckUrls = {"http://zcs.example.one:7780/aspell.php", " http://zcs.example.two:7780/aspell.php", "http://zcs.example.three:7780/aspell.php"};
+        Map<String, Object> map = new HashMap<>();
+        map.put("zimbraSpellCheckURL", spellCheckUrls);
+        server.setAttrs(map);
+        GetInfo getInfo = new GetInfo();
+        boolean value = getInfo.isSpellCheckServiceAvailable(server);
+        Assert.assertEquals(true, value);
+    }
+
+    /**
+     * spellcheck should return false when zimbraSpellCheckURL on the current server returns an empty list of urls.
+     */
+    @Test
+    public void falseWhenZimbraSpellCheckURLReturnsEmptyList() {
+        String[] spellCheckUrls = new String[]{};
+        Map<String, Object> map = new HashMap<>();
+        map.put("zimbraSpellCheckURL", spellCheckUrls);
+        server.setAttrs(map);
+        GetInfo getInfo = new GetInfo();
+        boolean value = getInfo.isSpellCheckServiceAvailable(server);
+        Assert.assertEquals(false, value);
+    }
+
+    /**
+     * spellcheck should return false when zimbraSpellCheckURL on the current server returns an empty list of urls.
+     */
+    @Test
+    public void falseWhenZimbraSpellCheckURLReturnsNull() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("zimbraSpellCheckURL", null);
+        server.setAttrs(map);
+        GetInfo getInfo = new GetInfo();
+        boolean value = getInfo.isSpellCheckServiceAvailable(server);
+        Assert.assertEquals(false, value);
+    }
+
+    /**
+     * spellcheck should return true when zimbraSpellCheckURL on the current server returns non-empty list of urls.
+     * zimbraServiceInstalled and zimbraServiceEnabled shouldn't impact the return value of this method even "spell" service is not available on current server.
+     */
+    @Test
+    public void trueWhenZimbraSpellCheckURLReturnsNonEmptyListWhenEnabled() {
+        String[] spellCheckUrls = {"http://zcs.example.one:7780/aspell.php", " http://zcs.example.two:7780/aspell.php", "http://zcs.example.three:7780/aspell.php"};
+        String[] servicesEnabled = { "amavis", "antivirus", "opendkim", "stats", "mailbox", "proxy"};
+        String[] servicesInstalled = {"amavis", "antivirus", "opendkim", "stats", "mailbox", "proxy"};
+        Map<String, Object> map = new HashMap<>();
+        map.put("zimbraSpellCheckURL", spellCheckUrls);
+        map.put("zimbraServiceEnabled", servicesEnabled);
+        map.put("zimbraServiceInstalled", servicesInstalled);
+        server.setAttrs(map);
+        GetInfo getInfo = new GetInfo();
+        boolean value = getInfo.isSpellCheckServiceAvailable(server);
+        Assert.assertEquals(true, value);
+    }
+
+    /**
+     * spellcheck should return false when zimbraSpellCheckURL on the current server returns with empty list of urls.
+     * zimbraServiceInstalled and zimbraServiceEnabled shouldn't impact the return value of this method even "spell" service is available on current server.
+     */
+    @Test
+    public void falseWhenZimbraSpellCheckURLReturnsEmptyListWhenEnabled() {
+        String[] spellCheckUrls = {};
+        String[] servicesEnabled = {"spell", "amavis", "antivirus", "opendkim", "stats", "mailbox", "proxy"};
+        String[] servicesInstalled = {"spell", "amavis", "antivirus", "opendkim", "stats", "mailbox", "proxy"};
+        Map<String, Object> map = new HashMap<>();
+        map.put("zimbraSpellCheckURL", spellCheckUrls);
+        map.put("zimbraServiceEnabled", servicesEnabled);
+        map.put("zimbraServiceInstalled", servicesInstalled);
+        server.setAttrs(map);
+        GetInfo getInfo = new GetInfo();
+        boolean value = getInfo.isSpellCheckServiceAvailable(server);
+        Assert.assertEquals(false, value);
+    }
+}

--- a/store/src/java-test/com/zimbra/cs/service/account/GetInfoTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/account/GetInfoTest.java
@@ -52,7 +52,7 @@ public class GetInfoTest {
     }
 
     /**
-     * spellcheck should return false when zimbraSpellCheckURL on the current server returns an empty list of urls.
+     * spellcheck should return false when zimbraSpellCheckURL on the current server returns null.
      */
     @Test
     public void falseWhenZimbraSpellCheckURLReturnsNull() {
@@ -66,7 +66,7 @@ public class GetInfoTest {
 
     /**
      * spellcheck should return true when zimbraSpellCheckURL on the current server returns non-empty list of urls.
-     * zimbraServiceInstalled and zimbraServiceEnabled shouldn't impact the return value of this method even "spell" service is not available on current server.
+     * zimbraServiceInstalled and zimbraServiceEnabled shouldn't impact the return value of this method when "spell" service is not available on current server.
      */
     @Test
     public void trueWhenZimbraSpellCheckURLReturnsNonEmptyListWhenEnabled() {
@@ -85,7 +85,7 @@ public class GetInfoTest {
 
     /**
      * spellcheck should return false when zimbraSpellCheckURL on the current server returns with empty list of urls.
-     * zimbraServiceInstalled and zimbraServiceEnabled shouldn't impact the return value of this method even "spell" service is available on current server.
+     * zimbraServiceInstalled and zimbraServiceEnabled shouldn't impact the return value of this method when "spell" service is available on current server.
      */
     @Test
     public void falseWhenZimbraSpellCheckURLReturnsEmptyListWhenEnabled() {

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -70966,7 +70966,8 @@ public abstract class ZAttrConfig extends Entry {
      * URL of the server running the spell checking service. Multi-valued
      * attribute that allows multiple spell check servers to be specified. If
      * the request to the first server fails, a request to the second server
-     * is sent and so on.
+     * is sent and so on. Spell check service is available only when this
+     * value is non-empty
      *
      * @return zimbraSpellCheckURL, or empty array if unset
      */
@@ -70979,7 +70980,8 @@ public abstract class ZAttrConfig extends Entry {
      * URL of the server running the spell checking service. Multi-valued
      * attribute that allows multiple spell check servers to be specified. If
      * the request to the first server fails, a request to the second server
-     * is sent and so on.
+     * is sent and so on. Spell check service is available only when this
+     * value is non-empty
      *
      * @param zimbraSpellCheckURL new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -70995,7 +70997,8 @@ public abstract class ZAttrConfig extends Entry {
      * URL of the server running the spell checking service. Multi-valued
      * attribute that allows multiple spell check servers to be specified. If
      * the request to the first server fails, a request to the second server
-     * is sent and so on.
+     * is sent and so on. Spell check service is available only when this
+     * value is non-empty
      *
      * @param zimbraSpellCheckURL new value
      * @param attrs existing map to populate, or null to create a new map
@@ -71012,7 +71015,8 @@ public abstract class ZAttrConfig extends Entry {
      * URL of the server running the spell checking service. Multi-valued
      * attribute that allows multiple spell check servers to be specified. If
      * the request to the first server fails, a request to the second server
-     * is sent and so on.
+     * is sent and so on. Spell check service is available only when this
+     * value is non-empty
      *
      * @param zimbraSpellCheckURL new to add to existing values
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -71028,7 +71032,8 @@ public abstract class ZAttrConfig extends Entry {
      * URL of the server running the spell checking service. Multi-valued
      * attribute that allows multiple spell check servers to be specified. If
      * the request to the first server fails, a request to the second server
-     * is sent and so on.
+     * is sent and so on. Spell check service is available only when this
+     * value is non-empty
      *
      * @param zimbraSpellCheckURL new to add to existing values
      * @param attrs existing map to populate, or null to create a new map
@@ -71045,7 +71050,8 @@ public abstract class ZAttrConfig extends Entry {
      * URL of the server running the spell checking service. Multi-valued
      * attribute that allows multiple spell check servers to be specified. If
      * the request to the first server fails, a request to the second server
-     * is sent and so on.
+     * is sent and so on. Spell check service is available only when this
+     * value is non-empty
      *
      * @param zimbraSpellCheckURL existing value to remove
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -71061,7 +71067,8 @@ public abstract class ZAttrConfig extends Entry {
      * URL of the server running the spell checking service. Multi-valued
      * attribute that allows multiple spell check servers to be specified. If
      * the request to the first server fails, a request to the second server
-     * is sent and so on.
+     * is sent and so on. Spell check service is available only when this
+     * value is non-empty
      *
      * @param zimbraSpellCheckURL existing value to remove
      * @param attrs existing map to populate, or null to create a new map
@@ -71078,7 +71085,8 @@ public abstract class ZAttrConfig extends Entry {
      * URL of the server running the spell checking service. Multi-valued
      * attribute that allows multiple spell check servers to be specified. If
      * the request to the first server fails, a request to the second server
-     * is sent and so on.
+     * is sent and so on. Spell check service is available only when this
+     * value is non-empty
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      */
@@ -71093,7 +71101,8 @@ public abstract class ZAttrConfig extends Entry {
      * URL of the server running the spell checking service. Multi-valued
      * attribute that allows multiple spell check servers to be specified. If
      * the request to the first server fails, a request to the second server
-     * is sent and so on.
+     * is sent and so on. Spell check service is available only when this
+     * value is non-empty
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -49509,7 +49509,8 @@ public abstract class ZAttrServer extends NamedEntry {
      * URL of the server running the spell checking service. Multi-valued
      * attribute that allows multiple spell check servers to be specified. If
      * the request to the first server fails, a request to the second server
-     * is sent and so on.
+     * is sent and so on. Spell check service is available only when this
+     * value is non-empty
      *
      * @return zimbraSpellCheckURL, or empty array if unset
      */
@@ -49522,7 +49523,8 @@ public abstract class ZAttrServer extends NamedEntry {
      * URL of the server running the spell checking service. Multi-valued
      * attribute that allows multiple spell check servers to be specified. If
      * the request to the first server fails, a request to the second server
-     * is sent and so on.
+     * is sent and so on. Spell check service is available only when this
+     * value is non-empty
      *
      * @param zimbraSpellCheckURL new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -49538,7 +49540,8 @@ public abstract class ZAttrServer extends NamedEntry {
      * URL of the server running the spell checking service. Multi-valued
      * attribute that allows multiple spell check servers to be specified. If
      * the request to the first server fails, a request to the second server
-     * is sent and so on.
+     * is sent and so on. Spell check service is available only when this
+     * value is non-empty
      *
      * @param zimbraSpellCheckURL new value
      * @param attrs existing map to populate, or null to create a new map
@@ -49555,7 +49558,8 @@ public abstract class ZAttrServer extends NamedEntry {
      * URL of the server running the spell checking service. Multi-valued
      * attribute that allows multiple spell check servers to be specified. If
      * the request to the first server fails, a request to the second server
-     * is sent and so on.
+     * is sent and so on. Spell check service is available only when this
+     * value is non-empty
      *
      * @param zimbraSpellCheckURL new to add to existing values
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -49571,7 +49575,8 @@ public abstract class ZAttrServer extends NamedEntry {
      * URL of the server running the spell checking service. Multi-valued
      * attribute that allows multiple spell check servers to be specified. If
      * the request to the first server fails, a request to the second server
-     * is sent and so on.
+     * is sent and so on. Spell check service is available only when this
+     * value is non-empty
      *
      * @param zimbraSpellCheckURL new to add to existing values
      * @param attrs existing map to populate, or null to create a new map
@@ -49588,7 +49593,8 @@ public abstract class ZAttrServer extends NamedEntry {
      * URL of the server running the spell checking service. Multi-valued
      * attribute that allows multiple spell check servers to be specified. If
      * the request to the first server fails, a request to the second server
-     * is sent and so on.
+     * is sent and so on. Spell check service is available only when this
+     * value is non-empty
      *
      * @param zimbraSpellCheckURL existing value to remove
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -49604,7 +49610,8 @@ public abstract class ZAttrServer extends NamedEntry {
      * URL of the server running the spell checking service. Multi-valued
      * attribute that allows multiple spell check servers to be specified. If
      * the request to the first server fails, a request to the second server
-     * is sent and so on.
+     * is sent and so on. Spell check service is available only when this
+     * value is non-empty
      *
      * @param zimbraSpellCheckURL existing value to remove
      * @param attrs existing map to populate, or null to create a new map
@@ -49621,7 +49628,8 @@ public abstract class ZAttrServer extends NamedEntry {
      * URL of the server running the spell checking service. Multi-valued
      * attribute that allows multiple spell check servers to be specified. If
      * the request to the first server fails, a request to the second server
-     * is sent and so on.
+     * is sent and so on. Spell check service is available only when this
+     * value is non-empty
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      */
@@ -49636,7 +49644,8 @@ public abstract class ZAttrServer extends NamedEntry {
      * URL of the server running the spell checking service. Multi-valued
      * attribute that allows multiple spell check servers to be specified. If
      * the request to the first server fails, a request to the second server
-     * is sent and so on.
+     * is sent and so on. Spell check service is available only when this
+     * value is non-empty
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/service/account/GetInfo.java
+++ b/store/src/java/com/zimbra/cs/service/account/GetInfo.java
@@ -178,7 +178,7 @@ public class GetInfo extends AccountDocumentHandler  {
             if (server != null) {
                 response.addAttribute(AccountConstants.A_DOCUMENT_SIZE_LIMIT, server.getFileUploadMaxSize());
                 //For ZBUG-1280: checks if atleast one URL is present from zimbraSpellCheckURL.
-                response.addAttribute(AccountConstants.A_IS_SPELL_CHECK_ENABLED, isSpellCheckServiceAvailable(server));
+                response.addAttribute(AccountConstants.A_IS_SPELL_CHECK_AVAILABLE, isSpellCheckServiceAvailable(server));
             }
             Config config = prov.getConfig();
             if (config != null) {

--- a/store/src/java/com/zimbra/cs/service/account/GetInfo.java
+++ b/store/src/java/com/zimbra/cs/service/account/GetInfo.java
@@ -37,6 +37,7 @@ import com.zimbra.common.account.ProvisioningConstants;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AccountConstants;
 import com.zimbra.common.soap.Element;
+import com.zimbra.common.util.ArrayUtil;
 import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
@@ -176,6 +177,8 @@ public class GetInfo extends AccountDocumentHandler  {
             Server server = prov.getLocalServer();
             if (server != null) {
                 response.addAttribute(AccountConstants.A_DOCUMENT_SIZE_LIMIT, server.getFileUploadMaxSize());
+                //For ZBUG-1280: checks if atleast one URL is present from zimbraSpellCheckURL.
+                response.addAttribute(AccountConstants.A_IS_SPELL_CHECK_ENABLED, isSpellCheckServiceAvailable(server));
             }
             Config config = prov.getConfig();
             if (config != null) {
@@ -475,6 +478,16 @@ public class GetInfo extends AccountDocumentHandler  {
 
     private void doDiscoverRights(Element eRights, Account account, Set<Right> rights) throws ServiceException {
         DiscoverRights.discoverRights(account, rights, eRights, false);
+    }
+
+    /**
+     * This check is done for zbug-1280.
+     * checks and returns true when zimbraSpellCheckURL is empty on a server
+     * The spellcheck button is shown only when zimbraSpellCheckURL returns non-empty value.
+     */
+    public boolean isSpellCheckServiceAvailable(Server server) {
+        String[] urls = server.getMultiAttr(Provisioning.A_zimbraSpellCheckURL);
+        return !ArrayUtil.isEmpty(urls);
     }
 
     private boolean checkIfPasteitcleanedInstalled() {

--- a/store/src/java/com/zimbra/cs/service/account/GetInfo.java
+++ b/store/src/java/com/zimbra/cs/service/account/GetInfo.java
@@ -482,7 +482,7 @@ public class GetInfo extends AccountDocumentHandler  {
 
     /**
      * This check is done for zbug-1280.
-     * checks and returns true when zimbraSpellCheckURL is empty on a server
+     * checks and returns true when zimbraSpellCheckURL is non-empty on a server
      * The spellcheck button is shown only when zimbraSpellCheckURL returns non-empty value.
      */
     public boolean isSpellCheckServiceAvailable(Server server) {


### PR DESCRIPTION
Jira ticket: https://jira.corp.synacor.com/browse/ZBUG-1280
Frontend PR: https://github.com/Zimbra/zm-web-client/pull/659

Retrieving list of urls using zimbraSpellCheckURL attribute and checking if it's empty on the primary server and adding it as a boolean value to the GetInfo response. This value will be used by frontend to display/hide the spell check button on compose page and mandatory spell check.
