### PR TITLE
ZBUG-2662:When using preauth, CSRF tokens are not checked on some pos…

### DIFF
--- a/store/src/java/com/zimbra/cs/service/PreAuthServlet.java
+++ b/store/src/java/com/zimbra/cs/service/PreAuthServlet.java
@@ -248,6 +248,7 @@ public class PreAuthServlet extends ZimbraServlet {
                     else
                         at = (expires ==  0) ? AuthProvider.getAuthToken(acct) : AuthProvider.getAuthToken(acct, expires);
 
+                    at.setCsrfTokenEnabled(true);
                     setCookieAndRedirect(req, resp, at);
 
                 } else {


### PR DESCRIPTION
Solution
ZBUG-2662: When using preauth, CSRF tokens are not checked on some post endpoints
In a normal flow authentication with user and password the validation of csrfToken works properly but when you are using 
preauth authentication those validations are missing.
So in PreAuthServlet we have multiples conditions to create the authToken where is the property csrfTokenEnabled,
now it is required set this property as TRUE to make sure csrfToken validation will be present.

Notes
preauth authentication is a particular flow where is not required your password to go to mailbox client and use the
preauth key generated as authentication

Tests
Please see ticket for further details.