### PR TITLE
ZCS-13211: stop creating the file shared with me folder for new users

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -2271,8 +2271,6 @@ public class Mailbox implements MailboxStore {
                             MailItem.Type.MESSAGE, 0, MailItem.DEFAULT_COLOR_RGB, null, null, null);
             Folder.create(ID_FOLDER_BRIEFCASE, UUIDUtil.generateUUID(), this, userRoot, "Briefcase", system,
                             MailItem.Type.DOCUMENT, 0, MailItem.DEFAULT_COLOR_RGB, null, null, null);
-            Folder.create(ID_FOLDER_FILE_SHARED_WITH_ME, UUIDUtil.generateUUID(), this, userRoot, "Files shared with me", system,
-                    MailItem.Type.DOCUMENT, 0, MailItem.DEFAULT_COLOR_RGB, null, null, null);
 
             if (LC.zimbra_feature_safe_unsubscribe_folder_enabled.booleanValue()) {
                 Folder.create(ID_FOLDER_UNSUBSCRIBE, UUIDUtil.generateUUID(), this, userRoot, "Unsubscribe", system,


### PR DESCRIPTION
Issue
Placeholder for creating the record for file shared in Z8 & Z9 also creates the folder "Files shared with me" for new user.

Fix
Stop the folder "Files shared with me" getting created for new user.