### PR TITLE
ZCS-11780: Set default value false for zimbraFeatureFileTypeUploadRes…

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1431,6 +1431,9 @@ public final class LC {
     // owasp handler
     public static final KnownKey zimbra_use_owasp_html_sanitizer = KnownKey.newKey(true);
 
+    // file content type blacklist
+    public static final KnownKey zimbra_file_content_type_blacklist = KnownKey.newKey("application/x-ms*");
+
     public static final KnownKey enable_delegated_admin_ldap_access = KnownKey.newKey(true);
 
     // OAuth2 Social

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -9873,7 +9873,7 @@ TODO: delete them permanently from here
  </attr>
 
  <attr id="3092" name="zimbraFeatureFileTypeUploadRestrictionsEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="10.0.0">
-  <defaultCOSValue>TRUE</defaultCOSValue>
+  <defaultCOSValue>FALSE</defaultCOSValue>
   <desc>Enable/Disable blocked file types set in zimbraFileUploadBlockedFileTypes for uploading</desc>
  </attr>
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -15327,13 +15327,13 @@ public abstract class ZAttrAccount  extends MailTarget {
      * Enable/Disable blocked file types set in
      * zimbraFileUploadBlockedFileTypes for uploading
      *
-     * @return zimbraFeatureFileTypeUploadRestrictionsEnabled, or true if unset
+     * @return zimbraFeatureFileTypeUploadRestrictionsEnabled, or false if unset
      *
      * @since ZCS 10.0.0
      */
     @ZAttr(id=3092)
     public boolean isFeatureFileTypeUploadRestrictionsEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraFeatureFileTypeUploadRestrictionsEnabled, true, true);
+        return getBooleanAttr(Provisioning.A_zimbraFeatureFileTypeUploadRestrictionsEnabled, false, true);
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -9911,13 +9911,13 @@ public abstract class ZAttrCos extends NamedEntry {
      * Enable/Disable blocked file types set in
      * zimbraFileUploadBlockedFileTypes for uploading
      *
-     * @return zimbraFeatureFileTypeUploadRestrictionsEnabled, or true if unset
+     * @return zimbraFeatureFileTypeUploadRestrictionsEnabled, or false if unset
      *
      * @since ZCS 10.0.0
      */
     @ZAttr(id=3092)
     public boolean isFeatureFileTypeUploadRestrictionsEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraFeatureFileTypeUploadRestrictionsEnabled, true, true);
+        return getBooleanAttr(Provisioning.A_zimbraFeatureFileTypeUploadRestrictionsEnabled, false, true);
     }
 
     /**


### PR DESCRIPTION
Set default value FALSE for zimbraFeatureFileTypeUploadRestrictionsEnabled

As well as reverted back the implementation done in ZBUG-1459 if value of zimbraFeatureFileTypeUploadRestrictionsEnabled is FALSE. 
PR for ZBUG-1459 was https://github.com/Zimbra/zm-mailbox/pull/1060