### PR TITLE
ZCS-11957 : Adding getter method for emailAddress and timeStamp

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -17,18 +17,17 @@
 
 package com.zimbra.common.localconfig;
 
+import com.google.common.base.Strings;
+import com.zimbra.common.util.Constants;
+import com.zimbra.common.util.ZimbraLog;
+import org.dom4j.DocumentException;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-
-import org.dom4j.DocumentException;
-
-import com.google.common.base.Strings;
-import com.zimbra.common.util.Constants;
-import com.zimbra.common.util.ZimbraLog;
 
 /**
  * Provides convenient means to get at local configuration - stuff that we do
@@ -978,6 +977,10 @@ public final class LC {
     public static final KnownKey httpclient_soaphttptransport_retry_count = KnownKey.newKey(2);
     public static final KnownKey httpclient_soaphttptransport_so_timeout = KnownKey.newKey(300 * Constants.MILLIS_PER_SECOND);
     public static final KnownKey httpclient_soaphttptransport_keepalive_connections = KnownKey.newKey(true);
+    public static final KnownKey httpclient_internal_connmgr_mailbox_timeout = KnownKey.newKey(3 * Constants.MILLIS_PER_SECOND);
+    public static final KnownKey httpclient_mdm_devices_limit_per_server = KnownKey.newKey(50);
+    public static final KnownKey httpclient_mdm_devices_total_limit= KnownKey.newKey(500);
+
 
     /**
      * Bug: 47051 Known key for the CLI utilities SOAP HTTP transport timeout.

--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -16,10 +16,11 @@
  */
 package com.zimbra.common.soap;
 
-import java.util.Arrays;
-import java.util.List;
 import org.dom4j.Namespace;
 import org.dom4j.QName;
