### PR TITLE
ZCS-12965 added session summary log on POP3 and IMAP

### DIFF
--- a/store/src/java/com/zimbra/cs/imap/NioImapHandler.java
+++ b/store/src/java/com/zimbra/cs/imap/NioImapHandler.java
@@ -18,6 +18,7 @@ package com.zimbra.cs.imap;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.Map;
 
 import org.apache.mina.filter.codec.ProtocolDecoderException;
 import org.apache.mina.filter.codec.RecoverableProtocolDecoderException;
@@ -160,6 +161,23 @@ final class NioImapHandler extends ImapHandler implements NioHandler {
      */
     @Override
     public void connectionClosed() {
+        try {
+            setLoggingContext();
+            String summary = new String();
+            for (Map.Entry<String, Integer> entry : commandCount.entrySet()) {
+                String result = entry.getKey() + "=" + entry.getValue();
+                summary += summary.isEmpty() ? result : ", " + result;
+            }
+            ZimbraLog.imap.info("[" + summary + "]" +
+                " MailboxSize:" + mailboxSize + "->" + getMailboxSize()+
+                " InboxNumMsgs:" + inboxNumMessages + "->" + getInboxNumMessages() +
+                " TrashNumMsgs:" + trashNumMessages + "->" + getTrashNumMessages() +
+                " read[" + connection.getReadBytes() +
+                "] write[" + connection.getWrittenBytes() +
+                "] time[" + connection.getSessionDuration() + "]");
+        } catch (Exception ignore) {
+        }
+
         if (request != null) {
             request.cleanup();
             request = null;

--- a/store/src/java/com/zimbra/cs/pop3/NioPop3Handler.java
+++ b/store/src/java/com/zimbra/cs/pop3/NioPop3Handler.java
@@ -24,6 +24,7 @@ import com.zimbra.cs.server.NioOutputStream;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.Map;
 
 import org.apache.mina.filter.codec.RecoverableProtocolDecoderException;
 
@@ -46,6 +47,21 @@ final class NioPop3Handler extends Pop3Handler implements NioHandler {
 
     @Override
     public void connectionClosed() throws IOException {
+        try {
+            setLoggingContext();
+            String summary = new String();
+            for (Map.Entry<String, Integer> entry : commandCount.entrySet()) {
+                String result = entry.getKey() + "=" + entry.getValue();
+                summary += summary.isEmpty() ? result : ", " + result;
+            }
+            ZimbraLog.pop.info("[" + summary + "]" +
+                " MailboxSize:" + mailboxSize + "->" + getMailboxSize() +
+                " InboxNumMsgs:" + inboxNumMsgs + "->" + getInboxNumMessages() +
+                " read[" + connection.getReadBytes() +
+                "] write[" + connection.getWrittenBytes() +
+                "] time[" + connection.getSessionDuration() + "]");
+        } catch (Exception ignore) {
+        }
         connection.close();
     }
 

--- a/store/src/java/com/zimbra/cs/pop3/Pop3Mailbox.java
+++ b/store/src/java/com/zimbra/cs/pop3/Pop3Mailbox.java
@@ -267,4 +267,13 @@ final class Pop3Mailbox {
         mbox.setTags(opContext, msgId, MailItem.Type.MESSAGE, flags, MailItem.TAG_UNCHANGED);
     }
 
+    long getMailboxSize() throws ServiceException {
+        Mailbox mbox = MailboxManager.getInstance().getMailboxById(id);
+        return mbox.getSize();
+    }
+
+    long getInboxNumMessages() throws ServiceException {
+        Mailbox mbox = MailboxManager.getInstance().getMailboxById(id);
+        return mbox.getFolderById(null, Mailbox.ID_FOLDER_INBOX).getItemCount();
+    }
 }

--- a/store/src/java/com/zimbra/cs/server/NioConnection.java
+++ b/store/src/java/com/zimbra/cs/server/NioConnection.java
@@ -18,6 +18,7 @@ package com.zimbra.cs.server;
 
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
+import java.util.Date;
 
 import javax.security.sasl.SaslServer;
 
@@ -101,4 +102,17 @@ public final class NioConnection {
         session.close(false);
     }
 
+    public long getWrittenBytes() {
+        return session.getWrittenBytes();
+    }
+
+    public long getReadBytes() {
+        return session.getReadBytes();
+    }
+
+    public long getSessionDuration() {
+        Date now = new Date();
+        long creationTime = session.getCreationTime();
+        return now.getTime() - creationTime;
+    }
 }


### PR DESCRIPTION
**Requirements:**

Log session summary of POP3 and IMAP

**POP3**
Mailbox size (byte size) and total number of messages in INBOX at the login, and at the log out
Total read and write data bytes during the session
Session's duration time in milliseconds
The number of executions of the following commands during the session
TOP
RETR
DELE
QUIT

**IMAP**
Mailbox size (byte size) and total number of messages in INBOX and Trash respectively at the login, and at the log out
Total read and write data bytes during the session
Session's duration time in milliseconds
The number of executions of the following commands during the session
FETCH
STORE
EXPUNGE
APPEND
SEARCH
COPY
CREATE
DELETE
LOGOUT
The number of executions of UID FETCH, UID COPY, UID STORE and UID SEARCH are counted as FETCH, COPY, STORE and SEARCH respectively.
The number of command execution that the "\DELETED" flag is added to and removed from the message separately.

**Log example:**

**IMAP**

> 2023-03-08 08:42:11,539 INFO  [ImapSSLServer-0] [name=shr1@platform-dev-activesync.zimbradev.com;mid=6;ip=10.0.0.68;oip=152.67.10.248;via=10.0.0.68(nginx/1.20.0);ua=Zimbra/9.0.0;cid=2;] imap - [FETCH=0, STORE=0, STORE +FLAGS \DELETED=0, STORE -FLAGS \DELETED=0, EXPUNGE=0, APPEND=0, SEARCH=1, COPY=0, CREATE=0, DELETE=0, LOGOUT=0] MailboxSize:153935->153935 InboxNumMsgs:24->24 TrashNumMsgs:5->5 read[882] write[4152] time[27384]
2023-03-08 08:42:11,549 INFO  [ImapSSLServer-0] [name=shr1@platform-dev-activesync.zimbradev.com;ip=10.0.0.68;oip=152.67.10.248;via=10.0.0.68(nginx/1.20.0);ua=Zimbra/9.0.0;cid=2;] imap - dropping connection for user shr1@platform-dev-activesync.zimbradev.com (LOGOUT)