### PR TITLE
ZCS-11691: Cannot send meeting with message attachment(.msg) using mo…

### DIFF
--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -125,6 +125,7 @@
   <dependency org="org.w3c.css" name="sac" rev="1.3"/>
   <dependency org="org.apache.tika" name="tika-core" rev="1.24.1"/>
   <dependency org="org.apache.tika" name="tika-parsers" rev="1.24.1"/>
+  <dependency org="org.apache.james" name="apache-mime4j-core" rev="0.8.7"/>
   <dependency org="org.apache.pdfbox" name="pdfbox" rev="2.0.24"/>
   <dependency org="org.apache.pdfbox" name="jempbox" rev="1.8.16"/>
   <dependency org="org.apache.pdfbox" name="fontbox" rev="2.0.24"/>


### PR DESCRIPTION
Issue: Cannot send meeting with message attachment(.msg) using modern UI(tika-parsers issue)

Whenever we attach a .msg file while sending an invite it would fail with an error
`ua=ZimbraXWebClient - GC103 (Windows)/9.1.0_BETA_4334;soapId=7e9080de;] SoapEngine - handler exception java.lang.NoClassDefFoundError: org/apache/james/mime4j/codec/DecodeMonitor at org.apache.tika.parser.microsoft.OutlookExtractor.decodeHeader(OutlookExtractor.java:563) ~[tika-parsers-1.24.1.jar:1.24.1] at org.apache.tika.parser.microsoft.OutlookExtractor.normalizeHeaders(OutlookExtractor.java:529) ~[tika-parsers-1.24.1.jar:1.24.1] at org.apache.tika.parser.microsoft.OutlookExtractor.parse(OutlookExtractor.java:161) ~[tika-parsers-1.24.1.jar:1.24.1] at org.apache.tika.parser.microsoft.OfficeParser.parse(OfficeParser.java:199) ~[tika-parsers-1.24.1.jar:1.24.1] at org.apache.tika.parser.microsoft.OfficeParser.parse(OfficeParser.java:131) ~[tika-parsers-1.24.1.jar:1.24.1] at org.apache.tika.parser.CompositeParser.parse(CompositeParser.java:280) ~[tika-core-1.24.1.jar:1.24.1]`

Basically upon checking `DecodeMonitor` class was missing. This class is available in `org.apache.james`. Adding this resolved the issue. Raised PR in zm-zcs-lib : https://github.com/Zimbra/zm-zcs-lib/pull/101

Testing: Manual testing to send invites by adding .msg attachment and it's successfully sent