### PR TITLE
ZCS-12111: null valued key 'zimbra_sm_blob_mover_parallelism_level'

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1514,6 +1514,10 @@ public final class LC {
     // Connection timeout for OpenIO external storage
     public static final KnownKey zimbra_sm_openio_connection_request_timeout_ms = KnownKey.newKey(20000);
 
+    // Storage Management
+    public final static KnownKey zimbra_sm_blob_mover_parallelism_level = KnownKey.newKey(5);
+    public final static KnownKey zimbra_s3_connection_request_timeout_ms = KnownKey.newKey(20000);
+    
     static {
         // Automatically set the key name with the variable name.
         for (Field field : LC.class.getFields()) {

--- a/store/src/java/com/zimbra/cs/store/CacheEnabledStoreManagerProvider.java
+++ b/store/src/java/com/zimbra/cs/store/CacheEnabledStoreManagerProvider.java
@@ -64,7 +64,7 @@ public class CacheEnabledStoreManagerProvider {
         String className = volume.getStoreManagerClass();
         StoreManager storeManager = null;
         try {
-            ZimbraLog.store.error("loading Store Manager: %s for %s", className, volumeId);
+            ZimbraLog.store.debug("loading Store Manager: %s for %s", className, volumeId);
             storeManager = (StoreManager) ClassHelper.getZimbraClassInstanceBy(className);
             ZimbraLog.store.debug("StoreManager loaded, starting up");
             storeManager.startup();


### PR DESCRIPTION
**Problem:** Local config attributes are null by default for Storage Management.
**Solution:** Loaded Storage Management local config. 