### PR TITLE
ZBUG-3129 - adding LC config for ClamAV timeout and data chunk size

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -408,6 +408,11 @@ public final class LC {
     @Supported
     public static final KnownKey ldap_starttls_required = KnownKey.newKey(true);
 
+    @Reloadable
+    public static final KnownKey clamav_socket_timeout = KnownKey.newKey(2000);
+    @Reloadable
+    public static final KnownKey clamav_scan_data_chunk_size = KnownKey.newKey(2048);
+
     @Supported
     public static final KnownKey zimbra_directory_max_search_result = KnownKey.newKey(5000);
 


### PR DESCRIPTION
Adding LC config for ClamAV timeout and data chunk size