### PR TITLE
ZBUG-2849 : Disabling stats logger by default

### DIFF
--- a/store-conf/conf/log4j.properties.production
+++ b/store-conf/conf/log4j.properties.production
@@ -207,7 +207,7 @@ logger.memcached.name = net.spy.memcached
 logger.memcached.level = WARN
 
 logger.slogger.name = zimbra.slogger
-logger.slogger.level = off
+logger.slogger.level = error
 logger.slogger.additivity = false
 logger.slogger.appenderRef.SLOGGER.ref = sloggerAppender
 

--- a/store-conf/conf/log4j.properties.production
+++ b/store-conf/conf/log4j.properties.production
@@ -207,7 +207,7 @@ logger.memcached.name = net.spy.memcached
 logger.memcached.level = WARN
 
 %%comment VAR:!zimbraLogHostname%%logger.slogger.name = zimbra.slogger
-%%comment VAR:!zimbraLogHostname%%logger.slogger.level = info
+%%comment VAR:!zimbraLogHostname%%logger.slogger.level = off
 %%uncomment VAR:!zimbraLogHostname%%logger.slogger.level = error
 %%comment VAR:!zimbraLogHostname%%logger.slogger.additivity = false
 %%comment VAR:!zimbraLogHostname%%logger.slogger.appenderRef.SLOGGER.ref = sloggerAppender

--- a/store-conf/conf/log4j.properties.production
+++ b/store-conf/conf/log4j.properties.production
@@ -136,14 +136,14 @@ appender.EWS.strategy.type = DefaultRolloverStrategy
 %%uncomment VAR:zimbraLogToSyslog%%appender.SYSLOG.layout.pattern = mailboxd: %-5p [%t] [%z] %c{1} - %m
 
 # Logger service appender
-%%comment VAR:!zimbraLogHostname%%appender.SLOGGER.type = Syslog
-%%comment VAR:!zimbraLogHostname%%appender.SLOGGER.name = sloggerAppender
-%%comment VAR:!zimbraLogHostname%%appender.SLOGGER.host = %%zimbraLogHostname%%
-%%comment VAR:!zimbraLogHostname%%appender.SLOGGER.facility = LOCAL1
-%%comment VAR:!zimbraLogHostname%%appender.SLOGGER.port = 514
-%%comment VAR:!zimbraLogHostname%%appender.SLOGGER.protocol = UDP
-%%comment VAR:!zimbraLogHostname%%appender.SLOGGER.layout.type = PatternLayout
-%%comment VAR:!zimbraLogHostname%%appender.SLOGGER.layout.pattern = mailboxd: %-5p [%t] [%z] %c{1} - %m
+appender.SLOGGER.type = Syslog
+appender.SLOGGER.name = sloggerAppender
+appender.SLOGGER.host = %%zimbraLogHostname%%
+appender.SLOGGER.facility = LOCAL1
+appender.SLOGGER.port = 514
+appender.SLOGGER.protocol = UDP
+appender.SLOGGER.layout.type = PatternLayout
+appender.SLOGGER.layout.pattern = mailboxd: %-5p [%t] [%z] %c{1} - %m
 
 logger.zimbra.name = zimbra.mailbox
 logger.zimbra.level = info
@@ -206,10 +206,10 @@ logger.httpmethodbase.level = ERROR
 logger.memcached.name = net.spy.memcached
 logger.memcached.level = WARN
 
-%%comment VAR:!zimbraLogHostname%%logger.slogger.name = zimbra.slogger
-%%comment VAR:!zimbraLogHostname%%logger.slogger.level = off
-%%comment VAR:!zimbraLogHostname%%logger.slogger.additivity = false
-%%comment VAR:!zimbraLogHostname%%logger.slogger.appenderRef.SLOGGER.ref = sloggerAppender
+logger.slogger.name = zimbra.slogger
+logger.slogger.level = off
+logger.slogger.additivity = false
+logger.slogger.appenderRef.SLOGGER.ref = sloggerAppender
 
 rootLogger.level=INFO
 

--- a/store-conf/conf/log4j.properties.production
+++ b/store-conf/conf/log4j.properties.production
@@ -136,14 +136,14 @@ appender.EWS.strategy.type = DefaultRolloverStrategy
 %%uncomment VAR:zimbraLogToSyslog%%appender.SYSLOG.layout.pattern = mailboxd: %-5p [%t] [%z] %c{1} - %m
 
 # Logger service appender
-appender.SLOGGER.type = Syslog
-appender.SLOGGER.name = sloggerAppender
-appender.SLOGGER.host = %%zimbraLogHostname%%
-appender.SLOGGER.facility = LOCAL1
-appender.SLOGGER.port = 514
-appender.SLOGGER.protocol = UDP
-appender.SLOGGER.layout.type = PatternLayout
-appender.SLOGGER.layout.pattern = mailboxd: %-5p [%t] [%z] %c{1} - %m
+%%comment VAR:!zimbraLogHostname%%appender.SLOGGER.type = Syslog
+%%comment VAR:!zimbraLogHostname%%appender.SLOGGER.name = sloggerAppender
+%%comment VAR:!zimbraLogHostname%%appender.SLOGGER.host = %%zimbraLogHostname%%
+%%comment VAR:!zimbraLogHostname%%appender.SLOGGER.facility = LOCAL1
+%%comment VAR:!zimbraLogHostname%%appender.SLOGGER.port = 514
+%%comment VAR:!zimbraLogHostname%%appender.SLOGGER.protocol = UDP
+%%comment VAR:!zimbraLogHostname%%appender.SLOGGER.layout.type = PatternLayout
+%%comment VAR:!zimbraLogHostname%%appender.SLOGGER.layout.pattern = mailboxd: %-5p [%t] [%z] %c{1} - %m
 
 logger.zimbra.name = zimbra.mailbox
 logger.zimbra.level = info
@@ -208,7 +208,6 @@ logger.memcached.level = WARN
 
 %%comment VAR:!zimbraLogHostname%%logger.slogger.name = zimbra.slogger
 %%comment VAR:!zimbraLogHostname%%logger.slogger.level = off
-%%uncomment VAR:!zimbraLogHostname%%logger.slogger.level = error
 %%comment VAR:!zimbraLogHostname%%logger.slogger.additivity = false
 %%comment VAR:!zimbraLogHostname%%logger.slogger.appenderRef.SLOGGER.ref = sloggerAppender
 


### PR DESCRIPTION
Issue :- Bydefault slogger level was set to info which caused unnecessary logs getting filled in /var/log folder.

Fix:- Set  default log level to off