### PR TITLE
ZCS-12108: add null check for auth account to get server

### DIFF
--- a/store/src/java/com/zimbra/cs/service/UserServlet.java
+++ b/store/src/java/com/zimbra/cs/service/UserServlet.java
@@ -907,7 +907,7 @@ public class UserServlet extends ZimbraServlet {
                 try {
                     Provisioning prov = Provisioning.getInstance();
                     Server server = prov.getServer(context.getAuthAccount());
-                    if (!StringUtil.isNullOrEmpty(server.getDocumentServerHost())) {
+                    if (server != null && !StringUtil.isNullOrEmpty(server.getDocumentServerHost())) {
                         context.formatter = FormatterFactory.mFormatters.get(FormatType.HTML_ONLYOFFICE);
                     }
                 } catch (ServiceException e) {


### PR DESCRIPTION
**Issue**
Document request from sharing resulting into NPE for getting DocumentServerHost 
`2022-08-28 16:44:22.058:WARN:oejs.HttpChannel:qtp364604394-230: /service/home/pa1@zqa-373.eng.zimbra.com/Briefcase/Sfolder2/bug65079.txt
java.lang.NullPointerException: Cannot invoke "com.zimbra.cs.account.Server.getDocumentServerHost()" because "server" is null
	at com.zimbra.cs.service.UserServlet.resolveFormatter(UserServlet.java:910)
	at com.zimbra.cs.service.UserServlet.doAuthGet(UserServlet.java:697)
	at com.zimbra.cs.service.UserServlet.doGet(UserServlet.java:402)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:687)`

**Fix**
Added null check for server