### PR TITLE
ZCS-12078 Storage management: Can not delete mail in IMAP clients

### DIFF
--- a/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
@@ -727,7 +727,7 @@ public class ItemActionHelper {
                 break;
             case MESSAGE:
                 try {
-                    in = StoreManager.getInstance(item.getLocator()).getContent(item.getBlob());
+                    in = StoreManager.getReaderSMInstance(item.getLocator()).getContent(item.getBlob());
                     createdId = zmbx.addMessage(folderStr, flags, (String) null, item.getDate(), in, item.getSize(), true);
                 } finally {
                     ByteUtil.closeStream(in);
@@ -739,7 +739,7 @@ public class ItemActionHelper {
                 for (Message msg : msgs) {
                     flags = (mOperation == Op.UPDATE && mFlags != null ? mFlags : msg.getFlagString());
                     try {
-                        in = StoreManager.getInstance(msg.getLocator()).getContent(msg.getBlob());
+                        in = StoreManager.getReaderSMInstance(msg.getLocator()).getContent(msg.getBlob());
                         createdId = zmbx.addMessage(folderStr, flags, (String) null, msg.getDate(), in, msg.getSize(), true);
                     } finally {
                         ByteUtil.closeStream(in);
@@ -751,7 +751,7 @@ public class ItemActionHelper {
                 Document doc = (Document) item;
                 SoapHttpTransport transport = new SoapHttpTransport(zoptions.getUri());
                 try {
-                    in = StoreManager.getInstance(doc.getLocator()).getContent(doc.getBlob());
+                    in = StoreManager.getReaderSMInstance(doc.getLocator()).getContent(doc.getBlob());
                     String uploadId = zmbx.uploadContentAsStream(name, in, doc.getContentType(), doc.getSize(), 4000, true);
                     // instead of using convenience method from ZMailbox
                     // we need to hand marshall the request and set the

--- a/store/src/java/com/zimbra/cs/service/mail/RemoveAttachments.java
+++ b/store/src/java/com/zimbra/cs/service/mail/RemoveAttachments.java
@@ -73,7 +73,7 @@ public class RemoveAttachments extends MailDocumentHandler {
 
         InputStream is = null;
         try {
-            MimeMessage mm = new Mime.FixedMimeMessage(JMSession.getSession(), is = StoreManager.getInstance(msg.getLocator()).getContent(msg.getBlob().getLocalBlob()));
+            MimeMessage mm = new Mime.FixedMimeMessage(JMSession.getSession(), is = StoreManager.getReaderSMInstance(msg.getLocator()).getContent(msg.getBlob().getLocalBlob()));
             // do not allow removing attachments of encrypted/pkcs7-signed messages
             if (Mime.isEncrypted(mm.getContentType()) || Mime.isPKCS7Signed(mm.getContentType())) {
                 throw ServiceException.OPERATION_DENIED("not allowed to remove attachments of encrypted/pkcs7-signed message");


### PR DESCRIPTION
**Problem**:
Not able to delete emails from IMPAC client when blobs are moved from External Storage(Primary) to Internal Storage(Secondary).  In the case of IMAP/POP/EWS clients, in delete operations email gets moved to the "trash" folder first basically email gets copied to the trash folder. So here Internal storage(VolumeBlob) item getting copied to External storage(ExternalBlob), and in the copy operation, it was failing due to incompatibility of MailBlobs.

**Solution:**
StoreManagers(External(primary) and Internal(secondary) volumes configured), make sure we are using the right store manager to extract source.