### PR TITLE
ZBUG-2588 : Autocomplete bug with "/" shares

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/ContactAutoComplete.java
+++ b/store/src/java/com/zimbra/cs/mailbox/ContactAutoComplete.java
@@ -764,14 +764,14 @@ public class ContactAutoComplete {
         Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(getRequestedAcctId());
         if (folderIDs == null) {
             for (Folder folder : mbox.getFolderList(octxt, SortBy.NONE)) {
-                if (folder.getDefaultView() != MailItem.Type.CONTACT || folder.inTrash()) {
-                    continue;
-                } else if (folder instanceof Mountpoint) {
+                if (folder instanceof Mountpoint) {
                     Mountpoint mp = (Mountpoint) folder;
                     mountpoints.put(mp.getTarget(), mp);
                     if (mIncludeSharedFolders) {
                         folders.add(folder);
                     }
+                } else if (folder.getDefaultView() != MailItem.Type.CONTACT || folder.inTrash()) {
+                    continue;
                 } else {
                     folders.add(folder);
                 }


### PR DESCRIPTION
[ZBUG-2588](https://jira.corp.synacor.com/browse/ZBUG-2588)

Problem:
The issue was basically after sharing root folders with another account contacts are not coming in autocomplete .
Exp - user1 and user2 is there. We need to share all root folders of user1 with user2 , automatically contacts has shared . But while we are sending any mail from user2 autocomplete is not working for shared contacts of user1

Solution:
There is one if conditions to check contacts and mount process but in this situation if condition is only checking for contacts , so it is never going to elseif condition that is required for mount process.
Just added one condition as '!(folder instanceof Mountpoint)' because when condition Mountpoint will come it will not skip , it will go inside elseif condition and move forward accordingly .

Testing:
Tested by adding multiple contacts in user1 . Autocomplete is working as expected .