### PR TITLE
ZBUG-2841 : Disable Syslog log submission by default in log4j V2

### DIFF
--- a/store-conf/conf/log4j.properties.production
+++ b/store-conf/conf/log4j.properties.production
@@ -126,14 +126,14 @@ appender.EWS.policies.time.modulate = true
 appender.EWS.strategy.type = DefaultRolloverStrategy
 
 # Syslog appender
-appender.SYSLOG.type = Syslog
-appender.SYSLOG.name = syslogAppender
-appender.SYSLOG.host = localhost
-appender.SYSLOG.port = 514
-appender.SYSLOG.protocol = UDP
-appender.SYSLOG.facility = LOCAL0
-appender.SYSLOG.layout.type = PatternLayout
-appender.SYSLOG.layout.pattern = mailboxd: %-5p [%t] [%z] %c{1} - %m
+%%uncomment VAR:zimbraLogToSyslog%%appender.SYSLOG.type = Syslog
+%%uncomment VAR:zimbraLogToSyslog%%appender.SYSLOG.name = syslogAppender
+%%uncomment VAR:zimbraLogToSyslog%%appender.SYSLOG.host = localhost
+%%uncomment VAR:zimbraLogToSyslog%%appender.SYSLOG.port = 514
+%%uncomment VAR:zimbraLogToSyslog%%appender.SYSLOG.protocol = UDP
+%%uncomment VAR:zimbraLogToSyslog%%appender.SYSLOG.facility = LOCAL0
+%%uncomment VAR:zimbraLogToSyslog%%appender.SYSLOG.layout.type = PatternLayout
+%%uncomment VAR:zimbraLogToSyslog%%appender.SYSLOG.layout.pattern = mailboxd: %-5p [%t] [%z] %c{1} - %m
 
 # Logger service appender
 %%comment VAR:!zimbraLogHostname%%appender.SLOGGER.type = Syslog
@@ -191,10 +191,10 @@ logger.ews.level = info
 logger.ews.additivity = false
 logger.ews.appenderRef.EWS.ref = ewsFile
 
-logger.syslog.name = com.zimbra
-logger.syslog.level = info
-logger.syslog.additivity = false
-logger.syslog.appenderRef.SYSLOG.ref = syslogAppender
+%%uncomment VAR:zimbraLogToSyslog%%logger.syslog.name = com.zimbra
+%%uncomment VAR:zimbraLogToSyslog%%logger.syslog.level = info
+%%uncomment VAR:zimbraLogToSyslog%%logger.syslog.additivity = false
+%%uncomment VAR:zimbraLogToSyslog%%logger.syslog.appenderRef.SYSLOG.ref = syslogAppender
 
 # HttpMethodBase spews out too many WARN on the badly formatted cookies.
 #logger.org.apache.commons.httpclient.HttpMethodBase=ERROR

--- a/store-conf/conf/log4j.properties.production
+++ b/store-conf/conf/log4j.properties.production
@@ -136,14 +136,14 @@ appender.EWS.strategy.type = DefaultRolloverStrategy
 %%uncomment VAR:zimbraLogToSyslog%%appender.SYSLOG.layout.pattern = mailboxd: %-5p [%t] [%z] %c{1} - %m
 
 # Logger service appender
-%%comment VAR:!zimbraLogHostname%%appender.SLOGGER.type = Syslog
-%%comment VAR:!zimbraLogHostname%%appender.SLOGGER.name = sloggerAppender
-%%comment VAR:!zimbraLogHostname%%appender.SLOGGER.host = %%zimbraLogHostname%%
-%%comment VAR:!zimbraLogHostname%%appender.SLOGGER.facility = LOCAL1
-%%comment VAR:!zimbraLogHostname%%appender.SLOGGER.port = 514
-%%comment VAR:!zimbraLogHostname%%appender.SLOGGER.protocol = UDP
-%%comment VAR:!zimbraLogHostname%%appender.SLOGGER.layout.type = PatternLayout
-%%comment VAR:!zimbraLogHostname%%appender.SLOGGER.layout.pattern = mailboxd: %-5p [%t] [%z] %c{1} - %m
+appender.SLOGGER.type = Syslog
+appender.SLOGGER.name = sloggerAppender
+appender.SLOGGER.host = %%zimbraLogHostname%%
+appender.SLOGGER.facility = LOCAL1
+appender.SLOGGER.port = 514
+appender.SLOGGER.protocol = UDP
+appender.SLOGGER.layout.type = PatternLayout
+appender.SLOGGER.layout.pattern = mailboxd: %-5p [%t] [%z] %c{1} - %m
 
 logger.zimbra.name = zimbra.mailbox
 logger.zimbra.level = info
@@ -208,6 +208,7 @@ logger.memcached.level = WARN
 
 %%comment VAR:!zimbraLogHostname%%logger.slogger.name = zimbra.slogger
 %%comment VAR:!zimbraLogHostname%%logger.slogger.level = info
+%%uncomment VAR:!zimbraLogHostname%%logger.slogger.level = error
 %%comment VAR:!zimbraLogHostname%%logger.slogger.additivity = false
 %%comment VAR:!zimbraLogHostname%%logger.slogger.appenderRef.SLOGGER.ref = sloggerAppender
 

--- a/store-conf/conf/log4j.properties.production
+++ b/store-conf/conf/log4j.properties.production
@@ -17,7 +17,7 @@ appender.LOGFILE.layout.type = PatternLayout
 appender.LOGFILE.layout.pattern = %d %-5p [%t] [%z] %c{1} - %m%n
 appender.LOGFILE.policies.type = Policies
 appender.LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
-appender.LOGFILE.policies.time.interval = 2
+appender.LOGFILE.policies.time.interval = 1
 appender.LOGFILE.policies.time.modulate = true
 appender.LOGFILE.strategy.type = DefaultRolloverStrategy
  
