### PR TITLE
ZCS-12778: renamed ldap attributes

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -2732,25 +2732,6 @@ public class ZAttrProvisioning {
     public static final String A_displayName = "displayName";
 
     /**
-     * A key in ZsMsg.properties for a body of a domain aggregate quota
-     * warning message. If it is not set, domainAggrQuotaWarnMsgBody is used.
-     *
-     * @since ZCS 11.0.0
-     */
-    @ZAttr(id=4025)
-    public static final String A_domainAggrQuotaWarnMsgBodyKey = "domainAggrQuotaWarnMsgBodyKey";
-
-    /**
-     * A key in ZsMsg.properties for a subject of a domain aggregate quota
-     * warning message. If it is not set, domainAggrQuotaWarnMsgSubject is
-     * used.
-     *
-     * @since ZCS 11.0.0
-     */
-    @ZAttr(id=4024)
-    public static final String A_domainAggrQuotaWarnMsgSubjectKey = "domainAggrQuotaWarnMsgSubjectKey";
-
-    /**
      * RFC2256: Facsimile (Fax) Telephone Number
      */
     @ZAttr(id=-1)
@@ -5982,6 +5963,25 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=1330)
     public static final String A_zimbraDomainAggregateQuotaWarnPercent = "zimbraDomainAggregateQuotaWarnPercent";
