### PR TITLE
ZCS-11145: use text/html for appointment description ignoring x-alt-desc for ms team invites

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1463,6 +1463,8 @@ public final class LC {
     @Supported
     public static final KnownKey delivery_report_enabled = KnownKey.newKey(true);
 
+    public static final KnownKey invite_ignore_x_alt_description = KnownKey.newKey(true);
+
     static {
         // Automatically set the key name with the variable name.
         for (Field field : LC.class.getFields()) {

--- a/store/src/java/com/zimbra/cs/mailbox/calendar/Invite.java
+++ b/store/src/java/com/zimbra/cs/mailbox/calendar/Invite.java
@@ -515,9 +515,18 @@ public class Invite {
         String descHtml = descInMeta ? meta.get(FN_DESC_HTML, null) : null;
         String xDescHtml = descInMeta ? meta.get(FN_X_ZIMBRA_DESC_HTML, null) : null;
 
-        // if desc html is missing but desc is present
-        if (desc != null && descHtml == null) {
-            descHtml = Util.textToHtml(desc);
+        boolean hasXMicrosoftHeader = false;
+        for (Map.Entry<String, ?> entry : meta.asMap().entrySet()) {
+            if (entry.getValue().toString().contains("X-MICROSOFT-SKYPETEAMSMEETINGURL")) {
+                hasXMicrosoftHeader = true;
+                break;
+            }
+        }
+
+        // update HTML description if invite_ignore_x_alt_description is true
+        // and contains X-MICROSOFT headers
+        if (hasXMicrosoftHeader && !StringUtil.isNullOrEmpty(xDescHtml) && LC.invite_ignore_x_alt_description.booleanValue()) {
+            descHtml = xDescHtml;
         }
 
         long completed = meta.getLong(FN_COMPLETED, 0);


### PR DESCRIPTION
**Issue**
MS Team invites with mime cast secure URL filter applied, mime cast does not add the links to content of text/calendar.

**Fix**
MS Team invites with mime cast secure URL filter when add X-ALT-DESC to MIME don't add the links causing the links the to not show in the outlook calendar items. As fix if the invite is of MS Teams and LC. invite_ignore_x_alt_description is true we update descHTML content in the invite to use xDescH(text/html) description instead of X-ALT-DESC

**Test**
Tested by injecting different MIME having X-ALT-DESC with missing links show the calendar items links fine from text/html
Tested GetAppointmentRequest is getting required descHtml from text/html
Verified its working fine for EWS & ZCO both.