### PR TITLE
Feature/ZCS 11854: Error when send CreateS3Bucket request with a non-…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .project
 .settings/
 .idea/
+*.iml
+.java-version
 build/
 bin/
 .DS_Store

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -8041,6 +8041,14 @@ public class ZAttrProvisioning {
     public static final String A_zimbraGlobalConfigExtraObjectClass = "zimbraGlobalConfigExtraObjectClass";
 
     /**
+     * Global level external store config
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4005)
+    public static final String A_zimbraGlobalExternalStoreConfig = "zimbraGlobalExternalStoreConfig";
+
+    /**
      * zimbraId of the main dynamic group for the dynamic group unit
      */
     @ZAttr(id=325)
@@ -15947,6 +15955,14 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=2071)
     public static final String A_zimbraScheduledTaskRetryPolicy = "zimbraScheduledTaskRetryPolicy";
+
+    /**
+     * Server level external store config
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4006)
+    public static final String A_zimbraServerExternalStoreConfig = "zimbraServerExternalStoreConfig";
 
     /**
      * Object classes to add when creating a zimbra server object.

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -16593,17 +16593,17 @@ public class ZAttrProvisioning {
     /**
      * Zimbra multiple reader StoreManagers enabled
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4008)
+    @ZAttr(id=4021)
     public static final String A_zimbraSMMultiReaderEnabled = "zimbraSMMultiReaderEnabled";
 
     /**
      * Zimbra StoreManager runtime switching enabled
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4009)
+    @ZAttr(id=4022)
     public static final String A_zimbraSMRuntimeSwitchEnabled = "zimbraSMRuntimeSwitchEnabled";
 
     /**

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -16591,6 +16591,22 @@ public class ZAttrProvisioning {
     public static final String A_zimbraSmimeUserCertificateExtensions = "zimbraSmimeUserCertificateExtensions";
 
     /**
+     * Zimbra multiple reader StoreManagers enabled
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public static final String A_zimbraSMMultiReaderEnabled = "zimbraSMMultiReaderEnabled";
+
+    /**
+     * Zimbra StoreManager runtime switching enabled
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public static final String A_zimbraSMRuntimeSwitchEnabled = "zimbraSMRuntimeSwitchEnabled";
+
+    /**
      * Whether to enable smtp debug trace
      *
      * @since ZCS 6.0.0_BETA1

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -8045,7 +8045,7 @@ public class ZAttrProvisioning {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4006)
     public static final String A_zimbraGlobalExternalStoreConfig = "zimbraGlobalExternalStoreConfig";
 
     /**
@@ -15961,7 +15961,7 @@ public class ZAttrProvisioning {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4006)
+    @ZAttr(id=4007)
     public static final String A_zimbraServerExternalStoreConfig = "zimbraServerExternalStoreConfig";
 
     /**

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -8043,9 +8043,9 @@ public class ZAttrProvisioning {
     /**
      * Global level external store config
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4006)
+    @ZAttr(id=4019)
     public static final String A_zimbraGlobalExternalStoreConfig = "zimbraGlobalExternalStoreConfig";
 
     /**
@@ -15959,9 +15959,9 @@ public class ZAttrProvisioning {
     /**
      * Server level external store config
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4007)
+    @ZAttr(id=4020)
     public static final String A_zimbraServerExternalStoreConfig = "zimbraServerExternalStoreConfig";
 
     /**

--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -83,6 +83,12 @@ public final class LC {
     public static final KnownKey zimbra_external_email_warning_message = KnownKey
             .newKey("This message originated outside of your organization.");
 
+    /**
+     * Sets whether the HybridBlobmover feature is enabled.
+     */
+    @Supported
+    public static final KnownKey zimbra_hybrid_blob_mover_enabled = KnownKey.newKey(true);
+
     @Supported
     public static final KnownKey zimbra_extension_directory = KnownKey.newKey("${zimbra_home}/lib/ext");
 

