### PR TITLE
ZCS-12471- adding LDAP attribute for mail recall

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -7141,6 +7141,23 @@ public class ZAttrProvisioning {
     public static final String A_zimbraFeatureMailPriorityEnabled = "zimbraFeatureMailPriorityEnabled";
 
     /**
+     * Enables the mail recall functionality
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4094)
+    public static final String A_zimbraFeatureMailRecallEnabled = "zimbraFeatureMailRecallEnabled";
+
+    /**
+     * Time(in minutes) within which a message can be recalled. The default
+     * time is 30 minutes and accepts value from 1 to 30.
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4095)
+    public static final String A_zimbraFeatureMailRecallTime = "zimbraFeatureMailRecallTime";
+
+    /**
      * whether the send later feature is enabled
      *
      * @since ZCS 7.0.0

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10319,6 +10319,16 @@ TODO: delete them permanently from here
 <attr id="4093" name="zimbraTrialConvertAtExpiration" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited,accountInfo" since="9.0.0">
   <desc>Can be used by an external service to indicate that a trial is set to convert to active at expiration.</desc>
 </attr>
+<attr id="4094" name="zimbraFeatureMailRecallEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,account,cos,domain" flags="domainInfo,accountInfo,domainInherited,accountCosDomainInherited" since="10.1.0">
+  <globalConfigValue>FALSE</globalConfigValue>
+  <defaultCOSValue>FALSE</defaultCOSValue>
+  <desc>Enables the mail recall functionality</desc>
+</attr>
+<attr id="4095" name="zimbraFeatureMailRecallTime" type="integer" min="1" max="30" cardinality="single" optionalIn="globalConfig,account,cos,domain" flags="domainInfo,accountInfo,domainInherited,accountCosDomainInherited" since="10.1.0">
+  <globalConfigValue>30</globalConfigValue>
+  <defaultCOSValue>30</defaultCOSValue>
+  <desc>Time(in minutes) within which a message can be recalled. The default time is 30 minutes and accepts value from 1 to 30.</desc>
+</attr>
 
 <attr id="9001" name="zimbraMailSieveScriptMaxSize" type="long" min="0" cardinality="single" optionalIn="globalConfig,account,cos,domain" flags="domainInfo,accountInfo,accountCosDomainInherited" since="11.0.0">
   <globalConfigValue>0</globalConfigValue>

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -17850,6 +17850,155 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * Enables the mail recall functionality
+     *
+     * @return zimbraFeatureMailRecallEnabled, or false if unset
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4094)
+    public boolean isFeatureMailRecallEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureMailRecallEnabled, false, true);
+    }
+
+    /**
+     * Enables the mail recall functionality
+     *
+     * @param zimbraFeatureMailRecallEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4094)
+    public void setFeatureMailRecallEnabled(boolean zimbraFeatureMailRecallEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallEnabled, zimbraFeatureMailRecallEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Enables the mail recall functionality
+     *
+     * @param zimbraFeatureMailRecallEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4094)
+    public Map<String,Object> setFeatureMailRecallEnabled(boolean zimbraFeatureMailRecallEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallEnabled, zimbraFeatureMailRecallEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Enables the mail recall functionality
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4094)
+    public void unsetFeatureMailRecallEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Enables the mail recall functionality
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4094)
+    public Map<String,Object> unsetFeatureMailRecallEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * Time(in minutes) within which a message can be recalled. The default
+     * time is 30 minutes and accepts value from 1 to 30.
+     *
+     * @return zimbraFeatureMailRecallTime, or 30 if unset
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4095)
+    public int getFeatureMailRecallTime() {
+        return getIntAttr(Provisioning.A_zimbraFeatureMailRecallTime, 30, true);
+    }
+
+    /**
+     * Time(in minutes) within which a message can be recalled. The default
+     * time is 30 minutes and accepts value from 1 to 30.
+     *
+     * @param zimbraFeatureMailRecallTime new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4095)
+    public void setFeatureMailRecallTime(int zimbraFeatureMailRecallTime) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallTime, Integer.toString(zimbraFeatureMailRecallTime));
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Time(in minutes) within which a message can be recalled. The default
+     * time is 30 minutes and accepts value from 1 to 30.
+     *
+     * @param zimbraFeatureMailRecallTime new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4095)
+    public Map<String,Object> setFeatureMailRecallTime(int zimbraFeatureMailRecallTime, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallTime, Integer.toString(zimbraFeatureMailRecallTime));
+        return attrs;
+    }
+
+    /**
+     * Time(in minutes) within which a message can be recalled. The default
+     * time is 30 minutes and accepts value from 1 to 30.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4095)
+    public void unsetFeatureMailRecallTime() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallTime, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Time(in minutes) within which a message can be recalled. The default
+     * time is 30 minutes and accepts value from 1 to 30.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4095)
+    public Map<String,Object> unsetFeatureMailRecallTime(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallTime, "");
+        return attrs;
+    }
+
+    /**
      * whether the send later feature is enabled
      *
      * @return zimbraFeatureMailSendLaterEnabled, or false if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -18598,6 +18598,155 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Enables the mail recall functionality
+     *
+     * @return zimbraFeatureMailRecallEnabled, or false if unset
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4094)
+    public boolean isFeatureMailRecallEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureMailRecallEnabled, false, true);
+    }
+
+    /**
+     * Enables the mail recall functionality
+     *
+     * @param zimbraFeatureMailRecallEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4094)
+    public void setFeatureMailRecallEnabled(boolean zimbraFeatureMailRecallEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallEnabled, zimbraFeatureMailRecallEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Enables the mail recall functionality
+     *
+     * @param zimbraFeatureMailRecallEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4094)
+    public Map<String,Object> setFeatureMailRecallEnabled(boolean zimbraFeatureMailRecallEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallEnabled, zimbraFeatureMailRecallEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Enables the mail recall functionality
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4094)
+    public void unsetFeatureMailRecallEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Enables the mail recall functionality
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4094)
+    public Map<String,Object> unsetFeatureMailRecallEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * Time(in minutes) within which a message can be recalled. The default
+     * time is 30 minutes and accepts value from 1 to 30.
+     *
+     * @return zimbraFeatureMailRecallTime, or 30 if unset
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4095)
+    public int getFeatureMailRecallTime() {
+        return getIntAttr(Provisioning.A_zimbraFeatureMailRecallTime, 30, true);
+    }
+
+    /**
+     * Time(in minutes) within which a message can be recalled. The default
+     * time is 30 minutes and accepts value from 1 to 30.
+     *
+     * @param zimbraFeatureMailRecallTime new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4095)
+    public void setFeatureMailRecallTime(int zimbraFeatureMailRecallTime) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallTime, Integer.toString(zimbraFeatureMailRecallTime));
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Time(in minutes) within which a message can be recalled. The default
+     * time is 30 minutes and accepts value from 1 to 30.
+     *
+     * @param zimbraFeatureMailRecallTime new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4095)
+    public Map<String,Object> setFeatureMailRecallTime(int zimbraFeatureMailRecallTime, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallTime, Integer.toString(zimbraFeatureMailRecallTime));
+        return attrs;
+    }
+
+    /**
+     * Time(in minutes) within which a message can be recalled. The default
+     * time is 30 minutes and accepts value from 1 to 30.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4095)
+    public void unsetFeatureMailRecallTime() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallTime, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Time(in minutes) within which a message can be recalled. The default
+     * time is 30 minutes and accepts value from 1 to 30.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4095)
+    public Map<String,Object> unsetFeatureMailRecallTime(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallTime, "");
+        return attrs;
+    }
+
+    /**
      * Maximum size in bytes for file uploads.
      *
      * @return zimbraFileUploadMaxSize, or 10485760 if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -12239,6 +12239,155 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * Enables the mail recall functionality
+     *
+     * @return zimbraFeatureMailRecallEnabled, or false if unset
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4094)
+    public boolean isFeatureMailRecallEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureMailRecallEnabled, false, true);
+    }
+
+    /**
+     * Enables the mail recall functionality
+     *
+     * @param zimbraFeatureMailRecallEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4094)
+    public void setFeatureMailRecallEnabled(boolean zimbraFeatureMailRecallEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallEnabled, zimbraFeatureMailRecallEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Enables the mail recall functionality
+     *
+     * @param zimbraFeatureMailRecallEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4094)
+    public Map<String,Object> setFeatureMailRecallEnabled(boolean zimbraFeatureMailRecallEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallEnabled, zimbraFeatureMailRecallEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Enables the mail recall functionality
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4094)
+    public void unsetFeatureMailRecallEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Enables the mail recall functionality
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4094)
+    public Map<String,Object> unsetFeatureMailRecallEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * Time(in minutes) within which a message can be recalled. The default
+     * time is 30 minutes and accepts value from 1 to 30.
+     *
+     * @return zimbraFeatureMailRecallTime, or 30 if unset
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4095)
+    public int getFeatureMailRecallTime() {
+        return getIntAttr(Provisioning.A_zimbraFeatureMailRecallTime, 30, true);
+    }
+
+    /**
+     * Time(in minutes) within which a message can be recalled. The default
+     * time is 30 minutes and accepts value from 1 to 30.
+     *
+     * @param zimbraFeatureMailRecallTime new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4095)
+    public void setFeatureMailRecallTime(int zimbraFeatureMailRecallTime) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallTime, Integer.toString(zimbraFeatureMailRecallTime));
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Time(in minutes) within which a message can be recalled. The default
+     * time is 30 minutes and accepts value from 1 to 30.
+     *
+     * @param zimbraFeatureMailRecallTime new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4095)
+    public Map<String,Object> setFeatureMailRecallTime(int zimbraFeatureMailRecallTime, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallTime, Integer.toString(zimbraFeatureMailRecallTime));
+        return attrs;
+    }
+
+    /**
+     * Time(in minutes) within which a message can be recalled. The default
+     * time is 30 minutes and accepts value from 1 to 30.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4095)
+    public void unsetFeatureMailRecallTime() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallTime, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Time(in minutes) within which a message can be recalled. The default
+     * time is 30 minutes and accepts value from 1 to 30.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4095)
+    public Map<String,Object> unsetFeatureMailRecallTime(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallTime, "");
+        return attrs;
+    }
+
+    /**
      * whether the send later feature is enabled
      *
      * @return zimbraFeatureMailSendLaterEnabled, or false if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -10754,6 +10754,155 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
+     * Enables the mail recall functionality
+     *
+     * @return zimbraFeatureMailRecallEnabled, or false if unset
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4094)
+    public boolean isFeatureMailRecallEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureMailRecallEnabled, false, true);
+    }
+
+    /**
+     * Enables the mail recall functionality
+     *
+     * @param zimbraFeatureMailRecallEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4094)
+    public void setFeatureMailRecallEnabled(boolean zimbraFeatureMailRecallEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallEnabled, zimbraFeatureMailRecallEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Enables the mail recall functionality
+     *
+     * @param zimbraFeatureMailRecallEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4094)
+    public Map<String,Object> setFeatureMailRecallEnabled(boolean zimbraFeatureMailRecallEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallEnabled, zimbraFeatureMailRecallEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Enables the mail recall functionality
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4094)
+    public void unsetFeatureMailRecallEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Enables the mail recall functionality
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4094)
+    public Map<String,Object> unsetFeatureMailRecallEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * Time(in minutes) within which a message can be recalled. The default
+     * time is 30 minutes and accepts value from 1 to 30.
+     *
+     * @return zimbraFeatureMailRecallTime, or 30 if unset
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4095)
+    public int getFeatureMailRecallTime() {
+        return getIntAttr(Provisioning.A_zimbraFeatureMailRecallTime, 30, true);
+    }
+
+    /**
+     * Time(in minutes) within which a message can be recalled. The default
+     * time is 30 minutes and accepts value from 1 to 30.
+     *
+     * @param zimbraFeatureMailRecallTime new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4095)
+    public void setFeatureMailRecallTime(int zimbraFeatureMailRecallTime) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallTime, Integer.toString(zimbraFeatureMailRecallTime));
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Time(in minutes) within which a message can be recalled. The default
+     * time is 30 minutes and accepts value from 1 to 30.
+     *
+     * @param zimbraFeatureMailRecallTime new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4095)
+    public Map<String,Object> setFeatureMailRecallTime(int zimbraFeatureMailRecallTime, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallTime, Integer.toString(zimbraFeatureMailRecallTime));
+        return attrs;
+    }
+
+    /**
+     * Time(in minutes) within which a message can be recalled. The default
+     * time is 30 minutes and accepts value from 1 to 30.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4095)
+    public void unsetFeatureMailRecallTime() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallTime, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Time(in minutes) within which a message can be recalled. The default
+     * time is 30 minutes and accepts value from 1 to 30.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4095)
+    public Map<String,Object> unsetFeatureMailRecallTime(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureMailRecallTime, "");
+        return attrs;
+    }
+
+    /**
      * Whether Chat feature is enabled or not
      *
      * @return zimbraFeatureModernChatEnabled, or false if unset


### PR DESCRIPTION
Requirement of ticket [[ZCS-12471](https://jira.corp.synacor.com/browse/ZCS-12471)]:

- Two new LDAP attributes to control the recall feature in Zimbra to be introduced for three levels  i.e. account, COS and domain  - zimbraFeatureMailRecallEnabled(default value is FALSE), zimbraFeatureMailRecallTime(default value is 30 minutes and time limit is from 1 minute to 30 minutes ).

Solution:

- Two new attributes are added and their setters/getters are generated. 

Testing:

- Testing is done on remote machine by installing custom build for all the three levels and getting expected results. 