### PR TITLE
httpclient version 4.5.8 to 4.5.13

### DIFF
--- a/build-ivysettings.xml
+++ b/build-ivysettings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ivysettings>
-  <property name="httpclient.version" value="4.5.8"/>
+  <property name="httpclient.version" value="4.5.13"/>
   <property name="httpclient.httpcore.version" value="4.4.11"/>
   <property name="httpclient.async.version" value="4.1.4"/>
   <property name="jetty.version" value="9.4.46.v20220331"/>


### PR DESCRIPTION
Update httpclient version because of security vulnerability
[CVE-2020-13956](https://nvd.nist.gov/vuln/detail/CVE-2020-13956)