### PR TITLE
ZCS-12779: Add a new LDAP attribute to manage chat and video users

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -7018,12 +7018,28 @@ public class ZAttrProvisioning {
     public static final String A_zimbraFeatureMobileSyncEnabled = "zimbraFeatureMobileSyncEnabled";
 
     /**
+     * Whether Chat feature is enabled or not
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4031)
+    public static final String A_zimbraFeatureModernChatEnabled = "zimbraFeatureModernChatEnabled";
+
+    /**
      * Whether to allow a user to access Zimbra modern desktop
      *
      * @since ZCS 8.9.0
      */
     @ZAttr(id=3082)
     public static final String A_zimbraFeatureModernDesktopEnabled = "zimbraFeatureModernDesktopEnabled";
+
+    /**
+     * Whether Video feature is enabled or not
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4032)
+    public static final String A_zimbraFeatureModernVideoEnabled = "zimbraFeatureModernVideoEnabled";
 
     /**
      * Whether user can create address books

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10036,6 +10036,16 @@ TODO: delete them permanently from here
   <desc>Block sending email from external email addresses.</desc>
 </attr>
 
+<attr id="4031" name="zimbraFeatureModernChatEnabled" type="boolean" callback="ModernChatVideoEnabled" cardinality="single" optionalIn="account,cos,domain" flags="accountInfo,domainInfo,domainAdminModifiable,accountCosDomainInherited" since="11.0.0">
+  <defaultCOSValue>FALSE</defaultCOSValue>
+  <desc>Whether Chat feature is enabled or not</desc>
+</attr>
+
+<attr id="4032" name="zimbraFeatureModernVideoEnabled" type="boolean" callback="ModernChatVideoEnabled" cardinality="single" optionalIn="account,cos,domain" flags="accountInfo,domainInfo,domainAdminModifiable,accountCosDomainInherited" since="11.0.0">
+  <defaultCOSValue>FALSE</defaultCOSValue>
+  <desc>Whether Video feature is enabled or not</desc>
+</attr>
+
 <attr id="9001" name="zimbraMailSieveScriptMaxSize" type="long" min="0" cardinality="single" requiredIn="globalConfig" optionalIn="account,cos,domain" flags="domainInfo,accountInfo,accountCosDomainInherited" since="11.0.0">
   <globalConfigValue>0</globalConfigValue>
   <defaultCOSValue>0</defaultCOSValue>
@@ -10068,4 +10078,5 @@ TODO: delete them permanently from here
     indexing         - Generate index
   </desc>
 </attr>
+
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -18064,6 +18064,78 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * Whether Chat feature is enabled or not
+     *
+     * @return zimbraFeatureModernChatEnabled, or false if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4031)
+    public boolean isFeatureModernChatEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureModernChatEnabled, false, true);
+    }
+
+    /**
+     * Whether Chat feature is enabled or not
+     *
+     * @param zimbraFeatureModernChatEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4031)
+    public void setFeatureModernChatEnabled(boolean zimbraFeatureModernChatEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernChatEnabled, zimbraFeatureModernChatEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether Chat feature is enabled or not
+     *
+     * @param zimbraFeatureModernChatEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4031)
+    public Map<String,Object> setFeatureModernChatEnabled(boolean zimbraFeatureModernChatEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernChatEnabled, zimbraFeatureModernChatEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether Chat feature is enabled or not
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4031)
+    public void unsetFeatureModernChatEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernChatEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether Chat feature is enabled or not
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4031)
+    public Map<String,Object> unsetFeatureModernChatEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernChatEnabled, "");
+        return attrs;
+    }
+
+    /**
      * Whether to allow a user to access Zimbra modern desktop
      *
      * @return zimbraFeatureModernDesktopEnabled, or false if unset
@@ -18132,6 +18204,78 @@ public abstract class ZAttrAccount  extends MailTarget {
     public Map<String,Object> unsetFeatureModernDesktopEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureModernDesktopEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * Whether Video feature is enabled or not
+     *
+     * @return zimbraFeatureModernVideoEnabled, or false if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4032)
+    public boolean isFeatureModernVideoEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureModernVideoEnabled, false, true);
+    }
+
+    /**
+     * Whether Video feature is enabled or not
+     *
+     * @param zimbraFeatureModernVideoEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4032)
+    public void setFeatureModernVideoEnabled(boolean zimbraFeatureModernVideoEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernVideoEnabled, zimbraFeatureModernVideoEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether Video feature is enabled or not
+     *
+     * @param zimbraFeatureModernVideoEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4032)
+    public Map<String,Object> setFeatureModernVideoEnabled(boolean zimbraFeatureModernVideoEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernVideoEnabled, zimbraFeatureModernVideoEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether Video feature is enabled or not
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4032)
+    public void unsetFeatureModernVideoEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernVideoEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether Video feature is enabled or not
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4032)
+    public Map<String,Object> unsetFeatureModernVideoEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernVideoEnabled, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -12445,6 +12445,78 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * Whether Chat feature is enabled or not
+     *
+     * @return zimbraFeatureModernChatEnabled, or false if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4031)
+    public boolean isFeatureModernChatEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureModernChatEnabled, false, true);
+    }
+
+    /**
+     * Whether Chat feature is enabled or not
+     *
+     * @param zimbraFeatureModernChatEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4031)
+    public void setFeatureModernChatEnabled(boolean zimbraFeatureModernChatEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernChatEnabled, zimbraFeatureModernChatEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether Chat feature is enabled or not
+     *
+     * @param zimbraFeatureModernChatEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4031)
+    public Map<String,Object> setFeatureModernChatEnabled(boolean zimbraFeatureModernChatEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernChatEnabled, zimbraFeatureModernChatEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether Chat feature is enabled or not
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4031)
+    public void unsetFeatureModernChatEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernChatEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether Chat feature is enabled or not
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4031)
+    public Map<String,Object> unsetFeatureModernChatEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernChatEnabled, "");
+        return attrs;
+    }
+
+    /**
      * Whether to allow a user to access Zimbra modern desktop
      *
      * @return zimbraFeatureModernDesktopEnabled, or false if unset
@@ -12513,6 +12585,78 @@ public abstract class ZAttrCos extends NamedEntry {
     public Map<String,Object> unsetFeatureModernDesktopEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureModernDesktopEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * Whether Video feature is enabled or not
+     *
+     * @return zimbraFeatureModernVideoEnabled, or false if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4032)
+    public boolean isFeatureModernVideoEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureModernVideoEnabled, false, true);
+    }
+
+    /**
+     * Whether Video feature is enabled or not
+     *
+     * @param zimbraFeatureModernVideoEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4032)
+    public void setFeatureModernVideoEnabled(boolean zimbraFeatureModernVideoEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernVideoEnabled, zimbraFeatureModernVideoEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether Video feature is enabled or not
+     *
+     * @param zimbraFeatureModernVideoEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4032)
+    public Map<String,Object> setFeatureModernVideoEnabled(boolean zimbraFeatureModernVideoEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernVideoEnabled, zimbraFeatureModernVideoEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether Video feature is enabled or not
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4032)
+    public void unsetFeatureModernVideoEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernVideoEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether Video feature is enabled or not
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4032)
+    public Map<String,Object> unsetFeatureModernVideoEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernVideoEnabled, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -10026,6 +10026,150 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
+     * Whether Chat feature is enabled or not
+     *
+     * @return zimbraFeatureModernChatEnabled, or false if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4031)
+    public boolean isFeatureModernChatEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureModernChatEnabled, false, true);
+    }
+
+    /**
+     * Whether Chat feature is enabled or not
+     *
+     * @param zimbraFeatureModernChatEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4031)
+    public void setFeatureModernChatEnabled(boolean zimbraFeatureModernChatEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernChatEnabled, zimbraFeatureModernChatEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether Chat feature is enabled or not
+     *
+     * @param zimbraFeatureModernChatEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4031)
+    public Map<String,Object> setFeatureModernChatEnabled(boolean zimbraFeatureModernChatEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernChatEnabled, zimbraFeatureModernChatEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether Chat feature is enabled or not
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4031)
+    public void unsetFeatureModernChatEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernChatEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether Chat feature is enabled or not
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4031)
+    public Map<String,Object> unsetFeatureModernChatEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernChatEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * Whether Video feature is enabled or not
+     *
+     * @return zimbraFeatureModernVideoEnabled, or false if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4032)
+    public boolean isFeatureModernVideoEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureModernVideoEnabled, false, true);
+    }
+
+    /**
+     * Whether Video feature is enabled or not
+     *
+     * @param zimbraFeatureModernVideoEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4032)
+    public void setFeatureModernVideoEnabled(boolean zimbraFeatureModernVideoEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernVideoEnabled, zimbraFeatureModernVideoEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether Video feature is enabled or not
+     *
+     * @param zimbraFeatureModernVideoEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4032)
+    public Map<String,Object> setFeatureModernVideoEnabled(boolean zimbraFeatureModernVideoEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernVideoEnabled, zimbraFeatureModernVideoEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether Video feature is enabled or not
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4032)
+    public void unsetFeatureModernVideoEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernVideoEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether Video feature is enabled or not
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4032)
+    public Map<String,Object> unsetFeatureModernVideoEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernVideoEnabled, "");
+        return attrs;
+    }
+
+    /**
      * status of password reset feature
      *
      * <p>Valid values: [enabled, suspended, disabled]

--- a/store/src/java/com/zimbra/cs/account/callback/ModernChatVideoEnabled.java
+++ b/store/src/java/com/zimbra/cs/account/callback/ModernChatVideoEnabled.java
@@ -1,0 +1,66 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.account.callback;
+import java.util.Map;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.StringUtil;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.AttributeCallback;
+import com.zimbra.cs.account.Cos;
+import com.zimbra.cs.account.Domain;
+import com.zimbra.cs.account.Entry;
+import com.zimbra.cs.account.callback.CallbackContext;
+import com.zimbra.cs.extension.ZimbraExtensionNotification;
+
+public class ModernChatVideoEnabled extends AttributeCallback {
+
+    private String oldValue = null;
+    private String newValue = null;
+    
+    @Override
+    public void preModify(CallbackContext context, String attrName, Object attrValue, Map attrsToModify, Entry entry)
+            throws ServiceException {
+        
+        SingleValueMod mod = singleValueMod(attrName, attrValue);
+        if (mod.unsetting()) {
+            return;
+        }
+        
+        if (entry != null) {
+            oldValue = entry.getAttr(attrName, true);
+        }
+        newValue = mod.value();
+        
+    }
+
+    @Override
+    public void postModify(CallbackContext context, String attrName, Entry entry) {
+        try {
+            if (context.isDoneAndSetIfNot(ModernChatVideoEnabled.class)) {
+                return;
+            }
+            ZimbraLog.misc.debug("attrName %s, oldValue %s, newValue %s", attrName, oldValue, newValue);
+            ZimbraExtensionNotification.notifyExtension("com.zimbra.cs.account.callback.ModernChatVideoEnabled:enabled",
+                    entry, attrName, oldValue, newValue);
+        } catch (ServiceException e) {
+            ZimbraLog.misc.warn("Unable to set zimbraFeatureModernVideoEnabled " + e);
+        }
+    }
+    
+}


### PR DESCRIPTION
Feature:  New LDAP attributes are required to manage chat and video at the account, cos, and domain level with notification through a callback.

Implementation: 
Added two LDAP attributes zimbraFeatureModernChatEnabled and zimbraFeatureModernVideoEnabled and defined a callback name ModernChatVideoEnabled.

Here, We are using ZimbraExtensionNotification for notifications from https://github.com/Zimbra/zm-mailbox/pull/1431
