### PR TITLE
ZCS-11656: and ZCS-11768

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -16593,17 +16593,17 @@ public class ZAttrProvisioning {
     /**
      * Zimbra multiple reader StoreManagers enabled
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4008)
+    @ZAttr(id=4021)
     public static final String A_zimbraSMMultiReaderEnabled = "zimbraSMMultiReaderEnabled";
 
     /**
      * Zimbra StoreManager runtime switching enabled
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4009)
+    @ZAttr(id=4022)
     public static final String A_zimbraSMRuntimeSwitchEnabled = "zimbraSMRuntimeSwitchEnabled";
 
     /**

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -16591,6 +16591,22 @@ public class ZAttrProvisioning {
     public static final String A_zimbraSmimeUserCertificateExtensions = "zimbraSmimeUserCertificateExtensions";
 
     /**
+     * Zimbra multiple reader StoreManagers enabled
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public static final String A_zimbraSMMultiReaderEnabled = "zimbraSMMultiReaderEnabled";
+
+    /**
+     * Zimbra StoreManager runtime switching enabled
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public static final String A_zimbraSMRuntimeSwitchEnabled = "zimbraSMRuntimeSwitchEnabled";
+
+    /**
      * Whether to enable smtp debug trace
      *
      * @since ZCS 6.0.0_BETA1

--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -1170,6 +1170,7 @@ public final class AdminConstants {
     public static final String E_VOLUME = "volume";
     public static final String E_VOLUME_EXT = "volumeExternalInfo";
     public static final String E_VOLUME_OPENIO_EXT = "volumeExternalOpenIoInfo";
+    public static final String E_STORE_MANAGER_RUNTIME_SWITCH_RESULT = "storeManagerRuntimeSwitchResult";
     public static final String E_PROGRESS = "progress";
     public static final String E_SOAP_URL = "soapURL";
     public static final String E_ADMIN_SOAP_URL = "adminSoapURL";
@@ -1311,6 +1312,7 @@ public final class AdminConstants {
     public static final String A_VOLUME_ACCOUNT_PORT = "accountPort";
     public static final String A_VOLUME_S3 = "S3";
     public static final String A_VOLUME_OPEN_IO = "OPENIO";
+    public static final String A_VOLUME_STORE_MANAGER_CLASS = "storeManagerClass";
 
     // Blob consistency check
     public static final String E_MISSING_BLOBS = "missingBlobs";
@@ -1581,6 +1583,9 @@ public final class AdminConstants {
     public static final String A_CLEAR_FILTER = "clearFilter";
 
     public static final String A_ZULIP_DOMAIN = "zulipDomain";
+
+    public static final String A_SM_RUNTIME_SWITCH_STATUS = "status";
+    public static final String A_SM_RUNTIME_SWITCH_MESSAGE = "message";
 
     // Global External Store Config
     public static final String E_GET_S3_BUCKET_CONFIG_REQUEST = "GetS3BucketConfigRequest";

--- a/soap/src/java/com/zimbra/soap/admin/enums/Status.java
+++ b/soap/src/java/com/zimbra/soap/admin/enums/Status.java
@@ -1,7 +1,0 @@
-package com.zimbra.soap.admin.enums;
-
-public enum Status {
-    SUCCESS,
-    FAIL,
-    NO_OPERATION;
-}

--- a/soap/src/java/com/zimbra/soap/admin/enums/Status.java
+++ b/soap/src/java/com/zimbra/soap/admin/enums/Status.java
@@ -1,0 +1,7 @@
+package com.zimbra.soap.admin.enums;
+
+public enum Status {
+    SUCCESS,
+    FAIL,
+    NO_OPERATION;
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/CreateVolumeResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/CreateVolumeResponse.java
@@ -23,6 +23,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.soap.admin.type.StoreManagerRuntimeSwitchResult;
 import com.zimbra.soap.admin.type.VolumeInfo;
 
 @XmlAccessorType(XmlAccessType.NONE)
@@ -34,6 +35,9 @@ public class CreateVolumeResponse {
      */
     @XmlElement(name=AdminConstants.E_VOLUME, required=true)
     private VolumeInfo volume;
+
+    @XmlElement(name=AdminConstants.E_STORE_MANAGER_RUNTIME_SWITCH_RESULT, required=false)
+    private StoreManagerRuntimeSwitchResult runtimeSwitchResult;
 
     /**
      * no-argument constructor wanted by JAXB
@@ -48,4 +52,12 @@ public class CreateVolumeResponse {
     }
 
     public VolumeInfo getVolume() { return volume; }
+
+    public StoreManagerRuntimeSwitchResult getRuntimeSwitchResult() {
+        return runtimeSwitchResult;
+    }
+
+    public void setRuntimeSwitchResult(StoreManagerRuntimeSwitchResult runtimeSwitchResult) {
+        this.runtimeSwitchResult = runtimeSwitchResult;
+    }
 }

--- a/soap/src/java/com/zimbra/soap/admin/message/SetCurrentVolumeResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/SetCurrentVolumeResponse.java
@@ -19,7 +19,21 @@ package com.zimbra.soap.admin.message;
 
 import javax.xml.bind.annotation.XmlRootElement;
 import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.soap.admin.type.StoreManagerRuntimeSwitchResult;
+
+import javax.xml.bind.annotation.XmlElement;
 
 @XmlRootElement(name=AdminConstants.E_SET_CURRENT_VOLUME_RESPONSE)
 public class SetCurrentVolumeResponse {
+
+    @XmlElement(name=AdminConstants.E_STORE_MANAGER_RUNTIME_SWITCH_RESULT, required=false)
+    private StoreManagerRuntimeSwitchResult runtimeSwitchResult;
+
+    public StoreManagerRuntimeSwitchResult getRuntimeSwitchResult() {
+        return runtimeSwitchResult;
+    }
+
+    public void setRuntimeSwitchResult(StoreManagerRuntimeSwitchResult runtimeSwitchResult) {
+        this.runtimeSwitchResult = runtimeSwitchResult;
+    }
 }

--- a/soap/src/java/com/zimbra/soap/admin/type/StoreManagerRuntimeSwitchResult.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/StoreManagerRuntimeSwitchResult.java
@@ -1,0 +1,63 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C)2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.type;
+
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.soap.admin.enums.Status;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+
+@XmlAccessorType(XmlAccessType.NONE)
+public class StoreManagerRuntimeSwitchResult {
+
+    @XmlAttribute(name= AdminConstants.A_SM_RUNTIME_SWITCH_STATUS /* status */, required=true)
+    private Status status;
+
+    /**
+     * @zm-api-field-tag volume-root-path
+     * @zm-api-field-description Absolute path to root of volume, e.g. /opt/zimbra/store
+     */
+    @XmlAttribute(name=AdminConstants.A_SM_RUNTIME_SWITCH_MESSAGE /* message */, required=true)
+    private String message;
+
+    public StoreManagerRuntimeSwitchResult() {
+    }
+
+    public StoreManagerRuntimeSwitchResult(Status status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/type/StoreManagerRuntimeSwitchResult.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/StoreManagerRuntimeSwitchResult.java
@@ -18,17 +18,24 @@
 package com.zimbra.soap.admin.type;
 
 import com.zimbra.common.soap.AdminConstants;
-import com.zimbra.soap.admin.enums.Status;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlEnum;
 
 @XmlAccessorType(XmlAccessType.NONE)
 public class StoreManagerRuntimeSwitchResult {
 
+    @XmlEnum
+    public enum RuntimeSwitchStatus {
+        SUCCESS,
+        FAIL,
+        NO_OPERATION;
+    }
+
     @XmlAttribute(name= AdminConstants.A_SM_RUNTIME_SWITCH_STATUS /* status */, required=true)
-    private Status status;
+    private RuntimeSwitchStatus runtimeSwitchStatus;
 
     /**
      * @zm-api-field-tag volume-root-path
@@ -40,17 +47,17 @@ public class StoreManagerRuntimeSwitchResult {
     public StoreManagerRuntimeSwitchResult() {
     }
 
-    public StoreManagerRuntimeSwitchResult(Status status, String message) {
-        this.status = status;
+    public StoreManagerRuntimeSwitchResult(RuntimeSwitchStatus status, String message) {
+        this.runtimeSwitchStatus = status;
         this.message = message;
     }
 
-    public Status getStatus() {
-        return status;
+    public RuntimeSwitchStatus getStatus() {
+        return runtimeSwitchStatus;
     }
 
-    public void setStatus(Status status) {
-        this.status = status;
+    public void setStatus(RuntimeSwitchStatus status) {
+        this.runtimeSwitchStatus = status;
     }
 
     public String getMessage() {

--- a/soap/src/java/com/zimbra/soap/admin/type/VolumeInfo.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/VolumeInfo.java
@@ -113,7 +113,7 @@ public final class VolumeInfo {
     private short storeType = 1;
 
     @XmlAttribute(name=AdminConstants.A_VOLUME_STORE_MANAGER_CLASS /* storeManagerClass*/, required=false)
-    private String storeManagerClass = LC.zimbra_class_store.value();
+    private String storeManagerClass;
 
     /**
      * @zm-api-field-description Volume external information for S3

--- a/soap/src/java/com/zimbra/soap/admin/type/VolumeInfo.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/VolumeInfo.java
@@ -22,6 +22,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 
+import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.soap.AdminConstants;
 
 @XmlAccessorType(XmlAccessType.NONE)
@@ -110,6 +111,9 @@ public final class VolumeInfo {
      */
     @XmlAttribute(name=AdminConstants.A_VOLUME_STORE_TYPE /* storeType */, required=false)
     private short storeType = 1;
+
+    @XmlAttribute(name=AdminConstants.A_VOLUME_STORE_MANAGER_CLASS /* storeManagerClass*/, required=false)
+    private String storeManagerClass = LC.zimbra_class_store.value();
 
     /**
      * @zm-api-field-description Volume external information for S3
@@ -233,5 +237,13 @@ public final class VolumeInfo {
 
     public void setVolumeExternalOpenIOInfo(VolumeExternalOpenIOInfo volumeExternalOpenIOInfo) {
         this.volumeExternalOpenIOInfo = volumeExternalOpenIOInfo;
+    }
+
+    public String getStoreManagerClass() {
+        return storeManagerClass;
+    }
+
+    public void setStoreManagerClass(String storeManagerClass) {
+        this.storeManagerClass = storeManagerClass;
     }
 }

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10025,4 +10025,12 @@ TODO: delete them permanently from here
 <attr id="4020" name="zimbraServerExternalStoreConfig" type="string" cardinality="single" optionalIn="server" since="10.0.0">
   <desc>Server level external store config</desc>
 </attr>
+<attr id="4008" name="zimbraSMMultiReaderEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited"  since="9.1.0">
+  <globalConfigValue>FALSE</globalConfigValue>
+  <desc>Zimbra multiple reader StoreManagers enabled </desc>
+</attr>
+<attr id="4009" name="zimbraSMRuntimeSwitchEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited"  since="9.1.0">
+  <globalConfigValue>FALSE</globalConfigValue>
+  <desc>Zimbra StoreManager runtime switching enabled </desc>
+</attr>
 </attrs>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10025,11 +10025,11 @@ TODO: delete them permanently from here
 <attr id="4020" name="zimbraServerExternalStoreConfig" type="string" cardinality="single" optionalIn="server" since="10.0.0">
   <desc>Server level external store config</desc>
 </attr>
-<attr id="4008" name="zimbraSMMultiReaderEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited"  since="9.1.0">
+<attr id="4021" name="zimbraSMMultiReaderEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited"  since="10.0.0">
   <globalConfigValue>TRUE</globalConfigValue>
   <desc>Zimbra multiple reader StoreManagers enabled </desc>
 </attr>
-<attr id="4009" name="zimbraSMRuntimeSwitchEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited"  since="9.1.0">
+<attr id="4022" name="zimbraSMRuntimeSwitchEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited"  since="10.0.0">
   <globalConfigValue>TRUE</globalConfigValue>
   <desc>Zimbra StoreManager runtime switching enabled </desc>
 </attr>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10026,11 +10026,11 @@ TODO: delete them permanently from here
   <desc>Server level external store config</desc>
 </attr>
 <attr id="4008" name="zimbraSMMultiReaderEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited"  since="9.1.0">
-  <globalConfigValue>FALSE</globalConfigValue>
+  <globalConfigValue>TRUE</globalConfigValue>
   <desc>Zimbra multiple reader StoreManagers enabled </desc>
 </attr>
 <attr id="4009" name="zimbraSMRuntimeSwitchEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited"  since="9.1.0">
-  <globalConfigValue>FALSE</globalConfigValue>
+  <globalConfigValue>TRUE</globalConfigValue>
   <desc>Zimbra StoreManager runtime switching enabled </desc>
 </attr>
 </attrs>

--- a/store/src/db/hsqldb/db.sql
+++ b/store/src/db/hsqldb/db.sql
@@ -32,7 +32,9 @@ CREATE TABLE volume (
    mailbox_group_bits     SMALLINT NOT NULL,
    compress_blobs         BOOLEAN NOT NULL,
    compression_threshold  BIGINT NOT NULL,
-   metadata               VARCHAR(255),
+   metadata               VARCHAR(255) NULL,
+   store_type             TINYINT DEFAULT 1 NOT NULL,
+   store_manager_class    VARCHAR(255),
 
    CONSTRAINT i_name UNIQUE (name),
    CONSTRAINT i_path UNIQUE (path)

--- a/store/src/java-test/com/zimbra/cs/store/CacheEnabledStoreManagerProviderTest.java
+++ b/store/src/java-test/com/zimbra/cs/store/CacheEnabledStoreManagerProviderTest.java
@@ -1,0 +1,116 @@
+package com.zimbra.cs.store;
+
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.store.helper.ClassHelper;
+import com.zimbra.cs.volume.Volume;
+import com.zimbra.cs.volume.VolumeManager;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore("javax.management.*")
+public class CacheEnabledStoreManagerProviderTest {
+    private static final String TEST_CONFIG_FILE_DIR_PATH = "../store/src/java-test/";
+    private static final String TEST_CONFIG_FILE_PATH = TEST_CONFIG_FILE_DIR_PATH + "localconfig-test.xml";
+
+    @BeforeClass
+    public static void init() throws Exception {
+        System.setProperty("zimbra.config", TEST_CONFIG_FILE_PATH);
+        MailboxTestUtil.initServer();
+        Provisioning prov = Provisioning.getInstance();
+        prov.getLocalServer().setSMRuntimeSwitchEnabled(true);
+        prov.getLocalServer().setSMMultiReaderEnabled(true);
+    }
+
+    @Test
+    @PrepareForTest({ClassHelper.class})
+    public void testGetStoreManagerForVolumeWithCacheSkip() throws Throwable {
+        Volume volume3 = Volume.builder().setId((short) 200)
+                .setName("TEST300")
+                .setPath("/test/300", false)
+                .setType((short) 1)
+                .setStoreType(Volume.StoreType.INTERNAL)
+                .setStoreManagerClass(MockStoreManager.class.getName()).build();
+        Volume volume4 = Volume.builder().setId((short) 201)
+                .setName("TEST400")
+                .setPath("/test/400", false)
+                .setType((short) 1)
+                .setStoreType(Volume.StoreType.EXTERNAL)
+                .setStoreManagerClass(MockStoreManager.class.getName()).build();
+
+        VolumeManager.getInstance().create(volume3);
+        VolumeManager.getInstance().create(volume4);
+
+        mockStatic(ClassHelper.class);
+        when(ClassHelper.getZimbraClassInstanceBy(Mockito.anyString())).thenReturn(new MockStoreManager());
+
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume3.getId(), true);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume3.getId(), true);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume3.getId(), true);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume3.getId(), true);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume3.getId(), true);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume4.getId(), true);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume4.getId(), true);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume4.getId(), true);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume4.getId(), true);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume4.getId(), true);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume4.getId(), true);
+
+        // delete volumes
+        VolumeManager.getInstance().delete(volume3.getId());
+        VolumeManager.getInstance().delete(volume4.getId());
+        // make sure only twice it was called
+        verifyStatic(Mockito.times(11));
+    }
+
+    @Test
+    @PrepareForTest({ClassHelper.class})
+    public void testGetStoreManagerForVolumeWithoutCacheSkip() throws Throwable {
+        Volume volume3 = Volume.builder().setId((short) 200)
+                .setName("TEST300")
+                .setPath("/test/300", false)
+                .setType((short) 1)
+                .setStoreType(Volume.StoreType.INTERNAL)
+                .setStoreManagerClass(MockStoreManager.class.getName()).build();
+        Volume volume4 = Volume.builder().setId((short) 201)
+                .setName("TEST400")
+                .setPath("/test/400", false)
+                .setType((short) 1)
+                .setStoreType(Volume.StoreType.EXTERNAL)
+                .setStoreManagerClass(MockStoreManager.class.getName()).build();
+
+        VolumeManager.getInstance().create(volume3);
+        VolumeManager.getInstance().create(volume4);
+
+        mockStatic(ClassHelper.class);
+        when(ClassHelper.getZimbraClassInstanceBy(Mockito.anyString())).thenReturn(new MockStoreManager());
+
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume3.getId(), false);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume3.getId(), false);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume3.getId(), false);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume3.getId(), false);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume3.getId(), false);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume4.getId(), false);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume4.getId(), false);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume4.getId(), false);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume4.getId(), false);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume4.getId(), false);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume4.getId(), false);
+
+        // delete volumes
+        VolumeManager.getInstance().delete(volume3.getId());
+        VolumeManager.getInstance().delete(volume4.getId());
+        // make sure only twice it was called
+        verifyStatic(Mockito.times(2));
+    }
+}

--- a/store/src/java-test/com/zimbra/cs/store/StoreManagerAfterReset.java
+++ b/store/src/java-test/com/zimbra/cs/store/StoreManagerAfterReset.java
@@ -1,0 +1,116 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.store;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.mailbox.Mailbox;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class StoreManagerAfterReset extends StoreManager {
+
+    @Override
+    public void startup() throws IOException, ServiceException {
+
+    }
+
+    @Override
+    public void shutdown() {
+
+    }
+
+    @Override
+    public boolean supports(StoreFeature feature) {
+        return false;
+    }
+
+    @Override
+    public boolean supports(StoreFeature feature, String locator) {
+        return false;
+    }
+
+    @Override
+    public BlobBuilder getBlobBuilder() throws IOException, ServiceException {
+        return null;
+    }
+
+    @Override
+    public Blob storeIncoming(InputStream data, boolean storeAsIs) throws IOException, ServiceException {
+        return null;
+    }
+
+    @Override
+    public StagedBlob stage(InputStream data, long actualSize, Mailbox mbox) throws IOException, ServiceException {
+        return null;
+    }
+
+    @Override
+    public StagedBlob stage(Blob blob, Mailbox mbox) throws IOException, ServiceException {
+        return null;
+    }
+
+    @Override
+    public MailboxBlob copy(MailboxBlob src, Mailbox destMbox, int destMsgId, int destRevision) throws IOException, ServiceException {
+        return null;
+    }
+
+    @Override
+    public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, int destRevision) throws IOException, ServiceException {
+        return null;
+    }
+
+    @Override
+    public MailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destMsgId, int destRevision) throws IOException, ServiceException {
+        return null;
+    }
+
+    @Override
+    public boolean delete(Blob blob) throws IOException {
+        return false;
+    }
+
+    @Override
+    public boolean delete(StagedBlob staged) throws IOException {
+        return false;
+    }
+
+    @Override
+    public boolean delete(MailboxBlob mblob) throws IOException {
+        return false;
+    }
+
+    @Override
+    public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, int revision, String locator, boolean validate) throws ServiceException {
+        return null;
+    }
+
+    @Override
+    public InputStream getContent(MailboxBlob mboxBlob) throws IOException {
+        return null;
+    }
+
+    @Override
+    public InputStream getContent(Blob blob) throws IOException {
+        return null;
+    }
+
+    @Override
+    public boolean deleteStore(Mailbox mbox, Iterable<MailboxBlob.MailboxBlobInfo> blobs) throws IOException, ServiceException {
+        return false;
+    }
+}

--- a/store/src/java-test/com/zimbra/cs/store/StoreManagerMultiThreadedTest.java
+++ b/store/src/java-test/com/zimbra/cs/store/StoreManagerMultiThreadedTest.java
@@ -1,0 +1,168 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.store;
+
+import com.zimbra.common.localconfig.ConfigException;
+import com.zimbra.common.localconfig.LC;
+import com.zimbra.common.localconfig.LocalConfig;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.store.helper.ClassHelper;
+import org.apache.commons.io.FileUtils;
+import org.apache.mina.util.ConcurrentHashSet;
+import org.dom4j.DocumentException;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.zimbra.common.localconfig.LC.zimbra_class_store;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore("javax.management.*")
+public class StoreManagerMultiThreadedTest {
+
+    private static final String TEST_CONFIG_FILE_DIR_PATH = "../store/src/java-test/";
+    private static final String TEST_CONFIG_FILE_PATH = TEST_CONFIG_FILE_DIR_PATH + "localconfig-test.xml";
+    private static final String TEST_CONFIG_FILE_COPY_PATH = TEST_CONFIG_FILE_DIR_PATH + "localconfig-test-copy.xml";
+
+    @BeforeClass
+    public static void init() throws Exception {
+        System.setProperty("zimbra.config", TEST_CONFIG_FILE_PATH);
+        MailboxTestUtil.initServer();
+        Provisioning prov = Provisioning.getInstance();
+        prov.getLocalServer().setSMRuntimeSwitchEnabled(true);
+        prov.getLocalServer().setSMMultiReaderEnabled(true);
+    }
+
+    @After
+    public void tearDownTest() throws IOException, DocumentException, ConfigException {
+        FileUtils.copyFile(new File(TEST_CONFIG_FILE_COPY_PATH), new File(TEST_CONFIG_FILE_PATH), true);
+        LC.reload();
+    }
+
+    @Test
+    public void testGetInstanceWithoutReset() throws InterruptedException {
+        Set<StoreManager> concurrentSet = new ConcurrentHashSet<>();
+        int numberOfThreads = 200;
+        ExecutorService service = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+        for (int i = 0; i < numberOfThreads; i++) {
+            service.execute(() -> {
+                concurrentSet.add(StoreManager.getInstance());
+                latch.countDown();
+            });
+        }
+        latch.await();
+        Assert.assertEquals(1, concurrentSet.size());
+    }
+
+    @Test
+    @PrepareForTest({ClassHelper.class})
+    public void testResetStoreManagerWithoutChangingLCValue() throws Throwable {
+        List newList = Collections.synchronizedList(new ArrayList<>());
+        int numberOfThreads = 200;
+        ExecutorService service = Executors.newFixedThreadPool(numberOfThreads);
+        AtomicInteger threadCounter = new AtomicInteger();
+        AtomicInteger resetCallCounter = new AtomicInteger();
+        mockStatic(ClassHelper.class);
+        when(ClassHelper.getZimbraClassInstanceBy(zimbra_class_store.value())).thenReturn(new MockStoreManager());
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+        for (int i = 0; i < numberOfThreads; i++) {
+            service.execute(() -> {
+                newList.add(StoreManager.getInstance());
+                if (threadCounter.incrementAndGet() % 19 == 0) {
+                    try {
+                        // calling reset store manager
+                        resetCallCounter.incrementAndGet();
+                        StoreManager.resetStoreManager();
+                    } catch (ServiceException | IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+                latch.countDown();
+            });
+        }
+        latch.await();
+        newList.remove(null);
+        Assert.assertEquals(numberOfThreads, newList.size());
+    }
+
+
+    @Test
+    @PrepareForTest({ClassHelper.class})
+    public void testResetStoreManagerWithChangingLCValue() throws Throwable {
+        Set<String> uniqueSM = new ConcurrentHashSet<>();
+        List smSynchronizedList = Collections.synchronizedList(new ArrayList<>());
+        int numberOfThreads = 200;
+        ExecutorService service = Executors.newFixedThreadPool(numberOfThreads);
+        AtomicInteger threadCounter = new AtomicInteger();
+        AtomicInteger resetCallCounter = new AtomicInteger();
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+        // add current store manager
+        uniqueSM.add(StoreManager.getInstance().getClass().getName());
+        for (int i = 0; i < numberOfThreads; i++) {
+            service.execute(() -> {
+                int count = threadCounter.incrementAndGet();
+                if (threadCounter.get() % 19 == 0) {
+                    try {
+                        LocalConfig localConfig = new LocalConfig(null);
+                        localConfig.set(zimbra_class_store.key(), StoreManagerAfterReset.class.getName());
+                        localConfig.save();
+                        LC.reload();
+                        // calling reset store manager
+                        resetCallCounter.incrementAndGet();
+                        StoreManager.resetStoreManager();
+                    } catch (ServiceException | IOException | DocumentException | ConfigException e) {
+                        e.printStackTrace();
+                    }
+                }
+                StoreManager storeManager = StoreManager.getInstance();
+                smSynchronizedList.add(storeManager);
+                uniqueSM.add(storeManager.getClass().getName());
+                latch.countDown();
+            });
+        }
+        latch.await();
+        verifyStatic(Mockito.times(resetCallCounter.get()));
+        // verify that it was never null instance
+        smSynchronizedList.remove(null);
+        Assert.assertEquals(numberOfThreads, smSynchronizedList.size());
+        // only two store managers
+        Assert.assertEquals(2, uniqueSM.size());
+    }
+}

--- a/store/src/java-test/localconfig-test-copy.xml
+++ b/store/src/java-test/localconfig-test-copy.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+
+<localconfig>
+  <key name="zimbra_mailbox_groups">
+    <value>1</value>
+  </key>
+  <key name="debug_disable_share_expiration_listener">
+    <value>true</value>
+  </key>
+  <key name="zimbra_home">
+    <value>build/zimbra</value>
+  </key>
+</localconfig>

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -66523,13 +66523,13 @@ public abstract class ZAttrConfig extends Entry {
     /**
      * Zimbra multiple reader StoreManagers enabled
      *
-     * @return zimbraSMMultiReaderEnabled, or false if unset
+     * @return zimbraSMMultiReaderEnabled, or true if unset
      *
      * @since ZCS 9.1.0
      */
     @ZAttr(id=4008)
     public boolean isSMMultiReaderEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraSMMultiReaderEnabled, false, true);
