### PR TITLE
commons compress version 1.20 to 1.21

### DIFF
--- a/store/build.xml
+++ b/store/build.xml
@@ -339,7 +339,7 @@
     <ivy:install organisation="org.eclipse.jetty" module="jetty-servlets" revision="9.4.46.v20220331" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.eclipse.jetty" module="jetty-servlet" revision="9.4.46.v20220331" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.tukaani" module="xz" revision="1.8" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
-    <ivy:install organisation="org.apache.commons" module="commons-compress" revision="1.20" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
+    <ivy:install organisation="org.apache.commons" module="commons-compress" revision="1.21" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     
     <war warfile="${warfile}" webxml="${war.web.xml}">
       <fileset dir="WebRoot"/>

--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -71,7 +71,7 @@
   <dependency org="org.apache.httpcomponents" name="httpcore" rev="${httpclient.httpcore.version}"/> 
   <dependency org="org.apache.httpcomponents" name="httpcore-nio" rev="${httpclient.httpcore.version}"/>
   <dependency org="org.apache.httpcomponents" name="httpmime" rev="${httpclient.version}"/>
-  <dependency org="org.apache.commons" name="commons-compress" rev="1.20" />
+  <dependency org="org.apache.commons" name="commons-compress" rev="1.21" />
   <dependency org="org.apache.mina" name="mina-core" rev="2.1.6"/>
   <dependency org="org.apache.curator" name="curator-recipes" rev="2.0.1-incubating" />
   <dependency org="org.apache.curator" name="curator-client" rev="2.0.1-incubating" />


### PR DESCRIPTION
Update commons compress version because of security vulnerability
[CVE-2021-35515](https://nvd.nist.gov/vuln/detail/CVE-2021-35515)
[CVE-2021-35516](https://nvd.nist.gov/vuln/detail/CVE-2021-35516)
[CVE-2021-35517](https://nvd.nist.gov/vuln/detail/CVE-2021-35517)
[CVE-2021-36090](https://nvd.nist.gov/vuln/detail/CVE-2021-36090)