### PR TITLE
ZCS-12777: CreateVolume SOAP API: Introduce flag for volume for marking volume as unified volume

### DIFF
--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -16,11 +16,11 @@
  */
 package com.zimbra.common.soap;
 
-import org.dom4j.Namespace;
-import org.dom4j.QName;
-
 import java.util.Arrays;
 import java.util.List;
+
+import org.dom4j.Namespace;
+import org.dom4j.QName;
 
 public final class AdminConstants {
 
@@ -1310,6 +1310,7 @@ public final class AdminConstants {
     public static final String A_VOLUME_STORE_MANAGER_CLASS = "storeManagerClass";
     public static final String A_VOLUME_BUCKET_ID = "bucketId";
     public static final String A_VOLUME_NAME_SPACE = "nameSpace";
+    public static final String A_VOLUME_UNIFIED = "unified";
 
     // Blob consistency check
     public static final String E_MISSING_BLOBS = "missingBlobs";

--- a/common/src/java/com/zimbra/common/soap/GlobalExternalStoreConfigConstants.java
+++ b/common/src/java/com/zimbra/common/soap/GlobalExternalStoreConfigConstants.java
@@ -14,4 +14,5 @@ public final class GlobalExternalStoreConfigConstants {
     public static final String A_S3_URL = "url";
     public static final String A_S3_BUCKET_STATUS = "bucketStatus";
 
+    public static final String A_S3_UNIFIED_VOLUME = "unified/volumes";
 }

--- a/soap/src/java/com/zimbra/soap/admin/type/VolumeExternalInfo.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/VolumeExternalInfo.java
@@ -60,6 +60,21 @@ public class VolumeExternalInfo extends BaseExternalVolume{
     @XmlAttribute(name=AdminConstants.A_VOLUME_USE_INTELLIGENT_TIERING /* useIntelligentTiering */, required=false)
     private boolean useIntelligentTiering = false;
 
+    /**
+     * @zm-api-field-description Specifies unified/shared enabled or not
+     */
+
+    @XmlAttribute(name=AdminConstants.A_VOLUME_UNIFIED /* unified */, required=false)
+    private boolean unified = false;
+
+    public boolean isUnified() {
+        return unified;
+    }
+
+    public void setUnified(boolean unified) {
+        this.unified = unified;
+    }
+
     public void setVolumePrefix(String value) {
         volumePrefix = value;
     }
@@ -111,6 +126,7 @@ public class VolumeExternalInfo extends BaseExternalVolume{
         volExtInfoObj.put(AdminConstants.A_VOLUME_USE_INTELLIGENT_TIERING, String.valueOf(volExtInfo.isUseIntelligentTiering()));
         volExtInfoObj.put(AdminConstants.A_VOLUME_GLB_BUCKET_CONFIG_ID, volExtInfo.getGlobalBucketConfigurationId());
         volExtInfoObj.put(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS_THRESHOLD, String.valueOf(volExtInfo.getUseInFrequentAccessThreshold()));
+        volExtInfoObj.put(AdminConstants.A_VOLUME_UNIFIED, String.valueOf(volExtInfo.isUnified()));
         return volExtInfoObj;
     }
 
@@ -122,6 +138,7 @@ public class VolumeExternalInfo extends BaseExternalVolume{
         volExtInfo.setUseIntelligentTiering(Boolean.valueOf(properties.getString(AdminConstants.A_VOLUME_USE_INTELLIGENT_TIERING)));
         volExtInfo.setUseInFrequentAccessThreshold(Integer.parseInt(properties.getString(AdminConstants.A_VOLUME_USE_IN_FREQ_ACCESS_THRESHOLD)));
         volExtInfo.setStorageType(properties.getString(AdminConstants.A_VOLUME_STORAGE_TYPE));
+        volExtInfo.setUnified(Boolean.valueOf(properties.optString(AdminConstants.A_VOLUME_UNIFIED)));
         return volExtInfo;
     }
 }

--- a/store/src/java-test/com/zimbra/util/ExternalVolumeInfoHandlerTest.java
+++ b/store/src/java-test/com/zimbra/util/ExternalVolumeInfoHandlerTest.java
@@ -1,0 +1,138 @@
+package com.zimbra.util;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.MockProvisioning;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.soap.admin.type.VolumeExternalInfo;
+import com.zimbra.soap.admin.type.VolumeInfo;
+
+@RunWith(PowerMockRunner.class)
+@PowerMockRunnerDelegate(MockitoJUnitRunner.class)
+@PrepareForTest({ ExternalVolumeInfoHandler.class })
+public class ExternalVolumeInfoHandlerTest {
+
+    // Static JSON having no unified structure
+    private static final String TEST_GLOBAL_BUCKETS = "{\"global/s3BucketConfigurations\":[{\"globalBucketUUID\": \"aaaa-bbbb-cccc-1111\", \"bucketName\": \"AWS_BUCKET1\", \"storeProvider\": \"AWS_S3\", \"protocol\": \"HTTPS\", \"storeType\": \"S3\", \"accessKey\": \"testAccess\", \"secret\": \"testSecret\", \"region\": \"US_EAST_1\", \"destinationPath\": \"somepath\", \"url\": \"https://aws.com\", \"bucketStatus\": \"ACTIVE\"}, {\"globalBucketUUID\": \"aaaa-bbbb-cccc-2222\", \"bucketName\": \"AWS_BUCKET2\", \"storeProvider\": \"AWS_S3\", \"protocol\": \"HTTPS\", \"accessKey\": \"testAccess\", \"secret\": \"testSecret\", \"region\": \"US_EAST_1\", \"destinationPath\": \"somepath\", \"url\": \"https://aws.com\", \"bucketStatus\": \"ACTIVE\"} ] }";
+    // Static JSON having 1 server and 1 volume
+    private static final String TEST_GLOBAL_BUCKETS_UNIFIED_1 = "{\"global/s3BucketConfigurations\":[{\"globalBucketUUID\": \"aaaa-bbbb-cccc-1111\", \"bucketName\": \"AWS_BUCKET1\", \"storeProvider\": \"AWS_S3\", \"protocol\": \"HTTPS\", \"storeType\": \"S3\", \"accessKey\": \"testAccess\", \"secret\": \"testSecret\", \"region\": \"US_EAST_1\", \"destinationPath\": \"somepath\", \"url\": \"https://aws.com\", \"bucketStatus\": \"ACTIVE\"}, {\"globalBucketUUID\": \"aaaa-bbbb-cccc-2222\", \"bucketName\": \"AWS_BUCKET2\", \"storeProvider\": \"AWS_S3\", \"protocol\": \"HTTPS\", \"accessKey\": \"testAccess\", \"secret\": \"testSecret\", \"region\": \"US_EAST_1\", \"destinationPath\": \"somepath\", \"url\": \"https://aws.com\", \"bucketStatus\": \"ACTIVE\"} ],\"unified/volumes\":{\"4b16223d-8b97-4562-8eeb-3f7727fa5d56\":[{\"globalBucketUUID\":\"GLOBAL_BUCKET_ID\",\"volumePrefix\":\"/JunitPrefix\",\"volumeId\":19}]} }";
+    // Static JSON having 1 server and 2 volumes
+    private static final String TEST_GLOBAL_BUCKETS_UNIFIED_2 = "{\"global/s3BucketConfigurations\":[{\"globalBucketUUID\": \"aaaa-bbbb-cccc-1111\", \"bucketName\": \"AWS_BUCKET1\", \"storeProvider\": \"AWS_S3\", \"protocol\": \"HTTPS\", \"storeType\": \"S3\", \"accessKey\": \"testAccess\", \"secret\": \"testSecret\", \"region\": \"US_EAST_1\", \"destinationPath\": \"somepath\", \"url\": \"https://aws.com\", \"bucketStatus\": \"ACTIVE\"}, {\"globalBucketUUID\": \"aaaa-bbbb-cccc-2222\", \"bucketName\": \"AWS_BUCKET2\", \"storeProvider\": \"AWS_S3\", \"protocol\": \"HTTPS\", \"accessKey\": \"testAccess\", \"secret\": \"testSecret\", \"region\": \"US_EAST_1\", \"destinationPath\": \"somepath\", \"url\": \"https://aws.com\", \"bucketStatus\": \"ACTIVE\"} ],\"unified/volumes\":{\"2da1249b-daa0-40cb-aa80-d90223c8d51b\":[{\"globalBucketUUID\":\"GLOBAL_BUCKET_ID\",\"volumePrefix\":\"/JunitPrefix\",\"volumeId\":18}, {\"globalBucketUUID\":\"GLOBAL_BUCKET_ID_1\",\"volumePrefix\":\"/JunitPrefix\",\"volumeId\":19}]} }";
+    // Static JSON having 2 servers and multiple volumes
+    private static final String TEST_GLOBAL_BUCKETS_UNIFIED_2Server = "{\"global/s3BucketConfigurations\":[{\"globalBucketUUID\": \"aaaa-bbbb-cccc-1111\", \"bucketName\": \"AWS_BUCKET1\", \"storeProvider\": \"AWS_S3\", \"protocol\": \"HTTPS\", \"storeType\": \"S3\", \"accessKey\": \"testAccess\", \"secret\": \"testSecret\", \"region\": \"US_EAST_1\", \"destinationPath\": \"somepath\", \"url\": \"https://aws.com\", \"bucketStatus\": \"ACTIVE\"}, {\"globalBucketUUID\": \"aaaa-bbbb-cccc-2222\", \"bucketName\": \"AWS_BUCKET2\", \"storeProvider\": \"AWS_S3\", \"protocol\": \"HTTPS\", \"accessKey\": \"testAccess\", \"secret\": \"testSecret\", \"region\": \"US_EAST_1\", \"destinationPath\": \"somepath\", \"url\": \"https://aws.com\", \"bucketStatus\": \"ACTIVE\"} ],\"unified/volumes\":{\"2da1249b-daa0-40cb-aa80-d90223c8d51b\":[{\"globalBucketUUID\":\"GLOBAL_BUCKET_ID\",\"volumePrefix\":\"/JunitPrefix\",\"volumeId\":20}, {\"globalBucketUUID\":\"GLOBAL_BUCKET_ID_1\",\"volumePrefix\":\"/JunitPrefix\",\"volumeId\":21}], \"2da1249b-daa0-40cb-aa80-d90223c8d51b\":[{\"globalBucketUUID_3\":\"GLOBAL_BUCKET_ID\",\"volumePrefix\":\"/JunitPrefix\",\"volumeId\":22}]} }";
+
+    private MockProvisioning mockProvisioning;
+    private ExternalVolumeInfoHandler externalVolumeInfoHandler = null;
+    String serverExternalStoreConfigJson = null;
+    String serverId = null;
+
+    @Before
+    public void setUp() throws ServiceException {
+        mockProvisioning = new MockProvisioning();
+        Provisioning.setInstance(mockProvisioning);
+        externalVolumeInfoHandler = new ExternalVolumeInfoHandler(mockProvisioning);
+        mockProvisioning.getConfig().setGlobalExternalStoreConfig(TEST_GLOBAL_BUCKETS);
+        serverExternalStoreConfigJson = mockProvisioning.getLocalServer().getServerExternalStoreConfig();
+        serverId = mockProvisioning.getLocalServer().getId();
+    }
+
+    //If the unified/volume does not exist
+    @Test
+    public void testEditGlobalConfigOnAddVolume_AddServerVolume() {
+        VolumeInfo volInfo = mockVolumeInfo();
+        String expectedServerExternalStoreConfigJson = TEST_GLOBAL_BUCKETS_UNIFIED_1;
+        String actualServerExternalStoreConfigJson = externalVolumeInfoHandler.editGlobalConfigOnAddVolume(volInfo,
+                serverId, TEST_GLOBAL_BUCKETS);
+        Assert.assertEquals(expectedServerExternalStoreConfigJson, actualServerExternalStoreConfigJson);
+    }
+
+    //If the unified/volume exist and adding 1 additional volume in existing server
+    @Test
+    public void testEditGlobalConfigOnAddVolume_AddAdditionalVolume() {
+        VolumeInfo volInfo = mockVolumeInfo();
+        String expectedServerExternalStoreConfigJson = TEST_GLOBAL_BUCKETS_UNIFIED_2;
+        String actualServerExternalStoreConfigJson = externalVolumeInfoHandler.editGlobalConfigOnAddVolume(volInfo,
+                serverId, TEST_GLOBAL_BUCKETS_UNIFIED_1);
+        Assert.assertEquals(expectedServerExternalStoreConfigJson, actualServerExternalStoreConfigJson);
+    }
+
+    //If the unified/volume exist and adding 1 additional volume in existing server
+    @Test
+    public void testEditGlobalConfigOnAddVolume_AddAdditionalServer() {
+        VolumeInfo volInfo = mockVolumeInfo();
+        String expectedServerExternalStoreConfigJson = TEST_GLOBAL_BUCKETS_UNIFIED_2Server;
+        String actualServerExternalStoreConfigJson = externalVolumeInfoHandler.editGlobalConfigOnAddVolume(volInfo,
+                serverId, TEST_GLOBAL_BUCKETS_UNIFIED_2);
+        Assert.assertEquals(expectedServerExternalStoreConfigJson, actualServerExternalStoreConfigJson);
+    }
+
+    private VolumeInfo mockVolumeInfo() {
+        VolumeInfo volInfo = new VolumeInfo();
+        volInfo.setId((short) 20);
+        volInfo.setName("JunitTest");
+        volInfo.setRootPath("/junit/");
+        volInfo.setType((short) 1);
+
+        VolumeExternalInfo volumeExternalInfo = new VolumeExternalInfo();
+        volumeExternalInfo.setGlobalBucketConfigurationId("GLOBAL_BUCKET_ID");
+        volumeExternalInfo.setVolumePrefix("/JunitPrefix");
+        volumeExternalInfo.setUnified(true);
+        volumeExternalInfo.setStorageType("1");
+
+        volInfo.setVolumeExternalInfo(volumeExternalInfo);
+        return volInfo;
+    }
+
+    @Test
+    public void testEditGlobalConfigOnAddVolume_AllNullCase() {
+        VolumeInfo volInfo = null;
+        String serverId = null;
+        serverExternalStoreConfigJson = null;
+        String expectedServerExternalStoreConfigJson = null;
+        String actualServerExternalStoreConfigJson = externalVolumeInfoHandler.editGlobalConfigOnAddVolume(volInfo,
+                serverId, serverExternalStoreConfigJson);
+        Assert.assertEquals(expectedServerExternalStoreConfigJson, actualServerExternalStoreConfigJson);
+    }
+
+    @Test
+    public void testEditGlobalConfigOnAddVolume_NullVolumeServer() {
+        VolumeInfo volInfo = null;
+        String serverId = null;
+        serverExternalStoreConfigJson = TEST_GLOBAL_BUCKETS;
+        String expectedServerExternalStoreConfigJson = null;
+        String actualServerExternalStoreConfigJson = externalVolumeInfoHandler.editGlobalConfigOnAddVolume(volInfo,
+                serverId, serverExternalStoreConfigJson);
+        Assert.assertEquals(expectedServerExternalStoreConfigJson, actualServerExternalStoreConfigJson);
+    }
+
+    @Test
+    public void testEditGlobalConfigOnAddVolume_NullServer() {
+        VolumeInfo volInfo = new VolumeInfo();
+        String serverId = null;
+        serverExternalStoreConfigJson = TEST_GLOBAL_BUCKETS;
+        String expectedServerExternalStoreConfigJson = null;
+        String actualServerExternalStoreConfigJson = externalVolumeInfoHandler.editGlobalConfigOnAddVolume(volInfo,
+                serverId, serverExternalStoreConfigJson);
+        Assert.assertEquals(expectedServerExternalStoreConfigJson, actualServerExternalStoreConfigJson);
+    }
+
+    @Test
+    public void testEditGlobalConfigOnAddVolume_Null_Volume() {
+        VolumeInfo volInfo = null;
+        String serverId = "abc";
+        serverExternalStoreConfigJson = TEST_GLOBAL_BUCKETS;
+        String expectedServerExternalStoreConfigJson = null;
+        String actualServerExternalStoreConfigJson = externalVolumeInfoHandler.editGlobalConfigOnAddVolume(volInfo,
+                serverId, serverExternalStoreConfigJson);
+        Assert.assertEquals(expectedServerExternalStoreConfigJson, actualServerExternalStoreConfigJson);
+    }
+
+}

--- a/store/src/java/com/zimbra/cs/lmtpserver/ZimbraLmtpBackend.java
+++ b/store/src/java/com/zimbra/cs/lmtpserver/ZimbraLmtpBackend.java
@@ -752,7 +752,7 @@ public class ZimbraLmtpBackend implements LmtpBackend {
                     ZimbraLog.lmtp.info("rejecting message from=%s,to=%s: sieve filter rule", envSender, rcptEmail);
                     reply = LmtpReply.PERMANENT_MESSAGE_REFUSED;
                 } catch (ServiceException e) {
-                    if (e.getCode().equals(MailServiceException.QUOTA_EXCEEDED)) {
+                    if (e.getCode().equals(MailServiceException.QUOTA_EXCEEDED) || e.getCode().equals(MailServiceException.DOMAIN_QUOTA_EXCEEDED)) {
                         ZimbraLog.lmtp.info("rejecting message from=%s,to=%s: overquota", envSender, rcptEmail);
                         if (config.isPermanentFailureWhenOverQuota()) {
                             reply = LmtpReply.PERMANENT_FAILURE_OVER_QUOTA;

--- a/store/src/java/com/zimbra/cs/service/admin/CreateVolume.java
+++ b/store/src/java/com/zimbra/cs/service/admin/CreateVolume.java
@@ -17,9 +17,13 @@
 
 package com.zimbra.cs.service.admin;
 
+import java.util.List;
+import java.util.Map;
+
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
 import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.Server;
 import com.zimbra.cs.account.accesscontrol.AdminRight;
 import com.zimbra.cs.account.accesscontrol.Rights.Admin;
 import com.zimbra.cs.service.util.VolumeConfigUtil;
@@ -32,9 +36,6 @@ import com.zimbra.soap.admin.message.CreateVolumeResponse;
 import com.zimbra.soap.admin.type.StoreManagerRuntimeSwitchResult;
 import com.zimbra.soap.admin.type.VolumeInfo;
 
-import java.util.List;
-import java.util.Map;
-
 public final class CreateVolume extends AdminDocumentHandler {
 
     @Override
@@ -45,7 +46,9 @@ public final class CreateVolume extends AdminDocumentHandler {
 
     private CreateVolumeResponse handle(CreateVolumeRequest request, Map<String, Object> ctx) throws ServiceException {
         ZimbraSoapContext zsc = getZimbraSoapContext(ctx);
-        checkRight(zsc, ctx, Provisioning.getInstance().getLocalServer(), Admin.R_manageVolume);
+        Server server = Provisioning.getInstance().getLocalServer();
+
+        checkRight(zsc, ctx, server, Admin.R_manageVolume);
 
         VolumeInfo volInfoRequest = request.getVolumeInfo();
         Volume.StoreType enumStoreType = (1 == volInfoRequest.getStoreType()) ? Volume.StoreType.INTERNAL : Volume.StoreType.EXTERNAL;
@@ -53,7 +56,7 @@ public final class CreateVolume extends AdminDocumentHandler {
 
         Volume volRequest = VolumeManager.getInstance().create(toVolume(volInfoRequest, enumStoreType));
         VolumeInfo volInfoResponse = volRequest.toJAXB();
-        VolumeConfigUtil.postCreateVolumeActions(request, volRequest, volInfoRequest, volInfoResponse, enumStoreType);
+        VolumeConfigUtil.postCreateVolumeActions(request, volRequest, volInfoRequest, volInfoResponse, enumStoreType, server.getId());
 
         CreateVolumeResponse createVolumeResponse = new CreateVolumeResponse(volInfoResponse);
         // if its primary volume then set respective store manager if it's different

--- a/store/src/java/com/zimbra/cs/service/admin/DeleteVolume.java
+++ b/store/src/java/com/zimbra/cs/service/admin/DeleteVolume.java
@@ -23,10 +23,10 @@ import java.util.Map;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
 import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.Server;
 import com.zimbra.cs.account.accesscontrol.AdminRight;
 import com.zimbra.cs.account.accesscontrol.Rights.Admin;
 import com.zimbra.cs.service.util.VolumeConfigUtil;
-import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.admin.message.DeleteVolumeRequest;
 import com.zimbra.soap.admin.message.DeleteVolumeResponse;
@@ -41,9 +41,9 @@ public final class DeleteVolume extends AdminDocumentHandler {
 
     private DeleteVolumeResponse handle(DeleteVolumeRequest req, Map<String, Object> ctx) throws ServiceException {
         ZimbraSoapContext zsc = getZimbraSoapContext(ctx);
-        checkRight(zsc, ctx, Provisioning.getInstance().getLocalServer(), Admin.R_manageVolume);
-
-        VolumeConfigUtil.parseDeleteVolumeRequest(req);
+        Server server = Provisioning.getInstance().getLocalServer();
+        checkRight(zsc, ctx, server, Admin.R_manageVolume);
+        VolumeConfigUtil.parseDeleteVolumeRequest(req, server.getId());
         return new DeleteVolumeResponse();
     }
 

--- a/store/src/java/com/zimbra/cs/service/util/VolumeConfigUtil.java
+++ b/store/src/java/com/zimbra/cs/service/util/VolumeConfigUtil.java
@@ -17,6 +17,9 @@
 
 package com.zimbra.cs.service.util;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import com.zimbra.client.ZMailbox;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AdminConstants;
@@ -38,8 +41,6 @@ import com.zimbra.soap.admin.type.VolumeExternalInfo;
 import com.zimbra.soap.admin.type.VolumeExternalOpenIOInfo;
 import com.zimbra.soap.admin.type.VolumeInfo;
 import com.zimbra.util.ExternalVolumeInfoHandler;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 public class VolumeConfigUtil {
 
@@ -210,7 +211,7 @@ public class VolumeConfigUtil {
      */
     public static void postCreateVolumeActions(CreateVolumeRequest request, Volume volRequest,
                                                VolumeInfo volInfoRequest, VolumeInfo volInfoResponse,
-                                               Volume.StoreType enumStoreType) throws ServiceException {
+                                               Volume.StoreType enumStoreType, String serverId) throws ServiceException {
         ExternalVolumeInfoHandler extVolInfoHandler = new ExternalVolumeInfoHandler(Provisioning.getInstance());
         if (Volume.StoreType.EXTERNAL.equals(enumStoreType)) {
             try {
@@ -221,7 +222,7 @@ public class VolumeConfigUtil {
                 } else {
                     volInfoResponse.setVolumeExternalOpenIOInfo(volInfoRequest.getVolumeExternalOpenIOInfo());
                 }
-                extVolInfoHandler.addServerProperties(volInfoRequest);
+                extVolInfoHandler.addServerProperties(volInfoRequest, serverId);
             } catch (JSONException e) {
                 throw ServiceException.FAILURE("Error while processing postCreateVolumeActions", e);
             }
@@ -290,7 +291,7 @@ public class VolumeConfigUtil {
      * @return
      * @throws ServiceException
      */
-    public static void parseDeleteVolumeRequest(DeleteVolumeRequest req) throws ServiceException {
+    public static void parseDeleteVolumeRequest(DeleteVolumeRequest req, String serverId) throws ServiceException {
         VolumeManager mgr = VolumeManager.getInstance();
         Volume vol = mgr.getVolume(req.getId()); // make sure the volume exists before doing anything heavyweight...
         StoreManager storeManager = StoreManager.getInstance();
@@ -302,7 +303,7 @@ public class VolumeConfigUtil {
             if (vol.getStoreType().equals(Volume.StoreType.EXTERNAL)) {
                 ExternalVolumeInfoHandler extVolInfoHandler = new ExternalVolumeInfoHandler(Provisioning.getInstance());
                 if (extVolInfoHandler.isVolumePresentInJson(req.getId())) {
-                    extVolInfoHandler.deleteServerProperties(req.getId());
+                    extVolInfoHandler.deleteServerProperties(req.getId(), serverId);
                 } else {
                     String errMsg = "External volume entry in JSON not found, Volume ID " + req.getId();
                     throw ServiceException.FAILURE(errMsg, null);


### PR DESCRIPTION
This ticket is the solution for [ZCS-12777](https://jira.corp.synacor.com/browse/ZCS-12777)
Requirement: While creating external(S3) Volume two LDAP attribute values which are in JSON format requires some structure modifications. JSON are:
1. zimbraServerExternalStoreConfig: `"unified":"true"` flag should be added. Default value is False.
2. zimbraGlobalExternalStoreConfig: Following structure _server wise_ should be added.
```
 "unified/volumes”:{[
       "{serverId1}": 
          {
              "volumeId": 3,
              "volumePrefix": "/",
              "globalBucketConfigId": "9243fd6d-4a4f-4b58-a695-6aabd726dd73"
          }
       ],
       "{serverId2}": []
  },
```
Point to consider:
- It is not applicable for OpenIO.
- We cannot edit unified attribute while editing volume.
- Volume API has been modified.
- UI still need to be introduced for unified volume.
- This is useful in multinode environment to share volume among multiple mailstore.

Solution: 
After volume creation, introduced a method which is appending required JSON in zimbraGlobalExternalStoreConfig attribute server wise.
After volume deletion, also deleting the volume details from above json.

Testing:
Manual testing and Junit testing done.

Please refer the ticket for more details.
Note: The rest of the part of the ticket is covered under [#41](https://github.com/Zimbra/zm-hsm-store/pull/41)
