### PR TITLE
ZCS-11154: GetAppointmentIdsSinceResponse not populating deleted item ids

### DIFF
--- a/soap/src/java/com/zimbra/soap/mail/message/GetAppointmentIdsSinceResponse.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/GetAppointmentIdsSinceResponse.java
@@ -32,7 +32,7 @@ import com.zimbra.common.soap.MailConstants;
 public class GetAppointmentIdsSinceResponse {
     @XmlElement(name=MailConstants.A_MODIFIED_IDS /* mids */, required=false)
     private List<Integer> mids;
-    @XmlElement(name=MailConstants.A_MODIFIED_IDS /* dids */, required=false)
+    @XmlElement(name=MailConstants.A_DELETED_IDS /* dids */, required=false)
     private List<Integer> dids;
 
     public GetAppointmentIdsSinceResponse() {


### PR DESCRIPTION
Fixed issue with deleted item ids in GetAppointmentIdsSinceResponse.
It was only returning all modified item ids