### PR TITLE
ZCS-12634: add ability to set domain-specific subject and body in domain aggregate quota warning message

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -2732,6 +2732,25 @@ public class ZAttrProvisioning {
     public static final String A_displayName = "displayName";
 
     /**
+     * A key in ZsMsg.properties for a body of a domain aggregate quota
+     * warning message. If it is not set, domainAggrQuotaWarnMsgBody is used.
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4025)
+    public static final String A_domainAggrQuotaWarnMsgBodyKey = "domainAggrQuotaWarnMsgBodyKey";
+
+    /**
+     * A key in ZsMsg.properties for a subject of a domain aggregate quota
+     * warning message. If it is not set, domainAggrQuotaWarnMsgSubject is
+     * used.
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4024)
+    public static final String A_domainAggrQuotaWarnMsgSubjectKey = "domainAggrQuotaWarnMsgSubjectKey";
+
+    /**
      * RFC2256: Facsimile (Fax) Telephone Number
      */
     @ZAttr(id=-1)

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10008,13 +10008,19 @@ TODO: delete them permanently from here
 <attr id="4020" name="zimbraServerExternalStoreConfig" type="string" cardinality="single" optionalIn="server" since="10.0.0">
   <desc>Server level external store config</desc>
 </attr>
+
 <attr id="4021" name="zimbraSMMultiReaderEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited"  since="10.0.0">
   <globalConfigValue>TRUE</globalConfigValue>
   <desc>Zimbra multiple reader StoreManagers enabled </desc>
 </attr>
+
 <attr id="4022" name="zimbraSMRuntimeSwitchEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited"  since="10.0.0">
   <globalConfigValue>TRUE</globalConfigValue>
   <desc>Zimbra StoreManager runtime switching enabled </desc>
+</attr>
+
+<attr id="4023" name="zimbraHelpModernURL" type="string" max="256" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainInfo,domainAdminModifiable" since="11.0.0">
+  <desc>Help URL for modern client</desc>
 </attr>
 
 <attr id="4024" name="domainAggrQuotaWarnMsgSubjectKey" type="string" cardinality="single" optionalIn="domain" since="11.0.0">
@@ -10023,6 +10029,11 @@ TODO: delete them permanently from here
 
 <attr id="4025" name="domainAggrQuotaWarnMsgBodyKey" type="string" cardinality="single" optionalIn="domain" since="11.0.0">
   <desc>A key in ZsMsg.properties for a body of a domain aggregate quota warning message. If it is not set, domainAggrQuotaWarnMsgBody is used.</desc>
+</attr>
+
+<attr id="4026" name="zimbraBlockEmailSendFromImapPop" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountInfo,accountCosDomainInherited" since="11.0.0">
+  <defaultCOSValue>FALSE</defaultCOSValue>
+  <desc>Block sending email from external email addresses.</desc>
 </attr>
 
 <attr id="9001" name="zimbraMailSieveScriptMaxSize" type="long" min="0" cardinality="single" requiredIn="globalConfig" optionalIn="account,cos,domain" flags="domainInfo,accountInfo,accountCosDomainInherited" since="11.0.0">
@@ -10057,14 +10068,4 @@ TODO: delete them permanently from here
     indexing         - Generate index
   </desc>
 </attr>
-
-<attr id="4023" name="zimbraHelpModernURL" type="string" max="256" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainInfo,domainAdminModifiable" since="11.0.0">
-  <desc>Help URL for modern client</desc>
-</attr>
-
-  <attr id="4026" name="zimbraBlockEmailSendFromImapPop" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountInfo,accountCosDomainInherited" since="11.0.0">
-    <defaultCOSValue>FALSE</defaultCOSValue>
-    <desc>Block sending email from external email addresses.</desc>
-  </attr>
-
 </attrs>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10017,6 +10017,14 @@ TODO: delete them permanently from here
   <desc>Zimbra StoreManager runtime switching enabled </desc>
 </attr>
 
+<attr id="4024" name="domainAggrQuotaWarnMsgSubjectKey" type="string" cardinality="single" optionalIn="domain" since="11.0.0">
+  <desc>A key in ZsMsg.properties for a subject of a domain aggregate quota warning message. If it is not set, domainAggrQuotaWarnMsgSubject is used.</desc>
+</attr>
+
+<attr id="4025" name="domainAggrQuotaWarnMsgBodyKey" type="string" cardinality="single" optionalIn="domain" since="11.0.0">
+  <desc>A key in ZsMsg.properties for a body of a domain aggregate quota warning message. If it is not set, domainAggrQuotaWarnMsgBody is used.</desc>
+</attr>
+
 <attr id="9001" name="zimbraMailSieveScriptMaxSize" type="long" min="0" cardinality="single" requiredIn="globalConfig" optionalIn="account,cos,domain" flags="domainInfo,accountInfo,accountCosDomainInherited" since="11.0.0">
   <globalConfigValue>0</globalConfigValue>
   <defaultCOSValue>0</defaultCOSValue>

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -164,6 +164,165 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
+     * A key in ZsMsg.properties for a body of a domain aggregate quota
+     * warning message. If it is not set, domainAggrQuotaWarnMsgBody is used.
+     *
+     * @return domainAggrQuotaWarnMsgBodyKey, or null if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4025)
+    public String getDomainAggrQuotaWarnMsgBodyKey() {
+        return getAttr(Provisioning.A_domainAggrQuotaWarnMsgBodyKey, null, true);
+    }
+
+    /**
+     * A key in ZsMsg.properties for a body of a domain aggregate quota
+     * warning message. If it is not set, domainAggrQuotaWarnMsgBody is used.
+     *
+     * @param domainAggrQuotaWarnMsgBodyKey new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4025)
+    public void setDomainAggrQuotaWarnMsgBodyKey(String domainAggrQuotaWarnMsgBodyKey) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_domainAggrQuotaWarnMsgBodyKey, domainAggrQuotaWarnMsgBodyKey);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * A key in ZsMsg.properties for a body of a domain aggregate quota
+     * warning message. If it is not set, domainAggrQuotaWarnMsgBody is used.
+     *
+     * @param domainAggrQuotaWarnMsgBodyKey new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4025)
+    public Map<String,Object> setDomainAggrQuotaWarnMsgBodyKey(String domainAggrQuotaWarnMsgBodyKey, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_domainAggrQuotaWarnMsgBodyKey, domainAggrQuotaWarnMsgBodyKey);
+        return attrs;
+    }
+
+    /**
+     * A key in ZsMsg.properties for a body of a domain aggregate quota
+     * warning message. If it is not set, domainAggrQuotaWarnMsgBody is used.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4025)
+    public void unsetDomainAggrQuotaWarnMsgBodyKey() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_domainAggrQuotaWarnMsgBodyKey, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * A key in ZsMsg.properties for a body of a domain aggregate quota
+     * warning message. If it is not set, domainAggrQuotaWarnMsgBody is used.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4025)
+    public Map<String,Object> unsetDomainAggrQuotaWarnMsgBodyKey(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_domainAggrQuotaWarnMsgBodyKey, "");
+        return attrs;
+    }
+
+    /**
+     * A key in ZsMsg.properties for a subject of a domain aggregate quota
+     * warning message. If it is not set, domainAggrQuotaWarnMsgSubject is
+     * used.
+     *
+     * @return domainAggrQuotaWarnMsgSubjectKey, or null if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4024)
+    public String getDomainAggrQuotaWarnMsgSubjectKey() {
+        return getAttr(Provisioning.A_domainAggrQuotaWarnMsgSubjectKey, null, true);
+    }
+
+    /**
+     * A key in ZsMsg.properties for a subject of a domain aggregate quota
+     * warning message. If it is not set, domainAggrQuotaWarnMsgSubject is
+     * used.
+     *
+     * @param domainAggrQuotaWarnMsgSubjectKey new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4024)
+    public void setDomainAggrQuotaWarnMsgSubjectKey(String domainAggrQuotaWarnMsgSubjectKey) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_domainAggrQuotaWarnMsgSubjectKey, domainAggrQuotaWarnMsgSubjectKey);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * A key in ZsMsg.properties for a subject of a domain aggregate quota
+     * warning message. If it is not set, domainAggrQuotaWarnMsgSubject is
+     * used.
+     *
+     * @param domainAggrQuotaWarnMsgSubjectKey new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4024)
+    public Map<String,Object> setDomainAggrQuotaWarnMsgSubjectKey(String domainAggrQuotaWarnMsgSubjectKey, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_domainAggrQuotaWarnMsgSubjectKey, domainAggrQuotaWarnMsgSubjectKey);
+        return attrs;
+    }
+
+    /**
+     * A key in ZsMsg.properties for a subject of a domain aggregate quota
+     * warning message. If it is not set, domainAggrQuotaWarnMsgSubject is
+     * used.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4024)
+    public void unsetDomainAggrQuotaWarnMsgSubjectKey() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_domainAggrQuotaWarnMsgSubjectKey, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * A key in ZsMsg.properties for a subject of a domain aggregate quota
+     * warning message. If it is not set, domainAggrQuotaWarnMsgSubject is
+     * used.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4024)
+    public Map<String,Object> unsetDomainAggrQuotaWarnMsgSubjectKey(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_domainAggrQuotaWarnMsgSubjectKey, "");
+        return attrs;
+    }
+
+    /**
      * Zimbra access control list
      *
      * @return zimbraACE, or empty array if unset

--- a/store/src/java/com/zimbra/cs/service/admin/ComputeAggregateQuotaUsage.java
+++ b/store/src/java/com/zimbra/cs/service/admin/ComputeAggregateQuotaUsage.java
@@ -39,6 +39,7 @@ import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.SoapHttpTransport;
 import com.zimbra.common.util.ArrayUtil;
 import com.zimbra.common.util.L10nUtil;
+import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Domain;
 import com.zimbra.cs.account.Provisioning;
@@ -153,9 +154,17 @@ public class ComputeAggregateQuotaUsage extends AdminDocumentHandler {
 
                     // using default locale since not sure which locale to pick
                     Locale locale = Locale.getDefault();
-                    out.setSubject(L10nUtil.getMessage(L10nUtil.MsgKey.domainAggrQuotaWarnMsgSubject, locale));
+                    String subjectKey = domain.getDomainAggrQuotaWarnMsgSubjectKey();
+                    if (StringUtil.isNullOrEmpty(subjectKey)) {
+                        subjectKey = L10nUtil.MsgKey.domainAggrQuotaWarnMsgSubject.toString();
+                    }
+                    out.setSubject(L10nUtil.getMessage(subjectKey, locale));
 
-                    out.setText(L10nUtil.getMessage(L10nUtil.MsgKey.domainAggrQuotaWarnMsgBody, locale,
+                    String bodyKey = domain.getDomainAggrQuotaWarnMsgBodyKey();
+                    if (StringUtil.isNullOrEmpty(bodyKey)) {
+                        bodyKey = L10nUtil.MsgKey.domainAggrQuotaWarnMsgBody.toString();
+                    }
+                    out.setText(L10nUtil.getMessage(bodyKey, locale,
                             domain.getName(),
                             domain.getAggregateQuotaLastUsage() / 1024.0 / 1024.0,
                             domain.getDomainAggregateQuotaWarnPercent(),


### PR DESCRIPTION
**Enhancement:**
Add an ability to set domain-specific subject and body in domain aggregate quota warning message.

**Changes:**
* adding new ldap attributes `domainAggrQuotaWarnMsgSubjectKey` and `domainAggrQuotaWarnMsgBodyKey` for a domain
* modifying ComputeAggregateQuotaUsage to use the custom key(s) if it is set.

**Usage:**
1. Add custom keys for subject and body of a domain aggregate quota warning message for a domain. For example,
```
$ diff -c ZsMsg.properties.original ZsMsg.properties
*** ZsMsg.properties.original   2022-12-07 11:20:42.395405534 +0900
--- ZsMsg.properties    2022-12-07 11:21:20.989016621 +0900
***************
*** 333,338 ****
--- 333,340 ----
  #

  domainAggrQuotaWarnMsgSubject = Domain aggregate quota warning
+ domainAggrQuotaWarnMsgSubjectForDomain1 = Custom Subject - Domain aggregate quota warning
+
  # {0} = domain name
  # {1} = domain aggregate quota usage
  # {2} = domain aggregate quota warn percentage
***************
*** 340,345 ****
--- 342,351 ----
  domainAggrQuotaWarnMsgBody =\
    Aggregate quota usage for domain {0} has reached {1}MB, which is over {2}% of the {3}MB maximum aggregate quota.\n\
    Appropriate steps should be taken to prevent exceeding the maximum aggregate quota.
+ domainAggrQuotaWarnMsgBodyForDomain1 =\
+   Custom message \
+   Aggregate quota usage for domain {0} has reached {1}MB, which is over {2}% of the {3}MB maximum aggregate quota.\n\
+   Appropriate steps should be taken to prevent exceeding the maximum aggregate quota.

  # errors
```
2. Restart mailboxd
3. Set the keys to the ldap attributes
```
$ zmprov md DOMAIN domainAggrQuotaWarnMsgSubjectKey domainAggrQuotaWarnMsgSubjectForDomain1 domainAggrQuotaWarnMsgBodyKey domainAggrQuotaWarnMsgBodyForDomain1
```
4. Run FlushCache
```
$ zmprov fc domain
or 
$ zmprov fc -a domain
```