### PR TITLE
ZBUG-3204: Webclient and AdminConsole both are not loading due to zim…

### DIFF
--- a/store/conf/web.xml.production
+++ b/store/conf/web.xml.production
@@ -222,7 +222,8 @@
       <location>/opt/zimbra/data/tmp</location>
       <max-file-size>%%zimbraFileUploadMaxSize%%</max-file-size>
       <max-request-size>%%zimbraMailContentMaxSize%%</max-request-size>
-      <file-size-threshold>%%zimbraFileUploadMaxSize%%</file-size-threshold>
+      <!-- The file size in bytes after which the file will be temporarily stored on disk -->
+      <file-size-threshold>1048576</file-size-threshold>
     </multipart-config>
   </servlet>
 


### PR DESCRIPTION
**Issue:** WebClient and AdminConsole both are not loading if we set the value of zimbraFileUploadMaxSize greater than 2147483647

**Solution:** Modify the value of file-size-threshold with 1048576 instead of zimbraFileUploadMaxSize.

- **fileSizeThreshold**: The file size in bytes after which the file will be temporarily stored on disk. 