### PR TITLE
ZCS-12029: remove LC dependancy of onlyoffice formatter usage with adding check for zimbraDocumentServerHost

### DIFF
--- a/store/src/java/com/zimbra/cs/service/UserServlet.java
+++ b/store/src/java/com/zimbra/cs/service/UserServlet.java
@@ -902,6 +902,19 @@ public class UserServlet extends ZimbraServlet {
 
         if (context.formatter == null) {
             context.formatter = FormatterFactory.mFormatters.get(context.format);
+            // check if its native formatter, and if onlyoffice formatter is available
+            if (context.formatter.getType().equals(FormatType.HTML_CONVERTED)) {
+                try {
+                    Provisioning prov = Provisioning.getInstance();
+                    Server server = prov.getServer(context.getAuthAccount());
+                    if (!StringUtil.isNullOrEmpty(server.getDocumentServerHost())) {
+                        context.formatter = FormatterFactory.mFormatters.get(FormatType.HTML_ONLYOFFICE);
+                    }
+                } catch (ServiceException e) {
+                    log.debug("Service Exception caught while resolving the formatter, default will be used.", e.getMessage());
+                }
+            }
+
             if (context.formatter == null) {
                 throw new UserServletException(HttpServletResponse.SC_BAD_REQUEST,
                         L10nUtil.getMessage(MsgKey.errUnsupportedFormat, context.req));

--- a/store/src/java/com/zimbra/cs/service/formatter/FormatterFactory.java
+++ b/store/src/java/com/zimbra/cs/service/formatter/FormatterFactory.java
@@ -42,6 +42,7 @@ public class FormatterFactory {
             FREE_BUSY("freebusy", MimeConstants.CT_TEXT_HTML),
             HTML("html", MimeConstants.CT_TEXT_HTML),
             HTML_CONVERTED("native", MimeConstants.CT_TEXT_HTML),
+            HTML_ONLYOFFICE("onlyoffice", MimeConstants.CT_TEXT_HTML),
             ICS("ics", MimeConstants.CT_TEXT_CALENDAR),
             IFB("ifb", MimeConstants.CT_TEXT_CALENDAR),
             JSON("json", MimeConstants.CT_APPLICATION_JSON),


### PR DESCRIPTION
**Issue**
On a multinode setup where onlyoffice package is not installed, extension does not gets initialized causing the preview to be used from convertd as the LC **oo_linux_install_path** is not having updated to onlyoffice.

**Fix**
During multionode setup if the mailbox is not having onlyoffice installation and is being installed as standalone, onlyoffice formatter will be registered since the check from formatter registration of onlyoffice will happen at run time during formatter resolving. Extension will get initialzed and formatter will register. 
During the formatter resolving, it will be checked if there is any standalone onlyoffice installation available from **zimbraDocumentServerHost** ldap attr. If the attr is set then the formatter will be resolved to onlyoffice.

https://github.com/Zimbra/zm-doc-server-ext/pull/12
https://github.com/Zimbra/zm-build/pull/237