### PR TITLE
ZCS-12192 : Added constants for active sync - SendMail, SmartReply, SmartForward

### DIFF
--- a/common/src/java/com/zimbra/common/soap/SyncConstants.java
+++ b/common/src/java/com/zimbra/common/soap/SyncConstants.java
@@ -151,4 +151,10 @@ public final class SyncConstants {
     public static final Integer ITEMOPERATIONS_STATUS_CREDENTIALS_REQUIRED = 18;
     public static final Integer ITEMOPERATIONS_STATUS_ELEMENT_MISSING = 155;
     public static final Integer ITEMOPERATIONS_STATUS_ACTION_NOT_SUPPORTED = 156;
+
+    // ZimbraSync Commands
+    public static final String ZIMBRASYNC_CMD_SEND_MAIL = "SendMail";
+    public static final String ZIMBRASYNC_CMD_MOVE_ITEMS = "MoveItems";
+    public static final String ZIMBRASYNC_CMD_SMART_REPLY = "SmartReply";
+    public static final String ZIMBRASYNC_CMD_SMART_FORWARD = "SmartForward";
 }


### PR DESCRIPTION
Issue :- MailApp able to send mail after blocking via reply/forward of inbox mail..

Fix :- Added block check while reply/forward and send mail..

https://github.com/Zimbra/zm-sync-store/pull/101