### PR TITLE
ZCS-12704: adding mechanism to notify extension

### DIFF
--- a/store/src/java/com/zimbra/cs/extension/ZimbraExtensionNotification.java
+++ b/store/src/java/com/zimbra/cs/extension/ZimbraExtensionNotification.java
@@ -1,0 +1,78 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.extension;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.StringUtil;
+import com.zimbra.common.util.ZimbraLog;
+
+public abstract class ZimbraExtensionNotification {
+
+    private static Map<String, ZimbraExtensionNotification> mHandlers;
+
+    /*
+     * Register a handler for a notification.
+     * Only a single handler can be registered on each notification ID.
+     *
+     * It should be invoked from the init() method of ZimbraExtension.
+     */
+    public synchronized static final void register(String notificationId, ZimbraExtensionNotification handler) {
+        if (mHandlers == null) {
+            mHandlers = new HashMap<String, ZimbraExtensionNotification>();
+        }
+        ZimbraExtensionNotification obj = getHandler(notificationId);
+        if (obj != null) {
+            ZimbraLog.extensions.warn("handler for " + notificationId + " is already registered, " +
+                                   "registering of " + obj.getClass().getCanonicalName() + " is ignored");
+            return;
+        }
+        mHandlers.put(notificationId, handler);
+    }
+
+    public synchronized static final void unregister(String notificationId) {
+        if (!StringUtil.isNullOrEmpty(notificationId)) {
+            mHandlers.remove(notificationId);
+        }
+    }
+
+    private static final ZimbraExtensionNotification getHandler(String notificationId) {
+        if (mHandlers == null || StringUtil.isNullOrEmpty(notificationId)) {
+            return null;
+        } else {
+            return mHandlers.get(notificationId);
+        }
+    }
+
+    /*
+     * It is responsible for an extension to make thread-safe process
+     */
+    public static final void notifyExtension(String notificationId, Object ... obj) throws ServiceException {
+        ZimbraExtensionNotification handler = getHandler(notificationId);
+        if (handler != null) {
+            handler.execute(obj);
+        }
+    }
+
+    /*
+     * It is responsible for an extension to cast a parameter to a right class
+     */
+    public abstract void execute(Object[] args) throws ServiceException;
+}

--- a/store/src/java/com/zimbra/cs/service/account/Auth.java
+++ b/store/src/java/com/zimbra/cs/service/account/Auth.java
@@ -20,6 +20,8 @@
  */
 package com.zimbra.cs.service.account;
 
+import io.jsonwebtoken.Claims;
+
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -64,6 +66,7 @@ import com.zimbra.cs.account.auth.twofactor.TrustedDevices;
 import com.zimbra.cs.account.auth.twofactor.TwoFactorAuth;
 import com.zimbra.cs.account.krb5.Krb5Principal;
 import com.zimbra.cs.account.names.NameUtil.EmailAddress;
+import com.zimbra.cs.extension.ZimbraExtensionNotification;
 import com.zimbra.cs.listeners.AuthListener;
 import com.zimbra.cs.service.AuthProvider;
 import com.zimbra.cs.service.util.JWTUtil;
@@ -75,8 +78,6 @@ import com.zimbra.cs.util.SkinUtil;
 import com.zimbra.soap.SoapEngine;
 import com.zimbra.soap.SoapServlet;
 import com.zimbra.soap.ZimbraSoapContext;
-
-import io.jsonwebtoken.Claims;
 
 /**
  * @author schemers
@@ -117,6 +118,8 @@ public class Auth extends AccountDocumentHandler {
             }
             acct = prov.get(acctBy, acctValue);
         }
+
+        ZimbraExtensionNotification.notifyExtension("com.zimbra.cs.service.account.Auth:validate", request, context);
 
         TrustedDeviceToken trustedToken = null;
         if (acct != null) {
@@ -435,7 +438,7 @@ public class Auth extends AccountDocumentHandler {
         if (jwtElem != null && authElem != null) {
             ZimbraLog.account.debug("both jwt and auth element can not be present in auth request");
             return Boolean.FALSE;
-        } 
+        }
         if (jwtElem == null && authElem != null && TokenType.JWT.equals(tokenType)) {
             ZimbraLog.account.debug("jwt token type not supported with auth element");
             return Boolean.FALSE;


### PR DESCRIPTION
**Enhancement:**
* Add an ability to insert a process into an existing code using extension framework to achieve more flexible customization.
* Add `ZimbraExtensionNotification.notifyExtension` to `Auth.java` (both account and admin) so that a custom validation can be added.

**Approach:**
* add a mechanism to call a extension handler with a notification ID and necessary parameters.
* an extension registers a handler for a notification.
  For example,
    * `handler1` is registered for `notif-id-A`
    * when a process (`process1`) calls `ZimbraExtensionNotification#notifyExtension("notif-ID-A", param1, param2, ..., paramN)`, `handler1#execute` is called. All parameters are passed to `handler1#execute` as `Object[]`.
    * In `handler1#execute` process, parameter(s) need to be casted to right class(es). After that, any process can be executed.
    * After the process of `handler1#execute` is completed, `process1` is resumed.
* If no handler has been registered for a specified notification ID, nothing happens.
* Only a single handler can be registered for each notification ID.
* It is responsible for an extension to cast parameters to right classes.
* It is responsible for an extension to make thread-safe process.
* `notifyExtension` is not Asynchronous; wait for completion of handler's process
* The approach is similar to `appCtxt.notifyZimlets` on Classic UI.

**Sample extension to handle a notification:**
* https://github.com/Zimbra/zm-notification-handler-ext-example/pull/1