### PR TITLE
ZBUG-2929 : adding LC zimbra_enable_dnssec to enable/disable DNSSEC

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -413,6 +413,9 @@ public final class LC {
     @Reloadable
     public static final KnownKey clamav_scan_data_chunk_size = KnownKey.newKey(2048);
 
+    @Reloadable
+    public static final KnownKey zimbra_enable_dnssec = KnownKey.newKey(true);
+
     @Supported
     public static final KnownKey zimbra_directory_max_search_result = KnownKey.newKey(5000);
 

--- a/store/conf/unbound.conf.in
+++ b/store/conf/unbound.conf.in
@@ -6,7 +6,7 @@ server:
 	do-tcp: %%zimbraDNSUseTCP%%
 	do-udp: %%zimbraDNSUseUDP%%
 	tcp-upstream: %%zimbraDNSTCPUpstream%%
-	trust-anchor-file: "/opt/zimbra/conf/root.key"
+	%%uncomment LOCAL:zimbra_enable_dnssec%%trust-anchor-file: "/opt/zimbra/conf/root.key"
 
 local-zone: "10.in-addr.arpa." nodefault
 local-zone: "16.172.in-addr.arpa." nodefault


### PR DESCRIPTION
Recently, we have added DNSSEC validation for DNS cache. Currently, there is no attribute to disable the DNSSEC in Zimbra config.

There should be an attribute to enable/disable DNSSEC because if any DNS server does not support DNSSEC then DNS cache will fail.

Added a boolean value local config `zimbra_enable_dnssec`. Default should be true.

When set to false, the DNSSEC validation should be disabled.