### PR TITLE
ZCS-12030: [Backend] Provide ability to edit the added S3 bucket

### DIFF
--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -535,11 +535,11 @@ public final class AdminConstants {
     // Skins
     public static final String E_GET_ALL_SKINS_REQUEST = "GetAllSkinsRequest";
     public static final String E_GET_ALL_SKINS_RESPONSE = "GetAllSkinsResponse";
-    
+
     // Sending Emails
     public static final String E_SEND_MDM_NOTIFICATION_EMAIL_REQUEST = "SendMdmNotificationEmailRequest";
     public static final String E_SEND_MDM_NOTIFICATION_EMAIL_RESPONSE = "SendMdmNotificationEmailResponse";
-    
+
     // Active Sync
     public static final QName SEND_MDM_NOTIFICATION_EMAIL_REQUEST = QName.get(E_SEND_MDM_NOTIFICATION_EMAIL_REQUEST, NAMESPACE);
     public static final QName SEND_MDM_NOTIFICATION_EMAIL_RESPONSE = QName.get(E_SEND_MDM_NOTIFICATION_EMAIL_RESPONSE, NAMESPACE);
@@ -1594,12 +1594,16 @@ public final class AdminConstants {
     // Global External Store Config
     public static final String E_GET_S3_BUCKET_CONFIG_REQUEST = "GetS3BucketConfigRequest";
     public static final String E_GET_S3_BUCKET_CONFIG_RESPONSE = "GetS3BucketConfigResponse";
+    public static final String E_EDIT_S3_BUCKET_CONFIG_REQUEST = "EditS3BucketConfigRequest";
+    public static final String E_EDIT_S3_BUCKET_CONFIG_RESPONSE = "EditS3BucketConfigResponse";
     public static final String E_CREATE_S3_BUCKET_CONFIG_REQUEST = "CreateS3BucketConfigRequest";
     public static final String E_CREATE_S3_BUCKET_CONFIG_RESPONSE = "CreateS3BucketConfigResponse";
     public static final String E_DELETE_S3_BUCKET_CONFIG_REQUEST = "DeleteS3BucketConfigRequest";
     public static final String E_DELETE_S3_BUCKET_CONFIG_RESPONSE = "DeleteS3BucketConfigResponse";
     public static final QName GET_S3_BUCKET_CONFIG_REQUEST = QName.get(E_GET_S3_BUCKET_CONFIG_REQUEST, NAMESPACE);
     public static final QName GET_S3_BUCKET_CONFIG_RESPONSE = QName.get(E_GET_S3_BUCKET_CONFIG_RESPONSE, NAMESPACE);
+    public static final QName EDIT_S3_BUCKET_CONFIG_REQUEST = QName.get(E_EDIT_S3_BUCKET_CONFIG_REQUEST, NAMESPACE);;
+    public static final QName EDIT_S3_BUCKET_CONFIG_RESPONSE = QName.get(E_EDIT_S3_BUCKET_CONFIG_RESPONSE, NAMESPACE);
     public static final QName CREATE_S3_BUCKET_CONFIG_REQUEST = QName.get(E_CREATE_S3_BUCKET_CONFIG_REQUEST, NAMESPACE);
     public static final QName CREATE_S3_BUCKET_CONFIG_RESPONSE = QName.get(E_CREATE_S3_BUCKET_CONFIG_RESPONSE, NAMESPACE);
     public static final QName DELETE_S3_BUCKET_CONFIG_REQUEST = QName.get(E_DELETE_S3_BUCKET_CONFIG_REQUEST, NAMESPACE);
@@ -1610,7 +1614,7 @@ public final class AdminConstants {
     public static final String E_VALIDATE_S3_BUCKET_REACHABLE_RESPONSE = "ValidateS3BucketReachableResponse";
     public static final QName VALIDATE_S3_BUCKET_REACHABLE_REQUEST = QName.get(E_VALIDATE_S3_BUCKET_REACHABLE_REQUEST, NAMESPACE);
     public static final QName VALIDATE_S3_BUCKET_REACHABLE_RESPONSE = QName.get(E_VALIDATE_S3_BUCKET_REACHABLE_RESPONSE, NAMESPACE);
-    
+
     // Removed Zetras zimlet package list
     public static final List<String> ZEXTRAS_PACKAGES_LIST = Arrays.asList("com_ng_auth", "com_zextras_zextras",
             "com_zextras_client", "com_zimbra_connect_classic", "com_zimbra_connect_modern", "com_zextras_docs",

--- a/soap/src/java/com/zimbra/soap/JaxbUtil.java
+++ b/soap/src/java/com/zimbra/soap/JaxbUtil.java
@@ -1161,7 +1161,9 @@ public final class JaxbUtil {
             com.zimbra.soap.admin.message.DeleteS3BucketConfigRequest.class,
             com.zimbra.soap.admin.message.DeleteS3BucketConfigResponse.class,
             com.zimbra.soap.admin.message.ValidateS3BucketReachableRequest.class,
-            com.zimbra.soap.admin.message.ValidateS3BucketReachableResponse.class
+            com.zimbra.soap.admin.message.ValidateS3BucketReachableResponse.class,
+            com.zimbra.soap.admin.message.EditS3BucketConfigRequest.class,
+            com.zimbra.soap.admin.message.EditS3BucketConfigResponse.class
         };
 
         try {

--- a/soap/src/java/com/zimbra/soap/admin/message/EditS3BucketConfigRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/EditS3BucketConfigRequest.java
@@ -1,0 +1,39 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.soap.admin.type.AdminAttrsImpl;
+
+/**
+ * @zm-api-command-auth-required true
+ * @zm-api-command-admin-auth-required true
+ * @zm-api-command-description Edit S3 Bucket Config
+ */
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name = AdminConstants.E_EDIT_S3_BUCKET_CONFIG_REQUEST)
+public class EditS3BucketConfigRequest extends AdminAttrsImpl {
+
+    public EditS3BucketConfigRequest() {
+    }
+
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/EditS3BucketConfigResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/EditS3BucketConfigResponse.java
@@ -1,0 +1,39 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.soap.admin.type.AdminAttrsImpl;
+
+/**
+ * @zm-api-command-auth-required true
+ * @zm-api-command-admin-auth-required true
+ * @zm-api-command-description Edit S3 Bucket Config
+ */
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name = AdminConstants.E_EDIT_S3_BUCKET_CONFIG_RESPONSE)
+public class EditS3BucketConfigResponse extends AdminAttrsImpl {
+
+    public EditS3BucketConfigResponse() {
+    }
+
+}


### PR DESCRIPTION
Requirement: Provide the ability to edit the existing S3 bucket.
Solution: Added methods to validate new updated credentials and edit S3 bucket for following credentials via SoapUI as well as CLI:
- URL
- Access Key
- Secret key
- Region

Added supported Constants and EditS3BucketConfugRequest/Response files are created in zm-mailbox repo.
Link to another PR : [#37](https://github.com/Zimbra/zm-hsm-store/pull/37)

