### PR TITLE
ZCS-11731 new emails are not getting synched for outlook app on device for active-sync

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1105,7 +1105,7 @@ public final class LC {
     public static final KnownKey zimbra_activesync_autodiscover_use_service_url = KnownKey.newKey(false);
     public static final KnownKey zimbra_activesync_metadata_cache_expiration = KnownKey.newKey(3600);
     public static final KnownKey zimbra_activesync_metadata_cache_max_size = KnownKey.newKey(5000);
-    public static final KnownKey zimbra_activesync_heartbeat_interval_min = KnownKey.newKey(300); //300 Seconds = 5 mins
+    public static final KnownKey zimbra_activesync_heartbeat_interval_min = KnownKey.newKey(180); //180 Seconds = 3 mins
     //make sure it's less than nginx's zimbraReverseProxyUpstreamPollingTimeout, which is now 3600 seconds
     public static final KnownKey zimbra_activesync_heartbeat_interval_max = KnownKey.newKey(3540); //3540 Seconds = 59 mins
     public static final KnownKey zimbra_activesync_search_max_results = KnownKey.newKey(500);


### PR DESCRIPTION
**Problem:**
new emails are not getting synched for outlook app on device for active-sync

**Fix:**
changed the LC attribute value as zimbra_activesync_heartbeat_interval_min=180
earlier it was 300 but the client send request with value 180, so status 5 is being set and no further emails are getting synched.

**Test-cases:**
Added account on outlook app on device, mails get synched initially, then sent more mails in that account, got expected result. Mails are continuously getting synched.