### PR TITLE
Revert "ZBUG-2310:Emailed contacts not updating"

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/MailSender.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailSender.java
@@ -54,7 +54,6 @@ import com.zimbra.common.localconfig.DebugConfig;
 import com.zimbra.common.mime.shim.JavaMailInternetAddress;
 import com.zimbra.common.mime.shim.JavaMailInternetHeaders;
 import com.zimbra.common.service.ServiceException;
-import com.zimbra.common.soap.MailConstants;
 import com.zimbra.common.util.ArrayUtil;
 import com.zimbra.common.util.ByteUtil;
 import com.zimbra.common.util.ListUtil;
@@ -75,7 +74,6 @@ import com.zimbra.cs.mailbox.Threader.ThreadIndex;
 import com.zimbra.cs.mime.Mime;
 import com.zimbra.cs.mime.MimeProcessor;
 import com.zimbra.cs.mime.MimeVisitor;
-import com.zimbra.cs.mime.ParsedContact;
 import com.zimbra.cs.mime.ParsedMessage;
 import com.zimbra.cs.service.AuthProvider;
 import com.zimbra.cs.service.FileUploadServlet;
@@ -624,12 +622,9 @@ public class MailSender {
             // To avoid this problem; let's determine a list of new address which we might need to add to emailed
             // contact later before we add the message to sent folder.
             Collection<Address> newAddrs = Collections.emptySet();
-            List<Map<com.zimbra.common.mime.InternetAddress, Pair<Integer, String>>> modifyAddrs = Collections.emptyList();
             Address[] rcptAddresses = getRecipients(mm);
-            if (rcptAddresses != null && rcptAddresses.length > 0) {
+            if (rcptAddresses != null && rcptAddresses.length > 0)
                 newAddrs = mbox.newContactAddrs(Arrays.asList(rcptAddresses));
-                modifyAddrs = mbox.findContactsInEmailedContacts(octxt, Arrays.asList(rcptAddresses));
-            }
 
             if (mimeProcessor != null) {
                 try {
@@ -788,12 +783,7 @@ public class MailSender {
                         }
                     }
                     try {
-                        if (!newAddrs.isEmpty()) {
-                            mbox.createAutoContact(octxt, iaddrs);
-                        }
-                        if (!modifyAddrs.isEmpty()) {
-                            mbox.modifyAutoContact(octxt, modifyAddrs);
-                        }
+                        mbox.createAutoContact(octxt, iaddrs);
                     } catch (IOException e) {
                         ZimbraLog.smtp.warn("Failed to auto-add contact addrs=%s", iaddrs, e);
                     }
@@ -801,6 +791,7 @@ public class MailSender {
             }
 
             return returnItemId;
+
         } catch (SafeSendFailedException sfe) {
             Address[] invalidAddrs = sfe.getInvalidAddresses();
             Address[] validUnsentAddrs = sfe.getValidUnsentAddresses();

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -79,7 +79,6 @@ import com.zimbra.common.localconfig.DebugConfig;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.mailbox.BaseItemInfo;
 import com.zimbra.common.mailbox.Color;
-import com.zimbra.common.mailbox.ContactConstants;
 import com.zimbra.common.mailbox.ExistingParentFolderStoreAndUnmatchedPart;
 import com.zimbra.common.mailbox.FolderConstants;
 import com.zimbra.common.mailbox.FolderStore;
@@ -94,7 +93,6 @@ import com.zimbra.common.mime.InternetAddress;
 import com.zimbra.common.mime.MimeConstants;
 import com.zimbra.common.mime.Rfc822ValidationInputStream;
 import com.zimbra.common.service.ServiceException;
-import com.zimbra.common.soap.MailConstants;
 import com.zimbra.common.soap.SoapProtocol;
 import com.zimbra.common.util.ArrayUtil;
 import com.zimbra.common.util.BufferStream;
@@ -133,13 +131,11 @@ import com.zimbra.cs.html.BrowserDefang;
 import com.zimbra.cs.html.DefangFactory;
 import com.zimbra.cs.imap.ImapMessage;
 import com.zimbra.cs.index.BrowseTerm;
-import com.zimbra.cs.index.ContactHit;
 import com.zimbra.cs.index.DomainBrowseTerm;
 import com.zimbra.cs.index.IndexDocument;
 import com.zimbra.cs.index.LuceneFields;
 import com.zimbra.cs.index.SearchParams;
 import com.zimbra.cs.index.SortBy;
-import com.zimbra.cs.index.ZimbraHit;
 import com.zimbra.cs.index.ZimbraQuery;
 import com.zimbra.cs.index.ZimbraQueryResults;
 import com.zimbra.cs.ldap.LdapConstants;
@@ -320,8 +316,6 @@ public class Mailbox implements MailboxStore {
 
 
     public static final String CONF_PREVIOUS_MAILBOX_IDS = "prev_mbox_ids";
-    
-    public static final String JAPANESE_LOCALE_CODE = "ja";
 
     public static final class MailboxData implements Cloneable {
         public int id;
@@ -8142,7 +8136,7 @@ public class Mailbox implements MailboxStore {
         List<Contact> result = new ArrayList<Contact>(addrs.size());
         String locale = octxt != null && octxt.getAuthenticatedUser() != null ? octxt.getAuthenticatedUser().getPrefLocale() : null;
         boolean nameFormatLastFirst = false;
-        if (locale != null && locale.equals(JAPANESE_LOCALE_CODE)) {
+        if (locale != null && locale.equals("ja")) {
             nameFormatLastFirst = true;
         }
         for (InternetAddress addr : addrs) {
@@ -8160,34 +8154,6 @@ public class Mailbox implements MailboxStore {
             }
         }
         return result;
-    }
-
-    /**
-     * It modifies contact's first and full name with display name
-     * @param octxt
-     * @param listOfContactsToBeModified This list consist list of Map, InternetAddress as key and Pair of ContactId and
-     * DisplayName as Value
-     */
-    public void modifyAutoContact(OperationContext octxt, List<Map<InternetAddress, Pair<Integer, String>>> listOfContactsToBeModified)
-            throws IOException {
-        String email = null;
-        String locale = octxt != null && octxt.getAuthenticatedUser() != null ? octxt.getAuthenticatedUser().getPrefLocale() : null;
-        boolean nameFormatLastFirst = false;
-        if (locale != null && locale.equals(JAPANESE_LOCALE_CODE)) {
-            nameFormatLastFirst = true;
-        }
-        for (Map<InternetAddress, Pair<Integer, String>> map : listOfContactsToBeModified) {
-            try {
-                for (InternetAddress address : map.keySet()) {
-                    email = address.getAddress();
-                    ZimbraLog.mailbox.debug("Modifying contact addr=%s", email);
-                    ParsedContact pc = new ParsedContact(new ParsedAddress(address, nameFormatLastFirst).getAttributes());
-                    modifyContact(octxt, map.get(address).getFirst(), pc);
-                }
-            } catch (Exception e) {
-                ZimbraLog.mailbox.warn("Failed to modify contact addr=%s", email, e);
-            }
-        }
     }
 
     /**
@@ -8222,54 +8188,6 @@ public class Mailbox implements MailboxStore {
             }
         }
         return newAddrs;
-    }
-    
-    /**
-     * Returns a list of contacts exist in emailed contacts folders.
-     * @param octxt OperationContext object
-     * @param addrs Recipient Email address list
-     * @return listOfContactsToBeModified This list consist list of Map, InternetAddress as key and Pair of ContactId and
-     * DisplayName as Value
-     * @throws ServiceException
-     */
-    public List<Map<InternetAddress, Pair<Integer, String>>> findContactsInEmailedContacts
-    (OperationContext octxt, Collection<Address> addrs) throws ServiceException {
-        if (addrs.isEmpty()) {
-            return Collections.emptyList();
-        }
-        List<Map<InternetAddress, Pair<Integer, String>>> list = new ArrayList<>();
-        Map<InternetAddress, Pair<Integer, String>> map = new HashMap<>();
-
-        for (Address addr : addrs) {
-            if (addr instanceof javax.mail.internet.InternetAddress) {
-                javax.mail.internet.InternetAddress iaddr = (javax.mail.internet.InternetAddress) addr;
-                try {
-                    if (!Strings.isNullOrEmpty(iaddr.getAddress())) {
-                        ZimbraQueryResults results = index.search(octxt, "inid:" + FolderConstants.ID_FOLDER_AUTO_CONTACTS + " field[email]:" + iaddr.getAddress(),
-                                EnumSet.of(MailItem.Type.CONTACT), SortBy.NONE, 1);
-                        while (results.hasNext()) {
-                            ZimbraHit hit = results.getNext();
-                            if (hit instanceof ContactHit) {
-                                ContactHit contactHit = (ContactHit) hit;
-                                Contact contact = contactHit.getContact();
-                                Map<String, String> m = contact.getFields();
-                                String fullName = m.get(ContactConstants.A_fullName);
-                                String emailSentName = iaddr.getPersonal();
-                                if (!Strings.isNullOrEmpty(fullName) && !Strings.isNullOrEmpty(emailSentName)
-                                        && !emailSentName.equals(fullName)) {
-                                    map.put(new InternetAddress(iaddr.getPersonal(), iaddr.getAddress()),
-                                            new Pair<Integer, String>(contactHit.getItemId(), iaddr.getPersonal()));
-                                    list.add(map);
-                                }
-                            }
-                        }
-                    }
-                } catch (ServiceException e) {
-                    ZimbraLog.search.error("error searching index for contacts." + e);
-                }
-            }
-        }
-        return list;
     }
 
     @Deprecated


### PR DESCRIPTION
**Problem:**
Error 502 issue while executing SOAP automation on Zimbra 9 Patch25 and 8815 Patch32 builds

**Impact:** 
During soap automation, QA found 502 and 504 errors.

**Solution:**
For the next release, we are reverting the ZBUG-2310 fix and will work on the new solution. 


