### PR TITLE
PREAPPS-7386 Add LocalConfig to enable folder retention feature

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1504,6 +1504,9 @@ public final class LC {
 
     // ZBUG-3105: zimbra_allowed_redirect_url is a url that allows in preauth redirectURL
     public static final KnownKey zimbra_allowed_redirect_url = KnownKey.newKey("");
+
+    // PREAPPS-7386 Enable folder retention feature in Modern UI, only for Kepler and 10.0.1 patches
+    public static final KnownKey enable_folder_retention_policy = KnownKey.newKey(true);
     
     static {
         // Automatically set the key name with the variable name.

--- a/store/src/java/com/zimbra/cs/service/account/GetInfo.java
+++ b/store/src/java/com/zimbra/cs/service/account/GetInfo.java
@@ -362,6 +362,10 @@ public class GetInfo extends AccountDocumentHandler  {
         // ZCS-10678: Include Local config change for zimbraPasswordAllowUsername in getinfo response
         ToXML.encodeAttr(response, "zimbraPasswordAllowUsername",
                 Boolean.toString(LC.allow_username_within_password.booleanValue()).toUpperCase());
+
+        // PREAPPS-7386: Enable folder retention feature of Modern UI in Zimbra 9 and 10.0.1
+        ToXML.encodeAttr(response, "zimbraFeatureRetentionPolicyEnabled",
+                Boolean.toString(LC.enable_folder_retention_policy.booleanValue()).toUpperCase());
     }
 
     private static void doZimlets(Element response, Account acct) {


### PR DESCRIPTION
- for 10.1.0 and above versions this is achieved using ldap attribute https://github.com/Zimbra/zm-mailbox/commit/32719bb9c7e084756c236710d59dad1cb875d0c4
- But as we are not able to backport ldap changes in patches, we are providing localconfig to enable/disable this feature