### PR TITLE
Bugfix/zbug 651

### DIFF
--- a/store/src/java/com/zimbra/cs/account/soap/SoapDistributionList.java
+++ b/store/src/java/com/zimbra/cs/account/soap/SoapDistributionList.java
@@ -81,6 +81,13 @@ class SoapDistributionList extends DistributionList implements SoapEntry {
                 SoapProvisioning.getAttrs(e), prov);
         addDlm(e, getRawAttrs());
     }
+    
+    //ZBUG-651: This bug is about to get correct member details for gadl command;
+  	//ZBUG-651: Below constructor is added, which does not call addDlm() as this method is not allowing to get member details
+  	//ZBUG-651: Added one more boolean parameter in here, to differentiate from other constructor
+  	SoapDistributionList(DistributionListInfo dlInfo, Provisioning prov, boolean hideMembers) throws ServiceException {
+  		super(dlInfo.getName(), dlInfo.getId(), Attr.collectionToMap(dlInfo.getAttrList()), prov);
+  	}
 
     private void addDlm(List <String> members, Map<String, Object> attrs) {
         attrs.put(Provisioning.A_zimbraMailForwardingAddress,

--- a/store/src/java/com/zimbra/cs/account/soap/SoapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/soap/SoapProvisioning.java
@@ -926,7 +926,7 @@ public class SoapProvisioning extends Provisioning {
         if (dlInfo.isDynamic()) {
             return new SoapDynamicGroup(dlInfo, this);
         } else {
-            return new SoapDistributionList(dlInfo, this);
+            return new SoapDistributionList(dlInfo, this, false);
         }
     }
 

--- a/store/src/java/com/zimbra/cs/service/admin/GetAllDistributionLists.java
+++ b/store/src/java/com/zimbra/cs/service/admin/GetAllDistributionLists.java
@@ -108,7 +108,7 @@ public class GetAllDistributionLists extends AdminDocumentHandler {
             }
             
             if (hasRightToList) {
-                GetDistributionList.encodeDistributionList(e, dl, true, false, null, aac.getAttrRightChecker(dl));
+                GetDistributionList.encodeDistributionList(e, dl, false, false, null, aac.getAttrRightChecker(dl));
             }
         }        
     }


### PR DESCRIPTION
Problem: zmprov gal -v command was not showing correct member details.
Solution: 
1. Send false value for hideMembers attribute in a function.
2. Created a constructor which is not call addDlm() as this method is not allowing to get member details and added one parameter to distinguish the constructor.
Fix Mode: Modified code
Test Done: Unit test done(tried steps mentioned in tickets and able to get members information.)