### PR TITLE
ZBUG-3376: Partially resolved ZBUG-2891

### DIFF
--- a/store/src/java/com/zimbra/cs/account/ShareInfo.java
+++ b/store/src/java/com/zimbra/cs/account/ShareInfo.java
@@ -677,8 +677,7 @@ public class ShareInfo {
                 msgKey = html ? MsgKey.shareNotifBodyHtml : MsgKey.shareNotifBodyText;
             }
             return sb.append(L10nUtil.getMessage(
-                    msgKey, locale,
-                    sid.getName(),
+                    msgKey, locale, AccountUtil.getTranslatedFolderName(sid, locale),
                     formatFolderDesc(locale, sid, notifyForDocument),
                     sid.getOwnerNotifName(),
                     sid.getGranteeNotifName(),
@@ -692,7 +691,7 @@ public class ShareInfo {
         private static String genRevokePart(ShareInfoData sid, Locale locale, boolean html, boolean notifyForDocument) {
             return L10nUtil.getMessage(html ? MsgKey.shareRevokeBodyHtml : MsgKey.shareRevokeBodyText,
                     locale,
-                    sid.getName(),
+                    AccountUtil.getTranslatedFolderName(sid, locale),
                     formatFolderDesc(locale, sid, notifyForDocument),
                     sid.getOwnerNotifName());
         }
@@ -700,7 +699,7 @@ public class ShareInfo {
         private static String genExpirePart(ShareInfoData sid, Locale locale, boolean html, boolean notifyForDocument) {
             return L10nUtil.getMessage((html ? MsgKey.shareExpireBodyHtml : MsgKey.shareExpireBodyText),
                     locale,
-                    sid.getName(),
+                    AccountUtil.getTranslatedFolderName(sid, locale),
                     formatFolderDesc(locale, sid, notifyForDocument),
                     sid.getOwnerNotifName());
         }

--- a/store/src/java/com/zimbra/cs/service/mail/SendShareNotification.java
+++ b/store/src/java/com/zimbra/cs/service/mail/SendShareNotification.java
@@ -606,7 +606,7 @@ public class SendShareNotification extends MailDocumentHandler {
         if (ownerAcctDisplayName == null) {
             ownerAcctDisplayName = ownerAccount.getName();
         }
-        subject += L10nUtil.getMessage(MsgKey.sharedBySubject, locale, sid.getName(),
+        subject += L10nUtil.getMessage(MsgKey.sharedBySubject, locale, AccountUtil.getTranslatedFolderName(sid, locale),
             ownerAcctDisplayName);
         String recipient = sid.getGranteeName();
         String extUserShareAcceptUrl = null;

--- a/store/src/java/com/zimbra/cs/util/AccountUtil.java
+++ b/store/src/java/com/zimbra/cs/util/AccountUtil.java
@@ -29,6 +29,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -41,6 +42,7 @@ import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
 
+import com.zimbra.common.util.L10nUtil;
 import org.apache.commons.codec.binary.Hex;
 
 import com.sun.mail.smtp.SMTPMessage;
@@ -87,6 +89,8 @@ import com.zimbra.cs.servlet.ZimbraServlet;
 import com.zimbra.soap.SoapEngine;
 import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.admin.type.DataSourceType;
+import com.zimbra.common.mailbox.FolderConstants;
+import com.zimbra.cs.account.ShareInfoData;
 
 public class AccountUtil {
     public static final String FN_SUBSCRIPTIONS = "subs";
@@ -1041,5 +1045,18 @@ public class AccountUtil {
         boolean isAdminAccount = (isDomainAdmin || isAdmin || isDelegatedAdmin);
         if (!isAdminAccount)
             throw ServiceException.PERM_DENIED("not an admin account");
+    }
+    
+    /**
+     * Utils method to translate system folder name
+     * @param shareInfo
+     * @param locale
+     * @return translated or original folder name
+     */
+    public static String getTranslatedFolderName(ShareInfoData shareInfo, Locale locale) {
+        if (shareInfo.getItemId() == FolderConstants.ID_FOLDER_CALENDAR) {
+            return L10nUtil.getMessage(L10nUtil.MsgKey.calendar, locale);
+        }
+        return shareInfo.getName();
     }
 }


### PR DESCRIPTION
**Issue**: For users with language set to German, the emails notifications for Calendar folders share/revoke displays the word "calendar" instead of "Kalender".
**Solution**: Add translation for the word Calendar.