### PR TITLE
ZCS-11367: adding java options for JDK 17 performance tunning

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -599,7 +599,9 @@ public final class LC {
             " -XX:G1MaxNewSizePercent=45" +
             " -XX:-OmitStackTraceInFastThrow" +
             " -verbose:gc" +
-            " -Xlog:gc*=info,safepoint=info:file=/opt/zimbra/log/gc.log:time:filecount=20,filesize=10m");
+            " -Xlog:gc*=info,safepoint=info:file=/opt/zimbra/log/gc.log:time:filecount=20,filesize=10m" +
+            " -Djava.security.egd=file:/dev/./urandom" +
+            " --add-opens java.base/java.lang=ALL-UNNAMED");
     @Supported
     public static final KnownKey mailboxd_pidfile = KnownKey.newKey("${zimbra_log_directory}/mailboxd.pid");
 


### PR DESCRIPTION
Issue
With JDK 17 update there were issue seen of thread locks in some load tests and some of the features working.
For e.g. Admin console test were having issue waiting for thread locks, 
```
"qtp572191680-2105:https://zqa-234.eng.zimbra.com:7071/service/admin/soap/GetCertRequest" #2105 prio=5 os_prio=0 cpu=22.97ms elapsed=214.24s tid=0x0000559d344e61c0 nid=0x173 waiting for monitor entry  [0x00007f5ae68ef000]
   java.lang.Thread.State: BLOCKED (on object monitor)
        at sun.security.provider.NativePRNG$RandomIO.implGenerateSeed(java.base@17.0.2/NativePRNG.java:441)
        - waiting to lock <0x00000000a4b8d1c8> (a java.lang.Object)
        at sun.security.provider.NativePRNG.engineGenerateSeed(java.base@17.0.2/NativePRNG.java:227)
```
```
java.lang.reflect.InaccessibleObjectException: Unable to make protected final java.lang.Class java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int) throws java.lang.ClassFormatError accessible: module java.base does not "opens java.lang" to unnamed module @92765af
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
```
Fix
Added java options -Djava.security.egd=file:/dev/./urandom & --add-opens java.base/java.lang=ALL-UNNAMED to fix the issue

Tests were performed with these options to for resolutions and tests were passed fine and features worked fine.