### PR TITLE
ZCS-13512 no need to check for patch while license activation.

### DIFF
--- a/common/src/java-test/com/zimbra/common/util/VersionTest.java
+++ b/common/src/java-test/com/zimbra/common/util/VersionTest.java
@@ -151,4 +151,17 @@ public class VersionTest {
         }
     }
 
+    @Test
+    public void checkPatchRelease() throws Exception {
+        Version currentVersion = new Version("10.0.0_GA_4518");
+        Version lastVersion = new Version("10.1.0_GA_4549");
+        Assert.assertFalse(currentVersion.isSameMinorRelease(lastVersion));
+        currentVersion = new Version("10.0.0_GA_4518");
+        lastVersion = new Version("11.0.0_GA_4549");
+        Assert.assertFalse(currentVersion.isSameMinorRelease(lastVersion));
+        currentVersion = new Version("10.0.0_GA_4518");
+        lastVersion = new Version("10.0.1_GA_454");
+        Assert.assertTrue(currentVersion.isSameMinorRelease(lastVersion));
+    }
+
 }


### PR DESCRIPTION
**Problem:**
License re-activation needed for patch upgrade Ex: while upgrading from 10.0.0 to 10.0.1

**Fix:**
no patch related check from versioning is needed

**Test-cases**
After applying changes, zmlicense -c is ok and no error for license on admin console found