### PR TITLE
ZCS-10995: ActiveSync 16.0 : Changing one of the instance response from device as attendee is not syncing due to NullPointer exception

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/CalendarItem.java
+++ b/store/src/java/com/zimbra/cs/mailbox/CalendarItem.java
@@ -736,7 +736,8 @@ public abstract class CalendarItem extends MailItem {
                             ((Recurrence.RecurrenceRule) mRecurrence).addException(cancelRule);
                         }
                     } else if (method.equals(ICalTok.REQUEST.toString()) ||
-                        method.equals(ICalTok.PUBLISH.toString())) {
+                        method.equals(ICalTok.PUBLISH.toString()) ||
+                        method.equals(ICalTok.REPLY.toString())) {
                         assert (cur.hasRecurId());
                         if (cur.hasRecurId() && cur.getStartTime() != null) {
                             checkRecurIdIsSensible(cur.getRecurId());


### PR DESCRIPTION
**Problem:**
Replies from attendee on single instance caused meeting series update.

**Fix Made:**
	• Added exception creation mechanism for the calendar event on attendee side.
	• These exceptions were not getting added to the recurrence rule --> so added Reply method in mailbox to handle it.

**Use Case Tested on Android - ActiveSync version 16.0:**

1. As n2 user from ZWC, send recurring meeting series invite to n1 user to attendee n1 on device
2. Sync calendar of n1 on device and accept meeting series
3. Modify one of the instance response to Maybe or Decline.
4. Verify that response email is sent to organizer and response is updated on attendee calendar in device and ZWC, organizer ZWC


**Note:**

- This is fixed for Android - 16.0 version. Android 14.0 and iOS device will be covered separately.
- Also with this ticket, [ZCS-10903](https://jira.corp.synacor.com/browse/ZCS-10903) can be tested.