### PR TITLE
ZBUG-2723 : add anchor key file path in unbound.conf.in

### DIFF
--- a/store/conf/unbound.conf.in
+++ b/store/conf/unbound.conf.in
@@ -6,6 +6,7 @@ server:
 	do-tcp: %%zimbraDNSUseTCP%%
 	do-udp: %%zimbraDNSUseUDP%%
 	tcp-upstream: %%zimbraDNSTCPUpstream%%
+	trust-anchor-file: "/opt/zimbra/conf/root.key"
 
 local-zone: "10.in-addr.arpa." nodefault
 local-zone: "16.172.in-addr.arpa." nodefault


### PR DESCRIPTION
**Problem :**  dnscache service does not support DNSSEC validation

**Fix :** This issue is due to anchor key file (/opt/zimbra/conf/root.key) is not present, to fix this need to generate anchor key file and add anchor key file path in /opt/zimbra/conf/unbound.conf.in

**Refer:**  Check the man page of "unbound-anchor" to get more details about the anchor key.

less  /opt/zimbra/common/share/man/man8/unbound-anchor.8

Related PR: https://github.com/Zimbra/packages/pull/154