### PR TITLE
ZCS-12912: LDAP global attributes latest value not available across node

### DIFF
--- a/store/src/java/com/zimbra/cs/service/admin/CreateVolume.java
+++ b/store/src/java/com/zimbra/cs/service/admin/CreateVolume.java
@@ -35,6 +35,7 @@ import com.zimbra.soap.admin.message.CreateVolumeRequest;
 import com.zimbra.soap.admin.message.CreateVolumeResponse;
 import com.zimbra.soap.admin.type.StoreManagerRuntimeSwitchResult;
 import com.zimbra.soap.admin.type.VolumeInfo;
+import com.zimbra.util.ExternalVolumeInfoHandler;
 
 public final class CreateVolume extends AdminDocumentHandler {
 
@@ -63,6 +64,10 @@ public final class CreateVolume extends AdminDocumentHandler {
         if (volInfoRequest.isCurrent() && volInfoRequest.getType() == Volume.TYPE_MESSAGE) {
             StoreManagerRuntimeSwitchResult runtimeSwitchResult = StoreManagerResetHelper.setNewStoreManager(volInfoRequest.getStoreManagerClass());
             createVolumeResponse.setRuntimeSwitchResult(runtimeSwitchResult);
+        }
+
+        if (volInfoRequest != null && volInfoRequest.getVolumeExternalInfo() != null && volInfoRequest.getVolumeExternalInfo().isUnified()) {
+            ExternalVolumeInfoHandler.flushConfigLevelCacheOnAllServers(this, ctx);
         }
 
         return new CreateVolumeResponse(volInfoResponse);

--- a/store/src/java/com/zimbra/cs/service/admin/DeleteVolume.java
+++ b/store/src/java/com/zimbra/cs/service/admin/DeleteVolume.java
@@ -30,6 +30,7 @@ import com.zimbra.cs.service.util.VolumeConfigUtil;
 import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.admin.message.DeleteVolumeRequest;
 import com.zimbra.soap.admin.message.DeleteVolumeResponse;
+import com.zimbra.util.ExternalVolumeInfoHandler;
 
 public final class DeleteVolume extends AdminDocumentHandler {
 
@@ -43,7 +44,12 @@ public final class DeleteVolume extends AdminDocumentHandler {
         ZimbraSoapContext zsc = getZimbraSoapContext(ctx);
         Server server = Provisioning.getInstance().getLocalServer();
         checkRight(zsc, ctx, server, Admin.R_manageVolume);
+        boolean isUnifiedVolume = VolumeConfigUtil.isUnifiedVolume(req.getId());
         VolumeConfigUtil.parseDeleteVolumeRequest(req, server.getId());
+
+        if (isUnifiedVolume) {
+            ExternalVolumeInfoHandler.flushConfigLevelCacheOnAllServers(this, ctx);
+        }
         return new DeleteVolumeResponse();
     }
 

--- a/store/src/java/com/zimbra/cs/service/util/VolumeConfigUtil.java
+++ b/store/src/java/com/zimbra/cs/service/util/VolumeConfigUtil.java
@@ -288,7 +288,7 @@ public class VolumeConfigUtil {
      * Perform required actions for processing parseDeleteVolumeRequest
      *
      * @param DeleteVolumeRequest
-     * @return
+     * @return nothing
      * @throws ServiceException
      */
     public static void parseDeleteVolumeRequest(DeleteVolumeRequest req, String serverId) throws ServiceException {
@@ -387,5 +387,17 @@ public class VolumeConfigUtil {
             }
         }
         mgr.update(builder.build());
+    }
+
+    /**
+     * Checks if volume is unified or not
+     * @param volumeId
+     * @return if true if volume is unified else false
+     */
+    public static boolean isUnifiedVolume(int volumeId) {
+        boolean isUnifiedVolume = false;
+        ExternalVolumeInfoHandler extVolInfoHandler = new ExternalVolumeInfoHandler(Provisioning.getInstance());
+        isUnifiedVolume = extVolInfoHandler.isUnifiedVolume(volumeId);
+        return isUnifiedVolume;
     }
 }


### PR DESCRIPTION
Problem ([ZCS-12912](https://jira.corp.synacor.com/browse/ZCS-12912)):
When we add or delete external S3 volume on one server, the LDAP global attribute `zimbraGlobalExternalStoreConfig` value is not updated across other mail servers. So on other servers, we have to execute `zmprov fc all`, to get the updated value of LDAP reflected.

Solution:
The cache should be flushed at _config level_ at the time of creating and deleting the S3 Volume. Cache should be  flushed for all the servers other than the server where changes were made, so that the updated LDAP value is reflected among all the servers right away.

Fix:
Executing a flushCache method after each S3 external volume addition and deletion.

Testing:
Done testing on multi-node server after adding and deleting multiple volumes.

Other PR: https://github.com/Zimbra/zm-hsm-store/pull/42