### PR TITLE
ZBUG-2397: Added cookie SameSite=Strict and zmlocalconfig attribute

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -863,6 +863,7 @@ public final class LC {
     public static final KnownKey zimbra_deregistered_authtoken_queue_size = KnownKey.newKey(5000);
     public static final KnownKey zimbra_jwt_cookie_size_limit = KnownKey.newKey(4096);
     public static final KnownKey zimbra_authtoken_cookie_domain = KnownKey.newKey("");
+    public static final KnownKey zimbra_same_site_cookie = KnownKey.newKey("Strict");
     public static final KnownKey zimbra_zmjava_options = KnownKey.newKey("-Xmx256m" +
             " -Dhttps.protocols=TLSv1.2,TLSv1.3" +
             " -Djdk.tls.client.protocols=TLSv1.2,TLSv1.3");

--- a/common/src/java/com/zimbra/common/util/ZimbraCookie.java
+++ b/common/src/java/com/zimbra/common/util/ZimbraCookie.java
@@ -72,8 +72,10 @@ public class ZimbraCookie {
 
         String cookieVal = LC.zimbra_same_site_cookie.value();
         if (!StringUtil.isNullOrEmpty(cookieVal)) {
+            String pathStr = cookie.getPath();
             // setting cookie value like "SameSite=Strict;", value can be Strict, Lax, None
-            path = new StringBuilder(path).append(";SameSite=").append(cookieVal).append(";").toString();
+            pathStr = new StringBuilder(pathStr).append(";SameSite=").append(cookieVal).append(";").toString();
+            cookie.setPath(pathStr);
             cookie.setSecure(true);
         } else {
             cookie.setSecure(secure);

--- a/common/src/java/com/zimbra/common/util/ZimbraCookie.java
+++ b/common/src/java/com/zimbra/common/util/ZimbraCookie.java
@@ -70,7 +70,14 @@ public class ZimbraCookie {
         }
         ZimbraCookie.setAuthTokenCookieDomainPath(cookie, ZimbraCookie.PATH_ROOT);
 
-        cookie.setSecure(secure);
+        String cookieVal = LC.zimbra_same_site_cookie.value();
+        if (!StringUtil.isNullOrEmpty(cookieVal)) {
+            // setting cookie value like "SameSite=Strict;", value can be Strict, Lax, None
+            path = new StringBuilder(path).append(";SameSite=").append(cookieVal).append(";").toString();
+            cookie.setSecure(true);
+        } else {
+            cookie.setSecure(secure);
+        }
 
         if (httpOnly) {
             cookie.setHttpOnly(httpOnly);


### PR DESCRIPTION
Supported SameSite=Strict cookie in ZM_AUTH_TOKEN cookie.
For this added a localconfig varible in LC.java named zimbra_same_site_cookie
By default value will be 'Strict' but user can change it to Lax, None and ""(empty) for existing behavior.

**Testing Instruction:**

**1** - On login in webclient, by default user can see the SameSite=Strict cookie for ZM_AUTH_TOKEN.
http://synscreen.buf.synacor.com/view/a5d6a2.png
**2** - User can control behavior using zmlocalconfig

zmlocalconfig -e zimbra_same_site_cookie="Strict"
User can provide value like Strict, Lax, None or "" (Empty)

**3** - To disable this behavior we can set value of SameSite=""
http://synscreen.buf.synacor.com/view/a7d8d2.png