### PR TITLE
Feature/zcs 11429: Accessing store_type column from volume table

### DIFF
--- a/common/src/java/com/zimbra/common/util/ZimbraLog.java
+++ b/common/src/java/com/zimbra/common/util/ZimbraLog.java
@@ -493,6 +493,11 @@ public final class ZimbraLog {
     public static final Log gql = LogFactory.getLog("zimbra.gql");
 
     /**
+     * Log for zimbra Store managers
+     */
+    public static final Log SM_LOG = LogFactory.getLog("zimbra.storemanagers");
+
+    /**
      * Maps the log category name to its description.
      */
     public static final Map<String, String> CATEGORY_DESCRIPTIONS;
@@ -603,6 +608,7 @@ public final class ZimbraLog {
         descriptions.put(passwordreset.getCategory(), "Password Reset operations");
         descriptions.put(addresslist.getCategory(), "Addresslist operations");
         descriptions.put(gql.getCategory(), "GraphQL operations");
+        descriptions.put(SM_LOG.getCategory(), "Generic Store managers");
         CATEGORY_DESCRIPTIONS = Collections.unmodifiableMap(descriptions);
     }
 

--- a/common/src/java/com/zimbra/common/util/ZimbraLog.java
+++ b/common/src/java/com/zimbra/common/util/ZimbraLog.java
@@ -495,7 +495,7 @@ public final class ZimbraLog {
     /**
      * Log for zimbra Store managers
      */
-    public static final Log SM_LOG = LogFactory.getLog("zimbra.storemanagers");
+    public static final Log smLog = LogFactory.getLog("zimbra.storemanagers");
 
     /**
      * Maps the log category name to its description.
@@ -608,7 +608,7 @@ public final class ZimbraLog {
         descriptions.put(passwordreset.getCategory(), "Password Reset operations");
         descriptions.put(addresslist.getCategory(), "Addresslist operations");
         descriptions.put(gql.getCategory(), "GraphQL operations");
-        descriptions.put(SM_LOG.getCategory(), "Generic Store managers");
+        descriptions.put(smLog.getCategory(), "Generic Store managers");
         CATEGORY_DESCRIPTIONS = Collections.unmodifiableMap(descriptions);
     }
 

--- a/store/src/java/com/zimbra/cs/db/DbVolume.java
+++ b/store/src/java/com/zimbra/cs/db/DbVolume.java
@@ -335,16 +335,17 @@ public final class DbVolume {
     }
 
     private static boolean isVolumeReferenced(DbConnection conn, short volumeId, int groupId) throws ServiceException {
-        return tableRefsVolume(conn, volumeId, groupId, "revision") || tableRefsVolume(conn, volumeId, groupId, "revision_dumpster") ||
-                tableRefsVolume(conn, volumeId, groupId, "mail_item_dumpster") || tableRefsVolume(conn, volumeId, groupId, "mail_item");
+        return tableRefsVolume(conn, volumeId, groupId, "revision") ||
+                tableRefsVolume(conn, volumeId, groupId, "revision_dumpster") ||
+                tableRefsVolume(conn, volumeId, groupId, "mail_item_dumpster") ||
+                tableRefsVolume(conn, volumeId, groupId, "mail_item");
     }
 
     private static boolean tableRefsVolume(DbConnection conn, short volumeId, int groupId, String table) throws ServiceException {
         PreparedStatement stmt = null;
         ResultSet rs = null;
         try {
-            stmt = conn.prepareStatement("SELECT count(*) from "+DbMailbox.qualifyTableName(groupId, table) +
-                    " where locator=?");
+            stmt = conn.prepareStatement("SELECT count(*) from "+DbMailbox.qualifyTableName(groupId, table) + " where locator=?");
             stmt.setInt(1, volumeId);
             rs = stmt.executeQuery();
             return (rs.next() && rs.getInt(1) > 0);

--- a/store/src/java/com/zimbra/cs/db/DbVolume.java
+++ b/store/src/java/com/zimbra/cs/db/DbVolume.java
@@ -47,6 +47,8 @@ public final class DbVolume {
     private static final String CN_FILE_GROUP_BITS = "file_group_bits";
     private static final String CN_MAILBOX_BITS = "mailbox_bits";
     private static final String CN_MAILBOX_GROUP_BITS = "mailbox_group_bits";
+
+    private static final String CN_STORE_TYPE = "store_type";
     private static final String CN_COMPRESS_BLOBS = "compress_blobs";
     private static final String CN_COMPRESSION_THRESHOLD = "compression_threshold";
     private static final String CN_METADATA = "metadata";
@@ -297,12 +299,17 @@ public final class DbVolume {
         } catch (ServiceException e) {
             throw VolumeServiceException.INVALID_METADATA(e);
         }
+
+        short storeTypeShort = rs.getShort(CN_STORE_TYPE);
+        Volume.StoreType storeType = Volume.StoreType.getStoreTypeBy(storeTypeShort);
+
         return Volume.builder().setId(rs.getShort(CN_ID)).setType(rs.getShort(CN_TYPE)).setName(rs.getString(CN_NAME))
                 .setPath(Volume.getAbsolutePath(rs.getString(CN_PATH)), false)
                 .setMboxGroupBits(rs.getShort(CN_MAILBOX_GROUP_BITS)).setMboxBit(rs.getShort(CN_MAILBOX_BITS))
                 .setFileGroupBits(rs.getShort(CN_FILE_GROUP_BITS)).setFileBits(rs.getShort(CN_FILE_BITS))
                 .setCompressBlobs(rs.getBoolean(CN_COMPRESS_BLOBS))
                 .setCompressionThreshold(rs.getLong(CN_COMPRESSION_THRESHOLD))
+                .setStoreType(storeType)
                 .setMetadata(metadata).build();
     }
 
@@ -329,7 +336,7 @@ public final class DbVolume {
 
     private static boolean isVolumeReferenced(DbConnection conn, short volumeId, int groupId) throws ServiceException {
         return tableRefsVolume(conn, volumeId, groupId, "revision") || tableRefsVolume(conn, volumeId, groupId, "revision_dumpster") ||
-            tableRefsVolume(conn, volumeId, groupId, "mail_item_dumpster") || tableRefsVolume(conn, volumeId, groupId, "mail_item");
+                tableRefsVolume(conn, volumeId, groupId, "mail_item_dumpster") || tableRefsVolume(conn, volumeId, groupId, "mail_item");
     }
 
     private static boolean tableRefsVolume(DbConnection conn, short volumeId, int groupId, String table) throws ServiceException {
@@ -337,7 +344,7 @@ public final class DbVolume {
         ResultSet rs = null;
         try {
             stmt = conn.prepareStatement("SELECT count(*) from "+DbMailbox.qualifyTableName(groupId, table) +
-                " where locator=?");
+                    " where locator=?");
             stmt.setInt(1, volumeId);
             rs = stmt.executeQuery();
             return (rs.next() && rs.getInt(1) > 0);

--- a/store/src/java/com/zimbra/cs/volume/Volume.java
+++ b/store/src/java/com/zimbra/cs/volume/Volume.java
@@ -65,7 +65,30 @@ public final class Volume {
     private boolean compressBlobs;
     private long compressionThreshold;
     private Metadata metadata;
-    
+
+    private StoreType storeType;
+
+    public static enum StoreType{
+        FILE_STORE(1),
+        EXTERNAL(2);
+
+        private final int storeType;
+        StoreType(final int storeType) {
+            this.storeType = storeType;
+        }
+
+        public int getStoreType() {
+            return storeType;
+        }
+        public static StoreType getStoreTypeBy(int value){
+            switch (value) {
+                case 1: return FILE_STORE;
+                case 2: return EXTERNAL;
+            }
+            return null;
+        }
+    }
+
     public static class VolumeMetadata {
         private int lastSyncDate;
         private int currentSyncDate;
@@ -88,37 +111,37 @@ public final class Volume {
             this.currentSyncDate = meta.getInt(FN_DATE_CURRENTSYNC, 0);
             this.groupId = meta.getInt(FN_LAST_GROUP_ID, 0);
         }
-        
+
         public VolumeMetadata(int lastSyncDate, int currentSyncDate, int groupId) {
             this.lastSyncDate = lastSyncDate;
             this.currentSyncDate = currentSyncDate;
             this.groupId = groupId;
         }
-        
+
         public int getLastSyncDate() {
             return lastSyncDate;
         }
-        
+
         public int getCurrentSyncDate() {
             return currentSyncDate;
         }
-        
+
         public int getGroupId() {
             return groupId;
         }
-        
+
         public void setLastSyncDate(int date) {
             this.lastSyncDate = date;
         }
-        
+
         public void setCurrentSyncDate(int date) {
             this.currentSyncDate = date;
         }
-        
+
         public void setGroupId(int id) {
             this.groupId = id;
         }
-        
+
         public String toString() {
             return serialize().toString();
         }
@@ -153,7 +176,8 @@ public final class Volume {
             volume.compressBlobs = copy.compressBlobs;
             volume.compressionThreshold = copy.compressionThreshold;
             volume.metadata = copy.metadata;
-            
+            volume.storeType = copy.storeType;
+
         }
 
         public Builder setId(short id) {
@@ -210,9 +234,14 @@ public final class Volume {
             volume.compressionThreshold = value;
             return this;
         }
-        
+
         public Builder setMetadata(VolumeMetadata metadata) {
             volume.metadata = metadata.serialize();
+            return this;
+        }
+
+        public Builder setStoreType(StoreType storeType){
+            volume.storeType = storeType;
             return this;
         }
 
@@ -314,36 +343,40 @@ public final class Volume {
     public long getCompressionThreshold() {
         return compressionThreshold;
     }
-    
+
     public VolumeMetadata getMetadata() throws ServiceException {
         return new VolumeMetadata(metadata);
     }
 
+    public StoreType getStoreType() {
+        return storeType;
+    }
+
     public static String getAbsolutePath(String path) throws ServiceException {
         //return LC.zimbra_relative_volume_path.booleanValue() ? LC.zimbra_home.value() + File.separator + getConfiguredRootPath(path) : path;
-    	return LC.zimbra_relative_volume_path.booleanValue() ? LC.zimbra_home.value() + File.separator + path : path;
+        return LC.zimbra_relative_volume_path.booleanValue() ? LC.zimbra_home.value() + File.separator + path : path;
     }
-    
+
     public static String getConfiguredServerID() throws ServiceException
     {
         StringBuilder finalPath = new StringBuilder();
         if (Zimbra.isAlwaysOn())
         {
-        	String alwaysOnServerClusterId = Zimbra.getAlwaysOnClusterId();
-        	String localServerId = Provisioning.getInstance().getLocalServer().getId();
-        	if (alwaysOnServerClusterId != null)
-        	{
-        		finalPath.append(alwaysOnServerClusterId);
-        	}
-        	else
-        	{
-        		finalPath.append(localServerId);
-        	}
+            String alwaysOnServerClusterId = Zimbra.getAlwaysOnClusterId();
+            String localServerId = Provisioning.getInstance().getLocalServer().getId();
+            if (alwaysOnServerClusterId != null)
+            {
+                finalPath.append(alwaysOnServerClusterId);
+            }
+            else
+            {
+                finalPath.append(localServerId);
+            }
         }
         else
         {
-        	String localServerId = Provisioning.getInstance().getLocalServer().getId();
-        	finalPath.append(localServerId);
+            String localServerId = Provisioning.getInstance().getLocalServer().getId();
+            finalPath.append(localServerId);
         }
         return finalPath.toString();
     }
@@ -351,14 +384,14 @@ public final class Volume {
     private StringBuilder getMailboxDir(int mboxId, String subdir) throws ServiceException {
         StringBuilder result = new StringBuilder();
         int dir = (mboxId >> mboxBits) & mboxGroupBitmask;
-        
+
         result.append(rootPath).append(File.separator);
 
         if (Provisioning.getInstance().getLocalServer().isConfiguredServerIDForBlobDirEnabled())
-        	result.append(getConfiguredServerID()).append(File.separator);
+            result.append(getConfiguredServerID()).append(File.separator);
 
         result.append(dir).append(File.separator).append(mboxId);
-        
+
         if (subdir != null) {
             result.append(File.separator).append(subdir);
         }
@@ -464,6 +497,7 @@ public final class Volume {
                 .add("mboxGroupBits", mboxGroupBits).add("mboxBits", mboxBits)
                 .add("fileGroupBits", fileGroupBits).add("fileBits", fileBits)
                 .add("compressBlobs", compressBlobs).add("compressionThreshold",compressionThreshold)
+                .add("storeType", storeType)
                 .toString();
     }
 

--- a/store/src/java/com/zimbra/cs/volume/Volume.java
+++ b/store/src/java/com/zimbra/cs/volume/Volume.java
@@ -31,7 +31,7 @@ import com.zimbra.soap.admin.type.VolumeInfo;
 /**
  * Based on default settings, there are 256 directories. We write blobs for id's 0-4095 to directory 0, 4096-8191 to
  * directory 1, etc. After filling directory 255, we wrap around and write 1048576-1052671 to directory 0 and so on.
- *
+ * <p>
  * Number of dirs: 2 ^ groupBits (2 ^ 8 = 256 by default)
  * Number of files per dir before wraparound: 2 ^ bits (2 ^ 12 = 4096 by default)
  */
@@ -41,7 +41,7 @@ public final class Volume {
     public static final short ID_NONE = -2;
     public static final short ID_MAX = 255;
 
-    public static final short TYPE_MESSAGE =  1;
+    public static final short TYPE_MESSAGE = 1;
     public static final short TYPE_MESSAGE_SECONDARY = 2;
     public static final short TYPE_INDEX = 10;
 
@@ -68,11 +68,12 @@ public final class Volume {
 
     private StoreType storeType;
 
-    public static enum StoreType{
+    public static enum StoreType {
         FILE_STORE(1),
         EXTERNAL(2);
 
         private final int storeType;
+
         StoreType(final int storeType) {
             this.storeType = storeType;
         }
@@ -80,10 +81,13 @@ public final class Volume {
         public int getStoreType() {
             return storeType;
         }
-        public static StoreType getStoreTypeBy(int value){
+
+        public static StoreType getStoreTypeBy(int value) {
             switch (value) {
-                case 1: return FILE_STORE;
-                case 2: return EXTERNAL;
+                case 1:
+                    return FILE_STORE;
+                case 2:
+                    return EXTERNAL;
             }
             return null;
         }
@@ -240,7 +244,7 @@ public final class Volume {
             return this;
         }
 
-        public Builder setStoreType(StoreType storeType){
+        public Builder setStoreType(StoreType storeType) {
             volume.storeType = storeType;
             return this;
         }
@@ -357,24 +361,17 @@ public final class Volume {
         return LC.zimbra_relative_volume_path.booleanValue() ? LC.zimbra_home.value() + File.separator + path : path;
     }
 
-    public static String getConfiguredServerID() throws ServiceException
-    {
+    public static String getConfiguredServerID() throws ServiceException {
         StringBuilder finalPath = new StringBuilder();
-        if (Zimbra.isAlwaysOn())
-        {
+        if (Zimbra.isAlwaysOn()) {
             String alwaysOnServerClusterId = Zimbra.getAlwaysOnClusterId();
             String localServerId = Provisioning.getInstance().getLocalServer().getId();
-            if (alwaysOnServerClusterId != null)
-            {
+            if (alwaysOnServerClusterId != null) {
                 finalPath.append(alwaysOnServerClusterId);
-            }
-            else
-            {
+            } else {
                 finalPath.append(localServerId);
             }
-        }
-        else
-        {
+        } else {
             String localServerId = Provisioning.getInstance().getLocalServer().getId();
             finalPath.append(localServerId);
         }
@@ -414,9 +411,9 @@ public final class Volume {
     /**
      * Make sure the path is an absolute path, and remove all "." and ".." from it. This is similar to
      * {@link File#getCanonicalPath()} except symbolic links are not resolved.
-     *
+     * <p>
      * If there are too many ".." in the path, navigating to parent directory stops at root.
-     *
+     * <p>
      * Supports UNIX absolute path, Windows absolute path with or without drive letter, and windows UNC share.
      *
      * @throws VolumeServiceException if path is not absolute
@@ -496,7 +493,7 @@ public final class Volume {
                 .add("id", id).add("type", type).add("name", name).add("path", rootPath)
                 .add("mboxGroupBits", mboxGroupBits).add("mboxBits", mboxBits)
                 .add("fileGroupBits", fileGroupBits).add("fileBits", fileBits)
-                .add("compressBlobs", compressBlobs).add("compressionThreshold",compressionThreshold)
+                .add("compressBlobs", compressBlobs).add("compressionThreshold", compressionThreshold)
                 .add("storeType", storeType)
                 .toString();
     }

--- a/store/src/java/com/zimbra/cs/volume/Volume.java
+++ b/store/src/java/com/zimbra/cs/volume/Volume.java
@@ -384,8 +384,9 @@ public final class Volume {
 
         result.append(rootPath).append(File.separator);
 
-        if (Provisioning.getInstance().getLocalServer().isConfiguredServerIDForBlobDirEnabled())
+        if (Provisioning.getInstance().getLocalServer().isConfiguredServerIDForBlobDirEnabled()) {
             result.append(getConfiguredServerID()).append(File.separator);
+        }
 
         result.append(dir).append(File.separator).append(mboxId);
 


### PR DESCRIPTION
[Reopening with correct destination branch old PR: https://github.com/Zimbra/zm-mailbox/pull/1281]
Problem:
Need provision to access store_type column from volume table.

Solution:
Modified related classes to access store_type column. We will be modifying these classes again for updating to create a query as part of [ZCS-11429](https://jira.corp.synacor.com/browse/ZCS-11428) and [ZCS-11430](https://jira.corp.synacor.com/browse/ZCS-11430)