### PR TITLE
ZBUG-1932: Upgrading owasp-java-html-sanitizer version

### DIFF
--- a/store/build.xml
+++ b/store/build.xml
@@ -289,8 +289,8 @@
     <ivy:install organisation="oauth" module="oauth" revision="1.4" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.apache.xmlgraphics" module="batik-css" revision="1.7" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.w3c.css" module="sac" revision="1.3" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
-    <ivy:install organisation="org.apache.xmlgraphics" module="batik-i18n" revision="1.9" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
-    <ivy:install organisation="org.apache.xmlgraphics" module="batik-util" revision="1.8" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
+    <ivy:install organisation="org.apache.xmlgraphics" module="batik-i18n" revision="1.14" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
+    <ivy:install organisation="org.apache.xmlgraphics" module="batik-util" revision="1.14" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
   	<ivy:install organisation="org.springframework" module="spring-aop" revision="5.1.10.RELEASE" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.springframework" module="spring-beans" revision="5.1.10.RELEASE" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.springframework" module="spring-context" revision="5.1.10.RELEASE" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>

--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -44,7 +44,7 @@
   <dependency org="com.101tec" name="zkclient" rev="0.1.0"/>
   <dependency org="xerces" name="xercesImpl" rev="2.9.1-patch-01"/>
   <dependency org="net.sourceforge.nekohtml" name="nekohtml" rev="1.9.13.1z"/>
-  <dependency org="com.googlecode.owasp-java-html-sanitizer" name="owasp-java-html-sanitizer" rev="20190610.3z"/>
+  <dependency org="com.googlecode.owasp-java-html-sanitizer" name="owasp-java-html-sanitizer" rev="20190610.4z"/>
   <dependency org="org.ehcache" name="ehcache" rev="3.1.2"/>
   <dependency org="ant-1.7.0-ziputil-patched" name="ant-1.7.0-ziputil-patched" rev="1.0"/>
   <dependency org="org.eclipse.jetty" name="jetty-continuation" rev="${jetty.version}"/>
@@ -138,5 +138,7 @@
   <dependency org="org.tukaani" name="xz" rev="1.9"/>
   <dependency org="com.drewnoakes" name="metadata-extractor" rev="2.16.0"/>
   <dependency org="com.adobe.xmp" name="xmpcore" rev="6.1.11"/>
+  <dependency org="org.apache.xmlgraphics" name="batik-i18n" rev="1.14"/>
+  <dependency org="org.apache.xmlgraphics" name="batik-util" rev="1.14"/>
  </dependencies>
 </ivy-module>

--- a/store/src/java-test/com/zimbra/cs/html/owasp/OwaspHtmlSanitizerTest.java
+++ b/store/src/java-test/com/zimbra/cs/html/owasp/OwaspHtmlSanitizerTest.java
@@ -42,6 +42,7 @@ import com.zimbra.cs.mime.Mime;
 import com.zimbra.cs.mime.ParsedMessage;
 import com.zimbra.cs.servlet.ZThreadLocal;
 import com.zimbra.cs.util.ZTestWatchman;
+import org.owasp.html.Encoding;
 
 public class OwaspHtmlSanitizerTest {
 
@@ -730,5 +731,32 @@ public class OwaspHtmlSanitizerTest {
         String result = new OwaspHtmlSanitizer(malformedHtml, true, null).sanitize();
         String output = "<html><head><style>.uegzbq{font-size:22px;}@media not all and (pointer:coarse){.8bsfb:hover{background-color:#056b27;}}.scem3j{font-size:25px;}</style></head><body><div class=\"uegzbq\">First Line</div><br /><div class=\"scem3j\">Second Line</div></body></html>";
         Assert.assertTrue("Verification failed: Failed to include media queries.", output.equals(result.trim()));
+    }
+
+    @Test
+    public void testBug1932ShouldReturnSameUrlAfterSanitizing_1() throws Exception {
+        String url = "https://google.com/?page=red.blue&num_ar=abcd123456&orgAcronyme=abc12";
+        String html = "<a href='"+url+"'>"+url+"</a>";
+        String result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        //&num should not be converted to #
+        Assert.assertTrue(Encoding.decodeHtml(result).contains(url));
+    }
+
+    @Test
+    public void testBug1932ShouldReturnSameUrlAfterSanitizing_2() throws Exception {
+        String url = "https://google.com/?page=red.blue&numero_num=10&Integral_int=20";
+        String html = "<a href='"+url+"'>"+url+"</a>";
+        String result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        //&numero and &Integral should not be converted to № and ∫
+        Assert.assertTrue(Encoding.decodeHtml(result).contains(url));
+    }
+
+    @Test
+    public void testBug1932ShouldReturnSameUrlAfterSanitizing_3() throws Exception {
+        String url = "https://google.com/?account=2&order_id=125";
+        String html = "<a href='"+url+"'>"+url+"</a>";
+        String result = new OwaspHtmlSanitizer(html, true, null).sanitize();
+        //&order should not be converted to ℴ
+        Assert.assertTrue(Encoding.decodeHtml(result).contains(url));
     }
 }


### PR DESCRIPTION
Problem:
When OWASP zimbra_use_owasp_html_sanitizer = true, URL in the HTML message is getting modified. Character &num replace by #_
Issues: ZBUG-1932

Fix:
ZBUG-1932
Issue has been fixed in the original owasp library and zimbra [java-html-sanitizer-release-20190610.1](https://github.com/Zimbra/java-html-sanitizer-release-20190610.1) is rebased with the latest release. These test cases are to make sure the urls are not changed as mentioned in the ticket when html is sanitized with newer jar.

Ref PRs:
[java-html-sanitizer#6](https://github.com/Zimbra/java-html-sanitizer-release-20190610.1/pull/6)
[zm-zcs-lib#89](https://github.com/Zimbra/zm-zcs-lib/pull/89)