### PR TITLE
ZCS-12874 log for modifying Preference settings

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1140,6 +1140,11 @@ public final class LC {
     public static final KnownKey smtp_to_lmtp_port = KnownKey.newKey(7024);
 
     @Supported
+    public static final KnownKey prefs_settings_value_logging_enabled = KnownKey.newKey(false);
+    public static final KnownKey prefs_settings_value_logging_delimeter = KnownKey.newKey("; ");
+    public static final KnownKey prefs_settings_value_logging_chars_limit = KnownKey.newKey(100);
+
+    @Supported
     public static final KnownKey socks_enabled = KnownKey.newKey(false);
 
     public static final KnownKey socket_connect_timeout = KnownKey.newKey(30000);


### PR DESCRIPTION
**Requirement:** 
Log changes in preference settings

**Testing done:**

1. After setting prefs_settings_value_logging_enabled=TRUE
> 2023-02-17 10:56:40,193 INFO  [qtp2138564891-20:https://platform-dev-activesync.zimbradev.com/service/soap/ModifyPrefsRequest] [name=admin@platform-dev-activesync.zimbradev.com;mid=2;ip=10.0.0.68;port=43338;ua=ZimbraXWebClient - GC110 (Mac)/9.0.0;soapId=7d69d4d4;] account - Setting Preference attributes : [zimbraPrefMailPollingInterval=360; zimbraPrefMailTrustedSenderList=w@w.co,x@x.co,y@y.co,z@z.co,d@d.co; zimbraPrefMailSendReadReceipts=always] 

2. After setting prefs_settings_value_logging_enabled=FALSE
> 2023-02-17 09:56:59,026 INFO  [qtp2138564891-133:https://platform-dev-activesync.zimbradev.com/service/soap/ModifyPrefsRequest] [name=admin@platform-dev-activesync.zimbradev.com;mid=2;ip=10.0.0.68;port=44068;ua=ZimbraXWebClient - GC110 (Mac)/9.0.0;soapId=2aa9ec6;] account - Setting Preference attributes: [zimbraPrefCalendarWorkingHours, zimbraPrefOutOfOfficeUntilDate, zimbraPrefOutOfOfficeFromDate] 