### PR TITLE
ZCS-11372: updating domain info attrs to include zimbraWebClientSkipLogoff during login

### DIFF
--- a/store/src/java/com/zimbra/cs/service/admin/GetDomainInfo.java
+++ b/store/src/java/com/zimbra/cs/service/admin/GetDomainInfo.java
@@ -140,6 +140,10 @@ public class GetDomainInfo extends AdminDocumentHandler {
                 for (String attr : bootstrapInfoAttrs) {
                     addAttrElementIfNotNull(entry, domain, attr);
                 }
+                if (entry instanceof Domain) {
+                    Domain d = (Domain)entry;
+                    addAttrSkipLogoff(domain, d.getWebClientLogoutURL(), StringUtils.split(LC.zimbra_web_client_logoff_urls.value()));
+                }
             }
             return;
         }


### PR DESCRIPTION
Issue
New attribute added GetDomainInfoResponse in https://github.com/Zimbra/zm-mailbox/pull/1264 was missing the attribute zimbraWebClientSkipLogoff during login when user is not authenticated.

Fix
Included the attribute zimbraWebClientSkipLogoff in GetDomainInfoResponse during login