### PR TITLE
ZCS-11675 Add support for OpenIO volume configuration.

### DIFF
--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -1169,6 +1169,7 @@ public final class AdminConstants {
     public static final String E_NUM_OF_PAGES = "numpages";
     public static final String E_VOLUME = "volume";
     public static final String E_VOLUME_EXT = "volumeExternalInfo";
+    public static final String E_VOLUME_OPENIO_EXT = "volumeExternalOpenIoInfo";
     public static final String E_PROGRESS = "progress";
     public static final String E_SOAP_URL = "soapURL";
     public static final String E_ADMIN_SOAP_URL = "adminSoapURL";
@@ -1303,6 +1304,13 @@ public final class AdminConstants {
     public static final String A_VOLUME_USE_IN_FREQ_ACCESS = "useInFrequentAccess";
     public static final String A_VOLUME_USE_IN_FREQ_ACCESS_THRESHOLD = "useInFrequentAccessThreshold";
     public static final String A_VOLUME_USE_INTELLIGENT_TIERING = "useIntelligentTiering";
+    public static final String A_VOLUME_URL = "url";
+    public static final String A_VOLUME_ACCOUNT = "account";
+    public static final String A_VOLUME_NAMESPACE = "nameSpace";
+    public static final String A_VOLUME_PROXY_PORT= "proxyPort";
+    public static final String A_VOLUME_ACCOUNT_PORT = "accountPort";
+    public static final String A_VOLUME_S3 = "S3";
+    public static final String A_VOLUME_OPEN_IO = "OPENIO";
 
     // Blob consistency check
     public static final String E_MISSING_BLOBS = "missingBlobs";

--- a/soap/ivy.xml
+++ b/soap/ivy.xml
@@ -27,5 +27,6 @@
   <dependency org="org.apache.james" name="apache-jsieve-core" rev="0.5"/>
   <dependency org="zimbra" name="zm-common" rev="latest.integration" />
   <dependency org="ant-contrib" name="ant-contrib" rev="1.0b3" />
+  <dependency org="org.json" name="json" rev="20090211"/>
  </dependencies>
 </ivy-module>

--- a/soap/src/java/com/zimbra/soap/admin/type/BaseExternalVolume.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/BaseExternalVolume.java
@@ -1,0 +1,47 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.type;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import org.json.JSONException;
+import org.json.JSONObject;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+
+
+import com.zimbra.common.soap.AdminConstants;
+
+@XmlAccessorType(XmlAccessType.NONE)
+abstract class BaseExternalVolume {
+    /**
+     * @zm-api-field-description Set to 1 for Internal and 2 for External.
+     */
+    @XmlAttribute(name=AdminConstants.A_VOLUME_STORAGE_TYPE /* storageType */, required=false)
+    private String storageType;
+
+    public void setStorageType(String value) {
+        storageType = value;
+    }
+
+    public String getStorageType() {
+        return storageType;
+    }
+
+    public abstract JSONObject toJSON(VolumeInfo volumeInfo) throws JSONException;
+
+}

--- a/soap/src/java/com/zimbra/soap/admin/type/VolumeExternalInfo.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/VolumeExternalInfo.java
@@ -21,16 +21,14 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import com.zimbra.common.soap.AdminConstants;
 
 @XmlAccessorType(XmlAccessType.NONE)
-public class VolumeExternalInfo {
 
-    /**
-     * @zm-api-field-description Set to 1 for Internal and 2 for External.
-     */
-    @XmlAttribute(name=AdminConstants.A_VOLUME_STORAGE_TYPE /* storageType */, required=false)
-    private String storageType = "S3";
+public class VolumeExternalInfo extends BaseExternalVolume{
 
     /**
      * @zm-api-field-description Prefix for bucket location e.g. server1_primary
@@ -61,14 +59,6 @@ public class VolumeExternalInfo {
      */
     @XmlAttribute(name=AdminConstants.A_VOLUME_USE_INTELLIGENT_TIERING /* useIntelligentTiering */, required=false)
     private boolean useIntelligentTiering = false;
-
-    public void setStorageType(String value) {
-        storageType = value;
-    }
-
-    public String getStorageType() {
-        return storageType;
-    }
 
     public void setVolumePrefix(String value) {
         volumePrefix = value;
@@ -108,5 +98,30 @@ public class VolumeExternalInfo {
 
     public int getUseInFrequentAccessThreshold() {
         return useInFrequentAccessThreshold;
+    }
+
+	@Override
+    public JSONObject toJSON(VolumeInfo volInfo) throws JSONException {
+        VolumeExternalInfo volExtInfo = volInfo.getVolumeExternalInfo();
+        JSONObject volExtInfoObj = new JSONObject();
+        volExtInfoObj.put(AdminConstants.A_VOLUME_ID, String.valueOf(volInfo.getId()));
+        volExtInfoObj.put(AdminConstants.A_VOLUME_STORAGE_TYPE, volExtInfo.getStorageType());
+        volExtInfoObj.put(AdminConstants.A_VOLUME_VOLUME_PREFIX, volExtInfo.getVolumePrefix());
+        volExtInfoObj.put(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS, String.valueOf(volExtInfo.isUseInFrequentAccess()));
+        volExtInfoObj.put(AdminConstants.A_VOLUME_USE_INTELLIGENT_TIERING, String.valueOf(volExtInfo.isUseIntelligentTiering()));
+        volExtInfoObj.put(AdminConstants.A_VOLUME_GLB_BUCKET_CONFIG_ID, volExtInfo.getGlobalBucketConfigurationId());
+        volExtInfoObj.put(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS_THRESHOLD, String.valueOf(volExtInfo.getUseInFrequentAccessThreshold()));
+        return volExtInfoObj;
+    }
+
+    public VolumeExternalInfo toExternalInfo(JSONObject properties) throws JSONException {
+        VolumeExternalInfo volExtInfo = new VolumeExternalInfo();
+        volExtInfo.setVolumePrefix(properties.getString(AdminConstants.A_VOLUME_VOLUME_PREFIX));
+        volExtInfo.setGlobalBucketConfigurationId(properties.getString(AdminConstants.A_VOLUME_GLB_BUCKET_CONFIG_ID));
+        volExtInfo.setUseInFrequentAccess(Boolean.valueOf(properties.getString(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS)));
+        volExtInfo.setUseIntelligentTiering(Boolean.valueOf(properties.getString(AdminConstants.A_VOLUME_USE_INTELLIGENT_TIERING)));
+        volExtInfo.setUseInFrequentAccessThreshold(Integer.parseInt(properties.getString(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS_THRESHOLD)));
+        volExtInfo.setStorageType(properties.getString(AdminConstants.A_VOLUME_STORAGE_TYPE));
+        return volExtInfo;
     }
 }

--- a/soap/src/java/com/zimbra/soap/admin/type/VolumeExternalOpenIOInfo.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/VolumeExternalOpenIOInfo.java
@@ -1,0 +1,127 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.type;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+
+import com.zimbra.common.soap.AdminConstants;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+@XmlAccessorType(XmlAccessType.NONE)
+
+public class VolumeExternalOpenIOInfo extends BaseExternalVolume {
+
+    /**
+     * @zm-api-field-description Specifies the standard HTTP URL for OpenIO
+     */
+    @XmlAttribute(name=AdminConstants.A_VOLUME_URL /* url */, required=false)
+    private String url;
+
+    /**
+     * @zm-api-field-description Specifies OpenIO account name
+     */
+    @XmlAttribute(name=AdminConstants.A_VOLUME_ACCOUNT/* account */, required=false)
+    private String account;
+
+    /**
+     * @zm-api-field-description Specifies OpenIO namespace
+     */
+    @XmlAttribute(name=AdminConstants.A_VOLUME_NAMESPACE /* namespace */, required=false)
+    private String nameSpace;
+
+    /**
+     * @zm-api-field-description Specifies OpenIO proxy port
+     */
+    @XmlAttribute(name=AdminConstants.A_VOLUME_PROXY_PORT /* proxyPort */, required=false)
+    private Integer proxyPort = -1;
+
+    /**
+     * @zm-api-field-description Specifies OpenIO account port
+     */
+    @XmlAttribute(name=AdminConstants.A_VOLUME_ACCOUNT_PORT /* accountPort */, required=false)
+    private Integer accountPort = -1;
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getAccount() {
+        return account;
+    }
+
+    public void setAccount(String account) {
+        this.account = account;
+    }
+
+    public String getNameSpace() {
+        return nameSpace;
+    }
+
+    public void setNameSpace(String nameSpace) {
+        this.nameSpace = nameSpace;
+    }
+
+    public Integer getProxyPort() {
+        return proxyPort;
+    }
+
+    public void setProxyPort(Integer proxyPort) {
+        this.proxyPort = proxyPort;
+    }
+
+    public Integer getAccountPort() {
+        return accountPort;
+    }
+
+    public void setAccountPort(Integer accountPort) {
+        this.accountPort = accountPort;
+    }
+
+	@Override
+    public JSONObject toJSON(VolumeInfo volInfo) throws JSONException {
+        VolumeExternalOpenIOInfo volExtOpenIOInfo = volInfo.getVolumeExternalOpenIOInfo();
+        JSONObject volExtInfoObj = new JSONObject();
+        volExtInfoObj.put(AdminConstants.A_VOLUME_ID, String.valueOf(volInfo.getId()));
+        volExtInfoObj.put(AdminConstants.A_VOLUME_STORAGE_TYPE, volExtOpenIOInfo.getStorageType());
+        volExtInfoObj.put(AdminConstants.A_VOLUME_URL, String.valueOf(volExtOpenIOInfo.getUrl()));
+        volExtInfoObj.put(AdminConstants.A_VOLUME_ACCOUNT, String.valueOf(volExtOpenIOInfo.getAccount()));
+        volExtInfoObj.put(AdminConstants.A_VOLUME_NAMESPACE, String.valueOf(volExtOpenIOInfo.getNameSpace()));
+        volExtInfoObj.put(AdminConstants.A_VOLUME_PROXY_PORT, String.valueOf(volExtOpenIOInfo.getProxyPort()));
+        volExtInfoObj.put(AdminConstants.A_VOLUME_ACCOUNT_PORT, String.valueOf(volExtOpenIOInfo.getAccountPort()));
+        return volExtInfoObj;
+    }
+
+    public VolumeExternalOpenIOInfo toExternalOpenIoInfo(JSONObject properties) throws JSONException {
+        VolumeExternalOpenIOInfo volExtOpenIOInfo = new VolumeExternalOpenIOInfo();
+        volExtOpenIOInfo.setUrl(properties.getString(AdminConstants.A_VOLUME_URL));
+        volExtOpenIOInfo.setAccount(properties.getString(AdminConstants.A_VOLUME_ACCOUNT));
+        volExtOpenIOInfo.setNameSpace(properties.getString(AdminConstants.A_VOLUME_NAMESPACE));
+        volExtOpenIOInfo.setAccountPort(Integer.parseInt(properties.getString(AdminConstants.A_VOLUME_ACCOUNT_PORT)));
+        volExtOpenIOInfo.setProxyPort(Integer.parseInt(properties.getString(AdminConstants.A_VOLUME_PROXY_PORT)));
+        volExtOpenIOInfo.setStorageType(properties.getString(AdminConstants.A_VOLUME_STORAGE_TYPE));
+        return volExtOpenIOInfo;
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/type/VolumeInfo.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/VolumeInfo.java
@@ -112,10 +112,16 @@ public final class VolumeInfo {
     private short storeType = 1;
 
     /**
-     * @zm-api-field-description Volume external information
+     * @zm-api-field-description Volume external information for S3
      */
     @XmlElement(name=AdminConstants.E_VOLUME_EXT /* volumeExternalInfo */, required=false)
     private VolumeExternalInfo volumeExternalInfo;
+
+    /**
+     * @zm-api-field-description Volume external information for OpenIO
+     */
+    @XmlElement(name=AdminConstants.E_VOLUME_OPENIO_EXT /* volumeExternalOpenIOInfo */, required=false)
+    private VolumeExternalOpenIOInfo volumeExternalOpenIOInfo;
 
     public void setId(short value) {
         id = value;
@@ -219,5 +225,13 @@ public final class VolumeInfo {
 
     public short getStoreType() {
         return storeType;
+    }
+
+    public VolumeExternalOpenIOInfo getVolumeExternalOpenIOInfo() {
+        return volumeExternalOpenIOInfo;
+    }
+
+    public void setVolumeExternalOpenIOInfo(VolumeExternalOpenIOInfo volumeExternalOpenIOInfo) {
+        this.volumeExternalOpenIOInfo = volumeExternalOpenIOInfo;
     }
 }

--- a/store/src/java/com/zimbra/cs/service/admin/ModifyVolume.java
+++ b/store/src/java/com/zimbra/cs/service/admin/ModifyVolume.java
@@ -20,6 +20,8 @@ package com.zimbra.cs.service.admin;
 import java.util.List;
 import java.util.Map;
 
+import org.json.JSONException;
+
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
 import com.zimbra.cs.account.Provisioning;
@@ -27,6 +29,7 @@ import com.zimbra.cs.account.accesscontrol.AdminRight;
 import com.zimbra.cs.account.accesscontrol.Rights.Admin;
 import com.zimbra.cs.service.util.VolumeConfigUtil;
 import com.zimbra.cs.store.StoreManager;
+import com.zimbra.cs.volume.VolumeServiceException;
 import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.admin.message.ModifyVolumeRequest;
@@ -44,7 +47,11 @@ public final class ModifyVolume extends AdminDocumentHandler {
         ZimbraSoapContext zsc = getZimbraSoapContext(ctx);
         checkRight(zsc, ctx, Provisioning.getInstance().getLocalServer(), Admin.R_manageVolume);
 
-        VolumeConfigUtil.parseModifyVolumeRequest(req);
+        try {
+            VolumeConfigUtil.parseModifyVolumeRequest(req);
+        } catch (JSONException e) {
+            throw VolumeServiceException.INVALID_REQUEST("Format is not correct Exception", VolumeServiceException.INVALID_REQUEST);
+        }
         return new ModifyVolumeResponse();
     }
 

--- a/store/src/java/com/zimbra/cs/service/util/VolumeConfigUtil.java
+++ b/store/src/java/com/zimbra/cs/service/util/VolumeConfigUtil.java
@@ -37,6 +37,7 @@ import com.zimbra.soap.admin.message.GetAllVolumesResponse;
 import com.zimbra.soap.admin.message.GetVolumeRequest;
 import com.zimbra.soap.admin.message.GetVolumeResponse;
 import com.zimbra.soap.admin.type.VolumeExternalInfo;
+import com.zimbra.soap.admin.type.VolumeExternalOpenIOInfo;
 import com.zimbra.soap.admin.type.VolumeInfo;
 import com.zimbra.util.ExternalVolumeInfoHandler;
 
@@ -62,8 +63,15 @@ public class VolumeConfigUtil {
         }
 
         // validate/set root path if store type is external
-        if (Volume.StoreType.EXTERNAL.getStoreType() == storeType.intValue()) {
+        if (volInfoRequest != null && volInfoRequest.getVolumeExternalInfo() != null
+                && Volume.StoreType.EXTERNAL.getStoreType() == storeType.intValue()) {
             String extRootPath = "/" + volInfoRequest.getVolumeExternalInfo().getStorageType() + "-" + volInfoRequest.getName() + "-" + volInfoRequest.getVolumeExternalInfo().getGlobalBucketConfigurationId();
+            volInfoRequest.setRootPath(extRootPath);
+        }
+
+        if (volInfoRequest != null && volInfoRequest.getVolumeExternalOpenIOInfo() != null
+                && Volume.StoreType.EXTERNAL.getStoreType() == storeType.intValue()) {
+            String extRootPath = "/" + volInfoRequest.getVolumeExternalOpenIOInfo().getStorageType() + "-" + volInfoRequest.getName();
             volInfoRequest.setRootPath(extRootPath);
         }
 
@@ -83,56 +91,71 @@ public class VolumeConfigUtil {
             throw VolumeServiceException.INVALID_REQUEST("Volume Type can be 1 for PRIMARY volume, 2 for SECONDARY volume or 10 for INDEX volume", VolumeServiceException.BAD_VOLUME_TYPE);
         }
 
-        // validate compress blobs
-        if (false != volInfoRequest.isCompressBlobs() &&
-            true != volInfoRequest.isCompressBlobs()) {
-            throw VolumeServiceException.INVALID_REQUEST("Volume Compress Blobs can be TRUE, FALSE or OPTIONAL(don't provide)", VolumeServiceException.BAD_VOLUME_COMPRESS_BLOBS);
-        }
-
         // validate compression threshold
         if (0 > volInfoRequest.getCompressionThreshold()) {
             throw VolumeServiceException.INVALID_REQUEST("Volume Compression Threshold can't be negative number", VolumeServiceException.BAD_VOLUME_COMPRESSION_THRESHOLD);
         }
 
-        // validate current
-        if (false != volInfoRequest.isCurrent() &&
-            true != volInfoRequest.isCurrent()) {
-            throw VolumeServiceException.INVALID_REQUEST("Volume Current can be TRUE, FALSE or OPTIONAL(don't provide)", VolumeServiceException.BAD_VOLUME_CURRENT);
-        }
-
-        if (enumStoreType.equals(Volume.StoreType.EXTERNAL)) {
-            // validate use in frequent access
-            if (false != volInfoRequest.getVolumeExternalInfo().isUseInFrequentAccess() &&
-                true != volInfoRequest.getVolumeExternalInfo().isUseInFrequentAccess()) {
-                throw VolumeServiceException.INVALID_REQUEST("Volume UseInFrequentAccess can be TRUE, FALSE or OPTIONAL(don't provide)", VolumeServiceException.BAD_VOLUME_USE_IN_FREQUENT_ACCESS);
-            }
-
-            // validate use intelligent tiering
-            if (false != volInfoRequest.getVolumeExternalInfo().isUseIntelligentTiering() &&
-                true != volInfoRequest.getVolumeExternalInfo().isUseIntelligentTiering()) {
-                throw VolumeServiceException.INVALID_REQUEST("Volume UseIntelligentTiering can be TRUE, FALSE or OPTIONAL(don't provide)", VolumeServiceException.BAD_VOLUME_USE_INTELLIGENT_TIERING);
-            }
-
+        if (Volume.StoreType.EXTERNAL.equals(enumStoreType)) {
             // validate storage type
-            String storageType = volInfoRequest.getVolumeExternalInfo().getStorageType();
-            if (false == storageType.equals("S3")) {
-                throw VolumeServiceException.INVALID_REQUEST("Volume Storage Type can be only S3", VolumeServiceException.BAD_VOLUME_STORAGE_TYPE);
-
+            String storageTypeS3 = null;
+            if (volInfoRequest != null && volInfoRequest.getVolumeExternalInfo() != null) {
+                storageTypeS3 = volInfoRequest.getVolumeExternalInfo().getStorageType();
+            }
+            String storageTypeOpenIO = null;
+            if (volInfoRequest != null && volInfoRequest.getVolumeExternalOpenIOInfo() != null) {
+                storageTypeOpenIO = volInfoRequest.getVolumeExternalOpenIOInfo().getStorageType();
             }
 
-            // validate use in frequent access threshold
-            int useInFrequentAccessThreshold = volInfoRequest.getVolumeExternalInfo().getUseInFrequentAccessThreshold();
-            if (0 > useInFrequentAccessThreshold) {
-                throw VolumeServiceException.INVALID_REQUEST("Volume UseInFrequentAccessThreshold can't be negative number", VolumeServiceException.BAD_VOLUME_USE_IN_FREQUENT_ACCESS_THRESHOLD);
+            if (storageTypeS3 != null && storageTypeOpenIO != null
+                    && !storageTypeS3.equalsIgnoreCase(AdminConstants.A_VOLUME_S3)
+                    && !storageTypeOpenIO.equalsIgnoreCase(AdminConstants.A_VOLUME_OPEN_IO)) {
+                throw VolumeServiceException.INVALID_REQUEST("Volume Storage Type can be only S3 or OpenIO",
+                        VolumeServiceException.BAD_VOLUME_STORAGE_TYPE);
             }
 
-            // validate global bucket id
-            String globalS3BucketId = volInfoRequest.getVolumeExternalInfo().getGlobalBucketConfigurationId();
-            if (false == extVolInfoHandler.validateGlobalBucketID(globalS3BucketId)) {
-                throw VolumeServiceException.INVALID_REQUEST("Volume GlobalBucketID provided is incorrect, missing or empty", VolumeServiceException.BAD_VOLUME_GLOBAL_BUCKET_ID);
-            }
+            if (AdminConstants.A_VOLUME_S3.equalsIgnoreCase(storageTypeS3)) {
+                // validate use in frequent access threshold
+                int useInFrequentAccessThreshold = volInfoRequest.getVolumeExternalInfo().getUseInFrequentAccessThreshold();
+                if (useInFrequentAccessThreshold < 0) {
+                    throw VolumeServiceException.INVALID_REQUEST("Volume UseInFrequentAccessThreshold can't be negative number", VolumeServiceException.BAD_VOLUME_USE_IN_FREQUENT_ACCESS_THRESHOLD);
+                }
 
-            // no validation for volume prefix as of now
+                // validate global bucket id
+                String globalS3BucketId = volInfoRequest.getVolumeExternalInfo().getGlobalBucketConfigurationId();
+                if (!extVolInfoHandler.validateGlobalBucketID(globalS3BucketId)) {
+                    throw VolumeServiceException.INVALID_REQUEST("Volume GlobalBucketID provided is incorrect, missing or empty", VolumeServiceException.BAD_VOLUME_GLOBAL_BUCKET_ID);
+                }
+                // no validation for volume prefix as of now
+            } else if (AdminConstants.A_VOLUME_OPEN_IO.equalsIgnoreCase(storageTypeOpenIO)) {
+                // validate proxy port as positive
+                if (volInfoRequest.getVolumeExternalOpenIOInfo().getProxyPort() <= 0) {
+                    throw VolumeServiceException.INVALID_REQUEST("Proxy port can't be negative number or null", VolumeServiceException.BAD_VOLUME_USE_IN_FREQUENT_ACCESS_THRESHOLD);
+                }
+
+                // validate account port as positive
+                if (volInfoRequest.getVolumeExternalOpenIOInfo().getAccountPort() <= 0) {
+                    throw VolumeServiceException.INVALID_REQUEST("Account port can't be negative number or null", VolumeServiceException.BAD_VOLUME_USE_IN_FREQUENT_ACCESS_THRESHOLD);
+                }
+
+                // validate url is empty or not
+                if (StringUtil.isNullOrEmpty(volInfoRequest.getVolumeExternalOpenIOInfo().getUrl())) {
+                    throw VolumeServiceException.INVALID_REQUEST("Url can't be null", VolumeServiceException.BAD_VOLUME_USE_IN_FREQUENT_ACCESS_THRESHOLD);
+                }
+
+                // validate account is empty or not
+                if (StringUtil.isNullOrEmpty(volInfoRequest.getVolumeExternalOpenIOInfo().getAccount())) {
+                    throw VolumeServiceException.INVALID_REQUEST("Account can't be null", VolumeServiceException.BAD_VOLUME_USE_IN_FREQUENT_ACCESS_THRESHOLD);
+                }
+
+                // validate namespace is empty or not
+                if (StringUtil.isNullOrEmpty(volInfoRequest.getVolumeExternalOpenIOInfo().getNameSpace())) {
+                    throw VolumeServiceException.INVALID_REQUEST("Name Space can't be null", VolumeServiceException.BAD_VOLUME_USE_IN_FREQUENT_ACCESS_THRESHOLD);
+                }
+            } else {
+                throw VolumeServiceException.INVALID_REQUEST("Volume Storage Type can be only S3 or OpenIO",
+                        VolumeServiceException.BAD_VOLUME_STORAGE_TYPE);
+            }
         }
     }
 
@@ -147,10 +170,15 @@ public class VolumeConfigUtil {
                                                VolumeInfo volInfoRequest, VolumeInfo volInfoResponse,
                                                Volume.StoreType enumStoreType) throws ServiceException {
         ExternalVolumeInfoHandler extVolInfoHandler = new ExternalVolumeInfoHandler(Provisioning.getInstance());
-        if (enumStoreType.equals(Volume.StoreType.EXTERNAL)) {
+        if (Volume.StoreType.EXTERNAL.equals(enumStoreType)) {
             try {
                 volInfoRequest.setId(volRequest.getId());
-                volInfoResponse.setVolumeExternalInfo(volInfoRequest.getVolumeExternalInfo());
+                if (volInfoRequest.getVolumeExternalInfo() != null && AdminConstants.A_VOLUME_S3
+                        .equalsIgnoreCase(volInfoRequest.getVolumeExternalInfo().getStorageType())) {
+                    volInfoResponse.setVolumeExternalInfo(volInfoRequest.getVolumeExternalInfo());
+                } else {
+                    volInfoResponse.setVolumeExternalOpenIOInfo(volInfoRequest.getVolumeExternalOpenIOInfo());
+                }
                 extVolInfoHandler.addServerProperties(volInfoRequest);
             } catch (JSONException e) {
                 throw ServiceException.FAILURE("Error while processing postCreateVolumeActions", e);
@@ -169,26 +197,17 @@ public class VolumeConfigUtil {
         for (Volume vol : VolumeManager.getInstance().getAllVolumes()) {
             VolumeInfo volInfo = vol.toJAXB();
 
-            if (vol.getStoreType().equals(Volume.StoreType.EXTERNAL)) {
-                VolumeExternalInfo volExtInfo = new VolumeExternalInfo();
+            if (Volume.StoreType.EXTERNAL.equals(vol.getStoreType())) {
                 ExternalVolumeInfoHandler extVolInfoHandler = new ExternalVolumeInfoHandler(Provisioning.getInstance());
 
                 try {
                     JSONObject properties = extVolInfoHandler.readServerProperties(volInfo.getId());
-                    String volumePrefix = properties.getString(AdminConstants.A_VOLUME_VOLUME_PREFIX);
-                    String globalBucketConfigId = properties.getString(AdminConstants.A_VOLUME_GLB_BUCKET_CONFIG_ID);
                     String storageType = properties.getString(AdminConstants.A_VOLUME_STORAGE_TYPE);
-                    Boolean useInFrequentAccess = Boolean.valueOf(properties.getString(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS));
-                    Boolean useIntelligentTiering = Boolean.valueOf(properties.getString(AdminConstants.A_VOLUME_USE_INTELLIGENT_TIERING));
-                    int useInFrequentAccessThreshold = Integer.parseInt(properties.getString(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS_THRESHOLD));
-
-                    volExtInfo.setVolumePrefix(volumePrefix);
-                    volExtInfo.setGlobalBucketConfigurationId(globalBucketConfigId);
-                    volExtInfo.setStorageType(storageType);
-                    volExtInfo.setUseInFrequentAccess(useInFrequentAccess);
-                    volExtInfo.setUseIntelligentTiering(useIntelligentTiering);
-                    volExtInfo.setUseInFrequentAccessThreshold(useInFrequentAccessThreshold);
-                    volInfo.setVolumeExternalInfo(volExtInfo);
+                    if (AdminConstants.A_VOLUME_S3.equalsIgnoreCase(storageType)) {
+                        volInfo.setVolumeExternalInfo(new VolumeExternalInfo().toExternalInfo(properties));
+                    } else {
+                        volInfo.setVolumeExternalOpenIOInfo(new VolumeExternalOpenIOInfo().toExternalOpenIoInfo(properties));
+                    }
                 } catch (JSONException e) {
                     throw ServiceException.FAILURE("Error while processing GetAllVolumesRequest", e);
                 }
@@ -205,26 +224,17 @@ public class VolumeConfigUtil {
      * @throws ServiceException
      */
     public static void parseGetVolumeRequest(GetVolumeRequest req, GetVolumeResponse resp,
-                                             Volume vol, VolumeInfo volInfo) throws ServiceException {
-        if (vol.getStoreType().equals(Volume.StoreType.EXTERNAL)) {
-            VolumeExternalInfo volExtInfo = new VolumeExternalInfo();
+            Volume vol, VolumeInfo volInfo) throws ServiceException {
+        if (Volume.StoreType.EXTERNAL.equals(vol.getStoreType())) {
             ExternalVolumeInfoHandler extVolInfoHandler = new ExternalVolumeInfoHandler(Provisioning.getInstance());
             try {
                 JSONObject properties = extVolInfoHandler.readServerProperties(volInfo.getId());
-                String volumePrefix = properties.getString(AdminConstants.A_VOLUME_VOLUME_PREFIX);
-                String globalBucketConfigId = properties.getString(AdminConstants.A_VOLUME_GLB_BUCKET_CONFIG_ID);
                 String storageType = properties.getString(AdminConstants.A_VOLUME_STORAGE_TYPE);
-                Boolean useInFrequentAccess = Boolean.valueOf(properties.getString(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS));
-                Boolean useIntelligentTiering = Boolean.valueOf(properties.getString(AdminConstants.A_VOLUME_USE_INTELLIGENT_TIERING));
-                int useInFrequentAccessThreshold = Integer.parseInt(properties.getString(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS_THRESHOLD));
-
-                volExtInfo.setVolumePrefix(volumePrefix);
-                volExtInfo.setGlobalBucketConfigurationId(globalBucketConfigId);
-                volExtInfo.setStorageType(storageType);
-                volExtInfo.setUseInFrequentAccess(useInFrequentAccess);
-                volExtInfo.setUseIntelligentTiering(useIntelligentTiering);
-                volExtInfo.setUseInFrequentAccessThreshold(useInFrequentAccessThreshold);
-                volInfo.setVolumeExternalInfo(volExtInfo);
+                if (storageType.equalsIgnoreCase(AdminConstants.A_VOLUME_S3)) {
+                    volInfo.setVolumeExternalInfo(new VolumeExternalInfo().toExternalInfo(properties));
+                } else {
+                    volInfo.setVolumeExternalOpenIOInfo(new VolumeExternalOpenIOInfo().toExternalOpenIoInfo(properties));
+                }
             } catch (JSONException e) {
                 throw ServiceException.FAILURE("Error while processing GetVolumesRequest", e);
             }
@@ -267,8 +277,9 @@ public class VolumeConfigUtil {
      * @param ModifyVolumeRequest
      * @return
      * @throws ServiceException
+     * @throws JSONException
      */
-    public static void parseModifyVolumeRequest(ModifyVolumeRequest req) throws ServiceException {
+    public static void parseModifyVolumeRequest(ModifyVolumeRequest req) throws ServiceException, JSONException {
         VolumeManager mgr = VolumeManager.getInstance();
         VolumeInfo volInfo = req.getVolumeInfo();
         Volume vol = mgr.getVolume(req.getId());
@@ -284,7 +295,7 @@ public class VolumeConfigUtil {
         }
 
         // store type == 1, allow modification of all parameters
-        if (vol.getStoreType().equals(Volume.StoreType.INTERNAL)) {
+        if (Volume.StoreType.INTERNAL.equals(vol.getStoreType())) {
             if (volInfo.getType() > 0) {
                 builder.setType(volInfo.getType());
             }
@@ -300,29 +311,36 @@ public class VolumeConfigUtil {
             builder.setCompressBlobs(volInfo.isCompressBlobs());
         }
         // store type == 2, allow modification of only volume name
-        else if (vol.getStoreType().equals(Volume.StoreType.EXTERNAL)) {
+        else if (Volume.StoreType.EXTERNAL.equals(vol.getStoreType())) {
             if (volInfo.getName() != null) {
                 String storageType = "";
                 String globalBucketConfigId = "";
                 ExternalVolumeInfoHandler extVolInfoHandler = new ExternalVolumeInfoHandler(Provisioning.getInstance());
-                try {
-                    JSONObject properties = extVolInfoHandler.readServerProperties(req.getId());
-                    storageType = properties.getString(AdminConstants.A_VOLUME_STORAGE_TYPE);
-                    globalBucketConfigId = properties.getString(AdminConstants.A_VOLUME_GLB_BUCKET_CONFIG_ID);
-                } catch (JSONException e) {
-                    throw ServiceException.FAILURE("Error while reading json data for external volume: " + req.getId(), e);
+                JSONObject properties = extVolInfoHandler.readServerProperties(req.getId());
+                if (JSONObject.NULL.equals(properties)) {
+                    throw VolumeServiceException.INVALID_REQUEST("Unable to read server properties", VolumeServiceException.INVALID_REQUEST);
                 }
-                // storageType should not be null
-                if (StringUtil.isNullOrEmpty(storageType)) {
-                    throw VolumeServiceException.INVALID_REQUEST("StorageType Empty for external volume " + req.getId(), VolumeServiceException.INVALID_REQUEST);
+                storageType = properties.getString(AdminConstants.A_VOLUME_STORAGE_TYPE);
+                if (storageType.equalsIgnoreCase(AdminConstants.A_VOLUME_S3)) {
+                    try {
+                        globalBucketConfigId = properties.getString(AdminConstants.A_VOLUME_GLB_BUCKET_CONFIG_ID);
+                    } catch (JSONException e) {
+                        throw ServiceException.FAILURE("Error while reading json data for external volume: " + req.getId(), e);
+                    }
+                    // storageType should not be null
+                    if (StringUtil.isNullOrEmpty(storageType)) {
+                        throw VolumeServiceException.INVALID_REQUEST("StorageType Empty for external volume " + req.getId(), VolumeServiceException.INVALID_REQUEST);
+                    }
+                    builder.setName(volInfo.getName());
+                    String extRootPath = ZMailbox.PATH_SEPARATOR + storageType + ROOT_PATH_ELE_SEPARATOR + volInfo.getName();
+                    // append global bucket id as well in case it is available
+                    if (!StringUtil.isNullOrEmpty(globalBucketConfigId)) {
+                        extRootPath = extRootPath + ROOT_PATH_ELE_SEPARATOR + globalBucketConfigId;
+                    }
+                    builder.setPath(extRootPath, false);
+                } else {
+                    builder.setName(volInfo.getName());
                 }
-                builder.setName(volInfo.getName());
-                String extRootPath = ZMailbox.PATH_SEPARATOR + storageType + ROOT_PATH_ELE_SEPARATOR + volInfo.getName();
-                // append global bucket id as well in case it is available
-                if (!StringUtil.isNullOrEmpty(globalBucketConfigId)) {
-                    extRootPath = extRootPath + ROOT_PATH_ELE_SEPARATOR + globalBucketConfigId;
-                }
-                builder.setPath(extRootPath, false);
             }
         }
         mgr.update(builder.build());

--- a/store/src/java/com/zimbra/util/ExternalVolumeInfoHandler.java
+++ b/store/src/java/com/zimbra/util/ExternalVolumeInfoHandler.java
@@ -10,15 +10,13 @@ import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AdminConstants;
 import com.zimbra.common.util.StringUtil;
 import com.zimbra.cs.account.Provisioning;
-import com.zimbra.cs.account.Server;
 import com.zimbra.soap.admin.type.VolumeInfo;
 import com.zimbra.soap.admin.type.VolumeExternalInfo;
+import com.zimbra.soap.admin.type.VolumeExternalOpenIOInfo;
 
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-
-import java.util.Iterator;
 
 /**
  * LDAP based properties handler
@@ -114,16 +112,16 @@ public class ExternalVolumeInfoHandler {
      */
     public void addServerProperties(VolumeInfo volInfo) throws ServiceException, JSONException {
         VolumeExternalInfo volExtInfo = volInfo.getVolumeExternalInfo();
+        VolumeExternalOpenIOInfo volExtOpenIoInfo = volInfo.getVolumeExternalOpenIOInfo();
+
         try {
-            // step 1: Create and update json object and array for new volume entry
+            // step 1: Create and update json object and array for new volume entry of S3
             JSONObject volExtInfoObj = new JSONObject();
-            volExtInfoObj.put(AdminConstants.A_VOLUME_ID, String.valueOf(volInfo.getId()));
-            volExtInfoObj.put(AdminConstants.A_VOLUME_STORAGE_TYPE, volExtInfo.getStorageType());
-            volExtInfoObj.put(AdminConstants.A_VOLUME_VOLUME_PREFIX, volExtInfo.getVolumePrefix());
-            volExtInfoObj.put(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS, String.valueOf(volExtInfo.isUseInFrequentAccess()));
-            volExtInfoObj.put(AdminConstants.A_VOLUME_USE_INTELLIGENT_TIERING, String.valueOf(volExtInfo.isUseIntelligentTiering()));
-            volExtInfoObj.put(AdminConstants.A_VOLUME_GLB_BUCKET_CONFIG_ID, volExtInfo.getGlobalBucketConfigurationId());
-            volExtInfoObj.put(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS_THRESHOLD, String.valueOf(volExtInfo.getUseInFrequentAccessThreshold()));
+            if (volInfo.getVolumeExternalInfo() != null && AdminConstants.A_VOLUME_S3.equalsIgnoreCase(volInfo.getVolumeExternalInfo().getStorageType())) {
+                volExtInfoObj = volExtInfo.toJSON(volInfo);
+            } else if (volInfo.getVolumeExternalOpenIOInfo() != null && AdminConstants.A_VOLUME_OPEN_IO.equalsIgnoreCase(volInfo.getVolumeExternalOpenIOInfo().getStorageType())) {
+                volExtInfoObj = volExtOpenIoInfo.toJSON(volInfo);
+            }
 
             // step 2: Fetch current JSON state
             String serverExternalStoreConfigJson = provisioning.getLocalServer().getServerExternalStoreConfig();


### PR DESCRIPTION
ticket - https://jira.corp.synacor.com/browse/ZCS-11675

Api changes is written to configure OpenIO storage as external volume for primary or secondary storage.

Here is the list of parameters that are required for OpenIO storage.

URL
Account
Namespace
Proxy port
Account port

API:
Following APIs will need to be changed/tested to implement OpenIO support:

CreateVolumeRequest
GetVolumeRequest
GetAllVolumeRequest
ModifyVolumeRequest
DeleteVolumeRequest

added all the request & response details on the ticket

- Fixed formatting comments, added null check for properties, and removed unnecessary boolean validations
- assorted bug fixes