### PR TITLE
ZCS-11603 changes

### DIFF
--- a/store/src/java/com/zimbra/cs/account/Account.java
+++ b/store/src/java/com/zimbra/cs/account/Account.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.zimbra.common.account.Key;
+import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Provisioning.GroupMembership;
@@ -534,5 +535,13 @@ public class Account extends ZAttrAccount implements GroupedEntry, AliasedEntry 
      */
     public void refreshUserCredentials() throws ServiceException {
         getProvisioning().refreshUserCredentials(this);
+    }
+
+    /**
+     * Returns whether username is allowed within password.
+     * @return true if username is allowed within password; otherwise, false.
+     */
+    public boolean getAllowUsernameWithinPassword() {
+        return LC.allow_username_within_password.booleanValue();
     }
 }


### PR DESCRIPTION
Solution
As per ZCS-11603 ticket requirement, a new method has been added to the Account class in order to encapsulate the local config allow_username_within_password property, in order to be accessed from Classic UI.

Notes
This is a technical requirement from ZCS-11302. Please check ticket for more information.

Testing
Please check ticket for more information.