### PR TITLE
ZCS-11802 : Backend implementation to show exact Item Id in search response

### DIFF
--- a/common/src/java/com/zimbra/common/soap/MailConstants.java
+++ b/common/src/java/com/zimbra/common/soap/MailConstants.java
@@ -746,6 +746,7 @@ public final class MailConstants {
     public static final String A_PASSWORD = "pw";
     public static final String A_ACCESSKEY = "key";
     public static final String A_EXPIRY = "expiry";
+    public static final String A_SHARED_FILE_ID = "sfid";
 
     // account ACLs
     public static final String E_ACE = "ace";

--- a/store/src/java/com/zimbra/cs/service/mail/ToXML.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ToXML.java
@@ -3058,6 +3058,7 @@ throws ServiceException {
                 && doc.getOwnerFileId() != null) {
             m.addAttribute(MailConstants.A_ID, doc.getOwnerAccountId() + ":" + doc.getOwnerFileId()); // accountid:fileid
             m.addAttribute(MailConstants.A_RIGHTS, doc.getPermission());
+            m.addAttribute(MailConstants.A_SHARED_FILE_ID, doc.getId());
         } else {
             m.addAttribute(MailConstants.A_ID, ifmt.formatItemId(doc));
         }


### PR DESCRIPTION
Tcket : [ZCS-11802](https://jira.corp.synacor.com/browse/ZCS-11802)
Issue: Deleted/permanently deleted files remains visible in the "Files shared with me" folder
1)Basically when the Owner file is deleted the file remains available at the grantee's end. 
2)The issue also persisted when a folder is shared and the subsequent file is shared with another user, and when the main folder is deleted file would still be present

The PR https://github.com/Zimbra/zm-mailbox/pull/1410 basically solved issue 1 , but during code review we came across 2nd situation
Hence to solve this all at once, we will provide the grantee an option to delete the file from their end 
When the owner deleted the file, the grantee has that file. Grantee tries to view the file, he would get a 404 exception,in this exception scenario we would assume the file is no more accessible i.e. owner file is deleted and the user would be prompted with a warning message about the same and given the option to delete the file from his end as well.
this solves Issues 1 and 2

In this scenario, implementation would be from the UI end, and this PR provides the exact ID required to trigger "ItemActionRequest" with the trash/delete operation


