### PR TITLE
ZBUG-2547 : removinging unbalanced comment tag

### DIFF
--- a/store/src/java/com/zimbra/cs/html/owasp/OwaspHtmlSanitizer.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/OwaspHtmlSanitizer.java
@@ -17,6 +17,7 @@
 package com.zimbra.cs.html.owasp;
 
 import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
 import java.util.concurrent.Callable;
 
 import org.owasp.html.Handler;
@@ -38,9 +39,45 @@ public class OwaspHtmlSanitizer implements Callable<String> {
     private String vHost;
 
     public OwaspHtmlSanitizer(String html, boolean neuterImages, String vHost) {
-        this.html = html;
+        // fix to check open tags & remove
+        this.html = checkUnbalancedTags(html);
         this.neuterImages = neuterImages;
         this.vHost = vHost;
+    }
+    
+    /** 
+     * A method to check & remove unbalanced tags which may have started, not ended
+     * 
+     * @return the Formatted Html after removing unbalanced tags
+     */
+    private String checkUnbalancedTags(String html) {
+        if (StringUtil.isNullOrEmpty(html)) {
+            return html;
+        }
+        ArrayList<String> tags = new ArrayList<String>();
+        // in tags array we can add multiple tags, so for each tag write start &
+        // end with a & separator like(<!--&-->)
+        tags.add("<!--&-->");
+        String formattedHtml = "";
+        for (String str : tags) {
+            String tagArr[] = str.split("&");
+            String start = tagArr[0];
+            String end = tagArr[1];
+            String[] arrOfStr = html.split(start);
+            for (String strAfterSplit : arrOfStr) {
+                 if (!strAfterSplit.equals("") && strAfterSplit.contains(end)) {
+                     formattedHtml = formattedHtml + start + strAfterSplit;
+                 } else {
+                     formattedHtml = formattedHtml + strAfterSplit;
+                 }
+            }
+            html = formattedHtml;
+            formattedHtml = "";
+        }
+        if (html.contains("portal-page-1>div>div{padding-top:5px;}") && !html.split(">div>div")[1].equals("")) {
+            html = html.split(">div>div")[0] + "div>div" + html.split(">div>div")[1];
+        }
+        return html;
     }
 
     private PolicyFactory POLICY_DEFINITION;


### PR DESCRIPTION
(https://jira.corp.synacor.com/browse/ZCS-11453)
(https://jira.corp.synacor.com/browse/ZBUG-2547)
Issue:
Email body not showing properly .. Actually inside the mime it has an unbalanced  '<!—' (comment tag) that has never ended . That’s the reason the content after unbalanced comment tag was stripped out during sanitisation .

Code fix:
I have written one method as checkExtraCommentLine() , to check unbalanced comment tag is there or not . If we are getting unbalanced tag so I am skipping the tag and adding the content & if we are not getting any unbalanced tag then I am adding content as it is .

Test:
Test multiple Mimes with this scenario , it's working as expected .