+        return getBooleanAttr(Provisioning.A_zimbraSMMultiReaderEnabled, true, true);
     }
 
     /**
@@ -66595,13 +66595,13 @@ public abstract class ZAttrConfig extends Entry {
     /**
      * Zimbra StoreManager runtime switching enabled
      *
-     * @return zimbraSMRuntimeSwitchEnabled, or false if unset
+     * @return zimbraSMRuntimeSwitchEnabled, or true if unset
      *
      * @since ZCS 9.1.0
      */
     @ZAttr(id=4009)
     public boolean isSMRuntimeSwitchEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraSMRuntimeSwitchEnabled, false, true);
+        return getBooleanAttr(Provisioning.A_zimbraSMRuntimeSwitchEnabled, true, true);
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -66525,9 +66525,9 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @return zimbraSMMultiReaderEnabled, or true if unset
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4008)
+    @ZAttr(id=4021)
     public boolean isSMMultiReaderEnabled() {
         return getBooleanAttr(Provisioning.A_zimbraSMMultiReaderEnabled, true, true);
     }
@@ -66538,9 +66538,9 @@ public abstract class ZAttrConfig extends Entry {
      * @param zimbraSMMultiReaderEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4008)
+    @ZAttr(id=4021)
     public void setSMMultiReaderEnabled(boolean zimbraSMMultiReaderEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, zimbraSMMultiReaderEnabled ? TRUE : FALSE);
