### PR TITLE
ZBUG-2978:In latest Patch mails are showing with code in the mail con…

### DIFF
--- a/store/src/java/com/zimbra/cs/html/owasp/OwaspHtmlSanitizer.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/OwaspHtmlSanitizer.java
@@ -57,6 +57,7 @@ public class OwaspHtmlSanitizer implements Callable<String> {
         ArrayList<String> tags = new ArrayList<String>();
         // in tags array we can add multiple tags, so for each tag write start &
         // end with a & separator like(<!--&-->)
+        html = html.replaceAll("<!-->","-->");
         tags.add("<!--&-->");
         String formattedHtml = "";
         for (String str : tags) {


### PR DESCRIPTION
Issue: [ZBUG-2978](https://jira.corp.synacor.com/browse/ZBUG-2978)
In latest Patch mails are showing with code in the mail content
Post code fix on unbalanced tags, there is a scenario where ending tag wasn't correctly present.
Hence this is fix for the particular scenario where the tag ends properly and the code is inside comment 
hence we don't see the particular code in emails now

Testing:
Inject mime using CLI and verify the email, the code is not seen post code change
