### PR TITLE
ZCS-11440: ZimbraBlobMover: add support for blob movement from S3 to S3

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -83,6 +83,12 @@ public final class LC {
     public static final KnownKey zimbra_external_email_warning_message = KnownKey
             .newKey("This message originated outside of your organization.");
 
+    /**
+     * Sets whether the HybridBlobmover feature is enabled.
+     */
+    @Supported
+    public static final KnownKey zimbra_hybrid_blob_mover_enabled = KnownKey.newKey(true);
+
     @Supported
     public static final KnownKey zimbra_extension_directory = KnownKey.newKey("${zimbra_home}/lib/ext");
 

--- a/store-conf/conf/msgs/ZsMsg.properties
+++ b/store-conf/conf/msgs/ZsMsg.properties
@@ -379,6 +379,7 @@ zimbra_db_directory = Directory for database files.
 zimbra_tmp_directory = Directory for temporary files.
 zimbra_external_email_warning_enabled = Sets whether the External Email Warning (EEW) feature is enabled. Defaults to: false
 zimbra_external_email_warning_message = Sets the base warning text for External Email Warning (EEW). Defaults to: This message originated outside of your organization.
+zimbra_hybrid_blob_mover_enabled = Sets whether the Hybrid Blob Mover feature is enabled. Defaults to: false
 zimbra_extensions_directory = Directory whose subdirs contain extensions.
 zimbra_extensions_common_directory = Directory with jar files that are common across all extensions.
 zimbra_mysql_shutdown_timeout = Time to wait for the mailbox MySQL/MariaDB process to die. \

--- a/store/src/java/com/zimbra/cs/store/file/FileBlobStore.java
+++ b/store/src/java/com/zimbra/cs/store/file/FileBlobStore.java
@@ -437,4 +437,41 @@ public final class FileBlobStore extends StoreManager {
     private static void ensureParentDirExists(File file) throws IOException {
         ensureDirExists(file.getParentFile());
     }
+
+    /**
+     * Store a blob from external S3 storage to internal store in volume/path
+     * specified by dest* parameters. Note this method is not part of the
+     * StoreManager interface It is only to be used for FileBlobStore specific code
+     * such as ExternalToInternal
+     * 
+     * @param in
+     * @param storeAsIs
+     * @param mbox
+     * @param itemId
+     * @param revision
+     * @param destVolumeId mail_item.volume_id for message in dest Mbox
+     * @throws IOException
+     * @throws ServiceException
+     */
+    public Blob storeIncoming(InputStream in, boolean storeAsIs, Mailbox mbox, int itemId, int revision,
+            short destVolumeId) throws IOException, ServiceException {
+        BlobBuilder builder = getBlobBuilder(mbox, itemId, revision, destVolumeId);
+        builder.disableCompression(storeAsIs).disableDigest(storeAsIs);
+        return builder.init().append(in).finish();
+    }
+
+    private BlobBuilder getBlobBuilder(Mailbox mbox, int itemId, int revision, short destVolumeId)
+            throws IOException, ServiceException {
+        Blob blob = getUniqueIncomingBlob(mbox, itemId, revision, destVolumeId);
+        return new VolumeBlobBuilder(blob);
+    }
+
+    private Blob getUniqueIncomingBlob(Mailbox mbox, int itemId, int revision, short destVolumeId)
+            throws IOException, ServiceException {
+        ZimbraLog.store.debug("getUniqueIncomingBlob destVolumeId %s.", destVolumeId);
+        File file = new File(getBlobPath(mbox, itemId, revision, destVolumeId));
+        ensureParentDirExists(file);
+        ZimbraLog.store.debug("getUniqueIncomingBlob getRootPath %s.", file.getAbsolutePath());
+        return new VolumeBlob(file, destVolumeId);
+    }
 }


### PR DESCRIPTION
### Solution
ZCS-11440 is about adding support for S3-to-S3 movement when it comes to executing the existing HSM policy (i.e. when both primary and secondary volumes are S3 Buckets). The solution works by adding a few new classes and updating existing classes in the `zm-hsm-project`, such as the `ZimbraBlobMoverAdaptor` and `BlobMoverThread` classes respectively.

### Notes
Now, regarding the `zm-mailbox` project, a new `zimbra_hybrid_blob_mover_enabled` local config property has been added, which default to `false`, for safety purposes (i.e. making easy to handover among the current `BlobMover` and new `ZimbraBlobMoverAdaptor`).

### Tests
Please go to ticket for further details.