### PR TITLE
ZBUG-2222: Inline attchmennt EWS MAC mail issue

### DIFF
--- a/store/src/java/com/zimbra/cs/mime/Mime.java
+++ b/store/src/java/com/zimbra/cs/mime/Mime.java
@@ -667,9 +667,14 @@ public class Mime {
     }
 
     public static void recursiveRepairTransferEncoding(MimeMessage mm) throws MessagingException, IOException {
+        String[] xMailerheaderArray = mm.getHeader("X-Mailer");
         for (MPartInfo mpi : listParts(mm, null)) {
             String cte = mpi.mPart.getHeader("Content-Transfer-Encoding", null);
             String ct = getContentType(mpi.mPart);
+            if (xMailerheaderArray != null && xMailerheaderArray[0].contains("Apple Mail")
+                    && mpi.mPart.getDisposition() != null && mpi.mPart.getDisposition().equals(Part.INLINE)) {
+                mpi.mPart.setDisposition(Part.ATTACHMENT);
+            }
             if (StringUtil.isNullOrEmpty(cte) &&
                 !ct.equals(MimeConstants.CT_MESSAGE_RFC822) &&
                 !ct.startsWith(MimeConstants.CT_MULTIPART_PREFIX)) {


### PR DESCRIPTION
https://jira.corp.synacor.com/browse/ZBUG-2222

Issue:
Inline attachments sent from apple mail to Outlook EWS cause garbled text.

Repro:
- Configure a Zimbra user(user1) account in Apple mail using EWS.
- Now compose one mail and add two pdf files as inline attachments.
- Then send this mail to the Zimbra user(user2) account which is configured in outlook on Mac(using EWS).
- Check user2 Outlook account. Mail is full of garbled text.

Fix:
The issue is basically when an email sent from Apple mail from EWS account configured which contains inline attachments(like single page PDF, png attachments) and the same email opened on Outlook tries to render inline attachment as a body which causes the issue to happen

Adding a condition wherein any email sent from EWS mail configured from apple mail and Content-Disposition gets changed from `inline ` to `attachment`
since Content-Disposition is changed from inline to attachment hence email renders properly without any garbled text


Testing:

Thorough Manual testing from Apple and Outlook EWS mail