### PR TITLE
ZRFE-991: Add a Date header to Zimbra-generated mails.

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/Notification.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Notification.java
@@ -578,6 +578,7 @@ public class Notification implements LmtpCallback {
             out.setFrom(address);
             address = new JavaMailInternetAddress(destination);
             out.setRecipient(javax.mail.Message.RecipientType.TO, address);
+            out.setSentDate(new Date());
 
             String charset = getCharset(account, subject);
             out.setSubject(subject, charset);

--- a/store/src/java/com/zimbra/cs/service/util/SpamHandler.java
+++ b/store/src/java/com/zimbra/cs/service/util/SpamHandler.java
@@ -18,6 +18,7 @@
 package com.zimbra.cs.service.util;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -128,6 +129,7 @@ public class SpamHandler {
 
         out.setRecipient(javax.mail.Message.RecipientType.TO, sr.reportRecipient);
         out.setEnvelopeFrom(config.getSpamReportEnvelopeFrom());
+        out.setSentDate(new Date());
         out.setSubject(config.getSpamTrainingSubjectPrefix() + " " + sr.accountName + ": " + isSpamString);
         Transport.send(out);
 


### PR DESCRIPTION
Some mails generated by Zimbra lack a Date header, which violates RFC5322 (section 3.6, exactly one Date header is mandatory).