### PR TITLE
ZCS-11318 Add zimbraWebClientSkipLogoff to ClientInfo. LC implementation for patch support.

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1485,6 +1485,10 @@ public final class LC {
 
     public static final KnownKey allow_username_within_password = KnownKey.newKey(false);
 
+    // TODO: ZCS-11319 move the following from LC to LDAP property.
+    // space-separated list of logout urls that are known to handle token de-registration.
+    public static final KnownKey zimbra_web_client_logoff_urls = KnownKey.newKey("");
+
     static {
         // Automatically set the key name with the variable name.
         for (Field field : LC.class.getFields()) {

--- a/store/src/java-test/com/zimbra/cs/service/account/ClientInfoTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/account/ClientInfoTest.java
@@ -1,0 +1,124 @@
+package com.zimbra.cs.service.account;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.zimbra.common.soap.AccountConstants;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.Element.KeyValuePair;
+import com.zimbra.common.soap.Element.XMLElement;
+
+public class ClientInfoTest {
+
+    protected static final String KEY_SKIP_LOGOFF = "zimbraWebClientSkipLogoff";
+
+    protected ClientInfo toTest = new ClientInfo();
+
+    protected Element parent;
+
+    @Before
+    public void setup() throws Exception {
+        parent =  new XMLElement(AccountConstants.CLIENT_INFO_RESPONSE);
+    }
+
+    @Test
+    public void testEncodeAttrSkipLogoffSingleLogoffURL() throws Exception {
+        String logoutURL = "https://localhost/service/extension/samllogout";
+
+        // test single known logoff url
+        toTest.encodeAttrSkipLogoff(parent, logoutURL, new String[] { logoutURL });
+
+        // verify skip logoff is true since the webclient logout url is a known logoff handler
+        List<KeyValuePair> pairs = parent.listKeyValuePairs(AccountConstants.E_ATTR, AccountConstants.E_NAME);
+        KeyValuePair pair = pairs.stream()
+            .filter(p -> KEY_SKIP_LOGOFF.equals(p.getKey()))
+            .findFirst().get();
+        assertTrue(Boolean.valueOf(pair.getValue()));
+    }
+
+    @Test
+    public void testEncodeAttrSkipLogoffMultipleLogoffURLs() throws Exception {
+        String url = "https://localhost/service/extension/samllogout";
+
+        // test multiple known logoff urls
+        toTest.encodeAttrSkipLogoff(parent, url, new String[] {
+            "https://localhost/service/extension/saml2slo",
+            url
+        });
+
+        // verify skip logoff is true since the webclient logout url is a known logoff handler
+        List<KeyValuePair> pairs = parent.listKeyValuePairs(AccountConstants.E_ATTR, AccountConstants.E_NAME);
+        KeyValuePair pair = pairs.stream()
+            .filter(p -> KEY_SKIP_LOGOFF.equals(p.getKey()))
+            .findFirst().get();
+        assertTrue(Boolean.valueOf(pair.getValue()));
+    }
+
+    @Test
+    public void testEncodeAttrSkipLogoffMultipleLogoffURLsNotInUse() throws Exception {
+        String url = "https://localhost/service/extension/samllogout";
+
+        // test multiple known logoff urls
+        toTest.encodeAttrSkipLogoff(parent, url, new String[] {
+            "https://localhost/service/extension/saml2slo",
+            "https://localhost/service/extension/extra",
+            "https://localhost/service/extension/example"
+        });
+
+        // verify skip logoff is false when logout url is not a known logoff handler
+        List<KeyValuePair> pairs = parent.listKeyValuePairs(AccountConstants.E_ATTR, AccountConstants.E_NAME);
+        KeyValuePair pair = pairs.stream()
+            .filter(p -> KEY_SKIP_LOGOFF.equals(p.getKey()))
+            .findFirst().get();
+        assertFalse(Boolean.valueOf(pair.getValue()));
+    }
+
+    @Test
+    public void testEncodeAttrSkipLogoffNoLogoffURLsNone() throws Exception {
+        String url = "https://localhost/service/extension/samllogout";
+
+        // test null known logoff urls
+        toTest.encodeAttrSkipLogoff(parent, url, new String[] {});
+
+        // verify skip logoff is false when logout url is not a known logoff handler
+        List<KeyValuePair> pairs = parent.listKeyValuePairs(AccountConstants.E_ATTR, AccountConstants.E_NAME);
+        KeyValuePair pair = pairs.stream()
+            .filter(p -> KEY_SKIP_LOGOFF.equals(p.getKey()))
+            .findFirst().get();
+        assertFalse(Boolean.valueOf(pair.getValue()));
+    }
+
+    @Test
+    public void testEncodeAttrSkipLogoffNoLogoffURLsNull() throws Exception {
+        String url = "https://localhost/service/extension/samllogout";
+
+        // test null known logoff urls
+        toTest.encodeAttrSkipLogoff(parent, url, null);
+
+        // verify skip logoff is false when logout url is not a known logoff handler
+        List<KeyValuePair> pairs = parent.listKeyValuePairs(AccountConstants.E_ATTR, AccountConstants.E_NAME);
+        KeyValuePair pair = pairs.stream()
+            .filter(p -> KEY_SKIP_LOGOFF.equals(p.getKey()))
+            .findFirst().get();
+        assertFalse(Boolean.valueOf(pair.getValue()));
+    }
+
+    @Test
+    public void testEncodeAttrSkipLogoffNoLogoffURLsEmpty() throws Exception {
+        String url = "https://localhost/service/extension/samllogout";
+
+        // test empty known logoff urls
+        toTest.encodeAttrSkipLogoff(parent, url, new String[]{ "" });
+
+        // verify skip logoff is false when logout url is not a known logoff handler
+        List<KeyValuePair> pairs = parent.listKeyValuePairs(AccountConstants.E_ATTR, AccountConstants.E_NAME);
+        KeyValuePair pair = pairs.stream()
+            .filter(p -> KEY_SKIP_LOGOFF.equals(p.getKey()))
+            .findFirst().get();
+        assertFalse(Boolean.valueOf(pair.getValue()));
+    }
+}


### PR DESCRIPTION
Webclient needs the list of SAML extension logout urls to be compared with **zimbraWebClientLogoutURL** during ClientInfoRequest and to decide whether to skip logoff of token de-registration. 

During ClientInfoRequest, backend will read this list from LC **zimbra_web_client_logoff_urls** which will be a space separated list of URLs and compare to **zimbraWebClientLogoutURL** for any match and if present will respond with zimbraWebClientSkipLogoff TRUE else FALSE

* Webclient can use this to end session, then send the user to the logout url to end tokens.