### PR TITLE
ZCS-10995: Activesync 16.0 : Changing one of the instance response from device as attendee is not syncing due to NullPointer exception

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/CalendarItem.java
+++ b/store/src/java/com/zimbra/cs/mailbox/CalendarItem.java
@@ -3525,6 +3525,8 @@ public abstract class CalendarItem extends MailItem {
                         } else {
                             localException.setMailItemId(reply.getMailItemId());
                         }
+                        sLog.debug("Exception invite for instanceId: %s with mailItemId: %s created", localException.getRecurId(),
+                                localException.getMailItemId());
                         mInvites.add(localException);
                         // create a fake ExceptionRule wrapper around the single-instance
                         recurrenceRule.addException(

--- a/store/src/java/com/zimbra/cs/mailbox/CalendarItem.java
+++ b/store/src/java/com/zimbra/cs/mailbox/CalendarItem.java
@@ -3522,6 +3522,8 @@ public abstract class CalendarItem extends MailItem {
                         if (itemIdGetter != null) {
                             /* ZWC expects a different mail item id for each exception */
                             localException.setMailItemId(itemIdGetter.get());
+                        } else {
+                            localException.setMailItemId(reply.getMailItemId());
                         }
                         mInvites.add(localException);
                         // create a fake ExceptionRule wrapper around the single-instance

--- a/store/src/java/com/zimbra/cs/mailbox/CalendarItem.java
+++ b/store/src/java/com/zimbra/cs/mailbox/CalendarItem.java
@@ -3523,7 +3523,7 @@ public abstract class CalendarItem extends MailItem {
                             /* ZWC expects a different mail item id for each exception */
                             localException.setMailItemId(itemIdGetter.get());
                         } else {
-                            localException.setMailItemId(reply.getMailItemId());
+                            localException.setMailItemId(reply.getMailItemId()); // ZCS-10995
                         }
                         sLog.debug("Exception invite for instanceId: %s with mailItemId: %s created", localException.getRecurId(),
                                 localException.getMailItemId());


### PR DESCRIPTION
**Problem:**
Replies from attendee on single instance caused meeting series update.
 
**Fix Made:**
* Added exception creation mechanism for the calendar event on attendee side.
* Every Exception should have a different mailItemId assigned. Handled it by adding an else block in mailbox.

**Use Case Tested - ActiveSync version 16.0:**
1. As n2 user from ZWC, send recurring meeting series invite to n1 user to attendee n1 on device
2. Sync calendar of n1 on device and accept meeting series
3. Modify one of the instance response to Maybe or Decline.
4. Verify that response email is sent to organizer and response is updated on attendee calendar in device and ZWC, organizer ZWC
 
 
**Note:**
This fix is for below tickets:
    * https://jira.corp.synacor.com/browse/ZCS-10995
    * https://jira.corp.synacor.com/browse/ZCS-11295
    * https://jira.corp.synacor.com/browse/ZCS-10903