### PR TITLE
ZCS-11458: Adding new LDAP attributes to let admins schedule backups …

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -144,6 +144,24 @@ public class ZAttrProvisioning {
         public boolean isMANUAL() { return this == MANUAL;}
     }
 
+    public static enum BackupBlobsCompressType {
+        zip("zip"),
+        zipStore("zipStore"),
+        noZip("noZip");
+        private String mValue;
+        private BackupBlobsCompressType(String value) { mValue = value; }
+        public String toString() { return mValue; }
+        public static BackupBlobsCompressType fromString(String s) throws ServiceException {
+            for (BackupBlobsCompressType value : values()) {
+                if (value.mValue.equals(s)) return value;
+             }
+             throw ServiceException.INVALID_REQUEST("invalid value: "+s+", valid values: "+ Arrays.asList(values()), null);
+        }
+        public boolean isZip() { return this == zip;}
+        public boolean isZipStore() { return this == zipStore;}
+        public boolean isNoZip() { return this == noZip;}
+    }
+
     public static enum BackupMode {
         Standard("Standard"),
         Auto_Grouped("Auto-Grouped");
@@ -3973,6 +3991,47 @@ public class ZAttrProvisioning {
     public static final String A_zimbraBackupAutoGroupedThrottled = "zimbraBackupAutoGroupedThrottled";
 
     /**
+     * Blobs inside a backup are compressed by default in zip format. zip -
+     * blobs are backed up into zip files with compression (default).
+     * zipStore - blobs are backed up into zip files without compression.
+     * noZip - blobs are backed up as individual files rather in zip files.
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4011)
+    public static final String A_zimbraBackupBlobsCompressType = "zimbraBackupBlobsCompressType";
+
+    /**
+     * Configures crontab schedule. Full, incremental and delete cron
+     * schedules can be set using this attribute. The entire backup can be
+     * scheduled as f &#039;0 1 * * 6&#039; i &#039;0 1 * * 0-5&#039; d 7d
+     * &#039;0 0 * * *&#039;. f &#039;0 1 * * 6&#039; can be passed if we are
+     * setting only the full-backup schedule. (f - full-backup) i &#039;0 1 *
+     * * 0-5&#039; can be passed if we are setting only the
+     * incremental-backup schedule. (i - incremental) d 7d &#039;0 0 * *
+     * *&#039; can be passed if we are setting only the delete-backup
+     * schedule. (d - delete).
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4016)
+    public static final String A_zimbraBackupCrontabConfig = "zimbraBackupCrontabConfig";
+
+    /**
+     * Whether or not account is eligible for backup If true on cos level
+     * then backup accounts for cos. zimbraDomainDefaultCOSId is considered.
+     * If unset on cos level but true on domain level then backup domains
+     * account. If unset on cos level, unset on domain level but true on
+     * account level then specific account will be backed up. If true on cos
+     * level , unset on domain level but zimbraDomainDefaultCOSId is set to
+     * cos then accounts for that domain will be backed up.
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=9014)
+    public static final String A_zimbraBackupEnabled = "zimbraBackupEnabled";
+
+    /**
      * Minimum percentage or TB/GB/MB/KB/bytes of free space on backup target
      * to allow a full or auto-grouped backup to start; 0 = no minimum is
      * enforced. Examples: 25%, 10GB
@@ -3987,6 +4046,17 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=512)
     public static final String A_zimbraBackupMode = "zimbraBackupMode";
+
+    /**
+     * If true, --accounts option will be set to useBackupConfig on
+     * zmschedulebackup command. Enables global,cos,domain,account level
+     * backup. If false, --accounts option will be set to all accounts on
+     * zmschedulebackup command. Backups all accounts.
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4015)
+    public static final String A_zimbraBackupObjectLevelEnabled = "zimbraBackupObjectLevelEnabled";
 
     /**
      * Backup report email recipients
@@ -4005,6 +4075,15 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=461)
     public static final String A_zimbraBackupReportEmailSubjectPrefix = "zimbraBackupReportEmailSubjectPrefix";
+
+    /**
+     * The number of days backups will be kept. Backup Scheduler deletes
+     * backups older than the set value.
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4010)
+    public static final String A_zimbraBackupRetentionDays = "zimbraBackupRetentionDays";
 
     /**
      * if true, do not backup blobs (HSM or not) during a full backup
@@ -4030,6 +4109,45 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=1003)
     public static final String A_zimbraBackupSkipSearchIndex = "zimbraBackupSkipSearchIndex";
+
+    /**
+     * The day of the week on which the full backup starts. When a day is
+     * select their relative value is set on the crontab. Default starts from
+     * Saturday 0-7 or names allowed (Sun, Wed), with both 0 and 7
+     * representing Sunday. Monday to Saturday (1-6)
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4014)
+    public static final String A_zimbraBackupStartDay = "zimbraBackupStartDay";
+
+    /**
+     * Starts backup each day at this time. This attribute is used to set
+     * hours and minutes on the crontab.
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public static final String A_zimbraBackupStartTime = "zimbraBackupStartTime";
+
+    /**
+     * If true, the full backup runs synchronously. If false, full backup
+     * runs in a separate thread and the soap call returns with the backup
+     * label.
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4012)
+    public static final String A_zimbraBackupSyncEnabled = "zimbraBackupSyncEnabled";
+
+    /**
+     * If true, will synchronize dumpster enabled accounts with backup
+     * eligible accounts from zimbraBackupEnabled list.
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public static final String A_zimbraBackupSyncUsersEnabled = "zimbraBackupSyncUsersEnabled";
 
     /**
      * Default backup target path
@@ -7885,6 +8003,15 @@ public class ZAttrProvisioning {
     public static final String A_zimbraGCMUrl = "zimbraGCMUrl";
 
     /**
+     * If true, enables backup globally and if there is pre-configured backup
+     * schedule the crontab will get that schedule.
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4007)
+    public static final String A_zimbraGlobalBackupEnabled = "zimbraGlobalBackupEnabled";
+
+    /**
      * Object classes added on the global config entry. Unlike other
      * zimbra***ExtraObjectClass attributes, object classes specified in this
      * attributes will not be automatically added to the global config entry.
@@ -9377,6 +9504,15 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=613)
     public static final String A_zimbraMailReferMode = "zimbraMailReferMode";
+
+    /**
+     * If true, sends an email report to the admin user. Admins can disable
+     * the email notification by setting it to FALSE.
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4013)
+    public static final String A_zimbraMailReportEnabled = "zimbraMailReportEnabled";
 
     /**
      * Deprecated since: 8.7.8. deprecated in favor of

--- a/common/src/java/com/zimbra/common/soap/BackupConstants.java
+++ b/common/src/java/com/zimbra/common/soap/BackupConstants.java
@@ -196,4 +196,6 @@ public final class BackupConstants {
     public static final String V_EXCLUDE = "exclude";
     public static final String V_CONFIG = "config";
     public static final String A_FORCE_DELETE_BLOBS = "forceDeleteBlobs";
+    public static final String A_SCHEDULE_BACKUP_RESULT = "scheduleBackupResult";
+
 }

--- a/soap/src/java/com/zimbra/soap/admin/message/ScheduleBackupsResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/ScheduleBackupsResponse.java
@@ -17,10 +17,15 @@
 
 package com.zimbra.soap.admin.message;
 
+import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import com.zimbra.common.soap.BackupConstants;
 
 @XmlRootElement(name=BackupConstants.E_SCHEDULE_BACKUPS_RESPONSE)
 public class ScheduleBackupsResponse {
+
+    @XmlAttribute(name=BackupConstants.A_SCHEDULE_BACKUP_RESULT)
+    private String scheduleBackupResult;
+
 }

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -5260,7 +5260,8 @@ TODO: delete them permanently from here
   <desc>enable/disable MAPI (Microsoft Outlook) Connector</desc>
 </attr>
 
-<attr id="1128" name="zimbraDumpsterEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="7.0.0">
+<attr id="1128" name="zimbraDumpsterEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,account,cos,domain" flags="accountInfo,accountInherited,domainAdminModifiable,domainInherited" since="7.0.0">
+  <globalConfigValue>FALSE</globalConfigValue>
   <defaultCOSValue>FALSE</defaultCOSValue>
   <desc>enable/disable dumpster</desc>
 </attr>
@@ -5284,7 +5285,8 @@ TODO: delete them permanently from here
   </desc>
 </attr>
 
-<attr id="1133" name="zimbraMailDumpsterLifetime" type="duration" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable,accountInfo" since="7.0.0">
+<attr id="1133" name="zimbraMailDumpsterLifetime" type="duration" cardinality="single" optionalIn="globalConfig,domain,account,cos" flags="accountInherited,domainInherited,domainAdminModifiable,accountInfo" since="7.0.0">
+  <globalConfigValue>30d</globalConfigValue>
   <defaultCOSValue>30d</defaultCOSValue>
   <desc>
     Retention period of messages in the dumpster.  0 means that all messages will be retained.
@@ -6601,12 +6603,14 @@ TODO: delete them permanently from here
   <desc>template for constructing the body of a file deletion warning message</desc>
 </attr>
 
-<attr id="1314" name="zimbraDumpsterUserVisibleAge" type="duration" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="8.0.0">
+<attr id="1314" name="zimbraDumpsterUserVisibleAge" type="duration" cardinality="single" optionalIn="globalConfig,domain,account,cos" flags="accountInherited,domainInherited,domainAdminModifiable" since="8.0.0">
+  <globalConfigValue>30d</globalConfigValue>
   <defaultCOSValue>30d</defaultCOSValue>
   <desc>limits how much of a dumpster data is viewable by the end user, based on the age since being put in dumpster</desc>
 </attr>
 
-<attr id="1315" name="zimbraDumpsterPurgeEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="8.0.0">
+<attr id="1315" name="zimbraDumpsterPurgeEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,domain,account,cos" flags="accountInherited,domainInherited,domainAdminModifiable" since="8.0.0">
+  <globalConfigValue>TRUE</globalConfigValue>
   <defaultCOSValue>TRUE</defaultCOSValue>
   <desc>disables purging from dumpster when set to FALSE</desc>
 </attr>
@@ -9925,8 +9929,83 @@ TODO: delete them permanently from here
   <defaultCOSValue>FALSE</defaultCOSValue>
   <desc>Creates unsubscribe system folder</desc>
  </attr>
- <attr id="4004" name="zimbraPrefCalenderScaling" type="enum" value="10,15,30" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="9.1.0">
+<attr id="4004" name="zimbraPrefCalenderScaling" type="enum" value="10,15,30" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="9.1.0">
   <defaultCOSValue>30</defaultCOSValue>
   <desc>Default calendar resolution preference</desc>
+</attr>
+
+<attr id="4007" name="zimbraGlobalBackupEnabled" type="boolean" cardinality="single" optionalIn="globalConfig" since="9.1.0">
+  <globalConfigValue>TRUE</globalConfigValue>
+  <desc>If true, enables backup globally and if there is pre-configured backup schedule the crontab will get that schedule.</desc>
+</attr>
+
+<attr id="4008" name="zimbraBackupSyncUsersEnabled" type="boolean" cardinality="single" optionalIn="globalConfig" since="9.1.0">
+  <globalConfigValue>FALSE</globalConfigValue>
+  <desc>If true, will synchronize dumpster enabled accounts with backup eligible accounts from zimbraBackupEnabled list.</desc>
+</attr>
+
+<attr id="4009" name="zimbraBackupStartTime" type="string" max="64" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="9.1.0">
+  <globalConfigValue>01:00</globalConfigValue>
+  <desc>Starts backup each day at this time. This attribute is used to set hours and minutes on the crontab.</desc>
+</attr>
+
+<attr id="4010" name="zimbraBackupRetentionDays" type="integer" min="1" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="9.1.0">
+  <globalConfigValue>8</globalConfigValue>
+  <desc>The number of days backups will be kept. Backup Scheduler deletes backups older than the set value.</desc>
+</attr>
+
+<attr id="4011" name="zimbraBackupBlobsCompressType" type="enum" value="zip,zipStore,noZip" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="9.1.0">
+  <globalConfigValue>zip</globalConfigValue>
+  <desc>Blobs inside a backup are compressed by default in zip format.
+        zip - blobs are backed up into zip files with compression (default).
+        zipStore - blobs are backed up into zip files without compression.
+        noZip - blobs are backed up as individual files rather in zip files.
+  </desc>
+</attr>
+
+<attr id="4012" name="zimbraBackupSyncEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="9.1.0">
+  <globalConfigValue>FALSE</globalConfigValue>
+  <desc>If true, the full backup runs synchronously.
+        If false, full backup runs in a separate thread and the soap call returns with the backup label.
+  </desc>
+</attr>
+
+<attr id="4013" name="zimbraMailReportEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="9.1.0">
+  <globalConfigValue>TRUE</globalConfigValue>
+  <desc>If true, sends an email report to the admin user. Admins can disable the email notification by setting it to FALSE.</desc>
+</attr>
+
+<attr id="4014" name="zimbraBackupStartDay" type="string" max="32" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="9.1.0">
+  <globalConfigValue>6</globalConfigValue>
+  <desc>The day of the week on which the full backup starts.
+        When a day is select their relative value is set on the crontab. Default starts from Saturday
+        0-7 or names allowed (Sun, Wed), with both 0 and 7 representing Sunday. Monday to Saturday (1-6)
+  </desc>
+</attr>
+
+<attr id="4015" name="zimbraBackupObjectLevelEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="9.1.0">
+  <globalConfigValue>FALSE</globalConfigValue>
+  <desc>If true, --accounts option will be set to useBackupConfig on zmschedulebackup command. Enables global,cos,domain,account level backup.
+        If false, --accounts option will be set to all accounts on zmschedulebackup command. Backups all accounts.
+  </desc>
+</attr>
+
+<attr id="4016" name="zimbraBackupCrontabConfig" type="string"  cardinality="multi" optionalIn="globalConfig,server" flags="serverInherited" since="9.1.0">
+  <globalConfigValue>f '0 1 * * 6'</globalConfigValue>
+  <desc>Configures crontab schedule. Full, incremental and delete cron schedules can be set using this attribute.
+        The entire backup can be scheduled as f '0 1 * * 6' i '0 1 * * 0-5'  d 7d '0 0 * * *'.
+        f '0 1 * * 6' can be passed if we are setting only the full-backup schedule. (f - full-backup)
+        i '0 1 * * 0-5' can be passed if we are setting only the incremental-backup schedule. (i - incremental)
+        d 7d '0 0 * * *' can be passed if we are setting only the delete-backup schedule. (d - delete).
+  </desc>
+</attr>
+
+<attr id="9014" name="zimbraBackupEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,domain,cos,account" flags="accountCosDomainInherited,domainInherited" since="9.1.0">
+  <desc>Whether or not account is eligible for backup
+        If true on cos level then backup accounts for cos. zimbraDomainDefaultCOSId is considered.
+        If unset on cos level but true on domain level then backup domains account.
+        If unset on cos level, unset on domain level but true on account level then specific account will be backed up.
+        If true on cos level , unset on domain level but zimbraDomainDefaultCOSId is set to cos then accounts for that domain will be backed up.
+  </desc>
 </attr>
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -5354,6 +5354,108 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * Whether or not account is eligible for backup If true on cos level
+     * then backup accounts for cos. zimbraDomainDefaultCOSId is considered.
+     * If unset on cos level but true on domain level then backup domains
+     * account. If unset on cos level, unset on domain level but true on
+     * account level then specific account will be backed up. If true on cos
+     * level , unset on domain level but zimbraDomainDefaultCOSId is set to
+     * cos then accounts for that domain will be backed up.
+     *
+     * @return zimbraBackupEnabled, or false if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=9014)
+    public boolean isBackupEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraBackupEnabled, false, true);
+    }
+
+    /**
+     * Whether or not account is eligible for backup If true on cos level
+     * then backup accounts for cos. zimbraDomainDefaultCOSId is considered.
+     * If unset on cos level but true on domain level then backup domains
+     * account. If unset on cos level, unset on domain level but true on
+     * account level then specific account will be backed up. If true on cos
+     * level , unset on domain level but zimbraDomainDefaultCOSId is set to
+     * cos then accounts for that domain will be backed up.
+     *
+     * @param zimbraBackupEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=9014)
+    public void setBackupEnabled(boolean zimbraBackupEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupEnabled, zimbraBackupEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether or not account is eligible for backup If true on cos level
+     * then backup accounts for cos. zimbraDomainDefaultCOSId is considered.
+     * If unset on cos level but true on domain level then backup domains
+     * account. If unset on cos level, unset on domain level but true on
+     * account level then specific account will be backed up. If true on cos
+     * level , unset on domain level but zimbraDomainDefaultCOSId is set to
+     * cos then accounts for that domain will be backed up.
+     *
+     * @param zimbraBackupEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=9014)
+    public Map<String,Object> setBackupEnabled(boolean zimbraBackupEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupEnabled, zimbraBackupEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether or not account is eligible for backup If true on cos level
+     * then backup accounts for cos. zimbraDomainDefaultCOSId is considered.
+     * If unset on cos level but true on domain level then backup domains
+     * account. If unset on cos level, unset on domain level but true on
+     * account level then specific account will be backed up. If true on cos
+     * level , unset on domain level but zimbraDomainDefaultCOSId is set to
+     * cos then accounts for that domain will be backed up.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=9014)
+    public void unsetBackupEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether or not account is eligible for backup If true on cos level
+     * then backup accounts for cos. zimbraDomainDefaultCOSId is considered.
+     * If unset on cos level but true on domain level then backup domains
+     * account. If unset on cos level, unset on domain level but true on
+     * account level then specific account will be backed up. If true on cos
+     * level , unset on domain level but zimbraDomainDefaultCOSId is set to
+     * cos then accounts for that domain will be backed up.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=9014)
+    public Map<String,Object> unsetBackupEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupEnabled, "");
+        return attrs;
+    }
+
+    /**
      * Batch size to use when indexing data
      *
      * @return zimbraBatchedIndexingSize, or 20 if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -5004,6 +5004,469 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Blobs inside a backup are compressed by default in zip format. zip -
+     * blobs are backed up into zip files with compression (default).
+     * zipStore - blobs are backed up into zip files without compression.
+     * noZip - blobs are backed up as individual files rather in zip files.
+     *
+     * <p>Valid values: [zip, zipStore, noZip]
+     *
+     * @return zimbraBackupBlobsCompressType, or ZAttrProvisioning.BackupBlobsCompressType.zip if unset and/or has invalid value
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4011)
+    public ZAttrProvisioning.BackupBlobsCompressType getBackupBlobsCompressType() {
+        try { String v = getAttr(Provisioning.A_zimbraBackupBlobsCompressType, true, true); return v == null ? ZAttrProvisioning.BackupBlobsCompressType.zip : ZAttrProvisioning.BackupBlobsCompressType.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.BackupBlobsCompressType.zip; }
+    }
+
+    /**
+     * Blobs inside a backup are compressed by default in zip format. zip -
+     * blobs are backed up into zip files with compression (default).
+     * zipStore - blobs are backed up into zip files without compression.
+     * noZip - blobs are backed up as individual files rather in zip files.
+     *
+     * <p>Valid values: [zip, zipStore, noZip]
+     *
+     * @return zimbraBackupBlobsCompressType, or "zip" if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4011)
+    public String getBackupBlobsCompressTypeAsString() {
+        return getAttr(Provisioning.A_zimbraBackupBlobsCompressType, "zip", true);
+    }
+
+    /**
+     * Blobs inside a backup are compressed by default in zip format. zip -
+     * blobs are backed up into zip files with compression (default).
+     * zipStore - blobs are backed up into zip files without compression.
+     * noZip - blobs are backed up as individual files rather in zip files.
+     *
+     * <p>Valid values: [zip, zipStore, noZip]
+     *
+     * @param zimbraBackupBlobsCompressType new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4011)
+    public void setBackupBlobsCompressType(ZAttrProvisioning.BackupBlobsCompressType zimbraBackupBlobsCompressType) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupBlobsCompressType, zimbraBackupBlobsCompressType.toString());
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Blobs inside a backup are compressed by default in zip format. zip -
+     * blobs are backed up into zip files with compression (default).
+     * zipStore - blobs are backed up into zip files without compression.
+     * noZip - blobs are backed up as individual files rather in zip files.
+     *
+     * <p>Valid values: [zip, zipStore, noZip]
+     *
+     * @param zimbraBackupBlobsCompressType new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4011)
+    public Map<String,Object> setBackupBlobsCompressType(ZAttrProvisioning.BackupBlobsCompressType zimbraBackupBlobsCompressType, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupBlobsCompressType, zimbraBackupBlobsCompressType.toString());
+        return attrs;
+    }
+
+    /**
+     * Blobs inside a backup are compressed by default in zip format. zip -
+     * blobs are backed up into zip files with compression (default).
+     * zipStore - blobs are backed up into zip files without compression.
+     * noZip - blobs are backed up as individual files rather in zip files.
+     *
+     * <p>Valid values: [zip, zipStore, noZip]
+     *
+     * @param zimbraBackupBlobsCompressType new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4011)
+    public void setBackupBlobsCompressTypeAsString(String zimbraBackupBlobsCompressType) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupBlobsCompressType, zimbraBackupBlobsCompressType);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Blobs inside a backup are compressed by default in zip format. zip -
+     * blobs are backed up into zip files with compression (default).
+     * zipStore - blobs are backed up into zip files without compression.
+     * noZip - blobs are backed up as individual files rather in zip files.
+     *
+     * <p>Valid values: [zip, zipStore, noZip]
+     *
+     * @param zimbraBackupBlobsCompressType new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4011)
+    public Map<String,Object> setBackupBlobsCompressTypeAsString(String zimbraBackupBlobsCompressType, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupBlobsCompressType, zimbraBackupBlobsCompressType);
+        return attrs;
+    }
+
+    /**
+     * Blobs inside a backup are compressed by default in zip format. zip -
+     * blobs are backed up into zip files with compression (default).
+     * zipStore - blobs are backed up into zip files without compression.
+     * noZip - blobs are backed up as individual files rather in zip files.
+     *
+     * <p>Valid values: [zip, zipStore, noZip]
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4011)
+    public void unsetBackupBlobsCompressType() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupBlobsCompressType, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Blobs inside a backup are compressed by default in zip format. zip -
+     * blobs are backed up into zip files with compression (default).
+     * zipStore - blobs are backed up into zip files without compression.
+     * noZip - blobs are backed up as individual files rather in zip files.
+     *
+     * <p>Valid values: [zip, zipStore, noZip]
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4011)
+    public Map<String,Object> unsetBackupBlobsCompressType(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupBlobsCompressType, "");
+        return attrs;
+    }
+
+    /**
+     * Configures crontab schedule. Full, incremental and delete cron
+     * schedules can be set using this attribute. The entire backup can be
+     * scheduled as f &#039;0 1 * * 6&#039; i &#039;0 1 * * 0-5&#039; d 7d
+     * &#039;0 0 * * *&#039;. f &#039;0 1 * * 6&#039; can be passed if we are
+     * setting only the full-backup schedule. (f - full-backup) i &#039;0 1 *
+     * * 0-5&#039; can be passed if we are setting only the
+     * incremental-backup schedule. (i - incremental) d 7d &#039;0 0 * *
+     * *&#039; can be passed if we are setting only the delete-backup
+     * schedule. (d - delete).
+     *
+     * @return zimbraBackupCrontabConfig, or empty array if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4016)
+    public String[] getBackupCrontabConfig() {
+        String[] value = getMultiAttr(Provisioning.A_zimbraBackupCrontabConfig, true, true); return value.length > 0 ? value : new String[] {"f '0 1 * * 6'"};
+    }
+
+    /**
+     * Configures crontab schedule. Full, incremental and delete cron
+     * schedules can be set using this attribute. The entire backup can be
+     * scheduled as f &#039;0 1 * * 6&#039; i &#039;0 1 * * 0-5&#039; d 7d
+     * &#039;0 0 * * *&#039;. f &#039;0 1 * * 6&#039; can be passed if we are
+     * setting only the full-backup schedule. (f - full-backup) i &#039;0 1 *
+     * * 0-5&#039; can be passed if we are setting only the
+     * incremental-backup schedule. (i - incremental) d 7d &#039;0 0 * *
+     * *&#039; can be passed if we are setting only the delete-backup
+     * schedule. (d - delete).
+     *
+     * @param zimbraBackupCrontabConfig new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4016)
+    public void setBackupCrontabConfig(String[] zimbraBackupCrontabConfig) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupCrontabConfig, zimbraBackupCrontabConfig);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures crontab schedule. Full, incremental and delete cron
+     * schedules can be set using this attribute. The entire backup can be
+     * scheduled as f &#039;0 1 * * 6&#039; i &#039;0 1 * * 0-5&#039; d 7d
+     * &#039;0 0 * * *&#039;. f &#039;0 1 * * 6&#039; can be passed if we are
+     * setting only the full-backup schedule. (f - full-backup) i &#039;0 1 *
+     * * 0-5&#039; can be passed if we are setting only the
+     * incremental-backup schedule. (i - incremental) d 7d &#039;0 0 * *
+     * *&#039; can be passed if we are setting only the delete-backup
+     * schedule. (d - delete).
+     *
+     * @param zimbraBackupCrontabConfig new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4016)
+    public Map<String,Object> setBackupCrontabConfig(String[] zimbraBackupCrontabConfig, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupCrontabConfig, zimbraBackupCrontabConfig);
+        return attrs;
+    }
+
+    /**
+     * Configures crontab schedule. Full, incremental and delete cron
+     * schedules can be set using this attribute. The entire backup can be
+     * scheduled as f &#039;0 1 * * 6&#039; i &#039;0 1 * * 0-5&#039; d 7d
+     * &#039;0 0 * * *&#039;. f &#039;0 1 * * 6&#039; can be passed if we are
+     * setting only the full-backup schedule. (f - full-backup) i &#039;0 1 *
+     * * 0-5&#039; can be passed if we are setting only the
+     * incremental-backup schedule. (i - incremental) d 7d &#039;0 0 * *
+     * *&#039; can be passed if we are setting only the delete-backup
+     * schedule. (d - delete).
+     *
+     * @param zimbraBackupCrontabConfig new to add to existing values
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4016)
+    public void addBackupCrontabConfig(String zimbraBackupCrontabConfig) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraBackupCrontabConfig, zimbraBackupCrontabConfig);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures crontab schedule. Full, incremental and delete cron
+     * schedules can be set using this attribute. The entire backup can be
+     * scheduled as f &#039;0 1 * * 6&#039; i &#039;0 1 * * 0-5&#039; d 7d
+     * &#039;0 0 * * *&#039;. f &#039;0 1 * * 6&#039; can be passed if we are
+     * setting only the full-backup schedule. (f - full-backup) i &#039;0 1 *
+     * * 0-5&#039; can be passed if we are setting only the
+     * incremental-backup schedule. (i - incremental) d 7d &#039;0 0 * *
+     * *&#039; can be passed if we are setting only the delete-backup
+     * schedule. (d - delete).
+     *
+     * @param zimbraBackupCrontabConfig new to add to existing values
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4016)
+    public Map<String,Object> addBackupCrontabConfig(String zimbraBackupCrontabConfig, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraBackupCrontabConfig, zimbraBackupCrontabConfig);
+        return attrs;
+    }
+
+    /**
+     * Configures crontab schedule. Full, incremental and delete cron
+     * schedules can be set using this attribute. The entire backup can be
+     * scheduled as f &#039;0 1 * * 6&#039; i &#039;0 1 * * 0-5&#039; d 7d
+     * &#039;0 0 * * *&#039;. f &#039;0 1 * * 6&#039; can be passed if we are
+     * setting only the full-backup schedule. (f - full-backup) i &#039;0 1 *
+     * * 0-5&#039; can be passed if we are setting only the
+     * incremental-backup schedule. (i - incremental) d 7d &#039;0 0 * *
+     * *&#039; can be passed if we are setting only the delete-backup
+     * schedule. (d - delete).
+     *
+     * @param zimbraBackupCrontabConfig existing value to remove
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4016)
+    public void removeBackupCrontabConfig(String zimbraBackupCrontabConfig) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraBackupCrontabConfig, zimbraBackupCrontabConfig);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures crontab schedule. Full, incremental and delete cron
+     * schedules can be set using this attribute. The entire backup can be
+     * scheduled as f &#039;0 1 * * 6&#039; i &#039;0 1 * * 0-5&#039; d 7d
+     * &#039;0 0 * * *&#039;. f &#039;0 1 * * 6&#039; can be passed if we are
+     * setting only the full-backup schedule. (f - full-backup) i &#039;0 1 *
+     * * 0-5&#039; can be passed if we are setting only the
+     * incremental-backup schedule. (i - incremental) d 7d &#039;0 0 * *
+     * *&#039; can be passed if we are setting only the delete-backup
+     * schedule. (d - delete).
+     *
+     * @param zimbraBackupCrontabConfig existing value to remove
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4016)
+    public Map<String,Object> removeBackupCrontabConfig(String zimbraBackupCrontabConfig, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraBackupCrontabConfig, zimbraBackupCrontabConfig);
+        return attrs;
+    }
+
+    /**
+     * Configures crontab schedule. Full, incremental and delete cron
+     * schedules can be set using this attribute. The entire backup can be
+     * scheduled as f &#039;0 1 * * 6&#039; i &#039;0 1 * * 0-5&#039; d 7d
+     * &#039;0 0 * * *&#039;. f &#039;0 1 * * 6&#039; can be passed if we are
+     * setting only the full-backup schedule. (f - full-backup) i &#039;0 1 *
+     * * 0-5&#039; can be passed if we are setting only the
+     * incremental-backup schedule. (i - incremental) d 7d &#039;0 0 * *
+     * *&#039; can be passed if we are setting only the delete-backup
+     * schedule. (d - delete).
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4016)
+    public void unsetBackupCrontabConfig() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupCrontabConfig, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures crontab schedule. Full, incremental and delete cron
+     * schedules can be set using this attribute. The entire backup can be
+     * scheduled as f &#039;0 1 * * 6&#039; i &#039;0 1 * * 0-5&#039; d 7d
+     * &#039;0 0 * * *&#039;. f &#039;0 1 * * 6&#039; can be passed if we are
+     * setting only the full-backup schedule. (f - full-backup) i &#039;0 1 *
+     * * 0-5&#039; can be passed if we are setting only the
+     * incremental-backup schedule. (i - incremental) d 7d &#039;0 0 * *
+     * *&#039; can be passed if we are setting only the delete-backup
+     * schedule. (d - delete).
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4016)
+    public Map<String,Object> unsetBackupCrontabConfig(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupCrontabConfig, "");
+        return attrs;
+    }
+
+    /**
+     * Whether or not account is eligible for backup If true on cos level
+     * then backup accounts for cos. zimbraDomainDefaultCOSId is considered.
+     * If unset on cos level but true on domain level then backup domains
+     * account. If unset on cos level, unset on domain level but true on
+     * account level then specific account will be backed up. If true on cos
+     * level , unset on domain level but zimbraDomainDefaultCOSId is set to
+     * cos then accounts for that domain will be backed up.
+     *
+     * @return zimbraBackupEnabled, or false if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=9014)
+    public boolean isBackupEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraBackupEnabled, false, true);
+    }
+
+    /**
+     * Whether or not account is eligible for backup If true on cos level
+     * then backup accounts for cos. zimbraDomainDefaultCOSId is considered.
+     * If unset on cos level but true on domain level then backup domains
+     * account. If unset on cos level, unset on domain level but true on
+     * account level then specific account will be backed up. If true on cos
+     * level , unset on domain level but zimbraDomainDefaultCOSId is set to
+     * cos then accounts for that domain will be backed up.
+     *
+     * @param zimbraBackupEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=9014)
+    public void setBackupEnabled(boolean zimbraBackupEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupEnabled, zimbraBackupEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether or not account is eligible for backup If true on cos level
+     * then backup accounts for cos. zimbraDomainDefaultCOSId is considered.
+     * If unset on cos level but true on domain level then backup domains
+     * account. If unset on cos level, unset on domain level but true on
+     * account level then specific account will be backed up. If true on cos
+     * level , unset on domain level but zimbraDomainDefaultCOSId is set to
+     * cos then accounts for that domain will be backed up.
+     *
+     * @param zimbraBackupEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=9014)
+    public Map<String,Object> setBackupEnabled(boolean zimbraBackupEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupEnabled, zimbraBackupEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether or not account is eligible for backup If true on cos level
+     * then backup accounts for cos. zimbraDomainDefaultCOSId is considered.
+     * If unset on cos level but true on domain level then backup domains
+     * account. If unset on cos level, unset on domain level but true on
+     * account level then specific account will be backed up. If true on cos
+     * level , unset on domain level but zimbraDomainDefaultCOSId is set to
+     * cos then accounts for that domain will be backed up.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=9014)
+    public void unsetBackupEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether or not account is eligible for backup If true on cos level
+     * then backup accounts for cos. zimbraDomainDefaultCOSId is considered.
+     * If unset on cos level but true on domain level then backup domains
+     * account. If unset on cos level, unset on domain level but true on
+     * account level then specific account will be backed up. If true on cos
+     * level , unset on domain level but zimbraDomainDefaultCOSId is set to
+     * cos then accounts for that domain will be backed up.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=9014)
+    public Map<String,Object> unsetBackupEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupEnabled, "");
+        return attrs;
+    }
+
+    /**
      * Minimum percentage or TB/GB/MB/KB/bytes of free space on backup target
      * to allow a full or auto-grouped backup to start; 0 = no minimum is
      * enforced. Examples: 25%, 10GB
@@ -5197,6 +5660,93 @@ public abstract class ZAttrConfig extends Entry {
     public Map<String,Object> unsetBackupMode(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraBackupMode, "");
+        return attrs;
+    }
+
+    /**
+     * If true, --accounts option will be set to useBackupConfig on
+     * zmschedulebackup command. Enables global,cos,domain,account level
+     * backup. If false, --accounts option will be set to all accounts on
+     * zmschedulebackup command. Backups all accounts.
+     *
+     * @return zimbraBackupObjectLevelEnabled, or false if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4015)
+    public boolean isBackupObjectLevelEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraBackupObjectLevelEnabled, false, true);
+    }
+
+    /**
+     * If true, --accounts option will be set to useBackupConfig on
+     * zmschedulebackup command. Enables global,cos,domain,account level
+     * backup. If false, --accounts option will be set to all accounts on
+     * zmschedulebackup command. Backups all accounts.
+     *
+     * @param zimbraBackupObjectLevelEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4015)
+    public void setBackupObjectLevelEnabled(boolean zimbraBackupObjectLevelEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupObjectLevelEnabled, zimbraBackupObjectLevelEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * If true, --accounts option will be set to useBackupConfig on
+     * zmschedulebackup command. Enables global,cos,domain,account level
+     * backup. If false, --accounts option will be set to all accounts on
+     * zmschedulebackup command. Backups all accounts.
+     *
+     * @param zimbraBackupObjectLevelEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4015)
+    public Map<String,Object> setBackupObjectLevelEnabled(boolean zimbraBackupObjectLevelEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupObjectLevelEnabled, zimbraBackupObjectLevelEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * If true, --accounts option will be set to useBackupConfig on
+     * zmschedulebackup command. Enables global,cos,domain,account level
+     * backup. If false, --accounts option will be set to all accounts on
+     * zmschedulebackup command. Backups all accounts.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4015)
+    public void unsetBackupObjectLevelEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupObjectLevelEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * If true, --accounts option will be set to useBackupConfig on
+     * zmschedulebackup command. Enables global,cos,domain,account level
+     * backup. If false, --accounts option will be set to all accounts on
+     * zmschedulebackup command. Backups all accounts.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4015)
+    public Map<String,Object> unsetBackupObjectLevelEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupObjectLevelEnabled, "");
         return attrs;
     }
 
@@ -5441,6 +5991,83 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * The number of days backups will be kept. Backup Scheduler deletes
+     * backups older than the set value.
+     *
+     * @return zimbraBackupRetentionDays, or 8 if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4010)
+    public int getBackupRetentionDays() {
+        return getIntAttr(Provisioning.A_zimbraBackupRetentionDays, 8, true);
+    }
+
+    /**
+     * The number of days backups will be kept. Backup Scheduler deletes
+     * backups older than the set value.
+     *
+     * @param zimbraBackupRetentionDays new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4010)
+    public void setBackupRetentionDays(int zimbraBackupRetentionDays) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupRetentionDays, Integer.toString(zimbraBackupRetentionDays));
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * The number of days backups will be kept. Backup Scheduler deletes
+     * backups older than the set value.
+     *
+     * @param zimbraBackupRetentionDays new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4010)
+    public Map<String,Object> setBackupRetentionDays(int zimbraBackupRetentionDays, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupRetentionDays, Integer.toString(zimbraBackupRetentionDays));
+        return attrs;
+    }
+
+    /**
+     * The number of days backups will be kept. Backup Scheduler deletes
+     * backups older than the set value.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4010)
+    public void unsetBackupRetentionDays() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupRetentionDays, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * The number of days backups will be kept. Backup Scheduler deletes
+     * backups older than the set value.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4010)
+    public Map<String,Object> unsetBackupRetentionDays(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupRetentionDays, "");
+        return attrs;
+    }
+
+    /**
      * if true, do not backup blobs (HSM or not) during a full backup
      *
      * @return zimbraBackupSkipBlobs, or false if unset
@@ -5658,6 +6285,329 @@ public abstract class ZAttrConfig extends Entry {
     public Map<String,Object> unsetBackupSkipSearchIndex(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraBackupSkipSearchIndex, "");
+        return attrs;
+    }
+
+    /**
+     * The day of the week on which the full backup starts. When a day is
+     * select their relative value is set on the crontab. Default starts from
+     * Saturday 0-7 or names allowed (Sun, Wed), with both 0 and 7
+     * representing Sunday. Monday to Saturday (1-6)
+     *
+     * @return zimbraBackupStartDay, or "6" if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4014)
+    public String getBackupStartDay() {
+        return getAttr(Provisioning.A_zimbraBackupStartDay, "6", true);
+    }
+
+    /**
+     * The day of the week on which the full backup starts. When a day is
+     * select their relative value is set on the crontab. Default starts from
+     * Saturday 0-7 or names allowed (Sun, Wed), with both 0 and 7
+     * representing Sunday. Monday to Saturday (1-6)
+     *
+     * @param zimbraBackupStartDay new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4014)
+    public void setBackupStartDay(String zimbraBackupStartDay) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStartDay, zimbraBackupStartDay);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * The day of the week on which the full backup starts. When a day is
+     * select their relative value is set on the crontab. Default starts from
+     * Saturday 0-7 or names allowed (Sun, Wed), with both 0 and 7
+     * representing Sunday. Monday to Saturday (1-6)
+     *
+     * @param zimbraBackupStartDay new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4014)
+    public Map<String,Object> setBackupStartDay(String zimbraBackupStartDay, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStartDay, zimbraBackupStartDay);
+        return attrs;
+    }
+
+    /**
+     * The day of the week on which the full backup starts. When a day is
+     * select their relative value is set on the crontab. Default starts from
+     * Saturday 0-7 or names allowed (Sun, Wed), with both 0 and 7
+     * representing Sunday. Monday to Saturday (1-6)
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4014)
+    public void unsetBackupStartDay() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStartDay, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * The day of the week on which the full backup starts. When a day is
+     * select their relative value is set on the crontab. Default starts from
+     * Saturday 0-7 or names allowed (Sun, Wed), with both 0 and 7
+     * representing Sunday. Monday to Saturday (1-6)
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4014)
+    public Map<String,Object> unsetBackupStartDay(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStartDay, "");
+        return attrs;
+    }
+
+    /**
+     * Starts backup each day at this time. This attribute is used to set
+     * hours and minutes on the crontab.
+     *
+     * @return zimbraBackupStartTime, or "01:00" if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public String getBackupStartTime() {
+        return getAttr(Provisioning.A_zimbraBackupStartTime, "01:00", true);
+    }
+
+    /**
+     * Starts backup each day at this time. This attribute is used to set
+     * hours and minutes on the crontab.
+     *
+     * @param zimbraBackupStartTime new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public void setBackupStartTime(String zimbraBackupStartTime) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStartTime, zimbraBackupStartTime);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Starts backup each day at this time. This attribute is used to set
+     * hours and minutes on the crontab.
+     *
+     * @param zimbraBackupStartTime new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public Map<String,Object> setBackupStartTime(String zimbraBackupStartTime, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStartTime, zimbraBackupStartTime);
+        return attrs;
+    }
+
+    /**
+     * Starts backup each day at this time. This attribute is used to set
+     * hours and minutes on the crontab.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public void unsetBackupStartTime() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStartTime, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Starts backup each day at this time. This attribute is used to set
+     * hours and minutes on the crontab.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public Map<String,Object> unsetBackupStartTime(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStartTime, "");
+        return attrs;
+    }
+
+    /**
+     * If true, the full backup runs synchronously. If false, full backup
+     * runs in a separate thread and the soap call returns with the backup
+     * label.
+     *
+     * @return zimbraBackupSyncEnabled, or false if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4012)
+    public boolean isBackupSyncEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraBackupSyncEnabled, false, true);
+    }
+
+    /**
+     * If true, the full backup runs synchronously. If false, full backup
+     * runs in a separate thread and the soap call returns with the backup
+     * label.
+     *
+     * @param zimbraBackupSyncEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4012)
+    public void setBackupSyncEnabled(boolean zimbraBackupSyncEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupSyncEnabled, zimbraBackupSyncEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * If true, the full backup runs synchronously. If false, full backup
+     * runs in a separate thread and the soap call returns with the backup
+     * label.
+     *
+     * @param zimbraBackupSyncEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4012)
+    public Map<String,Object> setBackupSyncEnabled(boolean zimbraBackupSyncEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupSyncEnabled, zimbraBackupSyncEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * If true, the full backup runs synchronously. If false, full backup
+     * runs in a separate thread and the soap call returns with the backup
+     * label.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4012)
+    public void unsetBackupSyncEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupSyncEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * If true, the full backup runs synchronously. If false, full backup
+     * runs in a separate thread and the soap call returns with the backup
+     * label.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4012)
+    public Map<String,Object> unsetBackupSyncEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupSyncEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * If true, will synchronize dumpster enabled accounts with backup
+     * eligible accounts from zimbraBackupEnabled list.
+     *
+     * @return zimbraBackupSyncUsersEnabled, or false if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public boolean isBackupSyncUsersEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraBackupSyncUsersEnabled, false, true);
+    }
+
+    /**
+     * If true, will synchronize dumpster enabled accounts with backup
+     * eligible accounts from zimbraBackupEnabled list.
+     *
+     * @param zimbraBackupSyncUsersEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public void setBackupSyncUsersEnabled(boolean zimbraBackupSyncUsersEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupSyncUsersEnabled, zimbraBackupSyncUsersEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * If true, will synchronize dumpster enabled accounts with backup
+     * eligible accounts from zimbraBackupEnabled list.
+     *
+     * @param zimbraBackupSyncUsersEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public Map<String,Object> setBackupSyncUsersEnabled(boolean zimbraBackupSyncUsersEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupSyncUsersEnabled, zimbraBackupSyncUsersEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * If true, will synchronize dumpster enabled accounts with backup
+     * eligible accounts from zimbraBackupEnabled list.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public void unsetBackupSyncUsersEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupSyncUsersEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * If true, will synchronize dumpster enabled accounts with backup
+     * eligible accounts from zimbraBackupEnabled list.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public Map<String,Object> unsetBackupSyncUsersEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupSyncUsersEnabled, "");
         return attrs;
     }
 
@@ -15311,6 +16261,262 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * enable/disable dumpster
+     *
+     * @return zimbraDumpsterEnabled, or false if unset
+     *
+     * @since ZCS 7.0.0
+     */
+    @ZAttr(id=1128)
+    public boolean isDumpsterEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraDumpsterEnabled, false, true);
+    }
+
+    /**
+     * enable/disable dumpster
+     *
+     * @param zimbraDumpsterEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 7.0.0
+     */
+    @ZAttr(id=1128)
+    public void setDumpsterEnabled(boolean zimbraDumpsterEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDumpsterEnabled, zimbraDumpsterEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * enable/disable dumpster
+     *
+     * @param zimbraDumpsterEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 7.0.0
+     */
+    @ZAttr(id=1128)
+    public Map<String,Object> setDumpsterEnabled(boolean zimbraDumpsterEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDumpsterEnabled, zimbraDumpsterEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * enable/disable dumpster
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 7.0.0
+     */
+    @ZAttr(id=1128)
+    public void unsetDumpsterEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDumpsterEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * enable/disable dumpster
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 7.0.0
+     */
+    @ZAttr(id=1128)
+    public Map<String,Object> unsetDumpsterEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDumpsterEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * disables purging from dumpster when set to FALSE
+     *
+     * @return zimbraDumpsterPurgeEnabled, or true if unset
+     *
+     * @since ZCS 8.0.0
+     */
+    @ZAttr(id=1315)
+    public boolean isDumpsterPurgeEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraDumpsterPurgeEnabled, true, true);
+    }
+
+    /**
+     * disables purging from dumpster when set to FALSE
+     *
+     * @param zimbraDumpsterPurgeEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.0.0
+     */
+    @ZAttr(id=1315)
+    public void setDumpsterPurgeEnabled(boolean zimbraDumpsterPurgeEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDumpsterPurgeEnabled, zimbraDumpsterPurgeEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * disables purging from dumpster when set to FALSE
+     *
+     * @param zimbraDumpsterPurgeEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.0.0
+     */
+    @ZAttr(id=1315)
+    public Map<String,Object> setDumpsterPurgeEnabled(boolean zimbraDumpsterPurgeEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDumpsterPurgeEnabled, zimbraDumpsterPurgeEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * disables purging from dumpster when set to FALSE
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.0.0
+     */
+    @ZAttr(id=1315)
+    public void unsetDumpsterPurgeEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDumpsterPurgeEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * disables purging from dumpster when set to FALSE
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.0.0
+     */
+    @ZAttr(id=1315)
+    public Map<String,Object> unsetDumpsterPurgeEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDumpsterPurgeEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * limits how much of a dumpster data is viewable by the end user, based
+     * on the age since being put in dumpster. Must be in valid duration
+     * format: {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h -
+     * hours, m - minutes, s - seconds, d - days, ms - milliseconds. If time
+     * unit is not specified, the default is s(seconds).
+     *
+     * <p>Use getDumpsterUserVisibleAgeAsString to access value as a string.
+     *
+     * @see #getDumpsterUserVisibleAgeAsString()
+     *
+     * @return zimbraDumpsterUserVisibleAge in millseconds, or 2592000000 (30d)  if unset
+     *
+     * @since ZCS 8.0.0
+     */
+    @ZAttr(id=1314)
+    public long getDumpsterUserVisibleAge() {
+        return getTimeInterval(Provisioning.A_zimbraDumpsterUserVisibleAge, 2592000000L, true);
+    }
+
+    /**
+     * limits how much of a dumpster data is viewable by the end user, based
+     * on the age since being put in dumpster. Must be in valid duration
+     * format: {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h -
+     * hours, m - minutes, s - seconds, d - days, ms - milliseconds. If time
+     * unit is not specified, the default is s(seconds).
+     *
+     * @return zimbraDumpsterUserVisibleAge, or "30d" if unset
+     *
+     * @since ZCS 8.0.0
+     */
+    @ZAttr(id=1314)
+    public String getDumpsterUserVisibleAgeAsString() {
+        return getAttr(Provisioning.A_zimbraDumpsterUserVisibleAge, "30d", true);
+    }
+
+    /**
+     * limits how much of a dumpster data is viewable by the end user, based
+     * on the age since being put in dumpster. Must be in valid duration
+     * format: {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h -
+     * hours, m - minutes, s - seconds, d - days, ms - milliseconds. If time
+     * unit is not specified, the default is s(seconds).
+     *
+     * @param zimbraDumpsterUserVisibleAge new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.0.0
+     */
+    @ZAttr(id=1314)
+    public void setDumpsterUserVisibleAge(String zimbraDumpsterUserVisibleAge) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDumpsterUserVisibleAge, zimbraDumpsterUserVisibleAge);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * limits how much of a dumpster data is viewable by the end user, based
+     * on the age since being put in dumpster. Must be in valid duration
+     * format: {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h -
+     * hours, m - minutes, s - seconds, d - days, ms - milliseconds. If time
+     * unit is not specified, the default is s(seconds).
+     *
+     * @param zimbraDumpsterUserVisibleAge new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.0.0
+     */
+    @ZAttr(id=1314)
+    public Map<String,Object> setDumpsterUserVisibleAge(String zimbraDumpsterUserVisibleAge, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDumpsterUserVisibleAge, zimbraDumpsterUserVisibleAge);
+        return attrs;
+    }
+
+    /**
+     * limits how much of a dumpster data is viewable by the end user, based
+     * on the age since being put in dumpster. Must be in valid duration
+     * format: {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h -
+     * hours, m - minutes, s - seconds, d - days, ms - milliseconds. If time
+     * unit is not specified, the default is s(seconds).
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.0.0
+     */
+    @ZAttr(id=1314)
+    public void unsetDumpsterUserVisibleAge() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDumpsterUserVisibleAge, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * limits how much of a dumpster data is viewable by the end user, based
+     * on the age since being put in dumpster. Must be in valid duration
+     * format: {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h -
+     * hours, m - minutes, s - seconds, d - days, ms - milliseconds. If time
+     * unit is not specified, the default is s(seconds).
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.0.0
+     */
+    @ZAttr(id=1314)
+    public Map<String,Object> unsetDumpsterUserVisibleAge(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDumpsterUserVisibleAge, "");
+        return attrs;
+    }
+
+    /**
      * EmptyFolderOpTimeout is the time in seconds for which empty folder
      * operation will wait for the current empty folder operation to complete
      *
@@ -19394,6 +20600,83 @@ public abstract class ZAttrConfig extends Entry {
     public Map<String,Object> unsetGalTokenizeSearchKey(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraGalTokenizeSearchKey, "");
+        return attrs;
+    }
+
+    /**
+     * If true, enables backup globally and if there is pre-configured backup
+     * schedule the crontab will get that schedule.
+     *
+     * @return zimbraGlobalBackupEnabled, or true if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4007)
+    public boolean isGlobalBackupEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraGlobalBackupEnabled, true, true);
+    }
+
+    /**
+     * If true, enables backup globally and if there is pre-configured backup
+     * schedule the crontab will get that schedule.
+     *
+     * @param zimbraGlobalBackupEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4007)
+    public void setGlobalBackupEnabled(boolean zimbraGlobalBackupEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraGlobalBackupEnabled, zimbraGlobalBackupEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * If true, enables backup globally and if there is pre-configured backup
+     * schedule the crontab will get that schedule.
+     *
+     * @param zimbraGlobalBackupEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4007)
+    public Map<String,Object> setGlobalBackupEnabled(boolean zimbraGlobalBackupEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraGlobalBackupEnabled, zimbraGlobalBackupEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * If true, enables backup globally and if there is pre-configured backup
+     * schedule the crontab will get that schedule.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4007)
+    public void unsetGlobalBackupEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraGlobalBackupEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * If true, enables backup globally and if there is pre-configured backup
+     * schedule the crontab will get that schedule.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4007)
+    public Map<String,Object> unsetGlobalBackupEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraGlobalBackupEnabled, "");
         return attrs;
     }
 
@@ -26554,6 +27837,118 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Retention period of messages in the dumpster. 0 means that all
+     * messages will be retained. . Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * <p>Use getMailDumpsterLifetimeAsString to access value as a string.
+     *
+     * @see #getMailDumpsterLifetimeAsString()
+     *
+     * @return zimbraMailDumpsterLifetime in millseconds, or 2592000000 (30d)  if unset
+     *
+     * @since ZCS 7.0.0
+     */
+    @ZAttr(id=1133)
+    public long getMailDumpsterLifetime() {
+        return getTimeInterval(Provisioning.A_zimbraMailDumpsterLifetime, 2592000000L, true);
+    }
+
+    /**
+     * Retention period of messages in the dumpster. 0 means that all
+     * messages will be retained. . Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @return zimbraMailDumpsterLifetime, or "30d" if unset
+     *
+     * @since ZCS 7.0.0
+     */
+    @ZAttr(id=1133)
+    public String getMailDumpsterLifetimeAsString() {
+        return getAttr(Provisioning.A_zimbraMailDumpsterLifetime, "30d", true);
+    }
+
+    /**
+     * Retention period of messages in the dumpster. 0 means that all
+     * messages will be retained. . Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @param zimbraMailDumpsterLifetime new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 7.0.0
+     */
+    @ZAttr(id=1133)
+    public void setMailDumpsterLifetime(String zimbraMailDumpsterLifetime) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailDumpsterLifetime, zimbraMailDumpsterLifetime);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Retention period of messages in the dumpster. 0 means that all
+     * messages will be retained. . Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @param zimbraMailDumpsterLifetime new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 7.0.0
+     */
+    @ZAttr(id=1133)
+    public Map<String,Object> setMailDumpsterLifetime(String zimbraMailDumpsterLifetime, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailDumpsterLifetime, zimbraMailDumpsterLifetime);
+        return attrs;
+    }
+
+    /**
+     * Retention period of messages in the dumpster. 0 means that all
+     * messages will be retained. . Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 7.0.0
+     */
+    @ZAttr(id=1133)
+    public void unsetMailDumpsterLifetime() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailDumpsterLifetime, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Retention period of messages in the dumpster. 0 means that all
+     * messages will be retained. . Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 7.0.0
+     */
+    @ZAttr(id=1133)
+    public Map<String,Object> unsetMailDumpsterLifetime(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailDumpsterLifetime, "");
+        return attrs;
+    }
+
+    /**
      * Maximum number of messages to delete during a single transaction when
      * emptying a large folder.
      *
@@ -27990,6 +29385,83 @@ public abstract class ZAttrConfig extends Entry {
     public Map<String,Object> unsetMailReferMode(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraMailReferMode, "");
+        return attrs;
+    }
+
+    /**
+     * If true, sends an email report to the admin user. Admins can disable
+     * the email notification by setting it to FALSE.
+     *
+     * @return zimbraMailReportEnabled, or true if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4013)
+    public boolean isMailReportEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraMailReportEnabled, true, true);
+    }
+
+    /**
+     * If true, sends an email report to the admin user. Admins can disable
+     * the email notification by setting it to FALSE.
+     *
+     * @param zimbraMailReportEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4013)
+    public void setMailReportEnabled(boolean zimbraMailReportEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailReportEnabled, zimbraMailReportEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * If true, sends an email report to the admin user. Admins can disable
+     * the email notification by setting it to FALSE.
+     *
+     * @param zimbraMailReportEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4013)
+    public Map<String,Object> setMailReportEnabled(boolean zimbraMailReportEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailReportEnabled, zimbraMailReportEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * If true, sends an email report to the admin user. Admins can disable
+     * the email notification by setting it to FALSE.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4013)
+    public void unsetMailReportEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailReportEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * If true, sends an email report to the admin user. Admins can disable
+     * the email notification by setting it to FALSE.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4013)
+    public Map<String,Object> unsetMailReportEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailReportEnabled, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -1807,6 +1807,108 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * Whether or not account is eligible for backup If true on cos level
+     * then backup accounts for cos. zimbraDomainDefaultCOSId is considered.
+     * If unset on cos level but true on domain level then backup domains
+     * account. If unset on cos level, unset on domain level but true on
+     * account level then specific account will be backed up. If true on cos
+     * level , unset on domain level but zimbraDomainDefaultCOSId is set to
+     * cos then accounts for that domain will be backed up.
+     *
+     * @return zimbraBackupEnabled, or false if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=9014)
+    public boolean isBackupEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraBackupEnabled, false, true);
+    }
+
+    /**
+     * Whether or not account is eligible for backup If true on cos level
+     * then backup accounts for cos. zimbraDomainDefaultCOSId is considered.
+     * If unset on cos level but true on domain level then backup domains
+     * account. If unset on cos level, unset on domain level but true on
+     * account level then specific account will be backed up. If true on cos
+     * level , unset on domain level but zimbraDomainDefaultCOSId is set to
+     * cos then accounts for that domain will be backed up.
+     *
+     * @param zimbraBackupEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=9014)
+    public void setBackupEnabled(boolean zimbraBackupEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupEnabled, zimbraBackupEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether or not account is eligible for backup If true on cos level
+     * then backup accounts for cos. zimbraDomainDefaultCOSId is considered.
+     * If unset on cos level but true on domain level then backup domains
+     * account. If unset on cos level, unset on domain level but true on
+     * account level then specific account will be backed up. If true on cos
+     * level , unset on domain level but zimbraDomainDefaultCOSId is set to
+     * cos then accounts for that domain will be backed up.
+     *
+     * @param zimbraBackupEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=9014)
+    public Map<String,Object> setBackupEnabled(boolean zimbraBackupEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupEnabled, zimbraBackupEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether or not account is eligible for backup If true on cos level
+     * then backup accounts for cos. zimbraDomainDefaultCOSId is considered.
+     * If unset on cos level but true on domain level then backup domains
+     * account. If unset on cos level, unset on domain level but true on
+     * account level then specific account will be backed up. If true on cos
+     * level , unset on domain level but zimbraDomainDefaultCOSId is set to
+     * cos then accounts for that domain will be backed up.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=9014)
+    public void unsetBackupEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether or not account is eligible for backup If true on cos level
+     * then backup accounts for cos. zimbraDomainDefaultCOSId is considered.
+     * If unset on cos level but true on domain level then backup domains
+     * account. If unset on cos level, unset on domain level but true on
+     * account level then specific account will be backed up. If true on cos
+     * level , unset on domain level but zimbraDomainDefaultCOSId is set to
+     * cos then accounts for that domain will be backed up.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=9014)
+    public Map<String,Object> unsetBackupEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupEnabled, "");
+        return attrs;
+    }
+
+    /**
      * Batch size to use when indexing data
      *
      * @return zimbraBatchedIndexingSize, or 20 if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -4376,6 +4376,108 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
+     * Whether or not account is eligible for backup If true on cos level
+     * then backup accounts for cos. zimbraDomainDefaultCOSId is considered.
+     * If unset on cos level but true on domain level then backup domains
+     * account. If unset on cos level, unset on domain level but true on
+     * account level then specific account will be backed up. If true on cos
+     * level , unset on domain level but zimbraDomainDefaultCOSId is set to
+     * cos then accounts for that domain will be backed up.
+     *
+     * @return zimbraBackupEnabled, or false if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=9014)
+    public boolean isBackupEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraBackupEnabled, false, true);
+    }
+
+    /**
+     * Whether or not account is eligible for backup If true on cos level
+     * then backup accounts for cos. zimbraDomainDefaultCOSId is considered.
+     * If unset on cos level but true on domain level then backup domains
+     * account. If unset on cos level, unset on domain level but true on
+     * account level then specific account will be backed up. If true on cos
+     * level , unset on domain level but zimbraDomainDefaultCOSId is set to
+     * cos then accounts for that domain will be backed up.
+     *
+     * @param zimbraBackupEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=9014)
+    public void setBackupEnabled(boolean zimbraBackupEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupEnabled, zimbraBackupEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether or not account is eligible for backup If true on cos level
+     * then backup accounts for cos. zimbraDomainDefaultCOSId is considered.
+     * If unset on cos level but true on domain level then backup domains
+     * account. If unset on cos level, unset on domain level but true on
+     * account level then specific account will be backed up. If true on cos
+     * level , unset on domain level but zimbraDomainDefaultCOSId is set to
+     * cos then accounts for that domain will be backed up.
+     *
+     * @param zimbraBackupEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=9014)
+    public Map<String,Object> setBackupEnabled(boolean zimbraBackupEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupEnabled, zimbraBackupEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether or not account is eligible for backup If true on cos level
+     * then backup accounts for cos. zimbraDomainDefaultCOSId is considered.
+     * If unset on cos level but true on domain level then backup domains
+     * account. If unset on cos level, unset on domain level but true on
+     * account level then specific account will be backed up. If true on cos
+     * level , unset on domain level but zimbraDomainDefaultCOSId is set to
+     * cos then accounts for that domain will be backed up.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=9014)
+    public void unsetBackupEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether or not account is eligible for backup If true on cos level
+     * then backup accounts for cos. zimbraDomainDefaultCOSId is considered.
+     * If unset on cos level but true on domain level then backup domains
+     * account. If unset on cos level, unset on domain level but true on
+     * account level then specific account will be backed up. If true on cos
+     * level , unset on domain level but zimbraDomainDefaultCOSId is set to
+     * cos then accounts for that domain will be backed up.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=9014)
+    public Map<String,Object> unsetBackupEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupEnabled, "");
+        return attrs;
+    }
+
+    /**
      * Realm for the basic auth challenge (WWW-Authenticate) header
      *
      * @return zimbraBasicAuthRealm, or "Zimbra" if unset
@@ -7364,6 +7466,262 @@ public abstract class ZAttrDomain extends NamedEntry {
     public Map<String,Object> unsetDriveOwnCloudURL(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraDriveOwnCloudURL, "");
+        return attrs;
+    }
+
+    /**
+     * enable/disable dumpster
+     *
+     * @return zimbraDumpsterEnabled, or false if unset
+     *
+     * @since ZCS 7.0.0
+     */
+    @ZAttr(id=1128)
+    public boolean isDumpsterEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraDumpsterEnabled, false, true);
+    }
+
+    /**
+     * enable/disable dumpster
+     *
+     * @param zimbraDumpsterEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 7.0.0
+     */
+    @ZAttr(id=1128)
+    public void setDumpsterEnabled(boolean zimbraDumpsterEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDumpsterEnabled, zimbraDumpsterEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * enable/disable dumpster
+     *
+     * @param zimbraDumpsterEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 7.0.0
+     */
+    @ZAttr(id=1128)
+    public Map<String,Object> setDumpsterEnabled(boolean zimbraDumpsterEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDumpsterEnabled, zimbraDumpsterEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * enable/disable dumpster
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 7.0.0
+     */
+    @ZAttr(id=1128)
+    public void unsetDumpsterEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDumpsterEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * enable/disable dumpster
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 7.0.0
+     */
+    @ZAttr(id=1128)
+    public Map<String,Object> unsetDumpsterEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDumpsterEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * disables purging from dumpster when set to FALSE
+     *
+     * @return zimbraDumpsterPurgeEnabled, or true if unset
+     *
+     * @since ZCS 8.0.0
+     */
+    @ZAttr(id=1315)
+    public boolean isDumpsterPurgeEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraDumpsterPurgeEnabled, true, true);
+    }
+
+    /**
+     * disables purging from dumpster when set to FALSE
+     *
+     * @param zimbraDumpsterPurgeEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.0.0
+     */
+    @ZAttr(id=1315)
+    public void setDumpsterPurgeEnabled(boolean zimbraDumpsterPurgeEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDumpsterPurgeEnabled, zimbraDumpsterPurgeEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * disables purging from dumpster when set to FALSE
+     *
+     * @param zimbraDumpsterPurgeEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.0.0
+     */
+    @ZAttr(id=1315)
+    public Map<String,Object> setDumpsterPurgeEnabled(boolean zimbraDumpsterPurgeEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDumpsterPurgeEnabled, zimbraDumpsterPurgeEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * disables purging from dumpster when set to FALSE
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.0.0
+     */
+    @ZAttr(id=1315)
+    public void unsetDumpsterPurgeEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDumpsterPurgeEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * disables purging from dumpster when set to FALSE
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.0.0
+     */
+    @ZAttr(id=1315)
+    public Map<String,Object> unsetDumpsterPurgeEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDumpsterPurgeEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * limits how much of a dumpster data is viewable by the end user, based
+     * on the age since being put in dumpster. Must be in valid duration
+     * format: {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h -
+     * hours, m - minutes, s - seconds, d - days, ms - milliseconds. If time
+     * unit is not specified, the default is s(seconds).
+     *
+     * <p>Use getDumpsterUserVisibleAgeAsString to access value as a string.
+     *
+     * @see #getDumpsterUserVisibleAgeAsString()
+     *
+     * @return zimbraDumpsterUserVisibleAge in millseconds, or 2592000000 (30d)  if unset
+     *
+     * @since ZCS 8.0.0
+     */
+    @ZAttr(id=1314)
+    public long getDumpsterUserVisibleAge() {
+        return getTimeInterval(Provisioning.A_zimbraDumpsterUserVisibleAge, 2592000000L, true);
+    }
+
+    /**
+     * limits how much of a dumpster data is viewable by the end user, based
+     * on the age since being put in dumpster. Must be in valid duration
+     * format: {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h -
+     * hours, m - minutes, s - seconds, d - days, ms - milliseconds. If time
+     * unit is not specified, the default is s(seconds).
+     *
+     * @return zimbraDumpsterUserVisibleAge, or "30d" if unset
+     *
+     * @since ZCS 8.0.0
+     */
+    @ZAttr(id=1314)
+    public String getDumpsterUserVisibleAgeAsString() {
+        return getAttr(Provisioning.A_zimbraDumpsterUserVisibleAge, "30d", true);
+    }
+
+    /**
+     * limits how much of a dumpster data is viewable by the end user, based
+     * on the age since being put in dumpster. Must be in valid duration
+     * format: {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h -
+     * hours, m - minutes, s - seconds, d - days, ms - milliseconds. If time
+     * unit is not specified, the default is s(seconds).
+     *
+     * @param zimbraDumpsterUserVisibleAge new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.0.0
+     */
+    @ZAttr(id=1314)
+    public void setDumpsterUserVisibleAge(String zimbraDumpsterUserVisibleAge) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDumpsterUserVisibleAge, zimbraDumpsterUserVisibleAge);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * limits how much of a dumpster data is viewable by the end user, based
+     * on the age since being put in dumpster. Must be in valid duration
+     * format: {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h -
+     * hours, m - minutes, s - seconds, d - days, ms - milliseconds. If time
+     * unit is not specified, the default is s(seconds).
+     *
+     * @param zimbraDumpsterUserVisibleAge new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.0.0
+     */
+    @ZAttr(id=1314)
+    public Map<String,Object> setDumpsterUserVisibleAge(String zimbraDumpsterUserVisibleAge, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDumpsterUserVisibleAge, zimbraDumpsterUserVisibleAge);
+        return attrs;
+    }
+
+    /**
+     * limits how much of a dumpster data is viewable by the end user, based
+     * on the age since being put in dumpster. Must be in valid duration
+     * format: {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h -
+     * hours, m - minutes, s - seconds, d - days, ms - milliseconds. If time
+     * unit is not specified, the default is s(seconds).
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 8.0.0
+     */
+    @ZAttr(id=1314)
+    public void unsetDumpsterUserVisibleAge() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDumpsterUserVisibleAge, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * limits how much of a dumpster data is viewable by the end user, based
+     * on the age since being put in dumpster. Must be in valid duration
+     * format: {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h -
+     * hours, m - minutes, s - seconds, d - days, ms - milliseconds. If time
+     * unit is not specified, the default is s(seconds).
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 8.0.0
+     */
+    @ZAttr(id=1314)
+    public Map<String,Object> unsetDumpsterUserVisibleAge(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDumpsterUserVisibleAge, "");
         return attrs;
     }
 
@@ -15752,6 +16110,118 @@ public abstract class ZAttrDomain extends NamedEntry {
     public Map<String,Object> unsetMailDomainQuota(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraMailDomainQuota, "");
+        return attrs;
+    }
+
+    /**
+     * Retention period of messages in the dumpster. 0 means that all
+     * messages will be retained. . Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * <p>Use getMailDumpsterLifetimeAsString to access value as a string.
+     *
+     * @see #getMailDumpsterLifetimeAsString()
+     *
+     * @return zimbraMailDumpsterLifetime in millseconds, or 2592000000 (30d)  if unset
+     *
+     * @since ZCS 7.0.0
+     */
+    @ZAttr(id=1133)
+    public long getMailDumpsterLifetime() {
+        return getTimeInterval(Provisioning.A_zimbraMailDumpsterLifetime, 2592000000L, true);
+    }
+
+    /**
+     * Retention period of messages in the dumpster. 0 means that all
+     * messages will be retained. . Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @return zimbraMailDumpsterLifetime, or "30d" if unset
+     *
+     * @since ZCS 7.0.0
+     */
+    @ZAttr(id=1133)
+    public String getMailDumpsterLifetimeAsString() {
+        return getAttr(Provisioning.A_zimbraMailDumpsterLifetime, "30d", true);
+    }
+
+    /**
+     * Retention period of messages in the dumpster. 0 means that all
+     * messages will be retained. . Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @param zimbraMailDumpsterLifetime new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 7.0.0
+     */
+    @ZAttr(id=1133)
+    public void setMailDumpsterLifetime(String zimbraMailDumpsterLifetime) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailDumpsterLifetime, zimbraMailDumpsterLifetime);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Retention period of messages in the dumpster. 0 means that all
+     * messages will be retained. . Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @param zimbraMailDumpsterLifetime new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 7.0.0
+     */
+    @ZAttr(id=1133)
+    public Map<String,Object> setMailDumpsterLifetime(String zimbraMailDumpsterLifetime, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailDumpsterLifetime, zimbraMailDumpsterLifetime);
+        return attrs;
+    }
+
+    /**
+     * Retention period of messages in the dumpster. 0 means that all
+     * messages will be retained. . Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 7.0.0
+     */
+    @ZAttr(id=1133)
+    public void unsetMailDumpsterLifetime() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailDumpsterLifetime, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Retention period of messages in the dumpster. 0 means that all
+     * messages will be retained. . Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 7.0.0
+     */
+    @ZAttr(id=1133)
+    public Map<String,Object> unsetMailDumpsterLifetime(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailDumpsterLifetime, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -2969,6 +2969,367 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
+     * Blobs inside a backup are compressed by default in zip format. zip -
+     * blobs are backed up into zip files with compression (default).
+     * zipStore - blobs are backed up into zip files without compression.
+     * noZip - blobs are backed up as individual files rather in zip files.
+     *
+     * <p>Valid values: [zip, zipStore, noZip]
+     *
+     * @return zimbraBackupBlobsCompressType, or ZAttrProvisioning.BackupBlobsCompressType.zip if unset and/or has invalid value
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4011)
+    public ZAttrProvisioning.BackupBlobsCompressType getBackupBlobsCompressType() {
+        try { String v = getAttr(Provisioning.A_zimbraBackupBlobsCompressType, true, true); return v == null ? ZAttrProvisioning.BackupBlobsCompressType.zip : ZAttrProvisioning.BackupBlobsCompressType.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.BackupBlobsCompressType.zip; }
+    }
+
+    /**
+     * Blobs inside a backup are compressed by default in zip format. zip -
+     * blobs are backed up into zip files with compression (default).
+     * zipStore - blobs are backed up into zip files without compression.
+     * noZip - blobs are backed up as individual files rather in zip files.
+     *
+     * <p>Valid values: [zip, zipStore, noZip]
+     *
+     * @return zimbraBackupBlobsCompressType, or "zip" if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4011)
+    public String getBackupBlobsCompressTypeAsString() {
+        return getAttr(Provisioning.A_zimbraBackupBlobsCompressType, "zip", true);
+    }
+
+    /**
+     * Blobs inside a backup are compressed by default in zip format. zip -
+     * blobs are backed up into zip files with compression (default).
+     * zipStore - blobs are backed up into zip files without compression.
+     * noZip - blobs are backed up as individual files rather in zip files.
+     *
+     * <p>Valid values: [zip, zipStore, noZip]
+     *
+     * @param zimbraBackupBlobsCompressType new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4011)
+    public void setBackupBlobsCompressType(ZAttrProvisioning.BackupBlobsCompressType zimbraBackupBlobsCompressType) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupBlobsCompressType, zimbraBackupBlobsCompressType.toString());
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Blobs inside a backup are compressed by default in zip format. zip -
+     * blobs are backed up into zip files with compression (default).
+     * zipStore - blobs are backed up into zip files without compression.
+     * noZip - blobs are backed up as individual files rather in zip files.
+     *
+     * <p>Valid values: [zip, zipStore, noZip]
+     *
+     * @param zimbraBackupBlobsCompressType new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4011)
+    public Map<String,Object> setBackupBlobsCompressType(ZAttrProvisioning.BackupBlobsCompressType zimbraBackupBlobsCompressType, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupBlobsCompressType, zimbraBackupBlobsCompressType.toString());
+        return attrs;
+    }
+
+    /**
+     * Blobs inside a backup are compressed by default in zip format. zip -
+     * blobs are backed up into zip files with compression (default).
+     * zipStore - blobs are backed up into zip files without compression.
+     * noZip - blobs are backed up as individual files rather in zip files.
+     *
+     * <p>Valid values: [zip, zipStore, noZip]
+     *
+     * @param zimbraBackupBlobsCompressType new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4011)
+    public void setBackupBlobsCompressTypeAsString(String zimbraBackupBlobsCompressType) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupBlobsCompressType, zimbraBackupBlobsCompressType);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Blobs inside a backup are compressed by default in zip format. zip -
+     * blobs are backed up into zip files with compression (default).
+     * zipStore - blobs are backed up into zip files without compression.
+     * noZip - blobs are backed up as individual files rather in zip files.
+     *
+     * <p>Valid values: [zip, zipStore, noZip]
+     *
+     * @param zimbraBackupBlobsCompressType new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4011)
+    public Map<String,Object> setBackupBlobsCompressTypeAsString(String zimbraBackupBlobsCompressType, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupBlobsCompressType, zimbraBackupBlobsCompressType);
+        return attrs;
+    }
+
+    /**
+     * Blobs inside a backup are compressed by default in zip format. zip -
+     * blobs are backed up into zip files with compression (default).
+     * zipStore - blobs are backed up into zip files without compression.
+     * noZip - blobs are backed up as individual files rather in zip files.
+     *
+     * <p>Valid values: [zip, zipStore, noZip]
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4011)
+    public void unsetBackupBlobsCompressType() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupBlobsCompressType, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Blobs inside a backup are compressed by default in zip format. zip -
+     * blobs are backed up into zip files with compression (default).
+     * zipStore - blobs are backed up into zip files without compression.
+     * noZip - blobs are backed up as individual files rather in zip files.
+     *
+     * <p>Valid values: [zip, zipStore, noZip]
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4011)
+    public Map<String,Object> unsetBackupBlobsCompressType(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupBlobsCompressType, "");
+        return attrs;
+    }
+
+    /**
+     * Configures crontab schedule. Full, incremental and delete cron
+     * schedules can be set using this attribute. The entire backup can be
+     * scheduled as f &#039;0 1 * * 6&#039; i &#039;0 1 * * 0-5&#039; d 7d
+     * &#039;0 0 * * *&#039;. f &#039;0 1 * * 6&#039; can be passed if we are
+     * setting only the full-backup schedule. (f - full-backup) i &#039;0 1 *
+     * * 0-5&#039; can be passed if we are setting only the
+     * incremental-backup schedule. (i - incremental) d 7d &#039;0 0 * *
+     * *&#039; can be passed if we are setting only the delete-backup
+     * schedule. (d - delete).
+     *
+     * @return zimbraBackupCrontabConfig, or empty array if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4016)
+    public String[] getBackupCrontabConfig() {
+        String[] value = getMultiAttr(Provisioning.A_zimbraBackupCrontabConfig, true, true); return value.length > 0 ? value : new String[] {"f '0 1 * * 6'"};
+    }
+
+    /**
+     * Configures crontab schedule. Full, incremental and delete cron
+     * schedules can be set using this attribute. The entire backup can be
+     * scheduled as f &#039;0 1 * * 6&#039; i &#039;0 1 * * 0-5&#039; d 7d
+     * &#039;0 0 * * *&#039;. f &#039;0 1 * * 6&#039; can be passed if we are
+     * setting only the full-backup schedule. (f - full-backup) i &#039;0 1 *
+     * * 0-5&#039; can be passed if we are setting only the
+     * incremental-backup schedule. (i - incremental) d 7d &#039;0 0 * *
+     * *&#039; can be passed if we are setting only the delete-backup
+     * schedule. (d - delete).
+     *
+     * @param zimbraBackupCrontabConfig new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4016)
+    public void setBackupCrontabConfig(String[] zimbraBackupCrontabConfig) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupCrontabConfig, zimbraBackupCrontabConfig);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures crontab schedule. Full, incremental and delete cron
+     * schedules can be set using this attribute. The entire backup can be
+     * scheduled as f &#039;0 1 * * 6&#039; i &#039;0 1 * * 0-5&#039; d 7d
+     * &#039;0 0 * * *&#039;. f &#039;0 1 * * 6&#039; can be passed if we are
+     * setting only the full-backup schedule. (f - full-backup) i &#039;0 1 *
+     * * 0-5&#039; can be passed if we are setting only the
+     * incremental-backup schedule. (i - incremental) d 7d &#039;0 0 * *
+     * *&#039; can be passed if we are setting only the delete-backup
+     * schedule. (d - delete).
+     *
+     * @param zimbraBackupCrontabConfig new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4016)
+    public Map<String,Object> setBackupCrontabConfig(String[] zimbraBackupCrontabConfig, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupCrontabConfig, zimbraBackupCrontabConfig);
+        return attrs;
+    }
+
+    /**
+     * Configures crontab schedule. Full, incremental and delete cron
+     * schedules can be set using this attribute. The entire backup can be
+     * scheduled as f &#039;0 1 * * 6&#039; i &#039;0 1 * * 0-5&#039; d 7d
+     * &#039;0 0 * * *&#039;. f &#039;0 1 * * 6&#039; can be passed if we are
+     * setting only the full-backup schedule. (f - full-backup) i &#039;0 1 *
+     * * 0-5&#039; can be passed if we are setting only the
+     * incremental-backup schedule. (i - incremental) d 7d &#039;0 0 * *
+     * *&#039; can be passed if we are setting only the delete-backup
+     * schedule. (d - delete).
+     *
+     * @param zimbraBackupCrontabConfig new to add to existing values
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4016)
+    public void addBackupCrontabConfig(String zimbraBackupCrontabConfig) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraBackupCrontabConfig, zimbraBackupCrontabConfig);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures crontab schedule. Full, incremental and delete cron
+     * schedules can be set using this attribute. The entire backup can be
+     * scheduled as f &#039;0 1 * * 6&#039; i &#039;0 1 * * 0-5&#039; d 7d
+     * &#039;0 0 * * *&#039;. f &#039;0 1 * * 6&#039; can be passed if we are
+     * setting only the full-backup schedule. (f - full-backup) i &#039;0 1 *
+     * * 0-5&#039; can be passed if we are setting only the
+     * incremental-backup schedule. (i - incremental) d 7d &#039;0 0 * *
+     * *&#039; can be passed if we are setting only the delete-backup
+     * schedule. (d - delete).
+     *
+     * @param zimbraBackupCrontabConfig new to add to existing values
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4016)
+    public Map<String,Object> addBackupCrontabConfig(String zimbraBackupCrontabConfig, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraBackupCrontabConfig, zimbraBackupCrontabConfig);
+        return attrs;
+    }
+
+    /**
+     * Configures crontab schedule. Full, incremental and delete cron
+     * schedules can be set using this attribute. The entire backup can be
+     * scheduled as f &#039;0 1 * * 6&#039; i &#039;0 1 * * 0-5&#039; d 7d
+     * &#039;0 0 * * *&#039;. f &#039;0 1 * * 6&#039; can be passed if we are
+     * setting only the full-backup schedule. (f - full-backup) i &#039;0 1 *
+     * * 0-5&#039; can be passed if we are setting only the
+     * incremental-backup schedule. (i - incremental) d 7d &#039;0 0 * *
+     * *&#039; can be passed if we are setting only the delete-backup
+     * schedule. (d - delete).
+     *
+     * @param zimbraBackupCrontabConfig existing value to remove
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4016)
+    public void removeBackupCrontabConfig(String zimbraBackupCrontabConfig) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraBackupCrontabConfig, zimbraBackupCrontabConfig);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures crontab schedule. Full, incremental and delete cron
+     * schedules can be set using this attribute. The entire backup can be
+     * scheduled as f &#039;0 1 * * 6&#039; i &#039;0 1 * * 0-5&#039; d 7d
+     * &#039;0 0 * * *&#039;. f &#039;0 1 * * 6&#039; can be passed if we are
+     * setting only the full-backup schedule. (f - full-backup) i &#039;0 1 *
+     * * 0-5&#039; can be passed if we are setting only the
+     * incremental-backup schedule. (i - incremental) d 7d &#039;0 0 * *
+     * *&#039; can be passed if we are setting only the delete-backup
+     * schedule. (d - delete).
+     *
+     * @param zimbraBackupCrontabConfig existing value to remove
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4016)
+    public Map<String,Object> removeBackupCrontabConfig(String zimbraBackupCrontabConfig, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraBackupCrontabConfig, zimbraBackupCrontabConfig);
+        return attrs;
+    }
+
+    /**
+     * Configures crontab schedule. Full, incremental and delete cron
+     * schedules can be set using this attribute. The entire backup can be
+     * scheduled as f &#039;0 1 * * 6&#039; i &#039;0 1 * * 0-5&#039; d 7d
+     * &#039;0 0 * * *&#039;. f &#039;0 1 * * 6&#039; can be passed if we are
+     * setting only the full-backup schedule. (f - full-backup) i &#039;0 1 *
+     * * 0-5&#039; can be passed if we are setting only the
+     * incremental-backup schedule. (i - incremental) d 7d &#039;0 0 * *
+     * *&#039; can be passed if we are setting only the delete-backup
+     * schedule. (d - delete).
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4016)
+    public void unsetBackupCrontabConfig() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupCrontabConfig, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Configures crontab schedule. Full, incremental and delete cron
+     * schedules can be set using this attribute. The entire backup can be
+     * scheduled as f &#039;0 1 * * 6&#039; i &#039;0 1 * * 0-5&#039; d 7d
+     * &#039;0 0 * * *&#039;. f &#039;0 1 * * 6&#039; can be passed if we are
+     * setting only the full-backup schedule. (f - full-backup) i &#039;0 1 *
+     * * 0-5&#039; can be passed if we are setting only the
+     * incremental-backup schedule. (i - incremental) d 7d &#039;0 0 * *
+     * *&#039; can be passed if we are setting only the delete-backup
+     * schedule. (d - delete).
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4016)
+    public Map<String,Object> unsetBackupCrontabConfig(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupCrontabConfig, "");
+        return attrs;
+    }
+
+    /**
      * Minimum percentage or TB/GB/MB/KB/bytes of free space on backup target
      * to allow a full or auto-grouped backup to start; 0 = no minimum is
      * enforced. Examples: 25%, 10GB
@@ -3162,6 +3523,93 @@ public abstract class ZAttrServer extends NamedEntry {
     public Map<String,Object> unsetBackupMode(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraBackupMode, "");
+        return attrs;
+    }
+
+    /**
+     * If true, --accounts option will be set to useBackupConfig on
+     * zmschedulebackup command. Enables global,cos,domain,account level
+     * backup. If false, --accounts option will be set to all accounts on
+     * zmschedulebackup command. Backups all accounts.
+     *
+     * @return zimbraBackupObjectLevelEnabled, or false if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4015)
+    public boolean isBackupObjectLevelEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraBackupObjectLevelEnabled, false, true);
+    }
+
+    /**
+     * If true, --accounts option will be set to useBackupConfig on
+     * zmschedulebackup command. Enables global,cos,domain,account level
+     * backup. If false, --accounts option will be set to all accounts on
+     * zmschedulebackup command. Backups all accounts.
+     *
+     * @param zimbraBackupObjectLevelEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4015)
+    public void setBackupObjectLevelEnabled(boolean zimbraBackupObjectLevelEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupObjectLevelEnabled, zimbraBackupObjectLevelEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * If true, --accounts option will be set to useBackupConfig on
+     * zmschedulebackup command. Enables global,cos,domain,account level
+     * backup. If false, --accounts option will be set to all accounts on
+     * zmschedulebackup command. Backups all accounts.
+     *
+     * @param zimbraBackupObjectLevelEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4015)
+    public Map<String,Object> setBackupObjectLevelEnabled(boolean zimbraBackupObjectLevelEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupObjectLevelEnabled, zimbraBackupObjectLevelEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * If true, --accounts option will be set to useBackupConfig on
+     * zmschedulebackup command. Enables global,cos,domain,account level
+     * backup. If false, --accounts option will be set to all accounts on
+     * zmschedulebackup command. Backups all accounts.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4015)
+    public void unsetBackupObjectLevelEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupObjectLevelEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * If true, --accounts option will be set to useBackupConfig on
+     * zmschedulebackup command. Enables global,cos,domain,account level
+     * backup. If false, --accounts option will be set to all accounts on
+     * zmschedulebackup command. Backups all accounts.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4015)
+    public Map<String,Object> unsetBackupObjectLevelEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupObjectLevelEnabled, "");
         return attrs;
     }
 
@@ -3406,6 +3854,83 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
+     * The number of days backups will be kept. Backup Scheduler deletes
+     * backups older than the set value.
+     *
+     * @return zimbraBackupRetentionDays, or 8 if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4010)
+    public int getBackupRetentionDays() {
+        return getIntAttr(Provisioning.A_zimbraBackupRetentionDays, 8, true);
+    }
+
+    /**
+     * The number of days backups will be kept. Backup Scheduler deletes
+     * backups older than the set value.
+     *
+     * @param zimbraBackupRetentionDays new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4010)
+    public void setBackupRetentionDays(int zimbraBackupRetentionDays) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupRetentionDays, Integer.toString(zimbraBackupRetentionDays));
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * The number of days backups will be kept. Backup Scheduler deletes
+     * backups older than the set value.
+     *
+     * @param zimbraBackupRetentionDays new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4010)
+    public Map<String,Object> setBackupRetentionDays(int zimbraBackupRetentionDays, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupRetentionDays, Integer.toString(zimbraBackupRetentionDays));
+        return attrs;
+    }
+
+    /**
+     * The number of days backups will be kept. Backup Scheduler deletes
+     * backups older than the set value.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4010)
+    public void unsetBackupRetentionDays() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupRetentionDays, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * The number of days backups will be kept. Backup Scheduler deletes
+     * backups older than the set value.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4010)
+    public Map<String,Object> unsetBackupRetentionDays(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupRetentionDays, "");
+        return attrs;
+    }
+
+    /**
      * if true, do not backup blobs (HSM or not) during a full backup
      *
      * @return zimbraBackupSkipBlobs, or false if unset
@@ -3623,6 +4148,252 @@ public abstract class ZAttrServer extends NamedEntry {
     public Map<String,Object> unsetBackupSkipSearchIndex(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraBackupSkipSearchIndex, "");
+        return attrs;
+    }
+
+    /**
+     * The day of the week on which the full backup starts. When a day is
+     * select their relative value is set on the crontab. Default starts from
+     * Saturday 0-7 or names allowed (Sun, Wed), with both 0 and 7
+     * representing Sunday. Monday to Saturday (1-6)
+     *
+     * @return zimbraBackupStartDay, or "6" if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4014)
+    public String getBackupStartDay() {
+        return getAttr(Provisioning.A_zimbraBackupStartDay, "6", true);
+    }
+
+    /**
+     * The day of the week on which the full backup starts. When a day is
+     * select their relative value is set on the crontab. Default starts from
+     * Saturday 0-7 or names allowed (Sun, Wed), with both 0 and 7
+     * representing Sunday. Monday to Saturday (1-6)
+     *
+     * @param zimbraBackupStartDay new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4014)
+    public void setBackupStartDay(String zimbraBackupStartDay) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStartDay, zimbraBackupStartDay);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * The day of the week on which the full backup starts. When a day is
+     * select their relative value is set on the crontab. Default starts from
+     * Saturday 0-7 or names allowed (Sun, Wed), with both 0 and 7
+     * representing Sunday. Monday to Saturday (1-6)
+     *
+     * @param zimbraBackupStartDay new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4014)
+    public Map<String,Object> setBackupStartDay(String zimbraBackupStartDay, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStartDay, zimbraBackupStartDay);
+        return attrs;
+    }
+
+    /**
+     * The day of the week on which the full backup starts. When a day is
+     * select their relative value is set on the crontab. Default starts from
+     * Saturday 0-7 or names allowed (Sun, Wed), with both 0 and 7
+     * representing Sunday. Monday to Saturday (1-6)
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4014)
+    public void unsetBackupStartDay() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStartDay, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * The day of the week on which the full backup starts. When a day is
+     * select their relative value is set on the crontab. Default starts from
+     * Saturday 0-7 or names allowed (Sun, Wed), with both 0 and 7
+     * representing Sunday. Monday to Saturday (1-6)
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4014)
+    public Map<String,Object> unsetBackupStartDay(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStartDay, "");
+        return attrs;
+    }
+
+    /**
+     * Starts backup each day at this time. This attribute is used to set
+     * hours and minutes on the crontab.
+     *
+     * @return zimbraBackupStartTime, or "01:00" if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public String getBackupStartTime() {
+        return getAttr(Provisioning.A_zimbraBackupStartTime, "01:00", true);
+    }
+
+    /**
+     * Starts backup each day at this time. This attribute is used to set
+     * hours and minutes on the crontab.
+     *
+     * @param zimbraBackupStartTime new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public void setBackupStartTime(String zimbraBackupStartTime) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStartTime, zimbraBackupStartTime);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Starts backup each day at this time. This attribute is used to set
+     * hours and minutes on the crontab.
+     *
+     * @param zimbraBackupStartTime new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public Map<String,Object> setBackupStartTime(String zimbraBackupStartTime, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStartTime, zimbraBackupStartTime);
+        return attrs;
+    }
+
+    /**
+     * Starts backup each day at this time. This attribute is used to set
+     * hours and minutes on the crontab.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public void unsetBackupStartTime() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStartTime, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Starts backup each day at this time. This attribute is used to set
+     * hours and minutes on the crontab.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public Map<String,Object> unsetBackupStartTime(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupStartTime, "");
+        return attrs;
+    }
+
+    /**
+     * If true, the full backup runs synchronously. If false, full backup
+     * runs in a separate thread and the soap call returns with the backup
+     * label.
+     *
+     * @return zimbraBackupSyncEnabled, or false if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4012)
+    public boolean isBackupSyncEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraBackupSyncEnabled, false, true);
+    }
+
+    /**
+     * If true, the full backup runs synchronously. If false, full backup
+     * runs in a separate thread and the soap call returns with the backup
+     * label.
+     *
+     * @param zimbraBackupSyncEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4012)
+    public void setBackupSyncEnabled(boolean zimbraBackupSyncEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupSyncEnabled, zimbraBackupSyncEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * If true, the full backup runs synchronously. If false, full backup
+     * runs in a separate thread and the soap call returns with the backup
+     * label.
+     *
+     * @param zimbraBackupSyncEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4012)
+    public Map<String,Object> setBackupSyncEnabled(boolean zimbraBackupSyncEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupSyncEnabled, zimbraBackupSyncEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * If true, the full backup runs synchronously. If false, full backup
+     * runs in a separate thread and the soap call returns with the backup
+     * label.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4012)
+    public void unsetBackupSyncEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupSyncEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * If true, the full backup runs synchronously. If false, full backup
+     * runs in a separate thread and the soap call returns with the backup
+     * label.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4012)
+    public Map<String,Object> unsetBackupSyncEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupSyncEnabled, "");
         return attrs;
     }
 
@@ -17653,6 +18424,83 @@ public abstract class ZAttrServer extends NamedEntry {
     public Map<String,Object> unsetMailReferMode(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraMailReferMode, "");
+        return attrs;
+    }
+
+    /**
+     * If true, sends an email report to the admin user. Admins can disable
+     * the email notification by setting it to FALSE.
+     *
+     * @return zimbraMailReportEnabled, or true if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4013)
+    public boolean isMailReportEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraMailReportEnabled, true, true);
+    }
+
+    /**
+     * If true, sends an email report to the admin user. Admins can disable
+     * the email notification by setting it to FALSE.
+     *
+     * @param zimbraMailReportEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4013)
+    public void setMailReportEnabled(boolean zimbraMailReportEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailReportEnabled, zimbraMailReportEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * If true, sends an email report to the admin user. Admins can disable
+     * the email notification by setting it to FALSE.
+     *
+     * @param zimbraMailReportEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4013)
+    public Map<String,Object> setMailReportEnabled(boolean zimbraMailReportEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailReportEnabled, zimbraMailReportEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * If true, sends an email report to the admin user. Admins can disable
+     * the email notification by setting it to FALSE.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4013)
+    public void unsetMailReportEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailReportEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * If true, sends an email report to the admin user. Admins can disable
+     * the email notification by setting it to FALSE.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4013)
+    public Map<String,Object> unsetMailReportEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailReportEnabled, "");
         return attrs;
     }
 


### PR DESCRIPTION
Feature:
Adding the flexibility where admins can schedule backups from UI not just through CLI.

Implementation:
The eventual plan is to move away from crontab to a java based scheduler like service. As part of this plan, we are adding the LDAP attributes where admins can schedule the backup using them from UI instead of doing it through the zmschedulebackup CLI command as the first step. These attributes will be used by ScheduleBackupsRequest to set the crontab schedule from UI.

Newly added attributes: 

- zimbraGlobalBackupEnabled: TRUE
- zimbraBackupSyncUsersEnabled: FALSE
- zimbraBackupStartTime: 01:00
- zimbraBackupRetentionDays: 8
- zimbraBackupBlobsCompressType: zip
- zimbraBackupSyncEnabled: FALSE
- zimbraMailReportEnabled: TRUE
- zimbraBackupStartDay: 6
- zimbraBackupObjectLevelEnabled: FALSE
- zimbraBackupCrontabConfig: FALSE

Updates:

- zimbraDumpsterEnabled - Added in GlobalConfig, domain and flag for domainInherited
- zimbraMailDumpsterLifetime - Added in GlobalConfig, domain and flag for domainInherited
- zimbraDumpsterPurgeEnabled -  Added in GlobalConfig, domain and flag for domainInherited
- zimbraDumpsterUserVisibleAge - Added in GlobalConfig, domain and flag for domainInherited

Re-use from ZimbraOS:

- zimbraBackupEnabled with ID 9014

Related PRs:

https://github.com/Zimbra/zm-core-utils/pull/118
https://github.com/Zimbra/zm-backup-store/pull/28