### PR TITLE
ZBUG-2547 : Email contents not shown in Webmail

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1517,6 +1517,13 @@ public final class LC {
     // Storage Management
     public final static KnownKey zimbra_sm_blob_mover_parallelism_level = KnownKey.newKey(5);
     public final static KnownKey zimbra_s3_connection_request_timeout_ms = KnownKey.newKey(20000);
+
+    // ZBUG-2547 : zimbra_strict_unclosed_comment_tag if this is false we relax rule
+    // of allowing unclosed tag based on zimbra_skip_tags_with_unclosed_cdata value
+    // zimbra_skip_tags_with_unclosed_cdata : Set values , based on this tags would be checked for closed comment
+    public static final KnownKey zimbra_strict_unclosed_comment_tag = KnownKey.newKey(true);
+    public static final KnownKey zimbra_skip_tags_with_unclosed_cdata = KnownKey.newKey("style");
+
     
     static {
         // Automatically set the key name with the variable name.

--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -46,7 +46,7 @@
   <dependency org="com.101tec" name="zkclient" rev="0.1.0"/>
   <dependency org="xerces" name="xercesImpl" rev="2.9.1-patch-01"/>
   <dependency org="net.sourceforge.nekohtml" name="nekohtml" rev="1.9.13.1z"/>
-  <dependency org="com.googlecode.owasp-java-html-sanitizer" name="owasp-java-html-sanitizer" rev="20190610.4z"/>
+  <dependency org="com.googlecode.owasp-java-html-sanitizer" name="owasp-java-html-sanitizer" rev="20190610.5z"/>
   <dependency org="org.ehcache" name="ehcache" rev="3.1.2"/>
   <dependency org="ant-1.7.0-ziputil-patched" name="ant-1.7.0-ziputil-patched" rev="1.0"/>
   <dependency org="org.eclipse.jetty" name="jetty-continuation" rev="${jetty.version}"/>

--- a/store/src/java/com/zimbra/cs/html/owasp/OwaspHtmlSanitizer.java
+++ b/store/src/java/com/zimbra/cs/html/owasp/OwaspHtmlSanitizer.java
@@ -18,15 +18,20 @@ package com.zimbra.cs.html.owasp;
 
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.Callable;
 
 import org.owasp.html.Handler;
 import org.owasp.html.HtmlSanitizer;
 import org.owasp.html.HtmlSanitizer.Policy;
-import org.owasp.html.HtmlStreamRenderer;
+import org.owasp.html.ExtensibleHtmlStreamRenderer;
 import org.owasp.html.PolicyFactory;
 
+import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.util.StringUtil;
+import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.html.owasp.policies.StyleTagReceiver;
 
 /*
@@ -40,41 +45,9 @@ public class OwaspHtmlSanitizer implements Callable<String> {
 
     public OwaspHtmlSanitizer(String html, boolean neuterImages, String vHost) {
         // fix to check open tags & remove
-        this.html = checkUnbalancedTags(html);
+        this.html = html;
         this.neuterImages = neuterImages;
         this.vHost = vHost;
-    }
-    
-    /** 
-     * A method to check & remove unbalanced tags which may have started, not ended
-     * 
-     * @return the Formatted Html after removing unbalanced tags
-     */
-    private String checkUnbalancedTags(String html) {
-        if (StringUtil.isNullOrEmpty(html)) {
-            return html;
-        }
-        ArrayList<String> tags = new ArrayList<String>();
-        // in tags array we can add multiple tags, so for each tag write start &
-        // end with a & separator like(<!--&-->)
-        tags.add("<!--&-->");
-        String formattedHtml = "";
-        for (String str : tags) {
-            String tagArr[] = str.split("&");
-            String start = tagArr[0];
-            String end = tagArr[1];
-            String[] arrOfStr = html.split(start);
-            for (String strAfterSplit : arrOfStr) {
-                 if (!strAfterSplit.equals("") && strAfterSplit.contains(end)) {
-                     formattedHtml = formattedHtml + start + strAfterSplit;
-                 } else {
-                     formattedHtml = formattedHtml + strAfterSplit;
-                 }
-            }
-            html = formattedHtml;
-            formattedHtml = "";
-        }
-        return html;
     }
 
     private PolicyFactory POLICY_DEFINITION;
@@ -100,8 +73,11 @@ public class OwaspHtmlSanitizer implements Callable<String> {
         }
         // create the builder into which the sanitized email will be written
         final StringBuilder htmlBuilder = new StringBuilder(html.length());
+
+        boolean zimbraStrictUnclosedCommentTag = LC.zimbra_strict_unclosed_comment_tag.booleanValue();
+        Set<String> zimbraSkipTagsWithUnclosedCdata = getSkipTagsUnclosedCdata();
         // create the renderer that will write the sanitized HTML to the builder
-        final HtmlStreamRenderer renderer = HtmlStreamRenderer.create(htmlBuilder,
+        final ExtensibleHtmlStreamRenderer renderer = ExtensibleHtmlStreamRenderer.create(htmlBuilder,
                 Handler.PROPAGATE,
                 // log errors resulting from exceptionally bizarre inputs
                 new Handler<String>() {
@@ -109,7 +85,7 @@ public class OwaspHtmlSanitizer implements Callable<String> {
             public void handle(final String x) {
                 throw new AssertionError(x);
             }
-        });
+        }, zimbraStrictUnclosedCommentTag, zimbraSkipTagsWithUnclosedCdata);
         // create a thread-specific policy
         instantiatePolicy();
         final Policy policy = POLICY_DEFINITION.apply(new StyleTagReceiver(renderer));
@@ -125,4 +101,14 @@ public class OwaspHtmlSanitizer implements Callable<String> {
         return sanitize();
     }
 
+    protected Set<String> getSkipTagsUnclosedCdata() {
+        Set<String> zimbraSkipTagsWithUnclosedCdata = new HashSet<>();
+        try {
+            zimbraSkipTagsWithUnclosedCdata = new HashSet<>(
+                    Arrays.asList(LC.zimbra_skip_tags_with_unclosed_cdata.value().toString().split(",")));
+        } catch (NullPointerException ex) {
+            ZimbraLog.mailbox.warn("Issue getting local config value of zimbra_skip_tags_with_unclosed_cdata ", ex);
+        }
+        return zimbraSkipTagsWithUnclosedCdata;
+    }
 }


### PR DESCRIPTION
Problem: When zimbra_use_owasp_html_sanitizer=true, then email wasn't showing up in web client

Issue: The issue was because when zimbra_use_owasp_html_sanitizer=true, OWASP sanitizes email i.e. tries to check all the opening comment tags and closing comment tags are closed. If either is being missed then it errors out email isn't formed properly and we don't see email content in ZWC

Solution: After discussion, we came to a point i.e. in HTML if there is any opening tag without a closing tag then we have included 2 local config 
zimbra_strict_unclosed_comment_tag = false
zimbra_skip_tags_unclosed_Cdata = style

If first is set to false, then there won't be strict checking for close tag and also zimbra_skip_tags_unclosed_Cdata is set to style(suspicious tag) we ignore it from rendering it in HTML

Scenarios and testing:
case1: Include some javascript code(I added calculator code) in mime && OWASP is false
--> In inspect the same code in the browser and "<!--" is seen. Although the chrome browser is smart enough to not render in email but shows up in Inspect tab.

case 2 : Include some javascript code(I added calculator code) in mime && OWASP is TRUE && Code modified to handle invalid scenario
--> In Inspect, the invalid tag is not visible and javascript code is not rendered when the closing tag is invalid. Hence we made is secure from vulnerabilities

Case 3: if anything is passed inside comment, OWASP set to true and zimbra_strict_unclosed_comment_tag = false
--> Email renders without throwing error

Case 3: if anything is passed inside comment, OWASP set to true and zimbra_strict_unclosed_comment_tag =true
--> Email has an issue and we expect strict checking for suspicious tags hence it fails to throw error and email doesn't show up

The available mimes of 2547 and 2478 show up properly when LC is set accordingly

OWASP PR: https://github.com/Zimbra/java-html-sanitizer-release-20190610.1/pull/9