@@ -66554,9 +66554,9 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4008)
+    @ZAttr(id=4021)
     public Map<String,Object> setSMMultiReaderEnabled(boolean zimbraSMMultiReaderEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, zimbraSMMultiReaderEnabled ? TRUE : FALSE);
@@ -66568,9 +66568,9 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4008)
+    @ZAttr(id=4021)
     public void unsetSMMultiReaderEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, "");
@@ -66583,9 +66583,9 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4008)
+    @ZAttr(id=4021)
     public Map<String,Object> unsetSMMultiReaderEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, "");
@@ -66597,9 +66597,9 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @return zimbraSMRuntimeSwitchEnabled, or true if unset
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4009)
+    @ZAttr(id=4022)
     public boolean isSMRuntimeSwitchEnabled() {
         return getBooleanAttr(Provisioning.A_zimbraSMRuntimeSwitchEnabled, true, true);
     }
@@ -66610,9 +66610,9 @@ public abstract class ZAttrConfig extends Entry {
      * @param zimbraSMRuntimeSwitchEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4009)
+    @ZAttr(id=4022)
     public void setSMRuntimeSwitchEnabled(boolean zimbraSMRuntimeSwitchEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, zimbraSMRuntimeSwitchEnabled ? TRUE : FALSE);
@@ -66626,9 +66626,9 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4009)
+    @ZAttr(id=4022)
     public Map<String,Object> setSMRuntimeSwitchEnabled(boolean zimbraSMRuntimeSwitchEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, zimbraSMRuntimeSwitchEnabled ? TRUE : FALSE);
