### PR TITLE
Revert "ZCS-11491 - Changing default backup mode for Backup and Restore"

### DIFF
--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -2690,7 +2690,7 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
 </attr>
 
 <attr id="512" name="zimbraBackupMode" type="enum" value="Standard,Auto-Grouped" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited">
-  <globalConfigValue>Auto-Grouped</globalConfigValue>
+  <globalConfigValue>Standard</globalConfigValue>
   <desc>backup mode</desc>
 </attr>
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -5553,11 +5553,11 @@ public abstract class ZAttrConfig extends Entry {
      *
      * <p>Valid values: [Standard, Auto-Grouped]
      *
-     * @return zimbraBackupMode, or ZAttrProvisioning.BackupMode.Auto_Grouped if unset and/or has invalid value
+     * @return zimbraBackupMode, or ZAttrProvisioning.BackupMode.Standard if unset and/or has invalid value
      */
     @ZAttr(id=512)
     public ZAttrProvisioning.BackupMode getBackupMode() {
-        try { String v = getAttr(Provisioning.A_zimbraBackupMode, true, true); return v == null ? ZAttrProvisioning.BackupMode.Auto_Grouped : ZAttrProvisioning.BackupMode.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.BackupMode.Auto_Grouped; }
+        try { String v = getAttr(Provisioning.A_zimbraBackupMode, true, true); return v == null ? ZAttrProvisioning.BackupMode.Standard : ZAttrProvisioning.BackupMode.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.BackupMode.Standard; }
     }
 
     /**
@@ -5565,11 +5565,11 @@ public abstract class ZAttrConfig extends Entry {
      *
      * <p>Valid values: [Standard, Auto-Grouped]
      *
-     * @return zimbraBackupMode, or "Auto-Grouped" if unset
+     * @return zimbraBackupMode, or "Standard" if unset
      */
     @ZAttr(id=512)
     public String getBackupModeAsString() {
-        return getAttr(Provisioning.A_zimbraBackupMode, "Auto-Grouped", true);
+        return getAttr(Provisioning.A_zimbraBackupMode, "Standard", true);
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -3416,11 +3416,11 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * <p>Valid values: [Standard, Auto-Grouped]
      *
-     * @return zimbraBackupMode, or ZAttrProvisioning.BackupMode.Auto_Grouped if unset and/or has invalid value
+     * @return zimbraBackupMode, or ZAttrProvisioning.BackupMode.Standard if unset and/or has invalid value
      */
     @ZAttr(id=512)
     public ZAttrProvisioning.BackupMode getBackupMode() {
-        try { String v = getAttr(Provisioning.A_zimbraBackupMode, true, true); return v == null ? ZAttrProvisioning.BackupMode.Auto_Grouped : ZAttrProvisioning.BackupMode.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.BackupMode.Auto_Grouped; }
+        try { String v = getAttr(Provisioning.A_zimbraBackupMode, true, true); return v == null ? ZAttrProvisioning.BackupMode.Standard : ZAttrProvisioning.BackupMode.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.BackupMode.Standard; }
     }
 
     /**
@@ -3428,11 +3428,11 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * <p>Valid values: [Standard, Auto-Grouped]
      *
-     * @return zimbraBackupMode, or "Auto-Grouped" if unset
+     * @return zimbraBackupMode, or "Standard" if unset
      */
     @ZAttr(id=512)
     public String getBackupModeAsString() {
-        return getAttr(Provisioning.A_zimbraBackupMode, "Auto-Grouped", true);
+        return getAttr(Provisioning.A_zimbraBackupMode, "Standard", true);
     }
 
     /**


### PR DESCRIPTION
This reverts commit a715a0afc7a7590509a9caae9f4e7b306c0c8334.

Currently Backup method is set to auto-grouped. Based on feedback from support as per business requirement, the Backup method should be set to Standard.