### PR TITLE
ZCS-12547: added zimbraPrefSkin to GetDomainInfo

### DIFF
--- a/store/src/java/com/zimbra/cs/service/admin/GetDomainInfo.java
+++ b/store/src/java/com/zimbra/cs/service/admin/GetDomainInfo.java
@@ -59,7 +59,8 @@ public class GetDomainInfo extends AdminDocumentHandler {
             ZAttrProvisioning.A_zimbraSkinSecondaryColor,
             ZAttrProvisioning.A_zimbraSkinSelectionColor,
             ZAttrProvisioning.A_zimbraSkinFavicon,
-            ZAttrProvisioning.A_zimbraFeatureResetPasswordStatus);
+            ZAttrProvisioning.A_zimbraFeatureResetPasswordStatus,
+            ZAttrProvisioning.A_zimbraPrefSkin);
 
     @Override
     public Element handle(Element request, Map<String, Object> context) throws ServiceException {


### PR DESCRIPTION
**Problem:**
When accessing login page with the URL specified in zimbraVirtualHostname, zimbraPrefSkin of the domain is not applied on the login page.
For example, set skin and virtualhostname of a domain as follows
```
$ zmprov md domain2.dev.zimbra.com zimbraPrefSkin serenity zimbraVirtualHostname vdomain2.dev.zimbra.com
```
and access `https://vdomain2.dev.zimbra.com`, css or messages of serenity skin is not loaded. Instead, default skin defined in `zimbra.web.xml.in` is loaded.

**Change:**
Adding `zimbraPrefSkin` to `GetDomainInfo`.