### PR TITLE
ZCS-11425 Configure LDAP attributes for storing S3 configurations

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -2708,6 +2708,14 @@ public class ZAttrProvisioning {
     public static final String A_givenName = "givenName";
 
     /**
+     * Global level external store config
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=5000)
+    public static final String A_globalExternalStoreConfig = "globalExternalStoreConfig";
+
+    /**
      * RFC2256: first name(s) for which the entity is known by
      */
     @ZAttr(id=-1)
@@ -2814,6 +2822,14 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=-1)
     public static final String A_registeredAddress = "registeredAddress";
+
+    /**
+     * Server level external store config
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=5001)
+    public static final String A_serverExternalStoreConfig = "serverExternalStoreConfig";
 
     /**
      * RFC2256: last (family) name(s) for which the entity is known by

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -2708,14 +2708,6 @@ public class ZAttrProvisioning {
     public static final String A_givenName = "givenName";
 
     /**
-     * Global level external store config
-     *
-     * @since ZCS 9.1.0
-     */
-    @ZAttr(id=5000)
-    public static final String A_globalExternalStoreConfig = "globalExternalStoreConfig";
-
-    /**
      * RFC2256: first name(s) for which the entity is known by
      */
     @ZAttr(id=-1)
@@ -2822,14 +2814,6 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=-1)
     public static final String A_registeredAddress = "registeredAddress";
