### PR TITLE
Feature/zcs 11481

### DIFF
--- a/common/src/java/com/zimbra/common/soap/HsmConstants.java
+++ b/common/src/java/com/zimbra/common/soap/HsmConstants.java
@@ -96,4 +96,5 @@ public final class HsmConstants {
     public static final String A_SM_INVALID_TIME_FORMAT = "Invalid time format.";
     public static final String A_SM_INVALID_HOURS_FORMAT = "Invalid hour defined.";
     public static final String A_SM_INVALID_MINUTES = "Minutes are not allowed.";
+    public static final int A_EXIT_STATUS = 0;
 }

--- a/common/src/java/com/zimbra/common/soap/HsmConstants.java
+++ b/common/src/java/com/zimbra/common/soap/HsmConstants.java
@@ -37,6 +37,12 @@ public final class HsmConstants {
 
     public static final String E_GET_APPLIANCE_HSM_FS_REQUEST = "GetApplianceHSMFSRequest";
     public static final String E_GET_APPLIANCE_HSM_FS_RESPONSE = "GetApplianceHSMFSResponse";
+    
+    public static final String E_GET_SCHEDULE_SM_POLICY_REQUEST = "GetScheduleSMPolicyRequest";
+    public static final String E_GET_SCHEDULE_SM_POLICY_RESPONSE = "GetScheduleSMPolicyResponse";
+    
+    public static final String E_SCHEDULE_SMPOLICY_REQUEST = "ScheduleSMPolicyRequest";
+    public static final String E_SCHEDULE_SMPOLICY_RESPONSE = "ScheduleSMPolicyResponse";
 
     public static final QName HSM_REQUEST = QName.get(E_HSM_REQUEST, NAMESPACE);
     public static final QName HSM_RESPONSE = QName.get(E_HSM_RESPONSE, NAMESPACE);
@@ -52,6 +58,12 @@ public final class HsmConstants {
 
     public static final QName GET_APPLIANCE_HSM_FS_REQUEST = QName.get(E_GET_APPLIANCE_HSM_FS_REQUEST, NAMESPACE);
     public static final QName GET_APPLIANCE_HSM_FS_RESPONSE = QName.get(E_GET_APPLIANCE_HSM_FS_RESPONSE, NAMESPACE);
+    
+    public static final QName GET_SCHEDULE_SM_POLICY_REQUEST = QName.get(E_GET_SCHEDULE_SM_POLICY_REQUEST, NAMESPACE);
+    public static final QName GET_SCHEDULE_SM_POLICY_RESPONSE = QName.get(E_GET_SCHEDULE_SM_POLICY_RESPONSE, NAMESPACE);
+    
+    public static final QName SCHEDULE_SMPOLICY_REQUEST = QName.get(E_SCHEDULE_SMPOLICY_REQUEST, NAMESPACE);
+    public static final QName SCHEDULE_SMPOLICY_RESPONSE = QName.get(E_SCHEDULE_SMPOLICY_RESPONSE, NAMESPACE);
 
     public static final String A_START_DATE = "startDate";
     public static final String A_END_DATE = "endDate";
@@ -73,4 +85,15 @@ public final class HsmConstants {
     // GetApplianceHSMFS
     public static final String E_FS = "fs";
     public static final String A_SIZE = "size";
+    
+    public static final String ZM_SCHEDULE_SM_POLICY = "zmschedulesmpolicy";
+    public static final String A_SM_SCHEDULE_POLICY_ENABLED = "smSchedulePolicyEnabled";
+    public static final String A_SM_SCHEDULE_POLICY_START_TIME = "smSchedulePolicyStartTime";
+    public static final String A_SM_START = "SM_START:";
+    public static final String A_SM_END = ":SM_END";
+    public static final String A_SM_SCHEDULE_POLICY_ENABLED_MISSING = "No smSchedulePolicyEnabled defined.";
+    public static final String A_SM_TIME_MISSING = "No time defined.";
+    public static final String A_SM_INVALID_TIME_FORMAT = "Invalid time format.";
+    public static final String A_SM_INVALID_HOURS_FORMAT = "Invalid hour defined.";
+    public static final String A_SM_INVALID_MINUTES = "Minutes are not allowed.";
 }

--- a/soap/src/java/com/zimbra/soap/admin/message/GetScheduleSMPolicyRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/GetScheduleSMPolicyRequest.java
@@ -1,0 +1,68 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.google.common.base.MoreObjects;
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.common.soap.HsmConstants;
+import com.zimbra.soap.admin.type.Name;
+
+/**
+ * @zm-api-command-network-edition
+ * @zm-api-command-auth-required true
+ * @zm-api-command-admin-auth-required true
+ * @zm-api-command-description Schedule Storage Management Policy
+ */
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name=HsmConstants.E_GET_SCHEDULE_SM_POLICY_REQUEST)
+public class GetScheduleSMPolicyRequest {
+
+    /**
+     * @zm-api-field-description Server specification
+     */
+    @XmlElement(name=AdminConstants.E_SERVER /* server */, required=true)
+    private final Name server;
+
+    /**
+     * no-argument constructor wanted by JAXB
+     */
+    @SuppressWarnings("unused")
+    private GetScheduleSMPolicyRequest() {
+        this((Name) null);
+    }
+
+    public GetScheduleSMPolicyRequest(Name server) {
+        this.server = server;
+    }
+
+    public Name getServer() { return server; }
+
+    public MoreObjects.ToStringHelper addToStringInfo(MoreObjects.ToStringHelper helper) {
+        return helper.add("server", server);
+    }
+
+    @Override
+    public String toString() {
+        return addToStringInfo(MoreObjects.toStringHelper(this)).toString();
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/GetScheduleSMPolicyResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/GetScheduleSMPolicyResponse.java
@@ -1,0 +1,96 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import com.google.common.base.MoreObjects;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.HsmConstants;
+import com.zimbra.soap.type.ZmBoolean;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name=HsmConstants.E_GET_SCHEDULE_SM_POLICY_RESPONSE)
+public class GetScheduleSMPolicyResponse {
+
+    /**
+     * @zm-api-field-description <b>1 (true)</b> if an HSM session is currently running, <b>0 (false)</b>
+     * if the information returned applies to the last completed HSM session
+     */
+    @XmlAttribute(name=HsmConstants.A_SM_SCHEDULE_POLICY_ENABLED /* running */, required=true)
+    private final ZmBoolean smSchedulePolicyEnabled;
+
+    /**
+     * @zm-api-field-tag error-text
+     * @zm-api-field-description The error message, if an error occurred while processing the last
+     * <b>&lt;HsmRequest></b>
+     */
+    @XmlAttribute(name=HsmConstants.A_ERROR /* error */, required=false)
+    private String error;
+
+    /**
+     * @zm-api-field-tag total-mailboxes
+     * @zm-api-field-description Total number of mailboxes that should be processed by the HSM session
+     */
+    @XmlAttribute(name=HsmConstants.A_SM_SCHEDULE_POLICY_START_TIME /* scheduletime */, required=true)
+    private Integer smSchedulePolicyStartTime;
+
+    /**
+     * no-argument constructor wanted by JAXB
+     */
+    @SuppressWarnings("unused")
+    private GetScheduleSMPolicyResponse() {
+        this(false);
+    }
+
+    public GetScheduleSMPolicyResponse(boolean smSchedulePolicyEnabled) {
+        this.smSchedulePolicyEnabled = ZmBoolean.fromBool(smSchedulePolicyEnabled);
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+    
+    public void setSmScheduleStartTime(Integer smSchedulePolicyStartTime) {
+        this.smSchedulePolicyStartTime = smSchedulePolicyStartTime;
+    }
+
+    public boolean getSmScheduleEnabled() {
+        return ZmBoolean.toBool(smSchedulePolicyEnabled);
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public Integer getSmScheduleStartTime() {
+        return smSchedulePolicyStartTime;
+    }
+
+    public MoreObjects.ToStringHelper addToStringInfo(MoreObjects.ToStringHelper helper) {
+        return helper.add("smSchedulePolicyEnabled", smSchedulePolicyEnabled)
+                .add("smSchedulePolicyStartTime", smSchedulePolicyStartTime).add("error", error);
+    }
+
+    @Override
+    public String toString() {
+        return addToStringInfo(MoreObjects.toStringHelper(this)).toString();
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/ScheduleSMPolicyRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/ScheduleSMPolicyRequest.java
@@ -1,0 +1,70 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.google.common.base.MoreObjects;
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.common.soap.HsmConstants;
+import com.zimbra.soap.admin.type.Name;
+
+/**
+ * @zm-api-command-network-edition
+ * @zm-api-command-auth-required true
+ * @zm-api-command-admin-auth-required true
+ * @zm-api-command-description Schedule Storage Management Policy
+ */
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name=HsmConstants.E_SCHEDULE_SMPOLICY_REQUEST)
+public class ScheduleSMPolicyRequest {
+
+    /**
+     * @zm-api-field-description Server specification
+     */
+    @XmlElement(name=AdminConstants.E_SERVER /* server */, required=true)
+    private final Name server;
+
+    /**
+     * no-argument constructor wanted by JAXB
+     */
+    @SuppressWarnings("unused")
+    private ScheduleSMPolicyRequest() {
+        this((Name) null);
+    }
+
+    public ScheduleSMPolicyRequest(Name server) {
+        this.server = server;
+    }
+
+    public Name getServer() {
+        return server;
+    }
+
+    public MoreObjects.ToStringHelper addToStringInfo(MoreObjects.ToStringHelper helper) {
+        return helper.add("server", server);
+    }
+
+    @Override
+    public String toString() {
+        return addToStringInfo(MoreObjects.toStringHelper(this)).toString();
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/ScheduleSMPolicyResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/ScheduleSMPolicyResponse.java
@@ -1,0 +1,95 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.google.common.base.MoreObjects;
+import com.zimbra.common.soap.HsmConstants;
+import com.zimbra.soap.type.ZmBoolean;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name=HsmConstants.E_SCHEDULE_SMPOLICY_RESPONSE)
+public class ScheduleSMPolicyResponse {
+
+    /**
+     * @zm-api-field-description <b>1 (true)</b> if an HSM session is currently running, <b>0 (false)</b>
+     * if the information returned applies to the last completed HSM session
+     */
+    @XmlAttribute(name=HsmConstants.A_SM_SCHEDULE_POLICY_ENABLED /* running */, required=true)
+    private final ZmBoolean smSchedulePolicyEnabled;
+
+    /**
+     * @zm-api-field-tag error-text
+     * @zm-api-field-description The error message, if an error occurred while processing the last
+     * <b>&lt;HsmRequest></b>
+     */
+    @XmlAttribute(name=HsmConstants.A_ERROR /* error */, required=false)
+    private String error;
+
+    /**
+     * @zm-api-field-tag total-mailboxes
+     * @zm-api-field-description Total number of mailboxes that should be processed by the HSM session
+     */
+    @XmlAttribute(name=HsmConstants.A_SM_SCHEDULE_POLICY_START_TIME /* totalMailboxes */, required=true)
+    private Integer smSchedulePolicyStartTime;
+
+    /**
+     * no-argument constructor wanted by JAXB
+     */
+    @SuppressWarnings("unused")
+    private ScheduleSMPolicyResponse() {
+        this(false);
+    }
+
+    public ScheduleSMPolicyResponse(boolean smSchedulePolicyEnabled) {
+        this.smSchedulePolicyEnabled = ZmBoolean.fromBool(smSchedulePolicyEnabled);
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+    public void setSmScheduleStartTime(Integer smSchedulePolicyStartTime) {
+        this.smSchedulePolicyStartTime = smSchedulePolicyStartTime;
+    }
+
+    public boolean getSmScheduleEnabled() {
+        return ZmBoolean.toBool(smSchedulePolicyEnabled);
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public Integer getSmScheduleStartTime() {
+        return smSchedulePolicyStartTime;
+    }
+
+    public MoreObjects.ToStringHelper addToStringInfo(MoreObjects.ToStringHelper helper) {
+        return helper.add("smSchedulePolicyEnabled", smSchedulePolicyEnabled)
+                .add("smSchedulePolicyStartTime", smSchedulePolicyStartTime).add("error", error);
+    }
+
+    @Override
+    public String toString() {
+        return addToStringInfo(MoreObjects.toStringHelper(this)).toString();
+    }
+}


### PR DESCRIPTION
**Feature**
Need API for scheduling HSM policy execution.

**Solution**
Created API for scheduling HSM policy and also created a script **zmschedulesmpolicy** for schedule from command line.

**Options for zmschedulesmpolicy**

**-l: list** - print existing schedule
**-h: help** - get help about zmschedulesmpolicy (default command)
**-f: flush** - remove current schedule (cancel all scheduled Storage Management policy)
**-e: edit** - edit current schedule with specified schedule