### PR TITLE
ZCS-12948: Strip double-double quotes from EphemeralResult

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1545,7 +1545,10 @@ public final class LC {
 
     // ZBUG-3105: zimbra_allowed_redirect_url is a url that allows in preauth redirectURL
     public static final KnownKey zimbra_allowed_redirect_url = KnownKey.newKey("");
-    
+
+	// ZCS-12948: ssdb_zok_compat is true if we should write ephemeral values as JSON strings.
+	public static final KnownKey ssdb_zok_compat = KnownKey.newKey(false);
+
     static {
         // Automatically set the key name with the variable name.
         for (Field field : LC.class.getFields()) {

--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1546,8 +1546,8 @@ public final class LC {
     // ZBUG-3105: zimbra_allowed_redirect_url is a url that allows in preauth redirectURL
     public static final KnownKey zimbra_allowed_redirect_url = KnownKey.newKey("");
 
-	// ZCS-12948: ssdb_zok_compat is true if we should write ephemeral values as JSON strings.
-	public static final KnownKey ssdb_zok_compat = KnownKey.newKey(false);
+	// ZCS-12948: ssdb_zimbrax_compat is true if we should write ephemeral values as JSON strings.
+	public static final KnownKey ssdb_zimbrax_compat = KnownKey.newKey(false);
 
     static {
         // Automatically set the key name with the variable name.

--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1546,8 +1546,8 @@ public final class LC {
     // ZBUG-3105: zimbra_allowed_redirect_url is a url that allows in preauth redirectURL
     public static final KnownKey zimbra_allowed_redirect_url = KnownKey.newKey("");
 
-	// ZCS-12948: ssdb_zimbrax_compat is true if we should write ephemeral values as JSON strings.
-	public static final KnownKey ssdb_zimbrax_compat = KnownKey.newKey(false);
+    // ZCS-12948: ssdb_zimbrax_compat is true if we should write ephemeral values as JSON strings.
+    public static final KnownKey ssdb_zimbrax_compat = KnownKey.newKey(false);
 
     static {
         // Automatically set the key name with the variable name.

--- a/store/src/java-test/com/zimbra/cs/mailbox/calendar/ZAttendeeTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/calendar/ZAttendeeTest.java
@@ -21,11 +21,11 @@ import java.io.InputStream;
 import java.util.Iterator;
 import java.util.List;
 
+import org.hamcrest.core.StringContains;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.internal.matchers.StringContains;
 import org.junit.rules.MethodRule;
 import org.junit.rules.TestName;
 

--- a/store/src/java/com/zimbra/cs/ephemeral/EphemeralResult.java
+++ b/store/src/java/com/zimbra/cs/ephemeral/EphemeralResult.java
@@ -224,7 +224,7 @@ public class EphemeralResult {
 	 * @return the clean values
 	 */
 	private String[] normalizeZokValues(final String[] values) {
-		if (!LC.ssdb_zok_compat.booleanValue()) {
+		if (!LC.ssdb_zimbrax_compat.booleanValue()) {
 			return values;
 		}
 

--- a/store/src/java/com/zimbra/cs/ephemeral/EphemeralResult.java
+++ b/store/src/java/com/zimbra/cs/ephemeral/EphemeralResult.java
@@ -22,7 +22,7 @@ public class EphemeralResult {
     private EphemeralKey key;
     private String[] values;
 
-	private final Pattern JSON_STRING_RE = Pattern.compile("^\"(.*)\"$");
+    private final Pattern JSON_STRING_RE = Pattern.compile("^\"(.*)\"$");
 
     public EphemeralResult(EphemeralKey key, String value) {
         this.key = key;
@@ -46,13 +46,13 @@ public class EphemeralResult {
             for (int i = 0; i < entries.length; i++) {
                 values[i] = entries[i].getValue();
             }
-			this.values = normalizeZokValues(values);
+            this.values = normalizeZokValues(values);
         }
     }
 
     public EphemeralResult(EphemeralKey key, List<String> values) {
         this(key, values.toArray(new String[values.size()]));
-		this.values = normalizeZokValues(this.values);
+        this.values = normalizeZokValues(this.values);
     }
 
     public String getValue() {
@@ -218,23 +218,23 @@ public class EphemeralResult {
     }
 
 
-	/** Replace extraneous quotes and other remnants of ZOK converting certain values to JSON.
-	 *
-	 * @param values the values to be set
-	 * @return the clean values
-	 */
-	private String[] normalizeZokValues(final String[] values) {
-		if (!LC.ssdb_zimbrax_compat.booleanValue()) {
-			return values;
-		}
+    /** Replace extraneous quotes and other remnants of ZOK converting certain values to JSON.
+     *
+     * @param values the values to be set
+     * @return the clean values
+     */
+    private String[] normalizeZokValues(final String[] values) {
+        if (!LC.ssdb_zimbrax_compat.booleanValue()) {
+            return values;
+        }
 
-		String[] normalized = new String[values.length];
+        String[] normalized = new String[values.length];
 
-		for (int i = 0; i < values.length; i++) {
-			final Matcher m = JSON_STRING_RE.matcher(values[i]);
-			normalized[i] = m.matches() ? m.group(1) : values[i];
-		}
+        for (int i = 0; i < values.length; i++) {
+            final Matcher m = JSON_STRING_RE.matcher(values[i]);
+            normalized[i] = m.matches() ? m.group(1) : values[i];
+        }
 
-		return normalized;
-	}
+        return normalized;
+    }
 }

--- a/store/src/java/com/zimbra/cs/server/ServerThrottle.java
+++ b/store/src/java/com/zimbra/cs/server/ServerThrottle.java
@@ -167,7 +167,7 @@ public class ServerThrottle {
         } catch (UnknownHostException e) {
             ZimbraLog.net.warn("unknown host %s cannot be added to throttle %slist." +
             		" %s requests from this host may be throttled. " +
-            		"If this host is a proxy please add it to your DNS.", (whitelist ? "white" : "ignore "), hostname, serverType);
+            		"If this host is a proxy please add it to your DNS.", hostname, (whitelist ? "white" : "ignore "), serverType);
         }
     }
 

--- a/store/src/java/com/zimbra/qa/unittest/TestUtil.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestUtil.java
@@ -1636,7 +1636,7 @@ public class TestUtil extends Assert {
         try {
             org.junit.Assume.assumeTrue(testVal);
         } catch (AssumptionViolatedException ave) {
-            throw new AssumptionViolatedException(missive, null);
+            throw new AssumptionViolatedException(missive, ave);
         }
     }
 


### PR DESCRIPTION
For compatibility with the JSON encoding over on ZOK. Turn on with `LC.ssdb_zok_compat=true`. See related [pull request for the SSDB extension](https://github.com/Zimbra/zm-ssdb-ephemeral-store/pull/16).