### PR TITLE
ZCS-11935: Check and Fix exceptions logged in build logs for test failures

### DIFF
--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -35,7 +35,7 @@
   <dependency org="commons-pool" name="commons-pool" rev="1.6"/>
   <dependency org="commons-dbcp" name="commons-dbcp" rev="1.4"/>
   <dependency org="commons-codec" name="commons-codec" rev="1.7"/>
-  <dependency org="commons-io" name="commons-io" rev="1.4"/>
+  <dependency org="commons-io" name="commons-io" rev="2.11.0"/>
   <dependency org="com.ibm.icu" name="icu4j" rev="4.8.1.1"/>
   <dependency org="oauth" name="oauth" rev="1.4"/>
   <dependency org="zimbra" name="zm-ews-stub" rev="4.0"/>

--- a/store/src/java-test/com/zimbra/cs/db/DbVolumeBlobsTest.java
+++ b/store/src/java-test/com/zimbra/cs/db/DbVolumeBlobsTest.java
@@ -53,6 +53,7 @@ import com.zimbra.cs.store.file.BlobReference;
 import com.zimbra.cs.store.file.FileBlobStore;
 import com.zimbra.cs.util.SpoolingCache;
 import com.zimbra.cs.volume.Volume;
+import com.zimbra.cs.volume.Volume.StoreType;
 import com.zimbra.cs.volume.VolumeManager;
 
 import junit.framework.Assert;
@@ -436,7 +437,7 @@ public class DbVolumeBlobsTest {
         volFile.mkdirs();
 
         Volume vol2 = Volume.builder().setPath(volFile.getAbsolutePath(), true)
-            .setType(Volume.TYPE_MESSAGE).setName("volume2").build();
+            .setType(Volume.TYPE_MESSAGE).setName("volume2").setStoreType(StoreType.INTERNAL).build();
 
         vol2 = VolumeManager.getInstance().create(vol2);
 

--- a/store/src/java-test/com/zimbra/cs/imap/MemcachedImapCacheTest.java
+++ b/store/src/java-test/com/zimbra/cs/imap/MemcachedImapCacheTest.java
@@ -54,7 +54,7 @@ public class MemcachedImapCacheTest {
      */
     @Before
     public void setUp() throws Exception {
-        MailboxTestUtil.initProvisioning("store/");
+        MailboxTestUtil.initProvisioning(MailboxTestUtil.getZimbraServerDir(null));
     }
 
     /**

--- a/store/src/java-test/com/zimbra/cs/service/mail/GetFolderTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/mail/GetFolderTest.java
@@ -120,7 +120,7 @@ public class GetFolderTest {
         Assert.assertNotNull("top-level folder is listed", root);
         Assert.assertTrue("top level folder is stubbed", isStubbed(root));
 
-        Set<String> subfolderNames = ImmutableSet.of("Trash", "Briefcase", "foo", "bar", "Inbox");
+        Set<String> subfolderNames = ImmutableSet.of("Trash", "Briefcase", "foo", "bar", "Inbox", "Files shared with me");
         Set<String> stubbedSubfolderNames = ImmutableSet.of("bar", "Inbox");
         List<Element> subfolders = root.listElements(MailConstants.E_FOLDER);
         Assert.assertEquals("number of listed subfolders", subfolderNames.size(), subfolders.size());

--- a/store/src/java-test/com/zimbra/cs/store/MockStoreManager.java
+++ b/store/src/java-test/com/zimbra/cs/store/MockStoreManager.java
@@ -276,7 +276,7 @@ public final class MockStoreManager extends StoreManager {
 
         @Override
         public String getLocator() {
-            return "0";
+            return "1";
         }
     }
 


### PR DESCRIPTION
All the errors and failures in tests have been fixed, except by:

- testBugZCS10594 (OwaspHtmlSanitizerTest)
      - Contacted Rupesh for possible fixes
- testBug64974 (OwaspHtmlSanitizerTest)
      - Contacted Rupesh for possible fixes

The following test failures were present in 9.0.0 builds. They will be fixed in a different ticket:
- testAdditionalQuotaProviderExceedsQuota (MailboxTest)
- testResendRecoveryCodePositiveAndNegativeScenarios (RecoverAccountTest)
- testResetPasswordUtilFeatureDisabled (RecoverAccountTest)

To run the tests locally, run inside zm-mailbox/store: ant clean test

Ticket: https://jira.corp.synacor.com/browse/ZCS-11935