@@ -30,7 +30,7 @@ appender.AUDIT.layout.type = PatternLayout
 appender.AUDIT.layout.pattern = %d %-5p [%t] [%z] %c{1} - %m%n
 appender.AUDIT.policies.type = Policies
 appender.AUDIT.policies.time.type = TimeBasedTriggeringPolicy
-appender.AUDIT.policies.time.interval = 2
+appender.AUDIT.policies.time.interval = 1
 appender.AUDIT.policies.time.modulate = true
 appender.AUDIT.strategy.type = DefaultRolloverStrategy
 
@@ -43,7 +43,7 @@ appender.SYNC.layout.type = PatternLayout
 appender.SYNC.layout.pattern = %d %-5p [%t] [%z] %c{1} - %m%n
 appender.SYNC.policies.type = Policies
 appender.SYNC.policies.time.type = TimeBasedTriggeringPolicy
-appender.SYNC.policies.time.interval = 2
+appender.SYNC.policies.time.interval = 1
 appender.SYNC.policies.time.modulate = true
 appender.SYNC.strategy.type = DefaultRolloverStrategy
 
@@ -56,7 +56,7 @@ appender.SYNCTRACE.layout.type = PatternLayout
 appender.SYNCTRACE.layout.pattern = %d %-5p [%t] [%z] %c{1} - %m%n
 appender.SYNCTRACE.policies.type = Policies
 appender.SYNCTRACE.policies.time.type = TimeBasedTriggeringPolicy
-appender.SYNCTRACE.policies.time.interval = 2
+appender.SYNCTRACE.policies.time.interval = 1
 appender.SYNCTRACE.policies.time.modulate = true
 appender.SYNCTRACE.strategy.type = DefaultRolloverStrategy
 
@@ -69,7 +69,7 @@ appender.SYNCSTATE.layout.type = PatternLayout
 appender.SYNCSTATE.layout.pattern = %d %-5p [%t] [%z] %c{1} - %m%n
 appender.SYNCSTATE.policies.type = Policies
 appender.SYNCSTATE.policies.time.type = TimeBasedTriggeringPolicy
-appender.SYNCSTATE.policies.time.interval = 2
+appender.SYNCSTATE.policies.time.interval = 1
 appender.SYNCSTATE.policies.time.modulate = true
 appender.SYNCSTATE.strategy.type = DefaultRolloverStrategy
 
@@ -82,7 +82,7 @@ appender.WBXML.layout.type = PatternLayout
 appender.WBXML.layout.pattern = %d %-5p [%t] [%z] %c{1} - %m%n
 appender.WBXML.policies.type = Policies
 appender.WBXML.policies.time.type = TimeBasedTriggeringPolicy
-appender.WBXML.policies.time.interval = 2
+appender.WBXML.policies.time.interval = 1
 appender.WBXML.policies.time.modulate = true
 appender.WBXML.strategy.type = DefaultRolloverStrategy
 
@@ -95,7 +95,7 @@ appender.ACTIVITY.layout.type = PatternLayout
 appender.ACTIVITY.layout.pattern = %d %-5p [%t] [%z] %c{1} - %m%n
 appender.ACTIVITY.policies.type = Policies
 appender.ACTIVITY.policies.time.type = TimeBasedTriggeringPolicy
-appender.ACTIVITY.policies.time.interval = 2
+appender.ACTIVITY.policies.time.interval = 1
 appender.ACTIVITY.policies.time.modulate = true
 appender.ACTIVITY.strategy.type = DefaultRolloverStrategy
 
@@ -108,7 +108,7 @@ appender.SEARCHSTAT.layout.type = PatternLayout
 appender.SEARCHSTAT.layout.pattern = %d %-5p [%t] [%z] %c{1} - %m%n
 appender.SEARCHSTAT.policies.type = Policies
 appender.SEARCHSTAT.policies.time.type = TimeBasedTriggeringPolicy
-appender.SEARCHSTAT.policies.time.interval = 2
+appender.SEARCHSTAT.policies.time.interval = 1
 appender.SEARCHSTAT.policies.time.modulate = true
 appender.SEARCHSTAT.strategy.type = DefaultRolloverStrategy
 
@@ -121,7 +121,7 @@ appender.EWS.layout.type = PatternLayout
 appender.EWS.layout.pattern = %d %-5p [%t] [%z] %c{1} - %m%n
 appender.EWS.policies.type = Policies
 appender.EWS.policies.time.type = TimeBasedTriggeringPolicy
-appender.EWS.policies.time.interval = 2
+appender.EWS.policies.time.interval = 1
 appender.EWS.policies.time.modulate = true
 appender.EWS.strategy.type = DefaultRolloverStrategy
 
@@ -207,8 +207,7 @@ logger.memcached.name = net.spy.memcached
 logger.memcached.level = WARN
 
 %%comment VAR:!zimbraLogHostname%%logger.slogger.name = zimbra.slogger
-%%comment VAR:!zimbraLogHostname%%logger.slogger.level=INFO
-%%uncomment VAR:!zimbraLogHostname%%logger.slogger.level=ERROR
+%%comment VAR:!zimbraLogHostname%%logger.slogger.level = info
 %%comment VAR:!zimbraLogHostname%%logger.slogger.additivity = false
 %%comment VAR:!zimbraLogHostname%%logger.slogger.appenderRef.SLOGGER.ref = sloggerAppender
 


### PR DESCRIPTION
Issue :- Bydefault syslogs where getting enabled as there was no flag to check weather to enable or disable syslogs.

Fix:- Added pre existing flag zimbraLogToSyslog to check either to enable or disable, by default the flag is FALSE.