@@ -66640,9 +66640,9 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4009)
+    @ZAttr(id=4022)
     public void unsetSMRuntimeSwitchEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, "");
@@ -66655,9 +66655,9 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4009)
+    @ZAttr(id=4022)
     public Map<String,Object> unsetSMRuntimeSwitchEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, "");

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -66521,6 +66521,150 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Zimbra multiple reader StoreManagers enabled
+     *
+     * @return zimbraSMMultiReaderEnabled, or false if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public boolean isSMMultiReaderEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraSMMultiReaderEnabled, false, true);
+    }
+
+    /**
+     * Zimbra multiple reader StoreManagers enabled
+     *
+     * @param zimbraSMMultiReaderEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public void setSMMultiReaderEnabled(boolean zimbraSMMultiReaderEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, zimbraSMMultiReaderEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Zimbra multiple reader StoreManagers enabled
+     *
+     * @param zimbraSMMultiReaderEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public Map<String,Object> setSMMultiReaderEnabled(boolean zimbraSMMultiReaderEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, zimbraSMMultiReaderEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Zimbra multiple reader StoreManagers enabled
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public void unsetSMMultiReaderEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Zimbra multiple reader StoreManagers enabled
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public Map<String,Object> unsetSMMultiReaderEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * Zimbra StoreManager runtime switching enabled
+     *
+     * @return zimbraSMRuntimeSwitchEnabled, or false if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public boolean isSMRuntimeSwitchEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraSMRuntimeSwitchEnabled, false, true);
+    }
+
+    /**
+     * Zimbra StoreManager runtime switching enabled
+     *
+     * @param zimbraSMRuntimeSwitchEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public void setSMRuntimeSwitchEnabled(boolean zimbraSMRuntimeSwitchEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, zimbraSMRuntimeSwitchEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Zimbra StoreManager runtime switching enabled
+     *
+     * @param zimbraSMRuntimeSwitchEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public Map<String,Object> setSMRuntimeSwitchEnabled(boolean zimbraSMRuntimeSwitchEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, zimbraSMRuntimeSwitchEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Zimbra StoreManager runtime switching enabled
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public void unsetSMRuntimeSwitchEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Zimbra StoreManager runtime switching enabled
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public Map<String,Object> unsetSMRuntimeSwitchEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, "");
+        return attrs;
+    }
+
+    /**
      * Specifies the JedisPool size used by SSDBEphemeralStore. Higher pool
      * sizes allow for more simultaneous connections to SSDB. A value of 0
      * will cause the pool size to be unlimited.

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -46980,6 +46980,150 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
+     * Zimbra multiple reader StoreManagers enabled
+     *
+     * @return zimbraSMMultiReaderEnabled, or false if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public boolean isSMMultiReaderEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraSMMultiReaderEnabled, false, true);
+    }
+
+    /**
+     * Zimbra multiple reader StoreManagers enabled
+     *
+     * @param zimbraSMMultiReaderEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public void setSMMultiReaderEnabled(boolean zimbraSMMultiReaderEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, zimbraSMMultiReaderEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Zimbra multiple reader StoreManagers enabled
+     *
+     * @param zimbraSMMultiReaderEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public Map<String,Object> setSMMultiReaderEnabled(boolean zimbraSMMultiReaderEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, zimbraSMMultiReaderEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Zimbra multiple reader StoreManagers enabled
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public void unsetSMMultiReaderEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Zimbra multiple reader StoreManagers enabled
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public Map<String,Object> unsetSMMultiReaderEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * Zimbra StoreManager runtime switching enabled
+     *
+     * @return zimbraSMRuntimeSwitchEnabled, or false if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public boolean isSMRuntimeSwitchEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraSMRuntimeSwitchEnabled, false, true);
+    }
+
+    /**
+     * Zimbra StoreManager runtime switching enabled
+     *
+     * @param zimbraSMRuntimeSwitchEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public void setSMRuntimeSwitchEnabled(boolean zimbraSMRuntimeSwitchEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, zimbraSMRuntimeSwitchEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Zimbra StoreManager runtime switching enabled
+     *
+     * @param zimbraSMRuntimeSwitchEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public Map<String,Object> setSMRuntimeSwitchEnabled(boolean zimbraSMRuntimeSwitchEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, zimbraSMRuntimeSwitchEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Zimbra StoreManager runtime switching enabled
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public void unsetSMRuntimeSwitchEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Zimbra StoreManager runtime switching enabled
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public Map<String,Object> unsetSMRuntimeSwitchEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, "");
+        return attrs;
+    }
+
+    /**
      * SSL certificate
      *
      * @return zimbraSSLCertificate, or null if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -46982,13 +46982,13 @@ public abstract class ZAttrServer extends NamedEntry {
     /**
      * Zimbra multiple reader StoreManagers enabled
      *
-     * @return zimbraSMMultiReaderEnabled, or false if unset
+     * @return zimbraSMMultiReaderEnabled, or true if unset
      *
      * @since ZCS 9.1.0
      */
     @ZAttr(id=4008)
     public boolean isSMMultiReaderEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraSMMultiReaderEnabled, false, true);
+        return getBooleanAttr(Provisioning.A_zimbraSMMultiReaderEnabled, true, true);
     }
 
     /**
@@ -47054,13 +47054,13 @@ public abstract class ZAttrServer extends NamedEntry {
     /**
      * Zimbra StoreManager runtime switching enabled
      *
-     * @return zimbraSMRuntimeSwitchEnabled, or false if unset
+     * @return zimbraSMRuntimeSwitchEnabled, or true if unset
      *
      * @since ZCS 9.1.0
      */
     @ZAttr(id=4009)
     public boolean isSMRuntimeSwitchEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraSMRuntimeSwitchEnabled, false, true);
+        return getBooleanAttr(Provisioning.A_zimbraSMRuntimeSwitchEnabled, true, true);
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -46984,9 +46984,9 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @return zimbraSMMultiReaderEnabled, or true if unset
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4008)
+    @ZAttr(id=4021)
     public boolean isSMMultiReaderEnabled() {
         return getBooleanAttr(Provisioning.A_zimbraSMMultiReaderEnabled, true, true);
     }
@@ -46997,9 +46997,9 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param zimbraSMMultiReaderEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4008)
+    @ZAttr(id=4021)
     public void setSMMultiReaderEnabled(boolean zimbraSMMultiReaderEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, zimbraSMMultiReaderEnabled ? TRUE : FALSE);
@@ -47013,9 +47013,9 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4008)
+    @ZAttr(id=4021)
     public Map<String,Object> setSMMultiReaderEnabled(boolean zimbraSMMultiReaderEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, zimbraSMMultiReaderEnabled ? TRUE : FALSE);
@@ -47027,9 +47027,9 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4008)
+    @ZAttr(id=4021)
     public void unsetSMMultiReaderEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, "");
@@ -47042,9 +47042,9 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4008)
+    @ZAttr(id=4021)
     public Map<String,Object> unsetSMMultiReaderEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, "");
@@ -47056,9 +47056,9 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @return zimbraSMRuntimeSwitchEnabled, or true if unset
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4009)
+    @ZAttr(id=4022)
     public boolean isSMRuntimeSwitchEnabled() {
         return getBooleanAttr(Provisioning.A_zimbraSMRuntimeSwitchEnabled, true, true);
     }
@@ -47069,9 +47069,9 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param zimbraSMRuntimeSwitchEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4009)
+    @ZAttr(id=4022)
     public void setSMRuntimeSwitchEnabled(boolean zimbraSMRuntimeSwitchEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, zimbraSMRuntimeSwitchEnabled ? TRUE : FALSE);
@@ -47085,9 +47085,9 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4009)
+    @ZAttr(id=4022)
     public Map<String,Object> setSMRuntimeSwitchEnabled(boolean zimbraSMRuntimeSwitchEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, zimbraSMRuntimeSwitchEnabled ? TRUE : FALSE);
@@ -47099,9 +47099,9 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4009)
+    @ZAttr(id=4022)
     public void unsetSMRuntimeSwitchEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, "");
@@ -47114,9 +47114,9 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4009)
+    @ZAttr(id=4022)
     public Map<String,Object> unsetSMRuntimeSwitchEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, "");

--- a/store/src/java/com/zimbra/cs/datasource/MessageContent.java
+++ b/store/src/java/com/zimbra/cs/datasource/MessageContent.java
@@ -26,6 +26,7 @@ import com.zimbra.cs.mailbox.DeliveryContext;
 import com.zimbra.cs.mime.ParsedMessage;
 import com.zimbra.cs.store.Blob;
 import com.zimbra.cs.store.StoreManager;
