### PR TITLE
ZCS-11694 : File Shared with me implementation

### DIFF
--- a/common/src/java/com/zimbra/common/mailbox/FolderConstants.java
+++ b/common/src/java/com/zimbra/common/mailbox/FolderConstants.java
@@ -49,5 +49,7 @@ public final class FolderConstants {
 
     public static final int ID_FOLDER_UNSUBSCRIBE = 19;
 
-    public static final int HIGHEST_SYSTEM_ID = 19;
+    public static final int ID_FOLDER_FILE_SHARED_WITH_ME = 20;
+
+    public static final int HIGHEST_SYSTEM_ID = 20;
 }

--- a/common/src/java/com/zimbra/common/soap/MailConstants.java
+++ b/common/src/java/com/zimbra/common/soap/MailConstants.java
@@ -302,6 +302,8 @@ public final class MailConstants {
     public static final String E_GET_IMAP_RECENT_CUTOFF_RESPONSE = "GetIMAPRecentCutoffResponse";
     public static final String E_IMAP_COPY_REQUEST = "IMAPCopyRequest";
     public static final String E_IMAP_COPY_RESPONSE = "IMAPCopyResponse";
+    public static final String E_FILE_SHARED_WITH_ME_REQUEST = "FileSharedWithMeRequest";
+    public static final String E_FILE_SHARED_WITH_ME_RESPONSE = "FileSharedWithMeResponse";
 
     // noop
     public static final QName NO_OP_REQUEST = QName.get(E_NO_OP_REQUEST, NAMESPACE);
@@ -604,6 +606,10 @@ public final class MailConstants {
     public static final QName RECORD_IMAP_SESSION_RESPONSE = QName.get(E_RECORD_IMAP_SESSION_RESPONSE, NAMESPACE);
     public static final QName IMAP_COPY_REQUEST = QName.get(E_IMAP_COPY_REQUEST, NAMESPACE);
     public static final QName IMAP_COPY_RESPONSE = QName.get(E_IMAP_COPY_RESPONSE, NAMESPACE);
+
+    //File Shared With Me
+    public static final QName FILE_SHARED_WITH_ME_REQUEST = QName.get(E_FILE_SHARED_WITH_ME_REQUEST, NAMESPACE);
+    public static final QName FILE_SHARED_WITH_ME_RESPONSE = QName.get(E_FILE_SHARED_WITH_ME_RESPONSE, NAMESPACE);
 
     public static final String E_MAILBOX = "mbx";
     public static final String E_ITEM = "item";

--- a/soap/src/java/com/zimbra/soap/JaxbUtil.java
+++ b/soap/src/java/com/zimbra/soap/JaxbUtil.java
@@ -1149,7 +1149,9 @@ public final class JaxbUtil {
             com.zimbra.soap.account.message.GetAddressListMembersRequest.class,
             com.zimbra.soap.account.message.GetAddressListMemberResponse.class,
             com.zimbra.soap.admin.message.GetAddressListInfoRequest.class,
-            com.zimbra.soap.admin.message.GetAddressListInfoResponse.class
+            com.zimbra.soap.admin.message.GetAddressListInfoResponse.class,
+            com.zimbra.soap.mail.message.FileSharedWithMeRequest.class,
+            com.zimbra.soap.mail.message.FileSharedWithMeResponse.class
         };
 
         try {

--- a/soap/src/java/com/zimbra/soap/mail/message/FileSharedWithMeRequest.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/FileSharedWithMeRequest.java
@@ -1,0 +1,174 @@
+/* 
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.mail.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.MailConstants;
+
+/**
+ * @zm-api-command-auth-required true
+ * @zm-api-command-admin-auth-required false
+ * @zm-api-command-description File Share With Me
+ * <br />
+ * This is an internal API, cannot be invoked directly
+ */
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name = MailConstants.E_FILE_SHARED_WITH_ME_REQUEST)
+public class FileSharedWithMeRequest {
+
+    /**
+     * @zm-api-field-tag action
+     * @zm-api-field-description Action - Create, Edit, Revoke
+     */
+    @XmlElement(name = MailConstants.E_ACTION, required = true)
+    private String action;
+
+    /**
+     * @zm-api-field-tag fileName
+     * @zm-api-field-description Name of the file which is to be shared
+     */
+    @XmlElement(name = MailConstants.A_CONTENT_FILENAME, required = true)
+    private String fileName;
+
+    /**
+     * @zm-api-field-tag ownerFileId
+     * @zm-api-field-description Owner File ID 
+     */
+    @XmlElement(name = MailConstants.A_ITEMID, required = true)
+    private int ownerFileId;
+
+    /**
+     * @zm-api-field-tag fileUUID
+     * @zm-api-field-description Owner File UUID
+     */
+    @XmlElement(name = MailConstants.A_REMOTE_UUID, required = true)
+    private String fileUUID;
+
+    /**
+     * @zm-api-field-tag fileOwnerName
+     * @zm-api-field-description File Owner Name
+     */
+    @XmlElement(name = MailConstants.A_OWNER_NAME, required = true)
+    private String fileOwnerName;
+
+    /**
+     * @zm-api-field-tag rights
+     * @zm-api-field-description Permission provided to the file
+     */
+    @XmlElement(name = MailConstants.A_RIGHTS, required = true)
+    private String rights;
+
+    /**
+     * @zm-api-field-tag contentType
+     * @zm-api-field-description Content type of the file
+     */
+    @XmlElement(name = MailConstants.A_CONTENT_TYPE, required = true)
+    private String contentType;
+
+    /**
+     * @zm-api-field-tag size
+     * @zm-api-field-description Actual file size
+     */
+    @XmlElement(name = MailConstants.A_SIZE, required = true)
+    private long size;
+
+    public FileSharedWithMeRequest() {
+    }
+
+    public FileSharedWithMeRequest(String action, String granteeId, String fileName, String ownerAccountId,
+            int ownerFileId, String fileUUID, String fileOwnerName, String rights, String contentType, long size) {
+        super();
+        this.action = action;
+        this.fileName = fileName;
+        this.ownerFileId = ownerFileId;
+        this.fileUUID = fileUUID;
+        this.fileOwnerName = fileOwnerName;
+        this.rights = rights;
+        this.contentType = contentType;
+        this.size = size;
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public void setAction(String action) {
+        this.action = action;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public int getOwnerFileId() {
+        return ownerFileId;
+    }
+
+    public void setOwnerFileId(int ownerFileId) {
+        this.ownerFileId = ownerFileId;
+    }
+
+    public String getFileUUID() {
+        return fileUUID;
+    }
+
+    public void setFileUUID(String fileUUID) {
+        this.fileUUID = fileUUID;
+    }
+
+    public String getFileOwnerName() {
+        return fileOwnerName;
+    }
+
+    public void setFileOwnerName(String fileOwnerName) {
+        this.fileOwnerName = fileOwnerName;
+    }
+
+    public String getRights() {
+        return rights;
+    }
+
+    public void setRights(String rights) {
+        this.rights = rights;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    public void setSize(long size) {
+        this.size = size;
+    }
+
+}

--- a/soap/src/java/com/zimbra/soap/mail/message/FileSharedWithMeResponse.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/FileSharedWithMeResponse.java
@@ -1,0 +1,47 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.mail.message;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.google.common.base.MoreObjects;
+import com.zimbra.common.soap.MailConstants;
+
+@XmlRootElement(name = MailConstants.E_FILE_SHARED_WITH_ME_RESPONSE)
+public class FileSharedWithMeResponse {
+
+    @XmlElement(name = MailConstants.A_STATUS, required = true)
+    private String status;
+
+    public FileSharedWithMeResponse() {
+    }
+
+    public FileSharedWithMeResponse(String status) {
+        this.status = status;
+    }
+
+    public MoreObjects.ToStringHelper addToStringInfo(MoreObjects.ToStringHelper helper) {
+        return helper.add(MailConstants.A_STATUS, status);
+    }
+
+    @Override
+    public String toString() {
+        return addToStringInfo(MoreObjects.toStringHelper(this)).toString();
+    }
+}

--- a/store/src/java/com/zimbra/cs/mailbox/Document.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Document.java
@@ -46,6 +46,9 @@ public class Document extends MailItem {
     protected long lockTimestamp;
     protected String description;
     protected boolean descEnabled;
+    protected String ownerAccountId;
+    protected String ownerFileId;
+    protected String permission;
 
     public Document(Mailbox mbox, UnderlyingData data) throws ServiceException {
         this(mbox, data, false);
@@ -86,6 +89,18 @@ public class Document extends MailItem {
 
     public boolean isDescriptionEnabled() {
         return descEnabled;
+    }
+
+    public String getOwnerAccountId() {
+        return ownerAccountId;
+    }
+
+    public String getPermission() {
+        return permission;
+    }
+
+    public String getOwnerFileId() {
+        return ownerFileId;
     }
 
     @Override
@@ -284,6 +299,15 @@ public class Document extends MailItem {
         fragment    = meta.get(Metadata.FN_FRAGMENT, fragment);
         lockOwner   = meta.get(Metadata.FN_LOCK_OWNER, lockOwner);
         description = meta.get(Metadata.FN_DESCRIPTION, description);
+        if (meta.containsKey(Metadata.FN_OWNER_ACCOUNT_ID)) {
+            ownerAccountId = meta.get(Metadata.FN_OWNER_ACCOUNT_ID);
+        }
+        if (meta.containsKey(Metadata.FN_OWNER_FILE_ID)) {
+            ownerFileId = meta.get(Metadata.FN_OWNER_FILE_ID);
+        }
+        if (meta.containsKey(Metadata.FN_FILE_PERMISSION)) {
+            permission = meta.get(Metadata.FN_FILE_PERMISSION);
+        }
         lockTimestamp = meta.getLong(Metadata.FN_LOCK_TIMESTAMP, 0);
         descEnabled = meta.getBool(Metadata.FN_DESC_ENABLED, true);
     }

--- a/store/src/java/com/zimbra/cs/mailbox/Metadata.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Metadata.java
@@ -122,6 +122,9 @@ public final class Metadata {
     public static final String FN_WIKI_WORD        = "ww";
     public static final String FN_ELIDED           = "X";
     public static final String FN_EXTRA_DATA       = "xd";
+    public static final String FN_OWNER_ACCOUNT_ID = "oai";
+    public static final String FN_OWNER_FILE_ID    = "ofi";
+    public static final String FN_FILE_PERMISSION  = "perm";
 
     private final Integer associatedItemId;
 

--- a/store/src/java/com/zimbra/cs/redolog/op/CreateFileSharedWithMe.java
+++ b/store/src/java/com/zimbra/cs/redolog/op/CreateFileSharedWithMe.java
@@ -1,0 +1,120 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.redolog.op;
+
+import java.io.IOException;
+
+import com.zimbra.cs.mailbox.MailboxOperation;
+import com.zimbra.cs.redolog.RedoLogInput;
+import com.zimbra.cs.redolog.RedoLogOutput;
+
+public class CreateFileSharedWithMe extends RedoableOp {
+
+    private int mId;
+    private String mUuid;
+    private int mFolderId;
+    private String mName;
+    private String mOwnerId;
+    private int mRemoteId;
+    private String mRemoteUuid;
+    private String mOwnerName;
+    private String mContentType;
+    private String mRights;
+
+    public CreateFileSharedWithMe() {
+        super(MailboxOperation.CreateMountpoint);
+        mId = UNKNOWN_ID;
+    }
+
+    public CreateFileSharedWithMe(int mailboxId, int folderId, String name, String ownerId, int remoteId,
+            String remoteUuid, String fileOwnerName, String contetnType, String rights) {
+        this();
+        setMailboxId(mailboxId);
+        mId = UNKNOWN_ID;
+        mFolderId = folderId;
+        mName = name != null ? name : "";
+        mOwnerId = ownerId;
+        mRemoteId = remoteId;
+        mRemoteUuid = remoteUuid;
+        mOwnerName = fileOwnerName;
+        mContentType = contetnType;
+        mRights = rights;
+    }
+
+    public CreateFileSharedWithMe(int mailboxId, String remoteUuid) {
+        this();
+        setMailboxId(mailboxId);
+        mRemoteUuid = remoteUuid;
+    }
+
+    public int getId() {
+        return mId;
+    }
+
+    public String getUuid() {
+        return mUuid;
+    }
+
+    public void setIdAndUuid(int id, String uuid) {
+        mId = id;
+        mUuid = uuid;
+    }
+
+    @Override
+    protected String getPrintableData() {
+        StringBuilder sb = new StringBuilder("id=").append(mId);
+        sb.append(", uuid=").append(mUuid);
+        sb.append(", name=").append(mName).append(", folder=").append(mFolderId);
+        sb.append(", owner=").append(mOwnerId).append(", remoteId=").append(mRemoteId).append(", remoteUuid=")
+                .append(mRemoteUuid);
+        return sb.toString();
+    }
+
+    @Override
+    protected void serializeData(RedoLogOutput out) throws IOException {
+        out.writeInt(mId);
+        out.writeUTF(mUuid);
+        out.writeUTF(mName);
+        out.writeUTF(mOwnerId);
+        out.writeInt(mRemoteId);
+        out.writeUTF(mRemoteUuid);
+        out.writeInt(mFolderId);
+        out.writeUTF(mOwnerName);
+        out.writeUTF(mContentType);
+        out.writeUTF(mRights);
+    }
+
+    @Override
+    protected void deserializeData(RedoLogInput in) throws IOException {
+        mId = in.readInt();
+        mUuid = in.readUTF();
+        mName = in.readUTF();
+        mOwnerId = in.readUTF();
+        mOwnerName = in.readUTF();
+        mRemoteId = in.readInt();
+        mRemoteUuid = in.readUTF();
+        mFolderId = in.readInt();
+        mContentType = in.readUTF();
+        mRights = in.readUTF();
+    }
+
+    @Override
+    public void redo() throws Exception {
+        // TODO Auto-generated method stub
+    }
+}

--- a/store/src/java/com/zimbra/cs/service/mail/DelegatableRequest.java
+++ b/store/src/java/com/zimbra/cs/service/mail/DelegatableRequest.java
@@ -1,0 +1,23 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.service.mail;
+
+public interface DelegatableRequest {
+
+    public boolean isDelegatable();
+
+}

--- a/store/src/java/com/zimbra/cs/service/mail/FileSharedWithMe.java
+++ b/store/src/java/com/zimbra/cs/service/mail/FileSharedWithMe.java
@@ -1,0 +1,91 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.service.mail;
+
+import java.util.Map;
+
+import com.zimbra.common.mailbox.FolderConstants;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.MailConstants;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailbox.OperationContext;
+import com.zimbra.soap.ZimbraSoapContext;
+
+public class FileSharedWithMe extends MailDocumentHandler implements DelegatableRequest {
+
+    private static final String REVOKE = "revoke";
+    private static final String EDIT = "edit";
+    private static final String CREATE = "create";
+
+    public Element handle(Element request, Map<String, Object> context) throws ServiceException {
+        try {
+            ZimbraSoapContext zsc = getZimbraSoapContext(context);
+            String ownerAccountId = zsc.getAuthtokenAccountId();
+            String granteeAccountID = zsc.getRequestedAccountId();
+            if (ownerAccountId.equals(granteeAccountID)) {
+                ZimbraLog.mailbox.error("File sharer and grantee cannot be same", new Throwable("invalid request source"));
+                throw ServiceException.FAILURE("invalid request", new Throwable("invalid"));
+            }
+            OperationContext octxt = getOperationContext(zsc, context);
+            Account account = getRequestedAccount(zsc);
+            Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account, false);
+
+            String action = request.getAttribute(MailConstants.E_ACTION);
+            String fileName = request.getAttribute(MailConstants.A_CONTENT_FILENAME);
+            int ownerFileId = request.getAttributeInt(MailConstants.A_ITEMID);
+            String fileUUID = request.getAttribute(MailConstants.A_REMOTE_UUID);
+            String fileOwnerName = request.getAttribute(MailConstants.A_OWNER_NAME);
+            String rights = request.getAttribute(MailConstants.A_RIGHTS);
+            String contentType = request.getAttribute(MailConstants.A_CONTENT_TYPE);
+            long size = request.getAttributeLong(MailConstants.A_SIZE);
+            Element response = zsc.createElement(MailConstants.FILE_SHARED_WITH_ME_RESPONSE);
+            if (Provisioning.onLocalServer(account)) {
+                // if file is shared, this file should be available at receivers end
+                if (action != null && CREATE.equals(action)) {
+                    mbox.createFileSharedWithMe(mbox, octxt, FolderConstants.ID_FOLDER_FILE_SHARED_WITH_ME, fileName,
+                            ownerAccountId, ownerFileId, fileUUID, fileOwnerName, contentType, size, rights);
+                } // if file access is revoked at source, delete it from receiver end as well
+                else if (action != null && REVOKE.equals(action)) {
+                    mbox.deleteFileSharedWithMe(mbox, octxt, fileUUID, ownerFileId, ownerAccountId, granteeAccountID);
+                } // if file rights is changed, update file permission accordingly
+                else if (action != null && EDIT.equalsIgnoreCase(action)) {
+                    mbox.updateFileSharedWithMe(mbox, octxt, ownerAccountId, ownerFileId, fileUUID, fileOwnerName,
+                            contentType, rights, granteeAccountID);
+                } else {
+                    throw ServiceException.FAILURE("invalid request", new Throwable("invalid"));
+                }
+                return response.addAttribute(MailConstants.A_STATUS, MailConstants.A_VERIFICATION_SUCCESS);
+            } else {
+                response = proxyRequest(request, context, granteeAccountID);
+                return response;
+            }
+        } catch (ServiceException ex) {
+            throw ServiceException.FAILURE("Error File Shared With me operation ", ex);
+        }
+    }
+
+    @Override
+    public boolean isDelegatable() {
+        return true;
+    }
+
+}

--- a/store/src/java/com/zimbra/cs/service/mail/MailService.java
+++ b/store/src/java/com/zimbra/cs/service/mail/MailService.java
@@ -255,5 +255,8 @@ public final class MailService implements DocumentService {
         dispatcher.registerHandler(OctopusXmlConstants.GET_NOTIFICATIONS_REQUEST, new GetNotifications());
         dispatcher.registerHandler(OctopusXmlConstants.GET_DOCUMENT_SHARE_URL_REQUEST, new GetDocumentShareURL());
         dispatcher.registerHandler(OctopusXmlConstants.GET_SHARE_DETAILS_REQUEST, new GetShareDetails());
+
+        // File Shared With Me
+        dispatcher.registerHandler(MailConstants.FILE_SHARED_WITH_ME_REQUEST, new FileSharedWithMe());
     }
 }

--- a/store/src/java/com/zimbra/cs/service/mail/SearchResponse.java
+++ b/store/src/java/com/zimbra/cs/service/mail/SearchResponse.java
@@ -150,9 +150,9 @@ final class SearchResponse {
      * @throws ServiceException error
      */
     void add(ZimbraHit zimbraHit) throws ServiceException{
-		add(zimbraHit,false);
+        add(zimbraHit,false);
+    }
 
-	}
     /* We need to pass in a boolean signifying whether to expand the message or not (bug 75990)
     */
     void add(ZimbraHit hit, boolean expandMsg) throws ServiceException {

--- a/store/src/java/com/zimbra/soap/ZimbraSoapContext.java
+++ b/store/src/java/com/zimbra/soap/ZimbraSoapContext.java
@@ -33,6 +33,7 @@ import com.zimbra.common.auth.ZAuthToken;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.HeaderConstants;
+import com.zimbra.common.soap.MailConstants;
 import com.zimbra.common.soap.SoapProtocol;
 import com.zimbra.common.soap.SoapTransport;
 import com.zimbra.common.util.Log;
@@ -51,6 +52,7 @@ import com.zimbra.cs.mailbox.ACL;
 import com.zimbra.cs.mailbox.OperationContext;
 import com.zimbra.cs.mailbox.acl.AclPushSerializer;
 import com.zimbra.cs.service.AuthProvider;
+import com.zimbra.cs.service.mail.DelegatableRequest;
 import com.zimbra.cs.servlet.continuation.ResumeContinuationListener;
 import com.zimbra.cs.session.Session;
 import com.zimbra.cs.session.SessionCache;
@@ -521,6 +523,12 @@ public final class ZimbraSoapContext {
         }
 
         if ((handler != null) && handler.handlesAccountHarvesting()) {
+            return;
+        }
+
+        if ((handler != null) && handler instanceof DelegatableRequest
+                && MailConstants.FILE_SHARED_WITH_ME_REQUEST.equals(requestName)
+                && ((DelegatableRequest) handler).isDelegatable()) {
             return;
         }
 


### PR DESCRIPTION
Problem: As of current when the file is shared i.e. User A shares any file with User B then the file is shared as an accessible link on the mail. So assume when I have to access the file again after a month I receive I'll have to scroll down to check the mail where the link was shared. By any chance, if that mail is deleted from the grantee's side, they won't be able to access it again and have to ask for resharing of the file

Solution: To overcome the above issue we came up with a solution i.e. to create a system folder `File Shared with` Me under the briefcase tab. Now when user A shares the file with User B, the file is accessible via the link, and also file is available under the File Shared with Me folder. This file can be previewed upon clicking, and based on the rights provided file can be viewed and edited accordingly. There is an option to download the file as well.

Implementation Approach: When user A shares a file with user B, then in SendShareNotification the grantee ID is used to fetch the mailbox details of user B. Based on the mailbox details retrieved DB actions are made. Now the mailbox can either be on the local server or on another server , hence added a check for that, if it's on the Local server it processes it away directly else we have created a new API `FileSharedWithMeRequest` which gets' triggered, and then the mailbox is retrieved from context and the DB action happens in new API
There are basically 3 scenarios that can happen:
When the File is shared -> The file details are captured, i.e. fileName, content type, permissions to the file, size, etc. Based on the grantee ID grantee's mailbox is retrieved and using mailbox detail and input available a new DB entry is made directly on the grantee's side on the File Shared with Me .This file can be accessed based on an ID that has a value like "AccountID: FieldId"

When Acess is revoked --> In this case the file is deleted from the grantee side using the delete query and file will no longer be accessible on the File Shared with Me folder

When File details/rights are changed --> In this case firstly older DB entry is deleted and then newer entry is created on UserB mailbox

Testing:
Manual testing through SOAP API to check what files are available when input is "File Shared With me Folder"
Testing through UI on a single Node server, when the file which has been shared can be accessed via a link. ALso same file is available under the File Shared With me Folder. These files can be previewed, and there is an option to open the file in a new tab and edit it according to the rights provided. The users could also download single file at a time . The scenario us verified on Multi-node server as well