### PR TITLE
ZCS-12188: Don't disable zextras zimlets when upgrading a mailbox in …

### DIFF
--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -16,6 +16,8 @@
  */
 package com.zimbra.common.soap;
 
+import java.util.Arrays;
+import java.util.List;
 import org.dom4j.Namespace;
 import org.dom4j.QName;
 
@@ -1608,4 +1610,10 @@ public final class AdminConstants {
     public static final String E_VALIDATE_S3_BUCKET_REACHABLE_RESPONSE = "ValidateS3BucketReachableResponse";
     public static final QName VALIDATE_S3_BUCKET_REACHABLE_REQUEST = QName.get(E_VALIDATE_S3_BUCKET_REACHABLE_REQUEST, NAMESPACE);
     public static final QName VALIDATE_S3_BUCKET_REACHABLE_RESPONSE = QName.get(E_VALIDATE_S3_BUCKET_REACHABLE_RESPONSE, NAMESPACE);
+    
+    // Removed Zetras zimlet package list
+    public static final List<String> ZEXTRAS_PACKAGES_LIST = Arrays.asList("com_ng_auth", "com_zextras_zextras",
+            "com_zextras_client", "com_zimbra_connect_classic", "com_zimbra_connect_modern", "com_zextras_docs",
+            "com_zimbra_docs_modern", "com_zimbra_drive_modern", "com_zextras_drive", "com_zextras_drive_open",
+            "com_zextras_chat_open", "com_zextras_talk", "zimbra-zimlet-briefcase-edit-lool");
 }

