### PR TITLE
ZCS-13100: Backported changes from Z10 for FileSharedWithMe

### DIFF
--- a/common/src/java/com/zimbra/common/mailbox/FolderConstants.java
+++ b/common/src/java/com/zimbra/common/mailbox/FolderConstants.java
@@ -49,5 +49,7 @@ public final class FolderConstants {
 
     public static final int ID_FOLDER_UNSUBSCRIBE = 19;
 
-    public static final int HIGHEST_SYSTEM_ID = 19;
+    public static final int ID_FOLDER_FILE_SHARED_WITH_ME = 20;
+
+    public static final int HIGHEST_SYSTEM_ID = 20;
 }

--- a/common/src/java/com/zimbra/common/soap/MailConstants.java
+++ b/common/src/java/com/zimbra/common/soap/MailConstants.java
@@ -298,6 +298,8 @@ public final class MailConstants {
     public static final String E_GET_IMAP_RECENT_CUTOFF_RESPONSE = "GetIMAPRecentCutoffResponse";
     public static final String E_IMAP_COPY_REQUEST = "IMAPCopyRequest";
     public static final String E_IMAP_COPY_RESPONSE = "IMAPCopyResponse";
+    public static final String E_FILE_SHARED_WITH_ME_REQUEST = "FileSharedWithMeRequest";
+    public static final String E_FILE_SHARED_WITH_ME_RESPONSE = "FileSharedWithMeResponse";
 
     // noop
     public static final QName NO_OP_REQUEST = QName.get(E_NO_OP_REQUEST, NAMESPACE);
@@ -596,6 +598,9 @@ public final class MailConstants {
     public static final QName RECORD_IMAP_SESSION_RESPONSE = QName.get(E_RECORD_IMAP_SESSION_RESPONSE, NAMESPACE);
     public static final QName IMAP_COPY_REQUEST = QName.get(E_IMAP_COPY_REQUEST, NAMESPACE);
     public static final QName IMAP_COPY_RESPONSE = QName.get(E_IMAP_COPY_RESPONSE, NAMESPACE);
+    //File Shared With Me
+    public static final QName FILE_SHARED_WITH_ME_REQUEST = QName.get(E_FILE_SHARED_WITH_ME_REQUEST, NAMESPACE);
+    public static final QName FILE_SHARED_WITH_ME_RESPONSE = QName.get(E_FILE_SHARED_WITH_ME_RESPONSE, NAMESPACE);
 
     public static final String E_MAILBOX = "mbx";
     public static final String E_ITEM = "item";
@@ -732,6 +737,7 @@ public final class MailConstants {
     public static final String A_PASSWORD = "pw";
     public static final String A_ACCESSKEY = "key";
     public static final String A_EXPIRY = "expiry";
+    public static final String A_SHARED_FILE_ID = "sfid";
 
     // account ACLs
     public static final String E_ACE = "ace";

--- a/common/src/java/com/zimbra/common/util/L10nUtil.java
+++ b/common/src/java/com/zimbra/common/util/L10nUtil.java
@@ -146,6 +146,7 @@ public class L10nUtil {
         shareNotifBodyGranteeRoleCustom,
 
         shareNotifBodyFolderDesc,
+        shareNotifyFileBodyDesc,
         shareNotifBodyExternalShareText,
         shareNotifBodyExternalShareHtml,
         shareNotifBodyNotesText,

--- a/soap/src/java/com/zimbra/soap/JaxbUtil.java
+++ b/soap/src/java/com/zimbra/soap/JaxbUtil.java
@@ -1123,7 +1123,9 @@ public final class JaxbUtil {
             com.zimbra.soap.account.message.GetAddressListMembersRequest.class,
             com.zimbra.soap.account.message.GetAddressListMemberResponse.class,
             com.zimbra.soap.admin.message.GetAddressListInfoRequest.class,
-            com.zimbra.soap.admin.message.GetAddressListInfoResponse.class
+            com.zimbra.soap.admin.message.GetAddressListInfoResponse.class,
+            com.zimbra.soap.mail.message.FileSharedWithMeRequest.class,
+            com.zimbra.soap.mail.message.FileSharedWithMeResponse.class
         };
 
         try {

--- a/soap/src/java/com/zimbra/soap/mail/message/FileSharedWithMeRequest.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/FileSharedWithMeRequest.java
@@ -1,0 +1,206 @@
+/* 
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.mail.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.MailConstants;
+
+/**
+ * @zm-api-command-auth-required true
+ * @zm-api-command-admin-auth-required false
+ * @zm-api-command-description File Share With Me
+ * <br />
+ * This is an internal API, cannot be invoked directly
+ */
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name = MailConstants.E_FILE_SHARED_WITH_ME_REQUEST)
+public class FileSharedWithMeRequest {
+
+    /**
+     * @zm-api-field-tag action
+     * @zm-api-field-description Action - Create, Edit, Revoke
+     */
+    @XmlElement(name = MailConstants.E_ACTION, required = true)
+    private String action;
+
+    /**
+     * @zm-api-field-tag fileName
+     * @zm-api-field-description Name of the file which is to be shared
+     */
+    @XmlElement(name = MailConstants.A_CONTENT_FILENAME, required = true)
+    private String fileName;
+
+    /**
+     * @zm-api-field-tag ownerFileId
+     * @zm-api-field-description Owner File ID 
+     */
+    @XmlElement(name = MailConstants.A_ITEMID, required = true)
+    private int ownerFileId;
+
+    /**
+     * @zm-api-field-tag fileUUID
+     * @zm-api-field-description Owner File UUID
+     */
+    @XmlElement(name = MailConstants.A_REMOTE_UUID, required = true)
+    private String fileUUID;
+
+    /**
+     * @zm-api-field-tag fileOwnerName
+     * @zm-api-field-description File Owner Name
+     */
+    @XmlElement(name = MailConstants.A_OWNER_NAME, required = true)
+    private String fileOwnerName;
+
+    /**
+     * @zm-api-field-tag rights
+     * @zm-api-field-description Permission provided to the file
+     */
+    @XmlElement(name = MailConstants.A_RIGHTS, required = true)
+    private String rights;
+
+    /**
+     * @zm-api-field-tag contentType
+     * @zm-api-field-description Content type of the file
+     */
+    @XmlElement(name = MailConstants.A_CONTENT_TYPE, required = true)
+    private String contentType;
+
+    /**
+     * @zm-api-field-tag size
+     * @zm-api-field-description Actual file size
+     */
+    @XmlElement(name = MailConstants.A_SIZE, required = true)
+    private long size;
+
+    /**
+     * @zm-api-field-tag ownerAccountId
+     * @zm-api-field-description Remote account owner ID
+     */
+    @XmlElement(name = MailConstants.A_REMOTE_ID, required = true)
+    private String ownerAccountId;
+
+    /**
+     * @zm-api-field-tag date
+     * @zm-api-field-description Actual file modified date
+     */
+    @XmlElement(name = MailConstants.A_DATE, required = true)
+    private Long date;
+
+    public FileSharedWithMeRequest() {
+    }
+
+    public FileSharedWithMeRequest(String action, String granteeId, String fileName, String ownerAccountId,
+            int ownerFileId, String fileUUID, String fileOwnerName, String rights, String contentType, long size, long date) {
+        super();
+        this.action = action;
+        this.fileName = fileName;
+        this.ownerFileId = ownerFileId;
+        this.fileUUID = fileUUID;
+        this.fileOwnerName = fileOwnerName;
+        this.rights = rights;
+        this.contentType = contentType;
+        this.size = size;
+        this.ownerAccountId = ownerAccountId;
+        this.date = date;
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public void setAction(String action) {
+        this.action = action;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public int getOwnerFileId() {
+        return ownerFileId;
+    }
+
+    public void setOwnerFileId(int ownerFileId) {
+        this.ownerFileId = ownerFileId;
+    }
+
+    public String getFileUUID() {
+        return fileUUID;
+    }
+
+    public void setFileUUID(String fileUUID) {
+        this.fileUUID = fileUUID;
+    }
+
+    public String getFileOwnerName() {
+        return fileOwnerName;
+    }
+
+    public void setFileOwnerName(String fileOwnerName) {
+        this.fileOwnerName = fileOwnerName;
+    }
+
+    public String getRights() {
+        return rights;
+    }
+
+    public void setRights(String rights) {
+        this.rights = rights;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    public void setSize(long size) {
+        this.size = size;
+    }
+
+    public String getOwnerAccountId() {
+        return ownerAccountId;
+    }
+
+    public void setOwnerAccountId(String ownerAccountId) {
+        this.ownerAccountId = ownerAccountId;
+    }
+
+    public Long getDate() {
+        return date;
+    }
+
+    public void setDate(Long date) {
+        this.date = date;
+    }
+
+}

--- a/soap/src/java/com/zimbra/soap/mail/message/FileSharedWithMeResponse.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/FileSharedWithMeResponse.java
@@ -1,0 +1,47 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.mail.message;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.google.common.base.MoreObjects;
+import com.zimbra.common.soap.MailConstants;
+
+@XmlRootElement(name = MailConstants.E_FILE_SHARED_WITH_ME_RESPONSE)
+public class FileSharedWithMeResponse {
+
+    @XmlElement(name = MailConstants.A_STATUS, required = true)
+    private String status;
+
+    public FileSharedWithMeResponse() {
+    }
+
+    public FileSharedWithMeResponse(String status) {
+        this.status = status;
+    }
+
+    public MoreObjects.ToStringHelper addToStringInfo(MoreObjects.ToStringHelper helper) {
+        return helper.add(MailConstants.A_STATUS, status);
+    }
+
+    @Override
+    public String toString() {
+        return addToStringInfo(MoreObjects.toStringHelper(this)).toString();
+    }
+}

--- a/store/src/java/com/zimbra/cs/account/ShareInfo.java
+++ b/store/src/java/com/zimbra/cs/account/ShareInfo.java
@@ -574,12 +574,12 @@ public class ShareInfo {
             // TEXT part (add me first!)
             String mimePartText;
             if (action == Action.revoke) {
-                mimePartText = genRevokePart(sid, locale, false);
+                mimePartText = genRevokePart(sid, locale, false, false);
             } else if (action == Action.expire) {
-                mimePartText = genExpirePart(sid, locale, false);
+                mimePartText = genExpirePart(sid, locale, false, false);
             } else {
                 mimePartText = genPart(sid, action == Action.edit, notes, extUserShareAcceptUrl, extUserLoginUrl,
-                        locale, null, false);
+                        locale, null, false, false);
             }
             MimeBodyPart textPart = new ZMimeBodyPart();
             textPart.setText(mimePartText, MimeConstants.P_CHARSET_UTF8);
@@ -587,12 +587,12 @@ public class ShareInfo {
 
             // HTML part
             if (action == Action.revoke) {
-                mimePartText = genRevokePart(sid, locale, true);
+                mimePartText = genRevokePart(sid, locale, true, false);
             } else if (action == Action.expire) {
-                mimePartText = genExpirePart(sid, locale, true);
+                mimePartText = genExpirePart(sid, locale, true, false);
             } else {
                 mimePartText = genPart(sid, action == Action.edit, notes, extUserShareAcceptUrl, extUserLoginUrl,
-                        locale, null, true);
+                        locale, null, true, false);
             }
             MimeBodyPart htmlPart = new ZMimeBodyPart();
             htmlPart.setDataHandler(new DataHandler(new HtmlPartDataSource(mimePartText)));
@@ -610,39 +610,47 @@ public class ShareInfo {
         }
 
         public static String getMimePartHtml(ShareInfoData sid, String notes, Locale locale,
-            Action action, String extUserShareAcceptUrl, String extUserLoginUrl) throws MessagingException, ServiceException {
+                                             Action action, String extUserShareAcceptUrl, String extUserLoginUrl) throws MessagingException, ServiceException {
+            return getMimePartHtml(sid, notes, locale, action, extUserShareAcceptUrl, extUserLoginUrl, false);
+        }
+
+        public static String getMimePartHtml(ShareInfoData sid, String notes, Locale locale,
+            Action action, String extUserShareAcceptUrl, String extUserLoginUrl, boolean notifyForDocument) throws MessagingException, ServiceException {
 
             String mimePartHtml;
             if (action == Action.revoke) {
-                mimePartHtml = genRevokePart(sid, locale, true);
+                mimePartHtml = genRevokePart(sid, locale, true, notifyForDocument);
             } else if (action == Action.expire) {
-                mimePartHtml = genExpirePart(sid, locale, true);
+                mimePartHtml = genExpirePart(sid, locale, true, notifyForDocument);
             } else {
                 mimePartHtml = genPart(sid, action == Action.edit, notes, extUserShareAcceptUrl,
-                    extUserLoginUrl, locale, null, true);
+                    extUserLoginUrl, locale, null, true, notifyForDocument);
             }
 
             return mimePartHtml;
         }
-        
-        
+
+        public static String getMimePartText(ShareInfoData sid, String notes, Locale locale,
+                                             Action action, String extUserShareAcceptUrl, String extUserLoginUrl) throws MessagingException, ServiceException {
+            return getMimePartText(sid, notes, locale, action, extUserShareAcceptUrl, extUserLoginUrl, false);
+        }
         
         public static String getMimePartText(ShareInfoData sid, String notes, Locale locale,
-            Action action, String extUserShareAcceptUrl, String extUserLoginUrl) throws MessagingException, ServiceException {
+            Action action, String extUserShareAcceptUrl, String extUserLoginUrl, boolean notifyForDocument) throws MessagingException, ServiceException {
             String mimePartText;
             if (action == Action.revoke) {
-                mimePartText = genRevokePart(sid, locale, false);
+                mimePartText = genRevokePart(sid, locale, false, notifyForDocument);
             } else if (action == Action.expire) {
-                mimePartText = genExpirePart(sid, locale, false);
+                mimePartText = genExpirePart(sid, locale, false, notifyForDocument);
             } else {
                 mimePartText = genPart(sid, action == Action.edit, notes, extUserShareAcceptUrl,
-                    extUserLoginUrl, locale, null, false);
+                    extUserLoginUrl, locale, null, false, notifyForDocument);
             }
             return mimePartText;
         }
 
         private static String genPart(ShareInfoData sid, boolean shareModified, String senderNotes,
-                String extUserShareAcceptUrl, String extUserLoginUrl, Locale locale, StringBuilder sb, boolean html) {
+                String extUserShareAcceptUrl, String extUserLoginUrl, Locale locale, StringBuilder sb, boolean html, boolean notifyForDocument) {
             if (sb == null) {
                 sb = new StringBuilder();
             }
@@ -672,7 +680,7 @@ public class ShareInfo {
             return sb.append(L10nUtil.getMessage(
                     msgKey, locale,
                     sid.getName(),
-                    formatFolderDesc(locale, sid),
+                    formatFolderDesc(locale, sid, notifyForDocument),
                     sid.getOwnerNotifName(),
                     sid.getGranteeNotifName(),
                     getRoleFromRights(sid, locale),
@@ -682,17 +690,19 @@ public class ShareInfo {
                     toString();
         }
 
-        private static String genRevokePart(ShareInfoData sid, Locale locale, boolean html) {
+        private static String genRevokePart(ShareInfoData sid, Locale locale, boolean html, boolean notifyForDocument) {
             return L10nUtil.getMessage(html ? MsgKey.shareRevokeBodyHtml : MsgKey.shareRevokeBodyText,
+                    locale,
                     sid.getName(),
-                    formatFolderDesc(locale, sid),
+                    formatFolderDesc(locale, sid, notifyForDocument),
                     sid.getOwnerNotifName());
         }
 
-        private static String genExpirePart(ShareInfoData sid, Locale locale, boolean html) {
+        private static String genExpirePart(ShareInfoData sid, Locale locale, boolean html, boolean notifyForDocument) {
             return L10nUtil.getMessage((html ? MsgKey.shareExpireBodyHtml : MsgKey.shareExpireBodyText),
+                    locale,
                     sid.getName(),
-                    formatFolderDesc(locale, sid),
+                    formatFolderDesc(locale, sid, notifyForDocument),
                     sid.getOwnerNotifName());
         }
 
@@ -770,7 +780,7 @@ public class ShareInfo {
             }
         }
 
-        private static String formatFolderDesc(Locale locale, ShareInfoData sid) {
+        private static String formatFolderDesc(Locale locale, ShareInfoData sid, boolean notifyForDocument) {
             MailItem.Type view = sid.getFolderDefaultViewCode();
             String folderView;
             switch (view) {
@@ -792,7 +802,7 @@ public class ShareInfo {
                 default:
                     folderView = sid.getFolderDefaultView();
             }
-            MsgKey key = MsgKey.shareNotifBodyFolderDesc;
+            MsgKey key = notifyForDocument ? MsgKey.shareNotifyFileBodyDesc : MsgKey.shareNotifBodyFolderDesc;
             try {
                 if (Provisioning.getInstance().isOctopus()) {
                     key = MsgKey.octopus_share_notification_email_bodyFolderDesc;
@@ -827,10 +837,10 @@ public class ShareInfo {
 
                 if (idx == null) {
                     for (ShareInfoData sid : mShares) {
-                        genPart(sid, false, null, null, null, locale, sb, false);
+                        genPart(sid, false, null, null, null, locale, sb, false, false);
                     }
                 } else
-                    genPart(mShares.get(idx), false, null, null, null, locale, sb, false);
+                    genPart(mShares.get(idx), false, null, null, null, locale, sb, false, false);
 
                 sb.append("\n\n");
                 return sb.toString();
@@ -848,10 +858,10 @@ public class ShareInfo {
 
                 if (idx == null) {
                     for (ShareInfoData sid : mShares) {
-                        genPart(sid, false, null, null, null, locale, sb, true);
+                        genPart(sid, false, null, null, null, locale, sb, true, false);
                     }
                 } else
-                    genPart(mShares.get(idx), false, null, null, null, locale, sb, true);
+                    genPart(mShares.get(idx), false, null, null, null, locale, sb, true, false);
 
                 return sb.toString();
             }

--- a/store/src/java/com/zimbra/cs/mailbox/Document.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Document.java
@@ -46,6 +46,9 @@ public class Document extends MailItem {
     protected long lockTimestamp;
     protected String description;
     protected boolean descEnabled;
+    protected String ownerAccountId;
+    protected String ownerFileId;
+    protected String permission;
 
     public Document(Mailbox mbox, UnderlyingData data) throws ServiceException {
         this(mbox, data, false);
@@ -86,6 +89,18 @@ public class Document extends MailItem {
 
     public boolean isDescriptionEnabled() {
         return descEnabled;
+    }
+
+    public String getOwnerAccountId() {
+        return ownerAccountId;
+    }
+
+    public String getPermission() {
+        return permission;
+    }
+
+    public String getOwnerFileId() {
+        return ownerFileId;
     }
 
     @Override
@@ -286,6 +301,15 @@ public class Document extends MailItem {
         description = meta.get(Metadata.FN_DESCRIPTION, description);
         lockTimestamp = meta.getLong(Metadata.FN_LOCK_TIMESTAMP, 0);
         descEnabled = meta.getBool(Metadata.FN_DESC_ENABLED, true);
+        if (meta.containsKey(Metadata.FN_OWNER_ACCOUNT_ID)) {
+            ownerAccountId = meta.get(Metadata.FN_OWNER_ACCOUNT_ID);
+        }
+        if (meta.containsKey(Metadata.FN_OWNER_FILE_ID)) {
+            ownerFileId = meta.get(Metadata.FN_OWNER_FILE_ID);
+        }
+        if (meta.containsKey(Metadata.FN_FILE_PERMISSION)) {
+            permission = meta.get(Metadata.FN_FILE_PERMISSION);
+        }
     }
 
     @Override

--- a/store/src/java/com/zimbra/cs/mailbox/Metadata.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Metadata.java
@@ -122,6 +122,9 @@ public final class Metadata {
     public static final String FN_WIKI_WORD        = "ww";
     public static final String FN_ELIDED           = "X";
     public static final String FN_EXTRA_DATA       = "xd";
+    public static final String FN_OWNER_ACCOUNT_ID = "oai";
+    public static final String FN_OWNER_FILE_ID    = "ofi";
+    public static final String FN_FILE_PERMISSION  = "perm";
 
     private final Integer associatedItemId;
 

--- a/store/src/java/com/zimbra/cs/redolog/op/CreateFileSharedWithMe.java
+++ b/store/src/java/com/zimbra/cs/redolog/op/CreateFileSharedWithMe.java
@@ -1,0 +1,120 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.redolog.op;
+
+import java.io.IOException;
+
+import com.zimbra.cs.mailbox.MailboxOperation;
+import com.zimbra.cs.redolog.RedoLogInput;
+import com.zimbra.cs.redolog.RedoLogOutput;
+
+public class CreateFileSharedWithMe extends RedoableOp {
+
+    private int mId;
+    private String mUuid;
+    private int mFolderId;
+    private String mName;
+    private String mOwnerId;
+    private int mRemoteId;
+    private String mRemoteUuid;
+    private String mOwnerName;
+    private String mContentType;
+    private String mRights;
+
+    public CreateFileSharedWithMe() {
+        super(MailboxOperation.CreateMountpoint);
+        mId = UNKNOWN_ID;
+    }
+
+    public CreateFileSharedWithMe(int mailboxId, int folderId, String name, String ownerId, int remoteId,
+            String remoteUuid, String fileOwnerName, String contetnType, String rights) {
+        this();
+        setMailboxId(mailboxId);
+        mId = UNKNOWN_ID;
+        mFolderId = folderId;
+        mName = name != null ? name : "";
+        mOwnerId = ownerId;
+        mRemoteId = remoteId;
+        mRemoteUuid = remoteUuid;
+        mOwnerName = fileOwnerName;
+        mContentType = contetnType;
+        mRights = rights;
+    }
+
+    public CreateFileSharedWithMe(int mailboxId, String remoteUuid) {
+        this();
+        setMailboxId(mailboxId);
+        mRemoteUuid = remoteUuid;
+    }
+
+    public int getId() {
+        return mId;
+    }
+
+    public String getUuid() {
+        return mUuid;
+    }
+
+    public void setIdAndUuid(int id, String uuid) {
+        mId = id;
+        mUuid = uuid;
+    }
+
+    @Override
+    protected String getPrintableData() {
+        StringBuilder sb = new StringBuilder("id=").append(mId);
+        sb.append(", uuid=").append(mUuid);
+        sb.append(", name=").append(mName).append(", folder=").append(mFolderId);
+        sb.append(", owner=").append(mOwnerId).append(", remoteId=").append(mRemoteId).append(", remoteUuid=")
+                .append(mRemoteUuid);
+        return sb.toString();
+    }
+
+    @Override
+    protected void serializeData(RedoLogOutput out) throws IOException {
+        out.writeInt(mId);
+        out.writeUTF(mUuid);
+        out.writeUTF(mName);
+        out.writeUTF(mOwnerId);
+        out.writeInt(mRemoteId);
+        out.writeUTF(mRemoteUuid);
+        out.writeInt(mFolderId);
+        out.writeUTF(mOwnerName);
+        out.writeUTF(mContentType);
+        out.writeUTF(mRights);
+    }
+
+    @Override
+    protected void deserializeData(RedoLogInput in) throws IOException {
+        mId = in.readInt();
+        mUuid = in.readUTF();
+        mName = in.readUTF();
+        mOwnerId = in.readUTF();
+        mOwnerName = in.readUTF();
+        mRemoteId = in.readInt();
+        mRemoteUuid = in.readUTF();
+        mFolderId = in.readInt();
+        mContentType = in.readUTF();
+        mRights = in.readUTF();
+    }
+
+    @Override
+    public void redo() throws Exception {
+        // TODO Auto-generated method stub
+    }
+}

--- a/store/src/java/com/zimbra/cs/service/mail/DelegatableRequest.java
+++ b/store/src/java/com/zimbra/cs/service/mail/DelegatableRequest.java
@@ -1,0 +1,23 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.service.mail;
+
+public interface DelegatableRequest {
+
+    public boolean isDelegatable();
+
+}

--- a/store/src/java/com/zimbra/cs/service/mail/FileSharedWithMe.java
+++ b/store/src/java/com/zimbra/cs/service/mail/FileSharedWithMe.java
@@ -1,0 +1,100 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.service.mail;
+
+import java.util.Map;
+
+import com.zimbra.common.mailbox.FolderConstants;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.MailConstants;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailbox.OperationContext;
+import com.zimbra.soap.ZimbraSoapContext;
+
+public class FileSharedWithMe extends MailDocumentHandler implements DelegatableRequest {
+
+    private static final String REVOKE = "revoke";
+    private static final String EDIT = "edit";
+    private static final String CREATE = "create";
+    private static final String DOCUMENT_REVISION = "createDocumentRevision";
+
+    public Element handle(Element request, Map<String, Object> context) throws ServiceException {
+        try {
+            ZimbraSoapContext zsc = getZimbraSoapContext(context);
+            String ownerAccountId = zsc.getAuthtokenAccountId();
+            String granteeAccountID = zsc.getRequestedAccountId();
+            // check in place so that API cannot be invoked directly, second check for if
+            // call is from document revision
+            if (ownerAccountId.equals(granteeAccountID) && !DOCUMENT_REVISION.equals(zsc.getOriginalUserAgent())) {
+                ZimbraLog.mailbox.error("File sharer and grantee cannot be same", new Throwable("invalid request source"));
+                throw ServiceException.FAILURE("invalid request", new Throwable("invalid"));
+            }
+            OperationContext octxt = getOperationContext(zsc, context);
+            Account account = getRequestedAccount(zsc);
+            Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account, false);
+
+            String action = request.getAttribute(MailConstants.E_ACTION, "");
+            String fileName = request.getAttribute(MailConstants.A_CONTENT_FILENAME, "");
+            int ownerFileId = request.getAttributeInt(MailConstants.A_ITEMID, -1);
+            String fileUUID = request.getAttribute(MailConstants.A_REMOTE_UUID, "");
+            String fileOwnerName = request.getAttribute(MailConstants.A_OWNER_NAME, "");
+            String rights = request.getAttribute(MailConstants.A_RIGHTS, "");
+            String contentType = request.getAttribute(MailConstants.A_CONTENT_TYPE, "");
+            // ZCS-11901: When A share's folder to B and B subsequent shares the file's from
+            // A folder to C,
+            // use actualOwnerAccountId i.e. accountId of A
+            // this remains correct when file is shared from A to B , or from B to C
+            String actualOwnerAccountId = request.getAttribute(MailConstants.A_REMOTE_ID, "");
+            long size = request.getAttributeLong(MailConstants.A_SIZE, -1);
+            long date = request.getAttributeLong(MailConstants.A_DATE, -1);
+            Element response = zsc.createElement(MailConstants.FILE_SHARED_WITH_ME_RESPONSE);
+            if (Provisioning.onLocalServer(account)) {
+                // if file is shared, this file should be available at receivers end
+                if (action != null && CREATE.equals(action)) {
+                    mbox.createFileSharedWithMe(mbox, octxt, FolderConstants.ID_FOLDER_FILE_SHARED_WITH_ME, fileName,
+                            actualOwnerAccountId, ownerFileId, fileUUID, fileOwnerName, contentType, size, rights);
+                } // if file access is revoked at source, delete it from receiver end as well
+                else if (action != null && REVOKE.equals(action)) {
+                    mbox.deleteFileSharedWithMe(mbox, octxt, fileUUID, ownerFileId, actualOwnerAccountId, granteeAccountID);
+                } // if file rights is changed, update file permission accordingly
+                else if (action != null && EDIT.equalsIgnoreCase(action)) {
+                    mbox.updateFileSharedWithMe(mbox, octxt, actualOwnerAccountId, ownerFileId, fileUUID, fileOwnerName,
+                            contentType, rights, granteeAccountID, fileName, date, size);
+                } else {
+                    throw ServiceException.FAILURE("invalid request", new Throwable("invalid"));
+                }
+                return response.addAttribute(MailConstants.A_STATUS, MailConstants.A_VERIFICATION_SUCCESS);
+            } else {
+                response = proxyRequest(request, context, granteeAccountID);
+                return response;
+            }
+        } catch (ServiceException ex) {
+            throw ServiceException.FAILURE("Error File Shared With me operation ", ex);
+        }
+    }
+
+    @Override
+    public boolean isDelegatable() {
+        return true;
+    }
+
+}

--- a/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemAction.java
@@ -44,7 +44,9 @@ import com.zimbra.cs.account.DataSource;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.datasource.imap.ImapFolder;
 import com.zimbra.cs.datasource.imap.ImapFolderCollection;
+import com.zimbra.cs.mailbox.ACL;
 import com.zimbra.cs.mailbox.Conversation;
+import com.zimbra.cs.mailbox.Document;
 import com.zimbra.cs.mailbox.Flag;
 import com.zimbra.cs.mailbox.Folder;
 import com.zimbra.cs.mailbox.MailItem;
@@ -61,9 +63,11 @@ import com.zimbra.cs.service.util.ItemId;
 import com.zimbra.cs.session.Session;
 import com.zimbra.cs.session.SoapSession;
 import com.zimbra.cs.util.AccountUtil;
+import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.SoapEngine;
 import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.admin.type.DataSourceType;
+import com.zimbra.soap.mail.message.FileSharedWithMeRequest;
 
 /**
  * @since May 29, 2005
@@ -213,6 +217,7 @@ public class ItemAction extends MailDocumentHandler {
                 String name = action.getAttribute(MailConstants.A_NAME);
                 ItemId iidFolder = new ItemId(action.getAttribute(MailConstants.A_FOLDER, "-1"), zsc);
                 localResults = ItemActionHelper.RENAME(octxt, mbox, responseProto, local, type, tcon, name, iidFolder).getResult();
+                handleRenameOperationForSharedFile(octxt, request, mbox, local, context, name);
             } else if (opStr.equals(MailConstants.OP_UPDATE)) {
                 String folderId = action.getAttribute(MailConstants.A_FOLDER, null);
                 ItemId iidFolder = null;
@@ -417,6 +422,41 @@ public class ItemAction extends MailDocumentHandler {
             }
         }
         return null;
+    }
+
+    /**
+     * This method renames the file at file receiver ed as well
+     * so that file name's are in sync always
+     * @param octxt
+     * @param request
+     * @param mbox
+     * @param local
+     * @param context
+     * @param name
+     * @throws ServiceException
+     */
+    protected void handleRenameOperationForSharedFile(OperationContext octxt, Element request, Mailbox mbox,
+                                                      List<Integer> local, Map<String, Object> context, String name) throws ServiceException {
+
+        MailItem[] items = mbox.getItemById(octxt, local, MailItem.Type.UNKNOWN);
+        for (MailItem item : items) {
+            if (item instanceof Document && item.getACL() != null) {
+                Document doc = (Document) item;
+                for (ACL.Grant grant : item.getACL().getGrants()) {
+                    FileSharedWithMeRequest req = new FileSharedWithMeRequest();
+                    req.setAction("edit");
+                    req.setFileUUID(doc.getUuid());
+                    req.setOwnerFileId(doc.getId());
+                    req.setFileName(doc.getName());
+                    req.setDate(doc.getDate());
+                    req.setSize(doc.getSize());
+                    req.setOwnerAccountId(doc.getAccountId());
+                    req.setContentType(doc.getContentType());
+                    Element sharedRequest = JaxbUtil.jaxbToElement(req);
+                    proxyRequest(sharedRequest, context, grant.getGranteeId());
+                }
+            }
+        }
     }
 
     private Integer getImapTrashFolder(Mailbox mbox, String dsId) throws ServiceException {

--- a/store/src/java/com/zimbra/cs/service/mail/MailService.java
+++ b/store/src/java/com/zimbra/cs/service/mail/MailService.java
@@ -243,5 +243,7 @@ public final class MailService implements DocumentService {
         // Password reset API
         dispatcher.registerHandler(MailConstants.RECOVER_ACCOUNT_REQUEST, new RecoverAccount());
         dispatcher.registerHandler(MailConstants.SET_RECOVERY_EMAIL_REQUEST, new SetRecoveryAccount());
+        // File Shared With Me
+        dispatcher.registerHandler(MailConstants.FILE_SHARED_WITH_ME_REQUEST, new FileSharedWithMe());
     }
 }

--- a/store/src/java/com/zimbra/cs/service/mail/SendShareNotification.java
+++ b/store/src/java/com/zimbra/cs/service/mail/SendShareNotification.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2009, 2010, 2011, 2012, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2009, 2010, 2011, 2012, 2013, 2014, 2016, 2022 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -40,6 +40,7 @@ import com.zimbra.common.util.L10nUtil.MsgKey;
 import com.zimbra.common.util.Log;
 import com.zimbra.common.util.LogFactory;
 import com.zimbra.common.util.Pair;
+import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.Domain;
 import com.zimbra.cs.account.Group;
@@ -50,6 +51,7 @@ import com.zimbra.cs.account.Provisioning.GroupMemberEmailAddrs;
 import com.zimbra.cs.account.ShareInfo;
 import com.zimbra.cs.account.ShareInfoData;
 import com.zimbra.cs.mailbox.ACL;
+import com.zimbra.cs.mailbox.Document;
 import com.zimbra.cs.mailbox.Folder;
 import com.zimbra.cs.mailbox.MailItem;
 import com.zimbra.cs.mailbox.MailServiceException;
@@ -61,7 +63,9 @@ import com.zimbra.cs.service.UserServlet;
 import com.zimbra.cs.service.util.ItemId;
 import com.zimbra.cs.util.AccountUtil;
 import com.zimbra.cs.util.Zimbra;
+import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.ZimbraSoapContext;
+import com.zimbra.soap.mail.message.FileSharedWithMeRequest;
 import com.zimbra.soap.mail.message.SendShareNotificationRequest;
 import com.zimbra.soap.mail.message.SendShareNotificationRequest.Action;
 import com.zimbra.soap.mail.type.EmailAddrInfo;
@@ -78,6 +82,7 @@ public class SendShareNotification extends MailDocumentHandler {
     }
 
     private static final String REVOKE = "revoke";
+    private static final String CREATE = "create";
 
     @Override
     public Element handle(Element request, Map<String, Object> context) throws ServiceException {
@@ -93,6 +98,14 @@ public class SendShareNotification extends MailDocumentHandler {
         Element eNotes = request.getOptionalElement(MailConstants.E_NOTES);
         Action action = Action.fromString(request.getAttribute(MailConstants.A_ACTION, null));
         String notes = eNotes==null ? null : eNotes.getText();
+        SendShareNotificationRequest req = zsc.elementToJaxb(request);
+        MailItem reqItem = null;
+        // if item element present
+        // get the requested item in the mailbox
+        if (req.getItem() != null) {
+            ItemId iid = new ItemId(req.getItem().getId(), zsc);
+            reqItem = mbox.getItemById(octxt, iid.getId(), MailItem.Type.UNKNOWN);
+        }
 
         // send the messages
         try {
@@ -103,13 +116,18 @@ public class SendShareNotification extends MailDocumentHandler {
                 if (ACL.GRANTEE_GROUP == sid.getGranteeTypeCode()) {
                     sharesWithGroupGrantee.add(sid);
                 } else {
-                    sendNotificationEmail(octxt, mbox, authAccount, account, sid, notes, action, null, null);
+                    sendNotificationEmail(octxt, mbox, authAccount, account, sid, notes, action, null, null, reqItem);
+                    if (reqItem instanceof Document) {
+                        processDBFilesSharedWithMe(reqItem, action, octxt, sid.getGranteeId(), sid.getPath(),
+                                sid.getOwnerAcctId(), sid.getItemId(), sid.getItemUuid(), sid.getOwnerNotifName(),
+                                sid.getRights(), context);
+                    }
                 }
             }
 
             // send to group grantees
             sendNotificationEmailToGroupGrantees(octxt, mbox, authAccount, account,
-                    sharesWithGroupGrantee, notes, action);
+                    sharesWithGroupGrantee, notes, action, reqItem);
 
         } catch (MessagingException e) {
             throw ServiceException.FAILURE(
@@ -261,20 +279,29 @@ public class SendShareNotification extends MailDocumentHandler {
             MailItem item,
             boolean revoke) throws ServiceException {
 
-        MatchingGrant matchingGrant;
+        MatchingGrant matchingGrant = null;
 
         Mountpoint mpt = item instanceof Mountpoint ? (Mountpoint) item : null;
 
-        // see if the share specified in the request is real
-        if (Provisioning.onLocalServer(ownerAcct)) {
-            matchingGrant = getMatchingGrantLocal(octxt, item, granteeType, granteeId, ownerAcct);
+        if (item instanceof Document) {
+            ZimbraLog.account.debug("Adding sharing information for document %s", item.getName());
+            Document doc = (Document) item;
+            ACL acl = doc.getEffectiveACL();
+            if (acl != null) {
+                for (ACL.Grant grant : acl.getGrants()) {
+                    if (grant.getGranteeType() == granteeType && grant.getGranteeId().equals(granteeId)) {
+                        matchingGrant =  new MatchingGrant(grant);
+                    }
+                }
+            }
         } else {
-            matchingGrant = getMatchingGrantRemote(zsc, context, granteeType, granteeId, ownerAcct,
-                    mpt == null ? item.getId() : mpt.getRemoteId());
-        }
-
-        if (!revoke && matchingGrant == null) {
-            throw ServiceException.INVALID_REQUEST("no matching grant", null);
+            // see if the share specified in the request is real
+            if (Provisioning.onLocalServer(ownerAcct)) {
+                matchingGrant = getMatchingGrantLocal(octxt, item, granteeType, granteeId, ownerAcct);
+            } else {
+                matchingGrant = getMatchingGrantRemote(zsc, context, granteeType, granteeId, ownerAcct,
+                        mpt == null ? item.getId() : mpt.getRemoteId());
+            }
         }
 
         //
@@ -541,8 +568,14 @@ public class SendShareNotification extends MailDocumentHandler {
     }
 
     protected MimeMessage generateShareNotification(Account authAccount, Account ownerAccount,
+                                                    ShareInfoData sid, String notes, Action action, Collection<String> internalRecipients,
+                                                    String externalRecipient) throws ServiceException, MessagingException {
+        return generateShareNotification(authAccount, ownerAccount, sid, notes, action, internalRecipients, externalRecipient, false);
+    }
+
+    protected MimeMessage generateShareNotification(Account authAccount, Account ownerAccount,
         ShareInfoData sid, String notes, Action action, Collection<String> internalRecipients,
-        String externalRecipient) throws ServiceException, MessagingException {
+        String externalRecipient, boolean notifyForDocument) throws ServiceException, MessagingException {
         Locale locale = authAccount.getLocale();
         String charset = authAccount.getAttr(Provisioning.A_zimbraPrefMailDefaultCharset,
             MimeConstants.P_CHARSET_UTF8);
@@ -589,17 +622,18 @@ public class SendShareNotification extends MailDocumentHandler {
             extUserLoginUrl = AccountUtil.getExtUserLoginURL(owner);
         }
         String mimePartText = ShareInfo.NotificationSender.getMimePartText(sid, notes, locale,
-            action, extUserShareAcceptUrl, extUserLoginUrl);
+            action, extUserShareAcceptUrl, extUserLoginUrl, notifyForDocument);
         String mimePartHtml = ShareInfo.NotificationSender.getMimePartHtml(sid, notes, locale,
-            action, extUserShareAcceptUrl, extUserLoginUrl);
+            action, extUserShareAcceptUrl, extUserLoginUrl, notifyForDocument);
 
         String mimePartXml = null;
-        if (!goesToExternalAddr) {
+        if (!goesToExternalAddr && !notifyForDocument) {
             mimePartXml = ShareInfo.NotificationSender.genXmlPart(sid, notes, null, action);
         }
 
+        // if notifyForDocument = true, do not attach the xml mimepart.
         MimeMultipart mmp = AccountUtil.generateMimeMultipart(mimePartText, mimePartHtml,
-            mimePartXml);
+                notifyForDocument ? null : mimePartXml);
         MimeMessage mm = AccountUtil.generateMimeMessage(authAccount, ownerAccount, subject,
             charset, internalRecipients, externalRecipient, recipient, mmp);
         return mm;
@@ -611,16 +645,24 @@ public class SendShareNotification extends MailDocumentHandler {
     private void sendNotificationEmail(OperationContext octxt, Mailbox mbox,
             Account authAccount, Account ownerAccount,
             ShareInfoData sid, String notes, Action action,
-            Collection<String> internalRecipients, String externalRecipient)
+            Collection<String> internalRecipients, String externalRecipient, MailItem reqItem)
     throws ServiceException, MessagingException  {
-        MimeMessage mm = generateShareNotification(authAccount, ownerAccount, sid, notes, action,
-                internalRecipients, externalRecipient);
+        ZimbraLog.account.debug("Item being Shared : %s ",reqItem);
+        MimeMessage mm = null;
+        if (reqItem instanceof Document) {
+            ZimbraLog.account.debug("Sending share notification to [ %s ] for document %s", sid.getGranteeName(), reqItem.getName());
+            mm = generateShareNotification(authAccount, ownerAccount, sid, notes, action,
+                    internalRecipients, externalRecipient, true);
+        } else {
+            mm = generateShareNotification(authAccount, ownerAccount, sid, notes, action,
+                    internalRecipients, externalRecipient);
+        }
         mbox.getMailSender().sendMimeMessage(octxt, mbox, true, mm, null, null, null, null, false);
     }
 
     private void sendNotificationEmailToGroupGrantees(OperationContext octxt, Mailbox mbox,
             Account authAccount, Account ownerAccount, Collection<ShareInfoData> sids,
-            String notes, Action action)
+            String notes, Action action, MailItem reqItem)
     throws ServiceException, MessagingException {
         Provisioning prov = Provisioning.getInstance();
 
@@ -645,12 +687,12 @@ public class SendShareNotification extends MailDocumentHandler {
             if (addrs.groupAddr() != null) {
                 // just send to the group's address, no treatment needed for recipients
                 sendNotificationEmail(octxt, mbox, authAccount, ownerAccount, sid,
-                        notes, action, null, null);
+                        notes, action, null, null, reqItem);
             } else {
                 // send one common notif email to all internal members,
                 if (addrs.internalAddrs() != null) {
                     sendNotificationEmail(octxt, mbox, authAccount, ownerAccount, sid,
-                            notes, action, addrs.internalAddrs(), null);
+                            notes, action, addrs.internalAddrs(), null, reqItem);
                 }
 
                 // send one personalized notif email to each external member
@@ -659,11 +701,11 @@ public class SendShareNotification extends MailDocumentHandler {
                     if (extMembers.size() <= DebugConfig.sendGroupShareNotificationSynchronouslyThreshold) {
                         // send synchronously
                         sendNotificationEmailToGroupExternalMembers(octxt, mbox,
-                                authAccount, ownerAccount, sid, notes, action, extMembers);
+                                authAccount, ownerAccount, sid, notes, action, extMembers, reqItem);
                     } else {
                         // send asynchronously in a separate thread to avoid holding up the request
                         sendNotificationEmailToGroupExternalMembersAsync(octxt, mbox,
-                                authAccount, ownerAccount, sid, notes, action, extMembers);
+                                authAccount, ownerAccount, sid, notes, action, extMembers, reqItem);
                     }
                 }
             }
@@ -673,11 +715,11 @@ public class SendShareNotification extends MailDocumentHandler {
     private void sendNotificationEmailToGroupExternalMembers(
             OperationContext octxt, Mailbox mbox,
             Account authAccount, Account ownerAccount, ShareInfoData sid,
-            String notes, Action action, Collection<String> extMembers) {
+            String notes, Action action, Collection<String> extMembers, MailItem reqItem) {
         for (String extMember : extMembers) {
             try {
                 sendNotificationEmail(octxt, mbox, authAccount, ownerAccount, sid,
-                        notes, action, null, extMember);
+                        notes, action, null, extMember, reqItem);
             } catch (ServiceException e) {
                 sLog.warn("Ignoring error while sending share notification to external group member " + extMember , e);
             } catch (MessagingException e) {
@@ -689,13 +731,13 @@ public class SendShareNotification extends MailDocumentHandler {
     private void sendNotificationEmailToGroupExternalMembersAsync(
             final OperationContext octxt, final Mailbox mbox,
             final Account authAccount, final Account ownerAccount, final ShareInfoData sid,
-            final String notes, final Action action, final Collection<String> extMembers) {
+            final String notes, final Action action, final Collection<String> extMembers, MailItem reqItem) {
         Runnable r = new Runnable() {
             @Override
             public void run() {
                 try {
                     sendNotificationEmailToGroupExternalMembers(octxt, mbox,
-                            authAccount, ownerAccount, sid, notes, action, extMembers);
+                            authAccount, ownerAccount, sid, notes, action, extMembers, reqItem);
                 } catch (OutOfMemoryError e) {
                     Zimbra.halt("OutOfMemoryError while sending share notification to external group members", e);
                 }
@@ -704,6 +746,25 @@ public class SendShareNotification extends MailDocumentHandler {
         Thread senderThread = new Thread(r, "SendShareNotification");
         senderThread.setDaemon(true);
         senderThread.start();
+    }
+
+    private void processDBFilesSharedWithMe(MailItem reqItem, Action action, OperationContext octxt, String granteeId,
+                                            String fileName, String ownerAccountId, int ownerFileId, String fileUUID, String fileOwnerName,
+                                            String rights, Map<String, Object> context) throws ServiceException {
+
+        Document docReqItem = (Document) reqItem;
+        FileSharedWithMeRequest req = new FileSharedWithMeRequest();
+        req.setAction(action == null ? CREATE : action.name());
+        req.setFileName(fileName);
+        req.setOwnerFileId(ownerFileId);
+        req.setFileUUID(fileUUID);
+        req.setFileOwnerName(fileOwnerName);
+        req.setRights(rights);
+        req.setContentType(docReqItem.getContentType());
+        req.setSize(docReqItem.getTotalSize());
+        req.setOwnerAccountId(ownerAccountId);
+        Element request = JaxbUtil.jaxbToElement(req);
+        proxyRequest(request, context, granteeId);
     }
 
 }

--- a/store/src/java/com/zimbra/cs/service/mail/ToXML.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ToXML.java
@@ -40,6 +40,7 @@ import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimePart;
 import javax.mail.internet.MimeUtility;
 
+import com.zimbra.common.mailbox.FolderConstants;
 import org.apache.commons.lang.StringUtils;
 import org.json.JSONException;
 
@@ -175,6 +176,7 @@ import com.zimbra.soap.type.WantRecipsSetting;
  */
 public final class ToXML {
     private static final Log LOG = LogFactory.getLog(ToXML.class);
+    private static final String FILE_SHARED_WITH_ME_ZIMBRA_ID = "0";
 
     public static enum OutputParticipants {
         PUT_SENDERS(0),
@@ -286,6 +288,10 @@ public final class ToXML {
         }
         Element elem = parent.addNonUniqueElement(MailConstants.E_FOLDER);
         encodeFolderCommon(elem, ifmt, folder, fields);
+        if (folder.getId() == FolderConstants.ID_FOLDER_FILE_SHARED_WITH_ME) {
+            elem.addAttribute(MailConstants.A_RIGHTS, "r"); //making this folder read only
+            elem.addAttribute(MailConstants.A_ZIMBRA_ID, FILE_SHARED_WITH_ME_ZIMBRA_ID);
+        }
         if (needToOutput(fields, Change.SIZE)) {
             int deleted = folder.getDeletedCount();
             elem.addAttribute(MailConstants.A_NUM, folder.getItemCount() - deleted);
@@ -3043,6 +3049,14 @@ throws ServiceException {
 
     public static Element encodeDocumentCommon(Element m, ItemIdFormatter ifmt, OperationContext octxt, Document doc, int fields)
     throws ServiceException {
+        if (doc.getFolderId() == FolderConstants.ID_FOLDER_FILE_SHARED_WITH_ME && doc.getOwnerAccountId() != null
+                && doc.getOwnerFileId() != null) {
+            m.addAttribute(MailConstants.A_ID, doc.getOwnerAccountId() + ":" + doc.getOwnerFileId()); // accountid:fileid
+            m.addAttribute(MailConstants.A_RIGHTS, doc.getPermission());
+            m.addAttribute(MailConstants.A_SHARED_FILE_ID, doc.getId());
+        } else {
+            m.addAttribute(MailConstants.A_ID, ifmt.formatItemId(doc));
+        }
         m.addAttribute(MailConstants.A_ID, ifmt.formatItemId(doc));
         m.addAttribute(MailConstants.A_UUID, doc.getUuid());
         if (needToOutput(fields, Change.NAME)) {

--- a/store/src/java/com/zimbra/soap/ZimbraSoapContext.java
+++ b/store/src/java/com/zimbra/soap/ZimbraSoapContext.java
@@ -24,6 +24,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.servlet.http.HttpServletRequest;
 
+import com.zimbra.common.soap.MailConstants;
+import com.zimbra.common.soap.OctopusXmlConstants;
+import com.zimbra.cs.service.mail.DelegatableRequest;
 import org.dom4j.QName;
 import org.eclipse.jetty.continuation.Continuation;
 
@@ -513,6 +516,12 @@ public final class ZimbraSoapContext {
         }
 
         if ((handler != null) && handler.handlesAccountHarvesting()) {
+            return;
+        }
+
+        if (((handler != null) && handler instanceof DelegatableRequest
+                && MailConstants.FILE_SHARED_WITH_ME_REQUEST.equals(requestName)
+                && ((DelegatableRequest) handler).isDelegatable()) || (OctopusXmlConstants.GET_DOCUMENT_SHARE_URL_REQUEST.equals(requestName))) {
             return;
         }
 


### PR DESCRIPTION
Back-ported changes from Z10 for FileSharedWithMe.

ZCS-11694 : File Shared with me implementation
commit - f14f0c82820bd5cd8f2e7286a8dd9da371e7cbc1

ZCS-11801 : Modifying file at grantee side doesn't update file size, time, new name and doesn't convert from .txt to .docx file format
commit - cc765046e6714f5613542d62599f4102d2f8b8f0

ZCS-11802 : Backend implementation to show exact Item Id in search response
commit - c7b11ffb0a1d20c42437260ad85c4643b3483e45

ZCS-11901 : HTTP ERROR 404 no such item error when admin granter shares file and subsequent grantee tries to view file from 'Files shared with me' folder
commit - 828bd1dc75ca68acb05248fc2a9501593264002a