### PR TITLE
ZBUG-2834: Using configure() to configure log4j instead of initialize()

### DIFF
--- a/common/src/java/com/zimbra/common/util/ZimbraLog.java
+++ b/common/src/java/com/zimbra/common/util/ZimbraLog.java
@@ -913,7 +913,7 @@ public final class ZimbraLog {
         }
         builder.add(builder.newRootLogger(level)
                .add(builder.newAppenderRef(DEFAULT_APPENDER_NAME)));
-        Configurator.initialize(builder.build());
+        Configurator.reconfigure(builder.build());
     }
 
     public static void toolSetupLog4jConsole(String defaultLevel, boolean stderr, boolean showThreads) {


### PR DESCRIPTION
**Issue**
No INFO logs after deploying the zimlets

**Fix**
We were using Configurator.initialize() this was causing issue and have replaced with Configurator.reconfigure().