### PR TITLE
ZBUG-2599: Defining generic error response for "Forgot Password".

### DIFF
--- a/store/src/java/com/zimbra/cs/service/util/ResetPasswordUtil.java
+++ b/store/src/java/com/zimbra/cs/service/util/ResetPasswordUtil.java
@@ -47,7 +47,7 @@ public class ResetPasswordUtil {
                     account.setFeatureResetPasswordStatus(FeatureResetPasswordStatus.enabled);
                     account.unsetResetPasswordRecoveryCode();
                 } else {
-                    throw ForgetPasswordException.FEATURE_RESET_PASSWORD_SUSPENDED("Password reset feature is suspended.");
+                    throw ForgetPasswordException.CONTACT_ADMIN("Something went wrong. Please contact your administrator.");
                 }
             } else {
                 account.setFeatureResetPasswordStatus(FeatureResetPasswordStatus.enabled);
@@ -55,7 +55,7 @@ public class ResetPasswordUtil {
             break;
         case disabled:
         default:
-            throw ForgetPasswordException.FEATURE_RESET_PASSWORD_DISABLED("Password reset feature is disabled.");
+            throw ForgetPasswordException.CONTACT_ADMIN("Something went wrong. Please contact your administrator.");
         }
     }
 
@@ -65,7 +65,7 @@ public class ResetPasswordUtil {
         }
         if (StringUtil.isNullOrEmpty(account.getPrefPasswordRecoveryAddress())) {
             ZimbraLog.passwordreset.warn("ResetPassword : Recovery Account is not found for %s", account.getName());
-            throw ForgetPasswordException.CONTACT_ADMIN("Recovery Account is not found. Please contact your administrator.");
+            throw ForgetPasswordException.CONTACT_ADMIN("Something went wrong. Please contact your administrator.");
         }
     }
 
@@ -76,7 +76,7 @@ public class ResetPasswordUtil {
         if (account.getPrefPasswordRecoveryAddressStatus() == null
                 || !account.getPrefPasswordRecoveryAddressStatus().isVerified()) {
             ZimbraLog.passwordreset.warn("Verified recovery email is not found for %s", account.getName());
-            throw ForgetPasswordException.CONTACT_ADMIN("Recovery Account is not verified. Please contact your administrator.");
+            throw ForgetPasswordException.CONTACT_ADMIN("Something went wrong. Please contact your administrator.");
         }
     }
 


### PR DESCRIPTION
### Solution

ZBUG-2599 is about the `RecoverAccountRequest` method of back-end, which under some circumstances could be maliciously invoked to harvest existing account names due to response differences whether the account is fully set up for password recovery. To solve this we have changed the `ResetPasswordUtil` class behavior in such a way that, unless the account is fully set up for password recovery, the response will be generic and equal to that of when the account does not exist.

### Notes

Being "fully set up for password recovery" means:

- The account name represents an existing account.
- The account has its password recovery feature enabled.
- The account has set a password recovery address.
- The password recovery address has been verified.

### Testing Done

**Setup**

1. Create a new test domain
2. Create new test account

**Scenarios**

See the ticket for testing scenarios.