--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -88,6 +88,11 @@ public final class LC {
      */
     @Supported
     public static final KnownKey zimbra_hybrid_blob_mover_enabled = KnownKey.newKey(true);
+    
+    // Timeout for HTTP(S) Head requests used to verify a successful connection to an S3 server.
+    @Supported
+    public static final KnownKey zimbra_s3_connection_request_timeout_ms = KnownKey.newKey(20000);
+
 
     @Supported
     public static final KnownKey zimbra_extension_directory = KnownKey.newKey("${zimbra_home}/lib/ext");

--- a/common/src/java/com/zimbra/common/service/ServiceException.java
+++ b/common/src/java/com/zimbra/common/service/ServiceException.java
@@ -456,6 +456,15 @@ public class ServiceException extends Exception {
         return new ServiceException("unsupported", UNSUPPORTED, RECEIVERS_FAULT);
     }
 
+    /**
+     * ServiceException in case wrong config provided by Sender
+     * @param msg
+     * @return
+     */
+    public static ServiceException UNSUPPORTED_CONFIG(String msg) {
+        return new ServiceException("unsupported: " + msg, UNSUPPORTED, SENDERS_FAULT);
+    }
+
     public static ServiceException FORBIDDEN(String str) {
         return new ServiceException("forbidden: " + str, FORBIDDEN, SENDERS_FAULT);
     }

--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -1573,4 +1573,24 @@ public final class AdminConstants {
     public static final String A_CLEAR_FILTER = "clearFilter";
 
     public static final String A_ZULIP_DOMAIN = "zulipDomain";
+
+    // Global External Store Config
+    public static final String E_GET_S3_BUCKET_CONFIG_REQUEST = "GetS3BucketConfigRequest";
+    public static final String E_GET_S3_BUCKET_CONFIG_RESPONSE = "GetS3BucketConfigResponse";
+    public static final String E_CREATE_S3_BUCKET_CONFIG_REQUEST = "CreateS3BucketConfigRequest";
+    public static final String E_CREATE_S3_BUCKET_CONFIG_RESPONSE = "CreateS3BucketConfigResponse";
+    public static final String E_DELETE_S3_BUCKET_CONFIG_REQUEST = "DeleteS3BucketConfigRequest";
+    public static final String E_DELETE_S3_BUCKET_CONFIG_RESPONSE = "DeleteS3BucketConfigResponse";
+    public static final QName GET_S3_BUCKET_CONFIG_REQUEST = QName.get(E_GET_S3_BUCKET_CONFIG_REQUEST, NAMESPACE);
+    public static final QName GET_S3_BUCKET_CONFIG_RESPONSE = QName.get(E_GET_S3_BUCKET_CONFIG_RESPONSE, NAMESPACE);
+    public static final QName CREATE_S3_BUCKET_CONFIG_REQUEST = QName.get(E_CREATE_S3_BUCKET_CONFIG_REQUEST, NAMESPACE);
+    public static final QName CREATE_S3_BUCKET_CONFIG_RESPONSE = QName.get(E_CREATE_S3_BUCKET_CONFIG_RESPONSE, NAMESPACE);
+    public static final QName DELETE_S3_BUCKET_CONFIG_REQUEST = QName.get(E_DELETE_S3_BUCKET_CONFIG_REQUEST, NAMESPACE);
+    public static final QName DELETE_S3_BUCKET_CONFIG_RESPONSE = QName.get(E_DELETE_S3_BUCKET_CONFIG_RESPONSE, NAMESPACE);
+
+    // Validate External Config
+    public static final String E_VALIDATE_S3_BUCKET_REACHABLE_REQUEST = "ValidateS3BucketReachableRequest";
+    public static final String E_VALIDATE_S3_BUCKET_REACHABLE_RESPONSE = "ValidateS3BucketReachableResponse";
+    public static final QName VALIDATE_S3_BUCKET_REACHABLE_REQUEST = QName.get(E_VALIDATE_S3_BUCKET_REACHABLE_REQUEST, NAMESPACE);
+    public static final QName VALIDATE_S3_BUCKET_REACHABLE_RESPONSE = QName.get(E_VALIDATE_S3_BUCKET_REACHABLE_RESPONSE, NAMESPACE);
 }

--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -1169,6 +1169,7 @@ public final class AdminConstants {
     public static final String E_NUM_OF_PAGES = "numpages";
     public static final String E_VOLUME = "volume";
     public static final String E_VOLUME_EXT = "volumeExternalInfo";
+    public static final String E_VOLUME_OPENIO_EXT = "volumeExternalOpenIoInfo";
     public static final String E_PROGRESS = "progress";
     public static final String E_SOAP_URL = "soapURL";
     public static final String E_ADMIN_SOAP_URL = "adminSoapURL";
@@ -1303,6 +1304,13 @@ public final class AdminConstants {
     public static final String A_VOLUME_USE_IN_FREQ_ACCESS = "useInFrequentAccess";
     public static final String A_VOLUME_USE_IN_FREQ_ACCESS_THRESHOLD = "useInFrequentAccessThreshold";
     public static final String A_VOLUME_USE_INTELLIGENT_TIERING = "useIntelligentTiering";
+    public static final String A_VOLUME_URL = "url";
+    public static final String A_VOLUME_ACCOUNT = "account";
+    public static final String A_VOLUME_NAMESPACE = "nameSpace";
+    public static final String A_VOLUME_PROXY_PORT= "proxyPort";
+    public static final String A_VOLUME_ACCOUNT_PORT = "accountPort";
+    public static final String A_VOLUME_S3 = "S3";
+    public static final String A_VOLUME_OPEN_IO = "OPENIO";
 
     // Blob consistency check
     public static final String E_MISSING_BLOBS = "missingBlobs";

--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2021 Synacor, Inc.
+ * Copyright (C) 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2021, 2022 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -1067,7 +1067,7 @@ public final class AdminConstants {
     public static final QName MODIFY_OUTGOING_FILTER_RULES_RESPONSE = QName.get(E_MODIFY_OUTGOING_FILTER_RULES_RESPONSE, NAMESPACE);
     public static final QName CONTACT_BACKUP_REQUEST = QName.get(E_CONTACT_BACKUP_REQUEST, NAMESPACE);
     public static final QName CONTACT_BACKUP_RESPONSE = QName.get(E_CONTACT_BACKUP_RESPONSE, NAMESPACE);
-    
+
     //HAB
     public static final String E_HAB_ORG_UNIT_REQUEST = "HABOrgUnitRequest";
     public static final String E_HAB_ORG_UNIT_RESPONSE = "HABOrgUnitResponse";
@@ -1168,6 +1168,7 @@ public final class AdminConstants {
     public static final String E_NI = "ni";
     public static final String E_NUM_OF_PAGES = "numpages";
     public static final String E_VOLUME = "volume";
+    public static final String E_VOLUME_EXT = "volumeExternalInfo";
     public static final String E_PROGRESS = "progress";
     public static final String E_SOAP_URL = "soapURL";
     public static final String E_ADMIN_SOAP_URL = "adminSoapURL";
@@ -1293,7 +1294,15 @@ public final class AdminConstants {
     public static final String A_VOLUME_FBITS = "fbits";
     public static final String A_VOLUME_COMPRESS_BLOBS = "compressBlobs";
     public static final String A_VOLUME_COMPRESSION_THRESHOLD = "compressionThreshold";
-    public static final String A_VOLUME_IS_CURRENT = "isCurrent";
+    public static final String A_VOLUME_CURRENT = "current";
+    public static final String A_VOLUME_STORE_TYPE = "storeType";
+    public static final String A_VOLUME_STORAGE_TYPE = "storageType";
+    public static final String A_VOLUME_VOLUME_PREFIX = "volumePrefix";
+    public static final String A_VOLUME_STORE_PROVIDER = "storeProvider";
+    public static final String A_VOLUME_GLB_BUCKET_CONFIG_ID = "globalBucketConfigId";
+    public static final String A_VOLUME_USE_IN_FREQ_ACCESS = "useInFrequentAccess";
+    public static final String A_VOLUME_USE_IN_FREQ_ACCESS_THRESHOLD = "useInFrequentAccessThreshold";
+    public static final String A_VOLUME_USE_INTELLIGENT_TIERING = "useIntelligentTiering";
 
     // Blob consistency check
     public static final String E_MISSING_BLOBS = "missingBlobs";
@@ -1343,7 +1352,7 @@ public final class AdminConstants {
     public static final String A_QUOTA_USED = "used";
     public static final String A_QUOTA_LIMIT = "limit";
     public static final String A_EFFECTIVE_QUOTA = "effectiveQuota";
-    
+
     public static final String E_TEMPLATE = "template";
     public static final String E_TEST = "test";
     public static final String A_DEST = "dest";
@@ -1552,7 +1561,7 @@ public final class AdminConstants {
     public static final String A_FORCE_DELETE = "forceDelete";
     public static final String E_MEMBERS = "members";
     public static final String A_CASCADE_DELETE = "cascadeDelete";
-    
+
     // address list
     public static final String E_CREATE_ADDRESS_LIST_REQUEST = "CreateAddressListRequest";
     public static final String E_CREATE_ADDRESS_LIST_RESPONSE = "CreateAddressListResponse";

--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -1170,6 +1170,7 @@ public final class AdminConstants {
     public static final String E_VOLUME = "volume";
     public static final String E_VOLUME_EXT = "volumeExternalInfo";
     public static final String E_VOLUME_OPENIO_EXT = "volumeExternalOpenIoInfo";
+    public static final String E_STORE_MANAGER_RUNTIME_SWITCH_RESULT = "storeManagerRuntimeSwitchResult";
     public static final String E_PROGRESS = "progress";
     public static final String E_SOAP_URL = "soapURL";
     public static final String E_ADMIN_SOAP_URL = "adminSoapURL";
@@ -1311,6 +1312,7 @@ public final class AdminConstants {
     public static final String A_VOLUME_ACCOUNT_PORT = "accountPort";
     public static final String A_VOLUME_S3 = "S3";
     public static final String A_VOLUME_OPEN_IO = "OPENIO";
+    public static final String A_VOLUME_STORE_MANAGER_CLASS = "storeManagerClass";
 
     // Blob consistency check
     public static final String E_MISSING_BLOBS = "missingBlobs";
@@ -1581,6 +1583,9 @@ public final class AdminConstants {
     public static final String A_CLEAR_FILTER = "clearFilter";
 
     public static final String A_ZULIP_DOMAIN = "zulipDomain";
+
+    public static final String A_SM_RUNTIME_SWITCH_STATUS = "status";
+    public static final String A_SM_RUNTIME_SWITCH_MESSAGE = "message";
 
     // Global External Store Config
     public static final String E_GET_S3_BUCKET_CONFIG_REQUEST = "GetS3BucketConfigRequest";

--- a/common/src/java/com/zimbra/common/soap/GlobalExternalStoreConfigConstants.java
+++ b/common/src/java/com/zimbra/common/soap/GlobalExternalStoreConfigConstants.java
@@ -1,0 +1,17 @@
+package com.zimbra.common.soap;
+
+public final class GlobalExternalStoreConfigConstants {
+
+    public static final String E_GLOBAL_S3_BUCKET_CONFIGURATIONS = "global/s3BucketConfigurations";
+    public static final String A_S3_GLOBAL_BUCKET_UUID = "globalBucketUUID";
+    public static final String A_S3_BUCKET_NAME = "bucketName";
+    public static final String A_S3_STORE_PROVIDER = "storeProvider";
+    public static final String A_S3_PROTOCOL = "protocol";
+    public static final String A_S3_ACCESS_KEY = "accessKey";
+    public static final String A_S3_SECRET_KEY = "secretKey";
+    public static final String A_S3_REGION = "region";
+    public static final String A_S3_DESTINATION_PATH = "destinationPath";
+    public static final String A_S3_URL = "url";
+    public static final String A_S3_BUCKET_STATUS = "bucketStatus";
+
+}

--- a/common/src/java/com/zimbra/common/soap/HsmConstants.java
+++ b/common/src/java/com/zimbra/common/soap/HsmConstants.java
@@ -37,6 +37,12 @@ public final class HsmConstants {
 
     public static final String E_GET_APPLIANCE_HSM_FS_REQUEST = "GetApplianceHSMFSRequest";
     public static final String E_GET_APPLIANCE_HSM_FS_RESPONSE = "GetApplianceHSMFSResponse";
+    
+    public static final String E_GET_SCHEDULE_SM_POLICY_REQUEST = "GetScheduleSMPolicyRequest";
+    public static final String E_GET_SCHEDULE_SM_POLICY_RESPONSE = "GetScheduleSMPolicyResponse";
+    
+    public static final String E_SCHEDULE_SMPOLICY_REQUEST = "ScheduleSMPolicyRequest";
+    public static final String E_SCHEDULE_SMPOLICY_RESPONSE = "ScheduleSMPolicyResponse";
 
     public static final QName HSM_REQUEST = QName.get(E_HSM_REQUEST, NAMESPACE);
     public static final QName HSM_RESPONSE = QName.get(E_HSM_RESPONSE, NAMESPACE);
@@ -52,6 +58,12 @@ public final class HsmConstants {
 
     public static final QName GET_APPLIANCE_HSM_FS_REQUEST = QName.get(E_GET_APPLIANCE_HSM_FS_REQUEST, NAMESPACE);
     public static final QName GET_APPLIANCE_HSM_FS_RESPONSE = QName.get(E_GET_APPLIANCE_HSM_FS_RESPONSE, NAMESPACE);
+    
+    public static final QName GET_SCHEDULE_SM_POLICY_REQUEST = QName.get(E_GET_SCHEDULE_SM_POLICY_REQUEST, NAMESPACE);
+    public static final QName GET_SCHEDULE_SM_POLICY_RESPONSE = QName.get(E_GET_SCHEDULE_SM_POLICY_RESPONSE, NAMESPACE);
+    
+    public static final QName SCHEDULE_SMPOLICY_REQUEST = QName.get(E_SCHEDULE_SMPOLICY_REQUEST, NAMESPACE);
+    public static final QName SCHEDULE_SMPOLICY_RESPONSE = QName.get(E_SCHEDULE_SMPOLICY_RESPONSE, NAMESPACE);
 
     public static final String A_START_DATE = "startDate";
     public static final String A_END_DATE = "endDate";
@@ -73,4 +85,19 @@ public final class HsmConstants {
     // GetApplianceHSMFS
     public static final String E_FS = "fs";
     public static final String A_SIZE = "size";
+    
+    public static final String ZM_SCHEDULE_SM_POLICY = "zmschedulesmpolicy";
+    public static final String A_SM_SCHEDULE_POLICY_ENABLED = "smSchedulePolicyEnabled";
+    public static final String A_SM_SCHEDULE_POLICY_START_TIME = "smSchedulePolicyStartTime";
+    public static final String A_SM_START = "SM_START:";
+    public static final String A_SM_END = ":SM_END";
+    public static final String A_SM_SCHEDULE_POLICY_ENABLED_MISSING = "No smSchedulePolicyEnabled defined.";
+    public static final String A_SM_TIME_MISSING = "No time defined.";
+    public static final String A_SM_INVALID_TIME_FORMAT = "Invalid time format.";
+    public static final String A_SM_INVALID_HOURS_FORMAT = "Invalid hour defined.";
+    public static final String A_SM_INVALID_MINUTES = "Minutes are not allowed.";
+    public static final int A_EXIT_STATUS = 0;
+    public static final String A_SM_SCHEDULE_POLICY_ENABLED_INVALID = "Only boolean value allowed in smSchedulePolicyEnabled";
+    public static final String A_TRUE = "true";
+    public static final String A_FALSE = "false";
 }

--- a/common/src/java/com/zimbra/common/util/ZimbraLog.java
+++ b/common/src/java/com/zimbra/common/util/ZimbraLog.java
@@ -493,6 +493,11 @@ public final class ZimbraLog {
     public static final Log gql = LogFactory.getLog("zimbra.gql");
 
     /**
+     * Log for zimbra Store managers
+     */
+    public static final Log smLog = LogFactory.getLog("zimbra.storemanagers");
+
+    /**
      * Maps the log category name to its description.
      */
     public static final Map<String, String> CATEGORY_DESCRIPTIONS;
@@ -603,6 +608,7 @@ public final class ZimbraLog {
         descriptions.put(passwordreset.getCategory(), "Password Reset operations");
         descriptions.put(addresslist.getCategory(), "Addresslist operations");
         descriptions.put(gql.getCategory(), "GraphQL operations");
+        descriptions.put(smLog.getCategory(), "Generic Store managers");
         CATEGORY_DESCRIPTIONS = Collections.unmodifiableMap(descriptions);
     }
 

--- a/soap/ivy.xml
+++ b/soap/ivy.xml
@@ -27,5 +27,6 @@
   <dependency org="org.apache.james" name="apache-jsieve-core" rev="0.5"/>
   <dependency org="zimbra" name="zm-common" rev="latest.integration" />
   <dependency org="ant-contrib" name="ant-contrib" rev="1.0b3" />
+  <dependency org="org.json" name="json" rev="20090211"/>
  </dependencies>
 </ivy-module>

--- a/soap/src/java/com/zimbra/soap/JaxbUtil.java
+++ b/soap/src/java/com/zimbra/soap/JaxbUtil.java
@@ -1149,7 +1149,11 @@ public final class JaxbUtil {
             com.zimbra.soap.account.message.GetAddressListMembersRequest.class,
             com.zimbra.soap.account.message.GetAddressListMemberResponse.class,
             com.zimbra.soap.admin.message.GetAddressListInfoRequest.class,
-            com.zimbra.soap.admin.message.GetAddressListInfoResponse.class
+            com.zimbra.soap.admin.message.GetAddressListInfoResponse.class,
+            com.zimbra.soap.admin.message.ScheduleSMPolicyRequest.class,
+            com.zimbra.soap.admin.message.ScheduleSMPolicyResponse.class,
+            com.zimbra.soap.admin.message.GetScheduleSMPolicyRequest.class,
+            com.zimbra.soap.admin.message.GetScheduleSMPolicyResponse.class
         };
 
         try {

--- a/soap/src/java/com/zimbra/soap/JaxbUtil.java
+++ b/soap/src/java/com/zimbra/soap/JaxbUtil.java
@@ -1159,7 +1159,9 @@ public final class JaxbUtil {
             com.zimbra.soap.admin.message.CreateS3BucketConfigRequest.class,
             com.zimbra.soap.admin.message.CreateS3BucketConfigResponse.class,
             com.zimbra.soap.admin.message.DeleteS3BucketConfigRequest.class,
-            com.zimbra.soap.admin.message.DeleteS3BucketConfigResponse.class
+            com.zimbra.soap.admin.message.DeleteS3BucketConfigResponse.class,
+            com.zimbra.soap.admin.message.ValidateS3BucketReachableRequest.class,
+            com.zimbra.soap.admin.message.ValidateS3BucketReachableResponse.class
         };
 
         try {

--- a/soap/src/java/com/zimbra/soap/JaxbUtil.java
+++ b/soap/src/java/com/zimbra/soap/JaxbUtil.java
@@ -1153,7 +1153,13 @@ public final class JaxbUtil {
             com.zimbra.soap.admin.message.ScheduleSMPolicyRequest.class,
             com.zimbra.soap.admin.message.ScheduleSMPolicyResponse.class,
             com.zimbra.soap.admin.message.GetScheduleSMPolicyRequest.class,
-            com.zimbra.soap.admin.message.GetScheduleSMPolicyResponse.class
+            com.zimbra.soap.admin.message.GetScheduleSMPolicyResponse.class,
+            com.zimbra.soap.admin.message.GetS3BucketConfigRequest.class,
+            com.zimbra.soap.admin.message.GetS3BucketConfigResponse.class,
+            com.zimbra.soap.admin.message.CreateS3BucketConfigRequest.class,
+            com.zimbra.soap.admin.message.CreateS3BucketConfigResponse.class,
+            com.zimbra.soap.admin.message.DeleteS3BucketConfigRequest.class,
+            com.zimbra.soap.admin.message.DeleteS3BucketConfigResponse.class
         };
 
         try {

--- a/soap/src/java/com/zimbra/soap/admin/enums/Status.java
+++ b/soap/src/java/com/zimbra/soap/admin/enums/Status.java
@@ -1,7 +1,0 @@
-package com.zimbra.soap.admin.enums;
-
-public enum Status {
-    SUCCESS,
-    FAIL,
-    NO_OPERATION;
-}

--- a/soap/src/java/com/zimbra/soap/admin/enums/Status.java
+++ b/soap/src/java/com/zimbra/soap/admin/enums/Status.java
@@ -1,0 +1,7 @@
+package com.zimbra.soap.admin.enums;
+
+public enum Status {
+    SUCCESS,
+    FAIL,
+    NO_OPERATION;
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/CreateS3BucketConfigRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/CreateS3BucketConfigRequest.java
@@ -1,0 +1,39 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.soap.admin.type.AdminAttrsImpl;
+
+/**
+ * @zm-api-command-auth-required true
+ * @zm-api-command-admin-auth-required true
+ * @zm-api-command-description Create S3 Bucket Config <br />
+ */
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name = AdminConstants.E_CREATE_S3_BUCKET_CONFIG_REQUEST)
+public class CreateS3BucketConfigRequest extends AdminAttrsImpl {
+
+    public CreateS3BucketConfigRequest() {
+    }
+
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/CreateS3BucketConfigResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/CreateS3BucketConfigResponse.java
@@ -1,0 +1,34 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.soap.admin.type.AdminAttrsImpl;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name = AdminConstants.E_CREATE_S3_BUCKET_CONFIG_RESPONSE)
+public class CreateS3BucketConfigResponse extends AdminAttrsImpl {
+
+    public CreateS3BucketConfigResponse() {
+    }
+
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/CreateVolumeRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/CreateVolumeRequest.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2011, 2012, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2011, 2012, 2013, 2014, 2016, 2022 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -24,6 +24,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 import com.zimbra.common.soap.AdminConstants;
 import com.zimbra.soap.admin.type.VolumeInfo;
+import com.zimbra.soap.admin.type.VolumeExternalInfo;
 
 /**
  * @zm-api-command-auth-required true
@@ -38,7 +39,7 @@ public class CreateVolumeRequest {
      * @zm-api-field-description Volume information
      */
     @XmlElement(name=AdminConstants.E_VOLUME, required=true)
-    private VolumeInfo volume;
+    private VolumeInfo volumeInfo;
 
     /**
      * no-argument constructor wanted by JAXB
@@ -48,9 +49,9 @@ public class CreateVolumeRequest {
         this((VolumeInfo)null);
     }
 
-    public CreateVolumeRequest(VolumeInfo volume) {
-        this.volume = volume;
+    public CreateVolumeRequest(VolumeInfo volumeInfo) {
+        this.volumeInfo = volumeInfo;
     }
 
-    public VolumeInfo getVolume() { return volume; }
+    public VolumeInfo getVolumeInfo() { return volumeInfo; }
 }

--- a/soap/src/java/com/zimbra/soap/admin/message/CreateVolumeResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/CreateVolumeResponse.java
@@ -23,6 +23,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.soap.admin.type.StoreManagerRuntimeSwitchResult;
 import com.zimbra.soap.admin.type.VolumeInfo;
 
 @XmlAccessorType(XmlAccessType.NONE)
@@ -34,6 +35,9 @@ public class CreateVolumeResponse {
      */
     @XmlElement(name=AdminConstants.E_VOLUME, required=true)
     private VolumeInfo volume;
+
+    @XmlElement(name=AdminConstants.E_STORE_MANAGER_RUNTIME_SWITCH_RESULT, required=false)
+    private StoreManagerRuntimeSwitchResult runtimeSwitchResult;
 
     /**
      * no-argument constructor wanted by JAXB
@@ -48,4 +52,12 @@ public class CreateVolumeResponse {
     }
 
     public VolumeInfo getVolume() { return volume; }
+
+    public StoreManagerRuntimeSwitchResult getRuntimeSwitchResult() {
+        return runtimeSwitchResult;
+    }
+
+    public void setRuntimeSwitchResult(StoreManagerRuntimeSwitchResult runtimeSwitchResult) {
+        this.runtimeSwitchResult = runtimeSwitchResult;
+    }
 }

--- a/soap/src/java/com/zimbra/soap/admin/message/DeleteS3BucketConfigRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/DeleteS3BucketConfigRequest.java
@@ -1,0 +1,39 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.soap.admin.type.AdminAttrsImpl;
+
+/**
+ * @zm-api-command-auth-required true
+ * @zm-api-command-admin-auth-required true
+ * @zm-api-command-description Delete S3 Bucket Config <br />
+ */
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name = AdminConstants.E_DELETE_S3_BUCKET_CONFIG_REQUEST)
+public class DeleteS3BucketConfigRequest extends AdminAttrsImpl {
+
+    public DeleteS3BucketConfigRequest() {
+    }
+
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/DeleteS3BucketConfigResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/DeleteS3BucketConfigResponse.java
@@ -1,0 +1,34 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.soap.admin.type.AdminAttrsImpl;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name = AdminConstants.E_DELETE_S3_BUCKET_CONFIG_RESPONSE)
+public class DeleteS3BucketConfigResponse extends AdminAttrsImpl {
+
+    public DeleteS3BucketConfigResponse() {
+    }
+
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/DeleteVolumeRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/DeleteVolumeRequest.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2011, 2012, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2011, 2012, 2013, 2014, 2016, 2022 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -55,5 +55,4 @@ public final class DeleteVolumeRequest {
     public short getId() {
         return id;
     }
-
 }

--- a/soap/src/java/com/zimbra/soap/admin/message/GetS3BucketConfigRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/GetS3BucketConfigRequest.java
@@ -1,0 +1,39 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2012 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.soap.admin.type.AdminAttrsImpl;
+
+/**
+ * @zm-api-command-auth-required true
+ * @zm-api-command-admin-auth-required true
+ * @zm-api-command-description Get S3 Bucket Config
+ */
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name = AdminConstants.E_GET_S3_BUCKET_CONFIG_REQUEST)
+public class GetS3BucketConfigRequest extends AdminAttrsImpl {
+
+    public GetS3BucketConfigRequest() {
+    }
+
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/GetS3BucketConfigResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/GetS3BucketConfigResponse.java
@@ -1,0 +1,57 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import java.util.Collection;
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.google.common.collect.Lists;
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.soap.type.GlobalS3BucketConfiguration;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name = AdminConstants.E_GET_S3_BUCKET_CONFIG_RESPONSE)
+public final class GetS3BucketConfigResponse {
+
+    /**
+     * @zm-api-field-description Information about globalS3BucketConfigs
+     */
+    @XmlElement(name = "globalS3BucketConfigurations", required = true)
+    private final List<GlobalS3BucketConfiguration> globalS3BucketConfigurations = Lists.newArrayList();
+
+    public void setGlobalS3BucketConfigurations(Collection<GlobalS3BucketConfiguration> list) {
+        globalS3BucketConfigurations.clear();
+        if (list != null && !list.isEmpty()) {
+            globalS3BucketConfigurations.addAll(list);
+        }
+    }
+
+    public List<GlobalS3BucketConfiguration> getGlobalS3BucketConfigurations() {
+        return globalS3BucketConfigurations;
+    }
+
+    public void addGlobalS3BucketConfiguration(GlobalS3BucketConfiguration globalS3BucketConfig) {
+        globalS3BucketConfigurations.add(globalS3BucketConfig);
+    }
+
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/GetScheduleSMPolicyRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/GetScheduleSMPolicyRequest.java
@@ -1,0 +1,68 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.google.common.base.MoreObjects;
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.common.soap.HsmConstants;
+import com.zimbra.soap.admin.type.Name;
+
+/**
+ * @zm-api-command-network-edition
+ * @zm-api-command-auth-required true
+ * @zm-api-command-admin-auth-required true
+ * @zm-api-command-description Schedule Storage Management Policy
+ */
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name=HsmConstants.E_GET_SCHEDULE_SM_POLICY_REQUEST)
+public class GetScheduleSMPolicyRequest {
+
+    /**
+     * @zm-api-field-description Server specification
+     */
+    @XmlElement(name=AdminConstants.E_SERVER /* server */, required=true)
+    private final Name server;
+
+    /**
+     * no-argument constructor wanted by JAXB
+     */
+    @SuppressWarnings("unused")
+    private GetScheduleSMPolicyRequest() {
+        this((Name) null);
+    }
+
+    public GetScheduleSMPolicyRequest(Name server) {
+        this.server = server;
+    }
+
+    public Name getServer() { return server; }
+
+    public MoreObjects.ToStringHelper addToStringInfo(MoreObjects.ToStringHelper helper) {
+        return helper.add("server", server);
+    }
+
+    @Override
+    public String toString() {
+        return addToStringInfo(MoreObjects.toStringHelper(this)).toString();
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/GetScheduleSMPolicyResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/GetScheduleSMPolicyResponse.java
@@ -1,0 +1,96 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import com.google.common.base.MoreObjects;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.HsmConstants;
+import com.zimbra.soap.type.ZmBoolean;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name=HsmConstants.E_GET_SCHEDULE_SM_POLICY_RESPONSE)
+public class GetScheduleSMPolicyResponse {
+
+    /**
+     * @zm-api-field-description <b>1 (true)</b> if an HSM session is currently running, <b>0 (false)</b>
+     * if the information returned applies to the last completed HSM session
+     */
+    @XmlAttribute(name=HsmConstants.A_SM_SCHEDULE_POLICY_ENABLED /* running */, required=true)
+    private final ZmBoolean smSchedulePolicyEnabled;
+
+    /**
+     * @zm-api-field-tag error-text
+     * @zm-api-field-description The error message, if an error occurred while processing the last
+     * <b>&lt;HsmRequest></b>
+     */
+    @XmlAttribute(name=HsmConstants.A_ERROR /* error */, required=false)
+    private String error;
+
+    /**
+     * @zm-api-field-tag total-mailboxes
+     * @zm-api-field-description Total number of mailboxes that should be processed by the HSM session
+     */
+    @XmlAttribute(name=HsmConstants.A_SM_SCHEDULE_POLICY_START_TIME /* scheduletime */, required=true)
+    private Integer smSchedulePolicyStartTime;
+
+    /**
+     * no-argument constructor wanted by JAXB
+     */
+    @SuppressWarnings("unused")
+    private GetScheduleSMPolicyResponse() {
+        this(false);
+    }
+
+    public GetScheduleSMPolicyResponse(boolean smSchedulePolicyEnabled) {
+        this.smSchedulePolicyEnabled = ZmBoolean.fromBool(smSchedulePolicyEnabled);
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+    
+    public void setSmScheduleStartTime(Integer smSchedulePolicyStartTime) {
+        this.smSchedulePolicyStartTime = smSchedulePolicyStartTime;
+    }
+
+    public boolean getSmScheduleEnabled() {
+        return ZmBoolean.toBool(smSchedulePolicyEnabled);
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public Integer getSmScheduleStartTime() {
+        return smSchedulePolicyStartTime;
+    }
+
+    public MoreObjects.ToStringHelper addToStringInfo(MoreObjects.ToStringHelper helper) {
+        return helper.add("smSchedulePolicyEnabled", smSchedulePolicyEnabled)
+                .add("smSchedulePolicyStartTime", smSchedulePolicyStartTime).add("error", error);
+    }
+
+    @Override
+    public String toString() {
+        return addToStringInfo(MoreObjects.toStringHelper(this)).toString();
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/ModifyVolumeRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/ModifyVolumeRequest.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2011, 2012, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2011, 2012, 2013, 2014, 2016, 2022 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -43,7 +43,7 @@ public class ModifyVolumeRequest {
      * @zm-api-field-description Volume information
      */
     @XmlElement(name=AdminConstants.E_VOLUME, required=true)
-    private VolumeInfo volume;
+    private VolumeInfo volumeInfo;
 
     /**
      * no-argument constructor wanted by JAXB
@@ -53,11 +53,11 @@ public class ModifyVolumeRequest {
         this((short)-1, (VolumeInfo)null);
     }
 
-    public ModifyVolumeRequest(short id, VolumeInfo volume) {
+    public ModifyVolumeRequest(short id, VolumeInfo volumeInfo) {
         this.id = id;
-        this.volume = volume;
+        this.volumeInfo = volumeInfo;
     }
 
     public short getId() { return id; }
-    public VolumeInfo getVolume() { return volume; }
+    public VolumeInfo getVolumeInfo() { return volumeInfo; }
 }

--- a/soap/src/java/com/zimbra/soap/admin/message/ScheduleSMPolicyRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/ScheduleSMPolicyRequest.java
@@ -1,0 +1,70 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.google.common.base.MoreObjects;
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.common.soap.HsmConstants;
+import com.zimbra.soap.admin.type.Name;
+
+/**
+ * @zm-api-command-network-edition
+ * @zm-api-command-auth-required true
+ * @zm-api-command-admin-auth-required true
+ * @zm-api-command-description Schedule Storage Management Policy
+ */
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name=HsmConstants.E_SCHEDULE_SMPOLICY_REQUEST)
+public class ScheduleSMPolicyRequest {
+
+    /**
+     * @zm-api-field-description Server specification
+     */
+    @XmlElement(name=AdminConstants.E_SERVER /* server */, required=true)
+    private final Name server;
+
+    /**
+     * no-argument constructor wanted by JAXB
+     */
+    @SuppressWarnings("unused")
+    private ScheduleSMPolicyRequest() {
+        this((Name) null);
+    }
+
+    public ScheduleSMPolicyRequest(Name server) {
+        this.server = server;
+    }
+
+    public Name getServer() {
+        return server;
+    }
+
+    public MoreObjects.ToStringHelper addToStringInfo(MoreObjects.ToStringHelper helper) {
+        return helper.add("server", server);
+    }
+
+    @Override
+    public String toString() {
+        return addToStringInfo(MoreObjects.toStringHelper(this)).toString();
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/ScheduleSMPolicyResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/ScheduleSMPolicyResponse.java
@@ -1,0 +1,95 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.google.common.base.MoreObjects;
+import com.zimbra.common.soap.HsmConstants;
+import com.zimbra.soap.type.ZmBoolean;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name=HsmConstants.E_SCHEDULE_SMPOLICY_RESPONSE)
+public class ScheduleSMPolicyResponse {
+
+    /**
+     * @zm-api-field-description <b>1 (true)</b> if an HSM session is currently running, <b>0 (false)</b>
+     * if the information returned applies to the last completed HSM session
+     */
+    @XmlAttribute(name=HsmConstants.A_SM_SCHEDULE_POLICY_ENABLED /* running */, required=true)
+    private final ZmBoolean smSchedulePolicyEnabled;
+
+    /**
+     * @zm-api-field-tag error-text
+     * @zm-api-field-description The error message, if an error occurred while processing the last
+     * <b>&lt;HsmRequest></b>
+     */
+    @XmlAttribute(name=HsmConstants.A_ERROR /* error */, required=false)
+    private String error;
+
+    /**
+     * @zm-api-field-tag total-mailboxes
+     * @zm-api-field-description Total number of mailboxes that should be processed by the HSM session
+     */
+    @XmlAttribute(name=HsmConstants.A_SM_SCHEDULE_POLICY_START_TIME /* totalMailboxes */, required=true)
+    private Integer smSchedulePolicyStartTime;
+
+    /**
+     * no-argument constructor wanted by JAXB
+     */
+    @SuppressWarnings("unused")
+    private ScheduleSMPolicyResponse() {
+        this(false);
+    }
+
+    public ScheduleSMPolicyResponse(boolean smSchedulePolicyEnabled) {
+        this.smSchedulePolicyEnabled = ZmBoolean.fromBool(smSchedulePolicyEnabled);
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+    public void setSmScheduleStartTime(Integer smSchedulePolicyStartTime) {
+        this.smSchedulePolicyStartTime = smSchedulePolicyStartTime;
+    }
+
+    public boolean getSmScheduleEnabled() {
+        return ZmBoolean.toBool(smSchedulePolicyEnabled);
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public Integer getSmScheduleStartTime() {
+        return smSchedulePolicyStartTime;
+    }
+
+    public MoreObjects.ToStringHelper addToStringInfo(MoreObjects.ToStringHelper helper) {
+        return helper.add("smSchedulePolicyEnabled", smSchedulePolicyEnabled)
+                .add("smSchedulePolicyStartTime", smSchedulePolicyStartTime).add("error", error);
+    }
+
+    @Override
+    public String toString() {
+        return addToStringInfo(MoreObjects.toStringHelper(this)).toString();
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/SetCurrentVolumeResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/SetCurrentVolumeResponse.java
@@ -19,7 +19,21 @@ package com.zimbra.soap.admin.message;
 
 import javax.xml.bind.annotation.XmlRootElement;
 import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.soap.admin.type.StoreManagerRuntimeSwitchResult;
+
+import javax.xml.bind.annotation.XmlElement;
 
 @XmlRootElement(name=AdminConstants.E_SET_CURRENT_VOLUME_RESPONSE)
 public class SetCurrentVolumeResponse {
+
+    @XmlElement(name=AdminConstants.E_STORE_MANAGER_RUNTIME_SWITCH_RESULT, required=false)
+    private StoreManagerRuntimeSwitchResult runtimeSwitchResult;
+
+    public StoreManagerRuntimeSwitchResult getRuntimeSwitchResult() {
+        return runtimeSwitchResult;
+    }
+
+    public void setRuntimeSwitchResult(StoreManagerRuntimeSwitchResult runtimeSwitchResult) {
+        this.runtimeSwitchResult = runtimeSwitchResult;
+    }
 }

--- a/soap/src/java/com/zimbra/soap/admin/message/ValidateS3BucketReachableRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/ValidateS3BucketReachableRequest.java
@@ -1,0 +1,103 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.AccountConstants;
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.common.soap.GlobalExternalStoreConfigConstants;
+import com.zimbra.soap.admin.type.AdminAttrsImpl;
+
+/**
+ * @zm-api-command-auth-required true
+ * @zm-api-command-admin-auth-required true
+ * @zm-api-command-description Get S3 Bucket Config
+ */
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name = AdminConstants.E_VALIDATE_S3_BUCKET_REACHABLE_REQUEST)
+public class ValidateS3BucketReachableRequest extends AdminAttrsImpl {
+
+    @XmlAttribute(name = GlobalExternalStoreConfigConstants.A_S3_URL /* url */, required = true)
+    private String url;
+
+    @XmlAttribute(name = GlobalExternalStoreConfigConstants.A_S3_BUCKET_NAME /* bucketName */, required = true)
+    private String bucketName;
+
+    @XmlAttribute(name = GlobalExternalStoreConfigConstants.A_S3_REGION /* region */, required = false)
+    private String region;
+
+    @XmlAttribute(name = GlobalExternalStoreConfigConstants.A_S3_ACCESS_KEY /* accessKey */, required = true)
+    private String accessKey;
+
+    @XmlAttribute(name = GlobalExternalStoreConfigConstants.A_S3_SECRET_KEY /* secretKey */, required = true)
+    private String secretKey;
+
+    @Override
+    public String toString() {
+        return "ValidateS3BucketReachableRequest [url=" + url + ", bucketName=" + bucketName + ", region=" + region
+                + ", accessKey=" + accessKey + ", secretKey=" + secretKey + "]";
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getBucketName() {
+        return bucketName;
+    }
+
+    public void setBucketName(String bucketName) {
+        this.bucketName = bucketName;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public void setRegion(String region) {
+        this.region = region;
+    }
+
+    public String getAccessKey() {
+        return accessKey;
+    }
+
+    public void setAccessKey(String accessKey) {
+        this.accessKey = accessKey;
+    }
+
+    public String getSecretKey() {
+        return secretKey;
+    }
+
+    public void setSecretKey(String secretKey) {
+        this.secretKey = secretKey;
+    }
+
+    public ValidateS3BucketReachableRequest() {
+    }
+
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/ValidateS3BucketReachableResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/ValidateS3BucketReachableResponse.java
@@ -1,0 +1,33 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.soap.admin.type.AdminAttrsImpl;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name = AdminConstants.E_VALIDATE_S3_BUCKET_REACHABLE_RESPONSE)
+public class ValidateS3BucketReachableResponse extends AdminAttrsImpl {
+
+    public ValidateS3BucketReachableResponse() {
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/type/BaseExternalVolume.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/BaseExternalVolume.java
@@ -1,0 +1,47 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.type;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import org.json.JSONException;
+import org.json.JSONObject;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+
+
+import com.zimbra.common.soap.AdminConstants;
+
+@XmlAccessorType(XmlAccessType.NONE)
+abstract class BaseExternalVolume {
+    /**
+     * @zm-api-field-description Set to 1 for Internal and 2 for External.
+     */
+    @XmlAttribute(name=AdminConstants.A_VOLUME_STORAGE_TYPE /* storageType */, required=false)
+    private String storageType;
+
+    public void setStorageType(String value) {
+        storageType = value;
+    }
+
+    public String getStorageType() {
+        return storageType;
+    }
+
+    public abstract JSONObject toJSON(VolumeInfo volumeInfo) throws JSONException;
+
+}

--- a/soap/src/java/com/zimbra/soap/admin/type/StoreManagerRuntimeSwitchResult.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/StoreManagerRuntimeSwitchResult.java
@@ -1,0 +1,63 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C)2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.type;
+
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.soap.admin.enums.Status;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+
+@XmlAccessorType(XmlAccessType.NONE)
+public class StoreManagerRuntimeSwitchResult {
+
+    @XmlAttribute(name= AdminConstants.A_SM_RUNTIME_SWITCH_STATUS /* status */, required=true)
+    private Status status;
+
+    /**
+     * @zm-api-field-tag volume-root-path
+     * @zm-api-field-description Absolute path to root of volume, e.g. /opt/zimbra/store
+     */
+    @XmlAttribute(name=AdminConstants.A_SM_RUNTIME_SWITCH_MESSAGE /* message */, required=true)
+    private String message;
+
+    public StoreManagerRuntimeSwitchResult() {
+    }
+
+    public StoreManagerRuntimeSwitchResult(Status status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/type/StoreManagerRuntimeSwitchResult.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/StoreManagerRuntimeSwitchResult.java
@@ -18,17 +18,24 @@
 package com.zimbra.soap.admin.type;
 
 import com.zimbra.common.soap.AdminConstants;
-import com.zimbra.soap.admin.enums.Status;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlEnum;
 
 @XmlAccessorType(XmlAccessType.NONE)
 public class StoreManagerRuntimeSwitchResult {
 
+    @XmlEnum
+    public enum RuntimeSwitchStatus {
+        SUCCESS,
+        FAIL,
+        NO_OPERATION;
+    }
+
     @XmlAttribute(name= AdminConstants.A_SM_RUNTIME_SWITCH_STATUS /* status */, required=true)
-    private Status status;
+    private RuntimeSwitchStatus runtimeSwitchStatus;
 
     /**
      * @zm-api-field-tag volume-root-path
@@ -40,17 +47,17 @@ public class StoreManagerRuntimeSwitchResult {
     public StoreManagerRuntimeSwitchResult() {
     }
 
-    public StoreManagerRuntimeSwitchResult(Status status, String message) {
-        this.status = status;
+    public StoreManagerRuntimeSwitchResult(RuntimeSwitchStatus status, String message) {
+        this.runtimeSwitchStatus = status;
         this.message = message;
     }
 
-    public Status getStatus() {
-        return status;
+    public RuntimeSwitchStatus getStatus() {
+        return runtimeSwitchStatus;
     }
 
-    public void setStatus(Status status) {
-        this.status = status;
+    public void setStatus(RuntimeSwitchStatus status) {
+        this.runtimeSwitchStatus = status;
     }
 
     public String getMessage() {

--- a/soap/src/java/com/zimbra/soap/admin/type/VolumeExternalInfo.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/VolumeExternalInfo.java
@@ -1,0 +1,112 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.type;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+
+import com.zimbra.common.soap.AdminConstants;
+
+@XmlAccessorType(XmlAccessType.NONE)
+public class VolumeExternalInfo {
+
+    /**
+     * @zm-api-field-description Set to 1 for Internal and 2 for External.
+     */
+    @XmlAttribute(name=AdminConstants.A_VOLUME_STORAGE_TYPE /* storageType */, required=false)
+    private String storageType = "S3";
+
+    /**
+     * @zm-api-field-description Prefix for bucket location e.g. server1_primary
+     */
+    @XmlAttribute(name=AdminConstants.A_VOLUME_VOLUME_PREFIX /* volumePrefix */, required=false)
+    private String volumePrefix = "";
+
+    /**
+     * @zm-api-field-description Specifies global bucket configuration Id
+     */
+    @XmlAttribute(name=AdminConstants.A_VOLUME_GLB_BUCKET_CONFIG_ID /* globalBucketConfigId */, required=true)
+    private String globalBucketConfigId = "";
+
+    /**
+     * @zm-api-field-description Specifies frequent access enabled or not
+     */
+    @XmlAttribute(name=AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS /* useInFrequentAccess */, required=false)
+    private boolean useInFrequentAccess = false;
+
+    /**
+     * @zm-api-field-description Specifies threshold value of useInFrequentAccess
+     */
+    @XmlAttribute(name=AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS_THRESHOLD /* useInFrequentAccessThreshold */, required=false)
+    private int useInFrequentAccessThreshold = 65536;
+
+    /**
+     * @zm-api-field-description Specifies intelligent tiering enabled or not
+     */
+    @XmlAttribute(name=AdminConstants.A_VOLUME_USE_INTELLIGENT_TIERING /* useIntelligentTiering */, required=false)
+    private boolean useIntelligentTiering = false;
+
+    public void setStorageType(String value) {
+        storageType = value;
+    }
+
+    public String getStorageType() {
+        return storageType;
+    }
+
+    public void setVolumePrefix(String value) {
+        volumePrefix = value;
+    }
+
+    public String getVolumePrefix() {
+        return volumePrefix;
+    }
+
+    public void setGlobalBucketConfigurationId(String value) {
+        globalBucketConfigId = value;
+    }
+
+    public String getGlobalBucketConfigurationId() {
+        return globalBucketConfigId;
+    }
+
+    public void setUseInFrequentAccess(boolean value) {
+        useInFrequentAccess = value;
+    }
+
+    public boolean isUseInFrequentAccess() {
+        return useInFrequentAccess;
+    }
+
+    public void setUseIntelligentTiering(boolean value) {
+        useIntelligentTiering = value;
+    }
+
+    public boolean isUseIntelligentTiering() {
+        return useIntelligentTiering;
+    }
+
+    public void setUseInFrequentAccessThreshold(int value) {
+        useInFrequentAccessThreshold = value;
+    }
+
+    public int getUseInFrequentAccessThreshold() {
+        return useInFrequentAccessThreshold;
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/type/VolumeExternalInfo.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/VolumeExternalInfo.java
@@ -21,16 +21,14 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import com.zimbra.common.soap.AdminConstants;
 
 @XmlAccessorType(XmlAccessType.NONE)
-public class VolumeExternalInfo {
 
-    /**
-     * @zm-api-field-description Set to 1 for Internal and 2 for External.
-     */
-    @XmlAttribute(name=AdminConstants.A_VOLUME_STORAGE_TYPE /* storageType */, required=false)
-    private String storageType = "S3";
+public class VolumeExternalInfo extends BaseExternalVolume{
 
     /**
      * @zm-api-field-description Prefix for bucket location e.g. server1_primary
@@ -61,14 +59,6 @@ public class VolumeExternalInfo {
      */
     @XmlAttribute(name=AdminConstants.A_VOLUME_USE_INTELLIGENT_TIERING /* useIntelligentTiering */, required=false)
     private boolean useIntelligentTiering = false;
-
-    public void setStorageType(String value) {
-        storageType = value;
-    }
-
-    public String getStorageType() {
-        return storageType;
-    }
 
     public void setVolumePrefix(String value) {
         volumePrefix = value;
@@ -108,5 +98,30 @@ public class VolumeExternalInfo {
 
     public int getUseInFrequentAccessThreshold() {
         return useInFrequentAccessThreshold;
+    }
+
+	@Override
+    public JSONObject toJSON(VolumeInfo volInfo) throws JSONException {
+        VolumeExternalInfo volExtInfo = volInfo.getVolumeExternalInfo();
+        JSONObject volExtInfoObj = new JSONObject();
+        volExtInfoObj.put(AdminConstants.A_VOLUME_ID, String.valueOf(volInfo.getId()));
+        volExtInfoObj.put(AdminConstants.A_VOLUME_STORAGE_TYPE, volExtInfo.getStorageType());
+        volExtInfoObj.put(AdminConstants.A_VOLUME_VOLUME_PREFIX, volExtInfo.getVolumePrefix());
+        volExtInfoObj.put(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS, String.valueOf(volExtInfo.isUseInFrequentAccess()));
+        volExtInfoObj.put(AdminConstants.A_VOLUME_USE_INTELLIGENT_TIERING, String.valueOf(volExtInfo.isUseIntelligentTiering()));
+        volExtInfoObj.put(AdminConstants.A_VOLUME_GLB_BUCKET_CONFIG_ID, volExtInfo.getGlobalBucketConfigurationId());
+        volExtInfoObj.put(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS_THRESHOLD, String.valueOf(volExtInfo.getUseInFrequentAccessThreshold()));
+        return volExtInfoObj;
+    }
+
+    public VolumeExternalInfo toExternalInfo(JSONObject properties) throws JSONException {
+        VolumeExternalInfo volExtInfo = new VolumeExternalInfo();
+        volExtInfo.setVolumePrefix(properties.getString(AdminConstants.A_VOLUME_VOLUME_PREFIX));
+        volExtInfo.setGlobalBucketConfigurationId(properties.getString(AdminConstants.A_VOLUME_GLB_BUCKET_CONFIG_ID));
+        volExtInfo.setUseInFrequentAccess(Boolean.valueOf(properties.getString(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS)));
+        volExtInfo.setUseIntelligentTiering(Boolean.valueOf(properties.getString(AdminConstants.A_VOLUME_USE_INTELLIGENT_TIERING)));
+        volExtInfo.setUseInFrequentAccessThreshold(Integer.parseInt(properties.getString(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS_THRESHOLD)));
+        volExtInfo.setStorageType(properties.getString(AdminConstants.A_VOLUME_STORAGE_TYPE));
+        return volExtInfo;
     }
 }

--- a/soap/src/java/com/zimbra/soap/admin/type/VolumeExternalOpenIOInfo.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/VolumeExternalOpenIOInfo.java
@@ -1,0 +1,127 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.type;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+
+import com.zimbra.common.soap.AdminConstants;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+@XmlAccessorType(XmlAccessType.NONE)
+
+public class VolumeExternalOpenIOInfo extends BaseExternalVolume {
+
+    /**
+     * @zm-api-field-description Specifies the standard HTTP URL for OpenIO
+     */
+    @XmlAttribute(name=AdminConstants.A_VOLUME_URL /* url */, required=false)
+    private String url;
+
+    /**
+     * @zm-api-field-description Specifies OpenIO account name
+     */
+    @XmlAttribute(name=AdminConstants.A_VOLUME_ACCOUNT/* account */, required=false)
+    private String account;
+
+    /**
+     * @zm-api-field-description Specifies OpenIO namespace
+     */
+    @XmlAttribute(name=AdminConstants.A_VOLUME_NAMESPACE /* namespace */, required=false)
+    private String nameSpace;
+
+    /**
+     * @zm-api-field-description Specifies OpenIO proxy port
+     */
+    @XmlAttribute(name=AdminConstants.A_VOLUME_PROXY_PORT /* proxyPort */, required=false)
+    private Integer proxyPort = -1;
+
+    /**
+     * @zm-api-field-description Specifies OpenIO account port
+     */
+    @XmlAttribute(name=AdminConstants.A_VOLUME_ACCOUNT_PORT /* accountPort */, required=false)
+    private Integer accountPort = -1;
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getAccount() {
+        return account;
+    }
+
+    public void setAccount(String account) {
+        this.account = account;
+    }
+
+    public String getNameSpace() {
+        return nameSpace;
+    }
+
+    public void setNameSpace(String nameSpace) {
+        this.nameSpace = nameSpace;
+    }
+
+    public Integer getProxyPort() {
+        return proxyPort;
+    }
+
+    public void setProxyPort(Integer proxyPort) {
+        this.proxyPort = proxyPort;
+    }
+
+    public Integer getAccountPort() {
+        return accountPort;
+    }
+
+    public void setAccountPort(Integer accountPort) {
+        this.accountPort = accountPort;
+    }
+
+	@Override
+    public JSONObject toJSON(VolumeInfo volInfo) throws JSONException {
+        VolumeExternalOpenIOInfo volExtOpenIOInfo = volInfo.getVolumeExternalOpenIOInfo();
+        JSONObject volExtInfoObj = new JSONObject();
+        volExtInfoObj.put(AdminConstants.A_VOLUME_ID, String.valueOf(volInfo.getId()));
+        volExtInfoObj.put(AdminConstants.A_VOLUME_STORAGE_TYPE, volExtOpenIOInfo.getStorageType());
+        volExtInfoObj.put(AdminConstants.A_VOLUME_URL, String.valueOf(volExtOpenIOInfo.getUrl()));
+        volExtInfoObj.put(AdminConstants.A_VOLUME_ACCOUNT, String.valueOf(volExtOpenIOInfo.getAccount()));
+        volExtInfoObj.put(AdminConstants.A_VOLUME_NAMESPACE, String.valueOf(volExtOpenIOInfo.getNameSpace()));
+        volExtInfoObj.put(AdminConstants.A_VOLUME_PROXY_PORT, String.valueOf(volExtOpenIOInfo.getProxyPort()));
+        volExtInfoObj.put(AdminConstants.A_VOLUME_ACCOUNT_PORT, String.valueOf(volExtOpenIOInfo.getAccountPort()));
+        return volExtInfoObj;
+    }
+
+    public VolumeExternalOpenIOInfo toExternalOpenIoInfo(JSONObject properties) throws JSONException {
+        VolumeExternalOpenIOInfo volExtOpenIOInfo = new VolumeExternalOpenIOInfo();
+        volExtOpenIOInfo.setUrl(properties.getString(AdminConstants.A_VOLUME_URL));
+        volExtOpenIOInfo.setAccount(properties.getString(AdminConstants.A_VOLUME_ACCOUNT));
+        volExtOpenIOInfo.setNameSpace(properties.getString(AdminConstants.A_VOLUME_NAMESPACE));
+        volExtOpenIOInfo.setAccountPort(Integer.parseInt(properties.getString(AdminConstants.A_VOLUME_ACCOUNT_PORT)));
+        volExtOpenIOInfo.setProxyPort(Integer.parseInt(properties.getString(AdminConstants.A_VOLUME_PROXY_PORT)));
+        volExtOpenIOInfo.setStorageType(properties.getString(AdminConstants.A_VOLUME_STORAGE_TYPE));
+        return volExtOpenIOInfo;
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/type/VolumeInfo.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/VolumeInfo.java
@@ -113,7 +113,7 @@ public final class VolumeInfo {
     private short storeType = 1;
 
     @XmlAttribute(name=AdminConstants.A_VOLUME_STORE_MANAGER_CLASS /* storeManagerClass*/, required=false)
-    private String storeManagerClass = LC.zimbra_class_store.value();
+    private String storeManagerClass;
 
     /**
      * @zm-api-field-description Volume external information for S3

--- a/soap/src/java/com/zimbra/soap/admin/type/VolumeInfo.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/VolumeInfo.java
@@ -112,10 +112,16 @@ public final class VolumeInfo {
     private short storeType = 1;
 
     /**
-     * @zm-api-field-description Volume external information
+     * @zm-api-field-description Volume external information for S3
      */
     @XmlElement(name=AdminConstants.E_VOLUME_EXT /* volumeExternalInfo */, required=false)
     private VolumeExternalInfo volumeExternalInfo;
+
+    /**
+     * @zm-api-field-description Volume external information for OpenIO
+     */
+    @XmlElement(name=AdminConstants.E_VOLUME_OPENIO_EXT /* volumeExternalOpenIOInfo */, required=false)
+    private VolumeExternalOpenIOInfo volumeExternalOpenIOInfo;
 
     public void setId(short value) {
         id = value;
@@ -219,5 +225,13 @@ public final class VolumeInfo {
 
     public short getStoreType() {
         return storeType;
+    }
+
+    public VolumeExternalOpenIOInfo getVolumeExternalOpenIOInfo() {
+        return volumeExternalOpenIOInfo;
+    }
+
+    public void setVolumeExternalOpenIOInfo(VolumeExternalOpenIOInfo volumeExternalOpenIOInfo) {
+        this.volumeExternalOpenIOInfo = volumeExternalOpenIOInfo;
     }
 }

--- a/soap/src/java/com/zimbra/soap/admin/type/VolumeInfo.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/VolumeInfo.java
@@ -22,6 +22,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 
+import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.soap.AdminConstants;
 
 @XmlAccessorType(XmlAccessType.NONE)
@@ -110,6 +111,9 @@ public final class VolumeInfo {
      */
     @XmlAttribute(name=AdminConstants.A_VOLUME_STORE_TYPE /* storeType */, required=false)
     private short storeType = 1;
+
+    @XmlAttribute(name=AdminConstants.A_VOLUME_STORE_MANAGER_CLASS /* storeManagerClass*/, required=false)
+    private String storeManagerClass = LC.zimbra_class_store.value();
 
     /**
      * @zm-api-field-description Volume external information for S3
@@ -233,5 +237,13 @@ public final class VolumeInfo {
 
     public void setVolumeExternalOpenIOInfo(VolumeExternalOpenIOInfo volumeExternalOpenIOInfo) {
         this.volumeExternalOpenIOInfo = volumeExternalOpenIOInfo;
+    }
+
+    public String getStoreManagerClass() {
+        return storeManagerClass;
+    }
+
+    public void setStoreManagerClass(String storeManagerClass) {
+        this.storeManagerClass = storeManagerClass;
     }
 }

--- a/soap/src/java/com/zimbra/soap/admin/type/VolumeInfo.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/VolumeInfo.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2011, 2012, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2011, 2012, 2013, 2014, 2016, 2022 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -20,9 +20,9 @@ package com.zimbra.soap.admin.type;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
 
 import com.zimbra.common.soap.AdminConstants;
-import com.zimbra.soap.type.ZmBoolean;
 
 @XmlAccessorType(XmlAccessType.NONE)
 public final class VolumeInfo {
@@ -38,14 +38,14 @@ public final class VolumeInfo {
      * @zm-api-field-tag volume-name
      * @zm-api-field-description Name or description of volume
      */
-    @XmlAttribute(name=AdminConstants.A_VOLUME_NAME /* name */, required=false)
+    @XmlAttribute(name=AdminConstants.A_VOLUME_NAME /* name */, required=true)
     private String name;
 
     /**
      * @zm-api-field-tag volume-root-path
      * @zm-api-field-description Absolute path to root of volume, e.g. /opt/zimbra/store
      */
-    @XmlAttribute(name=AdminConstants.A_VOLUME_ROOTPATH /* rootpath */, required=false)
+    @XmlAttribute(name=AdminConstants.A_VOLUME_ROOTPATH /* rootpath */, required=true)
     private String rootPath;
 
     /**
@@ -57,7 +57,7 @@ public final class VolumeInfo {
      * <tr> <td> <b>10</b> </td> <td> index volume </td> </tr>
      * </table>
      */
-    @XmlAttribute(name=AdminConstants.A_VOLUME_TYPE /* type */, required=false)
+    @XmlAttribute(name=AdminConstants.A_VOLUME_TYPE /* type */, required=true)
     private short type = -1;
 
     /**
@@ -65,7 +65,7 @@ public final class VolumeInfo {
      * @zm-api-field-description Specifies whether blobs in this volume are compressed
      */
     @XmlAttribute(name=AdminConstants.A_VOLUME_COMPRESS_BLOBS /* compressBlobs */, required=false)
-    private ZmBoolean compressBlobs;
+    private boolean compressBlobs = false;
 
     /**
      * @zm-api-field-tag compression-threshold
@@ -73,7 +73,7 @@ public final class VolumeInfo {
      * that will not be compressed (in other words blobs larger than this threshold are compressed)
      */
     @XmlAttribute(name=AdminConstants.A_VOLUME_COMPRESSION_THRESHOLD /* compressionThreshold */, required=false)
-    private long compressionThreshold = -1;
+    private long compressionThreshold = 4096;
 
     /**
      * @zm-api-field-description mgbits
@@ -102,8 +102,20 @@ public final class VolumeInfo {
     /**
      * @zm-api-field-description Set if the volume is current.
      */
-    @XmlAttribute(name=AdminConstants.A_VOLUME_IS_CURRENT /* isCurrent */, required=false)
-    private ZmBoolean current;
+    @XmlAttribute(name=AdminConstants.A_VOLUME_CURRENT /* current */, required=false)
+    private boolean current = false;
+
+    /**
+     * @zm-api-field-description Set to 1 for internal volumes and 2 for external volumes
+     */
+    @XmlAttribute(name=AdminConstants.A_VOLUME_STORE_TYPE /* storeType */, required=false)
+    private short storeType = 1;
+
+    /**
+     * @zm-api-field-description Volume external information
+     */
+    @XmlElement(name=AdminConstants.E_VOLUME_EXT /* volumeExternalInfo */, required=false)
+    private VolumeExternalInfo volumeExternalInfo;
 
     public void setId(short value) {
         id = value;
@@ -138,15 +150,11 @@ public final class VolumeInfo {
     }
 
     public void setCompressBlobs(Boolean value) {
-        compressBlobs = ZmBoolean.fromBool(value);
+        compressBlobs = value;
     }
 
     public boolean isCompressBlobs() {
-        return ZmBoolean.toBool(compressBlobs, false);
-    }
-
-    public Boolean getCompressBlobs() {
-        return ZmBoolean.toBool(compressBlobs);
+        return compressBlobs;
     }
 
     public void setCompressionThreshold(long value) {
@@ -190,10 +198,26 @@ public final class VolumeInfo {
     }
 
     public void setCurrent(boolean value) {
-        current = ZmBoolean.fromBool(value);
+        current = value;
     }
 
-    public Boolean isCurrent() {
-        return ZmBoolean.toBool(current);
+    public boolean isCurrent() {
+        return current;
+    }
+
+    public void setVolumeExternalInfo(VolumeExternalInfo value) {
+        volumeExternalInfo = value;
+    }
+
+    public VolumeExternalInfo getVolumeExternalInfo() {
+        return volumeExternalInfo;
+    }
+
+    public void setStoreType(short value) {
+        storeType = value;
+    }
+
+    public short getStoreType() {
+        return storeType;
     }
 }

--- a/soap/src/java/com/zimbra/soap/type/GlobalS3BucketConfiguration.java
+++ b/soap/src/java/com/zimbra/soap/type/GlobalS3BucketConfiguration.java
@@ -1,0 +1,179 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.type;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+
+import com.zimbra.common.soap.GlobalExternalStoreConfigConstants;
+
+@XmlAccessorType(XmlAccessType.NONE)
+public final class GlobalS3BucketConfiguration {
+
+    /**
+     * @zm-api-field-tag globalBucketUUID
+     * @zm-api-field-description Global Bucket UUID
+     */
+    @XmlAttribute(name=GlobalExternalStoreConfigConstants.A_S3_GLOBAL_BUCKET_UUID, /* globalBucketUUID */ required=false)
+    private String globalBucketUUID;
+
+    /**
+     * @zm-api-field-tag bucketName
+     * @zm-api-field-description Global Bucket Name
+     */
+    @XmlAttribute(name=GlobalExternalStoreConfigConstants.A_S3_BUCKET_NAME, /* bucketName */ required=false)
+    private String bucketName;
+
+    /**
+     * @zm-api-field-tag storeProvider
+     * @zm-api-field-description Global Store Provider
+     */
+    @XmlAttribute(name=GlobalExternalStoreConfigConstants.A_S3_STORE_PROVIDER, /* storeProvider */ required=false)
+    private String storeProvider;
+
+    /**
+     * @zm-api-field-tag protocol
+     * @zm-api-field-description Global Protocol
+     */
+    @XmlAttribute(name=GlobalExternalStoreConfigConstants.A_S3_PROTOCOL, /* protocol */ required=false)
+    private String protocol;
+
+    /**
+     * @zm-api-field-tag accessKey
+     * @zm-api-field-description Global Access Key
+     */
+    @XmlAttribute(name=GlobalExternalStoreConfigConstants.A_S3_ACCESS_KEY, /* accessKey */ required=false)
+    private String accessKey;
+
+    /**
+     * @zm-api-field-tag secret
+     * @zm-api-field-description Global Secret
+     */
+    @XmlAttribute(name=GlobalExternalStoreConfigConstants.A_S3_SECRET_KEY, /* secret */ required=false)
+    private String secretKey;
+
+    /**
+     * @zm-api-field-tag region
+     * @zm-api-field-description Global Region
+     */
+    @XmlAttribute(name=GlobalExternalStoreConfigConstants.A_S3_REGION, /* region */ required=false)
+    private String region;
+
+    /**
+     * @zm-api-field-tag destinationPath
+     * @zm-api-field-description Global Destination Path
+     */
+    @XmlAttribute(name=GlobalExternalStoreConfigConstants.A_S3_DESTINATION_PATH, /* destinationPath */ required=false)
+    private String destinationPath;
+
+    /**
+     * @zm-api-field-tag url
+     * @zm-api-field-description Global Url
+     */
+    @XmlAttribute(name=GlobalExternalStoreConfigConstants.A_S3_URL, /* url */ required=false)
+    private String url;
+
+    /**
+     * @zm-api-field-tag bucketStatus
+     * @zm-api-field-description Global Bucket Status
+     */
+    @XmlAttribute(name=GlobalExternalStoreConfigConstants.A_S3_BUCKET_STATUS, /* bucketStatus */ required=false)
+    private String bucketStatus;
+
+    public String getGlobalBucketUUID() {
+        return globalBucketUUID;
+    }
+
+    public void setGlobalBucketUUID(String globalBucketUUID) {
+        this.globalBucketUUID = globalBucketUUID;
+    }
+
+    public String getBucketName() {
+        return bucketName;
+    }
+
+    public void setBucketName(String bucketName) {
+        this.bucketName = bucketName;
+    }
+
+    public String getStoreProvider() {
+        return storeProvider;
+    }
+
+    public void setStoreProvider(String storeProvider) {
+        this.storeProvider = storeProvider;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    public String getAccessKey() {
+        return accessKey;
+    }
+
+    public void setAccessKey(String accessKey) {
+        this.accessKey = accessKey;
+    }
+
+    public String getSecretKey() {
+        return secretKey;
+    }
+
+    public void setSecretKey(String secretKey) {
+        this.secretKey = secretKey;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public void setRegion(String region) {
+        this.region = region;
+    }
+
+    public String getDestinationPath() {
+        return destinationPath;
+    }
+
+    public void setDestinationPath(String destinationPath) {
+        this.destinationPath = destinationPath;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getBucketStatus() {
+        return bucketStatus;
+    }
+
+    public void setBucketStatus(String bucketStatus) {
+        this.bucketStatus = bucketStatus;
+    }
+
+}

--- a/store-conf/conf/msgs/ZsMsg.properties
+++ b/store-conf/conf/msgs/ZsMsg.properties
@@ -379,6 +379,7 @@ zimbra_db_directory = Directory for database files.
 zimbra_tmp_directory = Directory for temporary files.
 zimbra_external_email_warning_enabled = Sets whether the External Email Warning (EEW) feature is enabled. Defaults to: false
 zimbra_external_email_warning_message = Sets the base warning text for External Email Warning (EEW). Defaults to: This message originated outside of your organization.
+zimbra_hybrid_blob_mover_enabled = Sets whether the Hybrid Blob Mover feature is enabled. Defaults to: false
 zimbra_extensions_directory = Directory whose subdirs contain extensions.
 zimbra_extensions_common_directory = Directory with jar files that are common across all extensions.
 zimbra_mysql_shutdown_timeout = Time to wait for the mailbox MySQL/MariaDB process to die. \

--- a/store-conf/conf/msgs/ZsMsg.properties
+++ b/store-conf/conf/msgs/ZsMsg.properties
@@ -380,6 +380,7 @@ zimbra_tmp_directory = Directory for temporary files.
 zimbra_external_email_warning_enabled = Sets whether the External Email Warning (EEW) feature is enabled. Defaults to: false
 zimbra_external_email_warning_message = Sets the base warning text for External Email Warning (EEW). Defaults to: This message originated outside of your organization.
 zimbra_hybrid_blob_mover_enabled = Sets whether the Hybrid Blob Mover feature is enabled. Defaults to: false
+zimbra_s3_connection_request_timeout_ms = Timeout in milliseconds for HTTP(S) requests used to verify a successful connection to an S3 server. Defaults to 20000
 zimbra_extensions_directory = Directory whose subdirs contain extensions.
 zimbra_extensions_common_directory = Directory with jar files that are common across all extensions.
 zimbra_mysql_shutdown_timeout = Time to wait for the mailbox MySQL/MariaDB process to die. \

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -2891,7 +2891,7 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
 
 <attr id="543" name="zimbraMailLastPurgedMailboxId" type="integer" cardinality="single" optionalIn="server" since="5.0.0" deprecatedSince="5.0.7">
   <desc>The id of the last purged mailbox.</desc>
-  <deprecateDesc>deprecated per bug 28842</deprecateDesc>>
+  <deprecateDesc>deprecated per bug 28842</deprecateDesc>
 </attr>
 
 <attr id="544" name="zimbraFeatureZimbraAssistantEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited" since="5.0.0">
@@ -5166,7 +5166,7 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
   <defaultCOSValue>TRUE</defaultCOSValue>
   <defaultExternalCOSValue>FALSE</defaultExternalCOSValue>
   <desc>whether people search feature is enabled</desc>
-  <deprecateDesc>Deprecated per bug 56924</deprecateDesc>>
+  <deprecateDesc>Deprecated per bug 56924</deprecateDesc>
 </attr>
 
 <attr id="1110" name="zimbraGalLdapValueMap" type="string" max="4096" cardinality="multi" optionalIn="globalConfig,domain,galDataSource" flags="domainInherited" since="7.0.0">
@@ -9941,7 +9941,6 @@ TODO: delete them permanently from here
       If set as 14.1, all device types android/ios connecting to this account will use 14.1 version.
       If the added values don't match the user agent/device Id/device type default zimbra_activesync_versions on the local config will be used.
   </desc>
-<<<<<<< HEAD
 </attr>    
 
 <attr id="4009" name="zimbraGlobalBackupEnabled" type="boolean" cardinality="single" optionalIn="globalConfig" since="10.0.0">
@@ -10026,5 +10025,4 @@ TODO: delete them permanently from here
 <attr id="4020" name="zimbraServerExternalStoreConfig" type="string" cardinality="single" optionalIn="server" since="10.0.0">
   <desc>Server level external store config</desc>
 </attr>
-
 </attrs>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10025,4 +10025,12 @@ TODO: delete them permanently from here
 <attr id="4020" name="zimbraServerExternalStoreConfig" type="string" cardinality="single" optionalIn="server" since="10.0.0">
   <desc>Server level external store config</desc>
 </attr>
+<attr id="4008" name="zimbraSMMultiReaderEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited"  since="9.1.0">
+  <globalConfigValue>FALSE</globalConfigValue>
+  <desc>Zimbra multiple reader StoreManagers enabled </desc>
+</attr>
+<attr id="4009" name="zimbraSMRuntimeSwitchEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited"  since="9.1.0">
+  <globalConfigValue>FALSE</globalConfigValue>
+  <desc>Zimbra StoreManager runtime switching enabled </desc>
+</attr>
 </attrs>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10017,4 +10017,13 @@ TODO: delete them permanently from here
         If true on cos level , unset on domain level but zimbraDomainDefaultCOSId is set to cos then accounts for that domain will be backed up.
   </desc>
 </attr>
+
+<attr id="4019" name="zimbraGlobalExternalStoreConfig" type="string" cardinality="single" optionalIn="globalConfig" since="10.0.0">
+  <desc>Global level external store config</desc>
+</attr>
+
+<attr id="4020" name="zimbraServerExternalStoreConfig" type="string" cardinality="single" optionalIn="server" since="10.0.0">
+  <desc>Server level external store config</desc>
+</attr>
+
 </attrs>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10025,11 +10025,11 @@ TODO: delete them permanently from here
 <attr id="4020" name="zimbraServerExternalStoreConfig" type="string" cardinality="single" optionalIn="server" since="10.0.0">
   <desc>Server level external store config</desc>
 </attr>
-<attr id="4008" name="zimbraSMMultiReaderEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited"  since="9.1.0">
+<attr id="4021" name="zimbraSMMultiReaderEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited"  since="10.0.0">
   <globalConfigValue>TRUE</globalConfigValue>
   <desc>Zimbra multiple reader StoreManagers enabled </desc>
 </attr>
-<attr id="4009" name="zimbraSMRuntimeSwitchEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited"  since="9.1.0">
+<attr id="4022" name="zimbraSMRuntimeSwitchEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited"  since="10.0.0">
   <globalConfigValue>TRUE</globalConfigValue>
   <desc>Zimbra StoreManager runtime switching enabled </desc>
 </attr>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10026,11 +10026,11 @@ TODO: delete them permanently from here
   <desc>Server level external store config</desc>
 </attr>
 <attr id="4008" name="zimbraSMMultiReaderEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited"  since="9.1.0">
-  <globalConfigValue>FALSE</globalConfigValue>
+  <globalConfigValue>TRUE</globalConfigValue>
   <desc>Zimbra multiple reader StoreManagers enabled </desc>
 </attr>
 <attr id="4009" name="zimbraSMRuntimeSwitchEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited"  since="9.1.0">
-  <globalConfigValue>FALSE</globalConfigValue>
+  <globalConfigValue>TRUE</globalConfigValue>
   <desc>Zimbra StoreManager runtime switching enabled </desc>
 </attr>
 </attrs>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9941,6 +9941,7 @@ TODO: delete them permanently from here
       If set as 14.1, all device types android/ios connecting to this account will use 14.1 version.
       If the added values don't match the user agent/device Id/device type default zimbra_activesync_versions on the local config will be used.
   </desc>
+<<<<<<< HEAD
 </attr>    
 
 <attr id="4009" name="zimbraGlobalBackupEnabled" type="boolean" cardinality="single" optionalIn="globalConfig" since="10.0.0">

--- a/store/src/db/hsqldb/db.sql
+++ b/store/src/db/hsqldb/db.sql
@@ -32,7 +32,9 @@ CREATE TABLE volume (
    mailbox_group_bits     SMALLINT NOT NULL,
    compress_blobs         BOOLEAN NOT NULL,
    compression_threshold  BIGINT NOT NULL,
-   metadata               VARCHAR(255),
+   metadata               VARCHAR(255) NULL,
+   store_type             TINYINT DEFAULT 1 NOT NULL,
+   store_manager_class    VARCHAR(255),
 
    CONSTRAINT i_name UNIQUE (name),
    CONSTRAINT i_path UNIQUE (path)

--- a/store/src/java-test/com/zimbra/cs/store/CacheEnabledStoreManagerProviderTest.java
+++ b/store/src/java-test/com/zimbra/cs/store/CacheEnabledStoreManagerProviderTest.java
@@ -1,0 +1,116 @@
+package com.zimbra.cs.store;
+
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.store.helper.ClassHelper;
+import com.zimbra.cs.volume.Volume;
+import com.zimbra.cs.volume.VolumeManager;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore("javax.management.*")
+public class CacheEnabledStoreManagerProviderTest {
+    private static final String TEST_CONFIG_FILE_DIR_PATH = "../store/src/java-test/";
+    private static final String TEST_CONFIG_FILE_PATH = TEST_CONFIG_FILE_DIR_PATH + "localconfig-test.xml";
+
+    @BeforeClass
+    public static void init() throws Exception {
+        System.setProperty("zimbra.config", TEST_CONFIG_FILE_PATH);
+        MailboxTestUtil.initServer();
+        Provisioning prov = Provisioning.getInstance();
+        prov.getLocalServer().setSMRuntimeSwitchEnabled(true);
+        prov.getLocalServer().setSMMultiReaderEnabled(true);
+    }
+
+    @Test
+    @PrepareForTest({ClassHelper.class})
+    public void testGetStoreManagerForVolumeWithCacheSkip() throws Throwable {
+        Volume volume3 = Volume.builder().setId((short) 200)
+                .setName("TEST300")
+                .setPath("/test/300", false)
+                .setType((short) 1)
+                .setStoreType(Volume.StoreType.INTERNAL)
+                .setStoreManagerClass(MockStoreManager.class.getName()).build();
+        Volume volume4 = Volume.builder().setId((short) 201)
+                .setName("TEST400")
+                .setPath("/test/400", false)
+                .setType((short) 1)
+                .setStoreType(Volume.StoreType.EXTERNAL)
+                .setStoreManagerClass(MockStoreManager.class.getName()).build();
+
+        VolumeManager.getInstance().create(volume3);
+        VolumeManager.getInstance().create(volume4);
+
+        mockStatic(ClassHelper.class);
+        when(ClassHelper.getZimbraClassInstanceBy(Mockito.anyString())).thenReturn(new MockStoreManager());
+
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume3.getId(), true);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume3.getId(), true);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume3.getId(), true);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume3.getId(), true);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume3.getId(), true);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume4.getId(), true);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume4.getId(), true);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume4.getId(), true);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume4.getId(), true);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume4.getId(), true);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume4.getId(), true);
+
+        // delete volumes
+        VolumeManager.getInstance().delete(volume3.getId());
+        VolumeManager.getInstance().delete(volume4.getId());
+        // make sure only twice it was called
+        verifyStatic(Mockito.times(11));
+    }
+
+    @Test
+    @PrepareForTest({ClassHelper.class})
+    public void testGetStoreManagerForVolumeWithoutCacheSkip() throws Throwable {
+        Volume volume3 = Volume.builder().setId((short) 200)
+                .setName("TEST300")
+                .setPath("/test/300", false)
+                .setType((short) 1)
+                .setStoreType(Volume.StoreType.INTERNAL)
+                .setStoreManagerClass(MockStoreManager.class.getName()).build();
+        Volume volume4 = Volume.builder().setId((short) 201)
+                .setName("TEST400")
+                .setPath("/test/400", false)
+                .setType((short) 1)
+                .setStoreType(Volume.StoreType.EXTERNAL)
+                .setStoreManagerClass(MockStoreManager.class.getName()).build();
+
+        VolumeManager.getInstance().create(volume3);
+        VolumeManager.getInstance().create(volume4);
+
+        mockStatic(ClassHelper.class);
+        when(ClassHelper.getZimbraClassInstanceBy(Mockito.anyString())).thenReturn(new MockStoreManager());
+
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume3.getId(), false);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume3.getId(), false);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume3.getId(), false);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume3.getId(), false);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume3.getId(), false);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume4.getId(), false);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume4.getId(), false);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume4.getId(), false);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume4.getId(), false);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume4.getId(), false);
+        CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volume4.getId(), false);
+
+        // delete volumes
+        VolumeManager.getInstance().delete(volume3.getId());
+        VolumeManager.getInstance().delete(volume4.getId());
+        // make sure only twice it was called
+        verifyStatic(Mockito.times(2));
+    }
+}

--- a/store/src/java-test/com/zimbra/cs/store/StoreManagerAfterReset.java
+++ b/store/src/java-test/com/zimbra/cs/store/StoreManagerAfterReset.java
@@ -1,0 +1,116 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.store;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.mailbox.Mailbox;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class StoreManagerAfterReset extends StoreManager {
+
+    @Override
+    public void startup() throws IOException, ServiceException {
+
+    }
+
+    @Override
+    public void shutdown() {
+
+    }
+
+    @Override
+    public boolean supports(StoreFeature feature) {
+        return false;
+    }
+
+    @Override
+    public boolean supports(StoreFeature feature, String locator) {
+        return false;
+    }
+
+    @Override
+    public BlobBuilder getBlobBuilder() throws IOException, ServiceException {
+        return null;
+    }
+
+    @Override
+    public Blob storeIncoming(InputStream data, boolean storeAsIs) throws IOException, ServiceException {
+        return null;
+    }
+
+    @Override
+    public StagedBlob stage(InputStream data, long actualSize, Mailbox mbox) throws IOException, ServiceException {
+        return null;
+    }
+
+    @Override
+    public StagedBlob stage(Blob blob, Mailbox mbox) throws IOException, ServiceException {
+        return null;
+    }
+
+    @Override
+    public MailboxBlob copy(MailboxBlob src, Mailbox destMbox, int destMsgId, int destRevision) throws IOException, ServiceException {
+        return null;
+    }
+
+    @Override
+    public MailboxBlob link(StagedBlob src, Mailbox destMbox, int destMsgId, int destRevision) throws IOException, ServiceException {
+        return null;
+    }
+
+    @Override
+    public MailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destMsgId, int destRevision) throws IOException, ServiceException {
+        return null;
+    }
+
+    @Override
+    public boolean delete(Blob blob) throws IOException {
+        return false;
+    }
+
+    @Override
+    public boolean delete(StagedBlob staged) throws IOException {
+        return false;
+    }
+
+    @Override
+    public boolean delete(MailboxBlob mblob) throws IOException {
+        return false;
+    }
+
+    @Override
+    public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, int revision, String locator, boolean validate) throws ServiceException {
+        return null;
+    }
+
+    @Override
+    public InputStream getContent(MailboxBlob mboxBlob) throws IOException {
+        return null;
+    }
+
+    @Override
+    public InputStream getContent(Blob blob) throws IOException {
+        return null;
+    }
+
+    @Override
+    public boolean deleteStore(Mailbox mbox, Iterable<MailboxBlob.MailboxBlobInfo> blobs) throws IOException, ServiceException {
+        return false;
+    }
+}

--- a/store/src/java-test/com/zimbra/cs/store/StoreManagerMultiThreadedTest.java
+++ b/store/src/java-test/com/zimbra/cs/store/StoreManagerMultiThreadedTest.java
@@ -1,0 +1,168 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.store;
+
+import com.zimbra.common.localconfig.ConfigException;
+import com.zimbra.common.localconfig.LC;
+import com.zimbra.common.localconfig.LocalConfig;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.store.helper.ClassHelper;
+import org.apache.commons.io.FileUtils;
+import org.apache.mina.util.ConcurrentHashSet;
+import org.dom4j.DocumentException;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.zimbra.common.localconfig.LC.zimbra_class_store;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore("javax.management.*")
+public class StoreManagerMultiThreadedTest {
+
+    private static final String TEST_CONFIG_FILE_DIR_PATH = "../store/src/java-test/";
+    private static final String TEST_CONFIG_FILE_PATH = TEST_CONFIG_FILE_DIR_PATH + "localconfig-test.xml";
+    private static final String TEST_CONFIG_FILE_COPY_PATH = TEST_CONFIG_FILE_DIR_PATH + "localconfig-test-copy.xml";
+
+    @BeforeClass
+    public static void init() throws Exception {
+        System.setProperty("zimbra.config", TEST_CONFIG_FILE_PATH);
+        MailboxTestUtil.initServer();
+        Provisioning prov = Provisioning.getInstance();
+        prov.getLocalServer().setSMRuntimeSwitchEnabled(true);
+        prov.getLocalServer().setSMMultiReaderEnabled(true);
+    }
+
+    @After
+    public void tearDownTest() throws IOException, DocumentException, ConfigException {
+        FileUtils.copyFile(new File(TEST_CONFIG_FILE_COPY_PATH), new File(TEST_CONFIG_FILE_PATH), true);
+        LC.reload();
+    }
+
+    @Test
+    public void testGetInstanceWithoutReset() throws InterruptedException {
+        Set<StoreManager> concurrentSet = new ConcurrentHashSet<>();
+        int numberOfThreads = 200;
+        ExecutorService service = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+        for (int i = 0; i < numberOfThreads; i++) {
+            service.execute(() -> {
+                concurrentSet.add(StoreManager.getInstance());
+                latch.countDown();
+            });
+        }
+        latch.await();
+        Assert.assertEquals(1, concurrentSet.size());
+    }
+
+    @Test
+    @PrepareForTest({ClassHelper.class})
+    public void testResetStoreManagerWithoutChangingLCValue() throws Throwable {
+        List newList = Collections.synchronizedList(new ArrayList<>());
+        int numberOfThreads = 200;
+        ExecutorService service = Executors.newFixedThreadPool(numberOfThreads);
+        AtomicInteger threadCounter = new AtomicInteger();
+        AtomicInteger resetCallCounter = new AtomicInteger();
+        mockStatic(ClassHelper.class);
+        when(ClassHelper.getZimbraClassInstanceBy(zimbra_class_store.value())).thenReturn(new MockStoreManager());
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+        for (int i = 0; i < numberOfThreads; i++) {
+            service.execute(() -> {
+                newList.add(StoreManager.getInstance());
+                if (threadCounter.incrementAndGet() % 19 == 0) {
+                    try {
+                        // calling reset store manager
+                        resetCallCounter.incrementAndGet();
+                        StoreManager.resetStoreManager();
+                    } catch (ServiceException | IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+                latch.countDown();
+            });
+        }
+        latch.await();
+        newList.remove(null);
+        Assert.assertEquals(numberOfThreads, newList.size());
+    }
+
+
+    @Test
+    @PrepareForTest({ClassHelper.class})
+    public void testResetStoreManagerWithChangingLCValue() throws Throwable {
+        Set<String> uniqueSM = new ConcurrentHashSet<>();
+        List smSynchronizedList = Collections.synchronizedList(new ArrayList<>());
+        int numberOfThreads = 200;
+        ExecutorService service = Executors.newFixedThreadPool(numberOfThreads);
+        AtomicInteger threadCounter = new AtomicInteger();
+        AtomicInteger resetCallCounter = new AtomicInteger();
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+        // add current store manager
+        uniqueSM.add(StoreManager.getInstance().getClass().getName());
+        for (int i = 0; i < numberOfThreads; i++) {
+            service.execute(() -> {
+                int count = threadCounter.incrementAndGet();
+                if (threadCounter.get() % 19 == 0) {
+                    try {
+                        LocalConfig localConfig = new LocalConfig(null);
+                        localConfig.set(zimbra_class_store.key(), StoreManagerAfterReset.class.getName());
+                        localConfig.save();
+                        LC.reload();
+                        // calling reset store manager
+                        resetCallCounter.incrementAndGet();
+                        StoreManager.resetStoreManager();
+                    } catch (ServiceException | IOException | DocumentException | ConfigException e) {
+                        e.printStackTrace();
+                    }
+                }
+                StoreManager storeManager = StoreManager.getInstance();
+                smSynchronizedList.add(storeManager);
+                uniqueSM.add(storeManager.getClass().getName());
+                latch.countDown();
+            });
+        }
+        latch.await();
+        verifyStatic(Mockito.times(resetCallCounter.get()));
+        // verify that it was never null instance
+        smSynchronizedList.remove(null);
+        Assert.assertEquals(numberOfThreads, smSynchronizedList.size());
+        // only two store managers
+        Assert.assertEquals(2, uniqueSM.size());
+    }
+}

--- a/store/src/java-test/localconfig-test-copy.xml
+++ b/store/src/java-test/localconfig-test-copy.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+
+<localconfig>
+  <key name="zimbra_mailbox_groups">
+    <value>1</value>
+  </key>
+  <key name="debug_disable_share_expiration_listener">
+    <value>true</value>
+  </key>
+  <key name="zimbra_home">
+    <value>build/zimbra</value>
+  </key>
+</localconfig>

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -66523,13 +66523,13 @@ public abstract class ZAttrConfig extends Entry {
     /**
      * Zimbra multiple reader StoreManagers enabled
      *
-     * @return zimbraSMMultiReaderEnabled, or false if unset
+     * @return zimbraSMMultiReaderEnabled, or true if unset
      *
      * @since ZCS 9.1.0
      */
     @ZAttr(id=4008)
     public boolean isSMMultiReaderEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraSMMultiReaderEnabled, false, true);
+        return getBooleanAttr(Provisioning.A_zimbraSMMultiReaderEnabled, true, true);
     }
 
     /**
@@ -66595,13 +66595,13 @@ public abstract class ZAttrConfig extends Entry {
     /**
      * Zimbra StoreManager runtime switching enabled
      *
-     * @return zimbraSMRuntimeSwitchEnabled, or false if unset
+     * @return zimbraSMRuntimeSwitchEnabled, or true if unset
      *
      * @since ZCS 9.1.0
      */
     @ZAttr(id=4009)
     public boolean isSMRuntimeSwitchEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraSMRuntimeSwitchEnabled, false, true);
+        return getBooleanAttr(Provisioning.A_zimbraSMRuntimeSwitchEnabled, true, true);
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -66525,9 +66525,9 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @return zimbraSMMultiReaderEnabled, or true if unset
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4008)
+    @ZAttr(id=4021)
     public boolean isSMMultiReaderEnabled() {
         return getBooleanAttr(Provisioning.A_zimbraSMMultiReaderEnabled, true, true);
     }
@@ -66538,9 +66538,9 @@ public abstract class ZAttrConfig extends Entry {
      * @param zimbraSMMultiReaderEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4008)
+    @ZAttr(id=4021)
     public void setSMMultiReaderEnabled(boolean zimbraSMMultiReaderEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, zimbraSMMultiReaderEnabled ? TRUE : FALSE);
@@ -66554,9 +66554,9 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4008)
+    @ZAttr(id=4021)
     public Map<String,Object> setSMMultiReaderEnabled(boolean zimbraSMMultiReaderEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, zimbraSMMultiReaderEnabled ? TRUE : FALSE);
@@ -66568,9 +66568,9 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4008)
+    @ZAttr(id=4021)
     public void unsetSMMultiReaderEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, "");
@@ -66583,9 +66583,9 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4008)
+    @ZAttr(id=4021)
     public Map<String,Object> unsetSMMultiReaderEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, "");
@@ -66597,9 +66597,9 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @return zimbraSMRuntimeSwitchEnabled, or true if unset
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4009)
+    @ZAttr(id=4022)
     public boolean isSMRuntimeSwitchEnabled() {
         return getBooleanAttr(Provisioning.A_zimbraSMRuntimeSwitchEnabled, true, true);
     }
@@ -66610,9 +66610,9 @@ public abstract class ZAttrConfig extends Entry {
      * @param zimbraSMRuntimeSwitchEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4009)
+    @ZAttr(id=4022)
     public void setSMRuntimeSwitchEnabled(boolean zimbraSMRuntimeSwitchEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, zimbraSMRuntimeSwitchEnabled ? TRUE : FALSE);
@@ -66626,9 +66626,9 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4009)
+    @ZAttr(id=4022)
     public Map<String,Object> setSMRuntimeSwitchEnabled(boolean zimbraSMRuntimeSwitchEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, zimbraSMRuntimeSwitchEnabled ? TRUE : FALSE);
@@ -66640,9 +66640,9 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4009)
+    @ZAttr(id=4022)
     public void unsetSMRuntimeSwitchEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, "");
@@ -66655,9 +66655,9 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4009)
+    @ZAttr(id=4022)
     public Map<String,Object> unsetSMRuntimeSwitchEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, "");

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -20866,7 +20866,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4006)
     public String getGlobalExternalStoreConfig() {
         return getAttr(Provisioning.A_zimbraGlobalExternalStoreConfig, null, true);
     }
@@ -20879,7 +20879,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4006)
     public void setGlobalExternalStoreConfig(String zimbraGlobalExternalStoreConfig) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraGlobalExternalStoreConfig, zimbraGlobalExternalStoreConfig);
@@ -20895,7 +20895,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4006)
     public Map<String,Object> setGlobalExternalStoreConfig(String zimbraGlobalExternalStoreConfig, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraGlobalExternalStoreConfig, zimbraGlobalExternalStoreConfig);
@@ -20909,7 +20909,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4006)
     public void unsetGlobalExternalStoreConfig() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraGlobalExternalStoreConfig, "");
@@ -20924,7 +20924,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4005)
+    @ZAttr(id=4006)
     public Map<String,Object> unsetGlobalExternalStoreConfig(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraGlobalExternalStoreConfig, "");

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -20864,9 +20864,9 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @return zimbraGlobalExternalStoreConfig, or null if unset
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4006)
+    @ZAttr(id=4019)
     public String getGlobalExternalStoreConfig() {
         return getAttr(Provisioning.A_zimbraGlobalExternalStoreConfig, null, true);
     }
@@ -20877,9 +20877,9 @@ public abstract class ZAttrConfig extends Entry {
      * @param zimbraGlobalExternalStoreConfig new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4006)
+    @ZAttr(id=4019)
     public void setGlobalExternalStoreConfig(String zimbraGlobalExternalStoreConfig) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraGlobalExternalStoreConfig, zimbraGlobalExternalStoreConfig);
@@ -20893,9 +20893,9 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4006)
+    @ZAttr(id=4019)
     public Map<String,Object> setGlobalExternalStoreConfig(String zimbraGlobalExternalStoreConfig, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraGlobalExternalStoreConfig, zimbraGlobalExternalStoreConfig);
@@ -20907,9 +20907,9 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4006)
+    @ZAttr(id=4019)
     public void unsetGlobalExternalStoreConfig() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraGlobalExternalStoreConfig, "");
