### PR TITLE
 ZBUG-2250: DOS Filter Whitelisting for Multiple IPs

### DIFF
--- a/store/src/java-test/com/zimbra/cs/servlet/ZimbraInvalidLoginFilterTest.java
+++ b/store/src/java-test/com/zimbra/cs/servlet/ZimbraInvalidLoginFilterTest.java
@@ -1,0 +1,53 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2023 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.servlet;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
+import org.powermock.reflect.Whitebox;
+
+@RunWith(PowerMockRunner.class)
+@PowerMockRunnerDelegate(MockitoJUnitRunner.class)
+public class ZimbraInvalidLoginFilterTest {
+
+    private ZimbraInvalidLoginFilter zimbraInvalidLoginFilter;
+
+    @Before
+    public void setup() {
+        zimbraInvalidLoginFilter = new ZimbraInvalidLoginFilter();
+    }
+
+    @Test
+    public void getFirstExternalIpTest1() throws Exception {
+        String origIPs = "193.3.142.123, 193.3.142.124";
+        origIPs = Whitebox.invokeMethod(zimbraInvalidLoginFilter, "getFirstExternalIp", origIPs);
+        assertEquals(origIPs, "193.3.142.123");
+    }
+
+    @Test
+    public void getFirstExternalIpTest2() throws Exception {
+        String origIPs = "193.3.142.123";
+        origIPs = Whitebox.invokeMethod(zimbraInvalidLoginFilter, "getFirstExternalIp", origIPs);
+        assertEquals(origIPs, "193.3.142.123");
+    }
+}

--- a/store/src/java/com/zimbra/cs/servlet/ZimbraInvalidLoginFilter.java
+++ b/store/src/java/com/zimbra/cs/servlet/ZimbraInvalidLoginFilter.java
@@ -110,7 +110,8 @@ public class ZimbraInvalidLoginFilter extends DoSFilter {
         HttpServletRequest req = (HttpServletRequest) request;
         HttpServletResponse res = (HttpServletResponse) response;
         RemoteIP remoteIp = new RemoteIP(req, ZimbraServlet.getTrustedIPs());
-        String clientIp = remoteIp.getOrigIP();
+        String origIp = remoteIp.getOrigIP();
+        String clientIp = getFirstExternalIp(origIp);
         if (clientIp == null || checkWhitelist(clientIp)) {
             // Bug: 89930 Account for request coming from local server
             // or case where the proxy server has not been added to zimbraMailTrustedIP
@@ -198,5 +199,16 @@ public class ZimbraInvalidLoginFilter extends DoSFilter {
             }
         }
 
+    }
+
+    private String getFirstExternalIp(String origIPs) {
+        if (origIPs == null) {
+            return null;
+        }
+        if (origIPs.indexOf(",") > 0) {
+            return origIPs.split(",")[0].trim();
+        } else {
+            return origIPs;
+        }
     }
 }


### PR DESCRIPTION
**Fix:** Cherrypicked commits and added unit tests.

**Testing Done:** 
Added Client IP to zimbraHttpThrottleSafeIPs and although Invalid login attempts through HAProxy load-balancer exceeds zimbraInvalidLoginFilterMaxFailedLogin, it does not block the user. i.e whitelisting of client IP gets successful.
