### PR TITLE
ZBUG-2722 : Install zimlet config if version updated in zimlet config

### DIFF
--- a/store/src/java/com/zimbra/cs/zimlet/ZimletUtil.java
+++ b/store/src/java/com/zimbra/cs/zimlet/ZimletUtil.java
@@ -673,7 +673,20 @@ public class ZimletUtil {
 
         // install the config
         if (zf.hasZimletConfig()) {
-            installConfig(zf.getZimletConfig());
+            ZimletConfig zc = getZimletConfig(zimletName);
+            if (zc != null) {
+                Version zimletConfigVersion = new Version (zf.getZimletConfig().getVersion().toString());
+                Version zimletConfigVersionInLDAP = new Version (zc.getVersion().toString());
+                if (zimletConfigVersion.compareTo(zimletConfigVersionInLDAP)> 0) {
+                    installConfig(zf.getZimletConfig());
+                }
+                if (zimletConfigVersion.compareTo(zimletConfigVersionInLDAP) == 0) {
+                    return;
+                }
+            }
+            else {
+                installConfig(zf.getZimletConfig());
+            }
         }
 
         // activate

--- a/store/src/java/com/zimbra/cs/zimlet/ZimletUtil.java
+++ b/store/src/java/com/zimbra/cs/zimlet/ZimletUtil.java
@@ -680,9 +680,6 @@ public class ZimletUtil {
                 if (zimletConfigVersion.compareTo(zimletConfigVersionInLDAP)> 0) {
                     installConfig(zf.getZimletConfig());
                 }
-                if (zimletConfigVersion.compareTo(zimletConfigVersionInLDAP) == 0) {
-                    return;
-                }
             }
             else {
                 installConfig(zf.getZimletConfig());

--- a/store/src/java/com/zimbra/cs/zimlet/ZimletUtil.java
+++ b/store/src/java/com/zimbra/cs/zimlet/ZimletUtil.java
@@ -675,9 +675,7 @@ public class ZimletUtil {
         if (zf.hasZimletConfig()) {
             ZimletConfig zc = getZimletConfig(zimletName);
             if (zc != null) {
-                Version zimletConfigVersion = new Version (zf.getZimletConfig().getVersion().toString());
-                Version zimletConfigVersionInLDAP = new Version (zc.getVersion().toString());
-                if (zimletConfigVersion.compareTo(zimletConfigVersionInLDAP)> 0) {
+                if (zf.getZimletConfig().getVersion().compareTo(zc.getVersion()) > 0) {
                     installConfig(zf.getZimletConfig());
                 }
             }


### PR DESCRIPTION
**Problem:**

`zmzimletctl deploy zimlet.zip` overwrites all previous zimlet configuration stored in LDAP, back to their defaults.

For example, we had a config change in com_zimbar_url to disable youtubePreview and  this config change had been reverted by deploying the patch.

**Fix:**
Install zimlet config if version updated in latest zimlet config 

Compare latest zimlet config version with zimlet config version stored in LDAP. If latest zimlet config version is higher than the zimlet config version stored in LDAP then install zimlet config, which will override customer's changes and it will loose customer's changes. Customer will take updated zimlet config and apply their customizations and deploy using zmzimletctl.