@@ -20922,9 +20922,9 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4006)
+    @ZAttr(id=4019)
     public Map<String,Object> unsetGlobalExternalStoreConfig(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraGlobalExternalStoreConfig, "");

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -20860,6 +20860,78 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Global level external store config
+     *
+     * @return zimbraGlobalExternalStoreConfig, or null if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4005)
+    public String getGlobalExternalStoreConfig() {
+        return getAttr(Provisioning.A_zimbraGlobalExternalStoreConfig, null, true);
+    }
+
+    /**
+     * Global level external store config
+     *
+     * @param zimbraGlobalExternalStoreConfig new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4005)
+    public void setGlobalExternalStoreConfig(String zimbraGlobalExternalStoreConfig) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraGlobalExternalStoreConfig, zimbraGlobalExternalStoreConfig);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Global level external store config
+     *
+     * @param zimbraGlobalExternalStoreConfig new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4005)
+    public Map<String,Object> setGlobalExternalStoreConfig(String zimbraGlobalExternalStoreConfig, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraGlobalExternalStoreConfig, zimbraGlobalExternalStoreConfig);
+        return attrs;
+    }
+
+    /**
+     * Global level external store config
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4005)
+    public void unsetGlobalExternalStoreConfig() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraGlobalExternalStoreConfig, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Global level external store config
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4005)
+    public Map<String,Object> unsetGlobalExternalStoreConfig(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraGlobalExternalStoreConfig, "");
+        return attrs;
+    }
+
+    /**
      * LDAP attribute to HAB Group Member attribute mapping
      *
      * @return zimbraHABMemberLdapAttrMap, or empty array if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -66521,6 +66521,150 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Zimbra multiple reader StoreManagers enabled
+     *
+     * @return zimbraSMMultiReaderEnabled, or false if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public boolean isSMMultiReaderEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraSMMultiReaderEnabled, false, true);
+    }
+
+    /**
+     * Zimbra multiple reader StoreManagers enabled
+     *
+     * @param zimbraSMMultiReaderEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public void setSMMultiReaderEnabled(boolean zimbraSMMultiReaderEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, zimbraSMMultiReaderEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Zimbra multiple reader StoreManagers enabled
+     *
+     * @param zimbraSMMultiReaderEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public Map<String,Object> setSMMultiReaderEnabled(boolean zimbraSMMultiReaderEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, zimbraSMMultiReaderEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Zimbra multiple reader StoreManagers enabled
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public void unsetSMMultiReaderEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Zimbra multiple reader StoreManagers enabled
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public Map<String,Object> unsetSMMultiReaderEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * Zimbra StoreManager runtime switching enabled
+     *
+     * @return zimbraSMRuntimeSwitchEnabled, or false if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public boolean isSMRuntimeSwitchEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraSMRuntimeSwitchEnabled, false, true);
+    }
+
+    /**
+     * Zimbra StoreManager runtime switching enabled
+     *
+     * @param zimbraSMRuntimeSwitchEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public void setSMRuntimeSwitchEnabled(boolean zimbraSMRuntimeSwitchEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, zimbraSMRuntimeSwitchEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Zimbra StoreManager runtime switching enabled
+     *
+     * @param zimbraSMRuntimeSwitchEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public Map<String,Object> setSMRuntimeSwitchEnabled(boolean zimbraSMRuntimeSwitchEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, zimbraSMRuntimeSwitchEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Zimbra StoreManager runtime switching enabled
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public void unsetSMRuntimeSwitchEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Zimbra StoreManager runtime switching enabled
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public Map<String,Object> unsetSMRuntimeSwitchEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, "");
+        return attrs;
+    }
+
+    /**
      * Specifies the JedisPool size used by SSDBEphemeralStore. Higher pool
      * sizes allow for more simultaneous connections to SSDB. A value of 0
      * will cause the pool size to be unlimited.

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -46980,6 +46980,150 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
+     * Zimbra multiple reader StoreManagers enabled
+     *
+     * @return zimbraSMMultiReaderEnabled, or false if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public boolean isSMMultiReaderEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraSMMultiReaderEnabled, false, true);
+    }
+
+    /**
+     * Zimbra multiple reader StoreManagers enabled
+     *
+     * @param zimbraSMMultiReaderEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public void setSMMultiReaderEnabled(boolean zimbraSMMultiReaderEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, zimbraSMMultiReaderEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Zimbra multiple reader StoreManagers enabled
+     *
+     * @param zimbraSMMultiReaderEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public Map<String,Object> setSMMultiReaderEnabled(boolean zimbraSMMultiReaderEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, zimbraSMMultiReaderEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Zimbra multiple reader StoreManagers enabled
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public void unsetSMMultiReaderEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Zimbra multiple reader StoreManagers enabled
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4008)
+    public Map<String,Object> unsetSMMultiReaderEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * Zimbra StoreManager runtime switching enabled
+     *
+     * @return zimbraSMRuntimeSwitchEnabled, or false if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public boolean isSMRuntimeSwitchEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraSMRuntimeSwitchEnabled, false, true);
+    }
+
+    /**
+     * Zimbra StoreManager runtime switching enabled
+     *
+     * @param zimbraSMRuntimeSwitchEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public void setSMRuntimeSwitchEnabled(boolean zimbraSMRuntimeSwitchEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, zimbraSMRuntimeSwitchEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Zimbra StoreManager runtime switching enabled
+     *
+     * @param zimbraSMRuntimeSwitchEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public Map<String,Object> setSMRuntimeSwitchEnabled(boolean zimbraSMRuntimeSwitchEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, zimbraSMRuntimeSwitchEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Zimbra StoreManager runtime switching enabled
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public void unsetSMRuntimeSwitchEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Zimbra StoreManager runtime switching enabled
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4009)
+    public Map<String,Object> unsetSMRuntimeSwitchEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, "");
+        return attrs;
+    }
+
+    /**
      * SSL certificate
      *
      * @return zimbraSSLCertificate, or null if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -47566,9 +47566,9 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @return zimbraServerExternalStoreConfig, or null if unset
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4007)
+    @ZAttr(id=4020)
     public String getServerExternalStoreConfig() {
         return getAttr(Provisioning.A_zimbraServerExternalStoreConfig, null, true);
     }
@@ -47579,9 +47579,9 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param zimbraServerExternalStoreConfig new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4007)
+    @ZAttr(id=4020)
     public void setServerExternalStoreConfig(String zimbraServerExternalStoreConfig) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraServerExternalStoreConfig, zimbraServerExternalStoreConfig);
@@ -47595,9 +47595,9 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4007)
+    @ZAttr(id=4020)
     public Map<String,Object> setServerExternalStoreConfig(String zimbraServerExternalStoreConfig, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraServerExternalStoreConfig, zimbraServerExternalStoreConfig);
@@ -47609,9 +47609,9 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4007)
+    @ZAttr(id=4020)
     public void unsetServerExternalStoreConfig() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraServerExternalStoreConfig, "");
@@ -47624,9 +47624,9 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4007)
+    @ZAttr(id=4020)
     public Map<String,Object> unsetServerExternalStoreConfig(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraServerExternalStoreConfig, "");

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -46982,13 +46982,13 @@ public abstract class ZAttrServer extends NamedEntry {
     /**
      * Zimbra multiple reader StoreManagers enabled
      *
-     * @return zimbraSMMultiReaderEnabled, or false if unset
+     * @return zimbraSMMultiReaderEnabled, or true if unset
      *
      * @since ZCS 9.1.0
      */
     @ZAttr(id=4008)
     public boolean isSMMultiReaderEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraSMMultiReaderEnabled, false, true);
