### PR TITLE
ZCS-11458: Adding new LDAP attributes to let admins schedule backups from UI 

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -7898,6 +7898,14 @@ public class ZAttrProvisioning {
     public static final String A_zimbraGlobalConfigExtraObjectClass = "zimbraGlobalConfigExtraObjectClass";
 
     /**
+     * Global level external store config
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4005)
+    public static final String A_zimbraGlobalExternalStoreConfig = "zimbraGlobalExternalStoreConfig";
+
+    /**
      * zimbraId of the main dynamic group for the dynamic group unit
      */
     @ZAttr(id=325)
@@ -15795,6 +15803,14 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=2071)
     public static final String A_zimbraScheduledTaskRetryPolicy = "zimbraScheduledTaskRetryPolicy";
+
+    /**
+     * Server level external store config
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4006)
+    public static final String A_zimbraServerExternalStoreConfig = "zimbraServerExternalStoreConfig";
 
     /**
      * Object classes to add when creating a zimbra server object.

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -3973,6 +3973,40 @@ public class ZAttrProvisioning {
     public static final String A_zimbraBackupAutoGroupedThrottled = "zimbraBackupAutoGroupedThrottled";
 
     /**
+     * Blobs inside backups are compressed in zip format by default unless
+     * specified
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4012)
+    public static final String A_zimbraBackupBlobsCompress = "zimbraBackupBlobsCompress";
+
+    /**
+     * Backup up blobs in zip files without compression.
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4013)
+    public static final String A_zimbraBackupBlobsCompressZipStore = "zimbraBackupBlobsCompressZipStore";
+
+    /**
+     * Whether or not account is eligible for backup
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4007)
+    public static final String A_zimbraBackupConfigEnabled = "zimbraBackupConfigEnabled";
+
+    /**
+     * If true, enables the UI and if there is pre-configured data the
+     * crontab should get that schedule
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public static final String A_zimbraBackupEnabled = "zimbraBackupEnabled";
+
+    /**
      * Minimum percentage or TB/GB/MB/KB/bytes of free space on backup target
      * to allow a full or auto-grouped backup to start; 0 = no minimum is
      * enforced. Examples: 25%, 10GB
@@ -4007,6 +4041,15 @@ public class ZAttrProvisioning {
     public static final String A_zimbraBackupReportEmailSubjectPrefix = "zimbraBackupReportEmailSubjectPrefix";
 
     /**
+     * The number of days backups will be kept. Backup Scheduler deletes
+     * backups older than the set value
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4011)
+    public static final String A_zimbraBackupRetentionDays = "zimbraBackupRetentionDays";
+
+    /**
      * if true, do not backup blobs (HSM or not) during a full backup
      *
      * @since ZCS 6.0.0_BETA2
@@ -4030,6 +4073,51 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=1003)
     public static final String A_zimbraBackupSkipSearchIndex = "zimbraBackupSkipSearchIndex";
+
+    /**
+     * Indicates a scheduled backup call is for full-backup
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4016)
+    public static final String A_zimbraBackupStandardFullBackup = "zimbraBackupStandardFullBackup";
+
+    /**
+     * Indicates a scheduled backup call is for incremental-backup
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4017)
+    public static final String A_ZimbraBackupStandardIncBackup = "ZimbraBackupStandardIncBackup";
+
+    /**
+     * Starts backup each day at this time. This attribute is used for
+     * cronjob to set hour. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4010)
+    public static final String A_zimbraBackupStartTime = "zimbraBackupStartTime";
+
+    /**
+     * Runs full backup synchronously
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4014)
+    public static final String A_zimbraBackupSyncMode = "zimbraBackupSyncMode";
+
+    /**
+     * if true, will ensure the same users are enabled within backup and
+     * Dumpster
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public static final String A_zimbraBackupSyncUsers = "zimbraBackupSyncUsers";
 
     /**
      * Default backup target path
@@ -9385,6 +9473,14 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=613)
     public static final String A_zimbraMailReferMode = "zimbraMailReferMode";
+
+    /**
+     * If true, send an email report to the admin user.
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4015)
+    public static final String A_zimbraMailReportEnabled = "zimbraMailReportEnabled";
 
     /**
      * Deprecated since: 8.7.8. deprecated in favor of

--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2021 Synacor, Inc.
+ * Copyright (C) 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2021, 2022 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -1067,7 +1067,7 @@ public final class AdminConstants {
     public static final QName MODIFY_OUTGOING_FILTER_RULES_RESPONSE = QName.get(E_MODIFY_OUTGOING_FILTER_RULES_RESPONSE, NAMESPACE);
     public static final QName CONTACT_BACKUP_REQUEST = QName.get(E_CONTACT_BACKUP_REQUEST, NAMESPACE);
     public static final QName CONTACT_BACKUP_RESPONSE = QName.get(E_CONTACT_BACKUP_RESPONSE, NAMESPACE);
-    
+
     //HAB
     public static final String E_HAB_ORG_UNIT_REQUEST = "HABOrgUnitRequest";
     public static final String E_HAB_ORG_UNIT_RESPONSE = "HABOrgUnitResponse";
@@ -1167,7 +1167,8 @@ public final class AdminConstants {
     public static final String E_MAILBOX = "mbox";
     public static final String E_NI = "ni";
     public static final String E_NUM_OF_PAGES = "numpages";
-    public static final String E_VOLUME = "volume";
+    public static final String E_VOLUME = "volumeInfo";
+    public static final String E_VOLUME_EXT = "volumeExternalInfo";
     public static final String E_PROGRESS = "progress";
     public static final String E_SOAP_URL = "soapURL";
     public static final String E_ADMIN_SOAP_URL = "adminSoapURL";
@@ -1294,6 +1295,14 @@ public final class AdminConstants {
     public static final String A_VOLUME_COMPRESS_BLOBS = "compressBlobs";
     public static final String A_VOLUME_COMPRESSION_THRESHOLD = "compressionThreshold";
     public static final String A_VOLUME_IS_CURRENT = "isCurrent";
+    public static final String A_VOLUME_STORE_TYPE = "storeType";
+    public static final String A_VOLUME_STORAGE_TYPE = "storageType";
+    public static final String A_VOLUME_VOLUME_PREFIX = "volumePrefix";
+    public static final String A_VOLUME_STORE_PROVIDER = "storeProvider";
+    public static final String A_VOLUME_GLB_BUCKET_CONFIG_ID = "glbBucketConfigId";
+    public static final String A_VOLUME_USE_IN_FREQ_ACCESS = "useInFrequentAccess";
+    public static final String A_VOLUME_USE_IN_FREQ_ACCESS_THRESHOLD = "useInFrequentAccessThreshold";
+    public static final String A_VOLUME_USE_INTELLIGENT_TIERING = "useIntelligentTiering";
 
     // Blob consistency check
     public static final String E_MISSING_BLOBS = "missingBlobs";
@@ -1343,7 +1352,7 @@ public final class AdminConstants {
     public static final String A_QUOTA_USED = "used";
     public static final String A_QUOTA_LIMIT = "limit";
     public static final String A_EFFECTIVE_QUOTA = "effectiveQuota";
-    
+
     public static final String E_TEMPLATE = "template";
     public static final String E_TEST = "test";
     public static final String A_DEST = "dest";
@@ -1552,7 +1561,7 @@ public final class AdminConstants {
     public static final String A_FORCE_DELETE = "forceDelete";
     public static final String E_MEMBERS = "members";
     public static final String A_CASCADE_DELETE = "cascadeDelete";
-    
+
     // address list
     public static final String E_CREATE_ADDRESS_LIST_REQUEST = "CreateAddressListRequest";
     public static final String E_CREATE_ADDRESS_LIST_RESPONSE = "CreateAddressListResponse";

--- a/common/src/java/com/zimbra/common/soap/HsmConstants.java
+++ b/common/src/java/com/zimbra/common/soap/HsmConstants.java
@@ -96,4 +96,5 @@ public final class HsmConstants {
     public static final String A_SM_INVALID_TIME_FORMAT = "Invalid time format.";
     public static final String A_SM_INVALID_HOURS_FORMAT = "Invalid hour defined.";
     public static final String A_SM_INVALID_MINUTES = "Minutes are not allowed.";
+    public static final int A_EXIT_STATUS = 0;
 }

--- a/common/src/java/com/zimbra/common/soap/HsmConstants.java
+++ b/common/src/java/com/zimbra/common/soap/HsmConstants.java
@@ -37,6 +37,12 @@ public final class HsmConstants {
 
     public static final String E_GET_APPLIANCE_HSM_FS_REQUEST = "GetApplianceHSMFSRequest";
     public static final String E_GET_APPLIANCE_HSM_FS_RESPONSE = "GetApplianceHSMFSResponse";
+    
+    public static final String E_GET_SCHEDULE_SM_POLICY_REQUEST = "GetScheduleSMPolicyRequest";
+    public static final String E_GET_SCHEDULE_SM_POLICY_RESPONSE = "GetScheduleSMPolicyResponse";
+    
+    public static final String E_SCHEDULE_SMPOLICY_REQUEST = "ScheduleSMPolicyRequest";
+    public static final String E_SCHEDULE_SMPOLICY_RESPONSE = "ScheduleSMPolicyResponse";
 
     public static final QName HSM_REQUEST = QName.get(E_HSM_REQUEST, NAMESPACE);
     public static final QName HSM_RESPONSE = QName.get(E_HSM_RESPONSE, NAMESPACE);
@@ -52,6 +58,12 @@ public final class HsmConstants {
 
     public static final QName GET_APPLIANCE_HSM_FS_REQUEST = QName.get(E_GET_APPLIANCE_HSM_FS_REQUEST, NAMESPACE);
     public static final QName GET_APPLIANCE_HSM_FS_RESPONSE = QName.get(E_GET_APPLIANCE_HSM_FS_RESPONSE, NAMESPACE);
+    
+    public static final QName GET_SCHEDULE_SM_POLICY_REQUEST = QName.get(E_GET_SCHEDULE_SM_POLICY_REQUEST, NAMESPACE);
+    public static final QName GET_SCHEDULE_SM_POLICY_RESPONSE = QName.get(E_GET_SCHEDULE_SM_POLICY_RESPONSE, NAMESPACE);
+    
+    public static final QName SCHEDULE_SMPOLICY_REQUEST = QName.get(E_SCHEDULE_SMPOLICY_REQUEST, NAMESPACE);
+    public static final QName SCHEDULE_SMPOLICY_RESPONSE = QName.get(E_SCHEDULE_SMPOLICY_RESPONSE, NAMESPACE);
 
     public static final String A_START_DATE = "startDate";
     public static final String A_END_DATE = "endDate";
@@ -73,4 +85,15 @@ public final class HsmConstants {
     // GetApplianceHSMFS
     public static final String E_FS = "fs";
     public static final String A_SIZE = "size";
+    
+    public static final String ZM_SCHEDULE_SM_POLICY = "zmschedulesmpolicy";
+    public static final String A_SM_SCHEDULE_POLICY_ENABLED = "smSchedulePolicyEnabled";
+    public static final String A_SM_SCHEDULE_POLICY_START_TIME = "smSchedulePolicyStartTime";
+    public static final String A_SM_START = "SM_START:";
+    public static final String A_SM_END = ":SM_END";
+    public static final String A_SM_SCHEDULE_POLICY_ENABLED_MISSING = "No smSchedulePolicyEnabled defined.";
+    public static final String A_SM_TIME_MISSING = "No time defined.";
+    public static final String A_SM_INVALID_TIME_FORMAT = "Invalid time format.";
+    public static final String A_SM_INVALID_HOURS_FORMAT = "Invalid hour defined.";
+    public static final String A_SM_INVALID_MINUTES = "Minutes are not allowed.";
 }

--- a/common/src/java/com/zimbra/common/util/ZimbraLog.java
+++ b/common/src/java/com/zimbra/common/util/ZimbraLog.java
@@ -493,6 +493,11 @@ public final class ZimbraLog {
     public static final Log gql = LogFactory.getLog("zimbra.gql");
 
     /**
+     * Log for zimbra Store managers
+     */
+    public static final Log SM_LOG = LogFactory.getLog("zimbra.storemanagers");
+
+    /**
      * Maps the log category name to its description.
      */
     public static final Map<String, String> CATEGORY_DESCRIPTIONS;
@@ -603,6 +608,7 @@ public final class ZimbraLog {
         descriptions.put(passwordreset.getCategory(), "Password Reset operations");
         descriptions.put(addresslist.getCategory(), "Addresslist operations");
         descriptions.put(gql.getCategory(), "GraphQL operations");
+        descriptions.put(SM_LOG.getCategory(), "Generic Store managers");
         CATEGORY_DESCRIPTIONS = Collections.unmodifiableMap(descriptions);
     }
 

