### PR TITLE
TempZCS-13176:Add LDAP attribute for Mail Recall to get secrate key

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -2870,6 +2870,14 @@ public class ZAttrProvisioning {
     public static final String A_registeredAddress = "registeredAddress";
 
     /**
+     * Can be used in Mail Recall to make it more secure from spoof.
+     *
+     * @since ZCS 10.0.0
+     */
+    @ZAttr(id=4103)
+    public static final String A_secretKeyForMailRecall = "secretKeyForMailRecall";
+
+    /**
      * RFC2256: last (family) name(s) for which the entity is known by
      */
     @ZAttr(id=-1)
@@ -7152,7 +7160,7 @@ public class ZAttrProvisioning {
     /**
      * Enables the mail recall functionality
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4094)
     public static final String A_zimbraFeatureMailRecallEnabled = "zimbraFeatureMailRecallEnabled";
@@ -7161,7 +7169,7 @@ public class ZAttrProvisioning {
      * Time(in minutes) within which a message can be recalled. The default
      * time is 30 minutes and accepts value from 1 to 30.
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4095)
     public static final String A_zimbraFeatureMailRecallTime = "zimbraFeatureMailRecallTime";

--- a/common/src/java/com/zimbra/common/service/ServiceException.java
+++ b/common/src/java/com/zimbra/common/service/ServiceException.java
@@ -37,6 +37,7 @@ import com.zimbra.common.util.StringUtil;
 public class ServiceException extends Exception {
 
     public static final String FAILURE = "service.FAILURE";
+    public static final String ERROR = "service.ERROR";
     public static final String INVALID_REQUEST = "service.INVALID_REQUEST";
     public static final String UNKNOWN_DOCUMENT = "service.UNKNOWN_DOCUMENT";
     public static final String PARSE_ERROR = "service.PARSE_ERROR";
@@ -291,6 +292,10 @@ public class ServiceException extends Exception {
      */
     public static ServiceException FAILURE(String message, Throwable cause) {
         return new ServiceException("system failure: "+message, FAILURE, RECEIVERS_FAULT, cause);
+    }
+
+    public static ServiceException ERROR_MESSAGE(String message, Throwable cause){
+        return new ServiceException(message, ERROR, SENDERS_FAULT, cause);
     }
 
     public static ServiceException ERROR_WHILE_PARSING_UPLOAD(String message, Throwable cause) {

--- a/common/src/java/com/zimbra/common/soap/AccountConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AccountConstants.java
@@ -644,4 +644,11 @@ public class AccountConstants {
     public static final String E_SKIN_SELECTION_COLOR = "zimbraSkinSelectionColor";
     public static final String E_SKIN_FAVICON = "zimbraSkinFavicon";
     public static final String E_HOSTNAME = "hostname";
+
+    // MailRecall Uses
+    public static final String E_MAIL_RECALL_REQUEST = "MailRecallRequest";
+    public static final String E_MAIL_RECALL_RESPONSE = "MailRecallResponse";
+    public static final QName MAIL_RECALL_REQUEST = QName.get(E_MAIL_RECALL_REQUEST, NAMESPACE);
+    public static final QName MAIL_RECALL_RESPONSE = QName.get(E_MAIL_RECALL_RESPONSE, NAMESPACE);
+    public static final String ITEM_ID = "itemId";
 }

--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -1617,6 +1617,12 @@ public final class AdminConstants {
     public static final QName VALIDATE_S3_BUCKET_REACHABLE_REQUEST = QName.get(E_VALIDATE_S3_BUCKET_REACHABLE_REQUEST, NAMESPACE);
     public static final QName VALIDATE_S3_BUCKET_REACHABLE_RESPONSE = QName.get(E_VALIDATE_S3_BUCKET_REACHABLE_RESPONSE, NAMESPACE);
 
+    // Secret key for mail recall
+    public static final String E_GENERATE_SECRET_KEY_REQUEST = "GenerateSecretKeyRequest";
+    public static final String E_GENERATE_SECRET_KEY_RESPONSE = "GenerateSecretKeyResponse";
+    public static final QName GENERATE_SECRET_KEY_REQUEST = QName.get(E_GENERATE_SECRET_KEY_REQUEST, NAMESPACE);
+    public static final QName GENERATE_SECRET_KEY_RESPONSE = QName.get(E_GENERATE_SECRET_KEY_RESPONSE, NAMESPACE);
+
     // Removed Zetras zimlet package list
     public static final List<String> ZEXTRAS_PACKAGES_LIST = Arrays.asList("com_ng_auth", "com_zextras_zextras",
             "com_zextras_client", "com_zimbra_connect_classic", "com_zimbra_connect_modern", "com_zextras_docs",

--- a/soap/src/java/com/zimbra/soap/JaxbUtil.java
+++ b/soap/src/java/com/zimbra/soap/JaxbUtil.java
@@ -30,6 +30,8 @@ import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 import javax.xml.namespace.QName;
 
+import com.zimbra.soap.admin.message.GenerateSecretKeyRequest;
+import com.zimbra.soap.admin.message.GenerateSecretKeyResponse;
 import org.dom4j.Document;
 import org.dom4j.Namespace;
 import org.dom4j.io.DocumentResult;
@@ -1169,7 +1171,11 @@ public final class JaxbUtil {
             com.zimbra.soap.admin.message.ValidateS3BucketReachableRequest.class,
             com.zimbra.soap.admin.message.ValidateS3BucketReachableResponse.class,
             com.zimbra.soap.admin.message.EditS3BucketConfigRequest.class,
-            com.zimbra.soap.admin.message.EditS3BucketConfigResponse.class
+            com.zimbra.soap.admin.message.EditS3BucketConfigResponse.class,
+            com.zimbra.soap.admin.message.GenerateSecretKeyRequest.class,
+            com.zimbra.soap.admin.message.GenerateSecretKeyResponse.class,
+            com.zimbra.soap.account.message.MailRecallRequest.class,
+            com.zimbra.soap.account.message.MailRecallResponse.class
         };
 
         try {

--- a/soap/src/java/com/zimbra/soap/account/message/MailRecallRequest.java
+++ b/soap/src/java/com/zimbra/soap/account/message/MailRecallRequest.java
@@ -1,0 +1,41 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2023 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.account.message;
+
+import com.zimbra.common.soap.AccountConstants;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name = AccountConstants.E_MAIL_RECALL_REQUEST)
+public class MailRecallRequest {
+    @XmlAttribute(name = AccountConstants.ITEM_ID /* more */, required = true)
+    private int itemId;
+
+    public int getItemId() {
+        return itemId;
+    }
+
+    public void setItemId(int itemId) {
+        this.itemId = itemId;
+    }
+}
+

--- a/soap/src/java/com/zimbra/soap/account/message/MailRecallResponse.java
+++ b/soap/src/java/com/zimbra/soap/account/message/MailRecallResponse.java
@@ -1,0 +1,61 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2023 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.account.message;
+
+import com.zimbra.common.soap.AccountConstants;
+import com.zimbra.soap.admin.type.AdminAttrsImpl;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name = AccountConstants.E_MAIL_RECALL_RESPONSE)
+public class MailRecallResponse extends AdminAttrsImpl {
+    @XmlAttribute
+    private int successfulRecall;
+    @XmlAttribute
+    private int unSuccessfulRecall;
+    @XmlAttribute
+    private boolean isAllMailRecalled;
+
+    public int getSuccessfulRecall() {
+        return successfulRecall;
+    }
+
+    public void setSuccessfulRecall(int successfulRecall) {
+        this.successfulRecall = successfulRecall;
+    }
+
+    public int getUnSuccessfulRecall() {
+        return unSuccessfulRecall;
+    }
+
+    public void setUnSuccessfulRecall(int unSuccessfulRecall) {
+        this.unSuccessfulRecall = unSuccessfulRecall;
+    }
+
+    public boolean isAllMailRecalled() {
+        return isAllMailRecalled;
+    }
+
+    public void setAllMailRecalled(boolean allMailRecalled) {
+        isAllMailRecalled = allMailRecalled;
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/GenerateSecretKeyRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/GenerateSecretKeyRequest.java
@@ -1,0 +1,39 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2023 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import com.zimbra.common.soap.AdminConstants;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+/**
+ * @zm-api-command-auth-required true
+ * @zm-api-command-admin-auth-required true
+ * @zm-api-command-description Create random secret key and update it to LDAP attribute.
+ */
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name = AdminConstants.E_GENERATE_SECRET_KEY_REQUEST)
+@XmlType(propOrder = {})
+public class GenerateSecretKeyRequest {
+
+    public GenerateSecretKeyRequest() {
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/GenerateSecretKeyResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/GenerateSecretKeyResponse.java
@@ -1,0 +1,34 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2023 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import com.zimbra.common.soap.AdminConstants;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name = AdminConstants.E_GENERATE_SECRET_KEY_RESPONSE)
+@XmlType(propOrder = {})
+public class GenerateSecretKeyResponse {
+
+    public GenerateSecretKeyResponse() {
+    }
+}

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10322,17 +10322,16 @@ TODO: delete them permanently from here
 <attr id="4093" name="zimbraTrialConvertAtExpiration" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited,accountInfo" since="9.0.0">
   <desc>Can be used by an external service to indicate that a trial is set to convert to active at expiration.</desc>
 </attr>
-<attr id="4094" name="zimbraFeatureMailRecallEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,account,cos,domain" flags="accountInfo,domainInherited,accountCosDomainInherited" since="10.1.0">
+<attr id="4094" name="zimbraFeatureMailRecallEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,account,cos,domain" flags="accountInfo,domainInherited,accountCosDomainInherited" callback="GenerateSecretKeyCallback" since="10.0.0">
   <globalConfigValue>FALSE</globalConfigValue>
   <defaultCOSValue>FALSE</defaultCOSValue>
   <desc>Enables the mail recall functionality</desc>
 </attr>
-<attr id="4095" name="zimbraFeatureMailRecallTime" type="integer" min="1" max="30" cardinality="single" optionalIn="globalConfig,account,cos,domain" flags="accountInfo,domainInherited,accountCosDomainInherited" since="10.1.0">
+<attr id="4095" name="zimbraFeatureMailRecallTime" type="integer" min="1" max="30" cardinality="single" optionalIn="globalConfig,account,cos,domain" flags="accountInfo,domainInherited,accountCosDomainInherited" since="10.0.0">
   <globalConfigValue>30</globalConfigValue>
   <defaultCOSValue>30</defaultCOSValue>
   <desc>Time(in minutes) within which a message can be recalled. The default time is 30 minutes and accepts value from 1 to 30.</desc>
 </attr>
-
 <attr id="9001" name="zimbraMailSieveScriptMaxSize" type="long" min="0" cardinality="single" optionalIn="globalConfig,account,cos,domain" flags="domainInfo,accountInfo,accountCosDomainInherited" since="11.0.0">
   <globalConfigValue>0</globalConfigValue>
   <defaultCOSValue>0</defaultCOSValue>
@@ -10389,6 +10388,10 @@ TODO: delete them permanently from here
   <defaultCOSValue>TRUE</defaultCOSValue>
   <defaultExternalCOSValue>FALSE</defaultExternalCOSValue>
   <desc>Whether retention policy feature is enabled</desc>
+</attr>
+
+<attr id="4103" name="secretKeyForMailRecall" type="string" max="128" cardinality="single" optionalIn="globalConfig" since="10.0.0">
+  <desc>Can be used in Mail Recall to make it more secure from spoof.</desc>
 </attr>
 
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -17931,7 +17931,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @return zimbraFeatureMailRecallEnabled, or false if unset
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4094)
     public boolean isFeatureMailRecallEnabled() {
@@ -17944,7 +17944,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param zimbraFeatureMailRecallEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4094)
     public void setFeatureMailRecallEnabled(boolean zimbraFeatureMailRecallEnabled) throws com.zimbra.common.service.ServiceException {
@@ -17960,7 +17960,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4094)
     public Map<String,Object> setFeatureMailRecallEnabled(boolean zimbraFeatureMailRecallEnabled, Map<String,Object> attrs) {
@@ -17974,7 +17974,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4094)
     public void unsetFeatureMailRecallEnabled() throws com.zimbra.common.service.ServiceException {
@@ -17989,7 +17989,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4094)
     public Map<String,Object> unsetFeatureMailRecallEnabled(Map<String,Object> attrs) {
@@ -18004,7 +18004,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @return zimbraFeatureMailRecallTime, or 30 if unset
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4095)
     public int getFeatureMailRecallTime() {
@@ -18018,7 +18018,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param zimbraFeatureMailRecallTime new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4095)
     public void setFeatureMailRecallTime(int zimbraFeatureMailRecallTime) throws com.zimbra.common.service.ServiceException {
@@ -18035,7 +18035,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4095)
     public Map<String,Object> setFeatureMailRecallTime(int zimbraFeatureMailRecallTime, Map<String,Object> attrs) {
@@ -18050,7 +18050,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4095)
     public void unsetFeatureMailRecallTime() throws com.zimbra.common.service.ServiceException {
@@ -18066,7 +18066,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4095)
     public Map<String,Object> unsetFeatureMailRecallTime(Map<String,Object> attrs) {

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -165,6 +165,78 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Can be used in Mail Recall to make it more secure from spoof.
+     *
+     * @return secretKeyForMailRecall, or null if unset
+     *
+     * @since ZCS 10.0.0
+     */
+    @ZAttr(id=4103)
+    public String getSecretKeyForMailRecall() {
+        return getAttr(Provisioning.A_secretKeyForMailRecall, null, true);
+    }
+
+    /**
+     * Can be used in Mail Recall to make it more secure from spoof.
+     *
+     * @param secretKeyForMailRecall new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.0.0
+     */
+    @ZAttr(id=4103)
+    public void setSecretKeyForMailRecall(String secretKeyForMailRecall) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_secretKeyForMailRecall, secretKeyForMailRecall);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Can be used in Mail Recall to make it more secure from spoof.
+     *
+     * @param secretKeyForMailRecall new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.0.0
+     */
+    @ZAttr(id=4103)
+    public Map<String,Object> setSecretKeyForMailRecall(String secretKeyForMailRecall, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_secretKeyForMailRecall, secretKeyForMailRecall);
+        return attrs;
+    }
+
+    /**
+     * Can be used in Mail Recall to make it more secure from spoof.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.0.0
+     */
+    @ZAttr(id=4103)
+    public void unsetSecretKeyForMailRecall() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_secretKeyForMailRecall, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Can be used in Mail Recall to make it more secure from spoof.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.0.0
+     */
+    @ZAttr(id=4103)
+    public Map<String,Object> unsetSecretKeyForMailRecall(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_secretKeyForMailRecall, "");
+        return attrs;
+    }
+
+    /**
      * Zimbra access control list
      *
      * @return zimbraACE, or empty array if unset
@@ -18602,7 +18674,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @return zimbraFeatureMailRecallEnabled, or false if unset
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4094)
     public boolean isFeatureMailRecallEnabled() {
@@ -18615,7 +18687,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param zimbraFeatureMailRecallEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4094)
     public void setFeatureMailRecallEnabled(boolean zimbraFeatureMailRecallEnabled) throws com.zimbra.common.service.ServiceException {
@@ -18631,7 +18703,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4094)
     public Map<String,Object> setFeatureMailRecallEnabled(boolean zimbraFeatureMailRecallEnabled, Map<String,Object> attrs) {
@@ -18645,7 +18717,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4094)
     public void unsetFeatureMailRecallEnabled() throws com.zimbra.common.service.ServiceException {
@@ -18660,7 +18732,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4094)
     public Map<String,Object> unsetFeatureMailRecallEnabled(Map<String,Object> attrs) {
@@ -18675,7 +18747,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @return zimbraFeatureMailRecallTime, or 30 if unset
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4095)
     public int getFeatureMailRecallTime() {
@@ -18689,7 +18761,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param zimbraFeatureMailRecallTime new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4095)
     public void setFeatureMailRecallTime(int zimbraFeatureMailRecallTime) throws com.zimbra.common.service.ServiceException {
@@ -18706,7 +18778,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4095)
     public Map<String,Object> setFeatureMailRecallTime(int zimbraFeatureMailRecallTime, Map<String,Object> attrs) {
@@ -18721,7 +18793,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4095)
     public void unsetFeatureMailRecallTime() throws com.zimbra.common.service.ServiceException {
@@ -18737,7 +18809,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4095)
     public Map<String,Object> unsetFeatureMailRecallTime(Map<String,Object> attrs) {

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -12320,7 +12320,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @return zimbraFeatureMailRecallEnabled, or false if unset
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4094)
     public boolean isFeatureMailRecallEnabled() {
@@ -12333,7 +12333,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param zimbraFeatureMailRecallEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4094)
     public void setFeatureMailRecallEnabled(boolean zimbraFeatureMailRecallEnabled) throws com.zimbra.common.service.ServiceException {
@@ -12349,7 +12349,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4094)
     public Map<String,Object> setFeatureMailRecallEnabled(boolean zimbraFeatureMailRecallEnabled, Map<String,Object> attrs) {
@@ -12363,7 +12363,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4094)
     public void unsetFeatureMailRecallEnabled() throws com.zimbra.common.service.ServiceException {
@@ -12378,7 +12378,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4094)
     public Map<String,Object> unsetFeatureMailRecallEnabled(Map<String,Object> attrs) {
@@ -12393,7 +12393,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @return zimbraFeatureMailRecallTime, or 30 if unset
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4095)
     public int getFeatureMailRecallTime() {
@@ -12407,7 +12407,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param zimbraFeatureMailRecallTime new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4095)
     public void setFeatureMailRecallTime(int zimbraFeatureMailRecallTime) throws com.zimbra.common.service.ServiceException {
@@ -12424,7 +12424,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4095)
     public Map<String,Object> setFeatureMailRecallTime(int zimbraFeatureMailRecallTime, Map<String,Object> attrs) {
@@ -12439,7 +12439,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4095)
     public void unsetFeatureMailRecallTime() throws com.zimbra.common.service.ServiceException {
@@ -12455,7 +12455,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4095)
     public Map<String,Object> unsetFeatureMailRecallTime(Map<String,Object> attrs) {

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -10835,7 +10835,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @return zimbraFeatureMailRecallEnabled, or false if unset
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4094)
     public boolean isFeatureMailRecallEnabled() {
@@ -10848,7 +10848,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param zimbraFeatureMailRecallEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4094)
     public void setFeatureMailRecallEnabled(boolean zimbraFeatureMailRecallEnabled) throws com.zimbra.common.service.ServiceException {
@@ -10864,7 +10864,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4094)
     public Map<String,Object> setFeatureMailRecallEnabled(boolean zimbraFeatureMailRecallEnabled, Map<String,Object> attrs) {
@@ -10878,7 +10878,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4094)
     public void unsetFeatureMailRecallEnabled() throws com.zimbra.common.service.ServiceException {
@@ -10893,7 +10893,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4094)
     public Map<String,Object> unsetFeatureMailRecallEnabled(Map<String,Object> attrs) {
@@ -10908,7 +10908,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @return zimbraFeatureMailRecallTime, or 30 if unset
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4095)
     public int getFeatureMailRecallTime() {
@@ -10922,7 +10922,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param zimbraFeatureMailRecallTime new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4095)
     public void setFeatureMailRecallTime(int zimbraFeatureMailRecallTime) throws com.zimbra.common.service.ServiceException {
@@ -10939,7 +10939,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4095)
     public Map<String,Object> setFeatureMailRecallTime(int zimbraFeatureMailRecallTime, Map<String,Object> attrs) {
@@ -10954,7 +10954,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4095)
     public void unsetFeatureMailRecallTime() throws com.zimbra.common.service.ServiceException {
@@ -10970,7 +10970,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 10.1.0
+     * @since ZCS 10.0.0
      */
     @ZAttr(id=4095)
     public Map<String,Object> unsetFeatureMailRecallTime(Map<String,Object> attrs) {

--- a/store/src/java/com/zimbra/cs/account/callback/GenerateSecretKeyCallback.java
+++ b/store/src/java/com/zimbra/cs/account/callback/GenerateSecretKeyCallback.java
@@ -1,0 +1,69 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2023 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.account.callback;
+
+import com.google.common.base.Strings;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+
+import com.zimbra.cs.account.AttributeCallback;
+import com.zimbra.cs.account.Entry;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.soap.SoapProvisioning;
+import com.zimbra.cs.service.util.SecretKey;
+
+import java.util.Map;
+
+public class GenerateSecretKeyCallback extends AttributeCallback {
+
+    @Override
+    public void preModify(CallbackContext context, String attrName, Object value, Map attrsToModify, Entry entry) {
+
+    }
+
+    @Override
+    public void postModify(CallbackContext context, String attrName, Entry entry) {
+
+        SoapProvisioning.getLocalConfigURI();
+
+        String secretKey = null;
+        try {
+            secretKey = Provisioning.getInstance().getConfig().getSecretKeyForMailRecall();
+            if(Strings.isNullOrEmpty(secretKey)) {
+                secretKey = SecretKey.generateRandomString();
+                Provisioning.getInstance().getConfig().setSecretKeyForMailRecall(secretKey);
+                flushCache();
+            }
+        } catch (ServiceException e) {
+            ZimbraLog.misc.warn("Encountered exception during getting Secret Key", e);
+        }
+    }
+
+    private void flushCache() {
+        try {
+            SoapProvisioning sp = new SoapProvisioning();
+            sp.soapSetURI(SoapProvisioning.getLocalConfigURI());
+            sp.soapZimbraAdminAuthenticate();
+            sp.flushCache("config", null, true);
+        } catch (ServiceException e) {
+            ZimbraLog.misc.warn("Encountered exception during FlushCache after creating Secret Key", e);
+        }
+    }
+
+}
+

--- a/store/src/java/com/zimbra/cs/service/admin/AdminService.java
+++ b/store/src/java/com/zimbra/cs/service/admin/AdminService.java
@@ -311,6 +311,9 @@ public class AdminService implements DocumentService {
 
         // ContactBackup API
         dispatcher.registerHandler(AdminConstants.CONTACT_BACKUP_REQUEST, new ContactBackup());
+
+        // GetSecretKey API
+        dispatcher.registerHandler(AdminConstants.GENERATE_SECRET_KEY_REQUEST, new GenerateSecretKey());
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/service/admin/GenerateSecretKey.java
+++ b/store/src/java/com/zimbra/cs/service/admin/GenerateSecretKey.java
@@ -1,0 +1,38 @@
+package com.zimbra.cs.service.admin;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.soap.SoapProvisioning;
+import com.zimbra.cs.service.util.SecretKey;
+import com.zimbra.soap.ZimbraSoapContext;
+
+import java.util.Map;
+
+public class GenerateSecretKey extends AdminDocumentHandler {
+    public Element handle(Element request, Map<String, Object> context) throws ServiceException {
+        ZimbraSoapContext zsc = getZimbraSoapContext(context);
+
+        String randomString = SecretKey.generateRandomString();
+        Provisioning.getInstance().getConfig().setSecretKeyForMailRecall(randomString);
+        flushCache();
+
+        Element response = zsc.createElement(AdminConstants.GENERATE_SECRET_KEY_RESPONSE);
+        return response;
+    }
+
+    private void flushCache() {
+        try {
+            SoapProvisioning sp = new SoapProvisioning();
+            sp.soapSetURI(SoapProvisioning.getLocalConfigURI());
+            sp.soapZimbraAdminAuthenticate();
+            sp.flushCache("config", null, true);
+        } catch (ServiceException e) {
+            ZimbraLog.misc.warn("Encountered exception during FlushCache after creating Secret Key", e);
+        }
+    }
+
+}
+

--- a/store/src/java/com/zimbra/cs/service/util/SecretKey.java
+++ b/store/src/java/com/zimbra/cs/service/util/SecretKey.java
@@ -1,0 +1,101 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2023 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.service.util;
+
+import com.google.common.base.Strings;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.Provisioning;
+import org.apache.commons.codec.binary.Hex;
+
+import javax.mail.MessagingException;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+public class SecretKey {
+
+    public static final int KEY_SIZE_BYTES = 32;
+    public static final String MSGVRFY_HEADER_PREFIX = "hash=SHA256;guid=";
+    public static final String MSGVRFY_ALGORITHM_NAME = "SHA-256";
+
+    /**
+     * returns the randomly generated String
+     *
+     * @return randomly generated String
+     * @throws ServiceException if an error occurred
+     */
+    public static String generateRandomString() throws ServiceException {
+        try {
+            SecureRandom random = SecureRandom.getInstance("SHA1PRNG");
+            byte[] key = new byte[KEY_SIZE_BYTES];
+            random.nextBytes(key);
+            return new String(Hex.encodeHex(key));
+        } catch (NoSuchAlgorithmException e) {
+            throw ServiceException.FAILURE("Unable to initialize SecureRandom for mail recall", e);
+        }
+    }
+
+    /**
+     * provide the Hash for Message-Verification header field.
+     *
+     * @param id
+     * @param date
+     * @param from
+     * @throws ServiceException
+     */
+    public static String getMessageVerificationHeaderValue(String id, String date, String from) throws MessagingException, ServiceException {
+        String secretKey = Provisioning.getInstance().getConfig().getSecretKeyForMailRecall();
+
+        if (Strings.isNullOrEmpty(secretKey)) {
+            secretKey = SecretKey.generateRandomString();
+            Provisioning.getInstance().getConfig().setSecretKeyForMailRecall(secretKey);
+        }
+
+        String guid = (id + date + from + secretKey);
+        String guidHash = getHashForMessageVerification(guid);
+        String hash = MSGVRFY_HEADER_PREFIX + guidHash;
+        return hash;
+    }
+
+    /**
+     * Create a digest of the given input with the given algorithm.
+     *
+     * @param input
+     * @throws ServiceException
+     */
+    private static String getHashForMessageVerification(String input) throws ServiceException {
+        try {
+            MessageDigest md = MessageDigest.getInstance(MSGVRFY_ALGORITHM_NAME);
+            byte[] messageDigest = md.digest(input.getBytes(StandardCharsets.UTF_8));
+            BigInteger number = new BigInteger(1, messageDigest);
+            StringBuilder hexString = new StringBuilder(number.toString(16));
+
+            while (hexString.length() < 64) {
+                hexString.insert(0, '0');
+            }
+
+            String basicBase64format = Base64.getEncoder().encodeToString(hexString.toString().getBytes());
+            return basicBase64format;
+        } catch (NoSuchAlgorithmException e) {
+            throw ServiceException.FAILURE("Unable to encrypt", e);
+        }
+    }
+}


### PR DESCRIPTION
Requirement of ticket [[ZCS-13176](https://jira.corp.synacor.com/browse/ZCS-13176)]

Requirements:

To make sure we don't recall a message accidentally or spoofed, we should add a LDAP attribute to get the secret key for mail recall.

[ZCS-13176]: https://synacor.atlassian.net/browse/ZCS-13176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