### PR TITLE
ZCS-12875: Request to extend LMTP log events for easy and clear confirmation of mail delivery

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2022 Synacor, Inc.
+ * Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2022, 2023 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -1380,6 +1380,9 @@ public final class LC {
 
     @Supported
     public static final KnownKey zimbra_listeners_maxsize = KnownKey.newKey(5);
+
+    @Supported
+    public static final KnownKey lmtp_extended_logs_enabled = KnownKey.newKey(false);
 
     public enum PUBLIC_SHARE_VISIBILITY { samePrimaryDomain, all, none };
 

--- a/store/src/java/com/zimbra/cs/filter/FilterUtil.java
+++ b/store/src/java/com/zimbra/cs/filter/FilterUtil.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017 Synacor, Inc.
+ * Copyright (C) 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2023 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -1105,6 +1105,12 @@ public final class FilterUtil {
         if (headerName.contains(" ")) {
             throw new SyntaxException("ZimbraComparatorUtils : Header name must not have space(s) : \"" + headerName + "\"");
         }
+    }
+
+    public static String getExtendedInfo(MimeMessage msg) {
+        String sender = Mime.getSender(msg);
+        sender = (sender.contains("<")) ? sender.substring(sender.indexOf("<") + 1, sender.length() - 1) : sender;
+        return ", sender=" + sender +  ", MsgId=" + Mime.getMessageID(msg);
     }
 }
 

--- a/store/src/java/com/zimbra/cs/filter/jsieve/AddHeader.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/AddHeader.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2016, 2017 Synacor, Inc.
+ * Copyright (C) 2016, 2017, 2023 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -41,6 +41,7 @@ import org.apache.jsieve.exception.SieveException;
 import org.apache.jsieve.exception.SyntaxException;
 import org.apache.jsieve.mail.MailAdapter;
 
+import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.CharsetUtil;
 import com.zimbra.common.util.StringUtil;
@@ -48,6 +49,7 @@ import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.filter.FilterUtil;
 import com.zimbra.cs.filter.ZimbraMailAdapter;
 import com.zimbra.cs.filter.ZimbraMailAdapter.PARSESTATUS;
+import com.zimbra.cs.mime.Mime;
 import com.zimbra.cs.mime.MimeUtil;
 
 
@@ -129,9 +131,15 @@ public class AddHeader extends AbstractCommand {
                 }
                 EditHeaderExtension.saveChanges(mailAdapter, "addheader", mm);
                 mailAdapter.updateIncomingBlob();
-                ZimbraLog.filter.info(
-                    "addheader: New header is added in mime with name: %s and value: %s",
-                    headerName, headerValue);
+                if (LC.lmtp_extended_logs_enabled.booleanValue()) {
+                    ZimbraLog.filter.info(
+                            "addheader: name=%s value=%s", headerName, headerValue
+                            + FilterUtil.getExtendedInfo(mm));
+                } else {
+                    ZimbraLog.filter.info(
+                            "addheader: New header is added in mime with name: %s and value: %s",
+                            headerName, headerValue);
+                }
             } catch (MessagingException e) {
                 throw new OperationException("addheader: Error occured while adding new header in mime.", e);
             }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/DeleteHeader.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/DeleteHeader.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2016 Synacor, Inc.
+ * Copyright (C) 2016, 2023 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -37,10 +37,12 @@ import org.apache.jsieve.exception.SieveException;
 import org.apache.jsieve.exception.SyntaxException;
 import org.apache.jsieve.mail.MailAdapter;
 
+import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.filter.FilterUtil;
 import com.zimbra.cs.filter.ZimbraMailAdapter;
 import com.zimbra.cs.filter.ZimbraMailAdapter.PARSESTATUS;
