### PR TITLE
ZBUG-2361: Modified Draft not synced to external imap account

### DIFF
--- a/store/src/java/com/zimbra/cs/datasource/imap/MessageChange.java
+++ b/store/src/java/com/zimbra/cs/datasource/imap/MessageChange.java
@@ -20,7 +20,7 @@ import com.zimbra.cs.mailbox.Message;
 
 final class MessageChange {
     public enum Type {
-        ADDED, UPDATED, MOVED, DELETED
+        ADDED, UPDATED, MOVED, DELETED, MODIFIED
     }
 
     private final Type type;
@@ -43,7 +43,11 @@ final class MessageChange {
     public static MessageChange deleted(int itemId, ImapMessage tracker) {
         return new MessageChange(Type.DELETED, itemId, null, tracker);
     }
-    
+
+    public static MessageChange modifiedDraft(Message msg, ImapMessage tracker) {
+        return new MessageChange(Type.MODIFIED, msg.getId(), msg, tracker);
+    }
+
     MessageChange(Type type, int itemId, Message msg, ImapMessage tracker) {
         this.type = type;
         this.itemId = itemId;
@@ -82,4 +86,9 @@ final class MessageChange {
     public boolean isDeleted() {
         return type == Type.DELETED;
     }
+
+    public boolean isModified() {
+        return type == Type.MODIFIED;
+    }
+
 }


### PR DESCRIPTION
Issue:
Modified Drafts are not synced to an external IMAP account

Fix:
- The issue was basically the logic was not in place to identify the draft content change when changed locally
- In order to identify the draft change content we have added a logic where we figure out the draft content has been updated
- Next step to query and find the modified items for Draft since previous sync state. This returns the required and expected modified items based on lastChangeID
- lastChangeID remains 0 when the server is restarted and we modify and sync the messages. In this case syncState remains null hence we have to check for all drafts messages and sync them up
- once we have Message changes identified we delete the corresponding message and push the updated new message

Repro:
There are two Accounts:

a Zimbra account
any IMAP account
Steps to reproduce:
1. Create a draft in the imap account

Open the IMAP account with any Client
create a draft and save it so that a mail is saved in the draft folder
2. Add the IMAP account as external account to zimbra

Go to "Preferences > Accounts"
"Add External Account"
Enter the data of the imap account
3. Try to edit the Draft

Go to "Mail" and open the folder structure of the added IMAP account
Open the "Drafts" folder. There should be the saved mail.
Click in "Edit"
Edit the draft
Click on "Save Draft

Testing:

Thorough Manual testing through different scenarios  in Draft message and also paralley modifying and syncing the Inbox , Sent, Drafts etc folder message all at a time