### PR TITLE
ZCS-12712: added ldap attributes for domain-specific login page

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -6059,6 +6059,46 @@ public class ZAttrProvisioning {
     public static final String A_zimbraDomainInheritedAttr = "zimbraDomainInheritedAttr";
 
     /**
+     * Whether to load a domain-specific login page without redirection.
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4027)
+    public static final String A_zimbraDomainLoginPageEnabled = "zimbraDomainLoginPageEnabled";
+
+    /**
+     * File path for error of domain-specific login page. If domain settings
+     * cannot be fetched, the file specified in
+     * zimbraDomainLoginPageErrorPath is loaded without redirection. It is
+     * ignored when zimbraDomainLoginPageEnabled is not TRUE.
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4030)
+    public static final String A_zimbraDomainLoginPageErrorPath = "zimbraDomainLoginPageErrorPath";
+
+    /**
+     * File path for fallback of domain-specific login page. If
+     * zimbraLoginFilePath is empty, the file specified in
+     * zimbraDomainLoginPageFallbackPath is loaded without redirection. It is
+     * ignored when zimbraDomainLoginPageEnabled is not TRUE.
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4029)
+    public static final String A_zimbraDomainLoginPageFallbackPath = "zimbraDomainLoginPageFallbackPath";
+
+    /**
+     * File path of domain-specific login page. If it is not empty, the
+     * specified file is loaded in login page without redirection. It is
+     * ignored when zimbraDomainLoginPageEnabled is not TRUE.
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4028)
+    public static final String A_zimbraDomainLoginPagePath = "zimbraDomainLoginPagePath";
+
+    /**
      * enable domain mandatory mail signature
      *
      * @since ZCS 6.0.4

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10036,6 +10036,32 @@ TODO: delete them permanently from here
   <desc>Block sending email from external email addresses.</desc>
 </attr>
 
+<attr id="4027" name="zimbraDomainLoginPageEnabled" type="boolean" cardinality="single" optionalIn="globalConfig" since="11.0.0">
+  <globalConfigValue>FALSE</globalConfigValue>
+  <desc>Whether to load a domain-specific login page without redirection.</desc>
+</attr>
+
+<attr id="4028" name="zimbraDomainLoginPagePath" type="string" max="256" cardinality="single" optionalIn="domain" flags="domainInfo" since="11.0.0">
+  <desc>File path of domain-specific login page.
+        If it is not empty, the specified file is loaded in login page without redirection.
+        It is ignored when zimbraDomainLoginPageEnabled is not TRUE.
+  </desc>
+</attr>
+
+<attr id="4029" name="zimbraDomainLoginPageFallbackPath" type="string" max="256" cardinality="single" optionalIn="domain" flags="domainInfo" since="11.0.0">
+  <desc>File path for fallback of domain-specific login page.
+        If zimbraLoginFilePath is empty, the file specified in zimbraDomainLoginPageFallbackPath is loaded without redirection.
+        It is ignored when zimbraDomainLoginPageEnabled is not TRUE.
+  </desc>
+</attr>
+
+<attr id="4030" name="zimbraDomainLoginPageErrorPath" type="string" max="256" cardinality="single" optionalIn="globalConfig" since="11.0.0">
+  <desc>File path for error of domain-specific login page.
+        If domain settings cannot be fetched, the file specified in zimbraDomainLoginPageErrorPath is loaded without redirection.
+        It is ignored when zimbraDomainLoginPageEnabled is not TRUE.
+  </desc>
+</attr>
+
 <attr id="4031" name="zimbraFeatureModernChatEnabled" type="boolean" callback="ModernChatVideoEnabled" cardinality="single" optionalIn="account,cos,domain" flags="accountInfo,domainInfo,domainAdminModifiable,accountCosDomainInherited" since="11.0.0">
   <defaultCOSValue>FALSE</defaultCOSValue>
   <desc>Whether Chat feature is enabled or not</desc>
@@ -10078,5 +10104,4 @@ TODO: delete them permanently from here
     indexing         - Generate index
   </desc>
 </attr>
-
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -15742,6 +15742,165 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Whether to load a domain-specific login page without redirection.
+     *
+     * @return zimbraDomainLoginPageEnabled, or false if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4027)
+    public boolean isDomainLoginPageEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraDomainLoginPageEnabled, false, true);
+    }
+
+    /**
+     * Whether to load a domain-specific login page without redirection.
+     *
+     * @param zimbraDomainLoginPageEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4027)
+    public void setDomainLoginPageEnabled(boolean zimbraDomainLoginPageEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDomainLoginPageEnabled, zimbraDomainLoginPageEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to load a domain-specific login page without redirection.
+     *
+     * @param zimbraDomainLoginPageEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4027)
+    public Map<String,Object> setDomainLoginPageEnabled(boolean zimbraDomainLoginPageEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDomainLoginPageEnabled, zimbraDomainLoginPageEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether to load a domain-specific login page without redirection.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4027)
+    public void unsetDomainLoginPageEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDomainLoginPageEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to load a domain-specific login page without redirection.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4027)
+    public Map<String,Object> unsetDomainLoginPageEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDomainLoginPageEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * File path for error of domain-specific login page. If domain settings
+     * cannot be fetched, the file specified in
+     * zimbraDomainLoginPageErrorPath is loaded without redirection. It is
+     * ignored when zimbraDomainLoginPageEnabled is not TRUE.
+     *
+     * @return zimbraDomainLoginPageErrorPath, or null if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4030)
+    public String getDomainLoginPageErrorPath() {
+        return getAttr(Provisioning.A_zimbraDomainLoginPageErrorPath, null, true);
+    }
+
+    /**
+     * File path for error of domain-specific login page. If domain settings
+     * cannot be fetched, the file specified in
+     * zimbraDomainLoginPageErrorPath is loaded without redirection. It is
+     * ignored when zimbraDomainLoginPageEnabled is not TRUE.
+     *
+     * @param zimbraDomainLoginPageErrorPath new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4030)
+    public void setDomainLoginPageErrorPath(String zimbraDomainLoginPageErrorPath) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDomainLoginPageErrorPath, zimbraDomainLoginPageErrorPath);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * File path for error of domain-specific login page. If domain settings
+     * cannot be fetched, the file specified in
+     * zimbraDomainLoginPageErrorPath is loaded without redirection. It is
+     * ignored when zimbraDomainLoginPageEnabled is not TRUE.
+     *
+     * @param zimbraDomainLoginPageErrorPath new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4030)
+    public Map<String,Object> setDomainLoginPageErrorPath(String zimbraDomainLoginPageErrorPath, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDomainLoginPageErrorPath, zimbraDomainLoginPageErrorPath);
+        return attrs;
+    }
+
+    /**
+     * File path for error of domain-specific login page. If domain settings
+     * cannot be fetched, the file specified in
+     * zimbraDomainLoginPageErrorPath is loaded without redirection. It is
+     * ignored when zimbraDomainLoginPageEnabled is not TRUE.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4030)
+    public void unsetDomainLoginPageErrorPath() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDomainLoginPageErrorPath, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * File path for error of domain-specific login page. If domain settings
+     * cannot be fetched, the file specified in
+     * zimbraDomainLoginPageErrorPath is loaded without redirection. It is
+     * ignored when zimbraDomainLoginPageEnabled is not TRUE.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4030)
+    public Map<String,Object> unsetDomainLoginPageErrorPath(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDomainLoginPageErrorPath, "");
+        return attrs;
+    }
+
+    /**
      * enable domain mandatory mail signature
      *
      * @return zimbraDomainMandatoryMailSignatureEnabled, or false if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -7005,6 +7005,175 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
+     * File path for fallback of domain-specific login page. If
+     * zimbraLoginFilePath is empty, the file specified in
+     * zimbraDomainLoginPageFallbackPath is loaded without redirection. It is
+     * ignored when zimbraDomainLoginPageEnabled is not TRUE.
+     *
+     * @return zimbraDomainLoginPageFallbackPath, or null if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4029)
+    public String getDomainLoginPageFallbackPath() {
+        return getAttr(Provisioning.A_zimbraDomainLoginPageFallbackPath, null, true);
+    }
+
+    /**
+     * File path for fallback of domain-specific login page. If
+     * zimbraLoginFilePath is empty, the file specified in
+     * zimbraDomainLoginPageFallbackPath is loaded without redirection. It is
+     * ignored when zimbraDomainLoginPageEnabled is not TRUE.
+     *
+     * @param zimbraDomainLoginPageFallbackPath new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4029)
+    public void setDomainLoginPageFallbackPath(String zimbraDomainLoginPageFallbackPath) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDomainLoginPageFallbackPath, zimbraDomainLoginPageFallbackPath);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * File path for fallback of domain-specific login page. If
+     * zimbraLoginFilePath is empty, the file specified in
+     * zimbraDomainLoginPageFallbackPath is loaded without redirection. It is
+     * ignored when zimbraDomainLoginPageEnabled is not TRUE.
+     *
+     * @param zimbraDomainLoginPageFallbackPath new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4029)
+    public Map<String,Object> setDomainLoginPageFallbackPath(String zimbraDomainLoginPageFallbackPath, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDomainLoginPageFallbackPath, zimbraDomainLoginPageFallbackPath);
+        return attrs;
+    }
+
+    /**
+     * File path for fallback of domain-specific login page. If
+     * zimbraLoginFilePath is empty, the file specified in
+     * zimbraDomainLoginPageFallbackPath is loaded without redirection. It is
+     * ignored when zimbraDomainLoginPageEnabled is not TRUE.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4029)
+    public void unsetDomainLoginPageFallbackPath() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDomainLoginPageFallbackPath, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * File path for fallback of domain-specific login page. If
+     * zimbraLoginFilePath is empty, the file specified in
+     * zimbraDomainLoginPageFallbackPath is loaded without redirection. It is
+     * ignored when zimbraDomainLoginPageEnabled is not TRUE.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4029)
+    public Map<String,Object> unsetDomainLoginPageFallbackPath(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDomainLoginPageFallbackPath, "");
+        return attrs;
+    }
+
+    /**
+     * File path of domain-specific login page. If it is not empty, the
+     * specified file is loaded in login page without redirection. It is
+     * ignored when zimbraDomainLoginPageEnabled is not TRUE.
+     *
+     * @return zimbraDomainLoginPagePath, or null if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4028)
+    public String getDomainLoginPagePath() {
+        return getAttr(Provisioning.A_zimbraDomainLoginPagePath, null, true);
+    }
+
+    /**
+     * File path of domain-specific login page. If it is not empty, the
+     * specified file is loaded in login page without redirection. It is
+     * ignored when zimbraDomainLoginPageEnabled is not TRUE.
+     *
+     * @param zimbraDomainLoginPagePath new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4028)
+    public void setDomainLoginPagePath(String zimbraDomainLoginPagePath) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDomainLoginPagePath, zimbraDomainLoginPagePath);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * File path of domain-specific login page. If it is not empty, the
+     * specified file is loaded in login page without redirection. It is
+     * ignored when zimbraDomainLoginPageEnabled is not TRUE.
+     *
+     * @param zimbraDomainLoginPagePath new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4028)
+    public Map<String,Object> setDomainLoginPagePath(String zimbraDomainLoginPagePath, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDomainLoginPagePath, zimbraDomainLoginPagePath);
+        return attrs;
+    }
+
+    /**
+     * File path of domain-specific login page. If it is not empty, the
+     * specified file is loaded in login page without redirection. It is
+     * ignored when zimbraDomainLoginPageEnabled is not TRUE.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4028)
+    public void unsetDomainLoginPagePath() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDomainLoginPagePath, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * File path of domain-specific login page. If it is not empty, the
+     * specified file is loaded in login page without redirection. It is
+     * ignored when zimbraDomainLoginPageEnabled is not TRUE.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4028)
+    public Map<String,Object> unsetDomainLoginPagePath(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDomainLoginPagePath, "");
+        return attrs;
+    }
+
+    /**
      * enable domain mandatory mail signature
      *
      * @return zimbraDomainMandatoryMailSignatureEnabled, or false if unset

--- a/store/src/java/com/zimbra/cs/service/admin/GetDomainInfo.java
+++ b/store/src/java/com/zimbra/cs/service/admin/GetDomainInfo.java
@@ -60,7 +60,9 @@ public class GetDomainInfo extends AdminDocumentHandler {
             ZAttrProvisioning.A_zimbraSkinSelectionColor,
             ZAttrProvisioning.A_zimbraSkinFavicon,
             ZAttrProvisioning.A_zimbraFeatureResetPasswordStatus,
-            ZAttrProvisioning.A_zimbraPrefSkin);
+            ZAttrProvisioning.A_zimbraPrefSkin,
+            ZAttrProvisioning.A_zimbraDomainLoginPagePath,
+            ZAttrProvisioning.A_zimbraDomainLoginPageFallbackPath);
 
     @Override
     public Element handle(Element request, Map<String, Object> context) throws ServiceException {


### PR DESCRIPTION
**Enhancement:**
Add attributes for an ability to provide domain-specific login page.

* `zimbraDomainLoginPageEnabled` is a globalConfig to enable/disable the feature. Default value is FALSE for backward compatibility.
* `zimbraDomainLoginPagePath` is a domain config to specify a file path of login page for a domain. 
* `zimbraDomainLoginPageFallbackPath` is a domain config to specify a file path for fallback; if `zimbraDomainLoginPageEnabled` is TRUE and `zimbraDomainLoginPagePath` is empty, `zimbraDomainLoginPageFallbackPath` is used.
* `zimbraDomainLoginPageErrorPath` is a globalConfig to specify a file path in case DomainInfo cannot be fetched in login page for some reason.

The two domain config attributes are added to `GetDomainInfo.bootstrapInfoAttrs` so that they can be fetched on login page.

**Related PRs:**
* https://github.com/Zimbra/zm-taglib/pull/46
* https://github.com/Zimbra/zm-web-client/pull/772