--- a/common/src/java/com/zimbra/common/util/ZimbraLog.java
+++ b/common/src/java/com/zimbra/common/util/ZimbraLog.java
@@ -495,7 +495,7 @@ public final class ZimbraLog {
     /**
      * Log for zimbra Store managers
      */
-    public static final Log SM_LOG = LogFactory.getLog("zimbra.storemanagers");
+    public static final Log smLog = LogFactory.getLog("zimbra.storemanagers");
 
     /**
      * Maps the log category name to its description.
@@ -608,7 +608,7 @@ public final class ZimbraLog {
         descriptions.put(passwordreset.getCategory(), "Password Reset operations");
         descriptions.put(addresslist.getCategory(), "Addresslist operations");
         descriptions.put(gql.getCategory(), "GraphQL operations");
-        descriptions.put(SM_LOG.getCategory(), "Generic Store managers");
+        descriptions.put(smLog.getCategory(), "Generic Store managers");
         CATEGORY_DESCRIPTIONS = Collections.unmodifiableMap(descriptions);
     }
 

--- a/soap/src/java/com/zimbra/soap/admin/message/CreateVolumeRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/CreateVolumeRequest.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2011, 2012, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2011, 2012, 2013, 2014, 2016, 2022 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -24,6 +24,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 import com.zimbra.common.soap.AdminConstants;
 import com.zimbra.soap.admin.type.VolumeInfo;
+import com.zimbra.soap.admin.type.VolumeExternalInfo;
 
 /**
  * @zm-api-command-auth-required true
@@ -38,7 +39,7 @@ public class CreateVolumeRequest {
      * @zm-api-field-description Volume information
      */
     @XmlElement(name=AdminConstants.E_VOLUME, required=true)
-    private VolumeInfo volume;
+    private VolumeInfo volumeInfo;
 
     /**
      * no-argument constructor wanted by JAXB
@@ -48,9 +49,9 @@ public class CreateVolumeRequest {
         this((VolumeInfo)null);
     }
 
-    public CreateVolumeRequest(VolumeInfo volume) {
-        this.volume = volume;
+    public CreateVolumeRequest(VolumeInfo volumeInfo) {
+        this.volumeInfo = volumeInfo;
     }
 
-    public VolumeInfo getVolume() { return volume; }
+    public VolumeInfo getVolume() { return volumeInfo; }
 }

--- a/soap/src/java/com/zimbra/soap/admin/message/DeleteVolumeRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/DeleteVolumeRequest.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2011, 2012, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2011, 2012, 2013, 2014, 2016, 2022 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -55,5 +55,4 @@ public final class DeleteVolumeRequest {
     public short getId() {
         return id;
     }
-
 }

--- a/soap/src/java/com/zimbra/soap/admin/message/GetScheduleSMPolicyRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/GetScheduleSMPolicyRequest.java
@@ -1,0 +1,68 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.google.common.base.MoreObjects;
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.common.soap.HsmConstants;
+import com.zimbra.soap.admin.type.Name;
+
+/**
+ * @zm-api-command-network-edition
+ * @zm-api-command-auth-required true
+ * @zm-api-command-admin-auth-required true
+ * @zm-api-command-description Schedule Storage Management Policy
+ */
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name=HsmConstants.E_GET_SCHEDULE_SM_POLICY_REQUEST)
+public class GetScheduleSMPolicyRequest {
+
+    /**
+     * @zm-api-field-description Server specification
+     */
+    @XmlElement(name=AdminConstants.E_SERVER /* server */, required=true)
+    private final Name server;
+
+    /**
+     * no-argument constructor wanted by JAXB
+     */
+    @SuppressWarnings("unused")
+    private GetScheduleSMPolicyRequest() {
+        this((Name) null);
+    }
+
+    public GetScheduleSMPolicyRequest(Name server) {
+        this.server = server;
+    }
+
+    public Name getServer() { return server; }
+
+    public MoreObjects.ToStringHelper addToStringInfo(MoreObjects.ToStringHelper helper) {
+        return helper.add("server", server);
+    }
+
+    @Override
+    public String toString() {
+        return addToStringInfo(MoreObjects.toStringHelper(this)).toString();
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/GetScheduleSMPolicyResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/GetScheduleSMPolicyResponse.java
@@ -1,0 +1,96 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import com.google.common.base.MoreObjects;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.HsmConstants;
+import com.zimbra.soap.type.ZmBoolean;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name=HsmConstants.E_GET_SCHEDULE_SM_POLICY_RESPONSE)
+public class GetScheduleSMPolicyResponse {
+
+    /**
+     * @zm-api-field-description <b>1 (true)</b> if an HSM session is currently running, <b>0 (false)</b>
+     * if the information returned applies to the last completed HSM session
+     */
+    @XmlAttribute(name=HsmConstants.A_SM_SCHEDULE_POLICY_ENABLED /* running */, required=true)
+    private final ZmBoolean smSchedulePolicyEnabled;
+
+    /**
+     * @zm-api-field-tag error-text
+     * @zm-api-field-description The error message, if an error occurred while processing the last
+     * <b>&lt;HsmRequest></b>
+     */
+    @XmlAttribute(name=HsmConstants.A_ERROR /* error */, required=false)
+    private String error;
+
+    /**
+     * @zm-api-field-tag total-mailboxes
+     * @zm-api-field-description Total number of mailboxes that should be processed by the HSM session
+     */
+    @XmlAttribute(name=HsmConstants.A_SM_SCHEDULE_POLICY_START_TIME /* scheduletime */, required=true)
+    private Integer smSchedulePolicyStartTime;
+
+    /**
+     * no-argument constructor wanted by JAXB
+     */
+    @SuppressWarnings("unused")
+    private GetScheduleSMPolicyResponse() {
+        this(false);
+    }
+
+    public GetScheduleSMPolicyResponse(boolean smSchedulePolicyEnabled) {
+        this.smSchedulePolicyEnabled = ZmBoolean.fromBool(smSchedulePolicyEnabled);
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+    
+    public void setSmScheduleStartTime(Integer smSchedulePolicyStartTime) {
+        this.smSchedulePolicyStartTime = smSchedulePolicyStartTime;
+    }
+
+    public boolean getSmScheduleEnabled() {
+        return ZmBoolean.toBool(smSchedulePolicyEnabled);
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public Integer getSmScheduleStartTime() {
+        return smSchedulePolicyStartTime;
+    }
+
+    public MoreObjects.ToStringHelper addToStringInfo(MoreObjects.ToStringHelper helper) {
+        return helper.add("smSchedulePolicyEnabled", smSchedulePolicyEnabled)
+                .add("smSchedulePolicyStartTime", smSchedulePolicyStartTime).add("error", error);
+    }
+
+    @Override
+    public String toString() {
+        return addToStringInfo(MoreObjects.toStringHelper(this)).toString();
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/ModifyVolumeRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/ModifyVolumeRequest.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2011, 2012, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2011, 2012, 2013, 2014, 2016, 2022 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -43,7 +43,7 @@ public class ModifyVolumeRequest {
      * @zm-api-field-description Volume information
      */
     @XmlElement(name=AdminConstants.E_VOLUME, required=true)
-    private VolumeInfo volume;
+    private VolumeInfo volumeInfo;
 
     /**
      * no-argument constructor wanted by JAXB
@@ -53,11 +53,11 @@ public class ModifyVolumeRequest {
         this((short)-1, (VolumeInfo)null);
     }
 
-    public ModifyVolumeRequest(short id, VolumeInfo volume) {
+    public ModifyVolumeRequest(short id, VolumeInfo volumeInfo) {
         this.id = id;
-        this.volume = volume;
+        this.volumeInfo = volumeInfo;
     }
 
     public short getId() { return id; }
-    public VolumeInfo getVolume() { return volume; }
+    public VolumeInfo getVolumeInfo() { return volumeInfo; }
 }

--- a/soap/src/java/com/zimbra/soap/admin/message/ScheduleSMPolicyRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/ScheduleSMPolicyRequest.java
@@ -1,0 +1,70 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.google.common.base.MoreObjects;
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.common.soap.HsmConstants;
+import com.zimbra.soap.admin.type.Name;
+
+/**
+ * @zm-api-command-network-edition
+ * @zm-api-command-auth-required true
+ * @zm-api-command-admin-auth-required true
+ * @zm-api-command-description Schedule Storage Management Policy
+ */
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name=HsmConstants.E_SCHEDULE_SMPOLICY_REQUEST)
+public class ScheduleSMPolicyRequest {
+
+    /**
+     * @zm-api-field-description Server specification
+     */
+    @XmlElement(name=AdminConstants.E_SERVER /* server */, required=true)
+    private final Name server;
+
+    /**
+     * no-argument constructor wanted by JAXB
+     */
+    @SuppressWarnings("unused")
+    private ScheduleSMPolicyRequest() {
+        this((Name) null);
+    }
+
+    public ScheduleSMPolicyRequest(Name server) {
+        this.server = server;
+    }
+
+    public Name getServer() {
+        return server;
+    }
+
+    public MoreObjects.ToStringHelper addToStringInfo(MoreObjects.ToStringHelper helper) {
+        return helper.add("server", server);
+    }
+
+    @Override
+    public String toString() {
+        return addToStringInfo(MoreObjects.toStringHelper(this)).toString();
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/ScheduleSMPolicyResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/ScheduleSMPolicyResponse.java
@@ -1,0 +1,95 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.google.common.base.MoreObjects;
+import com.zimbra.common.soap.HsmConstants;
+import com.zimbra.soap.type.ZmBoolean;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name=HsmConstants.E_SCHEDULE_SMPOLICY_RESPONSE)
+public class ScheduleSMPolicyResponse {
+
+    /**
+     * @zm-api-field-description <b>1 (true)</b> if an HSM session is currently running, <b>0 (false)</b>
+     * if the information returned applies to the last completed HSM session
+     */
+    @XmlAttribute(name=HsmConstants.A_SM_SCHEDULE_POLICY_ENABLED /* running */, required=true)
+    private final ZmBoolean smSchedulePolicyEnabled;
+
+    /**
+     * @zm-api-field-tag error-text
+     * @zm-api-field-description The error message, if an error occurred while processing the last
+     * <b>&lt;HsmRequest></b>
+     */
+    @XmlAttribute(name=HsmConstants.A_ERROR /* error */, required=false)
+    private String error;
+
+    /**
+     * @zm-api-field-tag total-mailboxes
+     * @zm-api-field-description Total number of mailboxes that should be processed by the HSM session
+     */
+    @XmlAttribute(name=HsmConstants.A_SM_SCHEDULE_POLICY_START_TIME /* totalMailboxes */, required=true)
+    private Integer smSchedulePolicyStartTime;
+
+    /**
+     * no-argument constructor wanted by JAXB
+     */
+    @SuppressWarnings("unused")
+    private ScheduleSMPolicyResponse() {
+        this(false);
+    }
+
+    public ScheduleSMPolicyResponse(boolean smSchedulePolicyEnabled) {
+        this.smSchedulePolicyEnabled = ZmBoolean.fromBool(smSchedulePolicyEnabled);
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+    public void setSmScheduleStartTime(Integer smSchedulePolicyStartTime) {
+        this.smSchedulePolicyStartTime = smSchedulePolicyStartTime;
+    }
+
+    public boolean getSmScheduleEnabled() {
+        return ZmBoolean.toBool(smSchedulePolicyEnabled);
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public Integer getSmScheduleStartTime() {
+        return smSchedulePolicyStartTime;
+    }
+
+    public MoreObjects.ToStringHelper addToStringInfo(MoreObjects.ToStringHelper helper) {
+        return helper.add("smSchedulePolicyEnabled", smSchedulePolicyEnabled)
+                .add("smSchedulePolicyStartTime", smSchedulePolicyStartTime).add("error", error);
+    }
+
+    @Override
+    public String toString() {
+        return addToStringInfo(MoreObjects.toStringHelper(this)).toString();
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/type/VolumeExternalInfo.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/VolumeExternalInfo.java
@@ -1,0 +1,113 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.type;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+
+import com.zimbra.soap.type.ZmBoolean;
+import com.zimbra.common.soap.AdminConstants;
+
+@XmlAccessorType(XmlAccessType.NONE)
+public class VolumeExternalInfo {
+
+    /**
+     * @zm-api-field-description Set to 1 for Internal and 2 for External.
+     */
+    @XmlAttribute(name=AdminConstants.A_VOLUME_STORAGE_TYPE /* storageType */, required=false)
+    private String storageType = "S3";
+
+    /**
+     * @zm-api-field-description Prefix for bucket location e.g. server1_primary
+     */
+    @XmlAttribute(name=AdminConstants.A_VOLUME_VOLUME_PREFIX /* volumePrefix */, required=false)
+    private String volumePrefix = "";
+
+    /**
+     * @zm-api-field-description Specifies global bucket configuration Id
+     */
+    @XmlAttribute(name=AdminConstants.A_VOLUME_GLB_BUCKET_CONFIG_ID /* glbBucketConfigId */, required=true)
+    private String glbBucketConfigId = "";
+
+    /**
+     * @zm-api-field-description Specifies frequent access enabled or not
+     */
+    @XmlAttribute(name=AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS /* useInFrequentAccess */, required=false)
+    private Boolean useInFrequentAccess = false;
+
+    /**
+     * @zm-api-field-description Specifies threshold value of useInFrequentAccess
+     */
+    @XmlAttribute(name=AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS_THRESHOLD /* useInFrequentAccessThreshold */, required=false)
+    private int useInFrequentAccessThreshold = 65536;
+
+    /**
+     * @zm-api-field-description Specifies intelligent tiering enabled or not
+     */
+    @XmlAttribute(name=AdminConstants.A_VOLUME_USE_INTELLIGENT_TIERING /* useIntelligentTiering */, required=false)
+    private Boolean useIntelligentTiering = false;
+
+    public void setStorageType(String value) {
+        storageType = value;
+    }
+
+    public String getStorageType() {
+        return storageType;
+    }
+
+    public void setVolumePrefix(String value) {
+        volumePrefix = value;
+    }
+
+    public String getVolumePrefix() {
+        return volumePrefix;
+    }
+
+    public void setGlobalBucketConfigurationId(String value) {
+        glbBucketConfigId = value;
+    }
+
+    public String getGlobalBucketConfigurationId() {
+        return glbBucketConfigId;
+    }
+
+    public void setUseInFrequentAccess(Boolean value) {
+        useInFrequentAccess = value;
+    }
+
+    public Boolean getUseInFrequentAccess() {
+        return useInFrequentAccess;
+    }
+
+    public void setUseIntelligentTiering(Boolean value) {
+        useIntelligentTiering = value;
+    }
+
+    public Boolean getUseIntelligentTiering() {
+        return useIntelligentTiering;
+    }
+
+    public void setUseInFrequentAccessThreshold(int value) {
+        useInFrequentAccessThreshold = value;
+    }
+
+    public int getUseInFrequentAccessThreshold() {
+        return useInFrequentAccessThreshold;
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/type/VolumeInfo.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/VolumeInfo.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2011, 2012, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2011, 2012, 2013, 2014, 2016, 2022 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -20,6 +20,7 @@ package com.zimbra.soap.admin.type;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
 
 import com.zimbra.common.soap.AdminConstants;
 import com.zimbra.soap.type.ZmBoolean;
@@ -38,14 +39,14 @@ public final class VolumeInfo {
      * @zm-api-field-tag volume-name
      * @zm-api-field-description Name or description of volume
      */
-    @XmlAttribute(name=AdminConstants.A_VOLUME_NAME /* name */, required=false)
+    @XmlAttribute(name=AdminConstants.A_VOLUME_NAME /* name */, required=true)
     private String name;
 
     /**
      * @zm-api-field-tag volume-root-path
      * @zm-api-field-description Absolute path to root of volume, e.g. /opt/zimbra/store
      */
-    @XmlAttribute(name=AdminConstants.A_VOLUME_ROOTPATH /* rootpath */, required=false)
+    @XmlAttribute(name=AdminConstants.A_VOLUME_ROOTPATH /* rootpath */, required=true)
     private String rootPath;
 
     /**
@@ -57,7 +58,7 @@ public final class VolumeInfo {
      * <tr> <td> <b>10</b> </td> <td> index volume </td> </tr>
      * </table>
      */
-    @XmlAttribute(name=AdminConstants.A_VOLUME_TYPE /* type */, required=false)
+    @XmlAttribute(name=AdminConstants.A_VOLUME_TYPE /* type */, required=true)
     private short type = -1;
 
     /**
@@ -65,7 +66,7 @@ public final class VolumeInfo {
      * @zm-api-field-description Specifies whether blobs in this volume are compressed
      */
     @XmlAttribute(name=AdminConstants.A_VOLUME_COMPRESS_BLOBS /* compressBlobs */, required=false)
-    private ZmBoolean compressBlobs;
+    private ZmBoolean compressBlobs = ZmBoolean.fromBool(false);
 
     /**
      * @zm-api-field-tag compression-threshold
@@ -73,7 +74,7 @@ public final class VolumeInfo {
      * that will not be compressed (in other words blobs larger than this threshold are compressed)
      */
     @XmlAttribute(name=AdminConstants.A_VOLUME_COMPRESSION_THRESHOLD /* compressionThreshold */, required=false)
-    private long compressionThreshold = -1;
+    private long compressionThreshold = 4096;
 
     /**
      * @zm-api-field-description mgbits
@@ -104,6 +105,18 @@ public final class VolumeInfo {
      */
     @XmlAttribute(name=AdminConstants.A_VOLUME_IS_CURRENT /* isCurrent */, required=false)
     private ZmBoolean current;
+
+    /**
+     * @zm-api-field-description Set to 1 for internal volumes and 2 for external volumes
+     */
+    @XmlAttribute(name=AdminConstants.A_VOLUME_STORE_TYPE /* storeType */, required=false)
+    private short storeType = 1;
+
+    /**
+     * @zm-api-field-description Volume external information
+     */
+    @XmlElement(name=AdminConstants.E_VOLUME_EXT /* volumeExternalInfo */, required=false)
+    private VolumeExternalInfo volumeExternalInfo;
 
     public void setId(short value) {
         id = value;
@@ -195,5 +208,21 @@ public final class VolumeInfo {
 
     public Boolean isCurrent() {
         return ZmBoolean.toBool(current);
+    }
+
+    public void setVolumeExternalInfo(VolumeExternalInfo value) {
+        volumeExternalInfo = value;
+    }
+
+    public VolumeExternalInfo getVolumeExternalInfo() {
+        return volumeExternalInfo;
+    }
+
+    public void setStoreType(short value) {
+        storeType = value;
+    }
+
+    public short getStoreType() {
+        return storeType;
     }
 }

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9929,4 +9929,10 @@ TODO: delete them permanently from here
   <defaultCOSValue>30</defaultCOSValue>
   <desc>Default calendar resolution preference</desc>
 </attr>
+<attr id="4005" name="zimbraGlobalExternalStoreConfig" type="string" cardinality="single" optionalIn="globalConfig" since="9.1.0">
+  <desc>Global level external store config</desc>
+</attr>
+<attr id="4006" name="zimbraServerExternalStoreConfig" type="string" cardinality="single" optionalIn="server" since="9.1.0">
+  <desc>Server level external store config</desc>
+</attr>
 </attrs>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9935,4 +9935,48 @@ TODO: delete them permanently from here
 <attr id="4006" name="zimbraServerExternalStoreConfig" type="string" cardinality="single" optionalIn="server" since="9.1.0">
   <desc>Server level external store config</desc>
 </attr>
+<attr id="4007" name="zimbraBackupConfigEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,domain,cos,account" flags="accountCosDomainInherited,domainInherited" since="9.1.0">
+    <desc>Whether or not account is eligible for backup</desc>
+  </attr>
+<attr id="4008" name="zimbraBackupEnabled" type="boolean" cardinality="single" optionalIn="globalConfig" since="9.1.0">
+    <globalConfigValue>TRUE</globalConfigValue>
+    <desc>If true, enables the UI and if there is pre-configured data the crontab should get that schedule</desc>
+  </attr>
+<attr id="4009" name="zimbraBackupSyncUsers" type="boolean" cardinality="single" optionalIn="globalConfig" since="9.1.0">
+    <globalConfigValue>FALSE</globalConfigValue>
+    <desc>if true,  will ensure the same users are enabled within backup and Dumpster</desc>
+  </attr>
+<attr id="4010" name="zimbraBackupStartTime" type="duration" cardinality="single" optionalIn="globalConfig,server"  flags="serverInherited" since="9.1.0">
+    <globalConfigValue>2</globalConfigValue>
+    <desc>Starts backup each day at this time. This attribute is used for cronjob to set hour</desc>
+  </attr>
+<attr id="4011" name="zimbraBackupRetentionDays" type="integer" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="9.1.0">
+    <globalConfigValue>8</globalConfigValue>
+    <desc>The number of days backups will be kept. Backup Scheduler deletes backups older than the set value</desc>
+  </attr>
+<attr id="4012" name="zimbraBackupBlobsCompress" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="9.1.0">
+    <globalConfigValue>TRUE</globalConfigValue>
+    <desc>Blobs inside backups are compressed in zip format by default unless specified</desc>
+  </attr>
+<attr id="4013" name="zimbraBackupBlobsCompressZipStore" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="9.1.0">
+    <globalConfigValue>FALSE</globalConfigValue>
+    <desc>Backup up blobs in zip files without compression.</desc>
+  </attr>
+<attr id="4014" name="zimbraBackupSyncMode" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="9.1.0">
+    <globalConfigValue>FALSE</globalConfigValue>
+    <desc>Runs full backup synchronously</desc>
+  </attr>
+<attr id="4015" name="zimbraMailReportEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="9.1.0">
+    <globalConfigValue>TRUE</globalConfigValue>
+    <desc>If true, send an email report to the admin user.</desc>
+  </attr>
+<attr id="4016" name="zimbraBackupStandardFullBackup" type="astring" max="256" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="9.1.0">
+    <globalConfigValue>full</globalConfigValue>
+    <desc>Indicates a scheduled backup call is for full-backup</desc>
+  </attr>
+<attr id="4017" name="ZimbraBackupStandardIncBackup" type="astring" max="256" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="9.1.0">
+    <globalConfigValue>incr</globalConfigValue>
+    <desc>Indicates a scheduled backup call is for incremental-backup</desc>
+  </attr>
 </attrs>
+

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -5354,6 +5354,78 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * Whether or not account is eligible for backup
+     *
+     * @return zimbraBackupConfigEnabled, or false if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4007)
+    public boolean isBackupConfigEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraBackupConfigEnabled, false, true);
+    }
+
+    /**
+     * Whether or not account is eligible for backup
+     *
+     * @param zimbraBackupConfigEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4007)
+    public void setBackupConfigEnabled(boolean zimbraBackupConfigEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupConfigEnabled, zimbraBackupConfigEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether or not account is eligible for backup
+     *
+     * @param zimbraBackupConfigEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4007)
+    public Map<String,Object> setBackupConfigEnabled(boolean zimbraBackupConfigEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupConfigEnabled, zimbraBackupConfigEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether or not account is eligible for backup
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4007)
+    public void unsetBackupConfigEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupConfigEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether or not account is eligible for backup
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4007)
+    public Map<String,Object> unsetBackupConfigEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupConfigEnabled, "");
+        return attrs;
+    }
+
+    /**
      * Batch size to use when indexing data
      *
      * @return zimbraBatchedIndexingSize, or 20 if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -49,6 +49,78 @@ public abstract class ZAttrConfig extends Entry {
     ///// BEGIN-AUTO-GEN-REPLACE
 
     /**
+     * Indicates a scheduled backup call is for incremental-backup
+     *
+     * @return ZimbraBackupStandardIncBackup, or "incr" if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4017)
+    public String getZimbraBackupStandardIncBackup() {
+        return getAttr(Provisioning.A_ZimbraBackupStandardIncBackup, "incr", true);
+    }
+
+    /**
+     * Indicates a scheduled backup call is for incremental-backup
+     *
+     * @param ZimbraBackupStandardIncBackup new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4017)
+    public void setZimbraBackupStandardIncBackup(String ZimbraBackupStandardIncBackup) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_ZimbraBackupStandardIncBackup, ZimbraBackupStandardIncBackup);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Indicates a scheduled backup call is for incremental-backup
+     *
+     * @param ZimbraBackupStandardIncBackup new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4017)
+    public Map<String,Object> setZimbraBackupStandardIncBackup(String ZimbraBackupStandardIncBackup, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_ZimbraBackupStandardIncBackup, ZimbraBackupStandardIncBackup);
+        return attrs;
+    }
+
+    /**
+     * Indicates a scheduled backup call is for incremental-backup
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4017)
+    public void unsetZimbraBackupStandardIncBackup() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_ZimbraBackupStandardIncBackup, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Indicates a scheduled backup call is for incremental-backup
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4017)
+    public Map<String,Object> unsetZimbraBackupStandardIncBackup(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_ZimbraBackupStandardIncBackup, "");
+        return attrs;
+    }
+
+    /**
      * RFC2256: descriptive information
      *
      * @return description, or empty array if unset
@@ -5004,6 +5076,304 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Blobs inside backups are compressed in zip format by default unless
+     * specified
+     *
+     * @return zimbraBackupBlobsCompress, or true if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4012)
+    public boolean isBackupBlobsCompress() {
+        return getBooleanAttr(Provisioning.A_zimbraBackupBlobsCompress, true, true);
+    }
+
+    /**
+     * Blobs inside backups are compressed in zip format by default unless
+     * specified
+     *
+     * @param zimbraBackupBlobsCompress new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4012)
+    public void setBackupBlobsCompress(boolean zimbraBackupBlobsCompress) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupBlobsCompress, zimbraBackupBlobsCompress ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Blobs inside backups are compressed in zip format by default unless
+     * specified
+     *
+     * @param zimbraBackupBlobsCompress new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4012)
+    public Map<String,Object> setBackupBlobsCompress(boolean zimbraBackupBlobsCompress, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupBlobsCompress, zimbraBackupBlobsCompress ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Blobs inside backups are compressed in zip format by default unless
+     * specified
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4012)
+    public void unsetBackupBlobsCompress() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupBlobsCompress, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Blobs inside backups are compressed in zip format by default unless
+     * specified
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4012)
+    public Map<String,Object> unsetBackupBlobsCompress(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupBlobsCompress, "");
+        return attrs;
+    }
+
+    /**
+     * Backup up blobs in zip files without compression.
+     *
+     * @return zimbraBackupBlobsCompressZipStore, or false if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4013)
+    public boolean isBackupBlobsCompressZipStore() {
+        return getBooleanAttr(Provisioning.A_zimbraBackupBlobsCompressZipStore, false, true);
+    }
+
+    /**
+     * Backup up blobs in zip files without compression.
+     *
+     * @param zimbraBackupBlobsCompressZipStore new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4013)
+    public void setBackupBlobsCompressZipStore(boolean zimbraBackupBlobsCompressZipStore) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupBlobsCompressZipStore, zimbraBackupBlobsCompressZipStore ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Backup up blobs in zip files without compression.
+     *
+     * @param zimbraBackupBlobsCompressZipStore new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4013)
+    public Map<String,Object> setBackupBlobsCompressZipStore(boolean zimbraBackupBlobsCompressZipStore, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupBlobsCompressZipStore, zimbraBackupBlobsCompressZipStore ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Backup up blobs in zip files without compression.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4013)
+    public void unsetBackupBlobsCompressZipStore() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupBlobsCompressZipStore, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Backup up blobs in zip files without compression.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4013)
+    public Map<String,Object> unsetBackupBlobsCompressZipStore(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupBlobsCompressZipStore, "");
+        return attrs;
+    }
+
+    /**
+     * Whether or not account is eligible for backup
+     *
+     * @return zimbraBackupConfigEnabled, or false if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4007)
+    public boolean isBackupConfigEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraBackupConfigEnabled, false, true);
+    }
+
+    /**
+     * Whether or not account is eligible for backup
+     *
+     * @param zimbraBackupConfigEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4007)
+    public void setBackupConfigEnabled(boolean zimbraBackupConfigEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupConfigEnabled, zimbraBackupConfigEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether or not account is eligible for backup
+     *
+     * @param zimbraBackupConfigEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4007)
+    public Map<String,Object> setBackupConfigEnabled(boolean zimbraBackupConfigEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupConfigEnabled, zimbraBackupConfigEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether or not account is eligible for backup
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4007)
+    public void unsetBackupConfigEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupConfigEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether or not account is eligible for backup
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4007)
+    public Map<String,Object> unsetBackupConfigEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupConfigEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * If true, enables the UI and if there is pre-configured data the
+     * crontab should get that schedule
+     *
+     * @return zimbraBackupEnabled, or true if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public boolean isBackupEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraBackupEnabled, true, true);
+    }
+
+    /**
+     * If true, enables the UI and if there is pre-configured data the
+     * crontab should get that schedule
+     *
+     * @param zimbraBackupEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public void setBackupEnabled(boolean zimbraBackupEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupEnabled, zimbraBackupEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * If true, enables the UI and if there is pre-configured data the
+     * crontab should get that schedule
+     *
+     * @param zimbraBackupEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public Map<String,Object> setBackupEnabled(boolean zimbraBackupEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupEnabled, zimbraBackupEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * If true, enables the UI and if there is pre-configured data the
+     * crontab should get that schedule
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public void unsetBackupEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * If true, enables the UI and if there is pre-configured data the
+     * crontab should get that schedule
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public Map<String,Object> unsetBackupEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupEnabled, "");
+        return attrs;
+    }
+
+    /**
      * Minimum percentage or TB/GB/MB/KB/bytes of free space on backup target
      * to allow a full or auto-grouped backup to start; 0 = no minimum is
      * enforced. Examples: 25%, 10GB
@@ -5441,6 +5811,83 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * The number of days backups will be kept. Backup Scheduler deletes
+     * backups older than the set value
+     *
+     * @return zimbraBackupRetentionDays, or 8 if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4011)
+    public int getBackupRetentionDays() {
+        return getIntAttr(Provisioning.A_zimbraBackupRetentionDays, 8, true);
+    }
+
+    /**
+     * The number of days backups will be kept. Backup Scheduler deletes
+     * backups older than the set value
+     *
+     * @param zimbraBackupRetentionDays new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4011)
+    public void setBackupRetentionDays(int zimbraBackupRetentionDays) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupRetentionDays, Integer.toString(zimbraBackupRetentionDays));
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * The number of days backups will be kept. Backup Scheduler deletes
+     * backups older than the set value
+     *
+     * @param zimbraBackupRetentionDays new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4011)
+    public Map<String,Object> setBackupRetentionDays(int zimbraBackupRetentionDays, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupRetentionDays, Integer.toString(zimbraBackupRetentionDays));
+        return attrs;
+    }
+
+    /**
+     * The number of days backups will be kept. Backup Scheduler deletes
+     * backups older than the set value
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4011)
+    public void unsetBackupRetentionDays() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupRetentionDays, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * The number of days backups will be kept. Backup Scheduler deletes
+     * backups older than the set value
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4011)
+    public Map<String,Object> unsetBackupRetentionDays(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupRetentionDays, "");
+        return attrs;
+    }
+
+    /**
      * if true, do not backup blobs (HSM or not) during a full backup
      *
      * @return zimbraBackupSkipBlobs, or false if unset
@@ -5658,6 +6105,339 @@ public abstract class ZAttrConfig extends Entry {
     public Map<String,Object> unsetBackupSkipSearchIndex(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraBackupSkipSearchIndex, "");
+        return attrs;
+    }
+
+    /**
+     * Indicates a scheduled backup call is for full-backup
+     *
+     * @return zimbraBackupStandardFullBackup, or "full" if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4016)
+    public String getBackupStandardFullBackup() {
+        return getAttr(Provisioning.A_zimbraBackupStandardFullBackup, "full", true);
+    }
+
+    /**
+     * Indicates a scheduled backup call is for full-backup
+     *
+     * @param zimbraBackupStandardFullBackup new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4016)
+    public void setBackupStandardFullBackup(String zimbraBackupStandardFullBackup) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStandardFullBackup, zimbraBackupStandardFullBackup);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Indicates a scheduled backup call is for full-backup
+     *
+     * @param zimbraBackupStandardFullBackup new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4016)
+    public Map<String,Object> setBackupStandardFullBackup(String zimbraBackupStandardFullBackup, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStandardFullBackup, zimbraBackupStandardFullBackup);
+        return attrs;
+    }
+
+    /**
+     * Indicates a scheduled backup call is for full-backup
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4016)
+    public void unsetBackupStandardFullBackup() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStandardFullBackup, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Indicates a scheduled backup call is for full-backup
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4016)
+    public Map<String,Object> unsetBackupStandardFullBackup(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStandardFullBackup, "");
+        return attrs;
+    }
+
+    /**
+     * Starts backup each day at this time. This attribute is used for
+     * cronjob to set hour. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * <p>Use getBackupStartTimeAsString to access value as a string.
+     *
+     * @see #getBackupStartTimeAsString()
+     *
+     * @return zimbraBackupStartTime in millseconds, or 2000 (2)  if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4010)
+    public long getBackupStartTime() {
+        return getTimeInterval(Provisioning.A_zimbraBackupStartTime, 2000L, true);
+    }
+
+    /**
+     * Starts backup each day at this time. This attribute is used for
+     * cronjob to set hour. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @return zimbraBackupStartTime, or "2" if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4010)
+    public String getBackupStartTimeAsString() {
+        return getAttr(Provisioning.A_zimbraBackupStartTime, "2", true);
+    }
+
+    /**
+     * Starts backup each day at this time. This attribute is used for
+     * cronjob to set hour. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @param zimbraBackupStartTime new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4010)
+    public void setBackupStartTime(String zimbraBackupStartTime) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStartTime, zimbraBackupStartTime);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Starts backup each day at this time. This attribute is used for
+     * cronjob to set hour. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @param zimbraBackupStartTime new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4010)
+    public Map<String,Object> setBackupStartTime(String zimbraBackupStartTime, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStartTime, zimbraBackupStartTime);
+        return attrs;
+    }
+
+    /**
+     * Starts backup each day at this time. This attribute is used for
+     * cronjob to set hour. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4010)
+    public void unsetBackupStartTime() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStartTime, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Starts backup each day at this time. This attribute is used for
+     * cronjob to set hour. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4010)
+    public Map<String,Object> unsetBackupStartTime(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStartTime, "");
+        return attrs;
+    }
+
+    /**
+     * Runs full backup synchronously
+     *
+     * @return zimbraBackupSyncMode, or false if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4014)
+    public boolean isBackupSyncMode() {
+        return getBooleanAttr(Provisioning.A_zimbraBackupSyncMode, false, true);
+    }
+
+    /**
+     * Runs full backup synchronously
+     *
+     * @param zimbraBackupSyncMode new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4014)
+    public void setBackupSyncMode(boolean zimbraBackupSyncMode) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupSyncMode, zimbraBackupSyncMode ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Runs full backup synchronously
+     *
+     * @param zimbraBackupSyncMode new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4014)
+    public Map<String,Object> setBackupSyncMode(boolean zimbraBackupSyncMode, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupSyncMode, zimbraBackupSyncMode ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Runs full backup synchronously
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4014)
+    public void unsetBackupSyncMode() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupSyncMode, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Runs full backup synchronously
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4014)
+    public Map<String,Object> unsetBackupSyncMode(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupSyncMode, "");
+        return attrs;
+    }
+
+    /**
+     * if true, will ensure the same users are enabled within backup and
+     * Dumpster
+     *
+     * @return zimbraBackupSyncUsers, or false if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public boolean isBackupSyncUsers() {
+        return getBooleanAttr(Provisioning.A_zimbraBackupSyncUsers, false, true);
+    }
+
+    /**
+     * if true, will ensure the same users are enabled within backup and
+     * Dumpster
+     *
+     * @param zimbraBackupSyncUsers new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public void setBackupSyncUsers(boolean zimbraBackupSyncUsers) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupSyncUsers, zimbraBackupSyncUsers ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * if true, will ensure the same users are enabled within backup and
+     * Dumpster
+     *
+     * @param zimbraBackupSyncUsers new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public Map<String,Object> setBackupSyncUsers(boolean zimbraBackupSyncUsers, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupSyncUsers, zimbraBackupSyncUsers ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * if true, will ensure the same users are enabled within backup and
+     * Dumpster
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public void unsetBackupSyncUsers() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupSyncUsers, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * if true, will ensure the same users are enabled within backup and
+     * Dumpster
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public Map<String,Object> unsetBackupSyncUsers(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupSyncUsers, "");
         return attrs;
     }
 
@@ -28062,6 +28842,78 @@ public abstract class ZAttrConfig extends Entry {
     public Map<String,Object> unsetMailReferMode(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraMailReferMode, "");
+        return attrs;
+    }
+
+    /**
+     * If true, send an email report to the admin user.
+     *
+     * @return zimbraMailReportEnabled, or true if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4015)
+    public boolean isMailReportEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraMailReportEnabled, true, true);
+    }
+
+    /**
+     * If true, send an email report to the admin user.
+     *
+     * @param zimbraMailReportEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4015)
+    public void setMailReportEnabled(boolean zimbraMailReportEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailReportEnabled, zimbraMailReportEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * If true, send an email report to the admin user.
+     *
+     * @param zimbraMailReportEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4015)
+    public Map<String,Object> setMailReportEnabled(boolean zimbraMailReportEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailReportEnabled, zimbraMailReportEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * If true, send an email report to the admin user.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4015)
+    public void unsetMailReportEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailReportEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * If true, send an email report to the admin user.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4015)
+    public Map<String,Object> unsetMailReportEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailReportEnabled, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -19577,6 +19577,78 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Global level external store config
+     *
+     * @return zimbraGlobalExternalStoreConfig, or null if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4005)
+    public String getGlobalExternalStoreConfig() {
+        return getAttr(Provisioning.A_zimbraGlobalExternalStoreConfig, null, true);
+    }
+
+    /**
+     * Global level external store config
+     *
+     * @param zimbraGlobalExternalStoreConfig new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4005)
+    public void setGlobalExternalStoreConfig(String zimbraGlobalExternalStoreConfig) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraGlobalExternalStoreConfig, zimbraGlobalExternalStoreConfig);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Global level external store config
+     *
+     * @param zimbraGlobalExternalStoreConfig new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4005)
+    public Map<String,Object> setGlobalExternalStoreConfig(String zimbraGlobalExternalStoreConfig, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraGlobalExternalStoreConfig, zimbraGlobalExternalStoreConfig);
+        return attrs;
+    }
+
+    /**
+     * Global level external store config
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4005)
+    public void unsetGlobalExternalStoreConfig() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraGlobalExternalStoreConfig, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Global level external store config
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4005)
+    public Map<String,Object> unsetGlobalExternalStoreConfig(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraGlobalExternalStoreConfig, "");
+        return attrs;
+    }
+
+    /**
      * LDAP attribute to HAB Group Member attribute mapping
      *
      * @return zimbraHABMemberLdapAttrMap, or empty array if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -1807,6 +1807,78 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * Whether or not account is eligible for backup
+     *
+     * @return zimbraBackupConfigEnabled, or false if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4007)
+    public boolean isBackupConfigEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraBackupConfigEnabled, false, true);
+    }
+
+    /**
+     * Whether or not account is eligible for backup
+     *
+     * @param zimbraBackupConfigEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4007)
+    public void setBackupConfigEnabled(boolean zimbraBackupConfigEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupConfigEnabled, zimbraBackupConfigEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether or not account is eligible for backup
+     *
+     * @param zimbraBackupConfigEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4007)
+    public Map<String,Object> setBackupConfigEnabled(boolean zimbraBackupConfigEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupConfigEnabled, zimbraBackupConfigEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether or not account is eligible for backup
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4007)
+    public void unsetBackupConfigEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupConfigEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether or not account is eligible for backup
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4007)
+    public Map<String,Object> unsetBackupConfigEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupConfigEnabled, "");
+        return attrs;
+    }
+
+    /**
      * Batch size to use when indexing data
      *
      * @return zimbraBatchedIndexingSize, or 20 if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -4376,6 +4376,78 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
+     * Whether or not account is eligible for backup
+     *
+     * @return zimbraBackupConfigEnabled, or false if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4007)
+    public boolean isBackupConfigEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraBackupConfigEnabled, false, true);
+    }
+
+    /**
+     * Whether or not account is eligible for backup
+     *
+     * @param zimbraBackupConfigEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4007)
+    public void setBackupConfigEnabled(boolean zimbraBackupConfigEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupConfigEnabled, zimbraBackupConfigEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether or not account is eligible for backup
+     *
+     * @param zimbraBackupConfigEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4007)
+    public Map<String,Object> setBackupConfigEnabled(boolean zimbraBackupConfigEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupConfigEnabled, zimbraBackupConfigEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether or not account is eligible for backup
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4007)
+    public void unsetBackupConfigEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupConfigEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether or not account is eligible for backup
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4007)
+    public Map<String,Object> unsetBackupConfigEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupConfigEnabled, "");
+        return attrs;
+    }
+
+    /**
      * Realm for the basic auth challenge (WWW-Authenticate) header
      *
      * @return zimbraBasicAuthRealm, or "Zimbra" if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -46714,6 +46714,78 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
+     * Server level external store config
+     *
+     * @return zimbraServerExternalStoreConfig, or null if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4006)
+    public String getServerExternalStoreConfig() {
+        return getAttr(Provisioning.A_zimbraServerExternalStoreConfig, null, true);
+    }
+
+    /**
+     * Server level external store config
+     *
+     * @param zimbraServerExternalStoreConfig new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4006)
+    public void setServerExternalStoreConfig(String zimbraServerExternalStoreConfig) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraServerExternalStoreConfig, zimbraServerExternalStoreConfig);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Server level external store config
+     *
+     * @param zimbraServerExternalStoreConfig new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4006)
+    public Map<String,Object> setServerExternalStoreConfig(String zimbraServerExternalStoreConfig, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraServerExternalStoreConfig, zimbraServerExternalStoreConfig);
+        return attrs;
+    }
+
+    /**
+     * Server level external store config
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4006)
+    public void unsetServerExternalStoreConfig() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraServerExternalStoreConfig, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Server level external store config
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4006)
+    public Map<String,Object> unsetServerExternalStoreConfig(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraServerExternalStoreConfig, "");
+        return attrs;
+    }
+
+    /**
      * Current version of ZCS installed on this server
      *
      * @return zimbraServerVersion, or null if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -47,6 +47,78 @@ public abstract class ZAttrServer extends NamedEntry {
     ///// BEGIN-AUTO-GEN-REPLACE
 
     /**
+     * Indicates a scheduled backup call is for incremental-backup
+     *
+     * @return ZimbraBackupStandardIncBackup, or "incr" if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4017)
+    public String getZimbraBackupStandardIncBackup() {
+        return getAttr(Provisioning.A_ZimbraBackupStandardIncBackup, "incr", true);
+    }
+
+    /**
+     * Indicates a scheduled backup call is for incremental-backup
+     *
+     * @param ZimbraBackupStandardIncBackup new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4017)
+    public void setZimbraBackupStandardIncBackup(String ZimbraBackupStandardIncBackup) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_ZimbraBackupStandardIncBackup, ZimbraBackupStandardIncBackup);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Indicates a scheduled backup call is for incremental-backup
+     *
+     * @param ZimbraBackupStandardIncBackup new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4017)
+    public Map<String,Object> setZimbraBackupStandardIncBackup(String ZimbraBackupStandardIncBackup, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_ZimbraBackupStandardIncBackup, ZimbraBackupStandardIncBackup);
+        return attrs;
+    }
+
+    /**
+     * Indicates a scheduled backup call is for incremental-backup
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4017)
+    public void unsetZimbraBackupStandardIncBackup() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_ZimbraBackupStandardIncBackup, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Indicates a scheduled backup call is for incremental-backup
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4017)
+    public Map<String,Object> unsetZimbraBackupStandardIncBackup(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_ZimbraBackupStandardIncBackup, "");
+        return attrs;
+    }
+
+    /**
      * RFC2256: common name(s) for which the entity is known by
      *
      * @return cn, or null if unset
@@ -2969,6 +3041,155 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
+     * Blobs inside backups are compressed in zip format by default unless
+     * specified
+     *
+     * @return zimbraBackupBlobsCompress, or true if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4012)
+    public boolean isBackupBlobsCompress() {
+        return getBooleanAttr(Provisioning.A_zimbraBackupBlobsCompress, true, true);
+    }
+
+    /**
+     * Blobs inside backups are compressed in zip format by default unless
+     * specified
+     *
+     * @param zimbraBackupBlobsCompress new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4012)
+    public void setBackupBlobsCompress(boolean zimbraBackupBlobsCompress) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupBlobsCompress, zimbraBackupBlobsCompress ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Blobs inside backups are compressed in zip format by default unless
+     * specified
+     *
+     * @param zimbraBackupBlobsCompress new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4012)
+    public Map<String,Object> setBackupBlobsCompress(boolean zimbraBackupBlobsCompress, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupBlobsCompress, zimbraBackupBlobsCompress ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Blobs inside backups are compressed in zip format by default unless
+     * specified
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4012)
+    public void unsetBackupBlobsCompress() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupBlobsCompress, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Blobs inside backups are compressed in zip format by default unless
+     * specified
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4012)
+    public Map<String,Object> unsetBackupBlobsCompress(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupBlobsCompress, "");
+        return attrs;
+    }
+
+    /**
+     * Backup up blobs in zip files without compression.
+     *
+     * @return zimbraBackupBlobsCompressZipStore, or false if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4013)
+    public boolean isBackupBlobsCompressZipStore() {
+        return getBooleanAttr(Provisioning.A_zimbraBackupBlobsCompressZipStore, false, true);
+    }
+
+    /**
+     * Backup up blobs in zip files without compression.
+     *
+     * @param zimbraBackupBlobsCompressZipStore new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4013)
+    public void setBackupBlobsCompressZipStore(boolean zimbraBackupBlobsCompressZipStore) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupBlobsCompressZipStore, zimbraBackupBlobsCompressZipStore ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Backup up blobs in zip files without compression.
+     *
+     * @param zimbraBackupBlobsCompressZipStore new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4013)
+    public Map<String,Object> setBackupBlobsCompressZipStore(boolean zimbraBackupBlobsCompressZipStore, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupBlobsCompressZipStore, zimbraBackupBlobsCompressZipStore ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Backup up blobs in zip files without compression.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4013)
+    public void unsetBackupBlobsCompressZipStore() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupBlobsCompressZipStore, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Backup up blobs in zip files without compression.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4013)
+    public Map<String,Object> unsetBackupBlobsCompressZipStore(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupBlobsCompressZipStore, "");
+        return attrs;
+    }
+
+    /**
      * Minimum percentage or TB/GB/MB/KB/bytes of free space on backup target
      * to allow a full or auto-grouped backup to start; 0 = no minimum is
      * enforced. Examples: 25%, 10GB
@@ -3406,6 +3627,83 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
+     * The number of days backups will be kept. Backup Scheduler deletes
+     * backups older than the set value
+     *
+     * @return zimbraBackupRetentionDays, or 8 if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4011)
+    public int getBackupRetentionDays() {
+        return getIntAttr(Provisioning.A_zimbraBackupRetentionDays, 8, true);
+    }
+
+    /**
+     * The number of days backups will be kept. Backup Scheduler deletes
+     * backups older than the set value
+     *
+     * @param zimbraBackupRetentionDays new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4011)
+    public void setBackupRetentionDays(int zimbraBackupRetentionDays) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupRetentionDays, Integer.toString(zimbraBackupRetentionDays));
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * The number of days backups will be kept. Backup Scheduler deletes
+     * backups older than the set value
+     *
+     * @param zimbraBackupRetentionDays new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4011)
+    public Map<String,Object> setBackupRetentionDays(int zimbraBackupRetentionDays, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupRetentionDays, Integer.toString(zimbraBackupRetentionDays));
+        return attrs;
+    }
+
+    /**
+     * The number of days backups will be kept. Backup Scheduler deletes
+     * backups older than the set value
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4011)
+    public void unsetBackupRetentionDays() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupRetentionDays, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * The number of days backups will be kept. Backup Scheduler deletes
+     * backups older than the set value
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4011)
+    public Map<String,Object> unsetBackupRetentionDays(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupRetentionDays, "");
+        return attrs;
+    }
+
+    /**
      * if true, do not backup blobs (HSM or not) during a full backup
      *
      * @return zimbraBackupSkipBlobs, or false if unset
@@ -3623,6 +3921,262 @@ public abstract class ZAttrServer extends NamedEntry {
     public Map<String,Object> unsetBackupSkipSearchIndex(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraBackupSkipSearchIndex, "");
+        return attrs;
+    }
+
+    /**
+     * Indicates a scheduled backup call is for full-backup
+     *
+     * @return zimbraBackupStandardFullBackup, or "full" if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4016)
+    public String getBackupStandardFullBackup() {
+        return getAttr(Provisioning.A_zimbraBackupStandardFullBackup, "full", true);
+    }
+
+    /**
+     * Indicates a scheduled backup call is for full-backup
+     *
+     * @param zimbraBackupStandardFullBackup new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4016)
+    public void setBackupStandardFullBackup(String zimbraBackupStandardFullBackup) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStandardFullBackup, zimbraBackupStandardFullBackup);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Indicates a scheduled backup call is for full-backup
+     *
+     * @param zimbraBackupStandardFullBackup new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4016)
+    public Map<String,Object> setBackupStandardFullBackup(String zimbraBackupStandardFullBackup, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStandardFullBackup, zimbraBackupStandardFullBackup);
+        return attrs;
+    }
+
+    /**
+     * Indicates a scheduled backup call is for full-backup
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4016)
+    public void unsetBackupStandardFullBackup() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStandardFullBackup, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Indicates a scheduled backup call is for full-backup
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4016)
+    public Map<String,Object> unsetBackupStandardFullBackup(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStandardFullBackup, "");
+        return attrs;
+    }
+
+    /**
+     * Starts backup each day at this time. This attribute is used for
+     * cronjob to set hour. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * <p>Use getBackupStartTimeAsString to access value as a string.
+     *
+     * @see #getBackupStartTimeAsString()
+     *
+     * @return zimbraBackupStartTime in millseconds, or 2000 (2)  if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4010)
+    public long getBackupStartTime() {
+        return getTimeInterval(Provisioning.A_zimbraBackupStartTime, 2000L, true);
+    }
+
+    /**
+     * Starts backup each day at this time. This attribute is used for
+     * cronjob to set hour. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @return zimbraBackupStartTime, or "2" if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4010)
+    public String getBackupStartTimeAsString() {
+        return getAttr(Provisioning.A_zimbraBackupStartTime, "2", true);
+    }
+
+    /**
+     * Starts backup each day at this time. This attribute is used for
+     * cronjob to set hour. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @param zimbraBackupStartTime new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4010)
+    public void setBackupStartTime(String zimbraBackupStartTime) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStartTime, zimbraBackupStartTime);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Starts backup each day at this time. This attribute is used for
+     * cronjob to set hour. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @param zimbraBackupStartTime new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4010)
+    public Map<String,Object> setBackupStartTime(String zimbraBackupStartTime, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStartTime, zimbraBackupStartTime);
+        return attrs;
+    }
+
+    /**
+     * Starts backup each day at this time. This attribute is used for
+     * cronjob to set hour. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4010)
+    public void unsetBackupStartTime() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStartTime, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Starts backup each day at this time. This attribute is used for
+     * cronjob to set hour. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4010)
+    public Map<String,Object> unsetBackupStartTime(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStartTime, "");
+        return attrs;
+    }
+
+    /**
+     * Runs full backup synchronously
+     *
+     * @return zimbraBackupSyncMode, or false if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4014)
+    public boolean isBackupSyncMode() {
+        return getBooleanAttr(Provisioning.A_zimbraBackupSyncMode, false, true);
+    }
+
+    /**
+     * Runs full backup synchronously
+     *
+     * @param zimbraBackupSyncMode new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4014)
+    public void setBackupSyncMode(boolean zimbraBackupSyncMode) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupSyncMode, zimbraBackupSyncMode ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Runs full backup synchronously
+     *
+     * @param zimbraBackupSyncMode new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4014)
+    public Map<String,Object> setBackupSyncMode(boolean zimbraBackupSyncMode, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupSyncMode, zimbraBackupSyncMode ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Runs full backup synchronously
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4014)
+    public void unsetBackupSyncMode() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupSyncMode, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Runs full backup synchronously
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4014)
+    public Map<String,Object> unsetBackupSyncMode(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupSyncMode, "");
         return attrs;
     }
 
@@ -17653,6 +18207,78 @@ public abstract class ZAttrServer extends NamedEntry {
     public Map<String,Object> unsetMailReferMode(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraMailReferMode, "");
+        return attrs;
+    }
+
+    /**
+     * If true, send an email report to the admin user.
+     *
+     * @return zimbraMailReportEnabled, or true if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4015)
+    public boolean isMailReportEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraMailReportEnabled, true, true);
+    }
+
+    /**
+     * If true, send an email report to the admin user.
+     *
+     * @param zimbraMailReportEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4015)
+    public void setMailReportEnabled(boolean zimbraMailReportEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailReportEnabled, zimbraMailReportEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * If true, send an email report to the admin user.
+     *
+     * @param zimbraMailReportEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4015)
+    public Map<String,Object> setMailReportEnabled(boolean zimbraMailReportEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailReportEnabled, zimbraMailReportEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * If true, send an email report to the admin user.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4015)
+    public void unsetMailReportEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailReportEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * If true, send an email report to the admin user.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4015)
+    public Map<String,Object> unsetMailReportEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailReportEnabled, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/db/DbVolume.java
+++ b/store/src/java/com/zimbra/cs/db/DbVolume.java
@@ -335,16 +335,17 @@ public final class DbVolume {
     }
 
     private static boolean isVolumeReferenced(DbConnection conn, short volumeId, int groupId) throws ServiceException {
-        return tableRefsVolume(conn, volumeId, groupId, "revision") || tableRefsVolume(conn, volumeId, groupId, "revision_dumpster") ||
-                tableRefsVolume(conn, volumeId, groupId, "mail_item_dumpster") || tableRefsVolume(conn, volumeId, groupId, "mail_item");
+        return tableRefsVolume(conn, volumeId, groupId, "revision") ||
+                tableRefsVolume(conn, volumeId, groupId, "revision_dumpster") ||
+                tableRefsVolume(conn, volumeId, groupId, "mail_item_dumpster") ||
+                tableRefsVolume(conn, volumeId, groupId, "mail_item");
     }
 
     private static boolean tableRefsVolume(DbConnection conn, short volumeId, int groupId, String table) throws ServiceException {
         PreparedStatement stmt = null;
         ResultSet rs = null;
         try {
-            stmt = conn.prepareStatement("SELECT count(*) from "+DbMailbox.qualifyTableName(groupId, table) +
-                    " where locator=?");
+            stmt = conn.prepareStatement("SELECT count(*) from "+DbMailbox.qualifyTableName(groupId, table) + " where locator=?");
             stmt.setInt(1, volumeId);
             rs = stmt.executeQuery();
             return (rs.next() && rs.getInt(1) > 0);

--- a/store/src/java/com/zimbra/cs/db/DbVolume.java
+++ b/store/src/java/com/zimbra/cs/db/DbVolume.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2005, 2006, 2007, 2009, 2010, 2011, 2012, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2005, 2006, 2007, 2009, 2010, 2011, 2012, 2013, 2014, 2016, 2022 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -64,8 +64,8 @@ public final class DbVolume {
         PreparedStatement stmt = null;
         try {
             stmt = conn.prepareStatement("INSERT INTO volume (id, type, name, path, mailbox_group_bits, " +
-                    "mailbox_bits, file_group_bits, file_bits, compress_blobs, compression_threshold, metadata) " +
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+                    "mailbox_bits, file_group_bits, file_bits, compress_blobs, compression_threshold, metadata, store_type) " +
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
             int pos = 1;
             stmt.setShort(pos++, nextId);
             stmt.setShort(pos++, volume.getType());
@@ -78,6 +78,7 @@ public final class DbVolume {
             stmt.setBoolean(pos++, volume.isCompressBlobs());
             stmt.setLong(pos++, volume.getCompressionThreshold());
             stmt.setString(pos++, volume.getMetadata().toString());
+            stmt.setShort(pos++, (short)(volume.getStoreType().getStoreType()));
             stmt.executeUpdate();
         } catch (SQLException e) {
             if (Db.errorMatches(e, Db.Error.DUPLICATE_ROW)) {

--- a/store/src/java/com/zimbra/cs/db/DbVolume.java
+++ b/store/src/java/com/zimbra/cs/db/DbVolume.java
@@ -47,6 +47,8 @@ public final class DbVolume {
     private static final String CN_FILE_GROUP_BITS = "file_group_bits";
     private static final String CN_MAILBOX_BITS = "mailbox_bits";
     private static final String CN_MAILBOX_GROUP_BITS = "mailbox_group_bits";
+
+    private static final String CN_STORE_TYPE = "store_type";
     private static final String CN_COMPRESS_BLOBS = "compress_blobs";
     private static final String CN_COMPRESSION_THRESHOLD = "compression_threshold";
     private static final String CN_METADATA = "metadata";
@@ -297,12 +299,17 @@ public final class DbVolume {
         } catch (ServiceException e) {
             throw VolumeServiceException.INVALID_METADATA(e);
         }
+
+        short storeTypeShort = rs.getShort(CN_STORE_TYPE);
+        Volume.StoreType storeType = Volume.StoreType.getStoreTypeBy(storeTypeShort);
+
         return Volume.builder().setId(rs.getShort(CN_ID)).setType(rs.getShort(CN_TYPE)).setName(rs.getString(CN_NAME))
                 .setPath(Volume.getAbsolutePath(rs.getString(CN_PATH)), false)
                 .setMboxGroupBits(rs.getShort(CN_MAILBOX_GROUP_BITS)).setMboxBit(rs.getShort(CN_MAILBOX_BITS))
                 .setFileGroupBits(rs.getShort(CN_FILE_GROUP_BITS)).setFileBits(rs.getShort(CN_FILE_BITS))
                 .setCompressBlobs(rs.getBoolean(CN_COMPRESS_BLOBS))
                 .setCompressionThreshold(rs.getLong(CN_COMPRESSION_THRESHOLD))
+                .setStoreType(storeType)
                 .setMetadata(metadata).build();
     }
 
@@ -329,7 +336,7 @@ public final class DbVolume {
 
     private static boolean isVolumeReferenced(DbConnection conn, short volumeId, int groupId) throws ServiceException {
         return tableRefsVolume(conn, volumeId, groupId, "revision") || tableRefsVolume(conn, volumeId, groupId, "revision_dumpster") ||
-            tableRefsVolume(conn, volumeId, groupId, "mail_item_dumpster") || tableRefsVolume(conn, volumeId, groupId, "mail_item");
+                tableRefsVolume(conn, volumeId, groupId, "mail_item_dumpster") || tableRefsVolume(conn, volumeId, groupId, "mail_item");
     }
 
     private static boolean tableRefsVolume(DbConnection conn, short volumeId, int groupId, String table) throws ServiceException {
@@ -337,7 +344,7 @@ public final class DbVolume {
         ResultSet rs = null;
         try {
             stmt = conn.prepareStatement("SELECT count(*) from "+DbMailbox.qualifyTableName(groupId, table) +
-                " where locator=?");
+                    " where locator=?");
             stmt.setInt(1, volumeId);
             rs = stmt.executeQuery();
             return (rs.next() && rs.getInt(1) > 0);

--- a/store/src/java/com/zimbra/cs/redolog/op/CreateVolume.java
+++ b/store/src/java/com/zimbra/cs/redolog/op/CreateVolume.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2013, 2014, 2016, 2022 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -38,6 +38,7 @@ public final class CreateVolume extends RedoableOp {
     private short mboxBits;
     private short fileGroupBits;
     private short fileBits;
+    private short storeType;
 
     private boolean compressBlobs;
     private long compressionThreshold;
@@ -57,6 +58,7 @@ public final class CreateVolume extends RedoableOp {
         fileBits = volume.getFileBits();
         compressBlobs = volume.isCompressBlobs();
         compressionThreshold = volume.getCompressionThreshold();
+        storeType = (short)(volume.getStoreType().getStoreType());
     }
 
     public void setId(short id) {
@@ -114,10 +116,14 @@ public final class CreateVolume extends RedoableOp {
             }
         }
         try {
+            Volume.StoreType enumStoreType =
+                (1 == storeType) ? Volume.StoreType.INTERNAL : Volume.StoreType.EXTERNAL;
+
             Volume volume = Volume.builder().setId(id).setType(type).setName(name).setPath(rootPath, false)
                     .setMboxGroupBits(mboxGroupBits).setMboxBit(mboxBits)
                     .setFileGroupBits(fileGroupBits).setFileBits(fileBits)
-                    .setCompressBlobs(compressBlobs).setCompressionThreshold(compressionThreshold).build();
+                    .setCompressBlobs(compressBlobs).setCompressionThreshold(compressionThreshold)
+                    .setStoreType(enumStoreType).build();
             mgr.create(volume, getUnloggedReplay());
         } catch (VolumeServiceException e) {
             if (e.getCode() == VolumeServiceException.ALREADY_EXISTS) {

--- a/store/src/java/com/zimbra/cs/service/admin/GetAllVolumes.java
+++ b/store/src/java/com/zimbra/cs/service/admin/GetAllVolumes.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2005, 2006, 2007, 2009, 2010, 2011, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2005, 2006, 2007, 2009, 2010, 2011, 2013, 2014, 2016, 2022 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -18,18 +18,27 @@ package com.zimbra.cs.service.admin;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.accesscontrol.AdminRight;
 import com.zimbra.cs.account.accesscontrol.Rights.Admin;
 import com.zimbra.cs.volume.Volume;
 import com.zimbra.cs.volume.VolumeManager;
-import com.zimbra.common.service.ServiceException;
-import com.zimbra.common.soap.Element;
 import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.admin.message.GetAllVolumesRequest;
 import com.zimbra.soap.admin.message.GetAllVolumesResponse;
+import com.zimbra.soap.admin.type.VolumeInfo;
+import com.zimbra.soap.admin.type.VolumeExternalInfo;
+import com.zimbra.util.ExternalVolumeInfoHandler;
 
 public final class GetAllVolumes extends AdminDocumentHandler {
 
@@ -46,7 +55,36 @@ public final class GetAllVolumes extends AdminDocumentHandler {
 
         GetAllVolumesResponse resp = new GetAllVolumesResponse();
         for (Volume vol : VolumeManager.getInstance().getAllVolumes()) {
-            resp.addVolume(vol.toJAXB());
+            VolumeInfo volInfo = vol.toJAXB();
+
+            if (vol.getStoreType().equals(Volume.StoreType.EXTERNAL)) {
+                VolumeExternalInfo volExtInfo = new VolumeExternalInfo();
+                ExternalVolumeInfoHandler extVolInfoHandler = new ExternalVolumeInfoHandler(Provisioning.getInstance());
+
+                try {
+                    JSONObject properties = extVolInfoHandler.readServerProperties(volInfo.getId());
+                    String volumePrefix = properties.getString(AdminConstants.A_VOLUME_VOLUME_PREFIX);
+                    String globalBucketConfigId = properties.getString(AdminConstants.A_VOLUME_GLB_BUCKET_CONFIG_ID);
+                    String storageType = properties.getString(AdminConstants.A_VOLUME_STORAGE_TYPE);
+                    Boolean useInFrequentAccess = Boolean.valueOf(properties.getString(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS));
+                    Boolean useIntelligentTiering = Boolean.valueOf(properties.getString(AdminConstants.A_VOLUME_USE_INTELLIGENT_TIERING));
+                    int useInFrequentAccessThreshold = Integer.parseInt(properties.getString(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS_THRESHOLD));
+
+                    volExtInfo.setVolumePrefix(volumePrefix);
+                    volExtInfo.setGlobalBucketConfigurationId(globalBucketConfigId);
+                    volExtInfo.setStorageType(storageType);
+                    volExtInfo.setUseInFrequentAccess(useInFrequentAccess);
+                    volExtInfo.setUseIntelligentTiering(useIntelligentTiering);
+                    volExtInfo.setUseInFrequentAccessThreshold(useInFrequentAccessThreshold);
+                    volInfo.setVolumeExternalInfo(volExtInfo);
+                } catch (ServiceException e) {
+                    ZimbraLog.store.error("Error while processing GetAllVolumesRequest", e);
+                    throw e;
+                } catch (JSONException e) {
+                    throw ServiceException.FAILURE("Error while reading server properties", null);
+                }
+            }
+            resp.addVolume(volInfo);
         }
         return resp;
     }

--- a/store/src/java/com/zimbra/cs/service/admin/GetVolume.java
+++ b/store/src/java/com/zimbra/cs/service/admin/GetVolume.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2005, 2006, 2007, 2009, 2010, 2011, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2005, 2006, 2007, 2009, 2010, 2011, 2013, 2014, 2016, 2022 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -19,9 +19,15 @@ package com.zimbra.cs.service.admin;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
+
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.AdminConstants;
 import com.zimbra.common.soap.Element;
+import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.accesscontrol.AdminRight;
 import com.zimbra.cs.account.accesscontrol.Rights.Admin;
@@ -31,6 +37,9 @@ import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.admin.message.GetVolumeRequest;
 import com.zimbra.soap.admin.message.GetVolumeResponse;
+import com.zimbra.soap.admin.type.VolumeInfo;
+import com.zimbra.soap.admin.type.VolumeExternalInfo;
+import com.zimbra.util.ExternalVolumeInfoHandler;
 
 public final class GetVolume extends AdminDocumentHandler {
 
@@ -45,7 +54,36 @@ public final class GetVolume extends AdminDocumentHandler {
         checkRight(zsc, ctx, Provisioning.getInstance().getLocalServer(), Admin.R_manageVolume);
 
         Volume vol = VolumeManager.getInstance().getVolume(req.getId());
-        GetVolumeResponse resp = new GetVolumeResponse(vol.toJAXB());
+        VolumeInfo volInfo = vol.toJAXB();
+
+        if (vol.getStoreType().equals(Volume.StoreType.EXTERNAL)) {
+            VolumeExternalInfo volExtInfo = new VolumeExternalInfo();
+            ExternalVolumeInfoHandler extVolInfoHandler = new ExternalVolumeInfoHandler(Provisioning.getInstance());
+            try {
+                JSONObject properties = extVolInfoHandler.readServerProperties(volInfo.getId());
+                String volumePrefix = properties.getString(AdminConstants.A_VOLUME_VOLUME_PREFIX);
+                String globalBucketConfigId = properties.getString(AdminConstants.A_VOLUME_GLB_BUCKET_CONFIG_ID);
+                String storageType = properties.getString(AdminConstants.A_VOLUME_STORAGE_TYPE);
+                Boolean useInFrequentAccess = Boolean.valueOf(properties.getString(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS));
+                Boolean useIntelligentTiering = Boolean.valueOf(properties.getString(AdminConstants.A_VOLUME_USE_INTELLIGENT_TIERING));
+                int useInFrequentAccessThreshold = Integer.parseInt(properties.getString(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS_THRESHOLD));
+
+                volExtInfo.setVolumePrefix(volumePrefix);
+                volExtInfo.setGlobalBucketConfigurationId(globalBucketConfigId);
+                volExtInfo.setStorageType(storageType);
+                volExtInfo.setUseInFrequentAccess(useInFrequentAccess);
+                volExtInfo.setUseIntelligentTiering(useIntelligentTiering);
+                volExtInfo.setUseInFrequentAccessThreshold(useInFrequentAccessThreshold);
+                volInfo.setVolumeExternalInfo(volExtInfo);
+            } catch (ServiceException e) {
+                ZimbraLog.store.error("Error while processing GetVolumesRequest", e);
+                throw e;
+            } catch (JSONException e) {
+                throw ServiceException.FAILURE("Error while reading server properties", null);
+            }
+        }
+
+        GetVolumeResponse resp = new GetVolumeResponse(volInfo);
         return resp;
     }
 
@@ -53,5 +91,4 @@ public final class GetVolume extends AdminDocumentHandler {
     public void docRights(List<AdminRight> relatedRights, List<String> notes) {
         relatedRights.add(Admin.R_manageVolume);
     }
-
 }

--- a/store/src/java/com/zimbra/cs/volume/Volume.java
+++ b/store/src/java/com/zimbra/cs/volume/Volume.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2016, 2022 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -69,7 +69,7 @@ public final class Volume {
     private StoreType storeType;
 
     public static enum StoreType {
-        FILE_STORE(1),
+        INTERNAL(1),
         EXTERNAL(2);
 
         private final int storeType;
@@ -85,7 +85,7 @@ public final class Volume {
         public static StoreType getStoreTypeBy(int value) {
             switch (value) {
                 case 1:
-                    return FILE_STORE;
+                    return INTERNAL;
                 case 2:
                     return EXTERNAL;
             }
@@ -181,7 +181,6 @@ public final class Volume {
             volume.compressionThreshold = copy.compressionThreshold;
             volume.metadata = copy.metadata;
             volume.storeType = copy.storeType;
-
         }
 
         public Builder setId(short id) {
@@ -512,6 +511,8 @@ public final class Volume {
         jaxb.setCompressBlobs(compressBlobs);
         jaxb.setCompressionThreshold(compressionThreshold);
         jaxb.setCurrent(VolumeManager.getInstance().isCurrent(this));
+        short value = (short)(this.getStoreType().getStoreType());
+        jaxb.setStoreType(value);
         return jaxb;
     }
 }

--- a/store/src/java/com/zimbra/cs/volume/Volume.java
+++ b/store/src/java/com/zimbra/cs/volume/Volume.java
@@ -65,7 +65,30 @@ public final class Volume {
     private boolean compressBlobs;
     private long compressionThreshold;
     private Metadata metadata;
-    
+
+    private StoreType storeType;
+
+    public static enum StoreType{
+        FILE_STORE(1),
+        EXTERNAL(2);
+
+        private final int storeType;
+        StoreType(final int storeType) {
+            this.storeType = storeType;
+        }
+
+        public int getStoreType() {
+            return storeType;
+        }
+        public static StoreType getStoreTypeBy(int value){
+            switch (value) {
+                case 1: return FILE_STORE;
+                case 2: return EXTERNAL;
+            }
+            return null;
+        }
+    }
+
     public static class VolumeMetadata {
         private int lastSyncDate;
         private int currentSyncDate;
@@ -88,37 +111,37 @@ public final class Volume {
             this.currentSyncDate = meta.getInt(FN_DATE_CURRENTSYNC, 0);
             this.groupId = meta.getInt(FN_LAST_GROUP_ID, 0);
         }
-        
+
         public VolumeMetadata(int lastSyncDate, int currentSyncDate, int groupId) {
             this.lastSyncDate = lastSyncDate;
             this.currentSyncDate = currentSyncDate;
             this.groupId = groupId;
         }
-        
+
         public int getLastSyncDate() {
             return lastSyncDate;
         }
-        
+
         public int getCurrentSyncDate() {
             return currentSyncDate;
         }
-        
+
         public int getGroupId() {
             return groupId;
         }
-        
+
         public void setLastSyncDate(int date) {
             this.lastSyncDate = date;
         }
-        
+
         public void setCurrentSyncDate(int date) {
             this.currentSyncDate = date;
         }
-        
+
         public void setGroupId(int id) {
             this.groupId = id;
         }
-        
+
         public String toString() {
             return serialize().toString();
         }
@@ -153,7 +176,8 @@ public final class Volume {
             volume.compressBlobs = copy.compressBlobs;
             volume.compressionThreshold = copy.compressionThreshold;
             volume.metadata = copy.metadata;
-            
+            volume.storeType = copy.storeType;
+
         }
 
         public Builder setId(short id) {
@@ -210,9 +234,14 @@ public final class Volume {
             volume.compressionThreshold = value;
             return this;
         }
-        
+
         public Builder setMetadata(VolumeMetadata metadata) {
             volume.metadata = metadata.serialize();
+            return this;
+        }
+
+        public Builder setStoreType(StoreType storeType){
+            volume.storeType = storeType;
             return this;
         }
 
@@ -314,36 +343,40 @@ public final class Volume {
     public long getCompressionThreshold() {
         return compressionThreshold;
     }
-    
+
     public VolumeMetadata getMetadata() throws ServiceException {
         return new VolumeMetadata(metadata);
     }
 
+    public StoreType getStoreType() {
+        return storeType;
+    }
+
     public static String getAbsolutePath(String path) throws ServiceException {
         //return LC.zimbra_relative_volume_path.booleanValue() ? LC.zimbra_home.value() + File.separator + getConfiguredRootPath(path) : path;
-    	return LC.zimbra_relative_volume_path.booleanValue() ? LC.zimbra_home.value() + File.separator + path : path;
+        return LC.zimbra_relative_volume_path.booleanValue() ? LC.zimbra_home.value() + File.separator + path : path;
     }
-    
+
     public static String getConfiguredServerID() throws ServiceException
     {
         StringBuilder finalPath = new StringBuilder();
         if (Zimbra.isAlwaysOn())
         {
-        	String alwaysOnServerClusterId = Zimbra.getAlwaysOnClusterId();
-        	String localServerId = Provisioning.getInstance().getLocalServer().getId();
-        	if (alwaysOnServerClusterId != null)
-        	{
-        		finalPath.append(alwaysOnServerClusterId);
-        	}
-        	else
-        	{
-        		finalPath.append(localServerId);
-        	}
+            String alwaysOnServerClusterId = Zimbra.getAlwaysOnClusterId();
+            String localServerId = Provisioning.getInstance().getLocalServer().getId();
+            if (alwaysOnServerClusterId != null)
+            {
+                finalPath.append(alwaysOnServerClusterId);
+            }
+            else
+            {
+                finalPath.append(localServerId);
+            }
         }
         else
         {
-        	String localServerId = Provisioning.getInstance().getLocalServer().getId();
-        	finalPath.append(localServerId);
+            String localServerId = Provisioning.getInstance().getLocalServer().getId();
+            finalPath.append(localServerId);
         }
         return finalPath.toString();
     }
@@ -351,14 +384,14 @@ public final class Volume {
     private StringBuilder getMailboxDir(int mboxId, String subdir) throws ServiceException {
         StringBuilder result = new StringBuilder();
         int dir = (mboxId >> mboxBits) & mboxGroupBitmask;
-        
+
         result.append(rootPath).append(File.separator);
 
         if (Provisioning.getInstance().getLocalServer().isConfiguredServerIDForBlobDirEnabled())
-        	result.append(getConfiguredServerID()).append(File.separator);
+            result.append(getConfiguredServerID()).append(File.separator);
 
         result.append(dir).append(File.separator).append(mboxId);
-        
+
         if (subdir != null) {
             result.append(File.separator).append(subdir);
         }
@@ -464,6 +497,7 @@ public final class Volume {
                 .add("mboxGroupBits", mboxGroupBits).add("mboxBits", mboxBits)
                 .add("fileGroupBits", fileGroupBits).add("fileBits", fileBits)
                 .add("compressBlobs", compressBlobs).add("compressionThreshold",compressionThreshold)
+                .add("storeType", storeType)
                 .toString();
     }
 

--- a/store/src/java/com/zimbra/cs/volume/Volume.java
+++ b/store/src/java/com/zimbra/cs/volume/Volume.java
@@ -31,7 +31,7 @@ import com.zimbra.soap.admin.type.VolumeInfo;
 /**
  * Based on default settings, there are 256 directories. We write blobs for id's 0-4095 to directory 0, 4096-8191 to
  * directory 1, etc. After filling directory 255, we wrap around and write 1048576-1052671 to directory 0 and so on.
- *
+ * <p>
  * Number of dirs: 2 ^ groupBits (2 ^ 8 = 256 by default)
  * Number of files per dir before wraparound: 2 ^ bits (2 ^ 12 = 4096 by default)
  */
@@ -41,7 +41,7 @@ public final class Volume {
     public static final short ID_NONE = -2;
     public static final short ID_MAX = 255;
 
-    public static final short TYPE_MESSAGE =  1;
+    public static final short TYPE_MESSAGE = 1;
     public static final short TYPE_MESSAGE_SECONDARY = 2;
     public static final short TYPE_INDEX = 10;
 
@@ -68,11 +68,12 @@ public final class Volume {
 
     private StoreType storeType;
 
-    public static enum StoreType{
+    public static enum StoreType {
         FILE_STORE(1),
         EXTERNAL(2);
 
         private final int storeType;
+
         StoreType(final int storeType) {
             this.storeType = storeType;
         }
@@ -80,10 +81,13 @@ public final class Volume {
         public int getStoreType() {
             return storeType;
         }
-        public static StoreType getStoreTypeBy(int value){
+
+        public static StoreType getStoreTypeBy(int value) {
             switch (value) {
-                case 1: return FILE_STORE;
-                case 2: return EXTERNAL;
+                case 1:
+                    return FILE_STORE;
+                case 2:
+                    return EXTERNAL;
             }
             return null;
         }
@@ -240,7 +244,7 @@ public final class Volume {
             return this;
         }
 
-        public Builder setStoreType(StoreType storeType){
+        public Builder setStoreType(StoreType storeType) {
             volume.storeType = storeType;
             return this;
         }
@@ -357,24 +361,17 @@ public final class Volume {
         return LC.zimbra_relative_volume_path.booleanValue() ? LC.zimbra_home.value() + File.separator + path : path;
     }
 
-    public static String getConfiguredServerID() throws ServiceException
-    {
+    public static String getConfiguredServerID() throws ServiceException {
         StringBuilder finalPath = new StringBuilder();
-        if (Zimbra.isAlwaysOn())
-        {
+        if (Zimbra.isAlwaysOn()) {
             String alwaysOnServerClusterId = Zimbra.getAlwaysOnClusterId();
             String localServerId = Provisioning.getInstance().getLocalServer().getId();
-            if (alwaysOnServerClusterId != null)
-            {
+            if (alwaysOnServerClusterId != null) {
                 finalPath.append(alwaysOnServerClusterId);
-            }
-            else
-            {
+            } else {
                 finalPath.append(localServerId);
             }
-        }
-        else
-        {
+        } else {
             String localServerId = Provisioning.getInstance().getLocalServer().getId();
             finalPath.append(localServerId);
         }
@@ -414,9 +411,9 @@ public final class Volume {
     /**
      * Make sure the path is an absolute path, and remove all "." and ".." from it. This is similar to
      * {@link File#getCanonicalPath()} except symbolic links are not resolved.
-     *
+     * <p>
      * If there are too many ".." in the path, navigating to parent directory stops at root.
-     *
+     * <p>
      * Supports UNIX absolute path, Windows absolute path with or without drive letter, and windows UNC share.
      *
      * @throws VolumeServiceException if path is not absolute
@@ -496,7 +493,7 @@ public final class Volume {
                 .add("id", id).add("type", type).add("name", name).add("path", rootPath)
                 .add("mboxGroupBits", mboxGroupBits).add("mboxBits", mboxBits)
                 .add("fileGroupBits", fileGroupBits).add("fileBits", fileBits)
-                .add("compressBlobs", compressBlobs).add("compressionThreshold",compressionThreshold)
+                .add("compressBlobs", compressBlobs).add("compressionThreshold", compressionThreshold)
                 .add("storeType", storeType)
                 .toString();
     }

--- a/store/src/java/com/zimbra/cs/volume/Volume.java
+++ b/store/src/java/com/zimbra/cs/volume/Volume.java
@@ -384,8 +384,9 @@ public final class Volume {
 
         result.append(rootPath).append(File.separator);
 
-        if (Provisioning.getInstance().getLocalServer().isConfiguredServerIDForBlobDirEnabled())
+        if (Provisioning.getInstance().getLocalServer().isConfiguredServerIDForBlobDirEnabled()) {
             result.append(getConfiguredServerID()).append(File.separator);
+        }
 
         result.append(dir).append(File.separator).append(mboxId);
 

--- a/store/src/java/com/zimbra/cs/volume/VolumeCLI.java
+++ b/store/src/java/com/zimbra/cs/volume/VolumeCLI.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2013, 2014, 2016, 2022 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -33,6 +33,7 @@ import com.zimbra.common.soap.SoapTransport;
 import com.zimbra.common.util.CliUtil;
 import com.zimbra.cs.util.BuildInfo;
 import com.zimbra.cs.util.SoapCLI;
+import com.zimbra.cs.volume.Volume.StoreType;
 import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.admin.message.CreateVolumeRequest;
 import com.zimbra.soap.admin.message.CreateVolumeResponse;
@@ -44,6 +45,7 @@ import com.zimbra.soap.admin.message.GetVolumeResponse;
 import com.zimbra.soap.admin.message.ModifyVolumeRequest;
 import com.zimbra.soap.admin.message.SetCurrentVolumeRequest;
 import com.zimbra.soap.admin.type.VolumeInfo;
+import com.zimbra.soap.admin.type.VolumeExternalInfo;
 
 public final class VolumeCLI extends SoapCLI {
 
@@ -60,6 +62,36 @@ public final class VolumeCLI extends SoapCLI {
     private static final String O_P = "p";
     private static final String O_C = "c";
     private static final String O_CT = "ct";
+    
+    /** attributes for external storetype **/
+    private static final String O_ST = "st";
+    private static final String O_VP = "vp";
+    private static final String O_STP = "stp";
+    private static final String O_BID = "bid";
+
+    private static final String NOT_ALLOWED_INTERNAL = " is not allowed for internal storetype";
+    private static final String NOT_ALLOWED_EXTERNAL = " is not allowed for external storetype";
+    private static final String NOT_ALLOWED = " is not allowed for edit";
+    private static final String INVALID_STORE_TYPE = "invalid storetype";
+    private static final String HELP_EXTERNAL_NAME = "  only name can be edited for external store volumes ";
+    private static final String MISSING_ATTRS = " is missing";
+    private static final String NOT_ALLOWED_ID = "id cannot be specified when adding a volume";
+
+    private static final String H_STORE_TYPE = "Store type: internal or external";
+    private static final String H_STORAGE_TYPE = "Name of the store provider (S3, ObjectStore)";
+    private static final String H_BUCKET_ID = "S3 Bucket ID";
+    private static final String H_VOLUME_PREFIX = "Volume Preifx";
+
+    private static final String A_ID = "id";
+    private static final String A_TYPE = "type";
+    private static final String A_PATH = "path";
+    private static final String A_NAME = "name";
+    private static final String A_COMPRESS = "compress";
+    private static final String A_COMPRESS_THRESHOLD = "compressThreshold";
+    private static final String A_STORE_TYPE = "storeType";
+    private static final String A_STORAGE_TYPE = "storageType";
+    private static final String A_BUCKET_ID = "bucketId";
+    private static final String A_VOLUME_PREFIX = "volumePrefix";
 
     private VolumeCLI() throws ServiceException {
         super();
@@ -73,6 +105,10 @@ public final class VolumeCLI extends SoapCLI {
     private String path;
     private String compress;
     private String compressThreshold;
+    private String storeType;
+    private String volumePrefix;
+    private String storageType;
+    private String bucketId;
 
     private void setArgs(CommandLine cl) throws ServiceException, ParseException, IOException {
         auth = getZAuthToken(cl);
@@ -82,6 +118,11 @@ public final class VolumeCLI extends SoapCLI {
         path = cl.getOptionValue(O_P);
         compress = cl.getOptionValue(O_C);
         compressThreshold = cl.getOptionValue(O_CT);
+        storeType = cl.getOptionValue(O_ST);
+        storeType = storeType == null ? null : storeType.toUpperCase();
+        volumePrefix = cl.getOptionValue(O_VP);
+        storageType = cl.getOptionValue(O_STP);
+        bucketId = cl.getOptionValue(O_BID);
     }
 
     public static void main(String[] args) {
@@ -129,7 +170,7 @@ public final class VolumeCLI extends SoapCLI {
 
     private void setCurrentVolume() throws ParseException, SoapFaultException, IOException, ServiceException, NumberFormatException, HttpException {
         if (id == null) {
-            throw new ParseException("id is missing");
+            throw new ParseException(A_ID + MISSING_ATTRS);
         }
 
         auth(auth);
@@ -196,7 +237,7 @@ public final class VolumeCLI extends SoapCLI {
 
     private void deleteVolume() throws ParseException, SoapFaultException, IOException, ServiceException, HttpException {
         if (id == null) {
-            throw new ParseException("id is missing");
+            throw new ParseException(A_ID + MISSING_ATTRS);
         }
 
         DeleteVolumeRequest req = new DeleteVolumeRequest(Short.parseShort(id));
@@ -207,25 +248,18 @@ public final class VolumeCLI extends SoapCLI {
 
     private void editVolume() throws ParseException, SoapFaultException, IOException, ServiceException, HttpException {
         if (Strings.isNullOrEmpty(id)) {
-            throw new ParseException("id is missing");
+            throw new ParseException(A_ID + MISSING_ATTRS);
         }
 
+        GetVolumeRequest getVolumeRequest = new GetVolumeRequest(Short.parseShort(id));
+        auth();
+        GetVolumeResponse getVolumeResponse = JaxbUtil
+                .elementToJaxb(getTransport().invokeWithoutSession(JaxbUtil.jaxbToElement(getVolumeRequest)));
+        Volume.StoreType enumStoreType = (1 == getVolumeResponse.getVolume().getStoreType()) ? Volume.StoreType.INTERNAL
+                : Volume.StoreType.EXTERNAL;
+
         VolumeInfo vol = new VolumeInfo();
-        if (!Strings.isNullOrEmpty(type)) {
-            vol.setType(toType(type));
-        }
-        if (!Strings.isNullOrEmpty(name)) {
-            vol.setName(name);
-        }
-        if (!Strings.isNullOrEmpty(path)) {
-            vol.setRootPath(path);
-        }
-        if (!Strings.isNullOrEmpty(compress)) {
-            vol.setCompressBlobs(Boolean.parseBoolean(compress));
-        }
-        if (!Strings.isNullOrEmpty(compressThreshold)) {
-            vol.setCompressionThreshold(Long.parseLong(compressThreshold));
-        }
+        validateEditCommand(vol, enumStoreType);
         ModifyVolumeRequest req = new ModifyVolumeRequest(Short.parseShort(id), vol);
         auth(auth);
         getTransport().invokeWithoutSession(JaxbUtil.jaxbToElement(req));
@@ -234,16 +268,16 @@ public final class VolumeCLI extends SoapCLI {
 
     private void addVolume() throws ParseException, SoapFaultException, IOException, ServiceException, HttpException {
         if (id != null) {
-            throw new ParseException("id cannot be specified when adding a volume");
+            throw new ParseException(NOT_ALLOWED_ID);
         }
         if (Strings.isNullOrEmpty(type)) {
-            throw new ParseException("type is missing");
+            throw new ParseException(A_TYPE + MISSING_ATTRS);
         }
         if (Strings.isNullOrEmpty(name)) {
-            throw new ParseException("name is missing");
+            throw new ParseException(A_NAME + MISSING_ATTRS);
         }
         if (Strings.isNullOrEmpty(path)) {
-            throw new ParseException("path is missing");
+            throw new ParseException(A_PATH + MISSING_ATTRS);
         }
 
         VolumeInfo vol = new VolumeInfo();
@@ -252,11 +286,102 @@ public final class VolumeCLI extends SoapCLI {
         vol.setRootPath(path);
         vol.setCompressBlobs(compress != null ? Boolean.parseBoolean(compress) : false);
         vol.setCompressionThreshold(compressThreshold != null ? Long.parseLong(compressThreshold) : 4096L);
+        validateAddCommand(vol);
         CreateVolumeRequest req = new CreateVolumeRequest(vol);
         auth();
         CreateVolumeResponse resp = JaxbUtil.elementToJaxb(getTransport().invokeWithoutSession(
                 JaxbUtil.jaxbToElement(req)));
         System.out.println("Volume " + resp.getVolume().getId() + " is created");
+    }
+    
+    /**
+     * This method validate the attributes in edit command.
+     * 
+     * @param volumeInfo, volStoreType
+     * @throws ParseException
+     */
+
+    private void validateEditCommand(VolumeInfo volumeInfo, Volume.StoreType volStoreType) throws ParseException {
+        if (volStoreType.equals(Volume.StoreType.INTERNAL)) {
+            if (!Strings.isNullOrEmpty(type)) {
+                volumeInfo.setType(toType(type));
+            }
+            if (!Strings.isNullOrEmpty(path)) {
+                volumeInfo.setRootPath(path);
+            }
+            if (!Strings.isNullOrEmpty(compress)) {
+                volumeInfo.setCompressBlobs(Boolean.parseBoolean(compress));
+            }
+            if (!Strings.isNullOrEmpty(compressThreshold)) {
+                volumeInfo.setCompressionThreshold(Long.parseLong(compressThreshold));
+            }
+        } else if (volStoreType.equals(Volume.StoreType.EXTERNAL)) {
+            if (!Strings.isNullOrEmpty(type)) {
+                throw new ParseException(A_TYPE + NOT_ALLOWED_EXTERNAL);
+            }
+            if (!Strings.isNullOrEmpty(path)) {
+                throw new ParseException(A_PATH + NOT_ALLOWED_EXTERNAL);
+            }
+            if (!Strings.isNullOrEmpty(compress)) {
+                throw new ParseException(A_COMPRESS + NOT_ALLOWED_EXTERNAL);
+            }
+            if (!Strings.isNullOrEmpty(compressThreshold)) {
+                throw new ParseException(A_COMPRESS_THRESHOLD + NOT_ALLOWED_EXTERNAL);
+            }
+        } else {
+            throw new ParseException(INVALID_STORE_TYPE);
+        }
+        if (!Strings.isNullOrEmpty(name)) {
+            volumeInfo.setName(name);
+        }
+        if (!Strings.isNullOrEmpty(storeType)) {
+            throw new ParseException(A_STORE_TYPE + NOT_ALLOWED);
+        }
+        if (!Strings.isNullOrEmpty(storageType)) {
+            throw new ParseException(A_STORAGE_TYPE + NOT_ALLOWED);
+        }
+        if (!Strings.isNullOrEmpty(bucketId)) {
+            throw new ParseException(A_BUCKET_ID + NOT_ALLOWED);
+        }
+        if (!Strings.isNullOrEmpty(volumePrefix)) {
+            throw new ParseException(A_VOLUME_PREFIX + NOT_ALLOWED);
+        }
+    }
+
+    /**
+     * This method validate the attributes in add command.
+     * 
+     * @param volumeInfo
+     * @throws ParseException
+     */
+
+    private void validateAddCommand(VolumeInfo volumeInfo) throws ParseException {
+        if (Strings.isNullOrEmpty(storeType) || Volume.StoreType.INTERNAL.name().equals(storeType)) {
+            if (!Strings.isNullOrEmpty(storageType)) {
+                throw new ParseException(A_STORAGE_TYPE + NOT_ALLOWED_INTERNAL);
+            }
+            if (!Strings.isNullOrEmpty(bucketId)) {
+                throw new ParseException(A_BUCKET_ID + NOT_ALLOWED_INTERNAL);
+            }
+            if (!Strings.isNullOrEmpty(volumePrefix)) {
+                throw new ParseException(A_VOLUME_PREFIX + NOT_ALLOWED_INTERNAL);
+            }
+        } else if (Volume.StoreType.EXTERNAL.name().equals(storeType)) {
+            VolumeExternalInfo volumeExternalInfo = new VolumeExternalInfo();
+            if (!Strings.isNullOrEmpty(storageType)) {
+                volumeExternalInfo.setStorageType(storageType);
+            }
+            if (!Strings.isNullOrEmpty(bucketId)) {
+                volumeExternalInfo.setGlobalBucketConfigurationId(bucketId);
+            }
+            if (!Strings.isNullOrEmpty(volumePrefix)) {
+                volumeExternalInfo.setVolumePrefix(volumePrefix);
+            }
+            volumeInfo.setStoreType((short) Volume.StoreType.EXTERNAL.getStoreType());
+            volumeInfo.setVolumeExternalInfo(volumeExternalInfo);
+        } else {
+            throw new ParseException(INVALID_STORE_TYPE);
+        }
     }
 
     @Override
@@ -286,6 +411,10 @@ public final class VolumeCLI extends SoapCLI {
         options.addOption(O_CT, "compressionThreshold", true, "Compression threshold; default 4KB");
         options.addOption(SoapCLI.OPT_AUTHTOKEN);
         options.addOption(SoapCLI.OPT_AUTHTOKENFILE);
+        options.addOption(new Option(O_ST, A_STORE_TYPE, true, H_STORE_TYPE));
+        options.addOption(new Option(O_VP, A_VOLUME_PREFIX, true, H_VOLUME_PREFIX));
+        options.addOption(new Option(O_STP, A_STORAGE_TYPE, true, H_STORAGE_TYPE));
+        options.addOption(new Option(O_BID, A_BUCKET_ID, true, H_BUCKET_ID));
     }
 
     @Override
@@ -297,6 +426,7 @@ public final class VolumeCLI extends SoapCLI {
         System.err.println(getCommandUsage());
         printOpt(O_A, 0);
         printOpt(O_N, 2);
+        System.err.println(HELP_EXTERNAL_NAME);
         printOpt(O_T, 2);
         printOpt(O_P, 2);
         printOpt(O_C, 2);
@@ -316,6 +446,10 @@ public final class VolumeCLI extends SoapCLI {
         printOpt(O_TS, 0);
         printOpt(SoapCLI.O_AUTHTOKEN, 0);
         printOpt(SoapCLI.O_AUTHTOKENFILE, 0);
+        printOpt(O_ST, 0);
+        printOpt(O_VP, 0);
+        printOpt(O_STP, 0);
+        printOpt(O_BID, 0);
     }
 
     private void printOpt(String optStr, int leftPad) {

--- a/store/src/java/com/zimbra/util/ExternalVolumeInfoHandler.java
+++ b/store/src/java/com/zimbra/util/ExternalVolumeInfoHandler.java
@@ -1,0 +1,195 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite, Network Edition.
+ * Copyright (C) 2022 Synacor, Inc.  All Rights Reserved.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.util;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.common.util.StringUtil;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.Server;
+import com.zimbra.soap.admin.type.VolumeInfo;
+import com.zimbra.soap.admin.type.VolumeExternalInfo;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Iterator;
+
+/**
+ * LDAP based properties handler
+ */
+public class ExternalVolumeInfoHandler {
+
+    /**
+     * LDAP Provision instance
+     */
+    private Provisioning provisioning;
+
+    public ExternalVolumeInfoHandler(Provisioning provisioning) {
+        this.provisioning = provisioning;
+    }
+
+    /**
+     * Read server level external volume properties
+     * @param volumeId
+     * @param server
+     * @return JSONObject as a server level volume properties
+     * @throws JSONException, ServiceException
+     */
+    public JSONObject readServerProperties(int volumeId) throws ServiceException, JSONException {
+        JSONObject retJsonObj = new JSONObject();
+        try {
+            // step 1: Fetch current JSON state object and current JSON state array
+            String serverExternalStoreConfigJson = provisioning.getLocalServer().getServerExternalStoreConfig();
+            JSONObject currentJsonObject = new JSONObject(serverExternalStoreConfigJson);
+            JSONArray currentJsonArray = currentJsonObject.getJSONArray("server/stores");
+
+            // step 2: Iterate JSON state array
+            for (int i = 0; i < currentJsonArray.length(); i++) {
+                JSONObject tempJsonObj = currentJsonArray.getJSONObject(i);
+
+                // step 3: Read required JSON object
+                if (volumeId == tempJsonObj.getInt("volumeId")) {
+                    // step 4: Copy temp JSON object to return JSON object and break
+                    retJsonObj = tempJsonObj;
+                    break;
+                }
+            }
+        } catch (JSONException e) {
+            throw e;
+        }
+
+        // step 5: Return JSON object
+        return retJsonObj;
+    }
+
+    /**
+     * Delete server level external volume properties
+     * @param volumeId
+     * @param server
+     * @throws JSONException, ServiceException
+     */
+    public void deleteServerProperties(int volumeId) throws ServiceException, JSONException {
+        try {
+            // step 1: Fetch current JSON state object and current JSON state array
+            String serverExternalStoreConfigJson = provisioning.getLocalServer().getServerExternalStoreConfig();
+            JSONObject currentJsonObject = new JSONObject(serverExternalStoreConfigJson);
+            JSONArray currentJsonArray = currentJsonObject.getJSONArray("server/stores");
+
+            // step 2: Create new/empty updated JSON state array
+            JSONArray updatedJsonArray = new JSONArray();
+
+            // step 3: Copy currentJsonArray to updatedJsonArray except the element to be deleted
+            for (int i = 0; i < currentJsonArray.length(); i++) {
+                JSONObject tempJsonObj = currentJsonArray.getJSONObject(i);
+                if (volumeId != tempJsonObj.getInt(AdminConstants.A_VOLUME_ID)) {
+                    updatedJsonArray.put(tempJsonObj);
+                }
+            }
+
+            // step 4: Copy updatedJsonArray to currentJsonArray
+            currentJsonArray = updatedJsonArray;
+
+            // step 5: Copy updatedJsonArray to currentJsonObject
+            currentJsonObject.put("server/stores", currentJsonArray);
+
+            // step 6: Set ldap attribute
+            provisioning.getLocalServer().setServerExternalStoreConfig(currentJsonObject.toString());
+
+        } catch (JSONException e) {
+            throw e;
+        }
+    }
+
+    /**
+     * Add server level external volume properties
+     * @param volumeId
+     * @param server
+     * @throws JSONException, ServiceException
+     */
+    public void addServerProperties(VolumeInfo volInfo) throws ServiceException, JSONException {
+        VolumeExternalInfo volExtInfo = volInfo.getVolumeExternalInfo();
+        try {
+            // step 1: Create and update json object and array for new volume entry
+            JSONObject volExtInfoObj = new JSONObject();
+            volExtInfoObj.put(AdminConstants.A_VOLUME_ID, String.valueOf(volInfo.getId()));
+            volExtInfoObj.put(AdminConstants.A_VOLUME_STORAGE_TYPE, volExtInfo.getStorageType());
+            volExtInfoObj.put(AdminConstants.A_VOLUME_VOLUME_PREFIX, volExtInfo.getVolumePrefix());
+            volExtInfoObj.put(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS, String.valueOf(volExtInfo.getUseInFrequentAccess()));
+            volExtInfoObj.put(AdminConstants.A_VOLUME_USE_INTELLIGENT_TIERING, String.valueOf(volExtInfo.getUseIntelligentTiering()));
+            volExtInfoObj.put(AdminConstants.A_VOLUME_GLB_BUCKET_CONFIG_ID, volExtInfo.getGlobalBucketConfigurationId());
+            volExtInfoObj.put(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS_THRESHOLD, String.valueOf(volExtInfo.getUseInFrequentAccessThreshold()));
+
+            // step 2: Fetch current JSON state
+            String serverExternalStoreConfigJson = provisioning.getLocalServer().getServerExternalStoreConfig();
+            JSONObject currentJsonObject = null;
+            if (StringUtil.isNullOrEmpty(serverExternalStoreConfigJson)) {
+                // If current JSON state is already empty, initialise current JSON state Object
+                currentJsonObject = new JSONObject();
+                currentJsonObject.put("server/stores", new JSONArray());
+            } else {
+                // Else convert current JSON state string to current JSON state Object
+                currentJsonObject = new JSONObject(serverExternalStoreConfigJson);
+            }
+
+            // step 3: Fetch current JSON state array
+            JSONArray currentJsonArray = currentJsonObject.getJSONArray("server/stores");
+
+            // step 4: Append current JSON state array with new volume entry
+            currentJsonArray.put(volExtInfoObj);
+
+            // step 5: Overwrite Appended current JSON state array with current JSON state Object
+            currentJsonObject.put("server/stores", currentJsonArray);
+
+            // step 6: Set ldap attribute
+            provisioning.getLocalServer().setServerExternalStoreConfig(currentJsonObject.toString());
+        } catch (JSONException e) {
+            throw e;
+        }
+    }
+
+    /**
+     * Modify server level external volume properties
+     * @param volumeId
+     * @param server
+     * @throws JSONException, ServiceException
+     */
+    public void modifyServerProperties(VolumeInfo volInfo) throws ServiceException, JSONException {
+        try {
+            // step 1: Fetch current JSON state object and current JSON state array
+            String serverExternalStoreConfigJson = provisioning.getLocalServer().getServerExternalStoreConfig();
+            JSONObject currentJsonObject = new JSONObject(serverExternalStoreConfigJson);
+            JSONArray currentJsonArray = currentJsonObject.getJSONArray("server/stores");
+
+            // step 2: Create new/empty updated JSON state array
+            JSONArray updatedJsonArray = new JSONArray();
+
+            // step 3: Do Modification and Copy currentJsonArray to updatedJsonArray
+            for (int i = 0; i < currentJsonArray.length(); i++) {
+                JSONObject tempJsonObj = currentJsonArray.getJSONObject(i);
+                if (volInfo.getId() != tempJsonObj.getInt(AdminConstants.A_VOLUME_ID)) {
+                    updatedJsonArray.put(tempJsonObj);
+                } else {
+                    tempJsonObj.put(AdminConstants.A_VOLUME_NAME, volInfo.getName());
+                    updatedJsonArray.put(tempJsonObj);
+                }
+            }
+
+            // step 4: Copy updatedJsonArray to currentJsonArray
+            currentJsonArray = updatedJsonArray;
+
+            // step 5: Copy updatedJsonArray to currentJsonObject
+            currentJsonObject.put("server/stores", currentJsonArray);
+
+            // step 6: Set ldap attribute
+            provisioning.getLocalServer().setServerExternalStoreConfig(currentJsonObject.toString());
+        }  catch (JSONException e) {
+            throw e;
+        }
+    }
+}


### PR DESCRIPTION
Feature:
Adding the flexibility where admins can schedule backups from UI not just through CLI.

Implementation:
The eventual plan is to move away from crontab to a java based scheduler like service. As part of this plan, we are adding the LDAP attributes where admins can schedule the backup using them from UI instead of doing it through the zmschedulebackup CLI command as the first step. These attributes will be used by ScheduleBackupsRequest to set the crontab schedule from UI.