### PR TITLE
ZCS-13315: Getting NulllPointer exception while importing HSM polici…

### DIFF
--- a/store/src/java/com/zimbra/cs/service/admin/DeleteVolume.java
+++ b/store/src/java/com/zimbra/cs/service/admin/DeleteVolume.java
@@ -44,8 +44,8 @@ public final class DeleteVolume extends AdminDocumentHandler {
         ZimbraSoapContext zsc = getZimbraSoapContext(ctx);
         Server server = Provisioning.getInstance().getLocalServer();
         checkRight(zsc, ctx, server, Admin.R_manageVolume);
-        boolean isUnifiedVolume = VolumeConfigUtil.isUnifiedVolume(req.getId());
         VolumeConfigUtil.parseDeleteVolumeRequest(req, server.getId());
+        boolean isUnifiedVolume = VolumeConfigUtil.isUnifiedVolume(req.getId());
 
         if (isUnifiedVolume) {
             ExternalVolumeInfoHandler.flushConfigLevelCacheOnAllServers(this, ctx);

--- a/store/src/java/com/zimbra/cs/service/util/VolumeConfigUtil.java
+++ b/store/src/java/com/zimbra/cs/service/util/VolumeConfigUtil.java
@@ -24,6 +24,7 @@ import com.zimbra.client.ZMailbox;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AdminConstants;
 import com.zimbra.common.util.StringUtil;
+import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.store.StoreManager;
 import com.zimbra.cs.store.helper.ClassHelper;
@@ -245,6 +246,12 @@ public class VolumeConfigUtil {
 
                 try {
                     JSONObject properties = extVolInfoHandler.readServerProperties(volInfo.getId());
+                    if (JSONObject.NULL.equals(properties)) {
+                        ZimbraLog.store.error("Unable to read server properties for volumeId %d", volInfo.getId());
+                        throw VolumeServiceException.INVALID_REQUEST(
+                                "Unable to read server properties for volumeId " + volInfo.getId(),
+                                VolumeServiceException.INVALID_REQUEST);
+                    }
                     String storageType = properties.getString(AdminConstants.A_VOLUME_STORAGE_TYPE);
                     if (AdminConstants.A_VOLUME_S3.equalsIgnoreCase(storageType)) {
                         volInfo.setVolumeExternalInfo(new VolumeExternalInfo().toExternalInfo(properties));
@@ -272,6 +279,9 @@ public class VolumeConfigUtil {
             ExternalVolumeInfoHandler extVolInfoHandler = new ExternalVolumeInfoHandler(Provisioning.getInstance());
             try {
                 JSONObject properties = extVolInfoHandler.readServerProperties(volInfo.getId());
+                if (JSONObject.NULL.equals(properties)) {
+                    throw VolumeServiceException.INVALID_REQUEST("Unable to read server properties", VolumeServiceException.INVALID_REQUEST);
+                }
                 String storageType = properties.getString(AdminConstants.A_VOLUME_STORAGE_TYPE);
                 if (storageType.equalsIgnoreCase(AdminConstants.A_VOLUME_S3)) {
                     volInfo.setVolumeExternalInfo(new VolumeExternalInfo().toExternalInfo(properties));

--- a/store/src/java/com/zimbra/util/ExternalVolumeInfoHandler.java
+++ b/store/src/java/com/zimbra/util/ExternalVolumeInfoHandler.java
@@ -21,6 +21,7 @@ import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.service.admin.AdminDocumentHandler;
 import com.zimbra.cs.service.admin.FlushCache;
+import com.zimbra.cs.volume.VolumeServiceException;
 import com.zimbra.soap.admin.message.FlushCacheRequest;
 import com.zimbra.soap.admin.type.CacheEntryType;
 import com.zimbra.soap.admin.type.CacheSelector;
@@ -54,6 +55,9 @@ public class ExternalVolumeInfoHandler {
         try {
             // step 1: Fetch current JSON state object and current JSON state array
             String serverExternalStoreConfigJson = provisioning.getLocalServer().getServerExternalStoreConfig();
+            if (serverExternalStoreConfigJson == null) {
+                return null;
+            }
             JSONObject currentJsonObject = new JSONObject(serverExternalStoreConfigJson);
             JSONArray currentJsonArray = currentJsonObject.getJSONArray("server/stores");
 
@@ -361,6 +365,9 @@ public class ExternalVolumeInfoHandler {
      */
     public Boolean isVolumePresentInJson(int volumeId) throws ServiceException, JSONException {
         String globalExternalStoreConfig = provisioning.getLocalServer().getServerExternalStoreConfig();
+        if (globalExternalStoreConfig == null) {
+            return false;
+        }
         JSONObject globalS3Configs = new JSONObject(globalExternalStoreConfig);
         JSONArray globalS3ConfigList = globalS3Configs.getJSONArray("server/stores");
         for (int i = 0; i < globalS3ConfigList.length(); i++) {
@@ -394,6 +401,9 @@ public class ExternalVolumeInfoHandler {
         boolean isUnifiedVolume = false;
         try {
             JSONObject currentJsonObject = new JSONObject(provisioning.getLocalServer().getServerExternalStoreConfig());
+            if (JSONObject.NULL.equals(currentJsonObject)) {
+                throw VolumeServiceException.INVALID_REQUEST("Unable to read server properties", VolumeServiceException.INVALID_REQUEST);
+            }
             JSONArray serverStoreJsonArray = currentJsonObject.getJSONArray("server/stores");
             for (int i = 0; i < serverStoreJsonArray.length(); i++) {
                 JSONObject tempJsonObj = serverStoreJsonArray.getJSONObject(i);


### PR DESCRIPTION
**Issue:** At the time of in place upgrade database entry for external volumes are copied but there is no entry in server config corresponding to that external volumes. So it was throwing the null pointer exception while reading the config.

**Solution:**  Handled the null pointer exception.