### PR TITLE
ZBUG-2310:Emailed contacts not updating

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/MailSender.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailSender.java
@@ -54,6 +54,7 @@ import com.zimbra.common.localconfig.DebugConfig;
 import com.zimbra.common.mime.shim.JavaMailInternetAddress;
 import com.zimbra.common.mime.shim.JavaMailInternetHeaders;
 import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.MailConstants;
 import com.zimbra.common.util.ArrayUtil;
 import com.zimbra.common.util.ByteUtil;
 import com.zimbra.common.util.ListUtil;
@@ -74,6 +75,7 @@ import com.zimbra.cs.mailbox.Threader.ThreadIndex;
 import com.zimbra.cs.mime.Mime;
 import com.zimbra.cs.mime.MimeProcessor;
 import com.zimbra.cs.mime.MimeVisitor;
+import com.zimbra.cs.mime.ParsedContact;
 import com.zimbra.cs.mime.ParsedMessage;
 import com.zimbra.cs.service.AuthProvider;
 import com.zimbra.cs.service.FileUploadServlet;
@@ -622,9 +624,12 @@ public class MailSender {
             // To avoid this problem; let's determine a list of new address which we might need to add to emailed
             // contact later before we add the message to sent folder.
             Collection<Address> newAddrs = Collections.emptySet();
+            List<Map<com.zimbra.common.mime.InternetAddress, Pair<Integer, String>>> modifyAddrs = Collections.emptyList();
             Address[] rcptAddresses = getRecipients(mm);
-            if (rcptAddresses != null && rcptAddresses.length > 0)
+            if (rcptAddresses != null && rcptAddresses.length > 0) {
                 newAddrs = mbox.newContactAddrs(Arrays.asList(rcptAddresses));
+                modifyAddrs = mbox.findContactsInEmailedContacts(octxt, Arrays.asList(rcptAddresses));
+            }
 
             if (mimeProcessor != null) {
                 try {
@@ -783,7 +788,12 @@ public class MailSender {
                         }
                     }
                     try {
-                        mbox.createAutoContact(octxt, iaddrs);
+                        if (!newAddrs.isEmpty()) {
+                            mbox.createAutoContact(octxt, iaddrs);
+                        }
+                        if (!modifyAddrs.isEmpty()) {
+                            mbox.modifyAutoContact(octxt, modifyAddrs);
+                        }
                     } catch (IOException e) {
                         ZimbraLog.smtp.warn("Failed to auto-add contact addrs=%s", iaddrs, e);
                     }
@@ -791,7 +801,6 @@ public class MailSender {
             }
 
             return returnItemId;
-
         } catch (SafeSendFailedException sfe) {
             Address[] invalidAddrs = sfe.getInvalidAddresses();
             Address[] validUnsentAddrs = sfe.getValidUnsentAddresses();

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -79,6 +79,7 @@ import com.zimbra.common.localconfig.DebugConfig;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.mailbox.BaseItemInfo;
 import com.zimbra.common.mailbox.Color;
+import com.zimbra.common.mailbox.ContactConstants;
 import com.zimbra.common.mailbox.ExistingParentFolderStoreAndUnmatchedPart;
 import com.zimbra.common.mailbox.FolderConstants;
 import com.zimbra.common.mailbox.FolderStore;
@@ -93,6 +94,7 @@ import com.zimbra.common.mime.InternetAddress;
 import com.zimbra.common.mime.MimeConstants;
 import com.zimbra.common.mime.Rfc822ValidationInputStream;
 import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.MailConstants;
 import com.zimbra.common.soap.SoapProtocol;
 import com.zimbra.common.util.ArrayUtil;
 import com.zimbra.common.util.BufferStream;
@@ -131,11 +133,13 @@ import com.zimbra.cs.html.BrowserDefang;
 import com.zimbra.cs.html.DefangFactory;
 import com.zimbra.cs.imap.ImapMessage;
 import com.zimbra.cs.index.BrowseTerm;
+import com.zimbra.cs.index.ContactHit;
 import com.zimbra.cs.index.DomainBrowseTerm;
 import com.zimbra.cs.index.IndexDocument;
 import com.zimbra.cs.index.LuceneFields;
 import com.zimbra.cs.index.SearchParams;
 import com.zimbra.cs.index.SortBy;
+import com.zimbra.cs.index.ZimbraHit;
 import com.zimbra.cs.index.ZimbraQuery;
 import com.zimbra.cs.index.ZimbraQueryResults;
 import com.zimbra.cs.ldap.LdapConstants;
@@ -316,6 +320,8 @@ public class Mailbox implements MailboxStore {
 
 
     public static final String CONF_PREVIOUS_MAILBOX_IDS = "prev_mbox_ids";
+    
+    public static final String JAPANESE_LOCALE_CODE = "ja";
 
     public static final class MailboxData implements Cloneable {
         public int id;
@@ -8136,7 +8142,7 @@ public class Mailbox implements MailboxStore {
         List<Contact> result = new ArrayList<Contact>(addrs.size());
         String locale = octxt != null && octxt.getAuthenticatedUser() != null ? octxt.getAuthenticatedUser().getPrefLocale() : null;
         boolean nameFormatLastFirst = false;
-        if (locale != null && locale.equals("ja")) {
+        if (locale != null && locale.equals(JAPANESE_LOCALE_CODE)) {
             nameFormatLastFirst = true;
         }
         for (InternetAddress addr : addrs) {
@@ -8154,6 +8160,34 @@ public class Mailbox implements MailboxStore {
             }
         }
         return result;
+    }
+
+    /**
+     * It modifies contact's first and full name with display name
+     * @param octxt
+     * @param listOfContactsToBeModified This list consist list of Map, InternetAddress as key and Pair of ContactId and
+     * DisplayName as Value
+     */
+    public void modifyAutoContact(OperationContext octxt, List<Map<InternetAddress, Pair<Integer, String>>> listOfContactsToBeModified)
+            throws IOException {
+        String email = null;
+        String locale = octxt != null && octxt.getAuthenticatedUser() != null ? octxt.getAuthenticatedUser().getPrefLocale() : null;
+        boolean nameFormatLastFirst = false;
+        if (locale != null && locale.equals(JAPANESE_LOCALE_CODE)) {
+            nameFormatLastFirst = true;
+        }
+        for (Map<InternetAddress, Pair<Integer, String>> map : listOfContactsToBeModified) {
+            try {
+                for (InternetAddress address : map.keySet()) {
+                    email = address.getAddress();
+                    ZimbraLog.mailbox.debug("Modifying contact addr=%s", email);
+                    ParsedContact pc = new ParsedContact(new ParsedAddress(address, nameFormatLastFirst).getAttributes());
+                    modifyContact(octxt, map.get(address).getFirst(), pc);
+                }
+            } catch (Exception e) {
+                ZimbraLog.mailbox.warn("Failed to modify contact addr=%s", email, e);
+            }
+        }
     }
 
     /**
@@ -8188,6 +8222,54 @@ public class Mailbox implements MailboxStore {
             }
         }
         return newAddrs;
+    }
+    
+    /**
+     * Returns a list of contacts exist in emailed contacts folders.
+     * @param octxt OperationContext object
+     * @param addrs Recipient Email address list
+     * @return listOfContactsToBeModified This list consist list of Map, InternetAddress as key and Pair of ContactId and
+     * DisplayName as Value
+     * @throws ServiceException
+     */
+    public List<Map<InternetAddress, Pair<Integer, String>>> findContactsInEmailedContacts
+    (OperationContext octxt, Collection<Address> addrs) throws ServiceException {
+        if (addrs.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<Map<InternetAddress, Pair<Integer, String>>> list = new ArrayList<>();
+        Map<InternetAddress, Pair<Integer, String>> map = new HashMap<>();
+
+        for (Address addr : addrs) {
+            if (addr instanceof javax.mail.internet.InternetAddress) {
+                javax.mail.internet.InternetAddress iaddr = (javax.mail.internet.InternetAddress) addr;
+                try {
+                    if (!Strings.isNullOrEmpty(iaddr.getAddress())) {
+                        ZimbraQueryResults results = index.search(octxt, "inid:" + FolderConstants.ID_FOLDER_AUTO_CONTACTS + " field[email]:" + iaddr.getAddress(),
+                                EnumSet.of(MailItem.Type.CONTACT), SortBy.NONE, 1);
+                        while (results.hasNext()) {
+                            ZimbraHit hit = results.getNext();
+                            if (hit instanceof ContactHit) {
+                                ContactHit contactHit = (ContactHit) hit;
+                                Contact contact = contactHit.getContact();
+                                Map<String, String> m = contact.getFields();
+                                String fullName = m.get(ContactConstants.A_fullName);
+                                String emailSentName = iaddr.getPersonal();
+                                if (!Strings.isNullOrEmpty(fullName) && !Strings.isNullOrEmpty(emailSentName)
+                                        && !emailSentName.equals(fullName)) {
+                                    map.put(new InternetAddress(iaddr.getPersonal(), iaddr.getAddress()),
+                                            new Pair<Integer, String>(contactHit.getItemId(), iaddr.getPersonal()));
+                                    list.add(map);
+                                }
+                            }
+                        }
+                    }
+                } catch (ServiceException e) {
+                    ZimbraLog.search.error("error searching index for contacts." + e);
+                }
+            }
+        }
+        return list;
     }
 
     @Deprecated


### PR DESCRIPTION
Problem : Emailed contacts are not updating after updated display name from CLI and send email by selecting updated name.

Solution: We are getting results for emailed contacts from mail_item table where each contact is saved once we send email to that particular contact. It does not get updated when we modify displayName from either CLI or admin panel. So, the solution to this problem is to modify metadata/contact index file of that particular record with updated display name.

Code fix:
- Created findContactsInEmailedContacts () to find the list of eligible email Id whose display names have been modified and returning list of InternetAddress (for email ID), display name and contact id. It queries on the basis of email ID, if record is found then it checks if the display name is updated else it does not add the contact details into the retuning list.
- Created modifyAutoContact() to modify the display name.

Testing:
Verified the results after modifying display name multiple email ids multiple times on multiple emails id via CLI as well as Admin panel. 
Few test cases to be consider while testing it:
- First / middle / last name and displayName are set when a contact is created at sending a message.  The attributes should be updated when the contact is modified. The value of lastName or middleName should not be removed but updated.
Case 1: When a email is sent to "First2 Last" <[email@dev.zimbra.com](mailto:email@dev.zimbra.com)>, the contact should be updated to:
  firstName: First2
  lastName: Last
  fullName: First2 Last
  email: [email@dev.zimbra.com](mailto:email@dev.zimbra.com)

Case 2: when a email is sent to "First2 Middle Last" <email@dev.zimbra.com>, the contact should be updated to:
  firstName: First2
  lastName: Last
  fullName: First2 Middle Last
  middleName: Middle
  email: email@dev.zimbra.com

Case 3: when we type only email address(not choosing it from autocomplete may be appearing there with some name)
-In this case, not updating contact since there is no updation of name happened anywhere.

Case 4: A contact was created when an email was sent to "first last" <[xxx@domain.com](mailto:xxx@domain.com)>  and then assuming sending an email to "first" <[xxx@domain.com](mailto:xxx@domain.com)> or vice versa.
Display name of contact (=fullName attribute) is the combination of first-middle-last names when a contact in Emailed Contacts is created/updated. In this case, not only display name (fullName) but also all first, middle and last name should be updated.

Case 5: There are some patterns of display name or a recipient. 
a) display name exist eg: userB, changes in first name, no change in display name and mail sent by selecting display name
-No modification will happen, as we are only checking on the name which we are sending email on (which is same in above case).
-Note: First name change will not get reflected, already an identified issue will be get fix in another bug.

b) display name exist eg: userB, changes in first name and display name and mail sent by selecting updated display name
-First name as well as display name will get modified.

c) user type in entire name and email address by his own, where changes in first/middle/last name was made.
-Full name as well as corresponding first/middle/last name will get updated.

Note: Reverting below previous changes as that approach as discussed:
Previous solution: We are getting results from mail_item table which does not contain the updated display name data, in frontend we are displaying full name. So, iterating over the results and replacing full name with updated display name from Ldap. Hence, whenever user is updating display name, he will get the same displayed in emailed contact once refreshed.