### PR TITLE
ZBUG-2390: briefcase content accessible without 2FA

### DIFF
--- a/store/src/java/com/zimbra/cs/service/UserServlet.java
+++ b/store/src/java/com/zimbra/cs/service/UserServlet.java
@@ -381,6 +381,11 @@ public class UserServlet extends ZimbraServlet {
 
             checkTargetAccountStatus(context);
 
+            if (!checkTwoFactorAuthentication(context)) {
+                resp.addHeader(AuthUtil.WWW_AUTHENTICATE_HEADER, getRealmHeader(req, null));
+                resp.sendError(HttpServletResponse.SC_UNAUTHORIZED, L10nUtil.getMessage(MsgKey.errMustAuthenticate, req));
+            }
+
             if (proxyIfRemoteTargetAccount(req, resp, context)) {
                 return;
             }
@@ -480,6 +485,7 @@ public class UserServlet extends ZimbraServlet {
         if (context.getAuthAccount() == null) {
             context.setAnonymousRequest();
         }
+
         return true;
     }
 
@@ -498,6 +504,18 @@ public class UserServlet extends ZimbraServlet {
                 throw AccountServiceException.ACCOUNT_INACTIVE(context.targetAccount.getName());
             }
         }
+    }
+
+    // ZBUG-2390: if two-factor authentication is enabled or required for account
+    // while authentication was basic and not through cookie, reject access
+    private boolean checkTwoFactorAuthentication(UserServletContext context)
+            throws ServiceException {
+        if (context != null && context.getAuthAccount() != null
+                && (context.getAuthAccount().isTwoFactorAuthEnabled()
+                        || context.getAuthAccount().isFeatureTwoFactorAuthRequired())
+                && context.basicAuthHappened && !context.cookieAuthHappened)
+            return false;
+        return true;
     }
 
     protected static AuthToken getProxyAuthToken(UserServletContext context) throws ServiceException {


### PR DESCRIPTION
### Solution

ZBUG-2390 is about briefcase content being accessible without two-factor authentication.

As a solution to such issue, the `UserServlet` class has been updated with additional rules that evaluate the following conditions:
- Two-factor authentication is enabled or required for the target account, and
- Authentication to the servlet happened through Basic Authentication and not through Cookie-based Authentication.

If all of the above conditions are true, then content will be denied with HTTP `401 Unauthorized` response status code.

### Notes

- _Two-Factor Authentication Enabled_ means that two-factor authentication has been set up by the account, whether required or not by the class of service.
- _Two-Factor Authentication Required_ means that two-factor authentication is required by the class of service, whether already set up or not by the account.
- Both conditions will result in content denial if access is attempted from outside of Zimbra Web Client.

### Tests

Please see ticket for further details.