--- a/store/src/java/com/zimbra/cs/service/account/GetInfo.java
+++ b/store/src/java/com/zimbra/cs/service/account/GetInfo.java
@@ -375,7 +375,7 @@ public class GetInfo extends AccountDocumentHandler  {
 
             ZimletPresence userZimlets = ZimletUtil.getUserZimlets(acct);
             List<Zimlet> zimletList = ZimletUtil.orderZimletsByPriority(userZimlets.getZimletNamesAsArray());
-            zimletList.removeIf(x -> AdminConstants.ZEXTRAS_PACKAGES_LIST.contains(x.getName()));
+            zimletList.removeIf(zimlet -> AdminConstants.ZEXTRAS_PACKAGES_LIST.contains(zimlet.getName()));
             int priority = 0;
             for (Zimlet z : zimletList) {
                 if (z.isEnabled() && !z.isExtension()) {

--- a/store/src/java/com/zimbra/cs/service/account/GetInfo.java
+++ b/store/src/java/com/zimbra/cs/service/account/GetInfo.java
@@ -37,6 +37,7 @@ import com.zimbra.common.account.ProvisioningConstants;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AccountConstants;
+import com.zimbra.common.soap.AdminConstants;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.util.ArrayUtil;
 import com.zimbra.common.util.StringUtil;
@@ -374,6 +375,7 @@ public class GetInfo extends AccountDocumentHandler  {
 
             ZimletPresence userZimlets = ZimletUtil.getUserZimlets(acct);
             List<Zimlet> zimletList = ZimletUtil.orderZimletsByPriority(userZimlets.getZimletNamesAsArray());
+            zimletList.removeIf(x -> AdminConstants.ZEXTRAS_PACKAGES_LIST.contains(x.getName()));
             int priority = 0;
             for (Zimlet z : zimletList) {
                 if (z.isEnabled() && !z.isExtension()) {

--- a/store/src/java/com/zimbra/cs/service/admin/GetAdminExtensionZimlets.java
+++ b/store/src/java/com/zimbra/cs/service/admin/GetAdminExtensionZimlets.java
@@ -52,7 +52,9 @@ public class GetAdminExtensionZimlets extends AdminDocumentHandler  {
 
 	private void doExtensionZimlets(ZimbraSoapContext zsc, Map<String, Object> context, Element response) throws ServiceException {
         
-        Iterator<Zimlet> zimlets = Provisioning.getInstance().listAllZimlets().iterator();
+        List<Zimlet> zimletsList = Provisioning.getInstance().listAllZimlets();
+        zimletsList.removeIf(x -> AdminConstants.ZEXTRAS_PACKAGES_LIST.contains(x.getName()));
+        Iterator<Zimlet> zimlets = zimletsList.iterator();
 		while (zimlets.hasNext()) {
 		    
 		    Zimlet z = (Zimlet) zimlets.next();

--- a/store/src/java/com/zimbra/cs/service/admin/GetAdminExtensionZimlets.java
+++ b/store/src/java/com/zimbra/cs/service/admin/GetAdminExtensionZimlets.java
@@ -53,7 +53,7 @@ public class GetAdminExtensionZimlets extends AdminDocumentHandler  {
 	private void doExtensionZimlets(ZimbraSoapContext zsc, Map<String, Object> context, Element response) throws ServiceException {
         
         List<Zimlet> zimletsList = Provisioning.getInstance().listAllZimlets();
-        zimletsList.removeIf(x -> AdminConstants.ZEXTRAS_PACKAGES_LIST.contains(x.getName()));
+        zimletsList.removeIf(zimlet -> AdminConstants.ZEXTRAS_PACKAGES_LIST.contains(zimlet.getName()));
         Iterator<Zimlet> zimlets = zimletsList.iterator();
 		while (zimlets.hasNext()) {
 		    

--- a/store/src/java/com/zimbra/cs/service/admin/GetAllZimlets.java
+++ b/store/src/java/com/zimbra/cs/service/admin/GetAllZimlets.java
@@ -41,7 +41,7 @@ public class GetAllZimlets extends AdminDocumentHandler {
         Provisioning prov = Provisioning.getInstance();
 
 		List<Zimlet> zimlets = prov.listAllZimlets();
-		
+		zimlets.removeIf(x -> AdminConstants.ZEXTRAS_PACKAGES_LIST.contains(x.getName()));
 		AdminAccessControl aac = AdminAccessControl.getAdminAccessControl(zsc);
 
 	    Element response = zsc.createElement(AdminConstants.GET_ALL_ZIMLETS_RESPONSE);

--- a/store/src/java/com/zimbra/cs/service/admin/GetAllZimlets.java
+++ b/store/src/java/com/zimbra/cs/service/admin/GetAllZimlets.java
@@ -41,7 +41,7 @@ public class GetAllZimlets extends AdminDocumentHandler {
         Provisioning prov = Provisioning.getInstance();
 
 		List<Zimlet> zimlets = prov.listAllZimlets();
-		zimlets.removeIf(x -> AdminConstants.ZEXTRAS_PACKAGES_LIST.contains(x.getName()));
+		zimlets.removeIf(zimlet -> AdminConstants.ZEXTRAS_PACKAGES_LIST.contains(zimlet.getName()));
 		AdminAccessControl aac = AdminAccessControl.getAdminAccessControl(zsc);
 
 	    Element response = zsc.createElement(AdminConstants.GET_ALL_ZIMLETS_RESPONSE);

--- a/store/src/java/com/zimbra/cs/zimlet/ZimletUtil.java
+++ b/store/src/java/com/zimbra/cs/zimlet/ZimletUtil.java
@@ -195,16 +195,44 @@ public class ZimletUtil {
         if (domain != null) {
             String[] domainZimlets = domain.getMultiAttr(Provisioning.A_zimbraZimletDomainAvailableZimlets);
             for (String zimletWithPrefix : domainZimlets) {
-                availZimlets.put(zimletWithPrefix);
+                if(isNotZextrasZimlet(zimletWithPrefix)) {
+                    availZimlets.put(zimletWithPrefix);
+                }
             }
         }
 
         String[] acctCosZimlets = acct.getMultiAttr(Provisioning.A_zimbraZimletAvailableZimlets);
         for (String zimletWithPrefix : acctCosZimlets) {
-            availZimlets.put(zimletWithPrefix);
+            if(isNotZextrasZimlet(zimletWithPrefix)) {
+                availZimlets.put(zimletWithPrefix);
+            }
         }
 
         return availZimlets;
+    }
+    
+    private static boolean isNotZextrasZimlet(String zimletName) {
+        if(StringUtil.isNullOrEmpty(zimletName) || zimletName.length() == 1) {
+            return false;
+        }
+        
+        char prefix = zimletName.charAt(0);
+        Presence presence = Presence.fromPrefix(prefix);
+        
+        ZimbraLog.account.info("zimletName before: %s ", zimletName);
+        if (presence != null) {
+            zimletName = zimletName.substring(1);
+        }
+        ZimbraLog.account.info("zimletName after: %s ", zimletName);
+        
+        /* if (zimletName.startsWith("+") || zimletName.startsWith("-") || zimletName.startsWith("!")) {
+            zimletName = zimletName.substring(1);
+        } */
+        
+        if (AdminConstants.ZEXTRAS_PACKAGES_LIST.contains(zimletName)) {
+            return false;
+        }
+        return true;
     }
 
     public static ZimletPresence getAvailableZimlets(Cos cos) throws ServiceException {
@@ -212,7 +240,9 @@ public class ZimletUtil {
 
         String[] acctCosZimlets = cos.getMultiAttr(Provisioning.A_zimbraZimletAvailableZimlets);
         for (String zimletWithPrefix : acctCosZimlets) {
-            availZimlets.put(zimletWithPrefix);
+            if(isNotZextrasZimlet(zimletWithPrefix)) {
+                availZimlets.put(zimletWithPrefix);
+            }
         }
 
         return availZimlets;
@@ -440,7 +470,9 @@ public class ZimletUtil {
                     continue;
                 }
                 try {
-                    zimlets.put(zimletNames[i], new ZimletFile(zimletRootDir, zimletNames[i]));
+                    if(isNotZextrasZimlet(zimletNames[i])) {
+                        zimlets.put(zimletNames[i], new ZimletFile(zimletRootDir, zimletNames[i]));
+                    }
                 } catch (Exception e) {
                     ZimbraLog.zimlet.warn("error loading zimlet "+zimletNames[i], e);
                 }

--- a/store/src/java/com/zimbra/cs/zimlet/ZimletUtil.java
+++ b/store/src/java/com/zimbra/cs/zimlet/ZimletUtil.java
@@ -195,7 +195,7 @@ public class ZimletUtil {
         if (domain != null) {
             String[] domainZimlets = domain.getMultiAttr(Provisioning.A_zimbraZimletDomainAvailableZimlets);
             for (String zimletWithPrefix : domainZimlets) {
-                if (isNotZextrasZimlet(zimletWithPrefix)) {
+                if (!isZextrasZimlet(zimletWithPrefix)) {
                     availZimlets.put(zimletWithPrefix);
                 }
             }
@@ -203,7 +203,7 @@ public class ZimletUtil {
 
         String[] acctCosZimlets = acct.getMultiAttr(Provisioning.A_zimbraZimletAvailableZimlets);
         for (String zimletWithPrefix : acctCosZimlets) {
-            if (isNotZextrasZimlet(zimletWithPrefix)) {
+            if (!isZextrasZimlet(zimletWithPrefix)) {
                 availZimlets.put(zimletWithPrefix);
             }
         }
@@ -220,22 +220,20 @@ public class ZimletUtil {
      * @param zimletName
      * @return boolean
      */
-    private static boolean isNotZextrasZimlet(String zimletName) {
-        if (StringUtil.isNullOrEmpty(zimletName) || zimletName.length() == 1) {
-            return false;
-        }
+    private static boolean isZextrasZimlet(String zimletName) {
+        if (!StringUtil.isNullOrEmpty(zimletName) && zimletName.length() > 1) {
+            char prefix = zimletName.charAt(0);
+            Presence presence = Presence.fromPrefix(prefix);
 
-        char prefix = zimletName.charAt(0);
-        Presence presence = Presence.fromPrefix(prefix);
+            if (presence != null) {
+                zimletName = zimletName.substring(1);
+            }
 
-        if (presence != null) {
-            zimletName = zimletName.substring(1);
+            if (AdminConstants.ZEXTRAS_PACKAGES_LIST.contains(zimletName)) {
+                return true;
+            }
         }
-
-        if (AdminConstants.ZEXTRAS_PACKAGES_LIST.contains(zimletName)) {
-            return false;
-        }
-        return true;
+        return false;
     }
 
     public static ZimletPresence getAvailableZimlets(Cos cos) throws ServiceException {
@@ -243,7 +241,7 @@ public class ZimletUtil {
 
         String[] acctCosZimlets = cos.getMultiAttr(Provisioning.A_zimbraZimletAvailableZimlets);
         for (String zimletWithPrefix : acctCosZimlets) {
-            if (isNotZextrasZimlet(zimletWithPrefix)) {
+            if (!isZextrasZimlet(zimletWithPrefix)) {
                 availZimlets.put(zimletWithPrefix);
             }
         }
@@ -473,7 +471,7 @@ public class ZimletUtil {
                     continue;
                 }
                 try {
-                    if (isNotZextrasZimlet(zimletNames[i])) {
+                    if (!isZextrasZimlet(zimletNames[i])) {
                         zimlets.put(zimletNames[i], new ZimletFile(zimletRootDir, zimletNames[i]));
                     }
                 } catch (Exception e) {

--- a/store/src/java/com/zimbra/cs/zimlet/ZimletUtil.java
+++ b/store/src/java/com/zimbra/cs/zimlet/ZimletUtil.java
@@ -212,23 +212,17 @@ public class ZimletUtil {
     }
     
     private static boolean isNotZextrasZimlet(String zimletName) {
-        if(StringUtil.isNullOrEmpty(zimletName) || zimletName.length() == 1) {
+        if (StringUtil.isNullOrEmpty(zimletName) || zimletName.length() == 1) {
             return false;
         }
-        
+
         char prefix = zimletName.charAt(0);
         Presence presence = Presence.fromPrefix(prefix);
-        
-        ZimbraLog.account.info("zimletName before: %s ", zimletName);
+
         if (presence != null) {
             zimletName = zimletName.substring(1);
         }
-        ZimbraLog.account.info("zimletName after: %s ", zimletName);
-        
-        /* if (zimletName.startsWith("+") || zimletName.startsWith("-") || zimletName.startsWith("!")) {
-            zimletName = zimletName.substring(1);
-        } */
-        
+
         if (AdminConstants.ZEXTRAS_PACKAGES_LIST.contains(zimletName)) {
             return false;
         }

--- a/store/src/java/com/zimbra/cs/zimlet/ZimletUtil.java
+++ b/store/src/java/com/zimbra/cs/zimlet/ZimletUtil.java
@@ -195,7 +195,7 @@ public class ZimletUtil {
         if (domain != null) {
             String[] domainZimlets = domain.getMultiAttr(Provisioning.A_zimbraZimletDomainAvailableZimlets);
             for (String zimletWithPrefix : domainZimlets) {
-                if(isNotZextrasZimlet(zimletWithPrefix)) {
+                if (isNotZextrasZimlet(zimletWithPrefix)) {
                     availZimlets.put(zimletWithPrefix);
                 }
             }
@@ -203,7 +203,7 @@ public class ZimletUtil {
 
         String[] acctCosZimlets = acct.getMultiAttr(Provisioning.A_zimbraZimletAvailableZimlets);
         for (String zimletWithPrefix : acctCosZimlets) {
-            if(isNotZextrasZimlet(zimletWithPrefix)) {
+            if (isNotZextrasZimlet(zimletWithPrefix)) {
                 availZimlets.put(zimletWithPrefix);
             }
         }
@@ -211,6 +211,15 @@ public class ZimletUtil {
         return availZimlets;
     }
     
+    /**
+     * this method is also check whether zimletName is having prefix like +,- and !
+     * and this method is used to find out whether zimletName is related to remove
+     * ZEXTRAS list or not if zimletName is not in remove ZEXTRAS list then it
+     * returns true else it returns false
+     *
+     * @param zimletName
+     * @return boolean
+     */
     private static boolean isNotZextrasZimlet(String zimletName) {
         if (StringUtil.isNullOrEmpty(zimletName) || zimletName.length() == 1) {
             return false;
@@ -234,7 +243,7 @@ public class ZimletUtil {
 
         String[] acctCosZimlets = cos.getMultiAttr(Provisioning.A_zimbraZimletAvailableZimlets);
         for (String zimletWithPrefix : acctCosZimlets) {
-            if(isNotZextrasZimlet(zimletWithPrefix)) {
+            if (isNotZextrasZimlet(zimletWithPrefix)) {
                 availZimlets.put(zimletWithPrefix);
             }
         }
@@ -464,7 +473,7 @@ public class ZimletUtil {
                     continue;
                 }
                 try {
-                    if(isNotZextrasZimlet(zimletNames[i])) {
+                    if (isNotZextrasZimlet(zimletNames[i])) {
                         zimlets.put(zimletNames[i], new ZimletFile(zimletRootDir, zimletNames[i]));
                     }
                 } catch (Exception e) {


### PR DESCRIPTION
**Issue:** Zextras Zimlets are getting loaded in User WebClient and also in Admin console under Zimlet list when upgrading a mailbox in rolling upgrade setup. 

**Solution:** We have added a Constant list that have all the Zextras Zimlets, so while loading the Zimlets we are excluding the Zimlets from the Constant list.