### PR TITLE
ZCS-11798: Removed indexof() method causing issue was not required

### DIFF
--- a/common/src/java/com/zimbra/common/util/ZimbraLog.java
+++ b/common/src/java/com/zimbra/common/util/ZimbraLog.java
@@ -907,7 +907,7 @@ public final class ZimbraLog {
                     .addComponent(builder.newComponent(POLICY_TIME_TYPE).addAttribute(POLICY_TIME_TYPE_INTERVAL, POLICY_TIME_TYPE_INTERVAL_VALUE));
             appenderBuilder = builder.newAppender(APPENDER_NAME, APPENDER_TYPE)
                     .addAttribute(APPENDER_FILE_NAME, logFile)
-                    .addAttribute(APPENDER_FILE_PATTERN, logFile.substring(0, logFile.lastIndexOf(".log")) + "-%d{yyyy-MM-dd}")
+                    .addAttribute(APPENDER_FILE_PATTERN, logFile + "-%d{yyyy-MM-dd}")
                     .add(layoutBuilder)
                     .addComponent(policy);
             builder.add(appenderBuilder);


### PR DESCRIPTION
**Problem**
Some log files were failed to initialize only .log extension was supported

**Fix**
Found we were using indexOf() which were really didn't required. So removed and using logfile name as it is.