### PR TITLE
ZBUG-2390: Briefcase content accessible without 2FA

### DIFF
--- a/store/src/java/com/zimbra/cs/service/UserServlet.java
+++ b/store/src/java/com/zimbra/cs/service/UserServlet.java
@@ -382,8 +382,7 @@ public class UserServlet extends ZimbraServlet {
             checkTargetAccountStatus(context);
 
             if (!checkTwoFactorAuthentication(context)) {
-                resp.addHeader(AuthUtil.WWW_AUTHENTICATE_HEADER, getRealmHeader(req, null));
-                resp.sendError(HttpServletResponse.SC_UNAUTHORIZED, L10nUtil.getMessage(MsgKey.errMustAuthenticate, req));
+                throw ServiceException.AUTH_REQUIRED(String.format("two factor auth is required"));
             }
 
             if (proxyIfRemoteTargetAccount(req, resp, context)) {
@@ -405,6 +404,8 @@ public class UserServlet extends ZimbraServlet {
         } catch (ServiceException se) {
             if (se.getCode() == ServiceException.PERM_DENIED || se instanceof NoSuchItemException)
                 sendError(context, req, resp, L10nUtil.getMessage(MsgKey.errNoSuchItem, req));
+            else if (se.getCode() == ServiceException.AUTH_REQUIRED)
+                sendError(context, req, resp, L10nUtil.getMessage(MsgKey.errMustAuthenticate, req));
             else if (se.getCode() == AccountServiceException.MAINTENANCE_MODE
                     || se.getCode() == AccountServiceException.ACCOUNT_INACTIVE)
                 sendError(context, req, resp, se.getMessage());


### PR DESCRIPTION
### Solution

This is a revision for previous work done for the ZBUG-2390, which is about certain resources (e.g. Briefcase) being accessible with username and password alone even when two factor authentication was enabled for the account. The previous work passed every test scenario on Patch 23 at the moment, but failed some of them when tested on Patch 25. 

### Testing Done

Please go to ticket for further details.