### PR TITLE
ZCS-12110: fixing the default value of zimbraFeatureDocumentEditingEnabled to false if zimbraDocumentServerHost not set

### DIFF
--- a/store/src/java/com/zimbra/cs/util/AccountUtil.java
+++ b/store/src/java/com/zimbra/cs/util/AccountUtil.java
@@ -922,10 +922,10 @@ public class AccountUtil {
         if (isEnabled) {
             Provisioning prov = Provisioning.getInstance();
             try {
+                isEnabled = false;
                 Server server = prov.getServer(account);
                 if (server == null) {
                     ZimbraLog.account.warn("no server associated with acccount " + account.getName());
-                    isEnabled = false;
                 } else {
                     String value = server.getDocumentServerHost();
                     if (!StringUtil.isNullOrEmpty(value)) {


### PR DESCRIPTION
**Issue**
The change made in ZCS-11929 to default value zimbraFeatureDocumentEditingEnabled to false if zimbraDocumentServerHost value is not set and feature is not working as expected.

**Fix**
zimbraFeatureDocumentEditingEnabled was not disable with default value of false on missing value of zimbraDocumentServerHost, made default false and it works.

**Test**
Verified by setting empty value to zimbraDocumentServerHost and on ZWC checked the zimbraFeatureDocumentEditingEnabled is getting false.