### PR TITLE
ZCS-13340:Add an LDAP attribute to force users not to use username in…

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -6706,6 +6706,15 @@ public class ZAttrProvisioning {
     public static final String A_zimbraFeatureAdvancedSearchEnabled = "zimbraFeatureAdvancedSearchEnabled";
 
     /**
+     * To restrict/allow the use of username in the password when user reset
+     * or change their password to achieve greater password security.
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4098)
+    public static final String A_zimbraFeatureAllowUsernameInPassword = "zimbraFeatureAllowUsernameInPassword";
+
+    /**
      * whether or not to enable rerouting spam messages to Junk folder in
      * ZCS, exposing Junk folder and actions in the web UI, and exposing Junk
      * folder to IMAP clients.

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10375,4 +10375,8 @@ TODO: delete them permanently from here
   <globalConfigValue>TRUE</globalConfigValue>
   <desc>Whether to enable/disable modern ui option on the login screen.</desc>
 </attr>
+<attr id="4098" name="zimbraFeatureAllowUsernameInPassword" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountInfo,accountCosDomainInherited" since="10.1.0">
+  <defaultCOSValue>TRUE</defaultCOSValue>
+  <desc>To restrict/allow the use of username in the password when user reset or change their password to achieve greater password security.</desc>
+</attr>
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -14032,6 +14032,83 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * To restrict/allow the use of username in the password when user reset
+     * or change their password to achieve greater password security.
+     *
+     * @return zimbraFeatureAllowUsernameInPassword, or true if unset
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4098)
+    public boolean isFeatureAllowUsernameInPassword() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureAllowUsernameInPassword, true, true);
+    }
+
+    /**
+     * To restrict/allow the use of username in the password when user reset
+     * or change their password to achieve greater password security.
+     *
+     * @param zimbraFeatureAllowUsernameInPassword new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4098)
+    public void setFeatureAllowUsernameInPassword(boolean zimbraFeatureAllowUsernameInPassword) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAllowUsernameInPassword, zimbraFeatureAllowUsernameInPassword ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * To restrict/allow the use of username in the password when user reset
+     * or change their password to achieve greater password security.
+     *
+     * @param zimbraFeatureAllowUsernameInPassword new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4098)
+    public Map<String,Object> setFeatureAllowUsernameInPassword(boolean zimbraFeatureAllowUsernameInPassword, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAllowUsernameInPassword, zimbraFeatureAllowUsernameInPassword ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * To restrict/allow the use of username in the password when user reset
+     * or change their password to achieve greater password security.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4098)
+    public void unsetFeatureAllowUsernameInPassword() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAllowUsernameInPassword, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * To restrict/allow the use of username in the password when user reset
+     * or change their password to achieve greater password security.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4098)
+    public Map<String,Object> unsetFeatureAllowUsernameInPassword(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAllowUsernameInPassword, "");
+        return attrs;
+    }
+
+    /**
      * whether or not to enable rerouting spam messages to Junk folder in
      * ZCS, exposing Junk folder and actions in the web UI, and exposing Junk
      * folder to IMAP clients.

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -8421,6 +8421,83 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * To restrict/allow the use of username in the password when user reset
+     * or change their password to achieve greater password security.
+     *
+     * @return zimbraFeatureAllowUsernameInPassword, or true if unset
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4098)
+    public boolean isFeatureAllowUsernameInPassword() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureAllowUsernameInPassword, true, true);
+    }
+
+    /**
+     * To restrict/allow the use of username in the password when user reset
+     * or change their password to achieve greater password security.
+     *
+     * @param zimbraFeatureAllowUsernameInPassword new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4098)
+    public void setFeatureAllowUsernameInPassword(boolean zimbraFeatureAllowUsernameInPassword) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAllowUsernameInPassword, zimbraFeatureAllowUsernameInPassword ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * To restrict/allow the use of username in the password when user reset
+     * or change their password to achieve greater password security.
+     *
+     * @param zimbraFeatureAllowUsernameInPassword new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4098)
+    public Map<String,Object> setFeatureAllowUsernameInPassword(boolean zimbraFeatureAllowUsernameInPassword, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAllowUsernameInPassword, zimbraFeatureAllowUsernameInPassword ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * To restrict/allow the use of username in the password when user reset
+     * or change their password to achieve greater password security.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4098)
+    public void unsetFeatureAllowUsernameInPassword() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAllowUsernameInPassword, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * To restrict/allow the use of username in the password when user reset
+     * or change their password to achieve greater password security.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4098)
+    public Map<String,Object> unsetFeatureAllowUsernameInPassword(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAllowUsernameInPassword, "");
+        return attrs;
+    }
+
+    /**
      * whether or not to enable rerouting spam messages to Junk folder in
      * ZCS, exposing Junk folder and actions in the web UI, and exposing Junk
      * folder to IMAP clients.

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -10426,6 +10426,83 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
+     * To restrict/allow the use of username in the password when user reset
+     * or change their password to achieve greater password security.
+     *
+     * @return zimbraFeatureAllowUsernameInPassword, or false if unset
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4098)
+    public boolean isFeatureAllowUsernameInPassword() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureAllowUsernameInPassword, false, true);
+    }
+
+    /**
+     * To restrict/allow the use of username in the password when user reset
+     * or change their password to achieve greater password security.
+     *
+     * @param zimbraFeatureAllowUsernameInPassword new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4098)
+    public void setFeatureAllowUsernameInPassword(boolean zimbraFeatureAllowUsernameInPassword) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAllowUsernameInPassword, zimbraFeatureAllowUsernameInPassword ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * To restrict/allow the use of username in the password when user reset
+     * or change their password to achieve greater password security.
+     *
+     * @param zimbraFeatureAllowUsernameInPassword new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4098)
+    public Map<String,Object> setFeatureAllowUsernameInPassword(boolean zimbraFeatureAllowUsernameInPassword, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAllowUsernameInPassword, zimbraFeatureAllowUsernameInPassword ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * To restrict/allow the use of username in the password when user reset
+     * or change their password to achieve greater password security.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4098)
+    public void unsetFeatureAllowUsernameInPassword() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAllowUsernameInPassword, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * To restrict/allow the use of username in the password when user reset
+     * or change their password to achieve greater password security.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4098)
+    public Map<String,Object> unsetFeatureAllowUsernameInPassword(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureAllowUsernameInPassword, "");
+        return attrs;
+    }
+
+    /**
      * whether receiving reminders on the designated device for appointments
      * and tasks is enabled
      *


### PR DESCRIPTION
Requirement of ticket [[ZCS-13340](https://jira.corp.synacor.com/browse/ZCS-13340)]:

Add a new LDAP attribute `zimbraFeatureAllowUsernameInPassword` to restrict/allow the use of usernames in the password when users reset or change their passwords to achieve greater password security.

Solution:

One new attributes `zimbraFeatureAllowUsernameInPassword` is added and their setters/getters are generated.