+import com.zimbra.cs.mime.Mime;
 
 public class DeleteHeader extends AbstractCommand {
     private EditHeaderExtension ehe = new EditHeaderExtension();
@@ -137,9 +139,15 @@ public class DeleteHeader extends AbstractCommand {
                     mm.addHeaderLine(header.getName() + ": " + header.getValue());
                     hasEdited = true;
                 } else {
-                    ZimbraLog.filter.info(
-                        "deleteheader: deleted header in mime with name: %s and value: %s",
-                        header.getName(), header.getValue());
+                    if (LC.lmtp_extended_logs_enabled.booleanValue()) {
+                        ZimbraLog.filter.info(
+                                "deleteheader: name=%s value=%s", header.getName(), header.getValue()
+                                + FilterUtil.getExtendedInfo(mm));
+                    } else {
+                        ZimbraLog.filter.info(
+                                "deleteheader: deleted header in mime with name: %s and value: %s",
+                                header.getName(), header.getValue());
+                    }
                 }
             }
             if (hasEdited) {

--- a/store/src/java/com/zimbra/cs/filter/jsieve/Discard.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/Discard.java
@@ -33,11 +33,7 @@ public class Discard extends org.apache.jsieve.commands.Discard {
         if (!(mail instanceof ZimbraMailAdapter)) {
             return null;
         }
-        for (String msgId : mail.getHeader("Message-ID")) {
-            if (!msgId.isEmpty()) {
-                ZimbraLog.filter.info("Discarding Message: Message-ID=%s", msgId);
-            }
-        }
+        // removing logging as discard action is logged @setDiscardActionPresent() method
         ((ZimbraMailAdapter) mail).setDiscardActionPresent();
         return super.executeBasic(mail, arguments, block, context);
     }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/ReplaceHeader.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/ReplaceHeader.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2016, 2017 Synacor, Inc.
+ * Copyright (C) 2016, 2017, 2023 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -39,11 +39,13 @@ import org.apache.jsieve.exception.SieveException;
 import org.apache.jsieve.exception.SyntaxException;
 import org.apache.jsieve.mail.MailAdapter;
 
+import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.util.CharsetUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.filter.FilterUtil;
 import com.zimbra.cs.filter.ZimbraMailAdapter;
 import com.zimbra.cs.filter.ZimbraMailAdapter.PARSESTATUS;
+import com.zimbra.cs.mime.Mime;
 import com.zimbra.cs.mime.MimeUtil;
 
 public class ReplaceHeader extends AbstractCommand {
@@ -140,9 +142,15 @@ public class ReplaceHeader extends AbstractCommand {
                                 } else {
                                     newHeaderValue = header.getValue();
                                 }
-                                ZimbraLog.filter.info(
-                                    "replaceheader: replaced header in mime with name: %s and value: %s",
-                                    newHeaderName, newHeaderValue);
+                                if (LC.lmtp_extended_logs_enabled.booleanValue()) {
+                                    ZimbraLog.filter.info(
+                                            "replaceheader: name=%s value=%s", newHeaderName, newHeaderValue
+                                            + FilterUtil.getExtendedInfo(mm));
+                                } else {
+                                    ZimbraLog.filter.info(
+                                            "replaceheader: replaced header in mime with name: %s and value: %s",
+                                            newHeaderName, newHeaderValue);
+                                }
                                 header = new Header(newHeaderName, newHeaderValue);
                                 break;
                             }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/VariableLog.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/VariableLog.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2016, 2017 Synacor, Inc.
+ * Copyright (C) 2016, 2017, 2023 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -29,10 +29,14 @@ import org.apache.jsieve.exception.SieveException;
 import org.apache.jsieve.exception.SyntaxException;
 import org.apache.jsieve.mail.MailAdapter;
 
+import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.filter.FilterUtil;
 import com.zimbra.cs.filter.ZimbraMailAdapter;
+import com.zimbra.cs.mime.Mime;
 import com.zimbra.soap.mail.type.FilterAction;
+
+import javax.mail.internet.MimeMessage;
 
 public class VariableLog extends Log {
     private ZimbraMailAdapter mailAdapter = null;
@@ -46,6 +50,15 @@ public class VariableLog extends Log {
         }
 
         this.mailAdapter = (ZimbraMailAdapter) mail;
+        MimeMessage mm = mailAdapter.getMimeMessage();
+        if (LC.lmtp_extended_logs_enabled.booleanValue()) {
+            Iterator<Argument> itr = arguments.getArgumentList().iterator();
+            while (itr.hasNext()) {
+                Argument arg = itr.next();
+                ZimbraLog.filter.info(
+                        "Log: " + arg + FilterUtil.getExtendedInfo(mm));
+            }
+        }
         return super.executeBasic(mail, arguments, block, context);
 
     }

--- a/store/src/java/com/zimbra/cs/lmtpserver/ZimbraLmtpBackend.java
+++ b/store/src/java/com/zimbra/cs/lmtpserver/ZimbraLmtpBackend.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016 Synacor, Inc.
+ * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2023 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -582,7 +582,13 @@ public class ZimbraLmtpBackend implements LmtpBackend {
             }
 
             ZimbraLog.removeAccountFromContext();
-            if (ZimbraLog.lmtp.isInfoEnabled()) {
+            if (LC.lmtp_extended_logs_enabled.booleanValue()) {
+                ZimbraLog.lmtp.info("Delivering message started: size=%s, nrcpts=%d, sender=%s, msgid=%s",
+                        env.getSize() == 0 ? "unspecified" : Integer.toString(env.getSize()) + " bytes",
+                        recipients.size(),
+                        env.getSender(),
+                        msgId == null ? "" : msgId);
+            } else if (ZimbraLog.lmtp.isInfoEnabled()) {
                 ZimbraLog.lmtp.info("Delivering message: size=%s, nrcpts=%d, sender=%s, msgid=%s",
                                     env.getSize() == 0 ? "unspecified" : Integer.toString(env.getSize()) + " bytes",
                                     recipients.size(),
@@ -783,6 +789,13 @@ public class ZimbraLmtpBackend implements LmtpBackend {
                 }
             }
 
+            if (LC.lmtp_extended_logs_enabled.booleanValue()) {
+                ZimbraLog.lmtp.info("Delivering message completed: size=%s, nrcpts=%d, sender=%s, msgid=%s",
+                                    env.getSize() == 0 ? "unspecified" : Integer.toString(env.getSize()) + " bytes",
+                                    recipients.size(),
+                                    env.getSender(),
+                                    msgId == null ? "" : msgId);
+            }
             // If this message is being streamed from disk, cache it
             ParsedMessage mimeSource = pmAttachIndex != null ? pmAttachIndex : pmNoAttachIndex;
             MailboxBlob mblob = sharedDeliveryCtxt.getMailboxBlob();

--- a/store/src/java/com/zimbra/cs/mailbox/Message.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Message.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2021 Synacor, Inc.
+ * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2021, 2023 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -597,8 +597,8 @@ public class Message extends MailItem {
         data.contentChanged(mbox);
 
         ZimbraLog.mailop.info(
-                "Adding Message: id=%d, Message-ID=%s, parentId=%d, folderId=%d, folderName=%s acct=%s.",
-                data.id, pm.getMessageID(), data.parentId, folder.getId(), folder.getName(),
+                "Adding Message: id=%d, sender=%s, Message-ID=%s, parentId=%d, folderId=%d, folderName=%s acct=%s.",
+                data.id, sender, pm.getMessageID(), data.parentId, folder.getId(), folder.getName(),
                 mbox.getAccountId());
         new DbMailItem(mbox)
             .setSender(pm.getParsedSender().getSortString())


### PR DESCRIPTION
**Fix**: added an LC config: **lmtp_extended_logs_enabled**

when the value of the parameter is True, the extended log with sender and messageId is logged at the "info" level,
when the value is False, the existing logs get printed.