-
-    /**
-     * Server level external store config
-     *
-     * @since ZCS 9.1.0
-     */
-    @ZAttr(id=5001)
-    public static final String A_serverExternalStoreConfig = "serverExternalStoreConfig";
 
     /**
      * RFC2256: last (family) name(s) for which the entity is known by
@@ -7912,6 +7896,14 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=1254)
     public static final String A_zimbraGlobalConfigExtraObjectClass = "zimbraGlobalConfigExtraObjectClass";
+
+    /**
+     * Global level external store config
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=5000)
+    public static final String A_zimbraGlobalExternalStoreConfig = "zimbraGlobalExternalStoreConfig";
 
     /**
      * zimbraId of the main dynamic group for the dynamic group unit
@@ -15811,6 +15803,14 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=2071)
     public static final String A_zimbraScheduledTaskRetryPolicy = "zimbraScheduledTaskRetryPolicy";
+
+    /**
+     * Server level external store config
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=5001)
+    public static final String A_zimbraServerExternalStoreConfig = "zimbraServerExternalStoreConfig";
 
     /**
      * Object classes to add when creating a zimbra server object.

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9929,4 +9929,10 @@ TODO: delete them permanently from here
   <defaultCOSValue>30</defaultCOSValue>
   <desc>Default calendar resolution preference</desc>
 </attr>
+<attr id="5000" name="globalExternalStoreConfig" type="string" cardinality="single" optionalIn="globalConfig" since="9.1.0">
+  <desc>Global level external store config</desc>
+</attr>
+<attr id="5001" name="serverExternalStoreConfig" type="string" cardinality="single" optionalIn="server" since="9.1.0">
+  <desc>Server level external store config</desc>
+</attr>
 </attrs>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9929,10 +9929,10 @@ TODO: delete them permanently from here
   <defaultCOSValue>30</defaultCOSValue>
   <desc>Default calendar resolution preference</desc>
 </attr>
-<attr id="5000" name="globalExternalStoreConfig" type="string" cardinality="single" optionalIn="globalConfig" since="9.1.0">
+<attr id="5000" name="zimbraGlobalExternalStoreConfig" type="string" cardinality="single" optionalIn="globalConfig" since="9.1.0">
   <desc>Global level external store config</desc>
 </attr>
-<attr id="5001" name="serverExternalStoreConfig" type="string" cardinality="single" optionalIn="server" since="9.1.0">
+<attr id="5001" name="zimbraServerExternalStoreConfig" type="string" cardinality="single" optionalIn="server" since="9.1.0">
   <desc>Server level external store config</desc>
 </attr>
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -165,78 +165,6 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Global level external store config
-     *
-     * @return globalExternalStoreConfig, or null if unset
-     *
-     * @since ZCS 9.1.0
-     */
-    @ZAttr(id=5000)
-    public String getGlobalExternalStoreConfig() {
-        return getAttr(Provisioning.A_globalExternalStoreConfig, null, true);
-    }
-
-    /**
-     * Global level external store config
-     *
-     * @param globalExternalStoreConfig new value
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 9.1.0
-     */
-    @ZAttr(id=5000)
-    public void setGlobalExternalStoreConfig(String globalExternalStoreConfig) throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_globalExternalStoreConfig, globalExternalStoreConfig);
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Global level external store config
-     *
-     * @param globalExternalStoreConfig new value
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 9.1.0
-     */
-    @ZAttr(id=5000)
-    public Map<String,Object> setGlobalExternalStoreConfig(String globalExternalStoreConfig, Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_globalExternalStoreConfig, globalExternalStoreConfig);
-        return attrs;
-    }
-
-    /**
-     * Global level external store config
-     *
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 9.1.0
-     */
-    @ZAttr(id=5000)
-    public void unsetGlobalExternalStoreConfig() throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_globalExternalStoreConfig, "");
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Global level external store config
-     *
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 9.1.0
-     */
-    @ZAttr(id=5000)
-    public Map<String,Object> unsetGlobalExternalStoreConfig(Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_globalExternalStoreConfig, "");
-        return attrs;
-    }
-
-    /**
      * Zimbra access control list
      *
      * @return zimbraACE, or empty array if unset
@@ -19645,6 +19573,78 @@ public abstract class ZAttrConfig extends Entry {
     public Map<String,Object> unsetGlobalConfigExtraObjectClass(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraGlobalConfigExtraObjectClass, "");
+        return attrs;
+    }
+
+    /**
+     * Global level external store config
+     *
+     * @return zimbraGlobalExternalStoreConfig, or null if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=5000)
+    public String getGlobalExternalStoreConfig() {
+        return getAttr(Provisioning.A_zimbraGlobalExternalStoreConfig, null, true);
+    }
+
+    /**
+     * Global level external store config
+     *
+     * @param zimbraGlobalExternalStoreConfig new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=5000)
+    public void setGlobalExternalStoreConfig(String zimbraGlobalExternalStoreConfig) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraGlobalExternalStoreConfig, zimbraGlobalExternalStoreConfig);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Global level external store config
+     *
+     * @param zimbraGlobalExternalStoreConfig new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=5000)
+    public Map<String,Object> setGlobalExternalStoreConfig(String zimbraGlobalExternalStoreConfig, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraGlobalExternalStoreConfig, zimbraGlobalExternalStoreConfig);
+        return attrs;
+    }
+
+    /**
+     * Global level external store config
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=5000)
+    public void unsetGlobalExternalStoreConfig() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraGlobalExternalStoreConfig, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Global level external store config
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=5000)
+    public Map<String,Object> unsetGlobalExternalStoreConfig(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraGlobalExternalStoreConfig, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -165,6 +165,78 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Global level external store config
+     *
+     * @return globalExternalStoreConfig, or null if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=5000)
+    public String getGlobalExternalStoreConfig() {
+        return getAttr(Provisioning.A_globalExternalStoreConfig, null, true);
+    }
+
+    /**
+     * Global level external store config
+     *
+     * @param globalExternalStoreConfig new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=5000)
+    public void setGlobalExternalStoreConfig(String globalExternalStoreConfig) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_globalExternalStoreConfig, globalExternalStoreConfig);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Global level external store config
+     *
+     * @param globalExternalStoreConfig new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=5000)
+    public Map<String,Object> setGlobalExternalStoreConfig(String globalExternalStoreConfig, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_globalExternalStoreConfig, globalExternalStoreConfig);
+        return attrs;
+    }
+
+    /**
+     * Global level external store config
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=5000)
+    public void unsetGlobalExternalStoreConfig() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_globalExternalStoreConfig, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Global level external store config
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=5000)
+    public Map<String,Object> unsetGlobalExternalStoreConfig(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_globalExternalStoreConfig, "");
+        return attrs;
+    }
+
+    /**
      * Zimbra access control list
      *
      * @return zimbraACE, or empty array if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -225,78 +225,6 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Server level external store config
-     *
-     * @return serverExternalStoreConfig, or null if unset
-     *
-     * @since ZCS 9.1.0
-     */
-    @ZAttr(id=5001)
-    public String getServerExternalStoreConfig() {
-        return getAttr(Provisioning.A_serverExternalStoreConfig, null, true);
-    }
-
-    /**
-     * Server level external store config
-     *
-     * @param serverExternalStoreConfig new value
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 9.1.0
-     */
-    @ZAttr(id=5001)
-    public void setServerExternalStoreConfig(String serverExternalStoreConfig) throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_serverExternalStoreConfig, serverExternalStoreConfig);
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Server level external store config
-     *
-     * @param serverExternalStoreConfig new value
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 9.1.0
-     */
-    @ZAttr(id=5001)
-    public Map<String,Object> setServerExternalStoreConfig(String serverExternalStoreConfig, Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_serverExternalStoreConfig, serverExternalStoreConfig);
-        return attrs;
-    }
-
-    /**
-     * Server level external store config
-     *
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 9.1.0
-     */
-    @ZAttr(id=5001)
-    public void unsetServerExternalStoreConfig() throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_serverExternalStoreConfig, "");
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Server level external store config
-     *
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 9.1.0
-     */
-    @ZAttr(id=5001)
-    public Map<String,Object> unsetServerExternalStoreConfig(Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_serverExternalStoreConfig, "");
-        return attrs;
-    }
-
-    /**
      * Zimbra access control list
      *
      * @return zimbraACE, or empty array if unset
@@ -46782,6 +46710,78 @@ public abstract class ZAttrServer extends NamedEntry {
     public Map<String,Object> unsetScheduledTaskNumThreads(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraScheduledTaskNumThreads, "");
+        return attrs;
+    }
+
+    /**
+     * Server level external store config
+     *
+     * @return zimbraServerExternalStoreConfig, or null if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=5001)
+    public String getServerExternalStoreConfig() {
+        return getAttr(Provisioning.A_zimbraServerExternalStoreConfig, null, true);
+    }
+
+    /**
+     * Server level external store config
+     *
+     * @param zimbraServerExternalStoreConfig new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=5001)
+    public void setServerExternalStoreConfig(String zimbraServerExternalStoreConfig) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraServerExternalStoreConfig, zimbraServerExternalStoreConfig);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Server level external store config
+     *
+     * @param zimbraServerExternalStoreConfig new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=5001)
+    public Map<String,Object> setServerExternalStoreConfig(String zimbraServerExternalStoreConfig, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraServerExternalStoreConfig, zimbraServerExternalStoreConfig);
+        return attrs;
+    }
+
+    /**
+     * Server level external store config
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=5001)
+    public void unsetServerExternalStoreConfig() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraServerExternalStoreConfig, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Server level external store config
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=5001)
+    public Map<String,Object> unsetServerExternalStoreConfig(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraServerExternalStoreConfig, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -225,6 +225,78 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
+     * Server level external store config
+     *
+     * @return serverExternalStoreConfig, or null if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=5001)
+    public String getServerExternalStoreConfig() {
+        return getAttr(Provisioning.A_serverExternalStoreConfig, null, true);
+    }
+
+    /**
+     * Server level external store config
+     *
+     * @param serverExternalStoreConfig new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=5001)
+    public void setServerExternalStoreConfig(String serverExternalStoreConfig) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_serverExternalStoreConfig, serverExternalStoreConfig);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Server level external store config
+     *
+     * @param serverExternalStoreConfig new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=5001)
+    public Map<String,Object> setServerExternalStoreConfig(String serverExternalStoreConfig, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_serverExternalStoreConfig, serverExternalStoreConfig);
+        return attrs;
+    }
+
+    /**
+     * Server level external store config
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=5001)
+    public void unsetServerExternalStoreConfig() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_serverExternalStoreConfig, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Server level external store config
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=5001)
+    public Map<String,Object> unsetServerExternalStoreConfig(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_serverExternalStoreConfig, "");
+        return attrs;
+    }
+
+    /**
      * Zimbra access control list
      *
      * @return zimbraACE, or empty array if unset


### PR DESCRIPTION
**Problem Statement**
Add LDAP attributes to store S3 configurations

**Solution**
Added New Attributes:
1. globalExternalStoreConfig -> global level
2. serverExternalStoreConfig -> server level
