### PR TITLE
ZCS-12482:Adding a new LDAP attribute - zimbraBlockEmailSendFromImapPop

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -4206,6 +4206,14 @@ public class ZAttrProvisioning {
     public static final String A_zimbraBatchedIndexingSize = "zimbraBatchedIndexingSize";
 
     /**
+     * Block sending email from external email addresses.
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4026)
+    public static final String A_zimbraBlockEmailSendFromImapPop = "zimbraBlockEmailSendFromImapPop";
+
+    /**
      * alternate location for calendar and task folders
      *
      * @since ZCS 5.0.6

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10054,4 +10054,9 @@ TODO: delete them permanently from here
   <desc>Help URL for modern client</desc>
 </attr>
 
+  <attr id="4026" name="zimbraBlockEmailSendFromImapPop" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountInfo,accountCosDomainInherited" since="11.0.0">
+    <defaultCOSValue>FALSE</defaultCOSValue>
+    <desc>Block sending email from external email addresses.</desc>
+  </attr>
+
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -5734,6 +5734,78 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * Block sending email from external email addresses.
+     *
+     * @return zimbraBlockEmailSendFromImapPop, or false if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4026)
+    public boolean isBlockEmailSendFromImapPop() {
+        return getBooleanAttr(Provisioning.A_zimbraBlockEmailSendFromImapPop, false, true);
+    }
+
+    /**
+     * Block sending email from external email addresses.
+     *
+     * @param zimbraBlockEmailSendFromImapPop new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4026)
+    public void setBlockEmailSendFromImapPop(boolean zimbraBlockEmailSendFromImapPop) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBlockEmailSendFromImapPop, zimbraBlockEmailSendFromImapPop ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Block sending email from external email addresses.
+     *
+     * @param zimbraBlockEmailSendFromImapPop new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4026)
+    public Map<String,Object> setBlockEmailSendFromImapPop(boolean zimbraBlockEmailSendFromImapPop, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBlockEmailSendFromImapPop, zimbraBlockEmailSendFromImapPop ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Block sending email from external email addresses.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4026)
+    public void unsetBlockEmailSendFromImapPop() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBlockEmailSendFromImapPop, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Block sending email from external email addresses.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4026)
+    public Map<String,Object> unsetBlockEmailSendFromImapPop(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBlockEmailSendFromImapPop, "");
+        return attrs;
+    }
+
+    /**
      * COS zimbraID
      *
      * @return zimbraCOSId, or null if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -2187,6 +2187,78 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * Block sending email from external email addresses.
+     *
+     * @return zimbraBlockEmailSendFromImapPop, or false if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4026)
+    public boolean isBlockEmailSendFromImapPop() {
+        return getBooleanAttr(Provisioning.A_zimbraBlockEmailSendFromImapPop, false, true);
+    }
+
+    /**
+     * Block sending email from external email addresses.
+     *
+     * @param zimbraBlockEmailSendFromImapPop new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4026)
+    public void setBlockEmailSendFromImapPop(boolean zimbraBlockEmailSendFromImapPop) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBlockEmailSendFromImapPop, zimbraBlockEmailSendFromImapPop ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Block sending email from external email addresses.
+     *
+     * @param zimbraBlockEmailSendFromImapPop new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4026)
+    public Map<String,Object> setBlockEmailSendFromImapPop(boolean zimbraBlockEmailSendFromImapPop, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBlockEmailSendFromImapPop, zimbraBlockEmailSendFromImapPop ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Block sending email from external email addresses.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4026)
+    public void unsetBlockEmailSendFromImapPop() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBlockEmailSendFromImapPop, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Block sending email from external email addresses.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4026)
+    public Map<String,Object> unsetBlockEmailSendFromImapPop(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBlockEmailSendFromImapPop, "");
+        return attrs;
+    }
+
+    /**
      * CalDAV shared folder cache duration. Must be in valid duration format:
      * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
      * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -4756,6 +4756,78 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
+     * Block sending email from external email addresses.
+     *
+     * @return zimbraBlockEmailSendFromImapPop, or false if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4026)
+    public boolean isBlockEmailSendFromImapPop() {
+        return getBooleanAttr(Provisioning.A_zimbraBlockEmailSendFromImapPop, false, true);
+    }
+
+    /**
+     * Block sending email from external email addresses.
+     *
+     * @param zimbraBlockEmailSendFromImapPop new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4026)
+    public void setBlockEmailSendFromImapPop(boolean zimbraBlockEmailSendFromImapPop) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBlockEmailSendFromImapPop, zimbraBlockEmailSendFromImapPop ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Block sending email from external email addresses.
+     *
+     * @param zimbraBlockEmailSendFromImapPop new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4026)
+    public Map<String,Object> setBlockEmailSendFromImapPop(boolean zimbraBlockEmailSendFromImapPop, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBlockEmailSendFromImapPop, zimbraBlockEmailSendFromImapPop ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Block sending email from external email addresses.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4026)
+    public void unsetBlockEmailSendFromImapPop() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBlockEmailSendFromImapPop, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Block sending email from external email addresses.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4026)
+    public Map<String,Object> unsetBlockEmailSendFromImapPop(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBlockEmailSendFromImapPop, "");
+        return attrs;
+    }
+
+    /**
      * list of disabled fields in calendar location web UI
      *
      * @return zimbraCalendarLocationDisabledFields, or null if unset


### PR DESCRIPTION
Requirement of ticket  [ZCS-12482](https://jira.corp.synacor.com/browse/ZCS-12482):

> New Ldap attribute to block sending email from external email addresses i.e zimbraBlockEmailSendFromImapPop for Zimbra 11

Solution:
> New attribute is added and its setters/getters are generated.