### PR TITLE
ZCS-12826: added a logic to set custom X-Mailer header

### DIFF
--- a/store/src/java/com/zimbra/cs/extension/ZimbraExtensionNotification.java
+++ b/store/src/java/com/zimbra/cs/extension/ZimbraExtensionNotification.java
@@ -44,6 +44,7 @@ public abstract class ZimbraExtensionNotification {
                                    "registering of " + obj.getClass().getCanonicalName() + " is ignored");
             return;
         }
+        ZimbraLog.extensions.info("registered notification handler for " + notificationId);
         mHandlers.put(notificationId, handler);
     }
 

--- a/store/src/java/com/zimbra/cs/mailbox/MailSender.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailSender.java
@@ -68,6 +68,7 @@ import com.zimbra.cs.account.DataSource;
 import com.zimbra.cs.account.Domain;
 import com.zimbra.cs.account.Identity;
 import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.extension.ZimbraExtensionNotification;
 import com.zimbra.cs.filter.RuleManager;
 import com.zimbra.cs.mailbox.MailServiceException.NoSuchItemException;
 import com.zimbra.cs.mailbox.Threader.ThreadIndex;
@@ -985,7 +986,14 @@ public class MailSender {
         boolean addMailer = prov.getConfig().isSmtpSendAddMailer();
         if (addMailer) {
             String ua = octxt != null ? octxt.getUserAgent() : null;
-            String mailer = "Zimbra " + BuildInfo.VERSION + (ua == null ? "" : " (" + ua + ")");
+            String[] customXMailer = new String[] { null };
+            ZimbraExtensionNotification.notifyExtension("com.zimbra.cs.mailbox.MailSender:X_MAILER", customXMailer, ua);
+            String mailer;
+            if (customXMailer[0] == null) {
+                mailer = "Zimbra " + BuildInfo.VERSION + (ua == null ? "" : " (" + ua + ")");
+            } else {
+                mailer = customXMailer[0];
+            }
             mm.addHeader(X_MAILER, mailer);
         }
 


### PR DESCRIPTION
Adding `ZimbraExtensionNotification.notifyExtension` to replace X-Mailer header using an extension.

An extension cannot return any value. Then a reference of string array `String[] customXMailer` is passed to an extension. The extension can set a preferred string for X-Mailer header.
If no extension is called or no value is set by an extension, default string is used.