### PR TITLE
ZBUG-1541: Accounts created by a user for public sharing are being counted toward the account quota for the domain.

### DIFF
--- a/store/src/java/com/zimbra/cs/account/ldap/Validators.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/Validators.java
@@ -421,7 +421,7 @@ final public class Validators {
             void search() throws ServiceException {
                 LdapProv ldapProv = (LdapProv) prov;
                 String searchBaseDN = ldapProv.getDIT().domainToAccountSearchDN(domain);
-                ZLdapFilter query = ZLdapFilterFactory.getInstance().allNonSystemAccounts();
+                ZLdapFilter query = ZLdapFilterFactory.getInstance().allNonSystemInternalAccounts();
 
                 ldapProv.searchLdapOnReplica(searchBaseDN, query, null, this);
                 ZimbraLog.account.debug("COS/Feature counts: %s + %s", cosCount, featureCount);


### PR DESCRIPTION
**Problem**

Accounts created by a user for public sharing are being counted toward the account quota for the domain.

**Solution**

Fixed the `com.zimbra.cs.account.ldap.Validators` class where the LDAP database was being queried with the wrong LDAP filter. 

**Fix Mode**

Formerly the `allNonSystemAccounts` LDAP filter was being used, which included both internal and external accounts in the count, but now the `allNonSystemInternalAccounts` filter is being used, so that only internal accounts affect the count for the quota.

**Test Done**

Tested manually with the procedure included in the ticket, plus some extra validations:

1. Created the example.com domain for testing purposes.
2. Set the domain quota to 5 accounts maximum.
3. Created four (1st to 4th) internal accounts.
4. Created one (1st) external account.
5. Created a new internal account (5th) with good results (not possible before the solution to this bug was applied).
6. Created a new internal account (6th) with good results, since it was denied as expected (because of the 5 account quota).
7. Created a new external account (2nd) with good results, since it was allowed as expected.