### PR TITLE
ZCS-11785: Enhance zmvolume CLI to support OpenIO volume type

### DIFF
--- a/store/src/java/com/zimbra/cs/volume/VolumeCLI.java
+++ b/store/src/java/com/zimbra/cs/volume/VolumeCLI.java
@@ -17,14 +17,12 @@
 package com.zimbra.cs.volume;
 
 import java.io.IOException;
-
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionGroup;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.http.HttpException;
-
 import com.google.common.base.Strings;
 import com.zimbra.common.auth.ZAuthToken;
 import com.zimbra.common.service.ServiceException;
@@ -62,20 +60,20 @@ public final class VolumeCLI extends SoapCLI {
     private static final String O_P = "p";
     private static final String O_C = "c";
     private static final String O_CT = "ct";
-    
+
     /** attributes for external storetype **/
     private static final String O_ST = "st";
     private static final String O_VP = "vp";
     private static final String O_STP = "stp";
     private static final String O_BID = "bid";
-    
+
     /** attributes for store type OpenIO **/
     private static final String O_AP = "ap";
     private static final String O_PP = "pp";
     private static final String O_ACCOUNT = "acc";
     private static final String O_NS = "ns";
     private static final String O_URL = "url";
-    private static final String openIO = "OPENIO";
+    private static final String OPENIO = "OPENIO";
 
     private static final String NOT_ALLOWED_INTERNAL = " is not allowed for internal storetype";
     private static final String NOT_ALLOWED_EXTERNAL = " is not allowed for external storetype";
@@ -86,10 +84,9 @@ public final class VolumeCLI extends SoapCLI {
     private static final String NOT_ALLOWED_ID = "id cannot be specified when adding a volume";
 
     private static final String H_STORE_TYPE = "Store type: internal or external";
-    private static final String H_STORAGE_TYPE = "Name of the store provider (S3, ObjectStore, OpenIO)";
+    private static final String H_STORAGE_TYPE = "Name of the store provider (S3, ObjectStore, OPENIO)";
     private static final String H_BUCKET_ID = "S3 Bucket ID";
     private static final String H_VOLUME_PREFIX = "Volume Preifx";
-    
     private static final String H_URL = "URL of OpenIO";
     private static final String H_PROXY_PORT = "Proxy port";
     private static final String H_ACCOUNT_PORT = "Account port";
@@ -114,7 +111,6 @@ public final class VolumeCLI extends SoapCLI {
     private static final String A_NAME_SPACE = "nameSpace";
     private static final String A_ACCOUNT = "account";
 
-
     private VolumeCLI() throws ServiceException {
         super();
         setupCommandLineOptions();
@@ -138,7 +134,6 @@ public final class VolumeCLI extends SoapCLI {
     private String accountPort;
     private String nameSpace;
     private String account;
-
 
     private void setArgs(CommandLine cl) throws ServiceException, ParseException, IOException {
         auth = getZAuthToken(cl);
@@ -304,7 +299,6 @@ public final class VolumeCLI extends SoapCLI {
                 .elementToJaxb(getTransport().invokeWithoutSession(JaxbUtil.jaxbToElement(getVolumeRequest)));
         Volume.StoreType enumStoreType = (1 == getVolumeResponse.getVolume().getStoreType()) ? Volume.StoreType.INTERNAL
                 : Volume.StoreType.EXTERNAL;
-
         VolumeInfo vol = new VolumeInfo();
         validateEditCommand(vol, enumStoreType);
         ModifyVolumeRequest req = new ModifyVolumeRequest(Short.parseShort(id), vol);
@@ -374,6 +368,9 @@ public final class VolumeCLI extends SoapCLI {
             if (!Strings.isNullOrEmpty(url)) {
                 throw new ParseException(A_URL + NOT_ALLOWED_EXTERNAL);
             }
+            if (!Strings.isNullOrEmpty(account)) {
+                throw new ParseException(A_ACCOUNT + NOT_ALLOWED_EXTERNAL);
+            }
             if (!Strings.isNullOrEmpty(nameSpace)) {
                 throw new ParseException(A_NAME_SPACE + NOT_ALLOWED_EXTERNAL);
             }
@@ -426,7 +423,7 @@ public final class VolumeCLI extends SoapCLI {
             }
             volumeInfo.setRootPath(path);
         } else if (Volume.StoreType.EXTERNAL.name().equals(storeType)) {
-            if(storageType.equalsIgnoreCase(openIO)) {
+            if (OPENIO.equalsIgnoreCase(storageType)) {
                 VolumeExternalOpenIOInfo volumeExternalOpenIOInfo = new VolumeExternalOpenIOInfo();
                 if (!Strings.isNullOrEmpty(storageType)) {
                     volumeExternalOpenIOInfo.setStorageType(storageType);

--- a/store/src/java/com/zimbra/util/ExternalVolumeInfoHandler.java
+++ b/store/src/java/com/zimbra/util/ExternalVolumeInfoHandler.java
@@ -6,17 +6,18 @@
  */
 package com.zimbra.util;
 
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import com.google.common.base.Strings;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AdminConstants;
 import com.zimbra.common.util.StringUtil;
 import com.zimbra.cs.account.Provisioning;
-import com.zimbra.soap.admin.type.VolumeInfo;
 import com.zimbra.soap.admin.type.VolumeExternalInfo;
 import com.zimbra.soap.admin.type.VolumeExternalOpenIOInfo;
-
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.zimbra.soap.admin.type.VolumeInfo;
 
 /**
  * LDAP based properties handler
@@ -201,14 +202,17 @@ public class ExternalVolumeInfoHandler {
         try {
             // step 1: Fetch globalS3Configs and globalS3ConfigList
             String globalExternalStoreConfig = provisioning.getConfig().getGlobalExternalStoreConfig();
-            JSONObject globalS3Configs = new JSONObject(globalExternalStoreConfig);
-            JSONArray globalS3ConfigList = globalS3Configs.getJSONArray("global/s3BucketConfigurations");
 
-            // step 2: Find "globalBucketUUID" in current JSON array
-            for (int i = 0; i < globalS3ConfigList.length(); i++) {
-                // step 3: Mark validation as true if "globalBucketUUID" found
-                if (globalS3BucketId.equalsIgnoreCase(globalS3ConfigList.getJSONObject(i).getString("globalBucketUUID"))) {
-                    return true;
+            if(!Strings.isNullOrEmpty(globalExternalStoreConfig)) {
+                JSONObject globalS3Configs = new JSONObject(globalExternalStoreConfig);
+                JSONArray globalS3ConfigList = globalS3Configs.getJSONArray("global/s3BucketConfigurations");
+
+                // step 2: Find "globalBucketUUID" in current JSON array
+                for (int i = 0; i < globalS3ConfigList.length(); i++) {
+                    // step 3: Mark validation as true if "globalBucketUUID" found
+                    if (globalS3BucketId.equalsIgnoreCase(globalS3ConfigList.getJSONObject(i).getString("globalBucketUUID"))) {
+                        return true;
+                    }
                 }
             }
         } catch (JSONException e) {


### PR DESCRIPTION
Problem: 
Enhance zmvolume CLI to support OpenIO volume type

Solution:
Added constants, logic and validation in case user adds OpenIO as storage.
Following attributes are mandatory:
	•	URL
	•	Account
	•	Namespace
	•	Proxy port
	•	Account port
Fix mode:
Code fix
Test Done:
Manual testing done after creating volumes with the OpenIO mandatory parameters.
Id\f we do not add required parameters then it throws exception message and shows help menu how to use -options.
List(-l) is working fine.
Delete(-d) is working fine.
Edit(-e) is working fine.
Help(-h) is showing description of new added OpenIO attributes.