+        return getBooleanAttr(Provisioning.A_zimbraSMMultiReaderEnabled, true, true);
     }
 
     /**
@@ -47054,13 +47054,13 @@ public abstract class ZAttrServer extends NamedEntry {
     /**
      * Zimbra StoreManager runtime switching enabled
      *
-     * @return zimbraSMRuntimeSwitchEnabled, or false if unset
+     * @return zimbraSMRuntimeSwitchEnabled, or true if unset
      *
      * @since ZCS 9.1.0
      */
     @ZAttr(id=4009)
     public boolean isSMRuntimeSwitchEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraSMRuntimeSwitchEnabled, false, true);
+        return getBooleanAttr(Provisioning.A_zimbraSMRuntimeSwitchEnabled, true, true);
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -46984,9 +46984,9 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @return zimbraSMMultiReaderEnabled, or true if unset
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4008)
+    @ZAttr(id=4021)
     public boolean isSMMultiReaderEnabled() {
         return getBooleanAttr(Provisioning.A_zimbraSMMultiReaderEnabled, true, true);
     }
@@ -46997,9 +46997,9 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param zimbraSMMultiReaderEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4008)
+    @ZAttr(id=4021)
     public void setSMMultiReaderEnabled(boolean zimbraSMMultiReaderEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, zimbraSMMultiReaderEnabled ? TRUE : FALSE);
@@ -47013,9 +47013,9 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4008)
+    @ZAttr(id=4021)
     public Map<String,Object> setSMMultiReaderEnabled(boolean zimbraSMMultiReaderEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, zimbraSMMultiReaderEnabled ? TRUE : FALSE);
@@ -47027,9 +47027,9 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4008)
+    @ZAttr(id=4021)
     public void unsetSMMultiReaderEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, "");
@@ -47042,9 +47042,9 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4008)
+    @ZAttr(id=4021)
     public Map<String,Object> unsetSMMultiReaderEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMMultiReaderEnabled, "");
@@ -47056,9 +47056,9 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @return zimbraSMRuntimeSwitchEnabled, or true if unset
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4009)
+    @ZAttr(id=4022)
     public boolean isSMRuntimeSwitchEnabled() {
         return getBooleanAttr(Provisioning.A_zimbraSMRuntimeSwitchEnabled, true, true);
     }
@@ -47069,9 +47069,9 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param zimbraSMRuntimeSwitchEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4009)
+    @ZAttr(id=4022)
     public void setSMRuntimeSwitchEnabled(boolean zimbraSMRuntimeSwitchEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, zimbraSMRuntimeSwitchEnabled ? TRUE : FALSE);
@@ -47085,9 +47085,9 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4009)
+    @ZAttr(id=4022)
     public Map<String,Object> setSMRuntimeSwitchEnabled(boolean zimbraSMRuntimeSwitchEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, zimbraSMRuntimeSwitchEnabled ? TRUE : FALSE);
@@ -47099,9 +47099,9 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4009)
+    @ZAttr(id=4022)
     public void unsetSMRuntimeSwitchEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, "");
@@ -47114,9 +47114,9 @@ public abstract class ZAttrServer extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 9.1.0
+     * @since ZCS 10.0.0
      */
-    @ZAttr(id=4009)
+    @ZAttr(id=4022)
     public Map<String,Object> unsetSMRuntimeSwitchEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSMRuntimeSwitchEnabled, "");

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -47562,6 +47562,78 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
+     * Server level external store config
+     *
+     * @return zimbraServerExternalStoreConfig, or null if unset
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4006)
+    public String getServerExternalStoreConfig() {
+        return getAttr(Provisioning.A_zimbraServerExternalStoreConfig, null, true);
+    }
+
+    /**
+     * Server level external store config
+     *
+     * @param zimbraServerExternalStoreConfig new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4006)
+    public void setServerExternalStoreConfig(String zimbraServerExternalStoreConfig) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraServerExternalStoreConfig, zimbraServerExternalStoreConfig);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Server level external store config
+     *
+     * @param zimbraServerExternalStoreConfig new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4006)
+    public Map<String,Object> setServerExternalStoreConfig(String zimbraServerExternalStoreConfig, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraServerExternalStoreConfig, zimbraServerExternalStoreConfig);
+        return attrs;
+    }
+
+    /**
+     * Server level external store config
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4006)
+    public void unsetServerExternalStoreConfig() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraServerExternalStoreConfig, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Server level external store config
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 9.1.0
+     */
+    @ZAttr(id=4006)
+    public Map<String,Object> unsetServerExternalStoreConfig(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraServerExternalStoreConfig, "");
+        return attrs;
+    }
+
+    /**
      * Current version of ZCS installed on this server
      *
      * @return zimbraServerVersion, or null if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -47568,7 +47568,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4006)
+    @ZAttr(id=4007)
     public String getServerExternalStoreConfig() {
         return getAttr(Provisioning.A_zimbraServerExternalStoreConfig, null, true);
     }
@@ -47581,7 +47581,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4006)
+    @ZAttr(id=4007)
     public void setServerExternalStoreConfig(String zimbraServerExternalStoreConfig) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraServerExternalStoreConfig, zimbraServerExternalStoreConfig);
@@ -47597,7 +47597,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4006)
+    @ZAttr(id=4007)
     public Map<String,Object> setServerExternalStoreConfig(String zimbraServerExternalStoreConfig, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraServerExternalStoreConfig, zimbraServerExternalStoreConfig);
@@ -47611,7 +47611,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4006)
+    @ZAttr(id=4007)
     public void unsetServerExternalStoreConfig() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraServerExternalStoreConfig, "");
@@ -47626,7 +47626,7 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * @since ZCS 9.1.0
      */
-    @ZAttr(id=4006)
+    @ZAttr(id=4007)
     public Map<String,Object> unsetServerExternalStoreConfig(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraServerExternalStoreConfig, "");

--- a/store/src/java/com/zimbra/cs/datasource/MessageContent.java
+++ b/store/src/java/com/zimbra/cs/datasource/MessageContent.java
@@ -26,6 +26,7 @@ import com.zimbra.cs.mailbox.DeliveryContext;
 import com.zimbra.cs.mime.ParsedMessage;
 import com.zimbra.cs.store.Blob;
 import com.zimbra.cs.store.StoreManager;
