### PR TITLE
ZCS-13344 - Support for new extension(mailrecall)

### DIFF
--- a/common/src/java/com/zimbra/common/service/ServiceException.java
+++ b/common/src/java/com/zimbra/common/service/ServiceException.java
@@ -293,6 +293,10 @@ public class ServiceException extends Exception {
         return new ServiceException("system failure: "+message, FAILURE, RECEIVERS_FAULT, cause);
     }
 
+    public static ServiceException ERROR_MESSAGE(String str, Throwable cause){
+        return new ServiceException("error: " + str, null, SENDERS_FAULT, cause);
+    }
+
     public static ServiceException ERROR_WHILE_PARSING_UPLOAD(String message, Throwable cause) {
         return new ServiceException(
                 String.format("ioexception during upload: %s", message), ERROR_WHILE_PARSING_UPLOAD, RECEIVERS_FAULT, cause);

--- a/common/src/java/com/zimbra/common/soap/AccountConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AccountConstants.java
@@ -644,4 +644,11 @@ public class AccountConstants {
     public static final String E_SKIN_SELECTION_COLOR = "zimbraSkinSelectionColor";
     public static final String E_SKIN_FAVICON = "zimbraSkinFavicon";
     public static final String E_HOSTNAME = "hostname";
+
+    // MailRecall Uses
+    public static final String E_MAIL_RECALL_REQUEST = "MailRecallRequest";
+    public static final String E_MAIL_RECALL_RESPONSE = "MailRecallResponse";
+    public static final QName MAIL_RECALL_REQUEST = QName.get(E_MAIL_RECALL_REQUEST, NAMESPACE);
+    public static final QName MAIL_RECALL_RESPONSE = QName.get(E_MAIL_RECALL_RESPONSE, NAMESPACE);
+    public static final String ITEM_ID = "itemId";
 }

--- a/soap/src/java/com/zimbra/soap/JaxbUtil.java
+++ b/soap/src/java/com/zimbra/soap/JaxbUtil.java
@@ -30,8 +30,6 @@ import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 import javax.xml.namespace.QName;
 
-import com.zimbra.soap.admin.message.GenerateSecretKeyRequest;
-import com.zimbra.soap.admin.message.GenerateSecretKeyResponse;
 import org.dom4j.Document;
 import org.dom4j.Namespace;
 import org.dom4j.io.DocumentResult;
@@ -1175,8 +1173,9 @@ public final class JaxbUtil {
             com.zimbra.soap.admin.message.EditS3BucketConfigRequest.class,
             com.zimbra.soap.admin.message.EditS3BucketConfigResponse.class,
             com.zimbra.soap.admin.message.GenerateSecretKeyRequest.class,
-            com.zimbra.soap.admin.message.GenerateSecretKeyResponse.class
-
+            com.zimbra.soap.admin.message.GenerateSecretKeyResponse.class,
+            com.zimbra.soap.account.message.MailRecallRequest.class,
+            com.zimbra.soap.account.message.MailRecallResponse.class
         };
 
         try {
@@ -1686,7 +1685,7 @@ public final class JaxbUtil {
         ImapMessageInfo messageInfo = new ImapMessageInfo(mod.getIdInMailbox(), mod.getImapUid(), mod.getMailItemType().toString(), mod.getFlagBitmask(), tags);
         return new ModifyNotification.ModifyItemNotification(messageInfo, reason);
     }
-    
+
     public static DeleteItemNotification getDeletedItemSOAP(int itemId, String type) throws ServiceException {
         return new DeleteItemNotification(itemId, type);
     }

--- a/soap/src/java/com/zimbra/soap/account/message/MailRecallRequest.java
+++ b/soap/src/java/com/zimbra/soap/account/message/MailRecallRequest.java
@@ -1,0 +1,41 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2023 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.account.message;
+
+import com.zimbra.common.soap.AccountConstants;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name = AccountConstants.E_MAIL_RECALL_REQUEST)
+public class MailRecallRequest {
+    @XmlAttribute(name = AccountConstants.ITEM_ID /* more */, required = true)
+    private int itemId;
+
+    public int getItemId() {
+        return itemId;
+    }
+
+    public void setItemId(int itemId) {
+        this.itemId = itemId;
+    }
+}
+

--- a/soap/src/java/com/zimbra/soap/account/message/MailRecallResponse.java
+++ b/soap/src/java/com/zimbra/soap/account/message/MailRecallResponse.java
@@ -1,0 +1,29 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2023 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.account.message;
+
+import com.zimbra.common.soap.AccountConstants;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name = AccountConstants.E_MAIL_RECALL_RESPONSE)
+public class MailRecallResponse {
+}


### PR DESCRIPTION
Requirement of ticket [ZCS-13344](https://jira.corp.synacor.com/browse/ZCS-13344)
Solution:
Under this ticket in this repo, made the changes required for SOAP API for searching message from mail store on the basis of mail-item id received from frontend. 

Testing:
Manual testing.

Another PR link of : [Mail recall](https://github.com/Zimbra/mailrecall/pull/4)

[ZCS-13344]: https://synacor.atlassian.net/browse/ZCS-13344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