### PR TITLE
ZBUG-1869: Setting effective quota in zimbraMailQuota

### DIFF
--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -1342,7 +1342,8 @@ public final class AdminConstants {
 
     public static final String A_QUOTA_USED = "used";
     public static final String A_QUOTA_LIMIT = "limit";
-
+    public static final String A_EFFECTIVE_QUOTA = "effectiveQuota";
+    
     public static final String E_TEMPLATE = "template";
     public static final String E_TEST = "test";
     public static final String A_DEST = "dest";

--- a/soap/src/java/com/zimbra/soap/admin/message/GetAccountRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/GetAccountRequest.java
@@ -54,6 +54,17 @@ public class GetAccountRequest extends AttributeSelectorImpl {
     private ZmBoolean applyCos = ZmBoolean.ONE /* true */;
 
     /**
+     * @zm-api-field-tag effectiveQuota
+     * @zm-api-field-description Flag whether or not to get effective value (minimum of zimbraMailQuota and zimbraMailDomainQuota)
+     * <table>
+     * <tr> <td> <b>1 (true)</b> </td> <td> zimbraMailQuota attribute will contain effective value
+     * <tr> <td> <b>0 (false)[default]</b> </td> <td> zimbraMailQuota attribute will contain actual ldap value set </td> </tr>
+     * </table>
+     */
+    @XmlAttribute(name=AdminConstants.A_EFFECTIVE_QUOTA, required=false)
+    private ZmBoolean effectiveQuota;
+    
+    /**
      * @zm-api-field-description Account
      */
     @XmlElement(name=AdminConstants.E_ACCOUNT)
@@ -72,9 +83,15 @@ public class GetAccountRequest extends AttributeSelectorImpl {
 
     public GetAccountRequest(AccountSelector account, Boolean applyCos,
             Iterable<String> attrs) {
+        this(account, applyCos, false, attrs);
+    }
+
+    public GetAccountRequest(AccountSelector account, Boolean applyCos,
+            Boolean effectiveQuota, Iterable<String> attrs) {
         super(attrs);
         this.account = account;
         this.applyCos = ZmBoolean.fromBool(applyCos);
+        this.effectiveQuota = ZmBoolean.fromBool(effectiveQuota);
     }
 
     public void setAccount(AccountSelector account) {
@@ -85,6 +102,11 @@ public class GetAccountRequest extends AttributeSelectorImpl {
         this.applyCos = ZmBoolean.fromBool(applyCos);
     }
 
+    public void setEffectiveQuota(Boolean effectiveQuota) {
+        this.effectiveQuota = ZmBoolean.fromBool(effectiveQuota);
+    }
+
     public AccountSelector getAccount() { return account; }
     public Boolean isApplyCos() { return ZmBoolean.toBool(applyCos); }
+    public Boolean isEffectiveQuota() { return ZmBoolean.toBool(effectiveQuota); }
 }

--- a/store/src/java/com/zimbra/cs/service/account/GetInfo.java
+++ b/store/src/java/com/zimbra/cs/service/account/GetInfo.java
@@ -337,6 +337,9 @@ public class GetInfo extends AccountDocumentHandler  {
             } else if (Provisioning.A_zimbraFeatureZulipChatEnabled.equals(key)) {
                 value = AccountUtil.isZulipChatEnabled(acct) ?
                         ProvisioningConstants.TRUE : ProvisioningConstants.FALSE;
+            } else if (Provisioning.A_zimbraMailQuota.equals(key)) {
+                // setting effective quota value refer ZBUG-1869 
+                value = String.valueOf(AccountUtil.getEffectiveQuota(acct));
             } else {
                 value = attrsMap.get(key);
 

--- a/store/src/java/com/zimbra/cs/service/admin/GetAccount.java
+++ b/store/src/java/com/zimbra/cs/service/admin/GetAccount.java
@@ -85,7 +85,8 @@ public class GetAccount extends AdminDocumentHandler {
 
         boolean applyCos = !Boolean.FALSE.equals(req.isApplyCos());
         Set<String> reqAttrs = getReqAttrs(req.getAttrs(), AttributeClass.account);
-        ToXML.encodeAccount(response, account, applyCos, reqAttrs, aac.getAttrRightChecker(account));
+        boolean isEffectiveQuota = Boolean.TRUE.equals(req.isEffectiveQuota());
+        ToXML.encodeAccount(response, account, applyCos, false, reqAttrs, aac.getAttrRightChecker(account), isEffectiveQuota);
 
         return response;
     }

--- a/store/src/java/com/zimbra/cs/service/admin/ToXML.java
+++ b/store/src/java/com/zimbra/cs/service/admin/ToXML.java
@@ -54,6 +54,13 @@ public class ToXML {
     public static Element encodeAccount(Element parent, Account account,
             boolean applyCos, boolean needsExternalIndicator,
             Set<String> reqAttrs, AttrRightChecker attrRightChecker) {
+        return encodeAccount(parent, account,
+                applyCos, needsExternalIndicator, reqAttrs,  attrRightChecker, false);
+    }
+    
+    public static Element encodeAccount(Element parent, Account account,
+            boolean applyCos, boolean needsExternalIndicator,
+            Set<String> reqAttrs, AttrRightChecker attrRightChecker, boolean isEffectiveQuota) {
         Element acctElem = parent.addNonUniqueElement(AccountConstants.E_ACCOUNT);
         acctElem.addAttribute(AccountConstants.A_NAME, account.getUnicodeName());
         acctElem.addAttribute(AccountConstants.A_ID, account.getId());
@@ -67,11 +74,11 @@ public class ToXML {
             }
         }
         Map attrs = account.getUnicodeAttrs(applyCos);
-        if (null != reqAttrs && reqAttrs.contains(Provisioning.A_zimbraMailQuota)) {
+        if (isEffectiveQuota) {
             try {
                 // setting effective quota value refer ZBUG-1869
                 long effectiveQuota = AccountUtil.getEffectiveQuota(account);
-                attrs.put(Provisioning.A_zimbraMailQuota, Long.toString(effectiveQuota));
+                attrs.put(Provisioning.A_zimbraMailQuota, String.valueOf(effectiveQuota));
             } catch (ServiceException e) {
                 ZimbraLog.account.error("error in getting effective zimbra mail quota", e);
             }

--- a/store/src/java/com/zimbra/cs/service/admin/ToXML.java
+++ b/store/src/java/com/zimbra/cs/service/admin/ToXML.java
@@ -34,6 +34,7 @@ import com.zimbra.cs.account.AttributeManager.IDNType;
 import com.zimbra.cs.account.CalendarResource;
 import com.zimbra.cs.account.IDNUtil;
 import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.util.AccountUtil;
 
 public class ToXML {
     public static Element encodeAccount(Element parent, Account account) {
@@ -66,6 +67,15 @@ public class ToXML {
             }
         }
         Map attrs = account.getUnicodeAttrs(applyCos);
+        if (null != reqAttrs && reqAttrs.contains(Provisioning.A_zimbraMailQuota)) {
+            try {
+                // setting effective quota value refer ZBUG-1869
+                long effectiveQuota = AccountUtil.getEffectiveQuota(account);
+                attrs.put(Provisioning.A_zimbraMailQuota, Long.toString(effectiveQuota));
+            } catch (ServiceException e) {
+                ZimbraLog.account.error("error in getting effective zimbra mail quota", e);
+            }
+        }
         encodeAttrs(acctElem, attrs, AdminConstants.A_N, reqAttrs, attrRightChecker);
         return acctElem;
     }


### PR DESCRIPTION
**Problem**
* The value of `zimbraMailQuota` that we return in GetInfo is not the actual value that the server respects when limiting the user if `zimbraMailDomainQuota` contains a lower value than it.
  * This behavior is documented.
  * This behavior exists in order to support various configuration options on shared environments by admins/domain-admins.

**Solution**
* We can adjust the value of `zimbraMailQuota` that we return in `GetInfo` to respect the effective value (minimum between the relevant properties described above).
* We can also get the value of `zimbraMailQuota` from Admin `GetAccountRequest` so for consistency setting the effective quota value in `zimbraMailQuota` attribute.

**Pros**
* Keeps logic of choosing minimum between the two options in one place (the API).
* No UI or CLI tool changes needed to reflect the change (don't need to replicate the logic across the various clients we support).

**Cons**
* The actual value on the user is no longer exposed - only the effective value - so if any other clients need the actual value for some reason, that may be an issue.