### PR TITLE
ZCS-11657: Create New SOAP API for testing S3 bucket config

### DIFF
--- a/soap/src/java/com/zimbra/soap/JaxbUtil.java
+++ b/soap/src/java/com/zimbra/soap/JaxbUtil.java
@@ -1159,7 +1159,9 @@ public final class JaxbUtil {
             com.zimbra.soap.admin.message.CreateS3BucketConfigRequest.class,
             com.zimbra.soap.admin.message.CreateS3BucketConfigResponse.class,
             com.zimbra.soap.admin.message.DeleteS3BucketConfigRequest.class,
-            com.zimbra.soap.admin.message.DeleteS3BucketConfigResponse.class
+            com.zimbra.soap.admin.message.DeleteS3BucketConfigResponse.class,
+            com.zimbra.soap.admin.message.ValidateS3BucketReachableRequest.class,
+            com.zimbra.soap.admin.message.ValidateS3BucketReachableResponse.class
         };
 
         try {

--- a/soap/src/java/com/zimbra/soap/admin/message/ValidateS3BucketReachableRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/ValidateS3BucketReachableRequest.java
@@ -1,0 +1,103 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.AccountConstants;
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.common.soap.GlobalExternalStoreConfigConstants;
+import com.zimbra.soap.admin.type.AdminAttrsImpl;
+
+/**
+ * @zm-api-command-auth-required true
+ * @zm-api-command-admin-auth-required true
+ * @zm-api-command-description Get S3 Bucket Config
+ */
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name = AdminConstants.E_VALIDATE_S3_BUCKET_REACHABLE_REQUEST)
+public class ValidateS3BucketReachableRequest extends AdminAttrsImpl {
+
+    @XmlAttribute(name = GlobalExternalStoreConfigConstants.A_S3_URL /* url */, required = true)
+    private String url;
+
+    @XmlAttribute(name = GlobalExternalStoreConfigConstants.A_S3_BUCKET_NAME /* bucketName */, required = true)
+    private String bucketName;
+
+    @XmlAttribute(name = GlobalExternalStoreConfigConstants.A_S3_REGION /* region */, required = false)
+    private String region;
+
+    @XmlAttribute(name = GlobalExternalStoreConfigConstants.A_S3_ACCESS_KEY /* accessKey */, required = true)
+    private String accessKey;
+
+    @XmlAttribute(name = GlobalExternalStoreConfigConstants.A_S3_SECRET_KEY /* secretKey */, required = true)
+    private String secretKey;
+
+    @Override
+    public String toString() {
+        return "ValidateS3BucketReachableRequest [url=" + url + ", bucketName=" + bucketName + ", region=" + region
+                + ", accessKey=" + accessKey + ", secretKey=" + secretKey + "]";
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getBucketName() {
+        return bucketName;
+    }
+
+    public void setBucketName(String bucketName) {
+        this.bucketName = bucketName;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public void setRegion(String region) {
+        this.region = region;
+    }
+
+    public String getAccessKey() {
+        return accessKey;
+    }
+
+    public void setAccessKey(String accessKey) {
+        this.accessKey = accessKey;
+    }
+
+    public String getSecretKey() {
+        return secretKey;
+    }
+
+    public void setSecretKey(String secretKey) {
+        this.secretKey = secretKey;
+    }
+
+    public ValidateS3BucketReachableRequest() {
+    }
+
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/ValidateS3BucketReachableResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/ValidateS3BucketReachableResponse.java
@@ -1,0 +1,33 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.soap.admin.type.AdminAttrsImpl;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name = AdminConstants.E_VALIDATE_S3_BUCKET_REACHABLE_RESPONSE)
+public class ValidateS3BucketReachableResponse extends AdminAttrsImpl {
+
+    public ValidateS3BucketReachableResponse() {
+    }
+}


### PR DESCRIPTION
creating a new SOAP API to test the S3 configuration which will be accepting the following set of parameters and at the server-side, it will make a test request to the s3 bucket to verify if that bucket is reachable or not.

URL
Bucket Name
Access Key
Secret Key
Region

Created new API
ValidateS3BucketReachableRequest
ValidateS3BucketReachableResponse

Request -
<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:zimbra" xmlns:urn1="urn:zimbraAdmin">
soapenv:Header
urn:context
urn:authToken0_6a08477669d3d95ceadf1c38197a64ff47ed542c_69643d33363a31393531643831632d313362372d346139662d386337352d3262306537363963636465363b6578703d31333a313635383236313934343239383b61646d696e3d313a313b747970653d363a7a696d6272613b753d313a613b7469643d393a3937303333343737363b76657273696f6e3d31353a392e312e305f424554415f343330373b637372663d313a313b</urn:authToken>
urn:csrfToken4e5ca0e2943404a0f8649dce8d604fb43cc48174</urn:csrfToken>
</urn:context>
</soapenv:Header>
soapenv:Body
<urn1:ValidateS3BucketReachableRequest
url="https://idtnzfdm3vg6.compat.objectstorage.us-ashburn-1.oraclecloud.com/"
bucketName="s3_hsmtest"
region="com.synacor.zimbra.store.location.DefaultLocationFactory"
accessKey="ba5afac8d971aa1c438744a63b76c27403ae507c"
secrateKey="7Ogvx+9ZLkTBw3eIokFtzlpLEuMQdbl2IeZjr+EoJ7k="/>
</soapenv:Body>
</soapenv:Envelope>

Response -
<soap:Envelope xmlns:soap="[http://schemas.xmlsoap.org/soap/envelope/">](http://schemas.xmlsoap.org/soap/envelope/%22%3E)
soap:Header

</soap:Header>
soap:Body

S3 bucket connected Successfully

</soap:Body>
</soap:Envelope>