+
+import java.util.Arrays;
+import java.util.List;
 
 public final class AdminConstants {
 
@@ -535,16 +536,6 @@ public final class AdminConstants {
     // Skins
     public static final String E_GET_ALL_SKINS_REQUEST = "GetAllSkinsRequest";
     public static final String E_GET_ALL_SKINS_RESPONSE = "GetAllSkinsResponse";
-
-    // Sending Emails
-    public static final String E_SEND_MDM_NOTIFICATION_EMAIL_REQUEST = "SendMdmNotificationEmailRequest";
-    public static final String E_SEND_MDM_NOTIFICATION_EMAIL_RESPONSE = "SendMdmNotificationEmailResponse";
-
-    // Active Sync
-    public static final QName SEND_MDM_NOTIFICATION_EMAIL_REQUEST = QName.get(E_SEND_MDM_NOTIFICATION_EMAIL_REQUEST, NAMESPACE);
-    public static final QName SEND_MDM_NOTIFICATION_EMAIL_RESPONSE = QName.get(E_SEND_MDM_NOTIFICATION_EMAIL_RESPONSE, NAMESPACE);
-
-
     public static final QName PING_REQUEST = QName.get(E_PING_REQUEST, NAMESPACE);
     public static final QName PING_RESPONSE = QName.get(E_PING_RESPONSE, NAMESPACE);
     public static final QName CHECK_HEALTH_REQUEST = QName.get(E_CHECK_HEALTH_REQUEST, NAMESPACE);

--- a/common/src/java/com/zimbra/common/soap/SyncConstants.java
+++ b/common/src/java/com/zimbra/common/soap/SyncConstants.java
@@ -108,6 +108,7 @@ public final class SyncConstants {
     public static final String A_SHOWITEM = "showItems";
     public static final String A_OFFSET = "offset";
     public static final String A_LIMIT = "limit";
+    public static final String A_GET_ALL = "getAll";
     public static final String A_FILTERDEVICESBYAND = "filterDevicesByAnd";
     public static final String A_ADMIN = "Admin";
     public static final String A_USER = "User";

--- a/soap/src/java/com/zimbra/soap/admin/message/GetDeviceStatusRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/GetDeviceStatusRequest.java
@@ -283,11 +283,6 @@ public class GetDeviceStatusRequest {
         return this;
     }
 
-    public GetDeviceStatusRequest setNotificationEmail(Boolean notificationEmail){
-        this.notificationEmail = notificationEmail.toString();
-        return this;
-    }
-
     public void setDeviceSyncVersion(String deviceSyncVersion) {
         this.deviceSyncVersion = deviceSyncVersion;
     }

--- a/soap/src/java/com/zimbra/soap/admin/message/GetDeviceStatusRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/GetDeviceStatusRequest.java
@@ -17,19 +17,19 @@
 
 package com.zimbra.soap.admin.message;
 
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.SyncAdminConstants;
+import com.zimbra.common.soap.SyncConstants;
+import com.zimbra.soap.admin.type.CosSelector;
+import com.zimbra.soap.admin.type.DeviceId;
+import com.zimbra.soap.admin.type.DomainSelector;
+import com.zimbra.soap.type.AccountSelector;
+
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
-
-import com.zimbra.common.service.ServiceException;
-import com.zimbra.common.soap.AdminConstants;
-import com.zimbra.common.soap.SyncAdminConstants;
-import com.zimbra.common.soap.SyncConstants;
-import com.zimbra.soap.admin.type.DeviceId;
-import com.zimbra.soap.type.AccountSelector;
-import com.zimbra.common.soap.Element;
-import com.zimbra.soap.admin.type.DomainSelector;
-import com.zimbra.soap.admin.type.CosSelector;
 
 /**
  * @zm-api-command-network-edition
@@ -53,6 +53,13 @@ public class GetDeviceStatusRequest {
      */
     @XmlAttribute(name=SyncConstants.A_LIMIT /* limit */, required=false)
     private int limit = 0;
+
+    /**
+     * @zm-api-field-tag getAll
+     * @zm-api-field-description Indicates if the request needs to get all records for all matching conditions across mailbox servers without any limit
+     */
+    @XmlAttribute(name=SyncConstants.A_GET_ALL /* getAll */, required=false)
+    private String getAll = "false";
 
     /**
      * @zm-api-field-tag account
@@ -265,6 +272,20 @@ public class GetDeviceStatusRequest {
 
     public Boolean getFilterDevicesByAnd() throws ServiceException{
         return Element.parseBool(SyncConstants.A_FILTERDEVICESBYAND, filterDevicesByAnd);
+    }
+
+    public Boolean getAll() throws ServiceException{
+        return Element.parseBool(SyncConstants.A_GET_ALL, getAll);
+    }
+
+    public GetDeviceStatusRequest setAll(Boolean getAll){
+        this.getAll = getAll.toString();
+        return this;
+    }
+
+    public GetDeviceStatusRequest setNotificationEmail(Boolean notificationEmail){
+        this.notificationEmail = notificationEmail.toString();
+        return this;
     }
 
     public void setDeviceSyncVersion(String deviceSyncVersion) {

--- a/soap/src/java/com/zimbra/soap/admin/type/DeviceStatusInfo.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/DeviceStatusInfo.java
@@ -18,13 +18,13 @@
 package com.zimbra.soap.admin.type;
 
 import com.google.common.base.MoreObjects;
+import com.zimbra.common.soap.SyncConstants;
+import com.zimbra.soap.type.ZmBoolean;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
-
-import com.zimbra.common.soap.SyncConstants;
-import com.zimbra.soap.type.ZmBoolean;
 
 @XmlAccessorType(XmlAccessType.NONE)
 public class DeviceStatusInfo {
@@ -252,6 +252,8 @@ public class DeviceStatusInfo {
     public String getRecoveryPassword() { return recoveryPassword; }
     public String getLastUsedDate() { return lastUsedDate; }
     public String getUpdateTime() { return timestamp; }
+    public String getEmailAddress() { return emailAddress; }
+    public String getTimestamp() { return timestamp; }
 
     public MoreObjects.ToStringHelper addToStringInfo(
                 MoreObjects.ToStringHelper helper) {

--- a/store/src/java-test/com/zimbra/cs/datasource/SyncUtilTest.java
+++ b/store/src/java-test/com/zimbra/cs/datasource/SyncUtilTest.java
@@ -1,0 +1,12 @@
+package com.zimbra.cs.datasource;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+
+public class SyncUtilTest extends TestCase {
+
+    @Test
+    public void testSendReportEmail() {
+     assertEquals(true ,SyncUtil.sendReportEmail("test", "test", new String[]{"admin@platform-dev-abhishek.zimbradev.com"}));
+    }
+}

--- a/store/src/java/com/zimbra/cs/account/soap/SoapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/soap/SoapProvisioning.java
@@ -3251,7 +3251,7 @@ public class SoapProvisioning extends Provisioning {
                 .append(L10nUtil.getMessage(L10nUtil.MsgKey.sendMDMNotificationEmailHtmlTableOpen))
                 .append(L10nUtil.getMessage(L10nUtil.MsgKey.sendMDMNotificationEmailHtmlDeviceTableHeader));
 
-        GetDeviceStatusResponse resp = invokeJaxb(new GetDeviceStatusRequest(null, null, SyncAdminConstants.MDM_STATUS_SUSPENDED));
+        GetDeviceStatusResponse resp = invokeJaxb(new GetDeviceStatusRequest(null, null, SyncAdminConstants.MDM_STATUS_SUSPENDED).setAll(true));
         List<DeviceStatusInfo> statusOfDevices = resp.getDevices().stream()
                 .filter(devices -> DateTimeUtil.checkWithinTime(Timestamp.valueOf(devices.getUpdateTime()),
                         Long.parseLong(timeInterval), TimeUnit.MINUTES))

--- a/store/src/java/com/zimbra/cs/datasource/SyncUtil.java
+++ b/store/src/java/com/zimbra/cs/datasource/SyncUtil.java
@@ -197,7 +197,6 @@ public final class SyncUtil {
         } catch (MessagingException mex) {
             error = new MailSender.SafeMessagingException(mex);
         }
-
         if (error != null) {
             ZimbraLog.mailbox.warn("Unable to send notification report email to " + toStrs.toString() +
                             ", subject = " + subject,


### PR DESCRIPTION
Issue :- All users configured in devices are not shown on ABQ MDM UI in admin console. Only 1 node users are shown on ABQ MDM UI in admin console. For other node configured users, we need to search that user and then we can see.

Solution:-
Making multi server call and getting data from each server.
Collating limited data from each server to display on UI.
Added getter missing getter methods in DeviceStatusInfo