### PR TITLE
ZCS-12876 | ZCS-12878 logging changes for discard filter in mailbox logs & debug level for IMAP SEARCH command

### DIFF
--- a/store/src/java/com/zimbra/cs/filter/jsieve/Discard.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/Discard.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2011, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2011, 2013, 2014, 2016, 2023 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -16,6 +16,7 @@
  */
 package com.zimbra.cs.filter.jsieve;
 
+import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.filter.ZimbraMailAdapter;
 import org.apache.jsieve.Arguments;
 import org.apache.jsieve.Block;
@@ -29,8 +30,14 @@ public class Discard extends org.apache.jsieve.commands.Discard {
 
     @Override
     protected Object executeBasic(MailAdapter mail, Arguments arguments, Block block, SieveContext context) throws SieveException {
-        if (!(mail instanceof ZimbraMailAdapter))
+        if (!(mail instanceof ZimbraMailAdapter)) {
             return null;
+        }
+        for (String msgId : mail.getHeader("Message-ID")) {
+            if (!msgId.isEmpty()) {
+                ZimbraLog.filter.info("Discarding Message: Message-ID=%s", msgId);
+            }
+        }
         ((ZimbraMailAdapter) mail).setDiscardActionPresent();
         return super.executeBasic(mail, arguments, block, context);
     }

--- a/store/src/java/com/zimbra/cs/imap/ImapHandler.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapHandler.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016 Synacor, Inc.
+ * Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2023 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -3757,7 +3757,7 @@ public abstract class ImapHandler {
             } else {
                 search = '(' + i4folder.getQuery() + ") " + search;
             }
-            ZimbraLog.imap.info("[ search is: " + search + " ]");
+            ZimbraLog.imap.debug("[ search is: " + search + " ]");
         } finally {
             mbox.unlock();
         }


### PR DESCRIPTION
**Requirement:**
1. log event when discard filter action is called.
2. Change the log level of IMAP SEARCH command from info to debug

**Testing Done:**

Created a discard filter with a Subject contains spoof.
Checked from CLI for zimbraMailSieveScript

> zimbra@platform-dev-activesync:~$ zmprov ga admin@platform-dev-activesync.zimbradev.com zimbraMailSieveScript name admin@platform-dev-activesync.zimbradev.com
zimbraMailSieveScript: require ["fileinto", "copy", "reject", "tag", "flag", "variables", "log", "enotify", "envelope", "body", "ereject", "reject", "relational", "comparator-i;ascii-numeric"];
 spoof
if allof (header :contains ["subject"] "spoof") {
    discard;
    stop;
}

Mailbox.log 
`2023-02-06 06:55:09,178 INFO  [LmtpServer-621] [ip=10.0.0.68;] lmtp - Delivering message: size=2613 bytes, nrcpts=1, sender=admin@platform-dev-activesync.zimbradev.com, msgid=<794304375.17.1675666508750.JavaMail.zimbra@platform-dev-activesync.zimbradev.com>
2023-02-06 06:55:09,179 INFO  [LmtpServer-621] [name=admin@platform-dev-activesync.zimbradev.com;mid=2;ip=10.0.0.68;] filter - Discarding Message: Message-ID=<794304375.17.1675666508750.JavaMail.zimbra@platform-dev-activesync.zimbradev.com>
2023-02-06 06:55:09,179 INFO  [LmtpServer-621] [name=admin@platform-dev-activesync.zimbradev.com;mid=2;ip=10.0.0.68;] filter - Discarding message with Message-ID <794304375.17.1675666508750.JavaMail.zimbra@platform-dev-activesync.zimbradev.com> from admin <admin@platform-dev-activesync.zimbradev.com>`