### PR TITLE
ZBUG-1838: Auto complete displaying single email address from matching account

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/ContactAutoComplete.java
+++ b/store/src/java/com/zimbra/cs/mailbox/ContactAutoComplete.java
@@ -736,11 +736,10 @@ public class ContactAutoComplete {
                     }
                     addEntry(entry, result);
                     ZimbraLog.gal.debug("adding %s", entry.getEmail());
-                    if (folderId == FOLDER_ID_GAL) {
-                        // we've matched the first email address for this
-                        // GAL contact.  move onto the next contact.
-                        return;
-                    }
+                    /*
+                		Previously stopped at first matching email address for GAL contact. 
+                		See ZBUG-1838.
+                    */
                 }
             }
         } else { // IS a contact group


### PR DESCRIPTION
**Solution**

ZBUG-1838 is about the "GAL auto complete" feature. If you have an account with multiple aliases which starts with the same characters, e.g: alias01@domain.com, alias02@domain.com, alias03@domain.com, etc, and you try to send a message to that account typing a few first characteres of its related aliases into "To/Cc/Bcc" fields, e.g: "ali", you only get one alias, e.g: alias01@domain.com instead of all the related aliases. To fix this, we have deleted the lines 739-744 of "addMatchedContacts" function which belongs to "ContactAutoComplete" class. Those lines were the ones that caused to get only the first email address matching and skipped the next ones.

**Notes**

1- The expected behavior on Auto Complete feature into "To/Cc/Bcc" fields after this solution will be this one:

When you type something into "To", "Cc" or "Bcc" fields, the frontend waits until the first 3 letters are typed. Once this happen, frontend sends a request with your searching to the backend.

Example:

If you type "abc", the frontend sends "abc" to the backend which will finally returns:

- All the accounts with "Account name" starting with "abc"
- All the accounts with  "First name" starting with "abc"
- All the accounts with  "Last name" starting with "abc"
- All the aliases which are related to any account found in the previous 3 items

2- This solution fixes ZBUG-1304 too. 

**Scenarios**

See the ticket for testing scenarios.