+import com.zimbra.cs.store.external.ExternalBlob;
 
 public class MessageContent {
     private Blob blob;
@@ -85,7 +86,12 @@ public class MessageContent {
     
     public void cleanup() throws IOException {
         if (blob != null) {
-            StoreManager.getInstance().delete(blob);
+            if (blob instanceof ExternalBlob) {
+                String locator = ((ExternalBlob)blob).getLocator();
+                StoreManager.getReaderSMInstance(locator).delete(blob);
+            } else {
+                StoreManager.getInstance().delete(blob);
+            }
             blob = null;
         }
     }

--- a/store/src/java/com/zimbra/cs/datasource/imap/ImapAppender.java
+++ b/store/src/java/com/zimbra/cs/datasource/imap/ImapAppender.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2009, 2010, 2011, 2012, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2009, 2010, 2011, 2012, 2013, 2014, 2016, 2022 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -262,7 +262,7 @@ public class ImapAppender {
             data = new Data() {
                 @Override
                 public InputStream getInputStream() throws IOException {
-                    return StoreManager.getInstance().getContent(mblob);
+                    return StoreManager.getReaderSMInstance(mblob.getLocator()).getContent(mblob);
                 }
 
                 @Override

--- a/store/src/java/com/zimbra/cs/db/DbVolume.java
+++ b/store/src/java/com/zimbra/cs/db/DbVolume.java
@@ -49,6 +49,7 @@ public final class DbVolume {
     private static final String CN_MAILBOX_GROUP_BITS = "mailbox_group_bits";
 
     private static final String CN_STORE_TYPE = "store_type";
+    private static final String CN_STORE_MANAGER_CLASS = "store_manager_class";
     private static final String CN_COMPRESS_BLOBS = "compress_blobs";
     private static final String CN_COMPRESSION_THRESHOLD = "compression_threshold";
     private static final String CN_METADATA = "metadata";
@@ -64,8 +65,8 @@ public final class DbVolume {
         PreparedStatement stmt = null;
         try {
             stmt = conn.prepareStatement("INSERT INTO volume (id, type, name, path, mailbox_group_bits, " +
-                    "mailbox_bits, file_group_bits, file_bits, compress_blobs, compression_threshold, metadata, store_type) " +
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+                    "mailbox_bits, file_group_bits, file_bits, compress_blobs, compression_threshold, metadata, store_type, store_manager_class) " +
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
             int pos = 1;
             stmt.setShort(pos++, nextId);
             stmt.setShort(pos++, volume.getType());
@@ -79,6 +80,7 @@ public final class DbVolume {
             stmt.setLong(pos++, volume.getCompressionThreshold());
             stmt.setString(pos++, volume.getMetadata().toString());
             stmt.setShort(pos++, (short)(volume.getStoreType().getStoreType()));
+            stmt.setString(pos++, volume.getStoreManagerClass());
             stmt.executeUpdate();
         } catch (SQLException e) {
             if (Db.errorMatches(e, Db.Error.DUPLICATE_ROW)) {
@@ -311,7 +313,9 @@ public final class DbVolume {
                 .setCompressBlobs(rs.getBoolean(CN_COMPRESS_BLOBS))
                 .setCompressionThreshold(rs.getLong(CN_COMPRESSION_THRESHOLD))
                 .setStoreType(storeType)
-                .setMetadata(metadata).build();
+                .setMetadata(metadata)
+                .setStoreManagerClass(rs.getString(CN_STORE_MANAGER_CLASS))
+                .build();
     }
 
     public static boolean isVolumeReferenced(DbConnection conn, short volumeId) throws ServiceException {

--- a/store/src/java/com/zimbra/cs/db/DbVolume.java
+++ b/store/src/java/com/zimbra/cs/db/DbVolume.java
@@ -335,16 +335,17 @@ public final class DbVolume {
     }
 
     private static boolean isVolumeReferenced(DbConnection conn, short volumeId, int groupId) throws ServiceException {
-        return tableRefsVolume(conn, volumeId, groupId, "revision") || tableRefsVolume(conn, volumeId, groupId, "revision_dumpster") ||
-                tableRefsVolume(conn, volumeId, groupId, "mail_item_dumpster") || tableRefsVolume(conn, volumeId, groupId, "mail_item");
+        return tableRefsVolume(conn, volumeId, groupId, "revision") ||
+                tableRefsVolume(conn, volumeId, groupId, "revision_dumpster") ||
+                tableRefsVolume(conn, volumeId, groupId, "mail_item_dumpster") ||
+                tableRefsVolume(conn, volumeId, groupId, "mail_item");
     }
 
     private static boolean tableRefsVolume(DbConnection conn, short volumeId, int groupId, String table) throws ServiceException {
         PreparedStatement stmt = null;
         ResultSet rs = null;
         try {
-            stmt = conn.prepareStatement("SELECT count(*) from "+DbMailbox.qualifyTableName(groupId, table) +
-                    " where locator=?");
+            stmt = conn.prepareStatement("SELECT count(*) from "+DbMailbox.qualifyTableName(groupId, table) + " where locator=?");
             stmt.setInt(1, volumeId);
             rs = stmt.executeQuery();
             return (rs.next() && rs.getInt(1) > 0);

--- a/store/src/java/com/zimbra/cs/db/DbVolume.java
+++ b/store/src/java/com/zimbra/cs/db/DbVolume.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2005, 2006, 2007, 2009, 2010, 2011, 2012, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2005, 2006, 2007, 2009, 2010, 2011, 2012, 2013, 2014, 2016, 2022 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -64,8 +64,8 @@ public final class DbVolume {
         PreparedStatement stmt = null;
         try {
             stmt = conn.prepareStatement("INSERT INTO volume (id, type, name, path, mailbox_group_bits, " +
-                    "mailbox_bits, file_group_bits, file_bits, compress_blobs, compression_threshold, metadata) " +
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+                    "mailbox_bits, file_group_bits, file_bits, compress_blobs, compression_threshold, metadata, store_type) " +
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
             int pos = 1;
             stmt.setShort(pos++, nextId);
             stmt.setShort(pos++, volume.getType());
@@ -78,6 +78,7 @@ public final class DbVolume {
             stmt.setBoolean(pos++, volume.isCompressBlobs());
             stmt.setLong(pos++, volume.getCompressionThreshold());
             stmt.setString(pos++, volume.getMetadata().toString());
+            stmt.setShort(pos++, (short)(volume.getStoreType().getStoreType()));
             stmt.executeUpdate();
         } catch (SQLException e) {
             if (Db.errorMatches(e, Db.Error.DUPLICATE_ROW)) {

--- a/store/src/java/com/zimbra/cs/db/DbVolume.java
+++ b/store/src/java/com/zimbra/cs/db/DbVolume.java
@@ -47,6 +47,8 @@ public final class DbVolume {
     private static final String CN_FILE_GROUP_BITS = "file_group_bits";
     private static final String CN_MAILBOX_BITS = "mailbox_bits";
     private static final String CN_MAILBOX_GROUP_BITS = "mailbox_group_bits";
+
+    private static final String CN_STORE_TYPE = "store_type";
     private static final String CN_COMPRESS_BLOBS = "compress_blobs";
     private static final String CN_COMPRESSION_THRESHOLD = "compression_threshold";
     private static final String CN_METADATA = "metadata";
@@ -297,12 +299,17 @@ public final class DbVolume {
         } catch (ServiceException e) {
             throw VolumeServiceException.INVALID_METADATA(e);
         }
+
+        short storeTypeShort = rs.getShort(CN_STORE_TYPE);
+        Volume.StoreType storeType = Volume.StoreType.getStoreTypeBy(storeTypeShort);
+
         return Volume.builder().setId(rs.getShort(CN_ID)).setType(rs.getShort(CN_TYPE)).setName(rs.getString(CN_NAME))
                 .setPath(Volume.getAbsolutePath(rs.getString(CN_PATH)), false)
                 .setMboxGroupBits(rs.getShort(CN_MAILBOX_GROUP_BITS)).setMboxBit(rs.getShort(CN_MAILBOX_BITS))
                 .setFileGroupBits(rs.getShort(CN_FILE_GROUP_BITS)).setFileBits(rs.getShort(CN_FILE_BITS))
                 .setCompressBlobs(rs.getBoolean(CN_COMPRESS_BLOBS))
                 .setCompressionThreshold(rs.getLong(CN_COMPRESSION_THRESHOLD))
+                .setStoreType(storeType)
                 .setMetadata(metadata).build();
     }
 
@@ -329,7 +336,7 @@ public final class DbVolume {
 
     private static boolean isVolumeReferenced(DbConnection conn, short volumeId, int groupId) throws ServiceException {
         return tableRefsVolume(conn, volumeId, groupId, "revision") || tableRefsVolume(conn, volumeId, groupId, "revision_dumpster") ||
-            tableRefsVolume(conn, volumeId, groupId, "mail_item_dumpster") || tableRefsVolume(conn, volumeId, groupId, "mail_item");
+                tableRefsVolume(conn, volumeId, groupId, "mail_item_dumpster") || tableRefsVolume(conn, volumeId, groupId, "mail_item");
     }
 
     private static boolean tableRefsVolume(DbConnection conn, short volumeId, int groupId, String table) throws ServiceException {
@@ -337,7 +344,7 @@ public final class DbVolume {
         ResultSet rs = null;
         try {
             stmt = conn.prepareStatement("SELECT count(*) from "+DbMailbox.qualifyTableName(groupId, table) +
-                " where locator=?");
+                    " where locator=?");
             stmt.setInt(1, volumeId);
             rs = stmt.executeQuery();
             return (rs.next() && rs.getInt(1) > 0);

--- a/store/src/java/com/zimbra/cs/db/Versions.java
+++ b/store/src/java/com/zimbra/cs/db/Versions.java
@@ -41,7 +41,7 @@ public final class Versions {
      *
      * UPDATE THESE TO REQUIRE RESET-WORLD TO BE RUN
      */
-    public static final int DB_VERSION = 114;
+    public static final int DB_VERSION = 115;
 
     /**
      * The INDEX_VERSION is stored into the config table of the DB when the DB is created.

--- a/store/src/java/com/zimbra/cs/mailbox/MailItem.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailItem.java
@@ -1392,7 +1392,7 @@ public abstract class MailItem implements Comparable<MailItem>, ScheduledTaskRes
             if (mblob == null) {
                 throw ServiceException.FAILURE("missing blob for id: " + getId() + ", change: " + getModifiedSequence(), null);
             }
-            return StoreManager.getInstance().getContent(mblob);
+            return StoreManager.getReaderSMInstance(getLocator()).getContent(mblob);
         } catch (IOException e) {
             String msg = String.format("Unable to get content for %s %d", getClass().getSimpleName(), getId());
             throw ServiceException.FAILURE(msg, e);

--- a/store/src/java/com/zimbra/cs/mailbox/MailItem.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailItem.java
@@ -1364,7 +1364,9 @@ public abstract class MailItem implements Comparable<MailItem>, ScheduledTaskRes
      * */
     public synchronized MailboxBlob getBlob() throws ServiceException {
         if (mBlob == null && getDigest() != null) {
-            mBlob = StoreManager.getInstance().getMailboxBlob(this);
+            StoreManager storeManager = StoreManager.getReaderSMInstance(getLocator());
+            ZimbraLog.store.trace("Store Manager for %s MailboxBlob: %s ", storeManager.getClass().getSimpleName(), getId());
+            mBlob = storeManager.getMailboxBlob(this);
             if (mBlob == null) {
                 throw MailServiceException.NO_SUCH_BLOB(mMailbox.getId(), mId, mData.modContent);
             }

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -6756,7 +6756,6 @@ public class Mailbox implements MailboxStore {
         try {
             ZimbraLog.store.trace("StorageManager used for saving Draft is: %s", sm.getClass().getSimpleName());
             staged = sm.stage(is, this);
-            ZimbraLog.store.trace("Draft locator: %s", staged.getLocator());
         } finally {
             ByteUtil.closeStream(is);
         }

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -263,6 +263,7 @@ import com.zimbra.cs.store.MailboxBlobDataSource;
 import com.zimbra.cs.store.StagedBlob;
 import com.zimbra.cs.store.StoreManager;
 import com.zimbra.cs.store.StoreManager.StoreFeature;
+import com.zimbra.cs.store.external.ExternalBlob;
 import com.zimbra.cs.util.AccountUtil;
 import com.zimbra.cs.util.AccountUtil.AccountAddressMatcher;
 import com.zimbra.cs.util.SpoolingCache;
@@ -9900,19 +9901,23 @@ public class Mailbox implements MailboxStore {
                 }
                 if (deletes.blobs != null) {
                     // delete any blobs associated with items deleted from db/index
-                    StoreManager sm = StoreManager.getInstance();
                     for (MailboxBlob blob : deletes.blobs) {
+                        StoreManager sm = StoreManager.getReaderSMInstance(blob.getLocator());
                         sm.quietDelete(blob);
                     }
                 }
             }
             if (rollbackDeletes != null) {
-                StoreManager sm = StoreManager.getInstance();
                 for (Object obj : rollbackDeletes) {
                     if (obj instanceof MailboxBlob) {
+                        StoreManager sm = StoreManager.getReaderSMInstance(((MailboxBlob)obj).getLocator());
                         sm.quietDelete((MailboxBlob) obj);
                     } else if (obj instanceof Blob) {
-                        sm.quietDelete((Blob) obj);
+                        if (obj instanceof ExternalBlob) {
+                            StoreManager.getReaderSMInstance(((ExternalBlob) obj).getLocator()).quietDelete((ExternalBlob) obj);
+                        } else {
+                            StoreManager.getInstance().quietDelete((Blob) obj);
+                        }
                     }
                 }
             }

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -6753,7 +6753,9 @@ public class Mailbox implements MailboxStore {
         StagedBlob staged;
         InputStream is = pm.getRawInputStream();
         try {
+            ZimbraLog.store.trace("StorageManager used for saving Draft is: %s", sm.getClass().getSimpleName());
             staged = sm.stage(is, this);
+            ZimbraLog.store.trace("Draft locator: %s", staged.getLocator());
         } finally {
             ByteUtil.closeStream(is);
         }

--- a/store/src/java/com/zimbra/cs/mailbox/MessageCache.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MessageCache.java
@@ -127,7 +127,7 @@ public class MessageCache {
             synchronized (sCache) {
                 CacheNode node = sCache.remove(digest);
                 if (node != null) {
-                    sLog.debug("Purged digest %s from the message cache.", digest);
+                    sLog.error("Purged digest %s from the message cache.", digest);
                     sDataSize -= node.size;
                 }
             }

--- a/store/src/java/com/zimbra/cs/mailbox/MessageCache.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MessageCache.java
@@ -340,9 +340,9 @@ public class MessageCache {
             throw ServiceException.FAILURE("missing blob for id: " + item.getId() + ", change: " + item.getModifiedSequence(), null);
 
         if (item.getSize() < MESSAGE_CACHE_DISK_STREAMING_THRESHOLD) {
-            return StoreManager.getInstance().getContent(mblob);
+            return StoreManager.getReaderSMInstance(mblob.getLocator()).getContent(mblob);
         } else {
-            return StoreManager.getInstance().getContent(mblob.getLocalBlob());
+            return StoreManager.getReaderSMInstance(mblob.getLocator()).getContent(mblob.getLocalBlob());
         }
     }
 

--- a/store/src/java/com/zimbra/cs/mailbox/MessageCache.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MessageCache.java
@@ -127,7 +127,7 @@ public class MessageCache {
             synchronized (sCache) {
                 CacheNode node = sCache.remove(digest);
                 if (node != null) {
-                    sLog.error("Purged digest %s from the message cache.", digest);
+                    sLog.debug("Purged digest %s from the message cache.", digest);
                     sDataSize -= node.size;
                 }
             }

--- a/store/src/java/com/zimbra/cs/mailbox/util/MailItemHelper.java
+++ b/store/src/java/com/zimbra/cs/mailbox/util/MailItemHelper.java
@@ -1,0 +1,41 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.mailbox.util;
+
+import org.apache.commons.lang.StringUtils;
+
+import java.util.Optional;
+
+public class MailItemHelper {
+
+    public static final String VOL_ID_LOCATOR_SEPARATOR = "@@";
+
+    public static Optional<Short> findMyVolumeId(String locator) {
+
+        if (StringUtils.isNumeric(locator)) {
+            return Optional.of(Short.valueOf(locator));
+        }
+
+        if (locator.contains(VOL_ID_LOCATOR_SEPARATOR)) {
+            String[] parts = locator.split(VOL_ID_LOCATOR_SEPARATOR, 2);
+            if (parts.length ==  2 && StringUtils.isNumeric(parts[0])) {
+                return Optional.of(Short.valueOf(parts[0]));
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/store/src/java/com/zimbra/cs/redolog/op/CreateVolume.java
+++ b/store/src/java/com/zimbra/cs/redolog/op/CreateVolume.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2013, 2014, 2016, 2022 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -38,6 +38,7 @@ public final class CreateVolume extends RedoableOp {
     private short mboxBits;
     private short fileGroupBits;
     private short fileBits;
+    private short storeType;
 
     private boolean compressBlobs;
     private long compressionThreshold;
@@ -57,6 +58,7 @@ public final class CreateVolume extends RedoableOp {
         fileBits = volume.getFileBits();
         compressBlobs = volume.isCompressBlobs();
         compressionThreshold = volume.getCompressionThreshold();
+        storeType = (short)(volume.getStoreType().getStoreType());
     }
 
     public void setId(short id) {
@@ -114,10 +116,14 @@ public final class CreateVolume extends RedoableOp {
             }
         }
         try {
+            Volume.StoreType enumStoreType =
+                (1 == storeType) ? Volume.StoreType.INTERNAL : Volume.StoreType.EXTERNAL;
+
             Volume volume = Volume.builder().setId(id).setType(type).setName(name).setPath(rootPath, false)
                     .setMboxGroupBits(mboxGroupBits).setMboxBit(mboxBits)
                     .setFileGroupBits(fileGroupBits).setFileBits(fileBits)
-                    .setCompressBlobs(compressBlobs).setCompressionThreshold(compressionThreshold).build();
+                    .setCompressBlobs(compressBlobs).setCompressionThreshold(compressionThreshold)
+                    .setStoreType(enumStoreType).build();
             mgr.create(volume, getUnloggedReplay());
         } catch (VolumeServiceException e) {
             if (e.getCode() == VolumeServiceException.ALREADY_EXISTS) {

--- a/store/src/java/com/zimbra/cs/redolog/op/CreateVolume.java
+++ b/store/src/java/com/zimbra/cs/redolog/op/CreateVolume.java
@@ -40,6 +40,8 @@ public final class CreateVolume extends RedoableOp {
     private short fileBits;
     private short storeType;
 
+    private String storeManagerClass;
+
     private boolean compressBlobs;
     private long compressionThreshold;
 
@@ -59,6 +61,7 @@ public final class CreateVolume extends RedoableOp {
         compressBlobs = volume.isCompressBlobs();
         compressionThreshold = volume.getCompressionThreshold();
         storeType = (short)(volume.getStoreType().getStoreType());
+        storeManagerClass = volume.getStoreManagerClass();
     }
 
     public void setId(short id) {
@@ -72,6 +75,7 @@ public final class CreateVolume extends RedoableOp {
                 .add("mboxGroupBits", mboxGroupBits).add("mboxBit", mboxBits)
                 .add("fileGroupBits", fileGroupBits).add("fileBits", fileBits)
                 .add("compressBlobs", compressBlobs).add("compressionThreshold", compressionThreshold)
+                .add("storeType", storeType).add("storeManagerClass", storeManagerClass)
                 .toString();
     }
 
@@ -86,6 +90,8 @@ public final class CreateVolume extends RedoableOp {
         out.writeShort(fileGroupBits);
         out.writeShort(fileBits);
         out.writeBoolean(compressBlobs);
+        out.writeShort(storeType);
+        out.writeUTF(storeManagerClass);
     }
 
     @Override
@@ -99,6 +105,8 @@ public final class CreateVolume extends RedoableOp {
         fileGroupBits = in.readShort();
         fileBits = in.readShort();
         compressBlobs = in.readBoolean();
+        storeType = in.readShort();
+        storeManagerClass = in.readUTF();
     }
 
     @Override
@@ -123,7 +131,9 @@ public final class CreateVolume extends RedoableOp {
                     .setMboxGroupBits(mboxGroupBits).setMboxBit(mboxBits)
                     .setFileGroupBits(fileGroupBits).setFileBits(fileBits)
                     .setCompressBlobs(compressBlobs).setCompressionThreshold(compressionThreshold)
-                    .setStoreType(enumStoreType).build();
+                    .setStoreType(enumStoreType)
+                    .setStoreManagerClass(storeManagerClass)
+                    .build();
             mgr.create(volume, getUnloggedReplay());
         } catch (VolumeServiceException e) {
             if (e.getCode() == VolumeServiceException.ALREADY_EXISTS) {

--- a/store/src/java/com/zimbra/cs/service/admin/CreateVolume.java
+++ b/store/src/java/com/zimbra/cs/service/admin/CreateVolume.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2005, 2006, 2007, 2009, 2010, 2011, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2005, 2006, 2007, 2009, 2010, 2011, 2013, 2014, 2016, 2022 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -20,19 +20,22 @@ package com.zimbra.cs.service.admin;
 import java.util.List;
 import java.util.Map;
 
+import org.json.JSONException;
+
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
+import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.accesscontrol.AdminRight;
 import com.zimbra.cs.account.accesscontrol.Rights.Admin;
+import com.zimbra.cs.service.util.VolumeConfigUtil;
 import com.zimbra.cs.volume.Volume;
 import com.zimbra.cs.volume.VolumeManager;
-import com.zimbra.cs.volume.VolumeServiceException;
 import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.ZimbraSoapContext;
+import com.zimbra.soap.admin.type.VolumeInfo;
 import com.zimbra.soap.admin.message.CreateVolumeRequest;
 import com.zimbra.soap.admin.message.CreateVolumeResponse;
-import com.zimbra.soap.admin.type.VolumeInfo;
 
 public final class CreateVolume extends AdminDocumentHandler {
 
@@ -42,18 +45,24 @@ public final class CreateVolume extends AdminDocumentHandler {
         return zsc.jaxbToElement(handle((CreateVolumeRequest) zsc.elementToJaxb(req), ctx));
     }
 
-    private CreateVolumeResponse handle(CreateVolumeRequest req, Map<String, Object> ctx) throws ServiceException {
+    private CreateVolumeResponse handle(CreateVolumeRequest request, Map<String, Object> ctx) throws ServiceException {
         ZimbraSoapContext zsc = getZimbraSoapContext(ctx);
         checkRight(zsc, ctx, Provisioning.getInstance().getLocalServer(), Admin.R_manageVolume);
 
-        Volume vol = VolumeManager.getInstance().create(toVolume(req.getVolume()));
-        return new CreateVolumeResponse(vol.toJAXB());
+        VolumeInfo volInfoRequest = request.getVolumeInfo();
+        Volume.StoreType enumStoreType = (1 == volInfoRequest.getStoreType()) ? Volume.StoreType.INTERNAL : Volume.StoreType.EXTERNAL;
+        VolumeConfigUtil.validateCreateVolumeRequest(request, volInfoRequest, enumStoreType);
+
+        Volume volRequest = VolumeManager.getInstance().create(toVolume(volInfoRequest, enumStoreType));
+        VolumeInfo volInfoResponse = volRequest.toJAXB();
+        VolumeConfigUtil.postCreateVolumeActions(request, volRequest, volInfoRequest, volInfoResponse, enumStoreType);
+        return new CreateVolumeResponse(volInfoResponse);
     }
 
-    private Volume toVolume(VolumeInfo vol) throws ServiceException {
-        return Volume.builder().setType(vol.getType()).setName(vol.getName()).setPath(vol.getRootPath(), true)
+    private Volume toVolume(VolumeInfo vol, Volume.StoreType enumStoreType) throws ServiceException {
+        return Volume.builder().setType(vol.getType()).setName(vol.getName()).setPath(vol.getRootPath(), enumStoreType.equals(Volume.StoreType.INTERNAL))
                 .setCompressBlobs(vol.isCompressBlobs()).setCompressionThreshold(vol.getCompressionThreshold())
-                .build();
+                .setStoreType(enumStoreType).build();
     }
 
     @Override

--- a/store/src/java/com/zimbra/cs/service/admin/DeleteVolume.java
+++ b/store/src/java/com/zimbra/cs/service/admin/DeleteVolume.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2005, 2006, 2007, 2009, 2010, 2011, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2005, 2006, 2007, 2009, 2010, 2011, 2013, 2014, 2016, 2022 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -25,8 +25,7 @@ import com.zimbra.common.soap.Element;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.accesscontrol.AdminRight;
 import com.zimbra.cs.account.accesscontrol.Rights.Admin;
-import com.zimbra.cs.store.StoreManager;
-import com.zimbra.cs.volume.VolumeManager;
+import com.zimbra.cs.service.util.VolumeConfigUtil;
 import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.admin.message.DeleteVolumeRequest;
@@ -44,13 +43,7 @@ public final class DeleteVolume extends AdminDocumentHandler {
         ZimbraSoapContext zsc = getZimbraSoapContext(ctx);
         checkRight(zsc, ctx, Provisioning.getInstance().getLocalServer(), Admin.R_manageVolume);
 
-        VolumeManager mgr = VolumeManager.getInstance();
-        mgr.getVolume(req.getId()); // make sure the volume exists before doing anything heavyweight...
-        StoreManager storeManager = StoreManager.getInstance();
-        if (storeManager.supports(StoreManager.StoreFeature.CUSTOM_STORE_API, String.valueOf(req.getId()))) {
-          throw ServiceException.INVALID_REQUEST("Operation unsupported, use zxsuite to delete this volume", null);
-        }
-        mgr.delete(req.getId());
+        VolumeConfigUtil.parseDeleteVolumeRequest(req);
         return new DeleteVolumeResponse();
     }
 
@@ -58,5 +51,4 @@ public final class DeleteVolume extends AdminDocumentHandler {
     public void docRights(List<AdminRight> relatedRights, List<String> notes) {
         relatedRights.add(Admin.R_manageVolume);
     }
-
 }

--- a/store/src/java/com/zimbra/cs/service/admin/GetAllVolumes.java
+++ b/store/src/java/com/zimbra/cs/service/admin/GetAllVolumes.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2005, 2006, 2007, 2009, 2010, 2011, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2005, 2006, 2007, 2009, 2010, 2011, 2013, 2014, 2016, 2022 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -18,14 +18,15 @@ package com.zimbra.cs.service.admin;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.accesscontrol.AdminRight;
 import com.zimbra.cs.account.accesscontrol.Rights.Admin;
-import com.zimbra.cs.volume.Volume;
-import com.zimbra.cs.volume.VolumeManager;
-import com.zimbra.common.service.ServiceException;
-import com.zimbra.common.soap.Element;
+import com.zimbra.cs.service.util.VolumeConfigUtil;
 import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.admin.message.GetAllVolumesRequest;
@@ -45,9 +46,7 @@ public final class GetAllVolumes extends AdminDocumentHandler {
         checkRight(zsc, ctx, Provisioning.getInstance().getLocalServer(), Admin.R_manageVolume);
 
         GetAllVolumesResponse resp = new GetAllVolumesResponse();
-        for (Volume vol : VolumeManager.getInstance().getAllVolumes()) {
-            resp.addVolume(vol.toJAXB());
-        }
+        VolumeConfigUtil.parseGetAllVolumesRequest(req, resp);
         return resp;
     }
 

--- a/store/src/java/com/zimbra/cs/service/admin/GetVolume.java
+++ b/store/src/java/com/zimbra/cs/service/admin/GetVolume.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2005, 2006, 2007, 2009, 2010, 2011, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2005, 2006, 2007, 2009, 2010, 2011, 2013, 2014, 2016, 2022 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -19,18 +19,21 @@ package com.zimbra.cs.service.admin;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.accesscontrol.AdminRight;
 import com.zimbra.cs.account.accesscontrol.Rights.Admin;
+import com.zimbra.cs.service.util.VolumeConfigUtil;
 import com.zimbra.cs.volume.Volume;
 import com.zimbra.cs.volume.VolumeManager;
 import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.admin.message.GetVolumeRequest;
 import com.zimbra.soap.admin.message.GetVolumeResponse;
+import com.zimbra.soap.admin.type.VolumeInfo;
 
 public final class GetVolume extends AdminDocumentHandler {
 
@@ -43,9 +46,10 @@ public final class GetVolume extends AdminDocumentHandler {
     private GetVolumeResponse handle(GetVolumeRequest req, Map<String, Object> ctx) throws ServiceException {
         ZimbraSoapContext zsc = getZimbraSoapContext(ctx);
         checkRight(zsc, ctx, Provisioning.getInstance().getLocalServer(), Admin.R_manageVolume);
-
         Volume vol = VolumeManager.getInstance().getVolume(req.getId());
-        GetVolumeResponse resp = new GetVolumeResponse(vol.toJAXB());
+        VolumeInfo volInfo = vol.toJAXB();
+        GetVolumeResponse resp = new GetVolumeResponse(volInfo);
+        VolumeConfigUtil.parseGetVolumeRequest(req, resp, vol, volInfo);
         return resp;
     }
 
@@ -53,5 +57,4 @@ public final class GetVolume extends AdminDocumentHandler {
     public void docRights(List<AdminRight> relatedRights, List<String> notes) {
         relatedRights.add(Admin.R_manageVolume);
     }
-
 }

--- a/store/src/java/com/zimbra/cs/service/admin/ModifyVolume.java
+++ b/store/src/java/com/zimbra/cs/service/admin/ModifyVolume.java
@@ -20,6 +20,8 @@ package com.zimbra.cs.service.admin;
 import java.util.List;
 import java.util.Map;
 
+import org.json.JSONException;
+
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
 import com.zimbra.cs.account.Provisioning;
@@ -27,6 +29,7 @@ import com.zimbra.cs.account.accesscontrol.AdminRight;
 import com.zimbra.cs.account.accesscontrol.Rights.Admin;
 import com.zimbra.cs.service.util.VolumeConfigUtil;
 import com.zimbra.cs.store.StoreManager;
+import com.zimbra.cs.volume.VolumeServiceException;
 import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.admin.message.ModifyVolumeRequest;
@@ -44,7 +47,11 @@ public final class ModifyVolume extends AdminDocumentHandler {
         ZimbraSoapContext zsc = getZimbraSoapContext(ctx);
         checkRight(zsc, ctx, Provisioning.getInstance().getLocalServer(), Admin.R_manageVolume);
 
-        VolumeConfigUtil.parseModifyVolumeRequest(req);
+        try {
+            VolumeConfigUtil.parseModifyVolumeRequest(req);
+        } catch (JSONException e) {
+            throw VolumeServiceException.INVALID_REQUEST("Format is not correct Exception", VolumeServiceException.INVALID_REQUEST);
+        }
         return new ModifyVolumeResponse();
     }
 

--- a/store/src/java/com/zimbra/cs/service/admin/ModifyVolume.java
+++ b/store/src/java/com/zimbra/cs/service/admin/ModifyVolume.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2005, 2006, 2007, 2009, 2010, 2011, 2012, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2005, 2006, 2007, 2009, 2010, 2011, 2012, 2013, 2014, 2016, 2022 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -25,14 +25,12 @@ import com.zimbra.common.soap.Element;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.accesscontrol.AdminRight;
 import com.zimbra.cs.account.accesscontrol.Rights.Admin;
+import com.zimbra.cs.service.util.VolumeConfigUtil;
 import com.zimbra.cs.store.StoreManager;
-import com.zimbra.cs.volume.Volume;
-import com.zimbra.cs.volume.VolumeManager;
 import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.admin.message.ModifyVolumeRequest;
 import com.zimbra.soap.admin.message.ModifyVolumeResponse;
-import com.zimbra.soap.admin.type.VolumeInfo;
 
 public final class ModifyVolume extends AdminDocumentHandler {
 
@@ -46,39 +44,12 @@ public final class ModifyVolume extends AdminDocumentHandler {
         ZimbraSoapContext zsc = getZimbraSoapContext(ctx);
         checkRight(zsc, ctx, Provisioning.getInstance().getLocalServer(), Admin.R_manageVolume);
 
-        VolumeManager mgr = VolumeManager.getInstance();
-        Volume.Builder builder = Volume.builder(mgr.getVolume(req.getId()));
-        VolumeInfo vol = req.getVolume();
-        if (vol == null) {
-            throw ServiceException.INVALID_REQUEST("must specify a volume Element", null);
-        }
-        StoreManager storeManager = StoreManager.getInstance();
-        if (storeManager.supports(StoreManager.StoreFeature.CUSTOM_STORE_API, String.valueOf(vol.getId()))) {
-            throw ServiceException.INVALID_REQUEST("Operation unsupported, use zxsuite to edit this volume", null);
-        }
-        if (vol.getType() > 0) {
-            builder.setType(vol.getType());
-        }
-        if (vol.getName() != null) {
-            builder.setName(vol.getName());
-        }
-        if (vol.getRootPath() != null) {
-            builder.setPath(vol.getRootPath(), true);
-        }
-        if (vol.getCompressBlobs() != null) {
-            builder.setCompressBlobs(vol.getCompressBlobs());
-        }
-        if (vol.getCompressionThreshold() > 0) {
-            builder.setCompressionThreshold(vol.getCompressionThreshold());
-        }
-        mgr.update(builder.build());
+        VolumeConfigUtil.parseModifyVolumeRequest(req);
         return new ModifyVolumeResponse();
-
     }
 
     @Override
     public void docRights(List<AdminRight> relatedRights, List<String> notes) {
         relatedRights.add(Admin.R_manageVolume);
     }
-
 }

--- a/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
@@ -727,7 +727,7 @@ public class ItemActionHelper {
                 break;
             case MESSAGE:
                 try {
-                    in = StoreManager.getInstance().getContent(item.getBlob());
+                    in = StoreManager.getInstance(item.getLocator()).getContent(item.getBlob());
                     createdId = zmbx.addMessage(folderStr, flags, (String) null, item.getDate(), in, item.getSize(), true);
                 } finally {
                     ByteUtil.closeStream(in);
@@ -739,7 +739,7 @@ public class ItemActionHelper {
                 for (Message msg : msgs) {
                     flags = (mOperation == Op.UPDATE && mFlags != null ? mFlags : msg.getFlagString());
                     try {
-                        in = StoreManager.getInstance().getContent(msg.getBlob());
+                        in = StoreManager.getInstance(msg.getLocator()).getContent(msg.getBlob());
                         createdId = zmbx.addMessage(folderStr, flags, (String) null, msg.getDate(), in, msg.getSize(), true);
                     } finally {
                         ByteUtil.closeStream(in);
@@ -751,7 +751,7 @@ public class ItemActionHelper {
                 Document doc = (Document) item;
                 SoapHttpTransport transport = new SoapHttpTransport(zoptions.getUri());
                 try {
-                    in = StoreManager.getInstance().getContent(doc.getBlob());
+                    in = StoreManager.getInstance(doc.getLocator()).getContent(doc.getBlob());
                     String uploadId = zmbx.uploadContentAsStream(name, in, doc.getContentType(), doc.getSize(), 4000, true);
                     // instead of using convenience method from ZMailbox
                     // we need to hand marshall the request and set the

--- a/store/src/java/com/zimbra/cs/service/mail/RemoveAttachments.java
+++ b/store/src/java/com/zimbra/cs/service/mail/RemoveAttachments.java
@@ -73,7 +73,7 @@ public class RemoveAttachments extends MailDocumentHandler {
 
         InputStream is = null;
         try {
-            MimeMessage mm = new Mime.FixedMimeMessage(JMSession.getSession(), is = StoreManager.getInstance().getContent(msg.getBlob().getLocalBlob()));
+            MimeMessage mm = new Mime.FixedMimeMessage(JMSession.getSession(), is = StoreManager.getInstance(msg.getLocator()).getContent(msg.getBlob().getLocalBlob()));
             // do not allow removing attachments of encrypted/pkcs7-signed messages
             if (Mime.isEncrypted(mm.getContentType()) || Mime.isPKCS7Signed(mm.getContentType())) {
                 throw ServiceException.OPERATION_DENIED("not allowed to remove attachments of encrypted/pkcs7-signed message");

--- a/store/src/java/com/zimbra/cs/service/util/VolumeConfigUtil.java
+++ b/store/src/java/com/zimbra/cs/service/util/VolumeConfigUtil.java
@@ -37,6 +37,7 @@ import com.zimbra.soap.admin.message.GetAllVolumesResponse;
 import com.zimbra.soap.admin.message.GetVolumeRequest;
 import com.zimbra.soap.admin.message.GetVolumeResponse;
 import com.zimbra.soap.admin.type.VolumeExternalInfo;
+import com.zimbra.soap.admin.type.VolumeExternalOpenIOInfo;
 import com.zimbra.soap.admin.type.VolumeInfo;
 import com.zimbra.util.ExternalVolumeInfoHandler;
 
@@ -62,8 +63,15 @@ public class VolumeConfigUtil {
         }
 
         // validate/set root path if store type is external
-        if (Volume.StoreType.EXTERNAL.getStoreType() == storeType.intValue()) {
+        if (volInfoRequest != null && volInfoRequest.getVolumeExternalInfo() != null
+                && Volume.StoreType.EXTERNAL.getStoreType() == storeType.intValue()) {
             String extRootPath = "/" + volInfoRequest.getVolumeExternalInfo().getStorageType() + "-" + volInfoRequest.getName() + "-" + volInfoRequest.getVolumeExternalInfo().getGlobalBucketConfigurationId();
+            volInfoRequest.setRootPath(extRootPath);
+        }
+
+        if (volInfoRequest != null && volInfoRequest.getVolumeExternalOpenIOInfo() != null
+                && Volume.StoreType.EXTERNAL.getStoreType() == storeType.intValue()) {
+            String extRootPath = "/" + volInfoRequest.getVolumeExternalOpenIOInfo().getStorageType() + "-" + volInfoRequest.getName();
             volInfoRequest.setRootPath(extRootPath);
         }
 
@@ -83,56 +91,71 @@ public class VolumeConfigUtil {
             throw VolumeServiceException.INVALID_REQUEST("Volume Type can be 1 for PRIMARY volume, 2 for SECONDARY volume or 10 for INDEX volume", VolumeServiceException.BAD_VOLUME_TYPE);
         }
 
-        // validate compress blobs
-        if (false != volInfoRequest.isCompressBlobs() &&
-            true != volInfoRequest.isCompressBlobs()) {
-            throw VolumeServiceException.INVALID_REQUEST("Volume Compress Blobs can be TRUE, FALSE or OPTIONAL(don't provide)", VolumeServiceException.BAD_VOLUME_COMPRESS_BLOBS);
-        }
-
         // validate compression threshold
         if (0 > volInfoRequest.getCompressionThreshold()) {
             throw VolumeServiceException.INVALID_REQUEST("Volume Compression Threshold can't be negative number", VolumeServiceException.BAD_VOLUME_COMPRESSION_THRESHOLD);
         }
 
-        // validate current
-        if (false != volInfoRequest.isCurrent() &&
-            true != volInfoRequest.isCurrent()) {
-            throw VolumeServiceException.INVALID_REQUEST("Volume Current can be TRUE, FALSE or OPTIONAL(don't provide)", VolumeServiceException.BAD_VOLUME_CURRENT);
-        }
-
-        if (enumStoreType.equals(Volume.StoreType.EXTERNAL)) {
-            // validate use in frequent access
-            if (false != volInfoRequest.getVolumeExternalInfo().isUseInFrequentAccess() &&
-                true != volInfoRequest.getVolumeExternalInfo().isUseInFrequentAccess()) {
-                throw VolumeServiceException.INVALID_REQUEST("Volume UseInFrequentAccess can be TRUE, FALSE or OPTIONAL(don't provide)", VolumeServiceException.BAD_VOLUME_USE_IN_FREQUENT_ACCESS);
-            }
-
-            // validate use intelligent tiering
-            if (false != volInfoRequest.getVolumeExternalInfo().isUseIntelligentTiering() &&
-                true != volInfoRequest.getVolumeExternalInfo().isUseIntelligentTiering()) {
-                throw VolumeServiceException.INVALID_REQUEST("Volume UseIntelligentTiering can be TRUE, FALSE or OPTIONAL(don't provide)", VolumeServiceException.BAD_VOLUME_USE_INTELLIGENT_TIERING);
-            }
-
+        if (Volume.StoreType.EXTERNAL.equals(enumStoreType)) {
             // validate storage type
-            String storageType = volInfoRequest.getVolumeExternalInfo().getStorageType();
-            if (false == storageType.equals("S3")) {
-                throw VolumeServiceException.INVALID_REQUEST("Volume Storage Type can be only S3", VolumeServiceException.BAD_VOLUME_STORAGE_TYPE);
-
+            String storageTypeS3 = null;
+            if (volInfoRequest != null && volInfoRequest.getVolumeExternalInfo() != null) {
+                storageTypeS3 = volInfoRequest.getVolumeExternalInfo().getStorageType();
+            }
+            String storageTypeOpenIO = null;
+            if (volInfoRequest != null && volInfoRequest.getVolumeExternalOpenIOInfo() != null) {
+                storageTypeOpenIO = volInfoRequest.getVolumeExternalOpenIOInfo().getStorageType();
             }
 
-            // validate use in frequent access threshold
-            int useInFrequentAccessThreshold = volInfoRequest.getVolumeExternalInfo().getUseInFrequentAccessThreshold();
-            if (0 > useInFrequentAccessThreshold) {
-                throw VolumeServiceException.INVALID_REQUEST("Volume UseInFrequentAccessThreshold can't be negative number", VolumeServiceException.BAD_VOLUME_USE_IN_FREQUENT_ACCESS_THRESHOLD);
+            if (storageTypeS3 != null && storageTypeOpenIO != null
+                    && !storageTypeS3.equalsIgnoreCase(AdminConstants.A_VOLUME_S3)
+                    && !storageTypeOpenIO.equalsIgnoreCase(AdminConstants.A_VOLUME_OPEN_IO)) {
+                throw VolumeServiceException.INVALID_REQUEST("Volume Storage Type can be only S3 or OpenIO",
+                        VolumeServiceException.BAD_VOLUME_STORAGE_TYPE);
             }
 
-            // validate global bucket id
-            String globalS3BucketId = volInfoRequest.getVolumeExternalInfo().getGlobalBucketConfigurationId();
-            if (false == extVolInfoHandler.validateGlobalBucketID(globalS3BucketId)) {
-                throw VolumeServiceException.INVALID_REQUEST("Volume GlobalBucketID provided is incorrect, missing or empty", VolumeServiceException.BAD_VOLUME_GLOBAL_BUCKET_ID);
-            }
+            if (AdminConstants.A_VOLUME_S3.equalsIgnoreCase(storageTypeS3)) {
+                // validate use in frequent access threshold
+                int useInFrequentAccessThreshold = volInfoRequest.getVolumeExternalInfo().getUseInFrequentAccessThreshold();
+                if (useInFrequentAccessThreshold < 0) {
+                    throw VolumeServiceException.INVALID_REQUEST("Volume UseInFrequentAccessThreshold can't be negative number", VolumeServiceException.BAD_VOLUME_USE_IN_FREQUENT_ACCESS_THRESHOLD);
+                }
 
-            // no validation for volume prefix as of now
+                // validate global bucket id
+                String globalS3BucketId = volInfoRequest.getVolumeExternalInfo().getGlobalBucketConfigurationId();
+                if (!extVolInfoHandler.validateGlobalBucketID(globalS3BucketId)) {
+                    throw VolumeServiceException.INVALID_REQUEST("Volume GlobalBucketID provided is incorrect, missing or empty", VolumeServiceException.BAD_VOLUME_GLOBAL_BUCKET_ID);
+                }
+                // no validation for volume prefix as of now
+            } else if (AdminConstants.A_VOLUME_OPEN_IO.equalsIgnoreCase(storageTypeOpenIO)) {
+                // validate proxy port as positive
+                if (volInfoRequest.getVolumeExternalOpenIOInfo().getProxyPort() <= 0) {
+                    throw VolumeServiceException.INVALID_REQUEST("Proxy port can't be negative number or null", VolumeServiceException.BAD_VOLUME_USE_IN_FREQUENT_ACCESS_THRESHOLD);
+                }
+
+                // validate account port as positive
+                if (volInfoRequest.getVolumeExternalOpenIOInfo().getAccountPort() <= 0) {
+                    throw VolumeServiceException.INVALID_REQUEST("Account port can't be negative number or null", VolumeServiceException.BAD_VOLUME_USE_IN_FREQUENT_ACCESS_THRESHOLD);
+                }
+
+                // validate url is empty or not
+                if (StringUtil.isNullOrEmpty(volInfoRequest.getVolumeExternalOpenIOInfo().getUrl())) {
+                    throw VolumeServiceException.INVALID_REQUEST("Url can't be null", VolumeServiceException.BAD_VOLUME_USE_IN_FREQUENT_ACCESS_THRESHOLD);
+                }
+
+                // validate account is empty or not
+                if (StringUtil.isNullOrEmpty(volInfoRequest.getVolumeExternalOpenIOInfo().getAccount())) {
+                    throw VolumeServiceException.INVALID_REQUEST("Account can't be null", VolumeServiceException.BAD_VOLUME_USE_IN_FREQUENT_ACCESS_THRESHOLD);
+                }
+
+                // validate namespace is empty or not
+                if (StringUtil.isNullOrEmpty(volInfoRequest.getVolumeExternalOpenIOInfo().getNameSpace())) {
+                    throw VolumeServiceException.INVALID_REQUEST("Name Space can't be null", VolumeServiceException.BAD_VOLUME_USE_IN_FREQUENT_ACCESS_THRESHOLD);
+                }
+            } else {
+                throw VolumeServiceException.INVALID_REQUEST("Volume Storage Type can be only S3 or OpenIO",
+                        VolumeServiceException.BAD_VOLUME_STORAGE_TYPE);
+            }
         }
     }
 
@@ -147,10 +170,15 @@ public class VolumeConfigUtil {
                                                VolumeInfo volInfoRequest, VolumeInfo volInfoResponse,
                                                Volume.StoreType enumStoreType) throws ServiceException {
         ExternalVolumeInfoHandler extVolInfoHandler = new ExternalVolumeInfoHandler(Provisioning.getInstance());
-        if (enumStoreType.equals(Volume.StoreType.EXTERNAL)) {
+        if (Volume.StoreType.EXTERNAL.equals(enumStoreType)) {
             try {
                 volInfoRequest.setId(volRequest.getId());
-                volInfoResponse.setVolumeExternalInfo(volInfoRequest.getVolumeExternalInfo());
+                if (volInfoRequest.getVolumeExternalInfo() != null && AdminConstants.A_VOLUME_S3
+                        .equalsIgnoreCase(volInfoRequest.getVolumeExternalInfo().getStorageType())) {
+                    volInfoResponse.setVolumeExternalInfo(volInfoRequest.getVolumeExternalInfo());
+                } else {
+                    volInfoResponse.setVolumeExternalOpenIOInfo(volInfoRequest.getVolumeExternalOpenIOInfo());
+                }
                 extVolInfoHandler.addServerProperties(volInfoRequest);
             } catch (JSONException e) {
                 throw ServiceException.FAILURE("Error while processing postCreateVolumeActions", e);
@@ -169,26 +197,17 @@ public class VolumeConfigUtil {
         for (Volume vol : VolumeManager.getInstance().getAllVolumes()) {
             VolumeInfo volInfo = vol.toJAXB();
 
-            if (vol.getStoreType().equals(Volume.StoreType.EXTERNAL)) {
-                VolumeExternalInfo volExtInfo = new VolumeExternalInfo();
+            if (Volume.StoreType.EXTERNAL.equals(vol.getStoreType())) {
                 ExternalVolumeInfoHandler extVolInfoHandler = new ExternalVolumeInfoHandler(Provisioning.getInstance());
 
                 try {
                     JSONObject properties = extVolInfoHandler.readServerProperties(volInfo.getId());
-                    String volumePrefix = properties.getString(AdminConstants.A_VOLUME_VOLUME_PREFIX);
-                    String globalBucketConfigId = properties.getString(AdminConstants.A_VOLUME_GLB_BUCKET_CONFIG_ID);
                     String storageType = properties.getString(AdminConstants.A_VOLUME_STORAGE_TYPE);
-                    Boolean useInFrequentAccess = Boolean.valueOf(properties.getString(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS));
-                    Boolean useIntelligentTiering = Boolean.valueOf(properties.getString(AdminConstants.A_VOLUME_USE_INTELLIGENT_TIERING));
-                    int useInFrequentAccessThreshold = Integer.parseInt(properties.getString(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS_THRESHOLD));
-
-                    volExtInfo.setVolumePrefix(volumePrefix);
-                    volExtInfo.setGlobalBucketConfigurationId(globalBucketConfigId);
-                    volExtInfo.setStorageType(storageType);
-                    volExtInfo.setUseInFrequentAccess(useInFrequentAccess);
-                    volExtInfo.setUseIntelligentTiering(useIntelligentTiering);
-                    volExtInfo.setUseInFrequentAccessThreshold(useInFrequentAccessThreshold);
-                    volInfo.setVolumeExternalInfo(volExtInfo);
+                    if (AdminConstants.A_VOLUME_S3.equalsIgnoreCase(storageType)) {
+                        volInfo.setVolumeExternalInfo(new VolumeExternalInfo().toExternalInfo(properties));
+                    } else {
+                        volInfo.setVolumeExternalOpenIOInfo(new VolumeExternalOpenIOInfo().toExternalOpenIoInfo(properties));
+                    }
                 } catch (JSONException e) {
                     throw ServiceException.FAILURE("Error while processing GetAllVolumesRequest", e);
                 }
@@ -205,26 +224,17 @@ public class VolumeConfigUtil {
      * @throws ServiceException
      */
     public static void parseGetVolumeRequest(GetVolumeRequest req, GetVolumeResponse resp,
-                                             Volume vol, VolumeInfo volInfo) throws ServiceException {
-        if (vol.getStoreType().equals(Volume.StoreType.EXTERNAL)) {
-            VolumeExternalInfo volExtInfo = new VolumeExternalInfo();
+            Volume vol, VolumeInfo volInfo) throws ServiceException {
+        if (Volume.StoreType.EXTERNAL.equals(vol.getStoreType())) {
             ExternalVolumeInfoHandler extVolInfoHandler = new ExternalVolumeInfoHandler(Provisioning.getInstance());
             try {
                 JSONObject properties = extVolInfoHandler.readServerProperties(volInfo.getId());
-                String volumePrefix = properties.getString(AdminConstants.A_VOLUME_VOLUME_PREFIX);
-                String globalBucketConfigId = properties.getString(AdminConstants.A_VOLUME_GLB_BUCKET_CONFIG_ID);
                 String storageType = properties.getString(AdminConstants.A_VOLUME_STORAGE_TYPE);
-                Boolean useInFrequentAccess = Boolean.valueOf(properties.getString(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS));
-                Boolean useIntelligentTiering = Boolean.valueOf(properties.getString(AdminConstants.A_VOLUME_USE_INTELLIGENT_TIERING));
-                int useInFrequentAccessThreshold = Integer.parseInt(properties.getString(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS_THRESHOLD));
-
-                volExtInfo.setVolumePrefix(volumePrefix);
-                volExtInfo.setGlobalBucketConfigurationId(globalBucketConfigId);
-                volExtInfo.setStorageType(storageType);
-                volExtInfo.setUseInFrequentAccess(useInFrequentAccess);
-                volExtInfo.setUseIntelligentTiering(useIntelligentTiering);
-                volExtInfo.setUseInFrequentAccessThreshold(useInFrequentAccessThreshold);
-                volInfo.setVolumeExternalInfo(volExtInfo);
+                if (storageType.equalsIgnoreCase(AdminConstants.A_VOLUME_S3)) {
+                    volInfo.setVolumeExternalInfo(new VolumeExternalInfo().toExternalInfo(properties));
+                } else {
+                    volInfo.setVolumeExternalOpenIOInfo(new VolumeExternalOpenIOInfo().toExternalOpenIoInfo(properties));
+                }
             } catch (JSONException e) {
                 throw ServiceException.FAILURE("Error while processing GetVolumesRequest", e);
             }
@@ -267,8 +277,9 @@ public class VolumeConfigUtil {
      * @param ModifyVolumeRequest
      * @return
      * @throws ServiceException
+     * @throws JSONException
      */
-    public static void parseModifyVolumeRequest(ModifyVolumeRequest req) throws ServiceException {
+    public static void parseModifyVolumeRequest(ModifyVolumeRequest req) throws ServiceException, JSONException {
         VolumeManager mgr = VolumeManager.getInstance();
         VolumeInfo volInfo = req.getVolumeInfo();
         Volume vol = mgr.getVolume(req.getId());
@@ -284,7 +295,7 @@ public class VolumeConfigUtil {
         }
 
         // store type == 1, allow modification of all parameters
-        if (vol.getStoreType().equals(Volume.StoreType.INTERNAL)) {
+        if (Volume.StoreType.INTERNAL.equals(vol.getStoreType())) {
             if (volInfo.getType() > 0) {
                 builder.setType(volInfo.getType());
             }
@@ -300,29 +311,36 @@ public class VolumeConfigUtil {
             builder.setCompressBlobs(volInfo.isCompressBlobs());
         }
         // store type == 2, allow modification of only volume name
-        else if (vol.getStoreType().equals(Volume.StoreType.EXTERNAL)) {
+        else if (Volume.StoreType.EXTERNAL.equals(vol.getStoreType())) {
             if (volInfo.getName() != null) {
                 String storageType = "";
                 String globalBucketConfigId = "";
                 ExternalVolumeInfoHandler extVolInfoHandler = new ExternalVolumeInfoHandler(Provisioning.getInstance());
-                try {
-                    JSONObject properties = extVolInfoHandler.readServerProperties(req.getId());
-                    storageType = properties.getString(AdminConstants.A_VOLUME_STORAGE_TYPE);
-                    globalBucketConfigId = properties.getString(AdminConstants.A_VOLUME_GLB_BUCKET_CONFIG_ID);
-                } catch (JSONException e) {
-                    throw ServiceException.FAILURE("Error while reading json data for external volume: " + req.getId(), e);
+                JSONObject properties = extVolInfoHandler.readServerProperties(req.getId());
+                if (JSONObject.NULL.equals(properties)) {
+                    throw VolumeServiceException.INVALID_REQUEST("Unable to read server properties", VolumeServiceException.INVALID_REQUEST);
                 }
-                // storageType should not be null
-                if (StringUtil.isNullOrEmpty(storageType)) {
-                    throw VolumeServiceException.INVALID_REQUEST("StorageType Empty for external volume " + req.getId(), VolumeServiceException.INVALID_REQUEST);
+                storageType = properties.getString(AdminConstants.A_VOLUME_STORAGE_TYPE);
+                if (storageType.equalsIgnoreCase(AdminConstants.A_VOLUME_S3)) {
+                    try {
+                        globalBucketConfigId = properties.getString(AdminConstants.A_VOLUME_GLB_BUCKET_CONFIG_ID);
+                    } catch (JSONException e) {
+                        throw ServiceException.FAILURE("Error while reading json data for external volume: " + req.getId(), e);
+                    }
+                    // storageType should not be null
+                    if (StringUtil.isNullOrEmpty(storageType)) {
+                        throw VolumeServiceException.INVALID_REQUEST("StorageType Empty for external volume " + req.getId(), VolumeServiceException.INVALID_REQUEST);
+                    }
+                    builder.setName(volInfo.getName());
+                    String extRootPath = ZMailbox.PATH_SEPARATOR + storageType + ROOT_PATH_ELE_SEPARATOR + volInfo.getName();
+                    // append global bucket id as well in case it is available
+                    if (!StringUtil.isNullOrEmpty(globalBucketConfigId)) {
+                        extRootPath = extRootPath + ROOT_PATH_ELE_SEPARATOR + globalBucketConfigId;
+                    }
+                    builder.setPath(extRootPath, false);
+                } else {
+                    builder.setName(volInfo.getName());
                 }
-                builder.setName(volInfo.getName());
-                String extRootPath = ZMailbox.PATH_SEPARATOR + storageType + ROOT_PATH_ELE_SEPARATOR + volInfo.getName();
-                // append global bucket id as well in case it is available
-                if (!StringUtil.isNullOrEmpty(globalBucketConfigId)) {
-                    extRootPath = extRootPath + ROOT_PATH_ELE_SEPARATOR + globalBucketConfigId;
-                }
-                builder.setPath(extRootPath, false);
             }
         }
         mgr.update(builder.build());

--- a/store/src/java/com/zimbra/cs/service/util/VolumeConfigUtil.java
+++ b/store/src/java/com/zimbra/cs/service/util/VolumeConfigUtil.java
@@ -18,6 +18,8 @@
 package com.zimbra.cs.service.util;
 
 import com.zimbra.client.ZMailbox;
+import com.zimbra.common.localconfig.LC;
+import com.zimbra.cs.store.helper.ClassHelper;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -44,6 +46,15 @@ import com.zimbra.util.ExternalVolumeInfoHandler;
 public class VolumeConfigUtil {
 
     private static final String  ROOT_PATH_ELE_SEPARATOR = "-";
+
+    /**
+     * This is default store manager
+     */
+    private static final String DEFAULT_STORE_MANAGER = "com.zimbra.cs.store.file.FileBlobStore";
+    /**
+     * This is default external store manager, not part of FOSS edition
+     */
+    private static final String DEFAULT_EXTERNAL_STORE_MANAGER = "com.zimbra.storemanagers.store.GenericStoreManager";
 
     /**
      * Validate the create volume request parameters
@@ -96,6 +107,17 @@ public class VolumeConfigUtil {
             throw VolumeServiceException.INVALID_REQUEST("Volume Compression Threshold can't be negative number", VolumeServiceException.BAD_VOLUME_COMPRESSION_THRESHOLD);
         }
 
+        if (Volume.TYPE_MESSAGE == volInfoRequest.getType() || Volume.TYPE_MESSAGE_SECONDARY == volInfoRequest.getType()) {
+            if (!StringUtil.isNullOrEmpty(volInfoRequest.getStoreManagerClass())) {
+                if (!ClassHelper.isClassExist(volInfoRequest.getStoreManagerClass())) {
+                    throw VolumeServiceException.INVALID_REQUEST("Invalid StoreManager class, can not loaded", VolumeServiceException.BAD_VOLUME_STORE_MANAGER_CLASS);
+                }
+            } else {
+                // set to default store manager if not passed.
+                setDefaultStoreManager(volInfoRequest, storeType);
+            }
+        }
+
         if (Volume.StoreType.EXTERNAL.equals(enumStoreType)) {
             // validate storage type
             String storageTypeS3 = null;
@@ -105,8 +127,8 @@ public class VolumeConfigUtil {
             String storageTypeOpenIO = null;
             if (volInfoRequest != null && volInfoRequest.getVolumeExternalOpenIOInfo() != null) {
                 storageTypeOpenIO = volInfoRequest.getVolumeExternalOpenIOInfo().getStorageType();
-            }
 
+            }
             if (storageTypeS3 != null && storageTypeOpenIO != null
                     && !storageTypeS3.equalsIgnoreCase(AdminConstants.A_VOLUME_S3)
                     && !storageTypeOpenIO.equalsIgnoreCase(AdminConstants.A_VOLUME_OPEN_IO)) {
@@ -156,6 +178,19 @@ public class VolumeConfigUtil {
                 throw VolumeServiceException.INVALID_REQUEST("Volume Storage Type can be only S3 or OpenIO",
                         VolumeServiceException.BAD_VOLUME_STORAGE_TYPE);
             }
+        }
+    }
+
+    /**
+     * Set default StoreManager for volume
+     * @param volInfoRequest
+     * @param storeType
+     */
+    private static void setDefaultStoreManager(VolumeInfo volInfoRequest, Short storeType) {
+        if (Volume.StoreType.EXTERNAL.getStoreType() == storeType.intValue()) {
+            volInfoRequest.setStoreManagerClass(DEFAULT_EXTERNAL_STORE_MANAGER);
+        } else {
+            volInfoRequest.setStoreManagerClass(DEFAULT_STORE_MANAGER);
         }
     }
 

--- a/store/src/java/com/zimbra/cs/service/util/VolumeConfigUtil.java
+++ b/store/src/java/com/zimbra/cs/service/util/VolumeConfigUtil.java
@@ -186,7 +186,11 @@ public class VolumeConfigUtil {
      * @param volInfoRequest
      * @param storeType
      */
-    private static void setDefaultStoreManager(VolumeInfo volInfoRequest, Short storeType) {
+    private static void setDefaultStoreManager(VolumeInfo volInfoRequest, Short storeType) throws ServiceException {
+        if (Volume.StoreType.EXTERNAL.getStoreType() == storeType.intValue() && !ClassHelper.isClassExist(DEFAULT_EXTERNAL_STORE_MANAGER)) {
+            throw VolumeServiceException.UNSUPPORTED_CONFIG("StoreManager for external volumes not available in this version");
+        }
+        // set default StoreManager
         if (Volume.StoreType.EXTERNAL.getStoreType() == storeType.intValue()) {
             volInfoRequest.setStoreManagerClass(DEFAULT_EXTERNAL_STORE_MANAGER);
         } else {

--- a/store/src/java/com/zimbra/cs/service/util/VolumeConfigUtil.java
+++ b/store/src/java/com/zimbra/cs/service/util/VolumeConfigUtil.java
@@ -1,0 +1,330 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.service.util;
+
+import com.zimbra.client.ZMailbox;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.common.util.StringUtil;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.store.StoreManager;
+import com.zimbra.cs.volume.Volume;
+import com.zimbra.cs.volume.VolumeManager;
+import com.zimbra.cs.volume.VolumeServiceException;
+import com.zimbra.soap.admin.message.CreateVolumeRequest;
+import com.zimbra.soap.admin.message.DeleteVolumeRequest;
+import com.zimbra.soap.admin.message.ModifyVolumeRequest;
+import com.zimbra.soap.admin.message.GetAllVolumesRequest;
+import com.zimbra.soap.admin.message.GetAllVolumesResponse;
+import com.zimbra.soap.admin.message.GetVolumeRequest;
+import com.zimbra.soap.admin.message.GetVolumeResponse;
+import com.zimbra.soap.admin.type.VolumeExternalInfo;
+import com.zimbra.soap.admin.type.VolumeInfo;
+import com.zimbra.util.ExternalVolumeInfoHandler;
+
+public class VolumeConfigUtil {
+
+    private static final String  ROOT_PATH_ELE_SEPARATOR = "-";
+
+    /**
+     * Validate the create volume request parameters
+     *
+     * @param request
+     * @return
+     * @throws ServiceException
+     */
+    public static void validateCreateVolumeRequest(CreateVolumeRequest request, VolumeInfo volInfoRequest,
+                                                   Volume.StoreType enumStoreType) throws ServiceException {
+        ExternalVolumeInfoHandler extVolInfoHandler = new ExternalVolumeInfoHandler(Provisioning.getInstance());
+
+        // validate store type
+        Short storeType = volInfoRequest.getStoreType();
+        if (Volume.StoreType.INTERNAL.getStoreType() != storeType.intValue() && Volume.StoreType.EXTERNAL.getStoreType() != storeType.intValue()) {
+            throw VolumeServiceException.INVALID_REQUEST("Volume Store Type shall be either 1 for internal volume or 2 for external volume", VolumeServiceException.BAD_VOLUME_STORE_TYPE);
+        }
+
+        // validate/set root path if store type is external
+        if (Volume.StoreType.EXTERNAL.getStoreType() == storeType.intValue()) {
+            String extRootPath = "/" + volInfoRequest.getVolumeExternalInfo().getStorageType() + "-" + volInfoRequest.getName() + "-" + volInfoRequest.getVolumeExternalInfo().getGlobalBucketConfigurationId();
+            volInfoRequest.setRootPath(extRootPath);
+        }
+
+        // validate root path
+        if (StringUtil.isNullOrEmpty(volInfoRequest.getRootPath())) {
+            throw VolumeServiceException.INVALID_REQUEST("Volume Root Path can't be missing, empty or null", VolumeServiceException.BAD_VOLUME_PATH);
+        }
+
+        // validate name
+        if (StringUtil.isNullOrEmpty(volInfoRequest.getName())) {
+            throw VolumeServiceException.INVALID_REQUEST("Volume Name can't be missing, empty or null", VolumeServiceException.BAD_VOLUME_NAME);
+        }
+
+        // validate type
+        Short type = volInfoRequest.getType();
+        if (1 != type.intValue() && 2 != type.intValue() && 10 != type.intValue()) {
+            throw VolumeServiceException.INVALID_REQUEST("Volume Type can be 1 for PRIMARY volume, 2 for SECONDARY volume or 10 for INDEX volume", VolumeServiceException.BAD_VOLUME_TYPE);
+        }
+
+        // validate compress blobs
+        if (false != volInfoRequest.isCompressBlobs() &&
+            true != volInfoRequest.isCompressBlobs()) {
+            throw VolumeServiceException.INVALID_REQUEST("Volume Compress Blobs can be TRUE, FALSE or OPTIONAL(don't provide)", VolumeServiceException.BAD_VOLUME_COMPRESS_BLOBS);
+        }
+
+        // validate compression threshold
+        if (0 > volInfoRequest.getCompressionThreshold()) {
+            throw VolumeServiceException.INVALID_REQUEST("Volume Compression Threshold can't be negative number", VolumeServiceException.BAD_VOLUME_COMPRESSION_THRESHOLD);
+        }
+
+        // validate current
+        if (false != volInfoRequest.isCurrent() &&
+            true != volInfoRequest.isCurrent()) {
+            throw VolumeServiceException.INVALID_REQUEST("Volume Current can be TRUE, FALSE or OPTIONAL(don't provide)", VolumeServiceException.BAD_VOLUME_CURRENT);
+        }
+
+        if (enumStoreType.equals(Volume.StoreType.EXTERNAL)) {
+            // validate use in frequent access
+            if (false != volInfoRequest.getVolumeExternalInfo().isUseInFrequentAccess() &&
+                true != volInfoRequest.getVolumeExternalInfo().isUseInFrequentAccess()) {
+                throw VolumeServiceException.INVALID_REQUEST("Volume UseInFrequentAccess can be TRUE, FALSE or OPTIONAL(don't provide)", VolumeServiceException.BAD_VOLUME_USE_IN_FREQUENT_ACCESS);
+            }
+
+            // validate use intelligent tiering
+            if (false != volInfoRequest.getVolumeExternalInfo().isUseIntelligentTiering() &&
+                true != volInfoRequest.getVolumeExternalInfo().isUseIntelligentTiering()) {
+                throw VolumeServiceException.INVALID_REQUEST("Volume UseIntelligentTiering can be TRUE, FALSE or OPTIONAL(don't provide)", VolumeServiceException.BAD_VOLUME_USE_INTELLIGENT_TIERING);
+            }
+
+            // validate storage type
+            String storageType = volInfoRequest.getVolumeExternalInfo().getStorageType();
+            if (false == storageType.equals("S3")) {
+                throw VolumeServiceException.INVALID_REQUEST("Volume Storage Type can be only S3", VolumeServiceException.BAD_VOLUME_STORAGE_TYPE);
+
+            }
+
+            // validate use in frequent access threshold
+            int useInFrequentAccessThreshold = volInfoRequest.getVolumeExternalInfo().getUseInFrequentAccessThreshold();
+            if (0 > useInFrequentAccessThreshold) {
+                throw VolumeServiceException.INVALID_REQUEST("Volume UseInFrequentAccessThreshold can't be negative number", VolumeServiceException.BAD_VOLUME_USE_IN_FREQUENT_ACCESS_THRESHOLD);
+            }
+
+            // validate global bucket id
+            String globalS3BucketId = volInfoRequest.getVolumeExternalInfo().getGlobalBucketConfigurationId();
+            if (false == extVolInfoHandler.validateGlobalBucketID(globalS3BucketId)) {
+                throw VolumeServiceException.INVALID_REQUEST("Volume GlobalBucketID provided is incorrect, missing or empty", VolumeServiceException.BAD_VOLUME_GLOBAL_BUCKET_ID);
+            }
+
+            // no validation for volume prefix as of now
+        }
+    }
+
+    /**
+     * Perform required actions after creating volume
+     *
+     * @param request, volInfoResponse
+     * @return
+     * @throws ServiceException
+     */
+    public static void postCreateVolumeActions(CreateVolumeRequest request, Volume volRequest,
+                                               VolumeInfo volInfoRequest, VolumeInfo volInfoResponse,
+                                               Volume.StoreType enumStoreType) throws ServiceException {
+        ExternalVolumeInfoHandler extVolInfoHandler = new ExternalVolumeInfoHandler(Provisioning.getInstance());
+        if (enumStoreType.equals(Volume.StoreType.EXTERNAL)) {
+            try {
+                volInfoRequest.setId(volRequest.getId());
+                volInfoResponse.setVolumeExternalInfo(volInfoRequest.getVolumeExternalInfo());
+                extVolInfoHandler.addServerProperties(volInfoRequest);
+            } catch (JSONException e) {
+                throw ServiceException.FAILURE("Error while processing postCreateVolumeActions", e);
+            }
+        }
+    }
+
+    /**
+     * Perform required actions for processing GetAllVolumesRequest
+     *
+     * @param GetAllVolumesRequest, GetAllVolumesResponse
+     * @return
+     * @throws ServiceException
+     */
+    public static void parseGetAllVolumesRequest(GetAllVolumesRequest req, GetAllVolumesResponse resp) throws ServiceException {
+        for (Volume vol : VolumeManager.getInstance().getAllVolumes()) {
+            VolumeInfo volInfo = vol.toJAXB();
+
+            if (vol.getStoreType().equals(Volume.StoreType.EXTERNAL)) {
+                VolumeExternalInfo volExtInfo = new VolumeExternalInfo();
+                ExternalVolumeInfoHandler extVolInfoHandler = new ExternalVolumeInfoHandler(Provisioning.getInstance());
+
+                try {
+                    JSONObject properties = extVolInfoHandler.readServerProperties(volInfo.getId());
+                    String volumePrefix = properties.getString(AdminConstants.A_VOLUME_VOLUME_PREFIX);
+                    String globalBucketConfigId = properties.getString(AdminConstants.A_VOLUME_GLB_BUCKET_CONFIG_ID);
+                    String storageType = properties.getString(AdminConstants.A_VOLUME_STORAGE_TYPE);
+                    Boolean useInFrequentAccess = Boolean.valueOf(properties.getString(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS));
+                    Boolean useIntelligentTiering = Boolean.valueOf(properties.getString(AdminConstants.A_VOLUME_USE_INTELLIGENT_TIERING));
+                    int useInFrequentAccessThreshold = Integer.parseInt(properties.getString(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS_THRESHOLD));
+
+                    volExtInfo.setVolumePrefix(volumePrefix);
+                    volExtInfo.setGlobalBucketConfigurationId(globalBucketConfigId);
+                    volExtInfo.setStorageType(storageType);
+                    volExtInfo.setUseInFrequentAccess(useInFrequentAccess);
+                    volExtInfo.setUseIntelligentTiering(useIntelligentTiering);
+                    volExtInfo.setUseInFrequentAccessThreshold(useInFrequentAccessThreshold);
+                    volInfo.setVolumeExternalInfo(volExtInfo);
+                } catch (JSONException e) {
+                    throw ServiceException.FAILURE("Error while processing GetAllVolumesRequest", e);
+                }
+            }
+            resp.addVolume(volInfo);
+        }
+    }
+
+    /**
+     * Perform required actions for processing parseGetVolumeRequest
+     *
+     * @param GetVolumeResponse, GetVolumeResponse, Volume, VolumeInfo
+     * @return
+     * @throws ServiceException
+     */
+    public static void parseGetVolumeRequest(GetVolumeRequest req, GetVolumeResponse resp,
+                                             Volume vol, VolumeInfo volInfo) throws ServiceException {
+        if (vol.getStoreType().equals(Volume.StoreType.EXTERNAL)) {
+            VolumeExternalInfo volExtInfo = new VolumeExternalInfo();
+            ExternalVolumeInfoHandler extVolInfoHandler = new ExternalVolumeInfoHandler(Provisioning.getInstance());
+            try {
+                JSONObject properties = extVolInfoHandler.readServerProperties(volInfo.getId());
+                String volumePrefix = properties.getString(AdminConstants.A_VOLUME_VOLUME_PREFIX);
+                String globalBucketConfigId = properties.getString(AdminConstants.A_VOLUME_GLB_BUCKET_CONFIG_ID);
+                String storageType = properties.getString(AdminConstants.A_VOLUME_STORAGE_TYPE);
+                Boolean useInFrequentAccess = Boolean.valueOf(properties.getString(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS));
+                Boolean useIntelligentTiering = Boolean.valueOf(properties.getString(AdminConstants.A_VOLUME_USE_INTELLIGENT_TIERING));
+                int useInFrequentAccessThreshold = Integer.parseInt(properties.getString(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS_THRESHOLD));
+
+                volExtInfo.setVolumePrefix(volumePrefix);
+                volExtInfo.setGlobalBucketConfigurationId(globalBucketConfigId);
+                volExtInfo.setStorageType(storageType);
+                volExtInfo.setUseInFrequentAccess(useInFrequentAccess);
+                volExtInfo.setUseIntelligentTiering(useIntelligentTiering);
+                volExtInfo.setUseInFrequentAccessThreshold(useInFrequentAccessThreshold);
+                volInfo.setVolumeExternalInfo(volExtInfo);
+            } catch (JSONException e) {
+                throw ServiceException.FAILURE("Error while processing GetVolumesRequest", e);
+            }
+        }
+    }
+
+    /**
+     * Perform required actions for processing parseDeleteVolumeRequest
+     *
+     * @param DeleteVolumeRequest
+     * @return
+     * @throws ServiceException
+     */
+    public static void parseDeleteVolumeRequest(DeleteVolumeRequest req) throws ServiceException {
+        VolumeManager mgr = VolumeManager.getInstance();
+        Volume vol = mgr.getVolume(req.getId()); // make sure the volume exists before doing anything heavyweight...
+        StoreManager storeManager = StoreManager.getInstance();
+        if (storeManager.supports(StoreManager.StoreFeature.CUSTOM_STORE_API, String.valueOf(req.getId()))) {
+            throw VolumeServiceException.INVALID_REQUEST("Operation unsupported, use zxsuite to edit this volume", VolumeServiceException.INVALID_REQUEST);
+        }
+        mgr.delete(req.getId());
+        try {
+            if (vol.getStoreType().equals(Volume.StoreType.EXTERNAL)) {
+                ExternalVolumeInfoHandler extVolInfoHandler = new ExternalVolumeInfoHandler(Provisioning.getInstance());
+                if (extVolInfoHandler.isVolumePresentInJson(req.getId())) {
+                    extVolInfoHandler.deleteServerProperties(req.getId());
+                } else {
+                    String errMsg = "External volume entry in JSON not found, Volume ID " + req.getId();
+                    throw ServiceException.FAILURE(errMsg, null);
+                }
+            }
+        } catch (JSONException e) {
+            throw ServiceException.FAILURE("Error while processing DeleteVolumeRequest", e);
+        }
+    }
+
+    /**
+     * Perform required actions for processing parseModifyVolumeRequest
+     *
+     * @param ModifyVolumeRequest
+     * @return
+     * @throws ServiceException
+     */
+    public static void parseModifyVolumeRequest(ModifyVolumeRequest req) throws ServiceException {
+        VolumeManager mgr = VolumeManager.getInstance();
+        VolumeInfo volInfo = req.getVolumeInfo();
+        Volume vol = mgr.getVolume(req.getId());
+        Volume.Builder builder = Volume.builder(vol);
+
+        if (volInfo == null) {
+            throw VolumeServiceException.INVALID_REQUEST("Must specify a volume Element", VolumeServiceException.NO_SUCH_VOLUME);
+        }
+
+        StoreManager storeManager = StoreManager.getInstance();
+        if (storeManager.supports(StoreManager.StoreFeature.CUSTOM_STORE_API, String.valueOf(volInfo.getId()))) {
+            throw VolumeServiceException.INVALID_REQUEST("Operation unsupported, use zxsuite to edit this volume", VolumeServiceException.INVALID_REQUEST);
+        }
+
+        // store type == 1, allow modification of all parameters
+        if (vol.getStoreType().equals(Volume.StoreType.INTERNAL)) {
+            if (volInfo.getType() > 0) {
+                builder.setType(volInfo.getType());
+            }
+            if (!StringUtil.isNullOrEmpty(volInfo.getName())) {
+                builder.setName(volInfo.getName());
+            }
+            if (!StringUtil.isNullOrEmpty(volInfo.getRootPath())) {
+                builder.setPath(volInfo.getRootPath(), true);
+            }
+            if (volInfo.getCompressionThreshold() > 0) {
+                builder.setCompressionThreshold(volInfo.getCompressionThreshold());
+            }
+            builder.setCompressBlobs(volInfo.isCompressBlobs());
+        }
+        // store type == 2, allow modification of only volume name
+        else if (vol.getStoreType().equals(Volume.StoreType.EXTERNAL)) {
+            if (volInfo.getName() != null) {
+                String storageType = "";
+                String globalBucketConfigId = "";
+                ExternalVolumeInfoHandler extVolInfoHandler = new ExternalVolumeInfoHandler(Provisioning.getInstance());
+                try {
+                    JSONObject properties = extVolInfoHandler.readServerProperties(req.getId());
+                    storageType = properties.getString(AdminConstants.A_VOLUME_STORAGE_TYPE);
+                    globalBucketConfigId = properties.getString(AdminConstants.A_VOLUME_GLB_BUCKET_CONFIG_ID);
+                } catch (JSONException e) {
+                    throw ServiceException.FAILURE("Error while reading json data for external volume: " + req.getId(), e);
+                }
+                // storageType should not be null
+                if (StringUtil.isNullOrEmpty(storageType)) {
+                    throw VolumeServiceException.INVALID_REQUEST("StorageType Empty for external volume " + req.getId(), VolumeServiceException.INVALID_REQUEST);
+                }
+                builder.setName(volInfo.getName());
+                String extRootPath = ZMailbox.PATH_SEPARATOR + storageType + ROOT_PATH_ELE_SEPARATOR + volInfo.getName();
+                // append global bucket id as well in case it is available
+                if (!StringUtil.isNullOrEmpty(globalBucketConfigId)) {
+                    extRootPath = extRootPath + ROOT_PATH_ELE_SEPARATOR + globalBucketConfigId;
+                }
+                builder.setPath(extRootPath, false);
+            }
+        }
+        mgr.update(builder.build());
+    }
+}

--- a/store/src/java/com/zimbra/cs/store/CacheEnabledStoreManagerProvider.java
+++ b/store/src/java/com/zimbra/cs/store/CacheEnabledStoreManagerProvider.java
@@ -1,0 +1,86 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.store;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.store.helper.ClassHelper;
+import com.zimbra.cs.volume.Volume;
+import com.zimbra.cs.volume.VolumeManager;
+
+import java.io.IOException;
+
+/**
+ * Cache enable store manager provier
+ */
+public class CacheEnabledStoreManagerProvider {
+
+    /**
+     * StoreManager cache
+     */
+    private static final LoadingCache<Short, StoreManager> volumeStoreManagerCacheLoader = CacheBuilder.newBuilder()
+            .build(new CacheLoader<Short, StoreManager>() {
+                @Override
+                public StoreManager load(final Short volumeId) throws Exception {
+                    return getStoreManagerForVolume(volumeId);
+                }
+            });
+
+    /**
+     * Return StoreManager from cache if skiCache false otherwise cache object will be returned
+     * @param volumeId
+     * @param skipCache
+     * @return
+     * @throws Exception
+     */
+    public static StoreManager getStoreManagerForVolume(Short volumeId, boolean skipCache) throws Exception {
+        if (skipCache) {
+            ZimbraLog.store.error("Store Manager cached for %s", volumeId);
+            return volumeStoreManagerCacheLoader.get(volumeId);
+        }
+        return getStoreManagerForVolume(volumeId);
+    }
+
+    private static StoreManager getStoreManagerForVolume(Short volumeId) throws ServiceException {
+        // load volume
+        Volume volume = VolumeManager.getInstance().getVolume(volumeId);
+        String className = volume.getStoreManagerClass();
+        StoreManager storeManager = null;
+        try {
+            ZimbraLog.store.error("loading Store Manager: %s for %s", className, volumeId);
+            storeManager = (StoreManager) ClassHelper.getZimbraClassInstanceBy(className);
+            ZimbraLog.store.debug("StoreManager loaded, starting up");
+            storeManager.startup();
+        } catch (ReflectiveOperationException e) {
+            String msg = "error while loading StoreManager class: " + className;
+            ZimbraLog.store.error(msg, e);
+            throw ServiceException.FAILURE(msg, e);
+        } catch (IOException e) {
+            String msg = "error while StoreManager.startup() for class: " + className;
+            ZimbraLog.store.error(msg, e);
+            throw ServiceException.FAILURE(msg, e);
+        }
+        return storeManager;
+    }
+
+    protected static void refreshCache(short volumeId) {
+        volumeStoreManagerCacheLoader.refresh(volumeId);
+    }
+}

--- a/store/src/java/com/zimbra/cs/store/CacheEnabledStoreManagerProvider.java
+++ b/store/src/java/com/zimbra/cs/store/CacheEnabledStoreManagerProvider.java
@@ -51,8 +51,8 @@ public class CacheEnabledStoreManagerProvider {
      * @throws Exception
      */
     public static StoreManager getStoreManagerForVolume(Short volumeId, boolean skipCache) throws Exception {
-        if (skipCache) {
-            ZimbraLog.store.error("Store Manager cached for %s", volumeId);
+        if (!skipCache) {
+            ZimbraLog.store.trace("Store Manager cached for %s", volumeId);
             return volumeStoreManagerCacheLoader.get(volumeId);
         }
         return getStoreManagerForVolume(volumeId);

--- a/store/src/java/com/zimbra/cs/store/MailboxBlobDataSource.java
+++ b/store/src/java/com/zimbra/cs/store/MailboxBlobDataSource.java
@@ -43,7 +43,7 @@ public class MailboxBlobDataSource implements DataSource {
     }
 
     public InputStream getInputStream() throws IOException {
-        return StoreManager.getInstance().getContent(mBlob);
+        return StoreManager.getReaderSMInstance(mBlob.getLocator()).getContent(mBlob);
     }
 
     public String getName() {

--- a/store/src/java/com/zimbra/cs/store/StoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/StoreManager.java
@@ -50,7 +50,6 @@ public abstract class StoreManager {
                 if (sInstance != null) {
                     return sInstance;
                 }
-
                 try {
                     if (className != null && !className.equals("")) {
                         try {
@@ -69,12 +68,16 @@ public abstract class StoreManager {
         return sInstance;
     }
 
+
+
     /**
      * Used for unit testing.
      */
     public static void setInstance(StoreManager instance) {
-        ZimbraLog.store.info("Setting StoreManager to " + instance.getClass().getName());
-        sInstance = instance;
+        synchronized (StoreManager.class) {
+            ZimbraLog.store.info("Setting StoreManager to " + instance.getClass().getName());
+            sInstance = instance;
+        }
     }
 
     public static int getDiskStreamingThreshold() throws ServiceException {

--- a/store/src/java/com/zimbra/cs/store/StoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/StoreManager.java
@@ -144,8 +144,8 @@ public abstract class StoreManager {
                 Optional<Short> volumeId = MailItemHelper.findMyVolumeId(locator);
                 // can check this against current primary vol.if its same then return singleton instance, but need to consider db hit
                 if (volumeId.isPresent()) {
-                    ZimbraLog.store.debug("Volume for locator: %s volumeId: %s", locator, volumeId.get());
-                    StoreManager storeManager = CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volumeId.get(), true);
+                    ZimbraLog.store.trace("Volume for locator: %s volumeId: %s", locator, volumeId.get());
+                    StoreManager storeManager = CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volumeId.get(), false);
                     if (storeManager != null) {
                         ZimbraLog.store.debug("StoreManager for %s Volume: %s ", storeManager.getClass().getSimpleName(), volumeId.get());
                         return storeManager;

--- a/store/src/java/com/zimbra/cs/store/external/ExternalBlobInputStream.java
+++ b/store/src/java/com/zimbra/cs/store/external/ExternalBlobInputStream.java
@@ -85,7 +85,7 @@ public class ExternalBlobInputStream extends BlobInputStream {
             return file;
         } else {
             ZimbraLog.store.debug("blob file no longer on disk, fetching from remote store");
-            ExternalStoreManager sm = (ExternalStoreManager) StoreManager.getInstance();
+            ExternalStoreManager sm = (ExternalStoreManager) StoreManager.getReaderSMInstance(locator);
             Blob blob = sm.getLocalBlob(mbox, locator, false);
             return blob.getFile();
         }

--- a/store/src/java/com/zimbra/cs/store/external/ExternalMailboxBlob.java
+++ b/store/src/java/com/zimbra/cs/store/external/ExternalMailboxBlob.java
@@ -36,7 +36,7 @@ public class ExternalMailboxBlob extends MailboxBlob {
 
     @Override
     public Blob getLocalBlob() throws IOException {
-        ExternalStoreManager sm = (ExternalStoreManager) StoreManager.getInstance();
+        ExternalStoreManager sm = (ExternalStoreManager) StoreManager.getReaderSMInstance(getLocator());
         Blob blob = sm.getLocalBlob(getMailbox(), getLocator());
 
         setSize(blob.getRawSize());

--- a/store/src/java/com/zimbra/cs/store/file/FileBlobStore.java
+++ b/store/src/java/com/zimbra/cs/store/file/FileBlobStore.java
@@ -437,4 +437,41 @@ public final class FileBlobStore extends StoreManager {
     private static void ensureParentDirExists(File file) throws IOException {
         ensureDirExists(file.getParentFile());
     }
+
+    /**
+     * Store a blob from external S3 storage to internal store in volume/path
+     * specified by dest* parameters. Note this method is not part of the
+     * StoreManager interface It is only to be used for FileBlobStore specific code
+     * such as ExternalToInternal
+     * 
+     * @param in
+     * @param storeAsIs
+     * @param mbox
+     * @param itemId
+     * @param revision
+     * @param destVolumeId mail_item.volume_id for message in dest Mbox
+     * @throws IOException
+     * @throws ServiceException
+     */
+    public Blob storeIncoming(InputStream in, boolean storeAsIs, Mailbox mbox, int itemId, int revision,
+            short destVolumeId) throws IOException, ServiceException {
+        BlobBuilder builder = getBlobBuilder(mbox, itemId, revision, destVolumeId);
+        builder.disableCompression(storeAsIs).disableDigest(storeAsIs);
+        return builder.init().append(in).finish();
+    }
+
+    private BlobBuilder getBlobBuilder(Mailbox mbox, int itemId, int revision, short destVolumeId)
+            throws IOException, ServiceException {
+        Blob blob = getUniqueIncomingBlob(mbox, itemId, revision, destVolumeId);
+        return new VolumeBlobBuilder(blob);
+    }
+
+    private Blob getUniqueIncomingBlob(Mailbox mbox, int itemId, int revision, short destVolumeId)
+            throws IOException, ServiceException {
+        ZimbraLog.store.debug("getUniqueIncomingBlob destVolumeId %s.", destVolumeId);
+        File file = new File(getBlobPath(mbox, itemId, revision, destVolumeId));
+        ensureParentDirExists(file);
+        ZimbraLog.store.debug("getUniqueIncomingBlob getRootPath %s.", file.getAbsolutePath());
+        return new VolumeBlob(file, destVolumeId);
+    }
 }

--- a/store/src/java/com/zimbra/cs/store/helper/ClassHelper.java
+++ b/store/src/java/com/zimbra/cs/store/helper/ClassHelper.java
@@ -1,3 +1,19 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
 package com.zimbra.cs.store.helper;
 
 import com.zimbra.common.util.StringUtil;

--- a/store/src/java/com/zimbra/cs/store/helper/ClassHelper.java
+++ b/store/src/java/com/zimbra/cs/store/helper/ClassHelper.java
@@ -1,0 +1,46 @@
+package com.zimbra.cs.store.helper;
+
+import com.zimbra.common.util.StringUtil;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.extension.ExtensionUtil;
+
+/**
+ * Class helper
+ */
+public class ClassHelper {
+
+    /**
+     * Check if the class exist on class path
+     * @param classPath
+     * @return
+     */
+    public static boolean isClassExist(String classPath) {
+        if (!StringUtil.isNullOrEmpty(classPath)) {
+            try {
+                try {
+                    Class.forName(classPath);
+                } catch (ClassNotFoundException e) {
+                    ExtensionUtil.findClass(classPath);
+                }
+                return true;
+            } catch (Exception e) {
+                ZimbraLog.store.error("unable to initialize blob store", e);
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Get Class instance by className
+     * @param className
+     * @return
+     * @throws Throwable
+     */
+    public static Object getZimbraClassInstanceBy(String className) throws ReflectiveOperationException {
+        try {
+            return Class.forName(className).newInstance();
+        } catch (Exception e) {
+            return ExtensionUtil.findClass(className).newInstance();
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/store/helper/StoreManagerResetHelper.java
+++ b/store/src/java/com/zimbra/cs/store/helper/StoreManagerResetHelper.java
@@ -1,0 +1,96 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.store.helper;
+
+import com.zimbra.common.localconfig.ConfigException;
+import com.zimbra.common.localconfig.LC;
+import com.zimbra.common.localconfig.LocalConfig;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.StringUtil;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.store.StoreManager;
+import com.zimbra.soap.admin.enums.Status;
+import com.zimbra.soap.admin.type.StoreManagerRuntimeSwitchResult;
+import org.dom4j.DocumentException;
+
+import java.io.IOException;
+
+public class StoreManagerResetHelper {
+
+    /**
+     * In Zimbra Platform StoreManager object used to work with stores(current primary and current secondary)
+     * And current store manager class name is available as part of LocalConfig attribute `zimbra_class_store`.
+     * Instance of current StoreManger is being maintained as singleton and can be accessed via
+     * {@link StoreManager} static method getInstance(), check its implementation.
+     * Now as per new design StoreManager class can be mapped to associated Volume in database
+     * column volume.store_manager_class(string) and instance of new StoreManager can be used without restarting mailboxd
+     * just by resetting singleton object and overriding LocalConfig attribute `zimbra_class_store`.
+     * Following method performs part of reset process
+     *      1. New StoreManager class validation
+     *      2. Update local config attribute `zimbra_class_store`
+     *      3. Override LocalConfig and save it.
+     *      4. Reload LocalConfig cache.
+     *      5. Initiate Singleton reset {@link StoreManager}.getInstance()
+     *
+     * @param storeManagerClass
+     * @return
+     * @throws ServiceException
+     */
+    public static StoreManagerRuntimeSwitchResult setNewStoreManager(String storeManagerClass) throws ServiceException{
+        if (Provisioning.getInstance().getLocalServer().isSMRuntimeSwitchEnabled()) {
+            return new StoreManagerRuntimeSwitchResult(Status.NO_OPERATION, "StoreManager runtime switch not enabled, enabled SMRunTimeSwitchEnabled ldap attribute");
+        }
+        if (StringUtil.isNullOrEmpty(storeManagerClass)) {
+            String message = "storeManagerClass is empty: ";
+            ZimbraLog.store.error(message);
+            return new StoreManagerRuntimeSwitchResult(Status.FAIL, message);
+        }
+        if (LC.zimbra_class_store.value().equals(storeManagerClass)) {
+            String message = "store_manager class is same as set zimbra_class_store: "+ LC.zimbra_class_store.value();
+            ZimbraLog.store.debug(message);
+            return new StoreManagerRuntimeSwitchResult(Status.FAIL, message);
+        }
+        // if class not exist then throw exception
+        if (!ClassHelper.isClassExist(storeManagerClass)) {
+            throw ServiceException.OPERATION_DENIED(" store manager class " + storeManagerClass + " not found on classPath");
+        }
+
+        // update LC attribute
+        try {
+            LocalConfig localConfig = new LocalConfig(null);
+            localConfig.set(LC.zimbra_class_store.key(), storeManagerClass);
+            localConfig.save();
+            LC.reload();
+        } catch (DocumentException | ConfigException | IOException e) {
+            ZimbraLog.store.error("Error while updating LC.zimbra_class_store to StoreManager: %s", storeManagerClass, e);
+            return new StoreManagerRuntimeSwitchResult(Status.FAIL, "not able to update LC.zimbra_class_store with new StoreManager:" + storeManagerClass);
+        }
+
+        try {
+            // verify if its set correctly or not
+            if (!LC.zimbra_class_store.value().equals(storeManagerClass)) {
+                throw ServiceException.OPERATION_DENIED("not able to update StoreManager class " + storeManagerClass + " in cached zimbra_class_store attr");
+            }
+            StoreManager.resetStoreManager();
+        } catch (ServiceException | IOException e) {
+            ZimbraLog.store.error("not able to reset StoreManager: %s", storeManagerClass, e);
+            return new StoreManagerRuntimeSwitchResult(Status.FAIL, "not able to reset StoreManager:" + storeManagerClass);
+        }
+        return new StoreManagerRuntimeSwitchResult(Status.SUCCESS, "StoreManager LC updated with " + storeManagerClass + " and StoreManager.reset called");
+    }
+}

--- a/store/src/java/com/zimbra/cs/volume/Volume.java
+++ b/store/src/java/com/zimbra/cs/volume/Volume.java
@@ -68,6 +68,8 @@ public final class Volume {
 
     private StoreType storeType;
 
+    private String storeManagerClass;
+
     public static enum StoreType {
         INTERNAL(1),
         EXTERNAL(2);
@@ -181,6 +183,7 @@ public final class Volume {
             volume.compressionThreshold = copy.compressionThreshold;
             volume.metadata = copy.metadata;
             volume.storeType = copy.storeType;
+            volume.storeManagerClass = copy.storeManagerClass;
         }
 
         public Builder setId(short id) {
@@ -245,6 +248,11 @@ public final class Volume {
 
         public Builder setStoreType(StoreType storeType) {
             volume.storeType = storeType;
+            return this;
+        }
+
+        public Builder setStoreManagerClass(String storageManagerClass) {
+            volume.storeManagerClass = storageManagerClass;
             return this;
         }
 
@@ -353,6 +361,10 @@ public final class Volume {
 
     public StoreType getStoreType() {
         return storeType;
+    }
+
+    public String getStoreManagerClass() {
+        return storeManagerClass;
     }
 
     public static String getAbsolutePath(String path) throws ServiceException {
@@ -495,6 +507,7 @@ public final class Volume {
                 .add("fileGroupBits", fileGroupBits).add("fileBits", fileBits)
                 .add("compressBlobs", compressBlobs).add("compressionThreshold", compressionThreshold)
                 .add("storeType", storeType)
+                .add("storeManagerClass", storeManagerClass)
                 .toString();
     }
 
@@ -513,6 +526,7 @@ public final class Volume {
         jaxb.setCurrent(VolumeManager.getInstance().isCurrent(this));
         short value = (short)(this.getStoreType().getStoreType());
         jaxb.setStoreType(value);
+        jaxb.setStoreManagerClass(storeManagerClass);
         return jaxb;
     }
 }

--- a/store/src/java/com/zimbra/cs/volume/Volume.java
+++ b/store/src/java/com/zimbra/cs/volume/Volume.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2016, 2022 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -69,7 +69,7 @@ public final class Volume {
     private StoreType storeType;
 
     public static enum StoreType {
-        FILE_STORE(1),
+        INTERNAL(1),
         EXTERNAL(2);
 
         private final int storeType;
@@ -85,7 +85,7 @@ public final class Volume {
         public static StoreType getStoreTypeBy(int value) {
             switch (value) {
                 case 1:
-                    return FILE_STORE;
+                    return INTERNAL;
                 case 2:
                     return EXTERNAL;
             }
@@ -181,7 +181,6 @@ public final class Volume {
             volume.compressionThreshold = copy.compressionThreshold;
             volume.metadata = copy.metadata;
             volume.storeType = copy.storeType;
-
         }
 
         public Builder setId(short id) {
@@ -512,6 +511,8 @@ public final class Volume {
         jaxb.setCompressBlobs(compressBlobs);
         jaxb.setCompressionThreshold(compressionThreshold);
         jaxb.setCurrent(VolumeManager.getInstance().isCurrent(this));
+        short value = (short)(this.getStoreType().getStoreType());
+        jaxb.setStoreType(value);
         return jaxb;
     }
 }

--- a/store/src/java/com/zimbra/cs/volume/Volume.java
+++ b/store/src/java/com/zimbra/cs/volume/Volume.java
@@ -65,7 +65,30 @@ public final class Volume {
     private boolean compressBlobs;
     private long compressionThreshold;
     private Metadata metadata;
-    
+
+    private StoreType storeType;
+
+    public static enum StoreType{
+        FILE_STORE(1),
+        EXTERNAL(2);
+
+        private final int storeType;
+        StoreType(final int storeType) {
+            this.storeType = storeType;
+        }
+
+        public int getStoreType() {
+            return storeType;
+        }
+        public static StoreType getStoreTypeBy(int value){
+            switch (value) {
+                case 1: return FILE_STORE;
+                case 2: return EXTERNAL;
+            }
+            return null;
+        }
+    }
+
     public static class VolumeMetadata {
         private int lastSyncDate;
         private int currentSyncDate;
@@ -88,37 +111,37 @@ public final class Volume {
             this.currentSyncDate = meta.getInt(FN_DATE_CURRENTSYNC, 0);
             this.groupId = meta.getInt(FN_LAST_GROUP_ID, 0);
         }
-        
+
         public VolumeMetadata(int lastSyncDate, int currentSyncDate, int groupId) {
             this.lastSyncDate = lastSyncDate;
             this.currentSyncDate = currentSyncDate;
             this.groupId = groupId;
         }
-        
+
         public int getLastSyncDate() {
             return lastSyncDate;
         }
-        
+
         public int getCurrentSyncDate() {
             return currentSyncDate;
         }
-        
+
         public int getGroupId() {
             return groupId;
         }
-        
+
         public void setLastSyncDate(int date) {
             this.lastSyncDate = date;
         }
-        
+
         public void setCurrentSyncDate(int date) {
             this.currentSyncDate = date;
         }
-        
+
         public void setGroupId(int id) {
             this.groupId = id;
         }
-        
+
         public String toString() {
             return serialize().toString();
         }
@@ -153,7 +176,8 @@ public final class Volume {
             volume.compressBlobs = copy.compressBlobs;
             volume.compressionThreshold = copy.compressionThreshold;
             volume.metadata = copy.metadata;
-            
+            volume.storeType = copy.storeType;
+
         }
 
         public Builder setId(short id) {
@@ -210,9 +234,14 @@ public final class Volume {
             volume.compressionThreshold = value;
             return this;
         }
-        
+
         public Builder setMetadata(VolumeMetadata metadata) {
             volume.metadata = metadata.serialize();
+            return this;
+        }
+
+        public Builder setStoreType(StoreType storeType){
+            volume.storeType = storeType;
             return this;
         }
 
@@ -314,36 +343,40 @@ public final class Volume {
     public long getCompressionThreshold() {
         return compressionThreshold;
     }
-    
+
     public VolumeMetadata getMetadata() throws ServiceException {
         return new VolumeMetadata(metadata);
     }
 
+    public StoreType getStoreType() {
+        return storeType;
+    }
+
     public static String getAbsolutePath(String path) throws ServiceException {
         //return LC.zimbra_relative_volume_path.booleanValue() ? LC.zimbra_home.value() + File.separator + getConfiguredRootPath(path) : path;
-    	return LC.zimbra_relative_volume_path.booleanValue() ? LC.zimbra_home.value() + File.separator + path : path;
+        return LC.zimbra_relative_volume_path.booleanValue() ? LC.zimbra_home.value() + File.separator + path : path;
     }
-    
+
     public static String getConfiguredServerID() throws ServiceException
     {
         StringBuilder finalPath = new StringBuilder();
         if (Zimbra.isAlwaysOn())
         {
-        	String alwaysOnServerClusterId = Zimbra.getAlwaysOnClusterId();
-        	String localServerId = Provisioning.getInstance().getLocalServer().getId();
-        	if (alwaysOnServerClusterId != null)
-        	{
-        		finalPath.append(alwaysOnServerClusterId);
-        	}
-        	else
-        	{
-        		finalPath.append(localServerId);
-        	}
+            String alwaysOnServerClusterId = Zimbra.getAlwaysOnClusterId();
+            String localServerId = Provisioning.getInstance().getLocalServer().getId();
+            if (alwaysOnServerClusterId != null)
+            {
+                finalPath.append(alwaysOnServerClusterId);
+            }
+            else
+            {
+                finalPath.append(localServerId);
+            }
         }
         else
         {
-        	String localServerId = Provisioning.getInstance().getLocalServer().getId();
-        	finalPath.append(localServerId);
+            String localServerId = Provisioning.getInstance().getLocalServer().getId();
+            finalPath.append(localServerId);
         }
         return finalPath.toString();
     }
@@ -351,14 +384,14 @@ public final class Volume {
     private StringBuilder getMailboxDir(int mboxId, String subdir) throws ServiceException {
         StringBuilder result = new StringBuilder();
         int dir = (mboxId >> mboxBits) & mboxGroupBitmask;
-        
+
         result.append(rootPath).append(File.separator);
 
         if (Provisioning.getInstance().getLocalServer().isConfiguredServerIDForBlobDirEnabled())
-        	result.append(getConfiguredServerID()).append(File.separator);
+            result.append(getConfiguredServerID()).append(File.separator);
 
         result.append(dir).append(File.separator).append(mboxId);
-        
+
         if (subdir != null) {
             result.append(File.separator).append(subdir);
         }
@@ -464,6 +497,7 @@ public final class Volume {
                 .add("mboxGroupBits", mboxGroupBits).add("mboxBits", mboxBits)
                 .add("fileGroupBits", fileGroupBits).add("fileBits", fileBits)
                 .add("compressBlobs", compressBlobs).add("compressionThreshold",compressionThreshold)
+                .add("storeType", storeType)
                 .toString();
     }
 

--- a/store/src/java/com/zimbra/cs/volume/Volume.java
+++ b/store/src/java/com/zimbra/cs/volume/Volume.java
@@ -31,7 +31,7 @@ import com.zimbra.soap.admin.type.VolumeInfo;
 /**
  * Based on default settings, there are 256 directories. We write blobs for id's 0-4095 to directory 0, 4096-8191 to
  * directory 1, etc. After filling directory 255, we wrap around and write 1048576-1052671 to directory 0 and so on.
- *
+ * <p>
  * Number of dirs: 2 ^ groupBits (2 ^ 8 = 256 by default)
  * Number of files per dir before wraparound: 2 ^ bits (2 ^ 12 = 4096 by default)
  */
@@ -41,7 +41,7 @@ public final class Volume {
     public static final short ID_NONE = -2;
     public static final short ID_MAX = 255;
 
-    public static final short TYPE_MESSAGE =  1;
+    public static final short TYPE_MESSAGE = 1;
     public static final short TYPE_MESSAGE_SECONDARY = 2;
     public static final short TYPE_INDEX = 10;
 
@@ -68,11 +68,12 @@ public final class Volume {
 
     private StoreType storeType;
 
-    public static enum StoreType{
+    public static enum StoreType {
         FILE_STORE(1),
         EXTERNAL(2);
 
         private final int storeType;
+
         StoreType(final int storeType) {
             this.storeType = storeType;
         }
@@ -80,10 +81,13 @@ public final class Volume {
         public int getStoreType() {
             return storeType;
         }
-        public static StoreType getStoreTypeBy(int value){
+
+        public static StoreType getStoreTypeBy(int value) {
             switch (value) {
-                case 1: return FILE_STORE;
-                case 2: return EXTERNAL;
+                case 1:
+                    return FILE_STORE;
+                case 2:
+                    return EXTERNAL;
             }
             return null;
         }
@@ -240,7 +244,7 @@ public final class Volume {
             return this;
         }
 
-        public Builder setStoreType(StoreType storeType){
+        public Builder setStoreType(StoreType storeType) {
             volume.storeType = storeType;
             return this;
         }
@@ -357,24 +361,17 @@ public final class Volume {
         return LC.zimbra_relative_volume_path.booleanValue() ? LC.zimbra_home.value() + File.separator + path : path;
     }
 
-    public static String getConfiguredServerID() throws ServiceException
-    {
+    public static String getConfiguredServerID() throws ServiceException {
         StringBuilder finalPath = new StringBuilder();
-        if (Zimbra.isAlwaysOn())
-        {
+        if (Zimbra.isAlwaysOn()) {
             String alwaysOnServerClusterId = Zimbra.getAlwaysOnClusterId();
             String localServerId = Provisioning.getInstance().getLocalServer().getId();
-            if (alwaysOnServerClusterId != null)
-            {
+            if (alwaysOnServerClusterId != null) {
                 finalPath.append(alwaysOnServerClusterId);
-            }
-            else
-            {
+            } else {
                 finalPath.append(localServerId);
             }
-        }
-        else
-        {
+        } else {
             String localServerId = Provisioning.getInstance().getLocalServer().getId();
             finalPath.append(localServerId);
         }
@@ -387,8 +384,9 @@ public final class Volume {
 
         result.append(rootPath).append(File.separator);
 
-        if (Provisioning.getInstance().getLocalServer().isConfiguredServerIDForBlobDirEnabled())
+        if (Provisioning.getInstance().getLocalServer().isConfiguredServerIDForBlobDirEnabled()) {
             result.append(getConfiguredServerID()).append(File.separator);
+        }
 
         result.append(dir).append(File.separator).append(mboxId);
 
@@ -414,9 +412,9 @@ public final class Volume {
     /**
      * Make sure the path is an absolute path, and remove all "." and ".." from it. This is similar to
      * {@link File#getCanonicalPath()} except symbolic links are not resolved.
-     *
+     * <p>
      * If there are too many ".." in the path, navigating to parent directory stops at root.
-     *
+     * <p>
      * Supports UNIX absolute path, Windows absolute path with or without drive letter, and windows UNC share.
      *
      * @throws VolumeServiceException if path is not absolute
@@ -496,7 +494,7 @@ public final class Volume {
                 .add("id", id).add("type", type).add("name", name).add("path", rootPath)
                 .add("mboxGroupBits", mboxGroupBits).add("mboxBits", mboxBits)
                 .add("fileGroupBits", fileGroupBits).add("fileBits", fileBits)
-                .add("compressBlobs", compressBlobs).add("compressionThreshold",compressionThreshold)
+                .add("compressBlobs", compressBlobs).add("compressionThreshold", compressionThreshold)
                 .add("storeType", storeType)
                 .toString();
     }

--- a/store/src/java/com/zimbra/cs/volume/VolumeCLI.java
+++ b/store/src/java/com/zimbra/cs/volume/VolumeCLI.java
@@ -92,6 +92,7 @@ public final class VolumeCLI extends SoapCLI {
     private static final String A_STORAGE_TYPE = "storageType";
     private static final String A_BUCKET_ID = "bucketId";
     private static final String A_VOLUME_PREFIX = "volumePrefix";
+    private static final String A_VOLUME_S3 = "S3";
 
     private VolumeCLI() throws ServiceException {
         super();
@@ -221,20 +222,32 @@ public final class VolumeCLI extends SoapCLI {
     }
 
     private void print(VolumeInfo vol) {
-        System.out.println("   Volume id: " + vol.getId());
-        System.out.println("        name: " + vol.getName());
-        System.out.println("        type: " + toTypeName(vol.getType()));
-        System.out.println("        path: " + vol.getRootPath());
-        System.out.print("  compressed: " + vol.isCompressBlobs());
+        System.out.println("                   Volume id: " + vol.getId());
+        System.out.println("                        name: " + vol.getName());
+        System.out.println("                        type: " + toTypeName(vol.getType()));
+        System.out.println("                        path: " + vol.getRootPath());
+        System.out.print("                  compressed: " + vol.isCompressBlobs());
+        
         if (vol.isCompressBlobs()) {
-            System.out.println("\t         threshold: " + vol.getCompressionThreshold() + " bytes");
+            System.out.println("\t                 threshold: " + vol.getCompressionThreshold() + " bytes");
         } else {
             System.out.println();
         }
-        System.out.println("     current: " + vol.isCurrent());
+        System.out.println("                     current: " + vol.isCurrent());
+        if(vol.getStoreType() == 2) {
+            VolumeExternalInfo volumeExternalInfo = vol.getVolumeExternalInfo();
+            if (A_VOLUME_S3.equals(volumeExternalInfo.getStorageType())) {
+                System.out.println("                      prefix: " + volumeExternalInfo.getVolumePrefix());
+                System.out.println(" globalBucketConfigurationId: " + volumeExternalInfo.getGlobalBucketConfigurationId());
+                System.out.println("                 storageType: " + volumeExternalInfo.getStorageType());
+                System.out.println("       useIntelligentTiering: " + volumeExternalInfo.isUseIntelligentTiering());
+                System.out.println("         useInFrequentAccess: " + volumeExternalInfo.isUseInFrequentAccess());
+                System.out.println("useInFrequentAccessThreshold: " + volumeExternalInfo.getUseInFrequentAccessThreshold());
+            }
+        }
         System.out.println();
     }
-
+    
     private void deleteVolume() throws ParseException, SoapFaultException, IOException, ServiceException, HttpException {
         if (id == null) {
             throw new ParseException(A_ID + MISSING_ATTRS);

--- a/store/src/java/com/zimbra/cs/volume/VolumeCLI.java
+++ b/store/src/java/com/zimbra/cs/volume/VolumeCLI.java
@@ -94,7 +94,7 @@ public final class VolumeCLI extends SoapCLI {
     private static final String H_ACCOUNT_PORT = "Account port";
     private static final String H_ACCOUNT = "Name of account";
     private static final String H_NAME_SPACE = "Namespace";
-
+    private static final String H_STORE_MANAGER_CLASS = "Optional parameter to specify non-default store manager class path";
     private static final String A_ID = "id";
     private static final String A_TYPE = "type";
     private static final String A_PATH = "path";
@@ -138,6 +138,7 @@ public final class VolumeCLI extends SoapCLI {
     private String accountPort;
     private String nameSpace;
     private String account;
+    private String storeManagerClass;
 
     private void setArgs(CommandLine cl) throws ServiceException, ParseException, IOException {
         auth = getZAuthToken(cl);
@@ -157,6 +158,7 @@ public final class VolumeCLI extends SoapCLI {
         accountPort = cl.getOptionValue(O_AP);
         nameSpace = cl.getOptionValue(O_NS);
         account = cl.getOptionValue(O_ACCOUNT);
+        storeManagerClass = cl.getOptionValue(O_SMC);
     }
 
     public static void main(String[] args) {
@@ -327,6 +329,9 @@ public final class VolumeCLI extends SoapCLI {
         vol.setName(name);
         vol.setCompressBlobs(compress != null ? Boolean.parseBoolean(compress) : false);
         vol.setCompressionThreshold(compressThreshold != null ? Long.parseLong(compressThreshold) : 4096L);
+        if (!Strings.isNullOrEmpty(storeManagerClass)) {
+            vol.setStoreManagerClass(storeManagerClass);
+        }
         validateAddCommand(vol);
         CreateVolumeRequest req = new CreateVolumeRequest(vol);
         auth();
@@ -514,6 +519,8 @@ public final class VolumeCLI extends SoapCLI {
         options.addOption(new Option(O_URL, A_URL, true, H_URL));
         options.addOption(new Option(O_NS, A_NAME_SPACE, true, H_NAME_SPACE));
         options.addOption(new Option(O_ACCOUNT, A_ACCOUNT, true, H_ACCOUNT));
+
+        options.addOption(new Option(O_SMC, A_STORE_MANAGER_CLASS, true, H_STORE_MANAGER_CLASS));
     }
 
     @Override
@@ -549,12 +556,14 @@ public final class VolumeCLI extends SoapCLI {
         printOpt(O_VP, 0);
         printOpt(O_STP, 0);
         printOpt(O_BID, 0);
+
         printOpt(O_PP, 0);
         printOpt(O_AP, 0);
         printOpt(O_ACCOUNT, 0);
         printOpt(O_URL, 0);
         printOpt(O_NS, 0);
 
+        printOpt(O_SMC, 0);
     }
 
     private void printOpt(String optStr, int leftPad) {

--- a/store/src/java/com/zimbra/cs/volume/VolumeCLI.java
+++ b/store/src/java/com/zimbra/cs/volume/VolumeCLI.java
@@ -61,6 +61,8 @@ public final class VolumeCLI extends SoapCLI {
     private static final String O_C = "c";
     private static final String O_CT = "ct";
 
+    private static final String O_SMC = "smc";
+    
     /** attributes for external storetype **/
     private static final String O_ST = "st";
     private static final String O_VP = "vp";
@@ -100,6 +102,8 @@ public final class VolumeCLI extends SoapCLI {
     private static final String A_COMPRESS = "compress";
     private static final String A_COMPRESS_THRESHOLD = "compressThreshold";
     private static final String A_STORE_TYPE = "storeType";
+
+    private static final String A_STORE_MANAGER_CLASS = "storeManagerClass";
     private static final String A_STORAGE_TYPE = "storageType";
     private static final String A_BUCKET_ID = "bucketId";
     private static final String A_VOLUME_PREFIX = "volumePrefix";

--- a/store/src/java/com/zimbra/cs/volume/VolumeCLI.java
+++ b/store/src/java/com/zimbra/cs/volume/VolumeCLI.java
@@ -17,14 +17,12 @@
 package com.zimbra.cs.volume;
 
 import java.io.IOException;
-
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionGroup;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.http.HttpException;
-
 import com.google.common.base.Strings;
 import com.zimbra.common.auth.ZAuthToken;
 import com.zimbra.common.service.ServiceException;
@@ -62,20 +60,20 @@ public final class VolumeCLI extends SoapCLI {
     private static final String O_P = "p";
     private static final String O_C = "c";
     private static final String O_CT = "ct";
-    
+
     /** attributes for external storetype **/
     private static final String O_ST = "st";
     private static final String O_VP = "vp";
     private static final String O_STP = "stp";
     private static final String O_BID = "bid";
-    
+
     /** attributes for store type OpenIO **/
     private static final String O_AP = "ap";
     private static final String O_PP = "pp";
     private static final String O_ACCOUNT = "acc";
     private static final String O_NS = "ns";
     private static final String O_URL = "url";
-    private static final String openIO = "OPENIO";
+    private static final String OPENIO = "OPENIO";
 
     private static final String NOT_ALLOWED_INTERNAL = " is not allowed for internal storetype";
     private static final String NOT_ALLOWED_EXTERNAL = " is not allowed for external storetype";
@@ -86,10 +84,9 @@ public final class VolumeCLI extends SoapCLI {
     private static final String NOT_ALLOWED_ID = "id cannot be specified when adding a volume";
 
     private static final String H_STORE_TYPE = "Store type: internal or external";
-    private static final String H_STORAGE_TYPE = "Name of the store provider (S3, ObjectStore, OpenIO)";
+    private static final String H_STORAGE_TYPE = "Name of the store provider (S3, ObjectStore, OPENIO)";
     private static final String H_BUCKET_ID = "S3 Bucket ID";
     private static final String H_VOLUME_PREFIX = "Volume Preifx";
-    
     private static final String H_URL = "URL of OpenIO";
     private static final String H_PROXY_PORT = "Proxy port";
     private static final String H_ACCOUNT_PORT = "Account port";
@@ -114,7 +111,6 @@ public final class VolumeCLI extends SoapCLI {
     private static final String A_NAME_SPACE = "nameSpace";
     private static final String A_ACCOUNT = "account";
 
-
     private VolumeCLI() throws ServiceException {
         super();
         setupCommandLineOptions();
@@ -138,7 +134,6 @@ public final class VolumeCLI extends SoapCLI {
     private String accountPort;
     private String nameSpace;
     private String account;
-
 
     private void setArgs(CommandLine cl) throws ServiceException, ParseException, IOException {
         auth = getZAuthToken(cl);
@@ -304,7 +299,6 @@ public final class VolumeCLI extends SoapCLI {
                 .elementToJaxb(getTransport().invokeWithoutSession(JaxbUtil.jaxbToElement(getVolumeRequest)));
         Volume.StoreType enumStoreType = (1 == getVolumeResponse.getVolume().getStoreType()) ? Volume.StoreType.INTERNAL
                 : Volume.StoreType.EXTERNAL;
-
         VolumeInfo vol = new VolumeInfo();
         validateEditCommand(vol, enumStoreType);
         ModifyVolumeRequest req = new ModifyVolumeRequest(Short.parseShort(id), vol);
@@ -374,6 +368,9 @@ public final class VolumeCLI extends SoapCLI {
             if (!Strings.isNullOrEmpty(url)) {
                 throw new ParseException(A_URL + NOT_ALLOWED_EXTERNAL);
             }
+            if (!Strings.isNullOrEmpty(account)) {
+                throw new ParseException(A_ACCOUNT + NOT_ALLOWED_EXTERNAL);
+            }
             if (!Strings.isNullOrEmpty(nameSpace)) {
                 throw new ParseException(A_NAME_SPACE + NOT_ALLOWED_EXTERNAL);
             }
@@ -426,7 +423,7 @@ public final class VolumeCLI extends SoapCLI {
             }
             volumeInfo.setRootPath(path);
         } else if (Volume.StoreType.EXTERNAL.name().equals(storeType)) {
-            if(storageType.equalsIgnoreCase(openIO)) {
+            if (OPENIO.equalsIgnoreCase(storageType)) {
                 VolumeExternalOpenIOInfo volumeExternalOpenIOInfo = new VolumeExternalOpenIOInfo();
                 if (!Strings.isNullOrEmpty(storageType)) {
                     volumeExternalOpenIOInfo.setStorageType(storageType);

--- a/store/src/java/com/zimbra/cs/volume/VolumeServiceException.java
+++ b/store/src/java/com/zimbra/cs/volume/VolumeServiceException.java
@@ -22,19 +22,31 @@ import com.zimbra.common.service.ServiceException;
 public final class VolumeServiceException extends ServiceException {
     private static final long serialVersionUID = -3596326510079311719L;
 
-    public static final String BAD_CURRVOL_CONFIG            = "volume.BAD_CURRVOL_CONFIG";
-    public static final String NO_SUCH_VOLUME                = "volume.NO_SUCH_VOLUME";
-    public static final String NO_SUCH_PATH                  = "volume.NO_SUCH_PATH";
-    public static final String ALREADY_EXISTS                = "volume.ALREADY_EXISTS";
-    public static final String ID_OUT_OF_RANGE               = "volume.ID_OUT_OF_RANGE";
-    public static final String CANNOT_DELETE_VOLUME_IN_USE   = "volume.CANNOT_DELETE_VOLUME_IN_USE";
-    public static final String WRONG_TYPE_CURRVOL            = "volume.WRONG_TYPE_CURRVOL";
-    public static final String CANNOT_DELETE_CURRVOL         = "volume.CANNOT_DELETE_CURRVOL";
-    public static final String CANNOT_CHANGE_TYPE_OF_CURRVOL = "volume.CANNOT_CHANGE_TYPE_OF_CURRVOL";
-    public static final String INVALID_REQUEST               = "volume.INVALID_REQUEST";
-    public static final String NOT_ABSOLUTE_PATH             = "volume.NOT_ABSOLUTE_PATH";
-    public static final String SUBDIR_OF_ANOTHER_VOLUME      = "volume.SUBDIR_OF_ANOTHER_VOLUME";
-    public static final String INVALID_METADATA              = "volume.INVALID_METADATA";
+    public static final String BAD_CURRVOL_CONFIG                           = "volume.BAD_CURRVOL_CONFIG";
+    public static final String NO_SUCH_VOLUME                               = "volume.NO_SUCH_VOLUME";
+    public static final String NO_SUCH_PATH                                 = "volume.NO_SUCH_PATH";
+    public static final String ALREADY_EXISTS                               = "volume.ALREADY_EXISTS";
+    public static final String ID_OUT_OF_RANGE                              = "volume.ID_OUT_OF_RANGE";
+    public static final String CANNOT_DELETE_VOLUME_IN_USE                  = "volume.CANNOT_DELETE_VOLUME_IN_USE";
+    public static final String WRONG_TYPE_CURRVOL                           = "volume.WRONG_TYPE_CURRVOL";
+    public static final String CANNOT_DELETE_CURRVOL                        = "volume.CANNOT_DELETE_CURRVOL";
+    public static final String CANNOT_CHANGE_TYPE_OF_CURRVOL                = "volume.CANNOT_CHANGE_TYPE_OF_CURRVOL";
+    public static final String INVALID_REQUEST                              = "volume.INVALID_REQUEST";
+    public static final String NOT_ABSOLUTE_PATH                            = "volume.NOT_ABSOLUTE_PATH";
+    public static final String SUBDIR_OF_ANOTHER_VOLUME                     = "volume.SUBDIR_OF_ANOTHER_VOLUME";
+    public static final String INVALID_METADATA                             = "volume.INVALID_METADATA";
+    public static final String BAD_VOLUME_STORE_TYPE                        = "volume.BAD_STORE_TYPE";
+    public static final String BAD_VOLUME_PATH                              = "volume.BAD_PATH";
+    public static final String BAD_VOLUME_NAME                              = "volume.BAD_NAME";
+    public static final String BAD_VOLUME_TYPE                              = "volume.BAD_TYPE";
+    public static final String BAD_VOLUME_COMPRESSION_THRESHOLD             = "volume.BAD_COMPRESSION_THRESHOLD";
+    public static final String BAD_VOLUME_CURRENT                           = "volume.BAD_CURRENT";
+    public static final String BAD_VOLUME_COMPRESS_BLOBS                    = "volume.BAD_COMPRESS_BLOBS";
+    public static final String BAD_VOLUME_USE_IN_FREQUENT_ACCESS            = "volume.BAD_USE_IN_FREQUENT_ACCESS";
+    public static final String BAD_VOLUME_USE_INTELLIGENT_TIERING           = "volume.BAD_USE_INTELLIGENT_TIERING";
+    public static final String BAD_VOLUME_STORAGE_TYPE                      = "volume.BAD_STORAGE_TYPE";
+    public static final String BAD_VOLUME_USE_IN_FREQUENT_ACCESS_THRESHOLD  = "volume.BAD_USE_IN_FREQUENT_ACCESS_THRESHOLD";
+    public static final String BAD_VOLUME_GLOBAL_BUCKET_ID                  = "volume.BAD_GLOBAL_BUCKET_ID";
 
     private VolumeServiceException(String message, String code, boolean isReceiversFault) {
         super(message, code, isReceiversFault);
@@ -103,8 +115,12 @@ public final class VolumeServiceException extends ServiceException {
                 anotherVol.getId() + ", path=" + anotherVol.getRootPath() + ")",
                 SUBDIR_OF_ANOTHER_VOLUME, SENDERS_FAULT, null);
     }
-    
+
     public static VolumeServiceException INVALID_METADATA(Throwable cause) {
         return new VolumeServiceException("could not decode metadata", INVALID_METADATA, true, cause);
+    }
+
+    public static VolumeServiceException INVALID_REQUEST(String msg, String error) {
+        return new VolumeServiceException("invalid request: " + msg, error, SENDERS_FAULT, null);
     }
 }

--- a/store/src/java/com/zimbra/cs/volume/VolumeServiceException.java
+++ b/store/src/java/com/zimbra/cs/volume/VolumeServiceException.java
@@ -45,6 +45,7 @@ public final class VolumeServiceException extends ServiceException {
     public static final String BAD_VOLUME_USE_IN_FREQUENT_ACCESS            = "volume.BAD_USE_IN_FREQUENT_ACCESS";
     public static final String BAD_VOLUME_USE_INTELLIGENT_TIERING           = "volume.BAD_USE_INTELLIGENT_TIERING";
     public static final String BAD_VOLUME_STORAGE_TYPE                      = "volume.BAD_STORAGE_TYPE";
+    public static final String BAD_VOLUME_STORE_MANAGER_CLASS               = "volume.STORE_MANAGER_CLASS";
     public static final String BAD_VOLUME_USE_IN_FREQUENT_ACCESS_THRESHOLD  = "volume.BAD_USE_IN_FREQUENT_ACCESS_THRESHOLD";
     public static final String BAD_VOLUME_GLOBAL_BUCKET_ID                  = "volume.BAD_GLOBAL_BUCKET_ID";
 

--- a/store/src/java/com/zimbra/util/ExternalVolumeInfoHandler.java
+++ b/store/src/java/com/zimbra/util/ExternalVolumeInfoHandler.java
@@ -1,0 +1,239 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite, Network Edition.
+ * Copyright (C) 2022 Synacor, Inc.  All Rights Reserved.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.util;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.common.util.StringUtil;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.Server;
+import com.zimbra.soap.admin.type.VolumeInfo;
+import com.zimbra.soap.admin.type.VolumeExternalInfo;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Iterator;
+
+/**
+ * LDAP based properties handler
+ */
+public class ExternalVolumeInfoHandler {
+
+    /**
+     * LDAP Provision instance
+     */
+    private Provisioning provisioning;
+
+    public ExternalVolumeInfoHandler(Provisioning provisioning) {
+        this.provisioning = provisioning;
+    }
+
+    /**
+     * Read server level external volume properties
+     * @param volumeId
+     * @param server
+     * @return JSONObject as a server level volume properties
+     * @throws JSONException, ServiceException
+     */
+    public JSONObject readServerProperties(int volumeId) throws ServiceException, JSONException {
+        JSONObject retJsonObj = new JSONObject();
+        try {
+            // step 1: Fetch current JSON state object and current JSON state array
+            String serverExternalStoreConfigJson = provisioning.getLocalServer().getServerExternalStoreConfig();
+            JSONObject currentJsonObject = new JSONObject(serverExternalStoreConfigJson);
+            JSONArray currentJsonArray = currentJsonObject.getJSONArray("server/stores");
+
+            // step 2: Iterate JSON state array
+            for (int i = 0; i < currentJsonArray.length(); i++) {
+                JSONObject tempJsonObj = currentJsonArray.getJSONObject(i);
+
+                // step 3: Read required JSON object
+                if (volumeId == tempJsonObj.getInt("volumeId")) {
+                    // step 4: Copy temp JSON object to return JSON object and break
+                    retJsonObj = tempJsonObj;
+                    break;
+                }
+            }
+        } catch (JSONException e) {
+            throw e;
+        }
+
+        // step 5: Return JSON object
+        return retJsonObj;
+    }
+
+    /**
+     * Delete server level external volume properties
+     * @param volumeId
+     * @param server
+     * @throws JSONException, ServiceException
+     */
+    public void deleteServerProperties(int volumeId) throws ServiceException, JSONException {
+        try {
+            // step 1: Fetch current JSON state object and current JSON state array
+            String serverExternalStoreConfigJson = provisioning.getLocalServer().getServerExternalStoreConfig();
+            JSONObject currentJsonObject = new JSONObject(serverExternalStoreConfigJson);
+            JSONArray currentJsonArray = currentJsonObject.getJSONArray("server/stores");
+
+            // step 2: Create new/empty updated JSON state array
+            JSONArray updatedJsonArray = new JSONArray();
+
+            // step 3: Copy currentJsonArray to updatedJsonArray except the element to be deleted
+            for (int i = 0; i < currentJsonArray.length(); i++) {
+                JSONObject tempJsonObj = currentJsonArray.getJSONObject(i);
+                if (volumeId != tempJsonObj.getInt(AdminConstants.A_VOLUME_ID)) {
+                    updatedJsonArray.put(tempJsonObj);
+                }
+            }
+
+            // step 4: Copy updatedJsonArray to currentJsonArray
+            currentJsonArray = updatedJsonArray;
+
+            // step 5: Copy updatedJsonArray to currentJsonObject
+            currentJsonObject.put("server/stores", currentJsonArray);
+
+            // step 6: Set ldap attribute
+            provisioning.getLocalServer().setServerExternalStoreConfig(currentJsonObject.toString());
+
+        } catch (JSONException e) {
+            throw e;
+        }
+    }
+
+    /**
+     * Add server level external volume properties
+     * @param volumeId
+     * @param server
+     * @throws JSONException, ServiceException
+     */
+    public void addServerProperties(VolumeInfo volInfo) throws ServiceException, JSONException {
+        VolumeExternalInfo volExtInfo = volInfo.getVolumeExternalInfo();
+        try {
+            // step 1: Create and update json object and array for new volume entry
+            JSONObject volExtInfoObj = new JSONObject();
+            volExtInfoObj.put(AdminConstants.A_VOLUME_ID, String.valueOf(volInfo.getId()));
+            volExtInfoObj.put(AdminConstants.A_VOLUME_STORAGE_TYPE, volExtInfo.getStorageType());
+            volExtInfoObj.put(AdminConstants.A_VOLUME_VOLUME_PREFIX, volExtInfo.getVolumePrefix());
+            volExtInfoObj.put(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS, String.valueOf(volExtInfo.isUseInFrequentAccess()));
+            volExtInfoObj.put(AdminConstants.A_VOLUME_USE_INTELLIGENT_TIERING, String.valueOf(volExtInfo.isUseIntelligentTiering()));
+            volExtInfoObj.put(AdminConstants.A_VOLUME_GLB_BUCKET_CONFIG_ID, volExtInfo.getGlobalBucketConfigurationId());
+            volExtInfoObj.put(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS_THRESHOLD, String.valueOf(volExtInfo.getUseInFrequentAccessThreshold()));
+
+            // step 2: Fetch current JSON state
+            String serverExternalStoreConfigJson = provisioning.getLocalServer().getServerExternalStoreConfig();
+            JSONObject currentJsonObject = null;
+            if (StringUtil.isNullOrEmpty(serverExternalStoreConfigJson)) {
+                // If current JSON state is already empty, initialise current JSON state Object
+                currentJsonObject = new JSONObject();
+                currentJsonObject.put("server/stores", new JSONArray());
+            } else {
+                // Else convert current JSON state string to current JSON state Object
+                currentJsonObject = new JSONObject(serverExternalStoreConfigJson);
+            }
+
+            // step 3: Fetch current JSON state array
+            JSONArray currentJsonArray = currentJsonObject.getJSONArray("server/stores");
+
+            // step 4: Append current JSON state array with new volume entry
+            currentJsonArray.put(volExtInfoObj);
+
+            // step 5: Overwrite Appended current JSON state array with current JSON state Object
+            currentJsonObject.put("server/stores", currentJsonArray);
+
+            // step 6: Set ldap attribute
+            provisioning.getLocalServer().setServerExternalStoreConfig(currentJsonObject.toString());
+        } catch (JSONException e) {
+            throw e;
+        }
+    }
+
+    /**
+     * Modify server level external volume properties
+     * @param volumeId
+     * @param server
+     * @throws JSONException, ServiceException
+     */
+    public void modifyServerProperties(VolumeInfo volInfo) throws ServiceException, JSONException {
+        try {
+            // step 1: Fetch current JSON state object and current JSON state array
+            String serverExternalStoreConfigJson = provisioning.getLocalServer().getServerExternalStoreConfig();
+            JSONObject currentJsonObject = new JSONObject(serverExternalStoreConfigJson);
+            JSONArray currentJsonArray = currentJsonObject.getJSONArray("server/stores");
+
+            // step 2: Create new/empty updated JSON state array
+            JSONArray updatedJsonArray = new JSONArray();
+
+            // step 3: Do Modification and Copy currentJsonArray to updatedJsonArray
+            for (int i = 0; i < currentJsonArray.length(); i++) {
+                JSONObject tempJsonObj = currentJsonArray.getJSONObject(i);
+                if (volInfo.getId() != tempJsonObj.getInt(AdminConstants.A_VOLUME_ID)) {
+                    updatedJsonArray.put(tempJsonObj);
+                } else {
+                    tempJsonObj.put(AdminConstants.A_VOLUME_NAME, volInfo.getName());
+                    updatedJsonArray.put(tempJsonObj);
+                }
+            }
+
+            // step 4: Copy updatedJsonArray to currentJsonArray
+            currentJsonArray = updatedJsonArray;
+
+            // step 5: Copy updatedJsonArray to currentJsonObject
+            currentJsonObject.put("server/stores", currentJsonArray);
+
+            // step 6: Set ldap attribute
+            provisioning.getLocalServer().setServerExternalStoreConfig(currentJsonObject.toString());
+        }  catch (JSONException e) {
+            throw e;
+        }
+    }
+
+    /**
+     * Validate global bucket ID by reading LDAP atrribute
+     * @param globalS3BucketId
+     * @returns true if "global bucket ID" is valid
+     * @throws ServiceException, JSONException
+     */
+    public Boolean validateGlobalBucketID(String globalS3BucketId) throws ServiceException {
+        try {
+            // step 1: Fetch globalS3Configs and globalS3ConfigList
+            String globalExternalStoreConfig = provisioning.getConfig().getGlobalExternalStoreConfig();
+            JSONObject globalS3Configs = new JSONObject(globalExternalStoreConfig);
+            JSONArray globalS3ConfigList = globalS3Configs.getJSONArray("global/s3BucketConfigurations");
+
+            // step 2: Find "globalBucketUUID" in current JSON array
+            for (int i = 0; i < globalS3ConfigList.length(); i++) {
+                // step 3: Mark validation as true if "globalBucketUUID" found
+                if (globalS3BucketId.equalsIgnoreCase(globalS3ConfigList.getJSONObject(i).getString("globalBucketUUID"))) {
+                    return true;
+                }
+            }
+        } catch (JSONException e) {
+            throw ServiceException.FAILURE("Error while validating GlobalBucketID", null);
+        }
+        return false;
+    }
+
+    /**
+     * Validate if external volume entry is present in JSON or not
+     * @param volumeId
+     * @returns true if external volume entry is present
+     * @throws ServiceException, JSONException
+     */
+    public Boolean isVolumePresentInJson(int volumeId) throws ServiceException, JSONException {
+        String globalExternalStoreConfig = provisioning.getLocalServer().getServerExternalStoreConfig();
+        JSONObject globalS3Configs = new JSONObject(globalExternalStoreConfig);
+        JSONArray globalS3ConfigList = globalS3Configs.getJSONArray("server/stores");
+        for (int i = 0; i < globalS3ConfigList.length(); i++) {
+            if (volumeId == globalS3ConfigList.getJSONObject(i).getInt(AdminConstants.A_VOLUME_ID)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/store/src/java/com/zimbra/util/ExternalVolumeInfoHandler.java
+++ b/store/src/java/com/zimbra/util/ExternalVolumeInfoHandler.java
@@ -6,17 +6,18 @@
  */
 package com.zimbra.util;
 
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import com.google.common.base.Strings;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AdminConstants;
 import com.zimbra.common.util.StringUtil;
 import com.zimbra.cs.account.Provisioning;
-import com.zimbra.soap.admin.type.VolumeInfo;
 import com.zimbra.soap.admin.type.VolumeExternalInfo;
 import com.zimbra.soap.admin.type.VolumeExternalOpenIOInfo;
-
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.zimbra.soap.admin.type.VolumeInfo;
 
 /**
  * LDAP based properties handler
@@ -201,14 +202,17 @@ public class ExternalVolumeInfoHandler {
         try {
             // step 1: Fetch globalS3Configs and globalS3ConfigList
             String globalExternalStoreConfig = provisioning.getConfig().getGlobalExternalStoreConfig();
-            JSONObject globalS3Configs = new JSONObject(globalExternalStoreConfig);
-            JSONArray globalS3ConfigList = globalS3Configs.getJSONArray("global/s3BucketConfigurations");
 
-            // step 2: Find "globalBucketUUID" in current JSON array
-            for (int i = 0; i < globalS3ConfigList.length(); i++) {
-                // step 3: Mark validation as true if "globalBucketUUID" found
-                if (globalS3BucketId.equalsIgnoreCase(globalS3ConfigList.getJSONObject(i).getString("globalBucketUUID"))) {
-                    return true;
+            if(!Strings.isNullOrEmpty(globalExternalStoreConfig)) {
+                JSONObject globalS3Configs = new JSONObject(globalExternalStoreConfig);
+                JSONArray globalS3ConfigList = globalS3Configs.getJSONArray("global/s3BucketConfigurations");
+
+                // step 2: Find "globalBucketUUID" in current JSON array
+                for (int i = 0; i < globalS3ConfigList.length(); i++) {
+                    // step 3: Mark validation as true if "globalBucketUUID" found
+                    if (globalS3BucketId.equalsIgnoreCase(globalS3ConfigList.getJSONObject(i).getString("globalBucketUUID"))) {
+                        return true;
+                    }
                 }
             }
         } catch (JSONException e) {

--- a/store/src/java/com/zimbra/util/ExternalVolumeInfoHandler.java
+++ b/store/src/java/com/zimbra/util/ExternalVolumeInfoHandler.java
@@ -10,15 +10,13 @@ import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AdminConstants;
 import com.zimbra.common.util.StringUtil;
 import com.zimbra.cs.account.Provisioning;
-import com.zimbra.cs.account.Server;
 import com.zimbra.soap.admin.type.VolumeInfo;
 import com.zimbra.soap.admin.type.VolumeExternalInfo;
+import com.zimbra.soap.admin.type.VolumeExternalOpenIOInfo;
 
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-
-import java.util.Iterator;
 
 /**
  * LDAP based properties handler
@@ -114,16 +112,16 @@ public class ExternalVolumeInfoHandler {
      */
     public void addServerProperties(VolumeInfo volInfo) throws ServiceException, JSONException {
         VolumeExternalInfo volExtInfo = volInfo.getVolumeExternalInfo();
+        VolumeExternalOpenIOInfo volExtOpenIoInfo = volInfo.getVolumeExternalOpenIOInfo();
+
         try {
-            // step 1: Create and update json object and array for new volume entry
+            // step 1: Create and update json object and array for new volume entry of S3
             JSONObject volExtInfoObj = new JSONObject();
-            volExtInfoObj.put(AdminConstants.A_VOLUME_ID, String.valueOf(volInfo.getId()));
-            volExtInfoObj.put(AdminConstants.A_VOLUME_STORAGE_TYPE, volExtInfo.getStorageType());
-            volExtInfoObj.put(AdminConstants.A_VOLUME_VOLUME_PREFIX, volExtInfo.getVolumePrefix());
-            volExtInfoObj.put(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS, String.valueOf(volExtInfo.isUseInFrequentAccess()));
-            volExtInfoObj.put(AdminConstants.A_VOLUME_USE_INTELLIGENT_TIERING, String.valueOf(volExtInfo.isUseIntelligentTiering()));
-            volExtInfoObj.put(AdminConstants.A_VOLUME_GLB_BUCKET_CONFIG_ID, volExtInfo.getGlobalBucketConfigurationId());
-            volExtInfoObj.put(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS_THRESHOLD, String.valueOf(volExtInfo.getUseInFrequentAccessThreshold()));
+            if (volInfo.getVolumeExternalInfo() != null && AdminConstants.A_VOLUME_S3.equalsIgnoreCase(volInfo.getVolumeExternalInfo().getStorageType())) {
+                volExtInfoObj = volExtInfo.toJSON(volInfo);
+            } else if (volInfo.getVolumeExternalOpenIOInfo() != null && AdminConstants.A_VOLUME_OPEN_IO.equalsIgnoreCase(volInfo.getVolumeExternalOpenIOInfo().getStorageType())) {
+                volExtInfoObj = volExtOpenIoInfo.toJSON(volInfo);
+            }
 
             // step 2: Fetch current JSON state
             String serverExternalStoreConfigJson = provisioning.getLocalServer().getServerExternalStoreConfig();


### PR DESCRIPTION
[ZCS-11733](https://jira.corp.synacor.com/browse/ZCS-11733) and [ZCS-11657](https://jira.corp.synacor.com/browse/ZCS-11657) make use of this PR. The problem was that Zimbra's default timeout for HTTP requests is too long for the validation process. When URL's server exists but doesn't respond, The HttpClient just waited for over 2 minutes before throwing a connection timeout Exception.

The request is now made with a timeout of 20 seconds, so that the API sends a response quickly to avoid a SocketTimeOutException in the client side. This value is set in LocalConfig zimbra_s3_connection_request_timeout_ms 

For testing, please refer to the ticket https://jira.corp.synacor.com/browse/ZCS-11854