### PR TITLE
ZCS-11938: NPE for tag/contact/appointment delete action

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -9999,7 +9999,11 @@ public class Mailbox implements MailboxStore {
                 if (deletes.blobs != null) {
                     // delete any blobs associated with items deleted from db/index
                     for (MailboxBlob blob : deletes.blobs) {
-                        StoreManager sm = StoreManager.getReaderSMInstance(blob.getLocator());
+                        StoreManager sm = StoreManager.getInstance();
+                        // if blob is not null then pull respective SM instance
+                        if (blob != null) {
+                            sm = StoreManager.getReaderSMInstance(blob.getLocator());
+                        }
                         sm.quietDelete(blob);
                     }
                 }


### PR DESCRIPTION
**Problem**:
There NPE getting thrown while deleting blobless mail items such as task, tag, etc.

**Solution**:
Recently we introduce multiple StoreManagers for working with multiple volumes of different types and store managers get pulled based on locator values, here we are getting NPE for items that don't have blobs. Added null checks for blob before trying to access its locator. 

**Testing Done:**
1. Tag, Task, contact, and Calender Item Deletion.
2. Delete Contact Group
3. Delete Account and SyncGalAcccountRequest
4. Delete Domain
5. Delete Emails