### PR TITLE
ZCS-12180: add GetDocumentShareURLRequest as valid request in contextfor accessing documents in files shared with me folder

### DIFF
--- a/store/src/java/com/zimbra/soap/ZimbraSoapContext.java
+++ b/store/src/java/com/zimbra/soap/ZimbraSoapContext.java
@@ -34,6 +34,7 @@ import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.HeaderConstants;
 import com.zimbra.common.soap.MailConstants;
+import com.zimbra.common.soap.OctopusXmlConstants;
 import com.zimbra.common.soap.SoapProtocol;
 import com.zimbra.common.soap.SoapTransport;
 import com.zimbra.common.util.Log;
@@ -526,9 +527,9 @@ public final class ZimbraSoapContext {
             return;
         }
 
-        if ((handler != null) && handler instanceof DelegatableRequest
+        if (((handler != null) && handler instanceof DelegatableRequest
                 && MailConstants.FILE_SHARED_WITH_ME_REQUEST.equals(requestName)
-                && ((DelegatableRequest) handler).isDelegatable()) {
+                && ((DelegatableRequest) handler).isDelegatable()) || (OctopusXmlConstants.GET_DOCUMENT_SHARE_URL_REQUEST.equals(requestName))) {
             return;
         }
 


### PR DESCRIPTION
Issue
In a multinode setup with sharee & sharer on different mail store accessing documents from files shared me folder and trying to open fails to get shared url.

Fix
Sharer account sending the request to get shared file url using GetDocumentShareURLRequest is not recognized as valid request, adding the request to valid request resolves the issue. 
Verified the url received requires shared access and valid authentication. 