### PR TITLE
ZCS-12966 Ldap attribute for CountObjectsRequest on admin console changes

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -5145,6 +5145,15 @@ public class ZAttrProvisioning {
     public static final String A_zimbraCOSInheritedAttr = "zimbraCOSInheritedAttr";
 
     /**
+     * whether to enable CountObjectsRequest with userAccount/account type on
+     * Zimbra Admin Console
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4096)
+    public static final String A_zimbraCountAccountsEnabled = "zimbraCountAccountsEnabled";
+
+    /**
      * time object was created
      *
      * @since ZCS 6.0.0_BETA1

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10352,4 +10352,9 @@ TODO: delete them permanently from here
     indexing         - Generate index
   </desc>
 </attr>
+
+<attr id="4096" name="zimbraCountAccountsEnabled" type="boolean" cardinality="single" optionalIn="globalConfig" since="11.0.0">
+  <globalConfigValue>TRUE</globalConfigValue>
+  <desc>whether to enable CountObjectsRequest with userAccount/account type on Zimbra Admin Console</desc>
+</attr>
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -12697,6 +12697,83 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * whether to enable CountObjectsRequest with userAccount/account type on
+     * Zimbra Admin Console
+     *
+     * @return zimbraCountAccountsEnabled, or true if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4096)
+    public boolean isCountAccountsEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraCountAccountsEnabled, true, true);
+    }
+
+    /**
+     * whether to enable CountObjectsRequest with userAccount/account type on
+     * Zimbra Admin Console
+     *
+     * @param zimbraCountAccountsEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4096)
+    public void setCountAccountsEnabled(boolean zimbraCountAccountsEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraCountAccountsEnabled, zimbraCountAccountsEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * whether to enable CountObjectsRequest with userAccount/account type on
+     * Zimbra Admin Console
+     *
+     * @param zimbraCountAccountsEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4096)
+    public Map<String,Object> setCountAccountsEnabled(boolean zimbraCountAccountsEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraCountAccountsEnabled, zimbraCountAccountsEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * whether to enable CountObjectsRequest with userAccount/account type on
+     * Zimbra Admin Console
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4096)
+    public void unsetCountAccountsEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraCountAccountsEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * whether to enable CountObjectsRequest with userAccount/account type on
+     * Zimbra Admin Console
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4096)
+    public Map<String,Object> unsetCountAccountsEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraCountAccountsEnabled, "");
+        return attrs;
+    }
+
+    /**
      * time object was created
      *
      * <p>Use getCreateTimestampAsString to access value as a string.


### PR DESCRIPTION
**Problem:**
When millions of accounts exist on the system and CountObjectsRequest with userAccount type is sent from Admin Console to a server, it causes high load on a ldap server.

**Fix:**
Intoduced Ldap attr to enable/disable the counting of userAccount in CountObjectsRequest

**Test-cases:**
1. when zimbraCountObjectsEnabled is TRUE
send CountObjectsRequest with account or userAccount type.
show number of accounts in Home -> Summary -> Accounts and Manage -> left pane -> the number of accounts
2. when zimbraCountObjectsEnabled is FALSE
not to send CountObjectsRequest with account or userAccount type.
show N/A in Home -> Summary -> Accounts and Manage -> left pane -> the number of accounts