### PR TITLE
ZCS-2841 : Adding an extra flag for stats logger

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -8791,6 +8791,12 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=250)
     public static final String A_zimbraLogHostname = "zimbraLogHostname";
+    
+    /**
+     * flag for Stats logger to be enabled 
+     */
+    @ZAttr(id=4005)
+    public static final String A_zimbraStatsloggerEnabled = "zimbraStatsloggerEnabled";
 
     /**
      * Flag to control how authtokens are invalidated in multi-server

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -1,3 +1,4 @@
+
 <?xml version="1.0" encoding="UTF-8"?>
 
 <attrs group="ZimbraAttrType" groupid="1">
@@ -9928,5 +9929,8 @@ TODO: delete them permanently from here
  <attr id="4004" name="zimbraPrefCalenderScaling" type="enum" value="10,15,30" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="9.1.0">
   <defaultCOSValue>30</defaultCOSValue>
   <desc>Default calendar resolution preference</desc>
+</attr>
+ <attr id="4005" name="zimbraStatsloggerEnabled" type="boolean" cardinality="single" optionalIn="globalConfig">
+  <desc>destination for syslog messages</desc>
 </attr>
 </attrs>


### PR DESCRIPTION
Issue : Stats logger getting enabled and flooding /var/log location with logs

fix: added extra flag for checking if stats logger needs to be enabled