### PR TITLE
ZCS-10678: Server Side work to Force users not to use username in the password

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1466,6 +1466,8 @@ public final class LC {
 
     public static final KnownKey invite_ignore_x_alt_description = KnownKey.newKey(true);
 
+    public static final KnownKey allow_username_within_password = KnownKey.newKey(false);
+
     static {
         // Automatically set the key name with the variable name.
         for (Field field : LC.class.getFields()) {

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -6147,6 +6147,12 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
                     new Argument(Provisioning.A_zimbraPasswordMaxLength, maxLength, Argument.Type.NUM));
         }
 
+        if (LC.allow_username_within_password.booleanValue()
+                && StringUtils.containsIgnoreCase(password, acct.getUCUsername())) {
+            throw AccountServiceException.INVALID_PASSWORD("password contains username",
+                    new Argument("zimbraPasswordAllowUsername", "", Argument.Type.STR));
+        }
+
         if (getBoolean(acct, cos, entry, Provisioning.A_zimbraPasswordBlockCommonEnabled, false)
                 && commonPasswordFilter.mightContain(password)) {
             throw AccountServiceException.INVALID_PASSWORD("too common",

--- a/store/src/java/com/zimbra/cs/service/account/GetInfo.java
+++ b/store/src/java/com/zimbra/cs/service/account/GetInfo.java
@@ -34,6 +34,7 @@ import com.google.common.collect.Sets;
 import com.zimbra.common.account.Key;
 import com.zimbra.common.account.Key.AccountBy;
 import com.zimbra.common.account.ProvisioningConstants;
+import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AccountConstants;
 import com.zimbra.common.soap.Element;
@@ -361,6 +362,9 @@ public class GetInfo extends AccountDocumentHandler  {
 
             ToXML.encodeAttr(response, key, value);
         }
+        // ZCS-10678: Include Local config change for zimbraPasswordAllowUsername in getinfo response
+        ToXML.encodeAttr(response, "zimbraPasswordAllowUsername",
+                Boolean.toString(LC.allow_username_within_password.booleanValue()).toUpperCase());
     }
 
     private static void doZimlets(Element response, Account acct) {


### PR DESCRIPTION
https://jira.corp.synacor.com/browse/ZCS-10678
Feature: Server Side work to Force users not to use username in the password

Problem:
One of the customer (The Open university of Tanzania) is looking for an option in password policy - users should not be able to use their username in the password.

Code fix:
As discussed on the approach, we would be making using of Local config to enable the feature is password can contain the username or not. If the value is set to true then we check in checkPasswordStrength() to check for password containing username and throw a relevant exception

Test:
Through UI and soap UI API calls, the relevant exception is thrown
