### PR TITLE
Bugfix/zcs 11120: GetAppointmentIdsInRangeRequest soap request not working

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -4837,18 +4837,22 @@ public class Mailbox implements MailboxStore {
      */
     public Map<Integer, Integer> listCalendarItemIdsAndDateForRange(OperationContext octxt, MailItem.Type type, long start, long end,
                     int folderId) throws ServiceException {
+        boolean success = false;
         if (folderId == ID_AUTO_INCREMENT) {
             return new HashMap<Integer, Integer>();
         }
         lock.lock(false);
         try {
+            beginReadTransaction("listCalendarItemIdsAndDateForRange", octxt);
             // if they specified a folder, make sure it actually exists
             getFolderById(folderId);
 
             // get the list of all visible calendar items in the specified folder
             Map<Integer, Integer> map = DbMailItem.listCalendarItemIdsAndDates(this, type, start, end, folderId, null);
+            
             return map;
         } finally {
+            endTransaction(success);
             lock.release();
         }
     }
@@ -4858,11 +4862,13 @@ public class Mailbox implements MailboxStore {
      */
     public Map<Integer, Integer> listCalendarItemIdsAndDateForRange(OperationContext octxt, MailItem.Type type, int lastSync,
                     int folderId) throws ServiceException {
+        boolean success = false;
         if (folderId == ID_AUTO_INCREMENT) {
             return new HashMap<Integer, Integer>();
         }
         lock.lock(false);
         try {
+            beginReadTransaction("listCalendarItemIdsAndDateForRange", octxt);
             // if they specified a folder, make sure it actually exists
             getFolderById(folderId);
 
@@ -4870,6 +4876,7 @@ public class Mailbox implements MailboxStore {
             Map<Integer, Integer> map = DbMailItem.listCalendarItemIdsAndDates(this, type, lastSync, folderId, null);
             return map;
         } finally {
+            endTransaction(success);
             lock.release();
         }
     }

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -4849,7 +4849,7 @@ public class Mailbox implements MailboxStore {
 
             // get the list of all visible calendar items in the specified folder
             Map<Integer, Integer> map = DbMailItem.listCalendarItemIdsAndDates(this, type, start, end, folderId, null);
-            
+            success = true;
             return map;
         } finally {
             endTransaction(success);
@@ -4874,6 +4874,7 @@ public class Mailbox implements MailboxStore {
 
             // get the list of all visible calendar items in the specified folder
             Map<Integer, Integer> map = DbMailItem.listCalendarItemIdsAndDates(this, type, lastSync, folderId, null);
+            success = true;
             return map;
         } finally {
             endTransaction(success);


### PR DESCRIPTION
GetAppointmentIdsInRangeRequest  giving error for soap request.
Fixed issue with transaction before read operation

Also fixed failing soap request GetAppointmentIdsSinceRequest in the same ticket