### PR TITLE
ZCS-11824: updating ldap attribute ids

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -3002,7 +3002,7 @@ public class ZAttrProvisioning {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4008)
     public static final String A_zimbraActiveSyncVersion = "zimbraActiveSyncVersion";
 
     /**
@@ -6937,7 +6937,7 @@ public class ZAttrProvisioning {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4003)
+    @ZAttr(id=4006)
     public static final String A_zimbraFeatureSafeUnsubscribeFolderEnabled = "zimbraFeatureSafeUnsubscribeFolderEnabled";
 
     /**
@@ -13025,7 +13025,7 @@ public class ZAttrProvisioning {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4004)
+    @ZAttr(id=4007)
     public static final String A_zimbraPrefCalenderScaling = "zimbraPrefCalenderScaling";
 
     /**

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9921,15 +9921,15 @@ TODO: delete them permanently from here
   <defaultCOSValue>FALSE</defaultCOSValue>
   <desc>Whether to permit syncing shared calendar folders</desc>
 </attr>
-<attr id="4003" name="zimbraFeatureSafeUnsubscribeFolderEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="9.1.0">
+<attr id="4006" name="zimbraFeatureSafeUnsubscribeFolderEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="9.1.0">
   <defaultCOSValue>FALSE</defaultCOSValue>
   <desc>Creates unsubscribe system folder</desc>
  </attr>
- <attr id="4004" name="zimbraPrefCalenderScaling" type="enum" value="10,15,30" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="9.1.0">
+ <attr id="4007" name="zimbraPrefCalenderScaling" type="enum" value="10,15,30" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="9.1.0">
   <defaultCOSValue>30</defaultCOSValue>
   <desc>Default calendar resolution preference</desc>
 </attr>
-<attr id="4005" name="zimbraActiveSyncVersion" type="string" cardinality="multi" optionalIn="account,cos,domain" flags="accountInfo,accountCosDomainInherited,domainAdminModifiable" since="9.1.0">
+<attr id="4008" name="zimbraActiveSyncVersion" type="string" cardinality="multi" optionalIn="account,cos,domain" flags="accountInfo,accountCosDomainInherited,domainAdminModifiable" since="9.1.0">
   <desc>Sets the active sync version at the user level to override zimbra_activesync_versions on local config.
       Add multi-value attribute as android:14.1/iphone:16.1/ipod:16.0.
       If set as android:14.1, the android device will be connected over the 14.1 version.

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -3080,7 +3080,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4008)
     public String[] getActiveSyncVersion() {
         return getMultiAttr(Provisioning.A_zimbraActiveSyncVersion, true, true);
     }
@@ -3101,7 +3101,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4008)
     public void setActiveSyncVersion(String[] zimbraActiveSyncVersion) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraActiveSyncVersion, zimbraActiveSyncVersion);
@@ -3125,7 +3125,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4008)
     public Map<String,Object> setActiveSyncVersion(String[] zimbraActiveSyncVersion, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraActiveSyncVersion, zimbraActiveSyncVersion);
@@ -3148,7 +3148,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4008)
     public void addActiveSyncVersion(String zimbraActiveSyncVersion) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraActiveSyncVersion, zimbraActiveSyncVersion);
@@ -3172,7 +3172,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4008)
     public Map<String,Object> addActiveSyncVersion(String zimbraActiveSyncVersion, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraActiveSyncVersion, zimbraActiveSyncVersion);
@@ -3195,7 +3195,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4008)
     public void removeActiveSyncVersion(String zimbraActiveSyncVersion) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraActiveSyncVersion, zimbraActiveSyncVersion);
@@ -3219,7 +3219,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4008)
     public Map<String,Object> removeActiveSyncVersion(String zimbraActiveSyncVersion, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraActiveSyncVersion, zimbraActiveSyncVersion);
@@ -3241,7 +3241,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4008)
     public void unsetActiveSyncVersion() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraActiveSyncVersion, "");
@@ -3264,7 +3264,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4008)
     public Map<String,Object> unsetActiveSyncVersion(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraActiveSyncVersion, "");
@@ -18740,7 +18740,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4003)
+    @ZAttr(id=4006)
     public boolean isFeatureSafeUnsubscribeFolderEnabled() {
         return getBooleanAttr(Provisioning.A_zimbraFeatureSafeUnsubscribeFolderEnabled, false, true);
     }
@@ -18753,7 +18753,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4003)
+    @ZAttr(id=4006)
     public void setFeatureSafeUnsubscribeFolderEnabled(boolean zimbraFeatureSafeUnsubscribeFolderEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureSafeUnsubscribeFolderEnabled, zimbraFeatureSafeUnsubscribeFolderEnabled ? TRUE : FALSE);
@@ -18769,7 +18769,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4003)
+    @ZAttr(id=4006)
     public Map<String,Object> setFeatureSafeUnsubscribeFolderEnabled(boolean zimbraFeatureSafeUnsubscribeFolderEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureSafeUnsubscribeFolderEnabled, zimbraFeatureSafeUnsubscribeFolderEnabled ? TRUE : FALSE);
@@ -18783,7 +18783,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4003)
+    @ZAttr(id=4006)
     public void unsetFeatureSafeUnsubscribeFolderEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureSafeUnsubscribeFolderEnabled, "");
@@ -18798,7 +18798,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4003)
+    @ZAttr(id=4006)
     public Map<String,Object> unsetFeatureSafeUnsubscribeFolderEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureSafeUnsubscribeFolderEnabled, "");
@@ -42624,7 +42624,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4004)
+    @ZAttr(id=4007)
     public ZAttrProvisioning.PrefCalenderScaling getPrefCalenderScaling() {
         try { String v = getAttr(Provisioning.A_zimbraPrefCalenderScaling, true, true); return v == null ? ZAttrProvisioning.PrefCalenderScaling._30 : ZAttrProvisioning.PrefCalenderScaling.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.PrefCalenderScaling._30; }
     }
@@ -42638,7 +42638,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4004)
+    @ZAttr(id=4007)
     public String getPrefCalenderScalingAsString() {
         return getAttr(Provisioning.A_zimbraPrefCalenderScaling, "30", true);
     }
@@ -42653,7 +42653,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4004)
+    @ZAttr(id=4007)
     public void setPrefCalenderScaling(ZAttrProvisioning.PrefCalenderScaling zimbraPrefCalenderScaling) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraPrefCalenderScaling, zimbraPrefCalenderScaling.toString());
@@ -42671,7 +42671,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4004)
+    @ZAttr(id=4007)
     public Map<String,Object> setPrefCalenderScaling(ZAttrProvisioning.PrefCalenderScaling zimbraPrefCalenderScaling, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraPrefCalenderScaling, zimbraPrefCalenderScaling.toString());
@@ -42688,7 +42688,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4004)
+    @ZAttr(id=4007)
     public void setPrefCalenderScalingAsString(String zimbraPrefCalenderScaling) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraPrefCalenderScaling, zimbraPrefCalenderScaling);
@@ -42706,7 +42706,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4004)
+    @ZAttr(id=4007)
     public Map<String,Object> setPrefCalenderScalingAsString(String zimbraPrefCalenderScaling, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraPrefCalenderScaling, zimbraPrefCalenderScaling);
@@ -42722,7 +42722,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4004)
+    @ZAttr(id=4007)
     public void unsetPrefCalenderScaling() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraPrefCalenderScaling, "");
@@ -42739,7 +42739,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4004)
+    @ZAttr(id=4007)
     public Map<String,Object> unsetPrefCalenderScaling(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraPrefCalenderScaling, "");

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -373,7 +373,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4008)
     public String[] getActiveSyncVersion() {
         return getMultiAttr(Provisioning.A_zimbraActiveSyncVersion, true, true);
     }
@@ -394,7 +394,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4008)
     public void setActiveSyncVersion(String[] zimbraActiveSyncVersion) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraActiveSyncVersion, zimbraActiveSyncVersion);
@@ -418,7 +418,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4008)
     public Map<String,Object> setActiveSyncVersion(String[] zimbraActiveSyncVersion, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraActiveSyncVersion, zimbraActiveSyncVersion);
@@ -441,7 +441,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4008)
     public void addActiveSyncVersion(String zimbraActiveSyncVersion) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraActiveSyncVersion, zimbraActiveSyncVersion);
@@ -465,7 +465,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4008)
     public Map<String,Object> addActiveSyncVersion(String zimbraActiveSyncVersion, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraActiveSyncVersion, zimbraActiveSyncVersion);
@@ -488,7 +488,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4008)
     public void removeActiveSyncVersion(String zimbraActiveSyncVersion) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraActiveSyncVersion, zimbraActiveSyncVersion);
@@ -512,7 +512,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4008)
     public Map<String,Object> removeActiveSyncVersion(String zimbraActiveSyncVersion, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraActiveSyncVersion, zimbraActiveSyncVersion);
@@ -534,7 +534,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4008)
     public void unsetActiveSyncVersion() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraActiveSyncVersion, "");
@@ -557,7 +557,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4008)
     public Map<String,Object> unsetActiveSyncVersion(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraActiveSyncVersion, "");
@@ -13324,7 +13324,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4003)
+    @ZAttr(id=4006)
     public boolean isFeatureSafeUnsubscribeFolderEnabled() {
         return getBooleanAttr(Provisioning.A_zimbraFeatureSafeUnsubscribeFolderEnabled, false, true);
     }
@@ -13337,7 +13337,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4003)
+    @ZAttr(id=4006)
     public void setFeatureSafeUnsubscribeFolderEnabled(boolean zimbraFeatureSafeUnsubscribeFolderEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureSafeUnsubscribeFolderEnabled, zimbraFeatureSafeUnsubscribeFolderEnabled ? TRUE : FALSE);
@@ -13353,7 +13353,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4003)
+    @ZAttr(id=4006)
     public Map<String,Object> setFeatureSafeUnsubscribeFolderEnabled(boolean zimbraFeatureSafeUnsubscribeFolderEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureSafeUnsubscribeFolderEnabled, zimbraFeatureSafeUnsubscribeFolderEnabled ? TRUE : FALSE);
@@ -13367,7 +13367,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4003)
+    @ZAttr(id=4006)
     public void unsetFeatureSafeUnsubscribeFolderEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureSafeUnsubscribeFolderEnabled, "");
@@ -13382,7 +13382,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4003)
+    @ZAttr(id=4006)
     public Map<String,Object> unsetFeatureSafeUnsubscribeFolderEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureSafeUnsubscribeFolderEnabled, "");
@@ -33066,7 +33066,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4004)
+    @ZAttr(id=4007)
     public ZAttrProvisioning.PrefCalenderScaling getPrefCalenderScaling() {
         try { String v = getAttr(Provisioning.A_zimbraPrefCalenderScaling, true, true); return v == null ? ZAttrProvisioning.PrefCalenderScaling._30 : ZAttrProvisioning.PrefCalenderScaling.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.PrefCalenderScaling._30; }
     }
@@ -33080,7 +33080,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4004)
+    @ZAttr(id=4007)
     public String getPrefCalenderScalingAsString() {
         return getAttr(Provisioning.A_zimbraPrefCalenderScaling, "30", true);
     }
@@ -33095,7 +33095,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4004)
+    @ZAttr(id=4007)
     public void setPrefCalenderScaling(ZAttrProvisioning.PrefCalenderScaling zimbraPrefCalenderScaling) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraPrefCalenderScaling, zimbraPrefCalenderScaling.toString());
@@ -33113,7 +33113,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4004)
+    @ZAttr(id=4007)
     public Map<String,Object> setPrefCalenderScaling(ZAttrProvisioning.PrefCalenderScaling zimbraPrefCalenderScaling, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraPrefCalenderScaling, zimbraPrefCalenderScaling.toString());
@@ -33130,7 +33130,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4004)
+    @ZAttr(id=4007)
     public void setPrefCalenderScalingAsString(String zimbraPrefCalenderScaling) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraPrefCalenderScaling, zimbraPrefCalenderScaling);
@@ -33148,7 +33148,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4004)
+    @ZAttr(id=4007)
     public Map<String,Object> setPrefCalenderScalingAsString(String zimbraPrefCalenderScaling, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraPrefCalenderScaling, zimbraPrefCalenderScaling);
@@ -33164,7 +33164,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4004)
+    @ZAttr(id=4007)
     public void unsetPrefCalenderScaling() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraPrefCalenderScaling, "");
@@ -33181,7 +33181,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4004)
+    @ZAttr(id=4007)
     public Map<String,Object> unsetPrefCalenderScaling(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraPrefCalenderScaling, "");

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -312,7 +312,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4008)
     public String[] getActiveSyncVersion() {
         return getMultiAttr(Provisioning.A_zimbraActiveSyncVersion, true, true);
     }
@@ -333,7 +333,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4008)
     public void setActiveSyncVersion(String[] zimbraActiveSyncVersion) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraActiveSyncVersion, zimbraActiveSyncVersion);
@@ -357,7 +357,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4008)
     public Map<String,Object> setActiveSyncVersion(String[] zimbraActiveSyncVersion, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraActiveSyncVersion, zimbraActiveSyncVersion);
@@ -380,7 +380,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4008)
     public void addActiveSyncVersion(String zimbraActiveSyncVersion) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraActiveSyncVersion, zimbraActiveSyncVersion);
@@ -404,7 +404,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4008)
     public Map<String,Object> addActiveSyncVersion(String zimbraActiveSyncVersion, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraActiveSyncVersion, zimbraActiveSyncVersion);
@@ -427,7 +427,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4008)
     public void removeActiveSyncVersion(String zimbraActiveSyncVersion) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraActiveSyncVersion, zimbraActiveSyncVersion);
@@ -451,7 +451,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4008)
     public Map<String,Object> removeActiveSyncVersion(String zimbraActiveSyncVersion, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraActiveSyncVersion, zimbraActiveSyncVersion);
@@ -473,7 +473,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4008)
     public void unsetActiveSyncVersion() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraActiveSyncVersion, "");
@@ -496,7 +496,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4008)
     public Map<String,Object> unsetActiveSyncVersion(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraActiveSyncVersion, "");


### PR DESCRIPTION
Issue
LDAP attribute ID's for zimbraFeatureSafeUnsubscribeFolderEnabled, zimbraPrefCalenderScaling, zimbraActiveSyncVersion in conflict zimbrax IDs

Fix
Incremented the IDs for these attributes to not conflict with attribute IDs of zimbrax