+
+    /**
+     * A key in ZsMsg.properties for a body of a domain aggregate quota
+     * warning message. If it is not set, domainAggrQuotaWarnMsgBody is used.
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4025)
+    public static final String A_zimbraDomainAggrQuotaWarnMsgBodyKey = "zimbraDomainAggrQuotaWarnMsgBodyKey";
+
+    /**
+     * A key in ZsMsg.properties for a subject of a domain aggregate quota
+     * warning message. If it is not set, domainAggrQuotaWarnMsgSubject is
+     * used.
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4024)
+    public static final String A_zimbraDomainAggrQuotaWarnMsgSubjectKey = "zimbraDomainAggrQuotaWarnMsgSubjectKey";
 
     /**
      * zimbraId of domain alias target

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10023,11 +10023,11 @@ TODO: delete them permanently from here
   <desc>Help URL for modern client</desc>
 </attr>
 
-<attr id="4024" name="domainAggrQuotaWarnMsgSubjectKey" type="string" cardinality="single" optionalIn="domain" since="11.0.0">
+<attr id="4024" name="zimbraDomainAggrQuotaWarnMsgSubjectKey" type="string" cardinality="single" optionalIn="domain" since="11.0.0">
   <desc>A key in ZsMsg.properties for a subject of a domain aggregate quota warning message. If it is not set, domainAggrQuotaWarnMsgSubject is used.</desc>
 </attr>
 
-<attr id="4025" name="domainAggrQuotaWarnMsgBodyKey" type="string" cardinality="single" optionalIn="domain" since="11.0.0">
+<attr id="4025" name="zimbraDomainAggrQuotaWarnMsgBodyKey" type="string" cardinality="single" optionalIn="domain" since="11.0.0">
   <desc>A key in ZsMsg.properties for a body of a domain aggregate quota warning message. If it is not set, domainAggrQuotaWarnMsgBody is used.</desc>
 </attr>
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -164,165 +164,6 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * A key in ZsMsg.properties for a body of a domain aggregate quota
-     * warning message. If it is not set, domainAggrQuotaWarnMsgBody is used.
-     *
-     * @return domainAggrQuotaWarnMsgBodyKey, or null if unset
-     *
-     * @since ZCS 11.0.0
-     */
-    @ZAttr(id=4025)
-    public String getDomainAggrQuotaWarnMsgBodyKey() {
-        return getAttr(Provisioning.A_domainAggrQuotaWarnMsgBodyKey, null, true);
-    }
-
-    /**
-     * A key in ZsMsg.properties for a body of a domain aggregate quota
-     * warning message. If it is not set, domainAggrQuotaWarnMsgBody is used.
-     *
-     * @param domainAggrQuotaWarnMsgBodyKey new value
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 11.0.0
-     */
-    @ZAttr(id=4025)
-    public void setDomainAggrQuotaWarnMsgBodyKey(String domainAggrQuotaWarnMsgBodyKey) throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_domainAggrQuotaWarnMsgBodyKey, domainAggrQuotaWarnMsgBodyKey);
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * A key in ZsMsg.properties for a body of a domain aggregate quota
-     * warning message. If it is not set, domainAggrQuotaWarnMsgBody is used.
-     *
-     * @param domainAggrQuotaWarnMsgBodyKey new value
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 11.0.0
-     */
-    @ZAttr(id=4025)
-    public Map<String,Object> setDomainAggrQuotaWarnMsgBodyKey(String domainAggrQuotaWarnMsgBodyKey, Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_domainAggrQuotaWarnMsgBodyKey, domainAggrQuotaWarnMsgBodyKey);
-        return attrs;
-    }
-
-    /**
-     * A key in ZsMsg.properties for a body of a domain aggregate quota
-     * warning message. If it is not set, domainAggrQuotaWarnMsgBody is used.
-     *
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 11.0.0
-     */
-    @ZAttr(id=4025)
-    public void unsetDomainAggrQuotaWarnMsgBodyKey() throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_domainAggrQuotaWarnMsgBodyKey, "");
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * A key in ZsMsg.properties for a body of a domain aggregate quota
-     * warning message. If it is not set, domainAggrQuotaWarnMsgBody is used.
-     *
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 11.0.0
-     */
-    @ZAttr(id=4025)
-    public Map<String,Object> unsetDomainAggrQuotaWarnMsgBodyKey(Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_domainAggrQuotaWarnMsgBodyKey, "");
-        return attrs;
-    }
-
-    /**
-     * A key in ZsMsg.properties for a subject of a domain aggregate quota
-     * warning message. If it is not set, domainAggrQuotaWarnMsgSubject is
-     * used.
-     *
-     * @return domainAggrQuotaWarnMsgSubjectKey, or null if unset
-     *
-     * @since ZCS 11.0.0
-     */
-    @ZAttr(id=4024)
-    public String getDomainAggrQuotaWarnMsgSubjectKey() {
-        return getAttr(Provisioning.A_domainAggrQuotaWarnMsgSubjectKey, null, true);
-    }
-
-    /**
-     * A key in ZsMsg.properties for a subject of a domain aggregate quota
-     * warning message. If it is not set, domainAggrQuotaWarnMsgSubject is
-     * used.
-     *
-     * @param domainAggrQuotaWarnMsgSubjectKey new value
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 11.0.0
-     */
-    @ZAttr(id=4024)
-    public void setDomainAggrQuotaWarnMsgSubjectKey(String domainAggrQuotaWarnMsgSubjectKey) throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_domainAggrQuotaWarnMsgSubjectKey, domainAggrQuotaWarnMsgSubjectKey);
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * A key in ZsMsg.properties for a subject of a domain aggregate quota
-     * warning message. If it is not set, domainAggrQuotaWarnMsgSubject is
-     * used.
-     *
-     * @param domainAggrQuotaWarnMsgSubjectKey new value
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 11.0.0
-     */
-    @ZAttr(id=4024)
-    public Map<String,Object> setDomainAggrQuotaWarnMsgSubjectKey(String domainAggrQuotaWarnMsgSubjectKey, Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_domainAggrQuotaWarnMsgSubjectKey, domainAggrQuotaWarnMsgSubjectKey);
-        return attrs;
-    }
-
-    /**
-     * A key in ZsMsg.properties for a subject of a domain aggregate quota
-     * warning message. If it is not set, domainAggrQuotaWarnMsgSubject is
-     * used.
-     *
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 11.0.0
-     */
-    @ZAttr(id=4024)
-    public void unsetDomainAggrQuotaWarnMsgSubjectKey() throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_domainAggrQuotaWarnMsgSubjectKey, "");
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * A key in ZsMsg.properties for a subject of a domain aggregate quota
-     * warning message. If it is not set, domainAggrQuotaWarnMsgSubject is
-     * used.
-     *
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 11.0.0
-     */
-    @ZAttr(id=4024)
-    public Map<String,Object> unsetDomainAggrQuotaWarnMsgSubjectKey(Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_domainAggrQuotaWarnMsgSubjectKey, "");
-        return attrs;
-    }
-
-    /**
      * Zimbra access control list
      *
      * @return zimbraACE, or empty array if unset
@@ -5913,6 +5754,165 @@ public abstract class ZAttrDomain extends NamedEntry {
     public Map<String,Object> unsetDNSCheckHostname(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraDNSCheckHostname, "");
+        return attrs;
+    }
+
+    /**
+     * A key in ZsMsg.properties for a body of a domain aggregate quota
+     * warning message. If it is not set, domainAggrQuotaWarnMsgBody is used.
+     *
+     * @return zimbraDomainAggrQuotaWarnMsgBodyKey, or null if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4025)
+    public String getDomainAggrQuotaWarnMsgBodyKey() {
+        return getAttr(Provisioning.A_zimbraDomainAggrQuotaWarnMsgBodyKey, null, true);
+    }
+
+    /**
+     * A key in ZsMsg.properties for a body of a domain aggregate quota
+     * warning message. If it is not set, domainAggrQuotaWarnMsgBody is used.
+     *
+     * @param zimbraDomainAggrQuotaWarnMsgBodyKey new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4025)
+    public void setDomainAggrQuotaWarnMsgBodyKey(String zimbraDomainAggrQuotaWarnMsgBodyKey) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDomainAggrQuotaWarnMsgBodyKey, zimbraDomainAggrQuotaWarnMsgBodyKey);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * A key in ZsMsg.properties for a body of a domain aggregate quota
+     * warning message. If it is not set, domainAggrQuotaWarnMsgBody is used.
+     *
+     * @param zimbraDomainAggrQuotaWarnMsgBodyKey new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4025)
+    public Map<String,Object> setDomainAggrQuotaWarnMsgBodyKey(String zimbraDomainAggrQuotaWarnMsgBodyKey, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDomainAggrQuotaWarnMsgBodyKey, zimbraDomainAggrQuotaWarnMsgBodyKey);
+        return attrs;
+    }
+
+    /**
+     * A key in ZsMsg.properties for a body of a domain aggregate quota
+     * warning message. If it is not set, domainAggrQuotaWarnMsgBody is used.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4025)
+    public void unsetDomainAggrQuotaWarnMsgBodyKey() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDomainAggrQuotaWarnMsgBodyKey, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * A key in ZsMsg.properties for a body of a domain aggregate quota
+     * warning message. If it is not set, domainAggrQuotaWarnMsgBody is used.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4025)
+    public Map<String,Object> unsetDomainAggrQuotaWarnMsgBodyKey(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDomainAggrQuotaWarnMsgBodyKey, "");
+        return attrs;
+    }
+
+    /**
+     * A key in ZsMsg.properties for a subject of a domain aggregate quota
+     * warning message. If it is not set, domainAggrQuotaWarnMsgSubject is
+     * used.
+     *
+     * @return zimbraDomainAggrQuotaWarnMsgSubjectKey, or null if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4024)
+    public String getDomainAggrQuotaWarnMsgSubjectKey() {
+        return getAttr(Provisioning.A_zimbraDomainAggrQuotaWarnMsgSubjectKey, null, true);
+    }
+
+    /**
+     * A key in ZsMsg.properties for a subject of a domain aggregate quota
+     * warning message. If it is not set, domainAggrQuotaWarnMsgSubject is
+     * used.
+     *
+     * @param zimbraDomainAggrQuotaWarnMsgSubjectKey new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4024)
+    public void setDomainAggrQuotaWarnMsgSubjectKey(String zimbraDomainAggrQuotaWarnMsgSubjectKey) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDomainAggrQuotaWarnMsgSubjectKey, zimbraDomainAggrQuotaWarnMsgSubjectKey);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * A key in ZsMsg.properties for a subject of a domain aggregate quota
+     * warning message. If it is not set, domainAggrQuotaWarnMsgSubject is
+     * used.
+     *
+     * @param zimbraDomainAggrQuotaWarnMsgSubjectKey new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4024)
+    public Map<String,Object> setDomainAggrQuotaWarnMsgSubjectKey(String zimbraDomainAggrQuotaWarnMsgSubjectKey, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDomainAggrQuotaWarnMsgSubjectKey, zimbraDomainAggrQuotaWarnMsgSubjectKey);
+        return attrs;
+    }
+
+    /**
+     * A key in ZsMsg.properties for a subject of a domain aggregate quota
+     * warning message. If it is not set, domainAggrQuotaWarnMsgSubject is
+     * used.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4024)
+    public void unsetDomainAggrQuotaWarnMsgSubjectKey() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDomainAggrQuotaWarnMsgSubjectKey, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * A key in ZsMsg.properties for a subject of a domain aggregate quota
+     * warning message. If it is not set, domainAggrQuotaWarnMsgSubject is
+     * used.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4024)
+    public Map<String,Object> unsetDomainAggrQuotaWarnMsgSubjectKey(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDomainAggrQuotaWarnMsgSubjectKey, "");
         return attrs;
     }
 


### PR DESCRIPTION
Renamed the following ldap attributes which have been added on ZCS-12634, PR https://github.com/Zimbra/zm-mailbox/pull/1426
* domainAggrQuotaWarnMsgSubjectKey -> zimbraDomainAggrQuotaWarnMsgSubjectKey
* domainAggrQuotaWarnMsgBodyKey -> zimbraDomainAggrQuotaWarnMsgBodyKey