### PR TITLE
ZCS-11801 : Modifying file at grantee side doesn't update file size, time, new name and doesn't convert from .txt to .docx file format

### DIFF
--- a/soap/src/java/com/zimbra/soap/mail/message/FileSharedWithMeRequest.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/FileSharedWithMeRequest.java
@@ -98,11 +98,18 @@ public class FileSharedWithMeRequest {
     @XmlElement(name = MailConstants.A_REMOTE_ID, required = true)
     private String ownerAccountId;
 
+    /**
+     * @zm-api-field-tag date
+     * @zm-api-field-description Actual file modified date
+     */
+    @XmlElement(name = MailConstants.A_DATE, required = true)
+    private Long date;
+
     public FileSharedWithMeRequest() {
     }
 
     public FileSharedWithMeRequest(String action, String granteeId, String fileName, String ownerAccountId,
-            int ownerFileId, String fileUUID, String fileOwnerName, String rights, String contentType, long size) {
+            int ownerFileId, String fileUUID, String fileOwnerName, String rights, String contentType, long size, long date) {
         super();
         this.action = action;
         this.fileName = fileName;
@@ -113,6 +120,7 @@ public class FileSharedWithMeRequest {
         this.contentType = contentType;
         this.size = size;
         this.ownerAccountId = ownerAccountId;
+        this.date = date;
     }
 
     public String getAction() {
@@ -185,6 +193,14 @@ public class FileSharedWithMeRequest {
 
     public void setOwnerAccountId(String ownerAccountId) {
         this.ownerAccountId = ownerAccountId;
+    }
+
+    public Long getDate() {
+        return date;
+    }
+
+    public void setDate(Long date) {
+        this.date = date;
     }
 
 }

--- a/store/src/java/com/zimbra/cs/db/DbMailItem.java
+++ b/store/src/java/com/zimbra/cs/db/DbMailItem.java
@@ -1157,6 +1157,35 @@ public class DbMailItem {
             DbPool.closeStatement(stmt);
         }
     }
+    
+    public void updateSharedFile(MailItem item, Metadata metadata, String fileName, Long date, Long size) throws ServiceException {
+        String name = fileName.isEmpty() ? item.getName() : fileName;
+        checkNamingConstraint(mailbox, item.getFolderId(), name, item.getId());
+
+        DbConnection conn = mailbox.getOperationConnection();
+        PreparedStatement stmt = null;
+        try {
+            stmt = conn.prepareStatement("UPDATE " + getMailItemTableName(item)
+                    + " SET  date = ?, size = ? , name = ? , mod_metadata = ? , metadata = ?, "
+                    + "  change_date = ?, mod_content = ?" + " WHERE " + IN_THIS_MAILBOX_AND + "id = ?");
+            int pos = 1;
+            stmt.setInt(pos++, (int) (date / 1000));
+            stmt.setLong(pos++, size);
+            stmt.setString(pos++, name);
+            stmt.setInt(pos++, mailbox.getOperationChangeID());
+            stmt.setString(pos++, checkMetadataLength(metadata.toString()));
+            stmt.setInt(pos++, mailbox.getOperationTimestamp());
+            stmt.setInt(pos++, item.getSavedSequence());
+            pos = setMailboxId(stmt, mailbox, pos);
+            stmt.setInt(pos++, item.getId());
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            throw ServiceException.FAILURE("Failed to update item mbox = " + mailbox.getId() + ", id = " + item.getId(),
+                    e);
+        } finally {
+            DbPool.closeStatement(stmt);
+        }
+    }
 
     public static void saveBlobInfo(MailItem item) throws ServiceException {
         Mailbox mbox = item.getMailbox();

--- a/store/src/java/com/zimbra/cs/service/mail/FileSharedWithMe.java
+++ b/store/src/java/com/zimbra/cs/service/mail/FileSharedWithMe.java
@@ -35,14 +35,16 @@ public class FileSharedWithMe extends MailDocumentHandler implements Delegatable
     private static final String REVOKE = "revoke";
     private static final String EDIT = "edit";
     private static final String CREATE = "create";
+    private static final String DOCUMENT_REVISION = "createDocumentRevision";
 
     public Element handle(Element request, Map<String, Object> context) throws ServiceException {
         try {
             ZimbraSoapContext zsc = getZimbraSoapContext(context);
             String ownerAccountId = zsc.getAuthtokenAccountId();
             String granteeAccountID = zsc.getRequestedAccountId();
-            // Check in place so that API cannot be invoked directly
-            if (ownerAccountId.equals(granteeAccountID)) {
+            // check in place so that API cannot be invoked directly, second check for if
+            // call is from document revision
+            if (ownerAccountId.equals(granteeAccountID) && !DOCUMENT_REVISION.equals(zsc.getOriginalUserAgent())) {
                 ZimbraLog.mailbox.error("File sharer and grantee cannot be same", new Throwable("invalid request source"));
                 throw ServiceException.FAILURE("invalid request", new Throwable("invalid"));
             }
@@ -50,19 +52,20 @@ public class FileSharedWithMe extends MailDocumentHandler implements Delegatable
             Account account = getRequestedAccount(zsc);
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account, false);
 
-            String action = request.getAttribute(MailConstants.E_ACTION);
-            String fileName = request.getAttribute(MailConstants.A_CONTENT_FILENAME);
-            int ownerFileId = request.getAttributeInt(MailConstants.A_ITEMID);
-            String fileUUID = request.getAttribute(MailConstants.A_REMOTE_UUID);
-            String fileOwnerName = request.getAttribute(MailConstants.A_OWNER_NAME);
-            String rights = request.getAttribute(MailConstants.A_RIGHTS);
-            String contentType = request.getAttribute(MailConstants.A_CONTENT_TYPE);
+            String action = request.getAttribute(MailConstants.E_ACTION, "");
+            String fileName = request.getAttribute(MailConstants.A_CONTENT_FILENAME, "");
+            int ownerFileId = request.getAttributeInt(MailConstants.A_ITEMID, -1);
+            String fileUUID = request.getAttribute(MailConstants.A_REMOTE_UUID, "");
+            String fileOwnerName = request.getAttribute(MailConstants.A_OWNER_NAME, "");
+            String rights = request.getAttribute(MailConstants.A_RIGHTS, "");
+            String contentType = request.getAttribute(MailConstants.A_CONTENT_TYPE, "");
             // ZCS-11901: When A share's folder to B and B subsequent shares the file's from
             // A folder to C,
             // use actualOwnerAccountId i.e. accountId of A
             // this remains correct when file is shared from A to B , or from B to C
-            String actualOwnerAccountId = request.getAttribute(MailConstants.A_REMOTE_ID);
-            long size = request.getAttributeLong(MailConstants.A_SIZE);
+            String actualOwnerAccountId = request.getAttribute(MailConstants.A_REMOTE_ID, "");
+            long size = request.getAttributeLong(MailConstants.A_SIZE, -1);
+            long date = request.getAttributeLong(MailConstants.A_DATE, -1);
             Element response = zsc.createElement(MailConstants.FILE_SHARED_WITH_ME_RESPONSE);
             if (Provisioning.onLocalServer(account)) {
                 // if file is shared, this file should be available at receivers end
@@ -75,7 +78,7 @@ public class FileSharedWithMe extends MailDocumentHandler implements Delegatable
                 } // if file rights is changed, update file permission accordingly
                 else if (action != null && EDIT.equalsIgnoreCase(action)) {
                     mbox.updateFileSharedWithMe(mbox, octxt, actualOwnerAccountId, ownerFileId, fileUUID, fileOwnerName,
-                            contentType, rights, granteeAccountID);
+                            contentType, rights, granteeAccountID, fileName, date, size);
                 } else {
                     throw ServiceException.FAILURE("invalid request", new Throwable("invalid"));
                 }


### PR DESCRIPTION
Ticket: https://jira.corp.synacor.com/browse/ZCS-11801

Issue: Modifying file at grantee side doesn't update file size, time, new name and doesn't convert from .txt to .docx file format

Solution: 
.txt to .docx -> When file is shared, if file is in .txt format we need to convert it to .docx format and share.
Rename -> Update Item action request rename function , i.e. whenever file is renamed ACl object files should also be accordingly renamed
file size and time -> In this scenario whenever file revision is created we need to make sure updated file size and time is also updated at receiver end