### PR TITLE
ZBUG-2976 Faulty X-Forwarded-For Handling for IPv6 client

### DIFF
--- a/common/src/java/com/zimbra/common/util/RemoteIP.java
+++ b/common/src/java/com/zimbra/common/util/RemoteIP.java
@@ -160,6 +160,7 @@ public class RemoteIP {
 
     public static class TrustedIPs {
         private static final String IP_LOCALHOST = "127.0.0.1";
+        private static final String IPV6_LOCALHOST = "[0:0:0:0:0:0:0:1]";
 
         private Set<String> mTrustedIPs = new HashSet<String>();
 
@@ -177,7 +178,7 @@ public class RemoteIP {
         }
 
         private static boolean isLocalhost(String ip) {
-            return IP_LOCALHOST.equals(ip);
+            return IP_LOCALHOST.equals(ip) || IPV6_LOCALHOST.equals(ip);
         }
 
         @Override


### PR DESCRIPTION
Problem:
requesting client oip(X-Forwarded-For) is not set into the logging context instead proxy server oip was set when using ipv6 mode.

Fix:
Added handling for ipv6 localhost address too.
ipv4 localhost handing was already present.

Test-cases:

1. failed logins from users with IPv6-Adresses shows correct oip of requesting machine
2. failed login attempts after adding the client ip into zimbraHttpThrottleSafeIPs does not block the user.
3. Basic sanity test - Login to webclient/admin console, Send mails, appointments, sharing mails.
Please refer [ZBUG-2976](https://jira.corp.synacor.com/browse/ZBUG-2976) for configuration detals
