### PR TITLE
ZCS-12058 Can not delete mails which got moved to S3 storage from IMAP/POP/EWS account

### DIFF
--- a/store/src/java/com/zimbra/cs/imap/Literal.java
+++ b/store/src/java/com/zimbra/cs/imap/Literal.java
@@ -21,6 +21,7 @@ import com.zimbra.cs.store.StoreManager;
 import com.zimbra.cs.store.BlobBuilder;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ByteUtil;
+import com.zimbra.cs.store.external.ExternalBlob;
 
 import java.io.InputStream;
 import java.io.ByteArrayInputStream;
@@ -109,7 +110,12 @@ abstract class Literal {
         @Override public void cleanup() {
             buf = null;
             if (blob != null) {
-                StoreManager.getInstance().quietDelete(blob);
+                if (blob instanceof ExternalBlob) {
+                    String locator = ((ExternalBlob)blob).getLocator();
+                    StoreManager.getReaderSMInstance(locator).quietDelete(blob);
+                } else {
+                    StoreManager.getInstance().quietDelete(blob);
+                }
                 blob = null;
             }
         }

--- a/store/src/java/com/zimbra/cs/store/file/FileBlobStore.java
+++ b/store/src/java/com/zimbra/cs/store/file/FileBlobStore.java
@@ -28,6 +28,7 @@ import com.zimbra.common.util.FileUtil;
 import com.zimbra.common.util.SystemUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.util.MailItemHelper;
 import com.zimbra.cs.store.Blob;
 import com.zimbra.cs.store.BlobBuilder;
 import com.zimbra.cs.store.BlobInputStream;
@@ -36,6 +37,7 @@ import com.zimbra.cs.store.IncomingDirectory;
 import com.zimbra.cs.store.MailboxBlob;
 import com.zimbra.cs.store.StagedBlob;
 import com.zimbra.cs.store.StoreManager;
+import com.zimbra.cs.store.external.ExternalBlob;
 import com.zimbra.cs.volume.Volume;
 import com.zimbra.cs.volume.VolumeManager;
 import com.zimbra.znative.IO;
@@ -221,7 +223,17 @@ public final class FileBlobStore extends StoreManager {
 
         ensureParentDirExists(dest);
 
-        short srcVolumeId = ((VolumeBlob) src).getVolumeId();
+        short srcVolumeId;
+        /*
+         In order to support multiple StoreManagers, sometime may need to copy ExternalBlobs(mostly secondary)
+         to FileStore blobs. Following is to get coping item's correct volume id.
+         */
+        if(src instanceof ExternalBlob) {
+            srcVolumeId = MailItemHelper.findMyVolumeId(((ExternalBlob) src).getLocator()).get();
+        } else {
+            srcVolumeId = ((VolumeBlob) src).getVolumeId();
+        }
+
         if (srcVolumeId == destVolumeId) {
             try {
                 IO.link(srcPath, destPath);


### PR DESCRIPTION
**Problem:**
Can not delete emails that got moved to S3 storage from IMAP/POP/EWS account. In the case of IMAP/POP/EWS clients, in delete operations email gets moved to the "trash" folder first basically email gets copied to the trash folder. So here external storage(ExternalBlob) item getting copied to internal storage(VolumeBlob), and in the copy operation, it was failing due to incompatibility of Blobs for identifying source volume id. 

**Solution**
when there are multiple StoreManagers(internal(primary) and external(secondary) volumes configured), make sure we are using the right method to extract source volume. 