### PR TITLE
ZBUG-2821: add local config to enable disaable root folder sharing

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1494,6 +1494,9 @@ public final class LC {
     // ZCS-11349: Toggle off/on fallback to ldap search
     public static final KnownKey zimbra_gal_fallback_ldap_search_enabled = KnownKey.newKey(true);
 
+    // ZBUG-2821: disable root folder sharing by default
+    public static final KnownKey zimbra_root_folder_sharing_enabled = KnownKey.newKey(false);
+
     static {
         // Automatically set the key name with the variable name.
         for (Field field : LC.class.getFields()) {

--- a/store/src/java/com/zimbra/cs/service/mail/FolderAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/FolderAction.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2016, 2022 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -25,6 +25,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.zimbra.common.account.Key;
 import com.zimbra.common.account.Key.AccountBy;
+import com.zimbra.common.localconfig.LC;
+import com.zimbra.common.mailbox.FolderConstants;
 import com.zimbra.common.mime.InternetAddress;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
@@ -167,6 +169,10 @@ public class FolderAction extends ItemAction {
             String zid = action.getAttribute(MailConstants.A_ZIMBRA_ID);
             mbox.revokeAccess(octxt, iid.getId(), zid);
         } else if (operation.equals(OP_GRANT)) {
+            if (!LC.zimbra_root_folder_sharing_enabled.booleanValue() && iid != null
+                    && (iid.getId() == FolderConstants.ID_FOLDER_USER_ROOT || iid.getId() == FolderConstants.ID_FOLDER_ROOT)) {
+                throw ServiceException.INVALID_REQUEST("root folder sharing disabled", null);
+            }
             Element grant = action.getElement(MailConstants.E_GRANT);
             short rights = ACL.stringToRights(grant.getAttribute(MailConstants.A_RIGHTS));
             byte gtype   = ACL.stringToType(grant.getAttribute(MailConstants.A_GRANT_TYPE));


### PR DESCRIPTION
**Issue**
FolderActionRequest allowing root folder sharing

**Fix**
Add local config **zimbra_root_folder_sharing_enabled** to control the sharing on root folder with check of root folder ID to check the request against the folder for which request is triggered.

Test
```
<urn1:FolderActionRequest>
         <urn1:action id="1" op="grant">
            <!--Optional:-->
            <urn1:grant perm="rw" gt="usr" d="sharee@zdev-vm002.eng.zimbra.com" />
         </urn1:action>
      </urn1:FolderActionRequest>
```

```
<soap:Body>
      <soap:Fault>
         <faultcode>soap:Client</faultcode>
         <faultstring>invalid request: root folder sharing disabled</faultstring>
         <detail>
            <Error xmlns="urn:zimbra">
               <Code>service.INVALID_REQUEST</Code>
               <Trace>qtp436546048-21:1656415191856:e546cbb6b76e3ba7</Trace>
            </Error>
         </detail>
      </soap:Fault>
   </soap:Body>
```