### PR TITLE
ZBUG-2608: Contacts not importing references from ContactGroups

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,5 +1,4 @@
 <project name="zm-mailbox" default="all">
-
     <target name="all" depends="publish-local-all">
       <ant dir="./native" target="generate-native-headers" inheritAll="true"/>
       <exec dir="./native" executable="make"          failonerror="true"/>
@@ -17,6 +16,15 @@
       <ant dir="./store"  target="publish-local" inheritAll="true"/>
       <ant dir="./store"  target="set-dev-version" inheritAll="true"/>
       <echo>Starting package creation from war </echo>
+   </target>
+
+   <target name="deploy">
+      <ant dir="./native" target="deploy" inheritAll="true"/>
+      <ant dir="./common" target="deploy" inheritAll="true"/>
+      <ant dir="./soap"   target="deploy" inheritAll="true"/>
+      <ant dir="./client" target="deploy" inheritAll="true"/>
+      <ant dir="./store"  target="deploy" inheritAll="true"/>
+      <ant dir="./store"  target="set-dev-version" inheritAll="true"/>
    </target>
 
    <target name="set-no-halt-on-failure">

--- a/store/src/java-test/com/zimbra/cs/service/mail/ImportContactsTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/mail/ImportContactsTest.java
@@ -1,0 +1,154 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2016 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.service.mail;
+
+import java.io.BufferedReader;
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.NamedEntry;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.SearchDirectoryOptions;
+import com.zimbra.cs.ldap.ZLdapFilterFactory.FilterId;
+import com.zimbra.cs.mailbox.Contact;
+import com.zimbra.cs.mailbox.ContactGroup;
+import com.zimbra.cs.mailbox.ContactGroup.Member;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.service.formatter.ContactCSV;
+import com.zimbra.cs.service.util.ItemId;
+
+public class ImportContactsTest {
+    private static final String USERNAME = "user1@zimbra.com";
+    private static final String USERDN = "uid=user1,ou=people,dc=zimbra,dc=com";
+
+    @BeforeClass
+    public static void init() throws Exception {
+        System.setProperty("zimbra.config", "../store/src/java-test/localconfig-test.xml");
+        MailboxTestUtil.initServer();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        Provisioning prov = Provisioning.getInstance();
+        prov.createAccount(USERNAME, "secret", new HashMap<String, Object>());
+        Provisioning.setInstance(prov);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        Provisioning prov = Provisioning.getInstance();
+        prov.deleteAccount(USERNAME);
+    }
+
+    @Test
+    public void testImportContactsOK() throws Exception {
+        Provisioning prov = Provisioning.getInstance();
+        Account account = prov.getAccountByName(USERNAME);
+        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
+
+		String csvText = getCsvFile();
+		BufferedReader reader = new BufferedReader(new StringReader(csvText));
+        List<Map<String, String>> contactsMap = ContactCSV.getContacts(reader, null);
+
+        List<ItemId> ids = ImportContacts.ImportCsvContacts(null, mbox,
+				new ItemId(mbox, Mailbox.ID_FOLDER_CONTACTS), contactsMap);
+
+        Assert.assertFalse(ids.isEmpty());
+        Assert.assertEquals(4, ids.size());
+
+		Set<String> expectedContactEmails = getExpectedContactEmails();
+        Set<Contact> foundContactGroups = new HashSet<>();
+        
+        for (ItemId id : ids) {
+            Contact contact = mbox.getContactById(null, id.getId());
+            Assert.assertNotNull(contact);
+            
+            for (String addr : contact.getEmailAddresses()) {
+                expectedContactEmails.remove(addr);
+            }
+
+            if (contact.isContactGroup()) {
+                foundContactGroups.add(contact);
+            }
+        }
+
+        if (!expectedContactEmails.isEmpty()) {
+            Assert.fail("Missing expected contact emails: " + expectedContactEmails);
+        }
+
+        Assert.assertEquals("Found exactly one contact group after import",
+				1, foundContactGroups.size());
+
+		ContactGroup group = ContactGroup.init(foundContactGroups.iterator().next(), true);
+
+        for (Member member : group.getMembers()) {
+            Member.Type memberType = member.getType();
+            
+            if (memberType == Member.Type.INLINE) {
+                Assert.assertEquals("Found correct inline group member", "delta.user@example.org",
+                        member.getValue());
+            } else if (memberType != Member.Type.CONTACT_REF) {
+                Assert.fail(String.format("Found unexpected group member of type %s with value \"%s\"", memberType,
+                        member.getValue()));
+            }
+        }
+    }
+
+	private String getCsvFile() {
+		return ""
+			+ "email,fullName,type,dlist\r\n"
+			+ "alpha.user@example.org,Alpha User,inline,\"\"\r\n"
+			+ "bravo.user@example.org,Bravo User,inline,\"\"\r\n"
+			+ "testgroup@example.org,Test Group,group,\"alpha.user@example.org,bravo.user@example.org,charlie.user@example.org,delta.user@example.org\"\r\n"
+			+ "charlie.user@example.org,Charlie User,inline,\"\"\r\n";
+	}
+
+    private Set<String> getExpectedContactEmails() {
+		Set<String> expectedContactEmails = new HashSet<>();
+		expectedContactEmails.add("alpha.user@example.org");
+        expectedContactEmails.add("bravo.user@example.org");
+        expectedContactEmails.add("charlie.user@example.org");
+        expectedContactEmails.add("delta.user@example.org");
+        expectedContactEmails.add("testgroup@example.org");
+
+		return expectedContactEmails;
+	}
+
+    @Test
+    public void testFoo() throws Exception {
+        Provisioning prov = Provisioning.getInstance();
+//        Account account = prov.getAccountBy(USERDN);
+        SearchDirectoryOptions sdo = new SearchDirectoryOptions();
+        sdo.setFilterString((FilterId) null, USERDN);
+        List<NamedEntry> entries = prov.searchDirectory(sdo);
+        Assert.assertFalse(entries.isEmpty());
+    }
+}
+

