### PR TITLE
ZBUG-1455 : zimbraFeatureMailForwardingInFiltersEnabled, Attribute funtionality is wrong

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -6689,7 +6689,7 @@ public class ZAttrProvisioning {
     public static final String A_zimbraFeatureMailForwardingEnabled = "zimbraFeatureMailForwardingEnabled";
 
     /**
-     * enable end-user mail forwarding defined in mail filters features
+     * enable end-user mail redirecting defined in mail filters features
      *
      * @since ZCS 5.0.10
      */

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -3720,7 +3720,7 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
 
 <attr id="704" name="zimbraFeatureMailForwardingInFiltersEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="5.0.10">
   <defaultCOSValue>TRUE</defaultCOSValue>
-  <desc>enable end-user mail forwarding defined in mail filters features</desc>
+  <desc>enable end-user mail redirecting defined in mail filters features</desc>
 </attr>
 
 <attr id="705" name="zimbraPrefIMBuddyListSort" type="string" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="5.0.10" deprecatedSince="8.7.0">

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -16376,7 +16376,7 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * enable end-user mail forwarding defined in mail filters features
+     * enable end-user mail redirecting defined in mail filters features
      *
      * @return zimbraFeatureMailForwardingInFiltersEnabled, or true if unset
      *
@@ -16388,7 +16388,7 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * enable end-user mail forwarding defined in mail filters features
+     * enable end-user mail redirecting defined in mail filters features
      *
      * @param zimbraFeatureMailForwardingInFiltersEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -16403,7 +16403,7 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * enable end-user mail forwarding defined in mail filters features
+     * enable end-user mail redirecting defined in mail filters features
      *
      * @param zimbraFeatureMailForwardingInFiltersEnabled new value
      * @param attrs existing map to populate, or null to create a new map
@@ -16419,7 +16419,7 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * enable end-user mail forwarding defined in mail filters features
+     * enable end-user mail redirecting defined in mail filters features
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -16433,7 +16433,7 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * enable end-user mail forwarding defined in mail filters features
+     * enable end-user mail redirecting defined in mail filters features
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -10960,7 +10960,7 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * enable end-user mail forwarding defined in mail filters features
+     * enable end-user mail redirecting defined in mail filters features
      *
      * @return zimbraFeatureMailForwardingInFiltersEnabled, or true if unset
      *
@@ -10972,7 +10972,7 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * enable end-user mail forwarding defined in mail filters features
+     * enable end-user mail redirecting defined in mail filters features
      *
      * @param zimbraFeatureMailForwardingInFiltersEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -10987,7 +10987,7 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * enable end-user mail forwarding defined in mail filters features
+     * enable end-user mail redirecting defined in mail filters features
      *
      * @param zimbraFeatureMailForwardingInFiltersEnabled new value
      * @param attrs existing map to populate, or null to create a new map
@@ -11003,7 +11003,7 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * enable end-user mail forwarding defined in mail filters features
+     * enable end-user mail redirecting defined in mail filters features
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -11017,7 +11017,7 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * enable end-user mail forwarding defined in mail filters features
+     * enable end-user mail redirecting defined in mail filters features
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs


### PR DESCRIPTION
[ZBUG-1455](https://jira.corp.synacor.com/browse/ZBUG-1455)

Problem:
AccDescription of the zimbraFeatureMailForwardingInFiltersEnabled need to change . While we are hitting to get descriptions of zimbraFeatureMailForwardingInFiltersEnabled we are getting result as ( enable end-user mail **forwarding** defined in mail filters features ) but it should be ( enable end-user mail **redirecting** defined in mail filters features )

Solution:
I have replaced redirecting in the place of forwarding as we are doing operations of redirect on this attribute . 

Testing:
Tested on a new build for above changes as for this bug we have changed on zimbra-attrs.xml file . Description is working as expected .