### PR TITLE
ZCS-12478: Getting LDAP attr zimbraHelpModernURL in the response of ClientInfo API

### DIFF
--- a/store/src/java/com/zimbra/cs/service/account/ClientInfo.java
+++ b/store/src/java/com/zimbra/cs/service/account/ClientInfo.java
@@ -58,6 +58,7 @@ public class ClientInfo extends AccountDocumentHandler {
             ToXML.encodeAttr(parent, Provisioning.A_zimbraWebClientLoginURL, domain.getWebClientLoginURL());
             ToXML.encodeAttr(parent, Provisioning.A_zimbraWebClientLogoutURL, webClientLogoutURL);
             ToXML.encodeAttr(parent, Provisioning.A_zimbraWebClientStaySignedInDisabled, String.valueOf(domain.isWebClientStaySignedInDisabled()));
+            ToXML.encodeAttr(parent, Provisioning.A_zimbraHelpModernURL, domain.getHelpModernURL());
             // TODO: ZCS-11319 update this line to read from LDAP property once this is moved out of LC.
             // e.g. change the `split(LC.web_client_logoff_..)` -> `domain.getWebClientLogoffURLs()`
             encodeAttrSkipLogoff(parent, webClientLogoutURL, StringUtils.split(LC.zimbra_web_client_logoff_urls.value()));


### PR DESCRIPTION
Requirement of ticket [ZCS-12478](https://jira.corp.synacor.com/browse/ZCS-12478):

Requirement: The values of LDAP attribute zimbraHelpModernURL needs to be fetched in ClientInfo API.

Note: This LDAP attribute was added in PR [#1424](https://github.com/Zimbra/zm-mailbox/pull/1424) and due to frontend requirement of ticket [PSXMAIL-954](https://jira.corp.synacor.com/browse/PSXMAIL-954.), in modern UI the value needs to be fetched from the response of ClientInfo API as getDomainInfo API is not called in Modern UI.

