### PR TITLE
ZCS-11402:Null Pointer Exception while creating Account when Local Config allow_username_within_password is set to true

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1483,7 +1483,7 @@ public final class LC {
 
     public static final KnownKey invite_ignore_x_alt_description = KnownKey.newKey(true);
 
-    public static final KnownKey allow_username_within_password = KnownKey.newKey(false);
+    public static final KnownKey allow_username_within_password = KnownKey.newKey(true);
 
     // TODO: ZCS-11319 move the following from LC to LDAP property.
     // space-separated list of logout urls that are known to handle token de-registration.


### PR DESCRIPTION
https://jira.corp.synacor.com/browse/ZCS-11402

Issue:
Null Pointer Exception while creating Account when Local Config allow_username_within_password is set to true

Code fix:
The issue was basically in `checkPasswordStrength()` method the comparison of `password` and `username` was based on the username available from the account object. But while creating an account `acct` object passed was null hence when we try to get the username out of null we would get NPE. To resolve this created an overloaded method that accepts `username` in the parameter and modified the comparison based on the username available or not

Testing:
Creating Account from Admin UI, Terminal. Tested the Restpassword and Changepassword API. Working as expected