+import com.zimbra.cs.store.external.ExternalBlob;
 
 public class MessageContent {
     private Blob blob;
@@ -85,7 +86,12 @@ public class MessageContent {
     
     public void cleanup() throws IOException {
         if (blob != null) {
-            StoreManager.getInstance().delete(blob);
+            if (blob instanceof ExternalBlob) {
+                String locator = ((ExternalBlob)blob).getLocator();
+                StoreManager.getReaderSMInstance(locator).delete(blob);
+            } else {
+                StoreManager.getInstance().delete(blob);
+            }
             blob = null;
         }
     }

--- a/store/src/java/com/zimbra/cs/datasource/imap/ImapAppender.java
+++ b/store/src/java/com/zimbra/cs/datasource/imap/ImapAppender.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2009, 2010, 2011, 2012, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2009, 2010, 2011, 2012, 2013, 2014, 2016, 2022 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -262,7 +262,7 @@ public class ImapAppender {
             data = new Data() {
                 @Override
                 public InputStream getInputStream() throws IOException {
-                    return StoreManager.getInstance().getContent(mblob);
+                    return StoreManager.getReaderSMInstance(mblob.getLocator()).getContent(mblob);
                 }
 
                 @Override

--- a/store/src/java/com/zimbra/cs/db/DbVolume.java
+++ b/store/src/java/com/zimbra/cs/db/DbVolume.java
@@ -49,6 +49,7 @@ public final class DbVolume {
     private static final String CN_MAILBOX_GROUP_BITS = "mailbox_group_bits";
 
     private static final String CN_STORE_TYPE = "store_type";
+    private static final String CN_STORE_MANAGER_CLASS = "store_manager_class";
     private static final String CN_COMPRESS_BLOBS = "compress_blobs";
     private static final String CN_COMPRESSION_THRESHOLD = "compression_threshold";
     private static final String CN_METADATA = "metadata";
@@ -64,8 +65,8 @@ public final class DbVolume {
         PreparedStatement stmt = null;
         try {
             stmt = conn.prepareStatement("INSERT INTO volume (id, type, name, path, mailbox_group_bits, " +
-                    "mailbox_bits, file_group_bits, file_bits, compress_blobs, compression_threshold, metadata, store_type) " +
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+                    "mailbox_bits, file_group_bits, file_bits, compress_blobs, compression_threshold, metadata, store_type, store_manager_class) " +
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
             int pos = 1;
             stmt.setShort(pos++, nextId);
             stmt.setShort(pos++, volume.getType());
@@ -79,6 +80,7 @@ public final class DbVolume {
             stmt.setLong(pos++, volume.getCompressionThreshold());
             stmt.setString(pos++, volume.getMetadata().toString());
             stmt.setShort(pos++, (short)(volume.getStoreType().getStoreType()));
+            stmt.setString(pos++, volume.getStoreManagerClass());
             stmt.executeUpdate();
         } catch (SQLException e) {
             if (Db.errorMatches(e, Db.Error.DUPLICATE_ROW)) {
@@ -311,7 +313,9 @@ public final class DbVolume {
                 .setCompressBlobs(rs.getBoolean(CN_COMPRESS_BLOBS))
                 .setCompressionThreshold(rs.getLong(CN_COMPRESSION_THRESHOLD))
                 .setStoreType(storeType)
-                .setMetadata(metadata).build();
+                .setMetadata(metadata)
+                .setStoreManagerClass(rs.getString(CN_STORE_MANAGER_CLASS))
+                .build();
     }
 
     public static boolean isVolumeReferenced(DbConnection conn, short volumeId) throws ServiceException {

--- a/store/src/java/com/zimbra/cs/mailbox/MailItem.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailItem.java
@@ -1392,7 +1392,7 @@ public abstract class MailItem implements Comparable<MailItem>, ScheduledTaskRes
             if (mblob == null) {
                 throw ServiceException.FAILURE("missing blob for id: " + getId() + ", change: " + getModifiedSequence(), null);
             }
-            return StoreManager.getInstance().getContent(mblob);
+            return StoreManager.getReaderSMInstance(getLocator()).getContent(mblob);
         } catch (IOException e) {
             String msg = String.format("Unable to get content for %s %d", getClass().getSimpleName(), getId());
             throw ServiceException.FAILURE(msg, e);

--- a/store/src/java/com/zimbra/cs/mailbox/MailItem.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailItem.java
@@ -1364,7 +1364,9 @@ public abstract class MailItem implements Comparable<MailItem>, ScheduledTaskRes
      * */
     public synchronized MailboxBlob getBlob() throws ServiceException {
         if (mBlob == null && getDigest() != null) {
-            mBlob = StoreManager.getInstance().getMailboxBlob(this);
+            StoreManager storeManager = StoreManager.getReaderSMInstance(getLocator());
+            ZimbraLog.store.trace("Store Manager for %s MailboxBlob: %s ", storeManager.getClass().getSimpleName(), getId());
+            mBlob = storeManager.getMailboxBlob(this);
             if (mBlob == null) {
                 throw MailServiceException.NO_SUCH_BLOB(mMailbox.getId(), mId, mData.modContent);
             }

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -6756,7 +6756,6 @@ public class Mailbox implements MailboxStore {
         try {
             ZimbraLog.store.trace("StorageManager used for saving Draft is: %s", sm.getClass().getSimpleName());
             staged = sm.stage(is, this);
-            ZimbraLog.store.trace("Draft locator: %s", staged.getLocator());
         } finally {
             ByteUtil.closeStream(is);
         }

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -263,6 +263,7 @@ import com.zimbra.cs.store.MailboxBlobDataSource;
 import com.zimbra.cs.store.StagedBlob;
 import com.zimbra.cs.store.StoreManager;
 import com.zimbra.cs.store.StoreManager.StoreFeature;
+import com.zimbra.cs.store.external.ExternalBlob;
 import com.zimbra.cs.util.AccountUtil;
 import com.zimbra.cs.util.AccountUtil.AccountAddressMatcher;
 import com.zimbra.cs.util.SpoolingCache;
@@ -9900,19 +9901,23 @@ public class Mailbox implements MailboxStore {
                 }
                 if (deletes.blobs != null) {
                     // delete any blobs associated with items deleted from db/index
-                    StoreManager sm = StoreManager.getInstance();
                     for (MailboxBlob blob : deletes.blobs) {
+                        StoreManager sm = StoreManager.getReaderSMInstance(blob.getLocator());
                         sm.quietDelete(blob);
                     }
                 }
             }
             if (rollbackDeletes != null) {
-                StoreManager sm = StoreManager.getInstance();
                 for (Object obj : rollbackDeletes) {
                     if (obj instanceof MailboxBlob) {
+                        StoreManager sm = StoreManager.getReaderSMInstance(((MailboxBlob)obj).getLocator());
                         sm.quietDelete((MailboxBlob) obj);
                     } else if (obj instanceof Blob) {
-                        sm.quietDelete((Blob) obj);
+                        if (obj instanceof ExternalBlob) {
+                            StoreManager.getReaderSMInstance(((ExternalBlob) obj).getLocator()).quietDelete((ExternalBlob) obj);
+                        } else {
+                            StoreManager.getInstance().quietDelete((Blob) obj);
+                        }
                     }
                 }
             }

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -6753,7 +6753,9 @@ public class Mailbox implements MailboxStore {
         StagedBlob staged;
         InputStream is = pm.getRawInputStream();
         try {
+            ZimbraLog.store.trace("StorageManager used for saving Draft is: %s", sm.getClass().getSimpleName());
             staged = sm.stage(is, this);
+            ZimbraLog.store.trace("Draft locator: %s", staged.getLocator());
         } finally {
             ByteUtil.closeStream(is);
         }

--- a/store/src/java/com/zimbra/cs/mailbox/MessageCache.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MessageCache.java
@@ -127,7 +127,7 @@ public class MessageCache {
             synchronized (sCache) {
                 CacheNode node = sCache.remove(digest);
                 if (node != null) {
-                    sLog.debug("Purged digest %s from the message cache.", digest);
+                    sLog.error("Purged digest %s from the message cache.", digest);
                     sDataSize -= node.size;
                 }
             }

--- a/store/src/java/com/zimbra/cs/mailbox/MessageCache.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MessageCache.java
@@ -340,9 +340,9 @@ public class MessageCache {
             throw ServiceException.FAILURE("missing blob for id: " + item.getId() + ", change: " + item.getModifiedSequence(), null);
 
         if (item.getSize() < MESSAGE_CACHE_DISK_STREAMING_THRESHOLD) {
-            return StoreManager.getInstance().getContent(mblob);
+            return StoreManager.getReaderSMInstance(mblob.getLocator()).getContent(mblob);
         } else {
-            return StoreManager.getInstance().getContent(mblob.getLocalBlob());
+            return StoreManager.getReaderSMInstance(mblob.getLocator()).getContent(mblob.getLocalBlob());
         }
     }
 

--- a/store/src/java/com/zimbra/cs/mailbox/MessageCache.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MessageCache.java
@@ -127,7 +127,7 @@ public class MessageCache {
             synchronized (sCache) {
                 CacheNode node = sCache.remove(digest);
                 if (node != null) {
-                    sLog.error("Purged digest %s from the message cache.", digest);
+                    sLog.debug("Purged digest %s from the message cache.", digest);
                     sDataSize -= node.size;
                 }
             }

--- a/store/src/java/com/zimbra/cs/mailbox/util/MailItemHelper.java
+++ b/store/src/java/com/zimbra/cs/mailbox/util/MailItemHelper.java
@@ -1,0 +1,41 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.mailbox.util;
+
+import org.apache.commons.lang.StringUtils;
+
+import java.util.Optional;
+
+public class MailItemHelper {
+
+    public static final String VOL_ID_LOCATOR_SEPARATOR = "@@";
+
+    public static Optional<Short> findMyVolumeId(String locator) {
+
+        if (StringUtils.isNumeric(locator)) {
+            return Optional.of(Short.valueOf(locator));
+        }
+
+        if (locator.contains(VOL_ID_LOCATOR_SEPARATOR)) {
+            String[] parts = locator.split(VOL_ID_LOCATOR_SEPARATOR, 2);
+            if (parts.length ==  2 && StringUtils.isNumeric(parts[0])) {
+                return Optional.of(Short.valueOf(parts[0]));
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/store/src/java/com/zimbra/cs/redolog/op/CreateVolume.java
+++ b/store/src/java/com/zimbra/cs/redolog/op/CreateVolume.java
@@ -40,6 +40,8 @@ public final class CreateVolume extends RedoableOp {
     private short fileBits;
     private short storeType;
 
+    private String storeManagerClass;
+
     private boolean compressBlobs;
     private long compressionThreshold;
 
@@ -59,6 +61,7 @@ public final class CreateVolume extends RedoableOp {
         compressBlobs = volume.isCompressBlobs();
         compressionThreshold = volume.getCompressionThreshold();
         storeType = (short)(volume.getStoreType().getStoreType());
+        storeManagerClass = volume.getStoreManagerClass();
     }
 
     public void setId(short id) {
@@ -72,6 +75,7 @@ public final class CreateVolume extends RedoableOp {
                 .add("mboxGroupBits", mboxGroupBits).add("mboxBit", mboxBits)
                 .add("fileGroupBits", fileGroupBits).add("fileBits", fileBits)
                 .add("compressBlobs", compressBlobs).add("compressionThreshold", compressionThreshold)
+                .add("storeType", storeType).add("storeManagerClass", storeManagerClass)
                 .toString();
     }
 
@@ -86,6 +90,8 @@ public final class CreateVolume extends RedoableOp {
         out.writeShort(fileGroupBits);
         out.writeShort(fileBits);
         out.writeBoolean(compressBlobs);
+        out.writeShort(storeType);
+        out.writeUTF(storeManagerClass);
     }
 
     @Override
@@ -99,6 +105,8 @@ public final class CreateVolume extends RedoableOp {
         fileGroupBits = in.readShort();
         fileBits = in.readShort();
         compressBlobs = in.readBoolean();
+        storeType = in.readShort();
+        storeManagerClass = in.readUTF();
     }
 
     @Override
@@ -123,7 +131,9 @@ public final class CreateVolume extends RedoableOp {
                     .setMboxGroupBits(mboxGroupBits).setMboxBit(mboxBits)
                     .setFileGroupBits(fileGroupBits).setFileBits(fileBits)
                     .setCompressBlobs(compressBlobs).setCompressionThreshold(compressionThreshold)
-                    .setStoreType(enumStoreType).build();
+                    .setStoreType(enumStoreType)
+                    .setStoreManagerClass(storeManagerClass)
+                    .build();
             mgr.create(volume, getUnloggedReplay());
         } catch (VolumeServiceException e) {
             if (e.getCode() == VolumeServiceException.ALREADY_EXISTS) {

--- a/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
@@ -727,7 +727,7 @@ public class ItemActionHelper {
                 break;
             case MESSAGE:
                 try {
-                    in = StoreManager.getInstance().getContent(item.getBlob());
+                    in = StoreManager.getInstance(item.getLocator()).getContent(item.getBlob());
                     createdId = zmbx.addMessage(folderStr, flags, (String) null, item.getDate(), in, item.getSize(), true);
                 } finally {
                     ByteUtil.closeStream(in);
@@ -739,7 +739,7 @@ public class ItemActionHelper {
                 for (Message msg : msgs) {
                     flags = (mOperation == Op.UPDATE && mFlags != null ? mFlags : msg.getFlagString());
                     try {
-                        in = StoreManager.getInstance().getContent(msg.getBlob());
+                        in = StoreManager.getInstance(msg.getLocator()).getContent(msg.getBlob());
                         createdId = zmbx.addMessage(folderStr, flags, (String) null, msg.getDate(), in, msg.getSize(), true);
                     } finally {
                         ByteUtil.closeStream(in);
@@ -751,7 +751,7 @@ public class ItemActionHelper {
                 Document doc = (Document) item;
                 SoapHttpTransport transport = new SoapHttpTransport(zoptions.getUri());
                 try {
-                    in = StoreManager.getInstance().getContent(doc.getBlob());
+                    in = StoreManager.getInstance(doc.getLocator()).getContent(doc.getBlob());
                     String uploadId = zmbx.uploadContentAsStream(name, in, doc.getContentType(), doc.getSize(), 4000, true);
                     // instead of using convenience method from ZMailbox
                     // we need to hand marshall the request and set the

--- a/store/src/java/com/zimbra/cs/service/mail/RemoveAttachments.java
+++ b/store/src/java/com/zimbra/cs/service/mail/RemoveAttachments.java
@@ -73,7 +73,7 @@ public class RemoveAttachments extends MailDocumentHandler {
 
         InputStream is = null;
         try {
-            MimeMessage mm = new Mime.FixedMimeMessage(JMSession.getSession(), is = StoreManager.getInstance().getContent(msg.getBlob().getLocalBlob()));
+            MimeMessage mm = new Mime.FixedMimeMessage(JMSession.getSession(), is = StoreManager.getInstance(msg.getLocator()).getContent(msg.getBlob().getLocalBlob()));
             // do not allow removing attachments of encrypted/pkcs7-signed messages
             if (Mime.isEncrypted(mm.getContentType()) || Mime.isPKCS7Signed(mm.getContentType())) {
                 throw ServiceException.OPERATION_DENIED("not allowed to remove attachments of encrypted/pkcs7-signed message");

--- a/store/src/java/com/zimbra/cs/service/util/VolumeConfigUtil.java
+++ b/store/src/java/com/zimbra/cs/service/util/VolumeConfigUtil.java
@@ -18,6 +18,8 @@
 package com.zimbra.cs.service.util;
 
 import com.zimbra.client.ZMailbox;
+import com.zimbra.common.localconfig.LC;
+import com.zimbra.cs.store.helper.ClassHelper;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -44,6 +46,15 @@ import com.zimbra.util.ExternalVolumeInfoHandler;
 public class VolumeConfigUtil {
 
     private static final String  ROOT_PATH_ELE_SEPARATOR = "-";
+
+    /**
+     * This is default store manager
+     */
+    private static final String DEFAULT_STORE_MANAGER = "com.zimbra.cs.store.file.FileBlobStore";
+    /**
+     * This is default external store manager, not part of FOSS edition
+     */
+    private static final String DEFAULT_EXTERNAL_STORE_MANAGER = "com.zimbra.storemanagers.store.GenericStoreManager";
 
     /**
      * Validate the create volume request parameters
@@ -96,6 +107,17 @@ public class VolumeConfigUtil {
             throw VolumeServiceException.INVALID_REQUEST("Volume Compression Threshold can't be negative number", VolumeServiceException.BAD_VOLUME_COMPRESSION_THRESHOLD);
         }
 
+        if (Volume.TYPE_MESSAGE == volInfoRequest.getType() || Volume.TYPE_MESSAGE_SECONDARY == volInfoRequest.getType()) {
+            if (!StringUtil.isNullOrEmpty(volInfoRequest.getStoreManagerClass())) {
+                if (!ClassHelper.isClassExist(volInfoRequest.getStoreManagerClass())) {
+                    throw VolumeServiceException.INVALID_REQUEST("Invalid StoreManager class, can not loaded", VolumeServiceException.BAD_VOLUME_STORE_MANAGER_CLASS);
+                }
+            } else {
+                // set to default store manager if not passed.
+                setDefaultStoreManager(volInfoRequest, storeType);
+            }
+        }
+
         if (Volume.StoreType.EXTERNAL.equals(enumStoreType)) {
             // validate storage type
             String storageTypeS3 = null;
@@ -105,8 +127,8 @@ public class VolumeConfigUtil {
             String storageTypeOpenIO = null;
             if (volInfoRequest != null && volInfoRequest.getVolumeExternalOpenIOInfo() != null) {
                 storageTypeOpenIO = volInfoRequest.getVolumeExternalOpenIOInfo().getStorageType();
-            }
 
+            }
             if (storageTypeS3 != null && storageTypeOpenIO != null
                     && !storageTypeS3.equalsIgnoreCase(AdminConstants.A_VOLUME_S3)
                     && !storageTypeOpenIO.equalsIgnoreCase(AdminConstants.A_VOLUME_OPEN_IO)) {
@@ -156,6 +178,19 @@ public class VolumeConfigUtil {
                 throw VolumeServiceException.INVALID_REQUEST("Volume Storage Type can be only S3 or OpenIO",
                         VolumeServiceException.BAD_VOLUME_STORAGE_TYPE);
             }
+        }
+    }
+
+    /**
+     * Set default StoreManager for volume
+     * @param volInfoRequest
+     * @param storeType
+     */
+    private static void setDefaultStoreManager(VolumeInfo volInfoRequest, Short storeType) {
+        if (Volume.StoreType.EXTERNAL.getStoreType() == storeType.intValue()) {
+            volInfoRequest.setStoreManagerClass(DEFAULT_EXTERNAL_STORE_MANAGER);
+        } else {
+            volInfoRequest.setStoreManagerClass(DEFAULT_STORE_MANAGER);
         }
     }
 

--- a/store/src/java/com/zimbra/cs/service/util/VolumeConfigUtil.java
+++ b/store/src/java/com/zimbra/cs/service/util/VolumeConfigUtil.java
@@ -186,7 +186,11 @@ public class VolumeConfigUtil {
      * @param volInfoRequest
      * @param storeType
      */
-    private static void setDefaultStoreManager(VolumeInfo volInfoRequest, Short storeType) {
+    private static void setDefaultStoreManager(VolumeInfo volInfoRequest, Short storeType) throws ServiceException {
+        if (Volume.StoreType.EXTERNAL.getStoreType() == storeType.intValue() && !ClassHelper.isClassExist(DEFAULT_EXTERNAL_STORE_MANAGER)) {
+            throw VolumeServiceException.UNSUPPORTED_CONFIG("StoreManager for external volumes not available in this version");
+        }
+        // set default StoreManager
         if (Volume.StoreType.EXTERNAL.getStoreType() == storeType.intValue()) {
             volInfoRequest.setStoreManagerClass(DEFAULT_EXTERNAL_STORE_MANAGER);
         } else {

--- a/store/src/java/com/zimbra/cs/store/CacheEnabledStoreManagerProvider.java
+++ b/store/src/java/com/zimbra/cs/store/CacheEnabledStoreManagerProvider.java
@@ -1,0 +1,86 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.store;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.store.helper.ClassHelper;
+import com.zimbra.cs.volume.Volume;
+import com.zimbra.cs.volume.VolumeManager;
+
+import java.io.IOException;
+
+/**
+ * Cache enable store manager provier
+ */
+public class CacheEnabledStoreManagerProvider {
+
+    /**
+     * StoreManager cache
+     */
+    private static final LoadingCache<Short, StoreManager> volumeStoreManagerCacheLoader = CacheBuilder.newBuilder()
+            .build(new CacheLoader<Short, StoreManager>() {
+                @Override
+                public StoreManager load(final Short volumeId) throws Exception {
+                    return getStoreManagerForVolume(volumeId);
+                }
+            });
+
+    /**
+     * Return StoreManager from cache if skiCache false otherwise cache object will be returned
+     * @param volumeId
+     * @param skipCache
+     * @return
+     * @throws Exception
+     */
+    public static StoreManager getStoreManagerForVolume(Short volumeId, boolean skipCache) throws Exception {
+        if (skipCache) {
+            ZimbraLog.store.error("Store Manager cached for %s", volumeId);
+            return volumeStoreManagerCacheLoader.get(volumeId);
+        }
+        return getStoreManagerForVolume(volumeId);
+    }
+
+    private static StoreManager getStoreManagerForVolume(Short volumeId) throws ServiceException {
+        // load volume
+        Volume volume = VolumeManager.getInstance().getVolume(volumeId);
+        String className = volume.getStoreManagerClass();
+        StoreManager storeManager = null;
+        try {
+            ZimbraLog.store.error("loading Store Manager: %s for %s", className, volumeId);
+            storeManager = (StoreManager) ClassHelper.getZimbraClassInstanceBy(className);
+            ZimbraLog.store.debug("StoreManager loaded, starting up");
+            storeManager.startup();
+        } catch (ReflectiveOperationException e) {
+            String msg = "error while loading StoreManager class: " + className;
+            ZimbraLog.store.error(msg, e);
+            throw ServiceException.FAILURE(msg, e);
+        } catch (IOException e) {
+            String msg = "error while StoreManager.startup() for class: " + className;
+            ZimbraLog.store.error(msg, e);
+            throw ServiceException.FAILURE(msg, e);
+        }
+        return storeManager;
+    }
+
+    protected static void refreshCache(short volumeId) {
+        volumeStoreManagerCacheLoader.refresh(volumeId);
+    }
+}

--- a/store/src/java/com/zimbra/cs/store/CacheEnabledStoreManagerProvider.java
+++ b/store/src/java/com/zimbra/cs/store/CacheEnabledStoreManagerProvider.java
@@ -51,8 +51,8 @@ public class CacheEnabledStoreManagerProvider {
      * @throws Exception
      */
     public static StoreManager getStoreManagerForVolume(Short volumeId, boolean skipCache) throws Exception {
-        if (skipCache) {
-            ZimbraLog.store.error("Store Manager cached for %s", volumeId);
+        if (!skipCache) {
+            ZimbraLog.store.trace("Store Manager cached for %s", volumeId);
             return volumeStoreManagerCacheLoader.get(volumeId);
         }
         return getStoreManagerForVolume(volumeId);

--- a/store/src/java/com/zimbra/cs/store/MailboxBlobDataSource.java
+++ b/store/src/java/com/zimbra/cs/store/MailboxBlobDataSource.java
@@ -43,7 +43,7 @@ public class MailboxBlobDataSource implements DataSource {
     }
 
     public InputStream getInputStream() throws IOException {
-        return StoreManager.getInstance().getContent(mBlob);
+        return StoreManager.getReaderSMInstance(mBlob.getLocator()).getContent(mBlob);
     }
 
     public String getName() {

--- a/store/src/java/com/zimbra/cs/store/StoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/StoreManager.java
@@ -144,8 +144,8 @@ public abstract class StoreManager {
                 Optional<Short> volumeId = MailItemHelper.findMyVolumeId(locator);
                 // can check this against current primary vol.if its same then return singleton instance, but need to consider db hit
                 if (volumeId.isPresent()) {
-                    ZimbraLog.store.debug("Volume for locator: %s volumeId: %s", locator, volumeId.get());
-                    StoreManager storeManager = CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volumeId.get(), true);
+                    ZimbraLog.store.trace("Volume for locator: %s volumeId: %s", locator, volumeId.get());
+                    StoreManager storeManager = CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volumeId.get(), false);
                     if (storeManager != null) {
                         ZimbraLog.store.debug("StoreManager for %s Volume: %s ", storeManager.getClass().getSimpleName(), volumeId.get());
                         return storeManager;

--- a/store/src/java/com/zimbra/cs/store/external/ExternalBlobInputStream.java
+++ b/store/src/java/com/zimbra/cs/store/external/ExternalBlobInputStream.java
@@ -85,7 +85,7 @@ public class ExternalBlobInputStream extends BlobInputStream {
             return file;
         } else {
             ZimbraLog.store.debug("blob file no longer on disk, fetching from remote store");
-            ExternalStoreManager sm = (ExternalStoreManager) StoreManager.getInstance();
+            ExternalStoreManager sm = (ExternalStoreManager) StoreManager.getReaderSMInstance(locator);
             Blob blob = sm.getLocalBlob(mbox, locator, false);
             return blob.getFile();
         }

--- a/store/src/java/com/zimbra/cs/store/external/ExternalMailboxBlob.java
+++ b/store/src/java/com/zimbra/cs/store/external/ExternalMailboxBlob.java
@@ -36,7 +36,7 @@ public class ExternalMailboxBlob extends MailboxBlob {
 
     @Override
     public Blob getLocalBlob() throws IOException {
-        ExternalStoreManager sm = (ExternalStoreManager) StoreManager.getInstance();
+        ExternalStoreManager sm = (ExternalStoreManager) StoreManager.getReaderSMInstance(getLocator());
         Blob blob = sm.getLocalBlob(getMailbox(), getLocator());
 
         setSize(blob.getRawSize());

--- a/store/src/java/com/zimbra/cs/store/helper/ClassHelper.java
+++ b/store/src/java/com/zimbra/cs/store/helper/ClassHelper.java
@@ -1,3 +1,19 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
 package com.zimbra.cs.store.helper;
 
 import com.zimbra.common.util.StringUtil;

--- a/store/src/java/com/zimbra/cs/store/helper/ClassHelper.java
+++ b/store/src/java/com/zimbra/cs/store/helper/ClassHelper.java
@@ -1,0 +1,46 @@
+package com.zimbra.cs.store.helper;
+
+import com.zimbra.common.util.StringUtil;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.extension.ExtensionUtil;
+
+/**
+ * Class helper
+ */
+public class ClassHelper {
+
+    /**
+     * Check if the class exist on class path
+     * @param classPath
+     * @return
+     */
+    public static boolean isClassExist(String classPath) {
+        if (!StringUtil.isNullOrEmpty(classPath)) {
+            try {
+                try {
+                    Class.forName(classPath);
+                } catch (ClassNotFoundException e) {
+                    ExtensionUtil.findClass(classPath);
+                }
+                return true;
+            } catch (Exception e) {
+                ZimbraLog.store.error("unable to initialize blob store", e);
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Get Class instance by className
+     * @param className
+     * @return
+     * @throws Throwable
+     */
+    public static Object getZimbraClassInstanceBy(String className) throws ReflectiveOperationException {
+        try {
+            return Class.forName(className).newInstance();
+        } catch (Exception e) {
+            return ExtensionUtil.findClass(className).newInstance();
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/store/helper/StoreManagerResetHelper.java
+++ b/store/src/java/com/zimbra/cs/store/helper/StoreManagerResetHelper.java
@@ -1,0 +1,96 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.store.helper;
+
+import com.zimbra.common.localconfig.ConfigException;
+import com.zimbra.common.localconfig.LC;
+import com.zimbra.common.localconfig.LocalConfig;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.StringUtil;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.store.StoreManager;
+import com.zimbra.soap.admin.enums.Status;
+import com.zimbra.soap.admin.type.StoreManagerRuntimeSwitchResult;
+import org.dom4j.DocumentException;
+
+import java.io.IOException;
+
+public class StoreManagerResetHelper {
+
+    /**
+     * In Zimbra Platform StoreManager object used to work with stores(current primary and current secondary)
+     * And current store manager class name is available as part of LocalConfig attribute `zimbra_class_store`.
+     * Instance of current StoreManger is being maintained as singleton and can be accessed via
+     * {@link StoreManager} static method getInstance(), check its implementation.
+     * Now as per new design StoreManager class can be mapped to associated Volume in database
+     * column volume.store_manager_class(string) and instance of new StoreManager can be used without restarting mailboxd
+     * just by resetting singleton object and overriding LocalConfig attribute `zimbra_class_store`.
+     * Following method performs part of reset process
+     *      1. New StoreManager class validation
+     *      2. Update local config attribute `zimbra_class_store`
+     *      3. Override LocalConfig and save it.
+     *      4. Reload LocalConfig cache.
+     *      5. Initiate Singleton reset {@link StoreManager}.getInstance()
+     *
+     * @param storeManagerClass
+     * @return
+     * @throws ServiceException
+     */
+    public static StoreManagerRuntimeSwitchResult setNewStoreManager(String storeManagerClass) throws ServiceException{
+        if (Provisioning.getInstance().getLocalServer().isSMRuntimeSwitchEnabled()) {
+            return new StoreManagerRuntimeSwitchResult(Status.NO_OPERATION, "StoreManager runtime switch not enabled, enabled SMRunTimeSwitchEnabled ldap attribute");
+        }
+        if (StringUtil.isNullOrEmpty(storeManagerClass)) {
+            String message = "storeManagerClass is empty: ";
+            ZimbraLog.store.error(message);
+            return new StoreManagerRuntimeSwitchResult(Status.FAIL, message);
+        }
+        if (LC.zimbra_class_store.value().equals(storeManagerClass)) {
+            String message = "store_manager class is same as set zimbra_class_store: "+ LC.zimbra_class_store.value();
+            ZimbraLog.store.debug(message);
+            return new StoreManagerRuntimeSwitchResult(Status.FAIL, message);
+        }
+        // if class not exist then throw exception
+        if (!ClassHelper.isClassExist(storeManagerClass)) {
+            throw ServiceException.OPERATION_DENIED(" store manager class " + storeManagerClass + " not found on classPath");
+        }
+
+        // update LC attribute
+        try {
+            LocalConfig localConfig = new LocalConfig(null);
+            localConfig.set(LC.zimbra_class_store.key(), storeManagerClass);
+            localConfig.save();
+            LC.reload();
+        } catch (DocumentException | ConfigException | IOException e) {
+            ZimbraLog.store.error("Error while updating LC.zimbra_class_store to StoreManager: %s", storeManagerClass, e);
+            return new StoreManagerRuntimeSwitchResult(Status.FAIL, "not able to update LC.zimbra_class_store with new StoreManager:" + storeManagerClass);
+        }
+
+        try {
+            // verify if its set correctly or not
+            if (!LC.zimbra_class_store.value().equals(storeManagerClass)) {
+                throw ServiceException.OPERATION_DENIED("not able to update StoreManager class " + storeManagerClass + " in cached zimbra_class_store attr");
+            }
+            StoreManager.resetStoreManager();
+        } catch (ServiceException | IOException e) {
+            ZimbraLog.store.error("not able to reset StoreManager: %s", storeManagerClass, e);
+            return new StoreManagerRuntimeSwitchResult(Status.FAIL, "not able to reset StoreManager:" + storeManagerClass);
+        }
+        return new StoreManagerRuntimeSwitchResult(Status.SUCCESS, "StoreManager LC updated with " + storeManagerClass + " and StoreManager.reset called");
+    }
+}

--- a/store/src/java/com/zimbra/cs/volume/Volume.java
+++ b/store/src/java/com/zimbra/cs/volume/Volume.java
@@ -68,6 +68,8 @@ public final class Volume {
 
     private StoreType storeType;
 
+    private String storeManagerClass;
+
     public static enum StoreType {
         INTERNAL(1),
         EXTERNAL(2);
@@ -181,6 +183,7 @@ public final class Volume {
             volume.compressionThreshold = copy.compressionThreshold;
             volume.metadata = copy.metadata;
             volume.storeType = copy.storeType;
+            volume.storeManagerClass = copy.storeManagerClass;
         }
 
         public Builder setId(short id) {
@@ -245,6 +248,11 @@ public final class Volume {
 
         public Builder setStoreType(StoreType storeType) {
             volume.storeType = storeType;
+            return this;
+        }
+
+        public Builder setStoreManagerClass(String storageManagerClass) {
+            volume.storeManagerClass = storageManagerClass;
             return this;
         }
 
@@ -353,6 +361,10 @@ public final class Volume {
 
     public StoreType getStoreType() {
         return storeType;
+    }
+
+    public String getStoreManagerClass() {
+        return storeManagerClass;
     }
 
     public static String getAbsolutePath(String path) throws ServiceException {
@@ -495,6 +507,7 @@ public final class Volume {
                 .add("fileGroupBits", fileGroupBits).add("fileBits", fileBits)
                 .add("compressBlobs", compressBlobs).add("compressionThreshold", compressionThreshold)
                 .add("storeType", storeType)
+                .add("storeManagerClass", storeManagerClass)
                 .toString();
     }
 
@@ -513,6 +526,7 @@ public final class Volume {
         jaxb.setCurrent(VolumeManager.getInstance().isCurrent(this));
         short value = (short)(this.getStoreType().getStoreType());
         jaxb.setStoreType(value);
+        jaxb.setStoreManagerClass(storeManagerClass);
         return jaxb;
     }
 }

--- a/store/src/java/com/zimbra/cs/volume/VolumeCLI.java
+++ b/store/src/java/com/zimbra/cs/volume/VolumeCLI.java
@@ -94,7 +94,7 @@ public final class VolumeCLI extends SoapCLI {
     private static final String H_ACCOUNT_PORT = "Account port";
     private static final String H_ACCOUNT = "Name of account";
     private static final String H_NAME_SPACE = "Namespace";
-
+    private static final String H_STORE_MANAGER_CLASS = "Optional parameter to specify non-default store manager class path";
     private static final String A_ID = "id";
     private static final String A_TYPE = "type";
     private static final String A_PATH = "path";
@@ -138,6 +138,7 @@ public final class VolumeCLI extends SoapCLI {
     private String accountPort;
     private String nameSpace;
     private String account;
+    private String storeManagerClass;
 
     private void setArgs(CommandLine cl) throws ServiceException, ParseException, IOException {
         auth = getZAuthToken(cl);
@@ -157,6 +158,7 @@ public final class VolumeCLI extends SoapCLI {
         accountPort = cl.getOptionValue(O_AP);
         nameSpace = cl.getOptionValue(O_NS);
         account = cl.getOptionValue(O_ACCOUNT);
+        storeManagerClass = cl.getOptionValue(O_SMC);
     }
 
     public static void main(String[] args) {
@@ -327,6 +329,9 @@ public final class VolumeCLI extends SoapCLI {
         vol.setName(name);
         vol.setCompressBlobs(compress != null ? Boolean.parseBoolean(compress) : false);
         vol.setCompressionThreshold(compressThreshold != null ? Long.parseLong(compressThreshold) : 4096L);
+        if (!Strings.isNullOrEmpty(storeManagerClass)) {
+            vol.setStoreManagerClass(storeManagerClass);
+        }
         validateAddCommand(vol);
         CreateVolumeRequest req = new CreateVolumeRequest(vol);
         auth();
@@ -514,6 +519,8 @@ public final class VolumeCLI extends SoapCLI {
         options.addOption(new Option(O_URL, A_URL, true, H_URL));
         options.addOption(new Option(O_NS, A_NAME_SPACE, true, H_NAME_SPACE));
         options.addOption(new Option(O_ACCOUNT, A_ACCOUNT, true, H_ACCOUNT));
+
+        options.addOption(new Option(O_SMC, A_STORE_MANAGER_CLASS, true, H_STORE_MANAGER_CLASS));
     }
 
     @Override
@@ -549,12 +556,14 @@ public final class VolumeCLI extends SoapCLI {
         printOpt(O_VP, 0);
         printOpt(O_STP, 0);
         printOpt(O_BID, 0);
+
         printOpt(O_PP, 0);
         printOpt(O_AP, 0);
         printOpt(O_ACCOUNT, 0);
         printOpt(O_URL, 0);
         printOpt(O_NS, 0);
 
+        printOpt(O_SMC, 0);
     }
 
     private void printOpt(String optStr, int leftPad) {

--- a/store/src/java/com/zimbra/cs/volume/VolumeCLI.java
+++ b/store/src/java/com/zimbra/cs/volume/VolumeCLI.java
@@ -61,6 +61,8 @@ public final class VolumeCLI extends SoapCLI {
     private static final String O_C = "c";
     private static final String O_CT = "ct";
 
+    private static final String O_SMC = "smc";
+    
     /** attributes for external storetype **/
     private static final String O_ST = "st";
     private static final String O_VP = "vp";
@@ -100,6 +102,8 @@ public final class VolumeCLI extends SoapCLI {
     private static final String A_COMPRESS = "compress";
     private static final String A_COMPRESS_THRESHOLD = "compressThreshold";
     private static final String A_STORE_TYPE = "storeType";
+
+    private static final String A_STORE_MANAGER_CLASS = "storeManagerClass";
     private static final String A_STORAGE_TYPE = "storageType";
     private static final String A_BUCKET_ID = "bucketId";
     private static final String A_VOLUME_PREFIX = "volumePrefix";

--- a/store/src/java/com/zimbra/cs/volume/VolumeServiceException.java
+++ b/store/src/java/com/zimbra/cs/volume/VolumeServiceException.java
@@ -45,6 +45,7 @@ public final class VolumeServiceException extends ServiceException {
     public static final String BAD_VOLUME_USE_IN_FREQUENT_ACCESS            = "volume.BAD_USE_IN_FREQUENT_ACCESS";
     public static final String BAD_VOLUME_USE_INTELLIGENT_TIERING           = "volume.BAD_USE_INTELLIGENT_TIERING";
     public static final String BAD_VOLUME_STORAGE_TYPE                      = "volume.BAD_STORAGE_TYPE";
+    public static final String BAD_VOLUME_STORE_MANAGER_CLASS               = "volume.STORE_MANAGER_CLASS";
     public static final String BAD_VOLUME_USE_IN_FREQUENT_ACCESS_THRESHOLD  = "volume.BAD_USE_IN_FREQUENT_ACCESS_THRESHOLD";
     public static final String BAD_VOLUME_GLOBAL_BUCKET_ID                  = "volume.BAD_GLOBAL_BUCKET_ID";
 


### PR DESCRIPTION
This is just a clean version of https://github.com/Zimbra/zm-mailbox/pull/1335
### **Problem:**
Support Inbox blobs which are located on multiple volumes of different types.

### **Solution:**
**Single Current StoreManager and multiple secondary store managers (readers)**
There will be a single current store manager that can be accessible StoreManager.getInstance() for writing new emails. and for reading/deleting email there will be multiple secondary store managers in memory based on the location of email blobs from where it needs to be read.

**How do decide which store manager should get used to reading data from volume?**
This information will be available as part of the volume table as a new column "store_manager_class"([ZCS-11725](https://jira.corp.synacor.com/browse/ZCS-11725)).

**how to update the Current Writer Store Manager if the current primary volume changed?**
Once the current primary volume changes current store manager should get reset to the new store manager which is available as part of the volume.store_manager_class column value.

### **Change Included**
Support emails loading from multiple volumes and switch store managers on the fly
Multiple reader StoreManagers to support reading blobs from multiple volumes
Modify CreateVolume SOAP API to persist "storeManagerClass" attribute in column "store_manager_class"
Reset current writer StoreManager when the current primary volume changed
More details -> https://jira.corp.synacor.com/browse/ZCS-11656