### PR TITLE
ZCS:-11349: Toggle off/on direct searches for autocomplete

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1488,6 +1488,9 @@ public final class LC {
     // TODO: ZCS-11319 move the following from LC to LDAP property.
     // space-separated list of logout urls that are known to handle token de-registration.
     public static final KnownKey zimbra_web_client_logoff_urls = KnownKey.newKey("");
+    
+    // ZCS-11349: Toggle off/on fallback to ldap search
+    public static final KnownKey zimbra_gal_fallback_ldap_search_enabled = KnownKey.newKey(true);
 
     static {
         // Automatically set the key name with the variable name.


### PR DESCRIPTION
**Problem:**
Toggle off direct searches for autocomplete and galsync against Zimbra LDAP

**Solution:**
Created a localconfig attribute **zimbra_gal_fallback_ldap_search_enabled** to toggle off/on direct searches for autocomplete and galsync against Zimbra LDAP. 
The default value of this attribute is TRUE.