### PR TITLE
ZCS-11331: Added ignoreSameSite param, if true will not add Same SiteStrict cookie

### DIFF
--- a/common/src/java/com/zimbra/common/soap/AccountConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AccountConstants.java
@@ -481,6 +481,7 @@ public class AccountConstants {
     public static final String A_TOKEN_TYPE = "tokenType";
     public static final String E_JWT_TOKEN = "jwtToken";
     public static final String A_OFFSET = "offset";
+    public static final String A_IGNORE_SAME_SITE_COOKIE = "ignoreSameSite";
 
     // account ACLs
     public static final String A_ACCESSKEY = "key";

--- a/common/src/java/com/zimbra/common/util/ZimbraCookie.java
+++ b/common/src/java/com/zimbra/common/util/ZimbraCookie.java
@@ -56,11 +56,16 @@ public class ZimbraCookie {
 
     public static void addHttpOnlyCookie(HttpServletResponse response, String name, String value,
             String path, Integer maxAge, boolean secure) {
-        addCookie(response, name, value, path, maxAge, true, secure);
+        addHttpOnlyCookie(response, name, value, path, maxAge, secure, false);
+    }
+
+    public static void addHttpOnlyCookie(HttpServletResponse response, String name, String value,
+            String path, Integer maxAge, boolean secure, boolean ignoreSameSite) {
+        addCookie(response, name, value, path, maxAge, true, secure, ignoreSameSite);
     }
 
     private static void addCookie(HttpServletResponse response, String name, String value,
-            String path, Integer maxAge, boolean httpOnly, boolean secure) {
+            String path, Integer maxAge, boolean httpOnly, boolean secure, boolean ignoreSameSite) {
         Cookie cookie = new Cookie(name, value);
 
         if (maxAge != null) {
@@ -71,7 +76,7 @@ public class ZimbraCookie {
         ZimbraCookie.setAuthTokenCookieDomainPath(cookie, ZimbraCookie.PATH_ROOT);
 
         String cookieVal = LC.zimbra_same_site_cookie.value();
-        if (!StringUtil.isNullOrEmpty(cookieVal)) {
+        if (!ignoreSameSite && !StringUtil.isNullOrEmpty(cookieVal)) {
             String pathStr = cookie.getPath();
             // setting cookie value like "SameSite=Strict;", value can be Strict, Lax, None
             pathStr = new StringBuilder(pathStr).append(";SameSite=").append(cookieVal).append(";").toString();

--- a/soap/src/java/com/zimbra/soap/account/message/AuthRequest.java
+++ b/soap/src/java/com/zimbra/soap/account/message/AuthRequest.java
@@ -197,6 +197,13 @@ public class AuthRequest {
     @XmlAttribute(name = AccountConstants.A_TOKEN_TYPE /* token type to be returned */, required = false)
     private String tokenType;
 
+    /**
+     *@zm-api-field-description if true SameSite=Strict cookie will not be added in AuthToken
+     *
+     */
+    @XmlAttribute(name=AccountConstants.A_IGNORE_SAME_SITE_COOKIE /* ignoreSameSite cookie */, required=false)
+    private ZmBoolean ignoreSameSite;
+
     public AuthRequest() {
     }
 
@@ -345,5 +352,13 @@ public class AuthRequest {
 
     public ZmBoolean getGenerateDeviceId() {
         return generateDeviceId;
+    }
+
+    public ZmBoolean getIgnoreSameSite() {
+        return ignoreSameSite;
+    }
+
+    public void setIgnoreSameSite(Boolean ignoreSameSite) {
+        this.ignoreSameSite = ZmBoolean.fromBool(ignoreSameSite);
     }
 }

--- a/store/src/java/com/zimbra/cs/account/AuthToken.java
+++ b/store/src/java/com/zimbra/cs/account/AuthToken.java
@@ -47,6 +47,7 @@ public abstract class AuthToken {
     public static final long DEFAULT_AUTH_LIFETIME = 60*60*12;
     public static final long DEFAULT_TWO_FACTOR_AUTH_LIFETIME = 60*60;
     public static final long DEFAULT_TWO_FACTOR_ENABLEMENT_AUTH_LIFETIME = 60*60;
+    private boolean ignoreSameSite;
 
     public static String generateDigest(String a, String b) {
         if (a == null)
@@ -263,6 +264,14 @@ public abstract class AuthToken {
 
     public static Map getInfo(String encoded) throws AuthTokenException {
         return ZimbraAuthToken.getInfo(encoded);
+    }
+
+    public boolean isIgnoreSameSite() {
+        return ignoreSameSite;
+    }
+
+    public void setIgnoreSameSite(boolean ignoreSameSite) {
+        this.ignoreSameSite = ignoreSameSite;
     }
 
     public abstract Usage getUsage();

--- a/store/src/java/com/zimbra/cs/account/ZimbraAuthToken.java
+++ b/store/src/java/com/zimbra/cs/account/ZimbraAuthToken.java
@@ -484,7 +484,7 @@ public class ZimbraAuthToken extends AuthToken implements Cloneable {
 
         ZimbraCookie.addHttpOnlyCookie(resp,
                 ZimbraCookie.authTokenCookieName(isAdminReq), origAuthData,
-                ZimbraCookie.PATH_ROOT, maxAge, secureCookie);
+                ZimbraCookie.PATH_ROOT, maxAge, secureCookie, this.isIgnoreSameSite());
     }
 
     @Override

--- a/store/src/java/com/zimbra/cs/account/ZimbraJWToken.java
+++ b/store/src/java/com/zimbra/cs/account/ZimbraJWToken.java
@@ -298,7 +298,7 @@ public class ZimbraJWToken extends AuthToken {
                     }
                 }
             }
-            ZimbraCookie.addHttpOnlyCookie(resp, ZimbraCookie.COOKIE_ZM_JWT, finalValue, ZimbraCookie.PATH_ROOT, -1, true);
+            ZimbraCookie.addHttpOnlyCookie(resp, ZimbraCookie.COOKIE_ZM_JWT, finalValue, ZimbraCookie.PATH_ROOT, -1, true, this.isIgnoreSameSite());
         }
     }
 

--- a/store/src/java/com/zimbra/cs/service/account/Auth.java
+++ b/store/src/java/com/zimbra/cs/service/account/Auth.java
@@ -472,6 +472,7 @@ public class Auth extends AccountDocumentHandler {
                 HttpServletRequest httpReq = (HttpServletRequest) context.get(SoapServlet.SERVLET_REQUEST);
                 HttpServletResponse httpResp = (HttpServletResponse) context.get(SoapServlet.SERVLET_RESPONSE);
                 boolean rememberMe = requestElement.getAttributeBool(AccountConstants.A_PERSIST_AUTH_TOKEN_COOKIE, false);
+                authToken.setIgnoreSameSite(requestElement.getAttributeBool(AccountConstants.A_IGNORE_SAME_SITE_COOKIE, false));
                 authToken.encode(httpReq, httpResp, false, ZimbraCookie.secureCookie(httpReq), rememberMe);
             }
             response.addUniqueElement(AccountConstants.E_TRUSTED_DEVICES_ENABLED).setText(account.isFeatureTrustedDevicesEnabled() ? "true" : "false");
@@ -492,6 +493,7 @@ public class Auth extends AccountDocumentHandler {
         HttpServletRequest httpReq = (HttpServletRequest)context.get(SoapServlet.SERVLET_REQUEST);
         HttpServletResponse httpResp = (HttpServletResponse)context.get(SoapServlet.SERVLET_RESPONSE);
         boolean rememberMe = request.getAttributeBool(AccountConstants.A_PERSIST_AUTH_TOKEN_COOKIE, false);
+        at.setIgnoreSameSite(request.getAttributeBool(AccountConstants.A_IGNORE_SAME_SITE_COOKIE, false));
         at.encode(httpReq, httpResp, false, ZimbraCookie.secureCookie(httpReq), rememberMe);
 
         response.addAttribute(AccountConstants.E_LIFETIME, at.getExpires() - System.currentTimeMillis(), Element.Disposition.CONTENT);


### PR DESCRIPTION
**Problem**
User was not able to login in Zimbra Desktop when SameSite=Strict

**Fix**
Added a new boolean param in AuthRequest named ignoreSameSite, By default its value is false.
If it is set to true then SameSite=Strict will not be added in ZM_AUTH_TOKEN cookie.

**Testing**
Verified on local, able to login in zimbra desktop.

