### PR TITLE
ZCS-11799: Removed unnecessary code which had endless loop and blocki…

### DIFF
--- a/store/src/java/com/zimbra/cs/redolog/util/PlaybackUtil.java
+++ b/store/src/java/com/zimbra/cs/redolog/util/PlaybackUtil.java
@@ -381,22 +381,6 @@ public class PlaybackUtil {
     private static void setup() throws ServiceException {
         // set up log4j
         ZimbraLog.toolSetupLog4j("INFO", LC.zimbra_log4j_properties.value());
-        // remove the console appender if any
-        org.apache.logging.log4j.Logger rootLogger = LogManager.getRootLogger();
-        Appender consoleAppender = null;
-        LoggerContext context = LoggerContext.getContext(false);
-        Configuration configuration = context.getConfiguration();
-        LoggerConfig loggerConfig = configuration.getLoggerConfig(rootLogger.getName());
-        Map<String, Appender> appenders = loggerConfig.getAppenders();
-
-        while (appenders.values().iterator().hasNext()) {
-            Appender appender = appenders.values().iterator().next();
-            if (appender instanceof ConsoleAppender) {
-                consoleAppender = appender;
-            }
-        }
-        if (consoleAppender != null)
-            loggerConfig.removeAppender(consoleAppender.getName());
 
         DbPool.startup();
         Zimbra.startupCLI();


### PR DESCRIPTION
**Problem**
Redo log replaying process was blocked and redo logs were not replaying while running `zmplayredo` command

**Fix**
Found that there were a endless loop in code which was unnecessary as it was looking for console appender and then was deleting it. This was working fine in log4j-1.2 but in log4j-2.17.1 this while code block was running for infinite times.

Have removed this code block because we are initializing the /opt/zimbra/log4j.properties file which do not have any default console appender so searching for console appender and then deleting this after the initialization was seems pointless.

**Testing**
Tested in local environment and as able to run `zmplayredo`