### PR TITLE
ZBUG-733 SearchDirectoryRequest takes a long time on large directory (ISP size)

### DIFF
--- a/soap/src/java/com/zimbra/soap/admin/message/SearchDirectoryRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/SearchDirectoryRequest.java
@@ -53,6 +53,7 @@ public class SearchDirectoryRequest extends AttributeSelectorImpl {
 
     /**
      * @zm-api-field-description The maximum number of accounts to return (0 is default and means all)
+     * and it must be greater than or equal to 0.
      */
     @XmlAttribute(name=AdminConstants.A_LIMIT, required=false)
     private Integer limit;

--- a/store/src/java/com/zimbra/cs/account/SearchDirectoryOptions.java
+++ b/store/src/java/com/zimbra/cs/account/SearchDirectoryOptions.java
@@ -30,6 +30,7 @@ import com.zimbra.cs.ldap.ZLdapFilterFactory.FilterId;
 
 public class SearchDirectoryOptions {
     public static final int ALL_RESULTS = 0;
+    public static final int DEFAULT_LIMIT = 0;
     public static final String[] ALL_ATTRS = null;
     public static final SearchDirectoryOptions.SortOpt DEFAULT_SORT_OPT = SortOpt.NO_SORT;
     public static final String DEFAULT_SORT_ATTR = null;
@@ -137,6 +138,7 @@ public class SearchDirectoryOptions {
     private boolean onMaster = false;
     private final boolean useConnPool = true; // TODO: retire this
     private int maxResults = ALL_RESULTS;
+    private int resultPageSize = DEFAULT_LIMIT;
 
     /*
      * search base
@@ -221,6 +223,10 @@ public class SearchDirectoryOptions {
         }
 
         if (maxResults != other.getMaxResults()) {
+            return false;
+        }
+
+        if (resultPageSize != other.getResultPageSize()) {
             return false;
         }
 
@@ -341,6 +347,18 @@ public class SearchDirectoryOptions {
 
     public int getMaxResults() {
         return maxResults;
+    }
+
+    public void setResultPageSize(int resultPageSize) throws ServiceException {
+        if (resultPageSize >= 0) {
+            this.resultPageSize = resultPageSize;
+        } else {
+            throw ServiceException.INVALID_REQUEST("limit cannot be a negative value.", null);
+        }
+    }
+
+    public int getResultPageSize() {
+        return resultPageSize;
     }
 
     public void setDomain(Domain domain) {

--- a/store/src/java/com/zimbra/cs/account/SearchDirectoryOptions.java
+++ b/store/src/java/com/zimbra/cs/account/SearchDirectoryOptions.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Sets;
 import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.ldap.ZLdapFilter;
 import com.zimbra.cs.ldap.ZLdapFilterFactory.FilterId;
 
@@ -353,7 +354,8 @@ public class SearchDirectoryOptions {
         if (resultPageSize >= 0) {
             this.resultPageSize = resultPageSize;
         } else {
-            throw ServiceException.INVALID_REQUEST("limit cannot be a negative value.", null);
+            this.resultPageSize = DEFAULT_LIMIT;
+            ZimbraLog.search.info("Limit cannot be a negative value. Setting it back to %s", this.resultPageSize);
         }
     }
 

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -2218,9 +2218,13 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
                         opts.getMakeObjectOpt(), returnAttrs);
 
             SearchLdapOptions searchObjectsOptions = new SearchLdapOptions(base, filter,
-                    returnAttrs, opts.getMaxResults(), null, ZSearchScope.SEARCH_SCOPE_SUBTREE,
+                    returnAttrs, opts.getMaxResults(), null, opts.getResultPageSize(), ZSearchScope.SEARCH_SCOPE_SUBTREE,
                     searchObjectsVisitor);
-            searchObjectsOptions.setUseControl(opts.isUseControl());
+            if (opts.getResultPageSize() == 0 || opts.getResultPageSize() == Integer.MAX_VALUE) {
+                searchObjectsOptions.setUseControl(false);
+            } else {
+                searchObjectsOptions.setUseControl(opts.isUseControl());
+            }
             searchObjectsOptions.setManageDSAit(opts.isManageDSAit());
             zlc.searchPaged(searchObjectsOptions);
         } catch (LdapSizeLimitExceededException e) {
@@ -9485,7 +9489,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
             }
         }
 
-        // one more search if there are remainding
+        // one more search if there are remaining
         if (query.length() != queryStart.length()) {
             query.append(queryEnd);
             searchLdapOnReplica(base, query.toString(), returnAttrs, visitor);

--- a/store/src/java/com/zimbra/cs/ldap/SearchLdapOptions.java
+++ b/store/src/java/com/zimbra/cs/ldap/SearchLdapOptions.java
@@ -104,7 +104,7 @@ public class SearchLdapOptions {
     private String[] returnAttrs = RETURN_ALL_ATTRS;
     private int maxResults = SIZE_UNLIMITED;
     private Set<String> binaryAttrs;
-    private int resultPageSize  = DEFAULT_RESULT_PAGE_SIZE;
+    private int resultPageSize = DEFAULT_RESULT_PAGE_SIZE;
     private ZSearchScope searchScope;
     private SearchLdapOptions.SearchLdapVisitor visitor;
     private boolean isUseControl = true;
@@ -131,6 +131,20 @@ public class SearchLdapOptions {
         setFilter(filter);
         setReturnAttrs(returnAttrs);
         setMaxResults(maxResults);
+        setBinaryAttrs(binaryAttrs);
+        setSearchScope(searchScope);
+        setVisitor(visitor);
+    }
+
+ // TODO: use only this
+    public SearchLdapOptions(String searchbase, ZLdapFilter filter,
+            String[] returnAttrs, int maxResults, Set<String> binaryAttrs, int resultPageSize,
+            ZSearchScope searchScope, SearchLdapOptions.SearchLdapVisitor visitor) {
+        setSearchBase(searchbase);
+        setFilter(filter);
+        setReturnAttrs(returnAttrs);
+        setMaxResults(maxResults);
+        setResultPageSize(resultPageSize);
         setBinaryAttrs(binaryAttrs);
         setSearchScope(searchScope);
         setVisitor(visitor);

--- a/store/src/java/com/zimbra/cs/service/admin/SearchDirectory.java
+++ b/store/src/java/com/zimbra/cs/service/admin/SearchDirectory.java
@@ -174,6 +174,11 @@ public class SearchDirectory extends AdminDocumentHandler {
         options.setDomain(d);
         options.setTypes(types);
         options.setMaxResults(maxResults);
+        options.setResultPageSize(limit);
+        if (limit == Integer.MAX_VALUE) {
+            options.setUseControl(false);
+        }
+
         options.setFilterString(FilterId.ADMIN_SEARCH, query);
         options.setReturnAttrs(attrs);
         options.setSortOpt(sortAscending ? SortOpt.SORT_ASCENDING : SortOpt.SORT_DESCENDING);


### PR DESCRIPTION
**Problem:**
SearchDirectoryRequest takes a long time on large directory (ISP size).

**Requirements:**

limit parameter is not getting passed to the SearchDirectoryRequest but it should as per it's API document..
If the limit is specified as 0 or if the limit is not specified then it should return everything as per the API document and there should not be any pagination.
If the limit is non-zero and it's specified then it should handle the pagination.

**Analysis and Approach:**
SearchDirectoryRequest takes a long time on large directory which only happens for a large directory sites such as ISP who has +1M accounts because it always sends with paged search options like -E pr=1000 whether limit is specified as limit="0" or not. And as per SearchDirectoryRequest API document maxResults is the maximum results that the backend will attempt to fetch from the directory before returning a account.TOO_MANY_SEARCH_RESULTS error, and limit is the number of accounts to return per page (0 is default which means all). But the limit is fixed value in the code for SearchLdapOptions class is set to 1000.

**Test-cases:**
Test performed added to https://jira.corp.synacor.com/browse/ZBUG-733 as attachment ZBUG-733_test_result.txt