### PR TITLE
ZCS-11823: add custom mime type for rtf file detection

### DIFF
--- a/store-conf/conf/custom-mimetypes.xml
+++ b/store-conf/conf/custom-mimetypes.xml
@@ -60,4 +60,14 @@
         <sub-class-of type="text/plain"/>
     </mime-type>
 
+    <mime-type type="application/rtf">
+        <_comment>Rich Text Format File</_comment>
+        <alias type="text/rtf"/>
+        <magic priority="50">
+            <match value="{\\rtf" type="string" offset="0"/>
+        </magic>
+        <glob pattern="*.rtf"/>
+        <sub-class-of type="text/plain"/>
+    </mime-type>
+
 </mime-info>


### PR DESCRIPTION
Issue
Preview for RTF file in email attachment is showing the file code instead of text content as the content type being detected for rtf is text/plain

Fix
Added custom mime type support for detecting the correct mime type for RTF files to show content type as application/rtf