### PR TITLE
ZCS-12478 : New Ldap attribute for Modern UI help URL - zimbraHelpModernURL

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -8142,7 +8142,17 @@ public class ZAttrProvisioning {
     public static final String A_zimbraHelpDelegatedURL = "zimbraHelpDelegatedURL";
 
     /**
-     * help URL for standard client
+     * Help URL for modern client
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4023)
+    public static final String A_zimbraHelpModernURL = "zimbraHelpModernURL";
+
+    /**
+     * Deprecated since: 11.0.0. Zimbra help standard URL has been deprecated
+     * because standard client is removed from the product. Orig desc: help
+     * URL for standard client
      *
      * @since ZCS 5.0.7
      */

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -3599,8 +3599,9 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
   <desc>help URL for advanced client</desc>
 </attr>
 
-<attr id="677" name="zimbraHelpStandardURL" type="string" max="256" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainInfo,domainAdminModifiable" since="5.0.7">
+<attr id="677" name="zimbraHelpStandardURL" type="string" max="256" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainInfo,domainAdminModifiable" since="5.0.7" deprecatedSince="11.0.0">
   <desc>help URL for standard client</desc>
+  <deprecateDesc>Zimbra help standard URL has been deprecated because standard client is removed from the product</deprecateDesc>
 </attr>
 
 <attr id="678" name="zimbraPrefAdvancedClientEnforceMinDisplay" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited,domainAdminModifiable" since="5.0.7">
@@ -10048,4 +10049,9 @@ TODO: delete them permanently from here
     indexing         - Generate index
   </desc>
 </attr>
+
+<attr id="4023" name="zimbraHelpModernURL" type="string" max="256" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainInfo,domainAdminModifiable" since="11.0.0">
+  <desc>Help URL for modern client</desc>
+</attr>
+
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -21282,7 +21282,81 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * help URL for standard client
+     * Help URL for modern client
+     *
+     * @return zimbraHelpModernURL, or null if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4023)
+    public String getHelpModernURL() {
+        return getAttr(Provisioning.A_zimbraHelpModernURL, null, true);
+    }
+
+    /**
+     * Help URL for modern client
+     *
+     * @param zimbraHelpModernURL new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4023)
+    public void setHelpModernURL(String zimbraHelpModernURL) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHelpModernURL, zimbraHelpModernURL);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Help URL for modern client
+     *
+     * @param zimbraHelpModernURL new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4023)
+    public Map<String,Object> setHelpModernURL(String zimbraHelpModernURL, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHelpModernURL, zimbraHelpModernURL);
+        return attrs;
+    }
+
+    /**
+     * Help URL for modern client
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4023)
+    public void unsetHelpModernURL() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHelpModernURL, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Help URL for modern client
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4023)
+    public Map<String,Object> unsetHelpModernURL(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHelpModernURL, "");
+        return attrs;
+    }
+
+    /**
+     * Deprecated since: 11.0.0. Zimbra help standard URL has been deprecated
+     * because standard client is removed from the product. Orig desc: help
+     * URL for standard client
      *
      * @return zimbraHelpStandardURL, or null if unset
      *
@@ -21294,7 +21368,9 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * help URL for standard client
+     * Deprecated since: 11.0.0. Zimbra help standard URL has been deprecated
+     * because standard client is removed from the product. Orig desc: help
+     * URL for standard client
      *
      * @param zimbraHelpStandardURL new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -21309,7 +21385,9 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * help URL for standard client
+     * Deprecated since: 11.0.0. Zimbra help standard URL has been deprecated
+     * because standard client is removed from the product. Orig desc: help
+     * URL for standard client
      *
      * @param zimbraHelpStandardURL new value
      * @param attrs existing map to populate, or null to create a new map
@@ -21325,7 +21403,9 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * help URL for standard client
+     * Deprecated since: 11.0.0. Zimbra help standard URL has been deprecated
+     * because standard client is removed from the product. Orig desc: help
+     * URL for standard client
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -21339,7 +21419,9 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * help URL for standard client
+     * Deprecated since: 11.0.0. Zimbra help standard URL has been deprecated
+     * because standard client is removed from the product. Orig desc: help
+     * URL for standard client
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -15083,7 +15083,81 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * help URL for standard client
+     * Help URL for modern client
+     *
+     * @return zimbraHelpModernURL, or null if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4023)
+    public String getHelpModernURL() {
+        return getAttr(Provisioning.A_zimbraHelpModernURL, null, true);
+    }
+
+    /**
+     * Help URL for modern client
+     *
+     * @param zimbraHelpModernURL new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4023)
+    public void setHelpModernURL(String zimbraHelpModernURL) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHelpModernURL, zimbraHelpModernURL);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Help URL for modern client
+     *
+     * @param zimbraHelpModernURL new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4023)
+    public Map<String,Object> setHelpModernURL(String zimbraHelpModernURL, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHelpModernURL, zimbraHelpModernURL);
+        return attrs;
+    }
+
+    /**
+     * Help URL for modern client
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4023)
+    public void unsetHelpModernURL() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHelpModernURL, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Help URL for modern client
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4023)
+    public Map<String,Object> unsetHelpModernURL(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHelpModernURL, "");
+        return attrs;
+    }
+
+    /**
+     * Deprecated since: 11.0.0. Zimbra help standard URL has been deprecated
+     * because standard client is removed from the product. Orig desc: help
+     * URL for standard client
      *
      * @return zimbraHelpStandardURL, or null if unset
      *
@@ -15095,7 +15169,9 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * help URL for standard client
+     * Deprecated since: 11.0.0. Zimbra help standard URL has been deprecated
+     * because standard client is removed from the product. Orig desc: help
+     * URL for standard client
      *
      * @param zimbraHelpStandardURL new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -15110,7 +15186,9 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * help URL for standard client
+     * Deprecated since: 11.0.0. Zimbra help standard URL has been deprecated
+     * because standard client is removed from the product. Orig desc: help
+     * URL for standard client
      *
      * @param zimbraHelpStandardURL new value
      * @param attrs existing map to populate, or null to create a new map
@@ -15126,7 +15204,9 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * help URL for standard client
+     * Deprecated since: 11.0.0. Zimbra help standard URL has been deprecated
+     * because standard client is removed from the product. Orig desc: help
+     * URL for standard client
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -15140,7 +15220,9 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * help URL for standard client
+     * Deprecated since: 11.0.0. Zimbra help standard URL has been deprecated
+     * because standard client is removed from the product. Orig desc: help
+     * URL for standard client
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs


### PR DESCRIPTION
Requirement of ticket [ZCS-12478](https://jira.corp.synacor.com/browse/ZCS-12478):
- A new Ldap attribute for Modern UI help URL is to be introduced i.e. zimbraHelpModernURL  for Zimbra 11 and cloud.
- Also deprecate zimbraHelpStandardURL for Zimbra 11

Solution:
- New attribute is added and its setters/getters are generated.
- In zimbraHelpStandardURL, depracted tag has been added.
