### PR TITLE
ZCS-11435 : Adding port and protocol in syslogger

### DIFF
--- a/store-conf/conf/log4j.properties.production
+++ b/store-conf/conf/log4j.properties.production
@@ -129,6 +129,8 @@ appender.EWS.strategy.type = DefaultRolloverStrategy
 appender.SYSLOG.type = Syslog
 appender.SYSLOG.name = syslogAppender
 appender.SYSLOG.host = localhost
+appender.SYSLOG.port = 514
+appender.SYSLOG.protocol = UDP
 appender.SYSLOG.facility = LOCAL0
 appender.SYSLOG.layout.type = PatternLayout
 appender.SYSLOG.layout.pattern = mailboxd: %-5p [%t] [%z] %c{1} - %m
@@ -138,6 +140,8 @@ appender.SYSLOG.layout.pattern = mailboxd: %-5p [%t] [%z] %c{1} - %m
 %%comment VAR:!zimbraLogHostname%%appender.SLOGGER.name = sloggerAppender
 %%comment VAR:!zimbraLogHostname%%appender.SLOGGER.host = %%zimbraLogHostname%%
 %%comment VAR:!zimbraLogHostname%%appender.SLOGGER.facility = LOCAL1
+%%comment VAR:!zimbraLogHostname%%appender.SLOGGER.port = 514
+%%comment VAR:!zimbraLogHostname%%appender.SLOGGER.protocol = UDP
 %%comment VAR:!zimbraLogHostname%%appender.SLOGGER.layout.type = PatternLayout
 %%comment VAR:!zimbraLogHostname%%appender.SLOGGER.layout.pattern = mailboxd: %-5p [%t] [%z] %c{1} - %m
 

--- a/store/build.xml
+++ b/store/build.xml
@@ -272,6 +272,7 @@
     <!-- delete anything that may have been left over, e.g.: older versions of same libs -->
     <ivy:install organisation="org.slf4j" module="slf4j-api" revision="1.7.36" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.slf4j" module="slf4j-simple" revision="1.7.36" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
+    <ivy:install organisation="org.apache.logging.log4j" module="log4j-slf4j-impl" revision="2.17.1" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.apache.james" module="apache-jsieve-core" revision="0.5" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.apache.lucene" module="lucene-core" revision="3.5.0" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.apache.lucene" module="lucene-analyzers" revision="3.5.0" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>

--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -17,6 +17,7 @@
   <dependency org="org.javassist" name="javassist" rev="3.18.2-GA" />
   <dependency org="org.slf4j" name="slf4j-api" rev="1.7.36"/>
   <dependency org="org.slf4j" name="slf4j-simple" rev="1.7.36"/>
+  <dependency org="org.apache.logging.log4j" name="log4j-slf4j-impl" rev="2.17.1" />
   <dependency org="junit" name="junit" rev="4.8.2" />
   <dependency org="javax.mail" name="mail" rev="1.4.5" />
   <dependency org="jaxen" name="jaxen" rev="1.1-beta-10"/>


### PR DESCRIPTION
Issue1 :- Getting error in zmmailbox.out
2022-05-24 10:17:10,417 threads.csv ERROR Unable to write to stream TCP:zqa-226.eng.zimbra.com:4560 for appender sloggerAppender org.apache.logging.log4j.core.appender.AppenderLoggingException: Error writing to TCP:zqa-226.eng.zimbra.com:4560: socket not available
        at org.apache.logging.log4j.core.net.TcpSocketManager.write(TcpSocketManager.java:214)
        at org.apache.logging.log4j.core.appender.OutputStreamManager.write(OutputStreamManager.java:190)
        
 Solution:- An upgrade to log42 requires change in the default port of system logger i.e. 514 and protocol needs to be mentioned.
 
 Reference :-
![image](https://user-images.githubusercontent.com/37224867/170371475-51bf89a2-43a3-4f87-bf0c-764561dd2b9d.png)



Issue 2:- Getting below in the logs.
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.

Solution:- 
To fix it, we need a SLF4J Bridge. Puts log4j-slf4j-impl in the classpath.

Added <dependency org="org.apache.logging.log4j" name="log4j-slf4j-impl" rev="2.17.2" />
in ivy and build.xml

Reference :- 
https://logging.apache.org/log4j/2.x/maven-artifacts.html
