### PR TITLE
ZBUG-2119: Added disposition param to fetch the file from remote server

### DIFF
--- a/store/src/java/com/zimbra/cs/service/mail/ParseMimeMessage.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ParseMimeMessage.java
@@ -912,6 +912,8 @@ public final class ParseMimeMessage {
         if (!iid.isLocal()) {
             Map<String, String> params = new HashMap<String, String>(3);
             params.put(UserServlet.QP_PART, part);
+            // Content-Disposition here is always one of two values, `attachment' or `inline'.
+            params.put(UserServlet.QP_DISP, Part.ATTACHMENT.equals(contentDisposition) ? "a" : "i");
             attachRemoteItem(mmp, iid, contentID, ctxt, params, null);
             return;
         }


### PR DESCRIPTION
https://jira.corp.synacor.com/browse/ZBUG-2119

Problem:
Xml attachment truncated if sent from account with "sendAs" delegation

Fix: 

This issue will only happen when the file needs to fetched from the remote server not the local server. So this might not be visible on the regular emails with xml attachments. This is happening when the NativeFormatter#sendbackOriginalDoc is looking content-disposition to check if file needs to be sanitized. When the contentDisposition is null, it is automatically setting content-disposition to "inline" even when it's an "attachment". So we are now passing the contentDisposition value that we have from SendMsg call to the fetch remote call, so the NativeFormatter can use that paramter to decide if the file needs to be sanitized or not.

	Before: GET https://zqa-129.eng.zimbra.com:8443/home/two@zqa-128.eng.zimbra.com/?auth=co&part=2&id=3ac0ba63-f604-435e-b50d-2a5a16c59ed3:504
	After: GET https://zqa-129.eng.zimbra.com:8443/home/two@zqa-128.eng.zimbra.com/?auth=co&disp=a&part=2&id=c5204bd0-fe3b-4cc5-b493-e064cd7a9778:377

This parameter disp, is used switch the sanitize check in NativeFormatter#sendbackOriginalDoc.

Test:
Account-1: one@zqa-128.eng.zimbra.com Host: zqa-128.eng.zimbra.com
Account-2: two@zqa-128.eng.zimbra.com Host: zqa-129.eng.zimbra.com
Account-3: three@zqa-128.eng.zimbra.com Host: zqa-128.eng.zimbra.com

When Account-2 sends a message using the Account-1 as "sendAs" account, xml file is now not corrupted. This is actual issue reported on the ticket.

Notes: 
The issue will still exist when the xml file is an inline attachment and needs to fetched from the remote server. This is because, every inline attachment that resides on the remote server will go through a logic where it will be sanitized based on the condition and this will not happen for the item on the local server.
 	
 	if (disp.equals(Part.INLINE) && isScriptableContent(contentType)) // = true, will be sanitized

XML attachment being part of the SCRIPTABLE_CONTENT_TYPES and when it's inline and has tags that are not part of the DebugConfig.xhtmlWhitelistedTags will be removed from file content. 

So a simple xml file like this would be corrupted, because these tags are not part of current list of xhtmlWhitelistedTags (a,abbr,acronym,blockquote,div,font,h1,h2,h3,h4,h5,h6,img,li,ol,p,span,table,td,th,tr,ul) 

	Original file: 

		<?xml version="1.0" encoding="utf-8"?>
		<records>
		    <record>
		        <name>Emi Dixon</name>
		        <email>vitae.diam@icloud.org</email>
		    </record>
		</records>

	Current output: 
		<?xml version='1.0' encoding='UTF-8'?>

We either need to add more generic tags to the whitelist or blacklist only the problematic tags. Or find a better way of sanitizing the data. The approach is open for discussion but would be too much for the scope of this ticket.

Reference ticket for more info on this: 
https://jira.corp.synacor.com/browse/ZBUG-481

