### PR TITLE
guava version 28.1-jre to 31.1-jre

### DIFF
--- a/build-ivysettings.xml
+++ b/build-ivysettings.xml
@@ -7,7 +7,7 @@
   <property name="dom4j.version" value="2.1.1"/>  
   <property name="log4j.core.version" value="2.17.1" />
   <property name="log4j.api.version" value="2.17.1" />
-  <property name="com.google.guava.version" value="28.1-jre"/>
+  <property name="com.google.guava.version" value="31.1-jre"/>
 <settings defaultResolver="chain-resolver" />
   <caches defaultCacheDir="${dev.home}/.ivy2/cache"/>
   <resolvers>


### PR DESCRIPTION
Guava version update because of security vulnerability
[CVE-2020-8908](https://nvd.nist.gov/vuln/detail/cve-2020-8908)