--- a/store/src/java/com/zimbra/cs/mailbox/ContactGroup.java
+++ b/store/src/java/com/zimbra/cs/mailbox/ContactGroup.java
@@ -390,7 +390,7 @@ public class ContactGroup {
             }
         }
         
-        private static Member init(Member.Type type, String value) throws ServiceException {
+        public static Member init(Member.Type type, String value) throws ServiceException {
             Member member = null;
             switch (type) {
                 case CONTACT_REF:

--- a/store/src/java/com/zimbra/cs/mailbox/ContactGroup.java
+++ b/store/src/java/com/zimbra/cs/mailbox/ContactGroup.java
@@ -945,13 +945,8 @@ public class ContactGroup {
         }
 
         /**
-         * Add each dlist member to the given contact group, as either an inlined member
-         * or a contact reference if found in parsedByAddr.
-         *
-         * @param contactGroup
-         * @param dlist
-         * @param parsedByAddr
-         * @throws ServiceException
+         * Add each comma-delimited dlist member to the given contact group, as either
+         * an inlined member or a contact reference if found in parsedByAddr.
          */
         static void migrate(ContactGroup contactGroup, String dlist, Map<String, Contact> parsedByAddr)
                 throws ServiceException {
@@ -970,10 +965,11 @@ public class ContactGroup {
                             if (found == null) {
                                 contactGroup.addMember(Member.Type.INLINE, addr);
                             } else {
-                                contactGroup.addMember(Member.Type.CONTACT_REF, found.getAccountId());
+                                ItemId iid = new ItemId(found);
+                                contactGroup.addMember(Member.Type.CONTACT_REF, iid.toString());
                             }
                         } catch (ServiceException e) {
-                            ZimbraLog.contact.info("skipped contact group member %s", addr);
+                            ZimbraLog.contact.info("skipped contact group member %s: %s", addr, e.getMessage());
                         }
                     }
                 }

--- a/store/src/java/com/zimbra/cs/service/formatter/ArchiveFormatter.java
+++ b/store/src/java/com/zimbra/cs/service/formatter/ArchiveFormatter.java
@@ -1553,7 +1553,7 @@ public abstract class ArchiveFormatter extends Formatter {
     private Contact findContact(OperationContext octxt, Mailbox mbox, Contact ct, Folder fldr) {
         int folderId = fldr.getId();
         List<Contact> contactList = contacts.get(folderId);
-        if (contactList == null) {
+        if (contactList == null || contactList.isEmpty()) {
             try {
                 contactList = mbox.getContactList(octxt, folderId);
                 contacts.put(folderId, contactList);
@@ -1564,9 +1564,9 @@ public abstract class ArchiveFormatter extends Formatter {
         }
 
         for (Contact contact : contactList) {
-            HashSet<String> emailAdresses = new HashSet<String>(contact.getEmailAddresses());
+            HashSet<String> emailAddresses = new HashSet<String>(contact.getEmailAddresses());
             for (String emailId : ct.getEmailAddresses()) {
-                if (emailAdresses.contains(emailId)) {
+                if (emailAddresses.contains(emailId)) {
                     return contact;
                 }
             }

--- a/store/src/java/com/zimbra/cs/service/formatter/ArchiveFormatter.java
+++ b/store/src/java/com/zimbra/cs/service/formatter/ArchiveFormatter.java
@@ -1048,6 +1048,11 @@ public abstract class ArchiveFormatter extends Formatter {
             for (Member member : oldMembers) {
                 Member.Type memberType = member.getType();
                 String memberValue = member.getValue();
+
+                if (memberValue.contains(":")) {
+                    memberValue = memberValue.split(":")[1];
+                }
+
                 try {
                     if (Member.Type.CONTACT_REF.equals(memberType)) {
                         Contact rawContact = contactsById.get(Integer.valueOf(memberValue));

--- a/store/src/java/com/zimbra/cs/service/formatter/ContactCSV.java
+++ b/store/src/java/com/zimbra/cs/service/formatter/ContactCSV.java
@@ -645,6 +645,7 @@ public final class ContactCSV {
         return contact;
     }
 
+// HMMM
     private List<Map<String, String>> getContactsInternal(BufferedReader reader, String fmt, String locale) throws ParseException {
         try {
             CsvFormat format = null;

--- a/store/src/java/com/zimbra/cs/service/mail/ImportContacts.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ImportContacts.java
@@ -159,13 +159,12 @@ public class ImportContacts extends MailDocumentHandler  {
             createdContacts.add(contact);
 
             if (!contact.isGroup()) {
-                // The detail we get for an address from a contact group
-                // is less valuable than any individual record we've yet
-                // encountered in this import.
-
                 for (String addr : contact.getEmailAddresses()) {
                     createdContactsByEmail.put(addr.toLowerCase(), contact);
                 }
+                // createdContactsById.put(contact.getId(), contact) to match the tail end of
+                // the ID in contact group metadata from a TGZ meta file. Except this is
+                // explicitly for importing a CSV source, and CSV doesn't contain any ID.
             }
         }
 

--- a/store/src/java/com/zimbra/cs/service/mail/ImportContacts.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ImportContacts.java
@@ -158,8 +158,15 @@ public class ImportContacts extends MailDocumentHandler  {
             Contact contact = mbox.createContact(oc, new ParsedContact(csvContact), iidFolder.getId(), tags);
             createdContacts.add(contact);
 
-            for (String addr : contact.getEmailAddresses()) {
-                createdContactsByEmail.put(addr.toLowerCase(), contact);
+            if (!contact.isGroup()) {
+                // We don't want to match (in our second loop) an
+                // address to some group in which it is a member,
+                // clobbering any useful "real" Contact already
+                // found for a single contact address record.
+
+                for (String addr : contact.getEmailAddresses()) {
+                    createdContactsByEmail.put(addr.toLowerCase(), contact);
+                }
             }
         }
 

--- a/store/src/java/com/zimbra/cs/service/mail/ImportContacts.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ImportContacts.java
@@ -159,10 +159,9 @@ public class ImportContacts extends MailDocumentHandler  {
             createdContacts.add(contact);
 
             if (!contact.isGroup()) {
-                // We don't want to match (in our second loop) an
-                // address to some group in which it is a member,
-                // clobbering any useful "real" Contact already
-                // found for a single contact address record.
+                // The detail we get for an address from a contact group
+                // is less valuable than any individual record we've yet
+                // encountered in this import.
 
                 for (String addr : contact.getEmailAddresses()) {
                     createdContactsByEmail.put(addr.toLowerCase(), contact);
@@ -179,6 +178,6 @@ public class ImportContacts extends MailDocumentHandler  {
             mcg.migrate(contact, createdContactsByEmail);
         }
 
-        return createdContacts.stream().map(c -> new ItemId(c)).collect(Collectors.toList());
+        return createdContacts.stream().map(ItemId::new).collect(Collectors.toList());
     }
 }

--- a/store/src/java/com/zimbra/qa/unittest/TestContactGroup.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestContactGroup.java
@@ -405,7 +405,7 @@ public class TestContactGroup {
         assertEquals(Member.Type.INLINE, member.getType());
         assertEquals("user1@test.com", member.getValue());
     }
-    
+// HMMM
     @Test 
     public void returnMembersAsDlist() throws Exception {
         Account account = Provisioning.getInstance().get(AccountBy.name, TestUtil.getAddress("user1"));


### PR DESCRIPTION
Problem:
When importing an exported CSV or TGZ previously exported by Zimbra that has a ContactGroup, `CONTACT_REF` references are being turned into `INLINE`, losing any attributes defined for that contact in the imported file.

Fix:
For CSV, inside the `ContactGroup` class, for each member of the "dlist" field, convert all bare inline addresses that have also been imported in the same file with a reference to that imported contact.
For TGZ, the approach is similar, but it was very difficult to find just where to implement it. Ended up in `ArchiveFormatter::postProcessContacts`.

Progress:
CSV fix appears to be good. For TGZ, while the contact does go through `postProcessContacts`, I can't figure out how to save it back to the Zimbra store after converting inline addresses to contact references.
