### PR TITLE
ZBUG-2397: Added cookie SameSite=Strict 

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -863,6 +863,7 @@ public final class LC {
     public static final KnownKey zimbra_deregistered_authtoken_queue_size = KnownKey.newKey(5000);
     public static final KnownKey zimbra_jwt_cookie_size_limit = KnownKey.newKey(4096);
     public static final KnownKey zimbra_authtoken_cookie_domain = KnownKey.newKey("");
+    public static final KnownKey zimbra_same_site_cookie = KnownKey.newKey("Strict");
     public static final KnownKey zimbra_zmjava_options = KnownKey.newKey("-Xmx256m" +
             " -Dhttps.protocols=TLSv1.2,TLSv1.3" +
             " -Djdk.tls.client.protocols=TLSv1.2,TLSv1.3");

--- a/common/src/java/com/zimbra/common/util/ZimbraCookie.java
+++ b/common/src/java/com/zimbra/common/util/ZimbraCookie.java
@@ -47,6 +47,12 @@ public class ZimbraCookie {
             cookie.setDomain(LC.zimbra_authtoken_cookie_domain.value());
         }
 
+        String cookieVal = LC.zimbra_same_site_cookie.value();
+        if (!StringUtil.isNullOrEmpty(cookieVal)) {
+            // setting cookie value like "SameSite=Strict;", value can be Strict, Lax, None
+            path = new StringBuilder(path).append(";SameSite=").append(cookieVal).append(";").toString();
+        }
+
         cookie.setPath(path);
     }
 

--- a/common/src/java/com/zimbra/common/util/ZimbraCookie.java
+++ b/common/src/java/com/zimbra/common/util/ZimbraCookie.java
@@ -76,7 +76,12 @@ public class ZimbraCookie {
         }
         ZimbraCookie.setAuthTokenCookieDomainPath(cookie, ZimbraCookie.PATH_ROOT);
 
-        cookie.setSecure(secure);
+        String cookieVal = LC.zimbra_same_site_cookie.value();
+        if (!StringUtil.isNullOrEmpty(cookieVal)) {
+            cookie.setSecure(true);
+        } else {
+            cookie.setSecure(secure);
+        }
 
         if (httpOnly) {
             cookie.setHttpOnly(httpOnly);

--- a/common/src/java/com/zimbra/common/util/ZimbraCookie.java
+++ b/common/src/java/com/zimbra/common/util/ZimbraCookie.java
@@ -47,12 +47,6 @@ public class ZimbraCookie {
             cookie.setDomain(LC.zimbra_authtoken_cookie_domain.value());
         }
 
-        String cookieVal = LC.zimbra_same_site_cookie.value();
-        if (!StringUtil.isNullOrEmpty(cookieVal)) {
-            // setting cookie value like "SameSite=Strict;", value can be Strict, Lax, None
-            path = new StringBuilder(path).append(";SameSite=").append(cookieVal).append(";").toString();
-        }
-
         cookie.setPath(path);
     }
 
@@ -78,6 +72,8 @@ public class ZimbraCookie {
 
         String cookieVal = LC.zimbra_same_site_cookie.value();
         if (!StringUtil.isNullOrEmpty(cookieVal)) {
+            // setting cookie value like "SameSite=Strict;", value can be Strict, Lax, None
+            path = new StringBuilder(path).append(";SameSite=").append(cookieVal).append(";").toString();
             cookie.setSecure(true);
         } else {
             cookie.setSecure(secure);


### PR DESCRIPTION
Supported SameSite=Strict cookie in ZM_AUTH_TOKEN cookie.
For this added a localconfig varible in LC.java named **zimbra_same_site_cookie**
By default value will be '**Strict**' but user can change it to **Lax**, **None** and ""(**empty**) for existing behavior.