### PR TITLE
Feature/zcs 11481 new

### DIFF
--- a/common/src/java/com/zimbra/common/soap/HsmConstants.java
+++ b/common/src/java/com/zimbra/common/soap/HsmConstants.java
@@ -97,4 +97,7 @@ public final class HsmConstants {
     public static final String A_SM_INVALID_HOURS_FORMAT = "Invalid hour defined.";
     public static final String A_SM_INVALID_MINUTES = "Minutes are not allowed.";
     public static final int A_EXIT_STATUS = 0;
+    public static final String A_SM_SCHEDULE_POLICY_ENABLED_INVALID = "Only boolean value allowed in smSchedulePolicyEnabled";
+    public static final String A_TRUE = "true";
+    public static final String A_FALSE = "false";
 }

--- a/soap/src/java/com/zimbra/soap/JaxbUtil.java
+++ b/soap/src/java/com/zimbra/soap/JaxbUtil.java
@@ -1149,7 +1149,11 @@ public final class JaxbUtil {
             com.zimbra.soap.account.message.GetAddressListMembersRequest.class,
             com.zimbra.soap.account.message.GetAddressListMemberResponse.class,
             com.zimbra.soap.admin.message.GetAddressListInfoRequest.class,
-            com.zimbra.soap.admin.message.GetAddressListInfoResponse.class
+            com.zimbra.soap.admin.message.GetAddressListInfoResponse.class,
+            com.zimbra.soap.admin.message.ScheduleSMPolicyRequest.class,
+            com.zimbra.soap.admin.message.ScheduleSMPolicyResponse.class,
+            com.zimbra.soap.admin.message.GetScheduleSMPolicyRequest.class,
+            com.zimbra.soap.admin.message.GetScheduleSMPolicyResponse.class
         };
 
         try {


### PR DESCRIPTION
**Issue**: New SOAP call ScheduleSMPolicyRequest and GetScheduleSMPolicyRequest are not visible in wsdl.

**Solution**: Added new request and responses.

Origin PR for this ticket: https://github.com/Zimbra/zm-mailbox/pull/1298