### PR TITLE
ZBUG-3053 : changing localhost to zimbraloghostname for syslogger

### DIFF
--- a/store-conf/conf/log4j.properties.production
+++ b/store-conf/conf/log4j.properties.production
@@ -128,7 +128,7 @@ appender.EWS.strategy.type = DefaultRolloverStrategy
 # Syslog appender
 %%uncomment VAR:zimbraLogToSyslog%%appender.SYSLOG.type = Syslog
 %%uncomment VAR:zimbraLogToSyslog%%appender.SYSLOG.name = syslogAppender
-%%uncomment VAR:zimbraLogToSyslog%%appender.SYSLOG.host = localhost
+%%uncomment VAR:zimbraLogToSyslog%%appender.SYSLOG.host = %%zimbraLogHostname%%
 %%uncomment VAR:zimbraLogToSyslog%%appender.SYSLOG.port = 514
 %%uncomment VAR:zimbraLogToSyslog%%appender.SYSLOG.protocol = UDP
 %%uncomment VAR:zimbraLogToSyslog%%appender.SYSLOG.facility = LOCAL0


### PR DESCRIPTION
Issue :- In a multiserver installation, syslogger does not work if we have a logger server as localhost.
Resolution :- Changing default localhost to zimbraloghostname