### PR TITLE
ZCS-11925: updating ldap attr ids to be in sync with zimbra cloud

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -5861,7 +5861,7 @@ public class ZAttrProvisioning {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3101)
+    @ZAttr(id=9015)
     public static final String A_zimbraDocumentRecentlyViewedEnabled = "zimbraDocumentRecentlyViewedEnabled";
 
     /**
@@ -6659,7 +6659,7 @@ public class ZAttrProvisioning {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3097)
+    @ZAttr(id=9016)
     public static final String A_zimbraFeatureDocumentEditingEnabled = "zimbraFeatureDocumentEditingEnabled";
 
     /**
@@ -7272,7 +7272,7 @@ public class ZAttrProvisioning {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3093)
+    @ZAttr(id=9017)
     public static final String A_zimbraFeatureZulipChatEnabled = "zimbraFeatureZulipChatEnabled";
 
     /**
@@ -17969,7 +17969,7 @@ public class ZAttrProvisioning {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3094)
+    @ZAttr(id=9018)
     public static final String A_zimbraZulipChatDomainId = "zimbraZulipChatDomainId";
 
     /**

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9875,7 +9875,7 @@ TODO: delete them permanently from here
   <desc>Enable/Disable blocked file types set in zimbraFileUploadBlockedFileTypes for uploading</desc>
  </attr>
 
-<attr id="3093" name="zimbraFeatureZulipChatEnabled" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountInfo,accountInherited,domainAdminModifiable" since="10.0.0">
+<attr id="9017" name="zimbraFeatureZulipChatEnabled" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountInfo,accountInherited,domainAdminModifiable" since="10.0.0">
   <defaultCOSValue>TRUE</defaultCOSValue>
   <desc>Whether or not zulip chat is enabled.
         If false at domain level, feature not available at domain, cos &amp; account.
@@ -9883,7 +9883,7 @@ TODO: delete them permanently from here
         If true at domain &amp; cos and false at account, feature not available at account.
   </desc>
 </attr>
-<attr id="3094" name="zimbraZulipChatDomainId" type="string" cardinality="single" optionalIn="domain" flags="domainInfo" since="10.0.0">
+<attr id="9018" name="zimbraZulipChatDomainId" type="string" cardinality="single" optionalIn="domain" flags="domainInfo" since="10.0.0">
   <desc>Zulip chat domain ID</desc>
 </attr>
 <attr id="3095" name="zimbraZulipJwtSecret" type="string" cardinality="single" optionalIn="globalConfig" since="10.0.0">
@@ -9895,7 +9895,7 @@ TODO: delete them permanently from here
         Requires server restart if updating from empty value.
   </desc>
 </attr>
-<attr id="3097" name="zimbraFeatureDocumentEditingEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="10.0.0">
+<attr id="9016" name="zimbraFeatureDocumentEditingEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="10.0.0">
   <defaultCOSValue>TRUE</defaultCOSValue>
   <desc>Whether or not document editing feature is enabled within briefcase</desc>
 </attr>
@@ -9909,7 +9909,7 @@ TODO: delete them permanently from here
 <attr id="3100" name="zimbraDocumentEditingJwtSecret" type="string" cardinality="single" optionalIn="globalConfig" since="10.0.0">
   <desc>Document editing JWT secret</desc>
 </attr>
-<attr id="3101" name="zimbraDocumentRecentlyViewedEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="10.0.0">
+<attr id="9015" name="zimbraDocumentRecentlyViewedEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="10.0.0">
   <defaultCOSValue>TRUE</defaultCOSValue>
   <desc>Whether or not to log document accessed time</desc>
 </attr>

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -10597,7 +10597,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3101)
+    @ZAttr(id=9015)
     public boolean isDocumentRecentlyViewedEnabled() {
         return getBooleanAttr(Provisioning.A_zimbraDocumentRecentlyViewedEnabled, true, true);
     }
@@ -10610,7 +10610,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3101)
+    @ZAttr(id=9015)
     public void setDocumentRecentlyViewedEnabled(boolean zimbraDocumentRecentlyViewedEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraDocumentRecentlyViewedEnabled, zimbraDocumentRecentlyViewedEnabled ? TRUE : FALSE);
@@ -10626,7 +10626,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3101)
+    @ZAttr(id=9015)
     public Map<String,Object> setDocumentRecentlyViewedEnabled(boolean zimbraDocumentRecentlyViewedEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraDocumentRecentlyViewedEnabled, zimbraDocumentRecentlyViewedEnabled ? TRUE : FALSE);
@@ -10640,7 +10640,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3101)
+    @ZAttr(id=9015)
     public void unsetDocumentRecentlyViewedEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraDocumentRecentlyViewedEnabled, "");
@@ -10655,7 +10655,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3101)
+    @ZAttr(id=9015)
     public Map<String,Object> unsetDocumentRecentlyViewedEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraDocumentRecentlyViewedEnabled, "");
@@ -15042,7 +15042,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3097)
+    @ZAttr(id=9016)
     public boolean isFeatureDocumentEditingEnabled() {
         return getBooleanAttr(Provisioning.A_zimbraFeatureDocumentEditingEnabled, true, true);
     }
@@ -15055,7 +15055,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3097)
+    @ZAttr(id=9016)
     public void setFeatureDocumentEditingEnabled(boolean zimbraFeatureDocumentEditingEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureDocumentEditingEnabled, zimbraFeatureDocumentEditingEnabled ? TRUE : FALSE);
@@ -15071,7 +15071,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3097)
+    @ZAttr(id=9016)
     public Map<String,Object> setFeatureDocumentEditingEnabled(boolean zimbraFeatureDocumentEditingEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureDocumentEditingEnabled, zimbraFeatureDocumentEditingEnabled ? TRUE : FALSE);
@@ -15085,7 +15085,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3097)
+    @ZAttr(id=9016)
     public void unsetFeatureDocumentEditingEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureDocumentEditingEnabled, "");
@@ -15100,7 +15100,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3097)
+    @ZAttr(id=9016)
     public Map<String,Object> unsetFeatureDocumentEditingEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureDocumentEditingEnabled, "");
@@ -20929,7 +20929,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3093)
+    @ZAttr(id=9017)
     public boolean isFeatureZulipChatEnabled() {
         return getBooleanAttr(Provisioning.A_zimbraFeatureZulipChatEnabled, true, true);
     }
@@ -20946,7 +20946,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3093)
+    @ZAttr(id=9017)
     public void setFeatureZulipChatEnabled(boolean zimbraFeatureZulipChatEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureZulipChatEnabled, zimbraFeatureZulipChatEnabled ? TRUE : FALSE);
@@ -20966,7 +20966,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3093)
+    @ZAttr(id=9017)
     public Map<String,Object> setFeatureZulipChatEnabled(boolean zimbraFeatureZulipChatEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureZulipChatEnabled, zimbraFeatureZulipChatEnabled ? TRUE : FALSE);
@@ -20984,7 +20984,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3093)
+    @ZAttr(id=9017)
     public void unsetFeatureZulipChatEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureZulipChatEnabled, "");
@@ -21003,7 +21003,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3093)
+    @ZAttr(id=9017)
     public Map<String,Object> unsetFeatureZulipChatEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureZulipChatEnabled, "");

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -6422,7 +6422,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3101)
+    @ZAttr(id=9015)
     public boolean isDocumentRecentlyViewedEnabled() {
         return getBooleanAttr(Provisioning.A_zimbraDocumentRecentlyViewedEnabled, true, true);
     }
@@ -6435,7 +6435,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3101)
+    @ZAttr(id=9015)
     public void setDocumentRecentlyViewedEnabled(boolean zimbraDocumentRecentlyViewedEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraDocumentRecentlyViewedEnabled, zimbraDocumentRecentlyViewedEnabled ? TRUE : FALSE);
@@ -6451,7 +6451,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3101)
+    @ZAttr(id=9015)
     public Map<String,Object> setDocumentRecentlyViewedEnabled(boolean zimbraDocumentRecentlyViewedEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraDocumentRecentlyViewedEnabled, zimbraDocumentRecentlyViewedEnabled ? TRUE : FALSE);
@@ -6465,7 +6465,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3101)
+    @ZAttr(id=9015)
     public void unsetDocumentRecentlyViewedEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraDocumentRecentlyViewedEnabled, "");
@@ -6480,7 +6480,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3101)
+    @ZAttr(id=9015)
     public Map<String,Object> unsetDocumentRecentlyViewedEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraDocumentRecentlyViewedEnabled, "");
@@ -9626,7 +9626,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3097)
+    @ZAttr(id=9016)
     public boolean isFeatureDocumentEditingEnabled() {
         return getBooleanAttr(Provisioning.A_zimbraFeatureDocumentEditingEnabled, true, true);
     }
@@ -9639,7 +9639,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3097)
+    @ZAttr(id=9016)
     public void setFeatureDocumentEditingEnabled(boolean zimbraFeatureDocumentEditingEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureDocumentEditingEnabled, zimbraFeatureDocumentEditingEnabled ? TRUE : FALSE);
@@ -9655,7 +9655,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3097)
+    @ZAttr(id=9016)
     public Map<String,Object> setFeatureDocumentEditingEnabled(boolean zimbraFeatureDocumentEditingEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureDocumentEditingEnabled, zimbraFeatureDocumentEditingEnabled ? TRUE : FALSE);
@@ -9669,7 +9669,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3097)
+    @ZAttr(id=9016)
     public void unsetFeatureDocumentEditingEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureDocumentEditingEnabled, "");
@@ -9684,7 +9684,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3097)
+    @ZAttr(id=9016)
     public Map<String,Object> unsetFeatureDocumentEditingEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureDocumentEditingEnabled, "");
@@ -15513,7 +15513,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3093)
+    @ZAttr(id=9017)
     public boolean isFeatureZulipChatEnabled() {
         return getBooleanAttr(Provisioning.A_zimbraFeatureZulipChatEnabled, true, true);
     }
@@ -15530,7 +15530,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3093)
+    @ZAttr(id=9017)
     public void setFeatureZulipChatEnabled(boolean zimbraFeatureZulipChatEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureZulipChatEnabled, zimbraFeatureZulipChatEnabled ? TRUE : FALSE);
@@ -15550,7 +15550,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3093)
+    @ZAttr(id=9017)
     public Map<String,Object> setFeatureZulipChatEnabled(boolean zimbraFeatureZulipChatEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureZulipChatEnabled, zimbraFeatureZulipChatEnabled ? TRUE : FALSE);
@@ -15568,7 +15568,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3093)
+    @ZAttr(id=9017)
     public void unsetFeatureZulipChatEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureZulipChatEnabled, "");
@@ -15587,7 +15587,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3093)
+    @ZAttr(id=9017)
     public Map<String,Object> unsetFeatureZulipChatEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureZulipChatEnabled, "");

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -10045,7 +10045,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3093)
+    @ZAttr(id=9017)
     public boolean isFeatureZulipChatEnabled() {
         return getBooleanAttr(Provisioning.A_zimbraFeatureZulipChatEnabled, false, true);
     }
@@ -10062,7 +10062,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3093)
+    @ZAttr(id=9017)
     public void setFeatureZulipChatEnabled(boolean zimbraFeatureZulipChatEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureZulipChatEnabled, zimbraFeatureZulipChatEnabled ? TRUE : FALSE);
@@ -10082,7 +10082,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3093)
+    @ZAttr(id=9017)
     public Map<String,Object> setFeatureZulipChatEnabled(boolean zimbraFeatureZulipChatEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureZulipChatEnabled, zimbraFeatureZulipChatEnabled ? TRUE : FALSE);
@@ -10100,7 +10100,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3093)
+    @ZAttr(id=9017)
     public void unsetFeatureZulipChatEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureZulipChatEnabled, "");
@@ -10119,7 +10119,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3093)
+    @ZAttr(id=9017)
     public Map<String,Object> unsetFeatureZulipChatEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureZulipChatEnabled, "");
@@ -25691,7 +25691,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3094)
+    @ZAttr(id=9018)
     public String getZulipChatDomainId() {
         return getAttr(Provisioning.A_zimbraZulipChatDomainId, null, true);
     }
@@ -25704,7 +25704,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3094)
+    @ZAttr(id=9018)
     public void setZulipChatDomainId(String zimbraZulipChatDomainId) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraZulipChatDomainId, zimbraZulipChatDomainId);
@@ -25720,7 +25720,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3094)
+    @ZAttr(id=9018)
     public Map<String,Object> setZulipChatDomainId(String zimbraZulipChatDomainId, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraZulipChatDomainId, zimbraZulipChatDomainId);
@@ -25734,7 +25734,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3094)
+    @ZAttr(id=9018)
     public void unsetZulipChatDomainId() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraZulipChatDomainId, "");
@@ -25749,7 +25749,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 10.0.0
      */
-    @ZAttr(id=3094)
+    @ZAttr(id=9018)
     public Map<String,Object> unsetZulipChatDomainId(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraZulipChatDomainId, "");


### PR DESCRIPTION
Issue
LDAP attrs zimbraFeatureZulipChatEnabled, zimbraZulipChatDomainId, zimbraFeatureDocumentEditingEnabled, zimbraDocumentRecentlyViewedEnabled not in sync with zimbra cloud.

Fix 
Update IDs in sync with zimbra cloud