### PR TITLE
ZBUG-2222: Adding constant for image/ which is referenced from EWS code

### DIFF
--- a/common/src/java/com/zimbra/common/mime/MimeConstants.java
+++ b/common/src/java/com/zimbra/common/mime/MimeConstants.java
@@ -81,6 +81,7 @@ public class MimeConstants {
     public static final String CT_APPLICATION_ZIP = "application/zip";
     public static final String CT_SMIME_TYPE_ENVELOPED_DATA = "enveloped-data";
     public static final String CT_SMIME_TYPE_SIGNED_DATA = "signed-data";
+    public static final String CT_IMAGE = "image/";
 
     // encodings
     public static final String ET_7BIT = "7bit";


### PR DESCRIPTION
[ZBUG-2222](https://jira.corp.synacor.com/browse/ZBUG-2222)

The main code for this PR references in https://github.com/Zimbra/zm-ews-store/pull/43

Basically, a new constant had to be created for `"image/"` and all the constants are placed in` MimeConstants.java` class