### PR TITLE
ZCS-13415:Create a LDAP attribute zimbraHideAliasesInGal for GAL

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -8468,6 +8468,15 @@ public class ZAttrProvisioning {
     public static final String A_zimbraHelpStandardURL = "zimbraHelpStandardURL";
 
     /**
+     * Hide all the aliases from GAL for the user, so it will not be
+     * displayed in the autocomplete.
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4099)
+    public static final String A_zimbraHideAliasesInGal = "zimbraHideAliasesInGal";
+
+    /**
      * hide entry in Global Address List
      */
     @ZAttr(id=353)

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10379,4 +10379,7 @@ TODO: delete them permanently from here
   <defaultCOSValue>TRUE</defaultCOSValue>
   <desc>To restrict/allow the use of username in the password when user reset or change their password to achieve greater password security.</desc>
 </attr>
+<attr id="4099" name="zimbraHideAliasesInGal" type="boolean" cardinality="single" optionalIn="mailRecipient,group" flags="domainAdminModifiable" since="10.1.0">
+  <desc>Hide all the aliases from GAL for the user, so it will not be displayed in the autocomplete.</desc>
+</attr>
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -25239,6 +25239,83 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * Hide all the aliases from GAL for the user, so it will not be
+     * displayed in the autocomplete.
+     *
+     * @return zimbraHideAliasesInGal, or false if unset
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4099)
+    public boolean isHideAliasesInGal() {
+        return getBooleanAttr(Provisioning.A_zimbraHideAliasesInGal, false, true);
+    }
+
+    /**
+     * Hide all the aliases from GAL for the user, so it will not be
+     * displayed in the autocomplete.
+     *
+     * @param zimbraHideAliasesInGal new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4099)
+    public void setHideAliasesInGal(boolean zimbraHideAliasesInGal) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHideAliasesInGal, zimbraHideAliasesInGal ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Hide all the aliases from GAL for the user, so it will not be
+     * displayed in the autocomplete.
+     *
+     * @param zimbraHideAliasesInGal new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4099)
+    public Map<String,Object> setHideAliasesInGal(boolean zimbraHideAliasesInGal, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHideAliasesInGal, zimbraHideAliasesInGal ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Hide all the aliases from GAL for the user, so it will not be
+     * displayed in the autocomplete.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4099)
+    public void unsetHideAliasesInGal() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHideAliasesInGal, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Hide all the aliases from GAL for the user, so it will not be
+     * displayed in the autocomplete.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4099)
+    public Map<String,Object> unsetHideAliasesInGal(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHideAliasesInGal, "");
+        return attrs;
+    }
+
+    /**
      * hide entry in Global Address List
      *
      * @return zimbraHideInGal, or false if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrDynamicGroup.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDynamicGroup.java
@@ -1240,6 +1240,83 @@ public abstract class ZAttrDynamicGroup extends Group {
     }
 
     /**
+     * Hide all the aliases from GAL for the user, so it will not be
+     * displayed in the autocomplete.
+     *
+     * @return zimbraHideAliasesInGal, or false if unset
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4099)
+    public boolean isHideAliasesInGal() {
+        return getBooleanAttr(Provisioning.A_zimbraHideAliasesInGal, false, true);
+    }
+
+    /**
+     * Hide all the aliases from GAL for the user, so it will not be
+     * displayed in the autocomplete.
+     *
+     * @param zimbraHideAliasesInGal new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4099)
+    public void setHideAliasesInGal(boolean zimbraHideAliasesInGal) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHideAliasesInGal, zimbraHideAliasesInGal ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Hide all the aliases from GAL for the user, so it will not be
+     * displayed in the autocomplete.
+     *
+     * @param zimbraHideAliasesInGal new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4099)
+    public Map<String,Object> setHideAliasesInGal(boolean zimbraHideAliasesInGal, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHideAliasesInGal, zimbraHideAliasesInGal ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Hide all the aliases from GAL for the user, so it will not be
+     * displayed in the autocomplete.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4099)
+    public void unsetHideAliasesInGal() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHideAliasesInGal, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Hide all the aliases from GAL for the user, so it will not be
+     * displayed in the autocomplete.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4099)
+    public Map<String,Object> unsetHideAliasesInGal(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHideAliasesInGal, "");
+        return attrs;
+    }
+
+    /**
      * hide entry in Global Address List
      *
      * @return zimbraHideInGal, or false if unset


### PR DESCRIPTION
Requirement of ticket [[ZCS-13415](https://jira.corp.synacor.com/browse/ZCS-13415)]:

Introduce a new  boolean value LDAP attribute _zimbraHideAliasesInGal._
To hide all the aliases from GAL for that user.

Solution:

A new attribute is added and its setters/getters are generated.

Testing:

Testing is done on remote machine by installing custom build.