### PR TITLE
ZBUG-1340 Fix for inaccurate LmtpServer reply of zimbraDomainAggregateQuota

### DIFF
--- a/store/src/java/com/zimbra/cs/lmtpserver/ZimbraLmtpBackend.java
+++ b/store/src/java/com/zimbra/cs/lmtpserver/ZimbraLmtpBackend.java
@@ -752,7 +752,7 @@ public class ZimbraLmtpBackend implements LmtpBackend {
                     ZimbraLog.lmtp.info("rejecting message from=%s,to=%s: sieve filter rule", envSender, rcptEmail);
                     reply = LmtpReply.PERMANENT_MESSAGE_REFUSED;
                 } catch (ServiceException e) {
-                    if (e.getCode().equals(MailServiceException.QUOTA_EXCEEDED)) {
+                    if (e.getCode().equals(MailServiceException.QUOTA_EXCEEDED) || e.getCode().equals(MailServiceException.DOMAIN_QUOTA_EXCEEDED)) {
                         ZimbraLog.lmtp.info("rejecting message from=%s,to=%s: overquota", envSender, rcptEmail);
                         if (config.isPermanentFailureWhenOverQuota()) {
                             reply = LmtpReply.PERMANENT_FAILURE_OVER_QUOTA;


### PR DESCRIPTION
**Problem:**
LmtpServer reply message is inaccurate if the value of zimbraDomainAggregateQuota becomes less.

**Approach and Analysis:**
When the zimbraDomainAggregateQuota get exceeded it's limit it throws an inaccurate reply of 554;5.0.0 Permanent message delivery failure where as it should be 552;5.2.2 Over quota if the value of the zimbraLmtpPermanentFailureWhenOverQuotais set to TRUE or the452; 4.2.2 Over quota if the value of the zimbraLmtpPermanentFailureWhenOverQuotais set toFALSE. To fix this condition has been added to handle that if the value of zimbraDomainAggregateQuota` exceeds it's limit then it will throw the appropriate Over quota messages.

**Testing Done:**

Following is my environment and settings:
1. setting  zimbraLmtpPermanentFailureWhenOverQuota TRUE

> zimbra@platform-dev-yogesh:~$ zmlmtpinject -s admin@`zmhostname` -r admin@`zmhostname` -T -v /home/ubuntu/local_sent.eml 
Injecting 1 message(s) to 1 recipient(s).  Server localhost, port 7025, using 1 thread(s).
[error] Delivery failed msg=local_sent.eml rcpt=admin@platform-dev-yogesh.zimbradev.com response=552 5.2.2 Over quota
LmtpInject Finished
submitted=0 failed=1
0.32s, 0.00ms/msg, 0.00msg/s
average message size = 0.00KB

2. setting  zimbraLmtpPermanentFailureWhenOverQuota FALSE

>zimbra@platform-dev-yogesh:~$ zmlmtpinject -s admin@`zmhostname` -r admin@`zmhostname` -T -v /home/ubuntu/local_sent.eml 
Injecting 1 message(s) to 1 recipient(s).  Server localhost, port 7025, using 1 thread(s).
[error] Delivery failed msg=local_sent.eml rcpt=admin@platform-dev-yogesh.zimbradev.com response=452 4.2.2 Over quota
LmtpInject Finished
submitted=0 failed=1
0.17s, 0.00ms/msg, 0.00msg/s
average message size = 0.00KB