### PR TITLE
ZCS-13218 - Enforce LDAP attribute to force users not to use username in the password

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1513,8 +1513,6 @@ public final class LC {
 
     public static final KnownKey invite_ignore_x_alt_description = KnownKey.newKey(true);
 
-    public static final KnownKey allow_username_within_password = KnownKey.newKey(true);
-
     // TODO: ZCS-11319 move the following from LC to LDAP property.
     // space-separated list of logout urls that are known to handle token de-registration.
     public static final KnownKey zimbra_web_client_logoff_urls = KnownKey.newKey("");

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10379,6 +10379,7 @@ TODO: delete them permanently from here
   <globalConfigValue>FALSE</globalConfigValue>
   <desc>Whether to enable/disable the modern web client option on the login screen. Default value is FALSE, which makes the modern client option available.</desc>
 </attr>
+
 <attr id="4098" name="zimbraFeatureAllowUsernameInPassword" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountInfo,accountCosDomainInherited" since="10.1.0">
   <defaultCOSValue>TRUE</defaultCOSValue>
   <desc>To restrict/allow the use of username in the password when user reset or change their password to achieve greater password security.</desc>

--- a/store/src/java/com/zimbra/cs/account/Account.java
+++ b/store/src/java/com/zimbra/cs/account/Account.java
@@ -537,11 +537,4 @@ public class Account extends ZAttrAccount implements GroupedEntry, AliasedEntry 
         getProvisioning().refreshUserCredentials(this);
     }
 
-    /**
-     * Returns whether username is allowed within password.
-     * @return true if username is allowed within password; otherwise, false.
-     */
-    public boolean getAllowUsernameWithinPassword() {
-        return LC.allow_username_within_password.booleanValue();
-    }
 }

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -6159,10 +6159,16 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
         // userName is passed from createAccount() and else condition is invoked 
         // when called from other Api's Changepassword and Resetpassword Api
-        if (userName != null) {
-            checkPasswordHasUsername(password, userName);
+        boolean isFeatureAllowUsernameInPassword;
+        if (acct == null) {
+            isFeatureAllowUsernameInPassword = cos.isFeatureAllowUsernameInPassword();
         } else {
-            checkPasswordHasUsername(password, acct.getUCUsername());
+            isFeatureAllowUsernameInPassword = acct.isFeatureAllowUsernameInPassword();
+        }
+        if (userName != null) {
+            checkPasswordHasUsername(password, userName, isFeatureAllowUsernameInPassword);
+        } else {
+            checkPasswordHasUsername(password, acct.getUCUsername(), isFeatureAllowUsernameInPassword);
         }
 
         if (getBoolean(acct, cos, entry, Provisioning.A_zimbraPasswordBlockCommonEnabled, false)
@@ -6270,8 +6276,8 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
         }
     }
 
-    private void checkPasswordHasUsername(String password, String userName) throws ServiceException {
-        if (!LC.allow_username_within_password.booleanValue() && StringUtils.containsIgnoreCase(password, userName)) {
+    private void checkPasswordHasUsername(String password, String userName, boolean isFeatureAllowUsernameInPassword) throws ServiceException {
+        if (!isFeatureAllowUsernameInPassword && StringUtils.containsIgnoreCase(password, userName)) {
             throw AccountServiceException.INVALID_PASSWORD("password contains username",
                     new Argument("zimbraPasswordAllowUsername", "", Argument.Type.STR));
         }

--- a/store/src/java/com/zimbra/cs/service/account/GetInfo.java
+++ b/store/src/java/com/zimbra/cs/service/account/GetInfo.java
@@ -363,9 +363,6 @@ public class GetInfo extends AccountDocumentHandler  {
 
             ToXML.encodeAttr(response, key, value);
         }
-        // ZCS-10678: Include Local config change for zimbraPasswordAllowUsername in getinfo response
-        ToXML.encodeAttr(response, "zimbraPasswordAllowUsername",
-                Boolean.toString(LC.allow_username_within_password.booleanValue()).toUpperCase());
     }
 
     private static void doZimlets(Element response, Account acct) {

--- a/store/src/java/com/zimbra/cs/service/account/ToXML.java
+++ b/store/src/java/com/zimbra/cs/service/account/ToXML.java
@@ -106,7 +106,7 @@ public class ToXML {
 
     public static Element encodePasswordRules(Element parent, Account account) {
 
-        ToXML.encodeAttr(parent, "zimbraPasswordAllowUsername", Boolean.toString(LC.allow_username_within_password.booleanValue()));
+        ToXML.encodeAttr(parent, Provisioning.A_zimbraFeatureAllowUsernameInPassword, Boolean.toString(account.isFeatureAllowUsernameInPassword()));
         ToXML.encodeAttr(parent, Provisioning.A_zimbraPasswordLocked, Boolean.toString(account.isPasswordLocked()));
         ToXML.encodeAttr(parent, Provisioning.A_zimbraPasswordMinLength, Integer.toString(account.getPasswordMinLength()));
         ToXML.encodeAttr(parent, Provisioning.A_zimbraPasswordMaxLength, Integer.toString(account.getPasswordMaxLength()));


### PR DESCRIPTION
Requirement of ticket [ZCS-13218](https://jira.corp.synacor.com/browse/ZCS-13218)

Solution:
Under this ticket in this repo, made the changes to read the attribute value(featureAllowUsernameInPassword) from LDAP instead of Local Configuration and remove the local configuration part.

