### PR TITLE
ZBUG-2914: Proxy servlet SSRF

### DIFF
--- a/store/src/java-test/com/zimbra/cs/zimlet/ProxyServletTest.java
+++ b/store/src/java-test/com/zimbra/cs/zimlet/ProxyServletTest.java
@@ -5,8 +5,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.Collections;
-import java.util.Map;
+import java.util.HashMap;
 
 import org.apache.http.Header;
 import org.apache.http.HttpRequest;
@@ -19,8 +18,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.zimbra.common.account.Key.AccountBy;
-import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.AuthToken;
@@ -33,11 +30,11 @@ import com.zimbra.cs.zimlet.ProxyServlet.RestrictiveRedirectStrategy;
 public class ProxyServletTest {
     private static final String USERNAME = "username";
     private static final String PASSWORD = "password";
-    private static final String COSNAME = "cosname";
 
     private static final String[] ALLOWED_DOMAINS = new String[] { "*.webex.com" };
 
-    private static final String H_LOCATION = "Location";
+    private static final String COSPREFIX = "proxyservlettestcos";
+    private static int cosNumber = 0;
 
     private Cos cos;
     private Account account;
@@ -51,41 +48,42 @@ public class ProxyServletTest {
     public void setUp() throws ServiceException {
         MockProvisioning prov = new MockProvisioning();
 
-        cos = prov.createCos(COSNAME, Collections.emptyMap());
+        cos = prov.createCos(String.format("%s%d", COSPREFIX, cosNumber++), new HashMap<String,Object>());
         cos.setProxyAllowedDomains(ALLOWED_DOMAINS);
 
-        account = prov.createAccount(USERNAME, PASSWORD, Collections.emptyMap());
+        account = prov.createAccount(USERNAME, PASSWORD, new HashMap<String,Object>());
         account.setCOSId(cos.getId());
 
-		Provisioning.setInstance(prov);
+        Provisioning.setInstance(prov);
     }
 
     @Test
-    public void testNonWhitelistedDomain() throws ProtocolException {
+    public void testNonWhitelistedDomainRejected() throws ProtocolException {
         assertFalse(isLocationRedirectable("http://fazigu.org"));
     }
 
     @Test
-    public void testMalformedLocation() throws ProtocolException {
+    public void testMalformedLocationRejected() throws ProtocolException {
         assertFalse(isLocationRedirectable("http://f a z i g u.org"));
     }
 
     @Test
-    public void testWhitelistedDomain() throws ProtocolException {
+    public void testWhitelistedDomainOK() throws ProtocolException {
         assertTrue(isLocationRedirectable("http://foo.webex.com/foo"));
     }
 
     @Test
-    public void testRelativeLocation() throws ProtocolException {
-        assertTrue(isLocationRedirectable("/foo"));
+    public void testRelativeLocationRejected() throws ProtocolException {
+        assertFalse(isLocationRedirectable("/foo"));
     }
 
     public boolean isLocationRedirectable(final String location) throws ProtocolException {
         HttpRequest request = mock(HttpRequest.class);
 
         HttpResponse response = mock(HttpResponse.class);
-        Header header = new BasicHeader(H_LOCATION, location);
-        when(response.getHeaders(H_LOCATION)).thenReturn(new Header[] { header });
+        Header header = new BasicHeader("Location", location);
+        //when(response.getHeaders("Location")).thenReturn(new Header[] { header });
+        when(response.getFirstHeader("Location")).thenReturn(header);
 
         HttpContext context = mock(HttpContext.class);
         AuthToken authToken = mock(AuthToken.class);
@@ -100,6 +98,7 @@ public class ProxyServletTest {
         Provisioning prov = Provisioning.getInstance();
 
         prov.deleteAccount(account.getId());
-        prov.deleteCos(cos.getId());
+        // MockProvisioning doesn't support deleteCos as of this writing.
+        //prov.deleteCos(cos.getId());
     }
 }

--- a/store/src/java-test/com/zimbra/cs/zimlet/ProxyServletTest.java
+++ b/store/src/java-test/com/zimbra/cs/zimlet/ProxyServletTest.java
@@ -1,0 +1,105 @@
+package com.zimbra.cs.zimlet;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.http.Header;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.ProtocolException;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.protocol.HttpContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.zimbra.common.account.Key.AccountBy;
+import com.zimbra.common.localconfig.LC;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.AuthToken;
+import com.zimbra.cs.account.Cos;
+import com.zimbra.cs.account.MockProvisioning;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.zimlet.ProxyServlet.RestrictiveRedirectStrategy;
+
+public class ProxyServletTest {
+    private static final String USERNAME = "username";
+    private static final String PASSWORD = "password";
+    private static final String COSNAME = "cosname";
+
+    private static final String[] ALLOWED_DOMAINS = new String[] { "*.webex.com" };
+
+    private static final String H_LOCATION = "Location";
+
+    private Cos cos;
+    private Account account;
+
+    @BeforeClass
+    public static void init() throws Exception {
+        MailboxTestUtil.initServer();
+    }
+
+    @Before
+    public void setUp() throws ServiceException {
+        MockProvisioning prov = new MockProvisioning();
+
+        cos = prov.createCos(COSNAME, Collections.emptyMap());
+        cos.setProxyAllowedDomains(ALLOWED_DOMAINS);
+
+        account = prov.createAccount(USERNAME, PASSWORD, Collections.emptyMap());
+        account.setCOSId(cos.getId());
+
+		Provisioning.setInstance(prov);
+    }
+
+    @Test
+    public void testNonWhitelistedDomain() throws ProtocolException {
+        assertFalse(isLocationRedirectable("http://fazigu.org"));
+    }
+
+    @Test
+    public void testMalformedLocation() throws ProtocolException {
+        assertFalse(isLocationRedirectable("http://f a z i g u.org"));
+    }
+
+    @Test
+    public void testWhitelistedDomain() throws ProtocolException {
+        assertTrue(isLocationRedirectable("http://foo.webex.com/foo"));
+    }
+
+    @Test
+    public void testRelativeLocation() throws ProtocolException {
+        assertTrue(isLocationRedirectable("/foo"));
+    }
+
+    public boolean isLocationRedirectable(final String location) throws ProtocolException {
+        HttpRequest request = mock(HttpRequest.class);
+
+        HttpResponse response = mock(HttpResponse.class);
+        Header header = new BasicHeader(H_LOCATION, location);
+        when(response.getHeaders(H_LOCATION)).thenReturn(new Header[] { header });
+
+        HttpContext context = mock(HttpContext.class);
+        AuthToken authToken = mock(AuthToken.class);
+        when(authToken.getAccountId()).thenReturn(account.getId());
+
+        RestrictiveRedirectStrategy strategy = new RestrictiveRedirectStrategy(authToken);
+        return strategy.isRedirected(request, response, context);
+    }
+
+    @After
+    public void tearDown() throws ServiceException {
+        Provisioning prov = Provisioning.getInstance();
+
+        prov.deleteAccount(account.getId());
+        prov.deleteCos(cos.getId());
+    }
+}

--- a/store/src/java-test/com/zimbra/cs/zimlet/ProxyServletTest.java
+++ b/store/src/java-test/com/zimbra/cs/zimlet/ProxyServletTest.java
@@ -57,6 +57,16 @@ public class ProxyServletTest {
         Provisioning.setInstance(prov);
     }
 
+	@Test
+	public void testRedirectStatus() {
+		assertFalse(ProxyServlet.isRedirectStatus(200));
+		assertTrue(ProxyServlet.isRedirectStatus(300));
+		assertTrue(ProxyServlet.isRedirectStatus(301));
+		assertTrue(ProxyServlet.isRedirectStatus(302));
+		assertFalse(ProxyServlet.isRedirectStatus(400));
+		assertFalse(ProxyServlet.isRedirectStatus(500));
+	}
+
     @Test
     public void testNonWhitelistedDomainRejected() throws ProtocolException {
         assertFalse(isLocationRedirectable("http://fazigu.org"));

--- a/store/src/java/com/zimbra/cs/zimlet/ProxyServlet.java
+++ b/store/src/java/com/zimbra/cs/zimlet/ProxyServlet.java
@@ -88,7 +88,7 @@ public class ProxyServlet extends ZimbraServlet {
     private static final String AUTH_PARAM = "auth";
     private static final String AUTH_BASIC = "basic";
 
-    private static boolean isRedirectStatus(int status) {
+    protected static boolean isRedirectStatus(int status) {
         return status / 100 == 3; // 3xx Redirect
     }
 


### PR DESCRIPTION
**Problem**: https://jira.corp.synacor.com/browse/ZBUG-2914 describes this as a potential issue, but gives no indication of an actual problem in the real world.  So, going by the details and proposed fixes in that description, we want to prevent a proxied request from following any redirect that isn't also on our whitelist.

**Solution**: First, I wrote a custom redirect strategy that checked our whitelist. That should stop us from being redirected while the proxying request is running. Then I needed to re-check any ultimate "Location" header sent to report the proper client error  instead of allowing that header to fall through and (probably) fail due to existing browser CORS restrictions.

**Testing**: I grabbed a small URL-shortening go project to generate redirects and ensured our proxy did not follow them unless they matched a domain within our whitelist.