### PR TITLE
ZCS-11986: CreateVolumeAPI: useInfrequentAccess and useIntelligentTiering are not getting persisted correctly

### DIFF
--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -1310,8 +1310,8 @@ public final class AdminConstants {
     public static final String A_VOLUME_VOLUME_PREFIX = "volumePrefix";
     public static final String A_VOLUME_STORE_PROVIDER = "storeProvider";
     public static final String A_VOLUME_GLB_BUCKET_CONFIG_ID = "globalBucketConfigId";
-    public static final String A_VOLUME_USE_IN_FREQ_ACCESS = "useInFrequentAccess";
-    public static final String A_VOLUME_USE_IN_FREQ_ACCESS_THRESHOLD = "useInFrequentAccessThreshold";
+    public static final String A_VOLUME_USE_IN_FREQ_ACCESS = "useInfrequentAccess";
+    public static final String A_VOLUME_USE_IN_FREQ_ACCESS_THRESHOLD = "useInfrequentAccessThreshold";
     public static final String A_VOLUME_USE_INTELLIGENT_TIERING = "useIntelligentTiering";
     public static final String A_VOLUME_URL = "url";
     public static final String A_VOLUME_ACCOUNT = "account";


### PR DESCRIPTION
The issue was caused because of the following typos (uppercase F) in AdminConstants.java:
-  A_VOLUME_USE_IN_FREQ_ACCESS = "useInFrequentAccess"
-  A_VOLUME_USE_IN_FREQ_ACCESS_THRESHOLD = "useInFrequentAccessThreshold"

They have been changed to "Infrequent"

TESTING:
After creating volume in Admin UI, run: 
$ zmvolume -l
                   Volume id: 1
                       ...
                   Volume id: 2
                        ...
                   Volume id: 3
                        name: rakeshtestaws
                        type: primaryMessage
                        path: /S3-rakeshtestaws-0bb249e2-34d0-4ad6-bc9a-baed9b6e9e87
                        compressed: false
                        current: false
                        prefix: /rakeshtestaws
                        globalBucketConfigurationId: 0bb249e2-34d0-4ad6-bc9a-baed9b6e9e87
                        storageType: S3
                        useIntelligentTiering: false
                        useInFrequentAccess: true
                        useInFrequentAccessThreshold: 65536
