### PR TITLE
ZCS-11344: set default value of SameSite cookie to empty

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -880,7 +880,7 @@ public final class LC {
     public static final KnownKey zimbra_deregistered_authtoken_queue_size = KnownKey.newKey(5000);
     public static final KnownKey zimbra_jwt_cookie_size_limit = KnownKey.newKey(4096);
     public static final KnownKey zimbra_authtoken_cookie_domain = KnownKey.newKey("");
-    public static final KnownKey zimbra_same_site_cookie = KnownKey.newKey("Strict");
+    public static final KnownKey zimbra_same_site_cookie = KnownKey.newKey("");
     public static final KnownKey zimbra_zmjava_options = KnownKey.newKey("-Xmx256m" +
             " -Dhttps.protocols=TLSv1.2,TLSv1.3" +
             " -Djdk.tls.client.protocols=TLSv1.2,TLSv1.3");


### PR DESCRIPTION
**Problem**

From regression testing, we found some login issues in Desktop and Web.

**Solution**
We have decided that we will set default value zimbra_same_site_cookie to Empty.