### PR TITLE
ZCS-11929: Enabling doument feature is documentServerHost value is set

### DIFF
--- a/store/src/java/com/zimbra/cs/service/SharedFileServlet.java
+++ b/store/src/java/com/zimbra/cs/service/SharedFileServlet.java
@@ -37,6 +37,7 @@ import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.mailbox.Document;
 import com.zimbra.cs.mailbox.MailItem;
 import com.zimbra.cs.mailbox.MailServiceException;
+import com.zimbra.cs.util.AccountUtil;
 
 @SuppressWarnings("serial")
 public class SharedFileServlet extends UserServlet {
@@ -146,7 +147,7 @@ public class SharedFileServlet extends UserServlet {
         boolean zimbraFeatureDocumentEditingEnabled = false;
         Account account  = context.targetAccount;
         if (account != null) {
-            zimbraFeatureDocumentEditingEnabled = account.isFeatureDocumentEditingEnabled();
+            zimbraFeatureDocumentEditingEnabled = AccountUtil.isDocumentEditingEnabled(account);
             log.debug("Document editing account = %s, enabled = %s ", account.getName(), zimbraFeatureDocumentEditingEnabled);
         }
         log.debug("Document supported for editing = %s" , isAllowedDocType(item));

--- a/store/src/java/com/zimbra/cs/service/account/GetInfo.java
+++ b/store/src/java/com/zimbra/cs/service/account/GetInfo.java
@@ -338,6 +338,9 @@ public class GetInfo extends AccountDocumentHandler  {
             } else if (Provisioning.A_zimbraMailQuota.equals(key)) {
                 // setting effective quota value refer ZBUG-1869 
                 value = String.valueOf(AccountUtil.getEffectiveQuota(acct));
+            } else if (Provisioning.A_zimbraFeatureDocumentEditingEnabled.equals(key)) { 
+                value = AccountUtil.isDocumentEditingEnabled(acct) ? 
+                        ProvisioningConstants.TRUE : ProvisioningConstants.FALSE;
             } else {
                 value = attrsMap.get(key);
 


### PR DESCRIPTION
Document editing feature will be enabled iff Document editing server host is set ie value of ldap attribute `zimbraDocumentServerHost` must be set otherwise feature will be disabled even if  it is enabled at account level.