### PR TITLE
ZBUG-1435 :zimbraPrefImapSearchFoldersEnabled does not work for IMAP

### DIFF
--- a/store/src/java/com/zimbra/cs/imap/ImapHandler.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapHandler.java
@@ -2457,6 +2457,11 @@ public abstract class ImapHandler {
             if (!(folderStore instanceof MountpointStore) && isInMountpointHierarchy(folderStore)) {
                 continue;
             }
+            //ZBUG-1435: Exclude search folder based on config value
+            if (!acct.getBooleanAttr(Provisioning.A_zimbraPrefImapSearchFoldersEnabled, true)
+                    && folderStore.isSearchFolder()) {
+                continue;
+            }
             ImapPath path = relativeTo == null ? new ImapPath(owner, folderStore, credentials) :
                 new ImapPath(owner, folderStore, relativeTo);
             if (path.isVisible()) {


### PR DESCRIPTION
Issue: `zimbraPrefImapSearchFoldersEnabled` does not work for IMAP

Solution:
Added a check to check for `zimbraPrefImapSearchFoldersEnabled` value and correspondingly show the search folders in the list of returned folders

Testing:
Manual Testing through command line 
