### PR TITLE
ZBUG-13315: Getting NulllPointer exception while importing HSM polici…

### DIFF
--- a/store/src/java/com/zimbra/cs/service/util/VolumeConfigUtil.java
+++ b/store/src/java/com/zimbra/cs/service/util/VolumeConfigUtil.java
@@ -24,6 +24,7 @@ import com.zimbra.client.ZMailbox;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AdminConstants;
 import com.zimbra.common.util.StringUtil;
+import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.store.StoreManager;
 import com.zimbra.cs.store.helper.ClassHelper;
@@ -245,6 +246,10 @@ public class VolumeConfigUtil {
 
                 try {
                     JSONObject properties = extVolInfoHandler.readServerProperties(volInfo.getId());
+                    if (JSONObject.NULL.equals(properties)) {
+                        ZimbraLog.store.warn("Unable to read server properties for volumeId %d", volInfo.getId());
+                        continue;
+                    }
                     String storageType = properties.getString(AdminConstants.A_VOLUME_STORAGE_TYPE);
                     if (AdminConstants.A_VOLUME_S3.equalsIgnoreCase(storageType)) {
                         volInfo.setVolumeExternalInfo(new VolumeExternalInfo().toExternalInfo(properties));
@@ -272,6 +277,9 @@ public class VolumeConfigUtil {
             ExternalVolumeInfoHandler extVolInfoHandler = new ExternalVolumeInfoHandler(Provisioning.getInstance());
             try {
                 JSONObject properties = extVolInfoHandler.readServerProperties(volInfo.getId());
+                if (JSONObject.NULL.equals(properties)) {
+                    throw VolumeServiceException.INVALID_REQUEST("Unable to read server properties", VolumeServiceException.INVALID_REQUEST);
+                }
                 String storageType = properties.getString(AdminConstants.A_VOLUME_STORAGE_TYPE);
                 if (storageType.equalsIgnoreCase(AdminConstants.A_VOLUME_S3)) {
                     volInfo.setVolumeExternalInfo(new VolumeExternalInfo().toExternalInfo(properties));

--- a/store/src/java/com/zimbra/util/ExternalVolumeInfoHandler.java
+++ b/store/src/java/com/zimbra/util/ExternalVolumeInfoHandler.java
@@ -54,6 +54,9 @@ public class ExternalVolumeInfoHandler {
         try {
             // step 1: Fetch current JSON state object and current JSON state array
             String serverExternalStoreConfigJson = provisioning.getLocalServer().getServerExternalStoreConfig();
+            if (serverExternalStoreConfigJson == null) {
+                return null;
+            }
             JSONObject currentJsonObject = new JSONObject(serverExternalStoreConfigJson);
             JSONArray currentJsonArray = currentJsonObject.getJSONArray("server/stores");
 


### PR DESCRIPTION
**Issue:** At the time of in place upgrade database entry for external volumes are copied but there is no entry in server config corresponding to that external volumes. So it was throwing the null pointer exception while reading the config.

**Solution:**  Handled the null pointer exception.