### PR TITLE
ZCS-10630: Replaced zimbraDataSourceHost www.googleapis.com with apid…

### DIFF
--- a/store/src/java/com/zimbra/cs/datasource/CalDavDataImport.java
+++ b/store/src/java/com/zimbra/cs/datasource/CalDavDataImport.java
@@ -154,7 +154,10 @@ public class CalDavDataImport extends MailItemImport {
             url.append("http://");
         break;
         }
-        url.append(ds.getHost()).append(":").append(ds.getPort());
+        url.append(ds.getHost());
+        if (ds.getPort() != null) {
+            url.append(":").append(ds.getPort());
+        }
         return url.toString();
     }
 

--- a/store/src/java/com/zimbra/cs/dav/client/CalDavClient.java
+++ b/store/src/java/com/zimbra/cs/dav/client/CalDavClient.java
@@ -71,7 +71,7 @@ public class CalDavClient extends WebDavClient {
     }
 
     private String getCurrentUserPrincipal() {
-        DavRequest propfind = DavRequest.PROPFIND("/.well-known/caldav");
+        DavRequest propfind = DavRequest.PROPFIND("/caldav/v2");
         propfind.addRequestProp(DavElements.E_CURRENT_USER_PRINCIPAL);
         HttpResponse response = null;
         try {


### PR DESCRIPTION
**Problem**
Google calendar not syncing

**Reason** 
https://www.googleapis.com/.well-known/caldav is the endpoint which is currently used to fetch current-user-principal via PROPFIND. For this request endpoint we were seeing 404 error.

But when changing base URL to https://apidata.googleusercontent.com/ and when tried to fetch current-user-principal with PROPFIND endpoint(https://apidata.googleusercontent.com/caldav/v2) response was coming properly.
So seems like we have to change/update the base URL and respective endpoints to resolve this exception.