### PR TITLE
ZCS-13662: Create an LDAP attribute and modify AddAccountAlias API to save hide in GAL 

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -3277,6 +3277,14 @@ public class ZAttrProvisioning {
     public static final String A_zimbraAggregateQuotaLastUsage = "zimbraAggregateQuotaLastUsage";
 
     /**
+     * aliases list to be hidden in autocomplete
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4102)
+    public static final String A_zimbraAliasListToHide = "zimbraAliasListToHide";
+
+    /**
      * zimbraId of alias target
      */
     @ZAttr(id=40)

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -3277,7 +3277,9 @@ public class ZAttrProvisioning {
     public static final String A_zimbraAggregateQuotaLastUsage = "zimbraAggregateQuotaLastUsage";
 
     /**
-     * aliases list to be hidden in autocomplete
+     * Aliases list to be hidden in autocomplete results of &#039;compose
+     * email&#039; page. Aliases get added in this when user opts to make an
+     * alias hidden in admin&#039;s aliases screen
      *
      * @since ZCS 10.1.0
      */

--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -1620,4 +1620,5 @@ public final class AdminConstants {
             "com_zimbra_docs_modern", "com_zimbra_drive_modern", "com_zextras_drive", "com_zextras_drive_open",
             "com_zextras_chat_open", "com_zextras_talk", "zimbra-zimlet-briefcase-edit-lool");
 
+    public static final String E_ALIAS_TO_BE_HIDDEN = "aliasToBeHidden";
 }

--- a/soap/src/java/com/zimbra/soap/admin/message/AddAccountAliasRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/AddAccountAliasRequest.java
@@ -55,8 +55,8 @@ public class AddAccountAliasRequest {
      * @zm-api-field-tag zimbra alias to be hidden or not
      * @zm-api-field-description aliasToBeHidden
      */
-    @XmlAttribute(name=AdminConstants.E_ALIAS_TO_BE_HIDDEN /* id */, required=true)
-    private final boolean aliasToBeHidden;
+    @XmlAttribute(name=AdminConstants.E_ALIAS_TO_BE_HIDDEN /* aliasToBeHidden */, required=false)
+    private  boolean aliasToBeHidden;
     /**
      * no-argument constructor wanted by JAXB
      */
@@ -65,14 +65,16 @@ public class AddAccountAliasRequest {
         this((String)null, (String)null, false);
     }
 
+    public AddAccountAliasRequest(String id, String alias) {
+        this.id = id;
+        this.alias = alias;
+    }
     public AddAccountAliasRequest(String id, String alias, boolean aliasToBeHidden) {
         this.id = id;
         this.alias = alias;
         this.aliasToBeHidden = aliasToBeHidden;
     }
-
     public String getId() { return id; }
     public String getAlias() { return alias; }
-
     public boolean isAliasToBeHidden() { return aliasToBeHidden; }
 }

--- a/soap/src/java/com/zimbra/soap/admin/message/AddAccountAliasRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/AddAccountAliasRequest.java
@@ -52,18 +52,27 @@ public class AddAccountAliasRequest {
     private final String alias;
 
     /**
+     * @zm-api-field-tag zimbra alias to be hidden or not
+     * @zm-api-field-description aliasToBeHidden
+     */
+    @XmlAttribute(name=AdminConstants.E_ALIAS_TO_BE_HIDDEN /* id */, required=true)
+    private final boolean aliasToBeHidden;
+    /**
      * no-argument constructor wanted by JAXB
      */
     @SuppressWarnings("unused")
     private AddAccountAliasRequest() {
-        this((String)null, (String)null);
+        this((String)null, (String)null, false);
     }
 
-    public AddAccountAliasRequest(String id, String alias) {
+    public AddAccountAliasRequest(String id, String alias, boolean aliasToBeHidden) {
         this.id = id;
         this.alias = alias;
+        this.aliasToBeHidden = aliasToBeHidden;
     }
 
     public String getId() { return id; }
     public String getAlias() { return alias; }
+
+    public boolean isAliasToBeHidden() { return aliasToBeHidden; }
 }

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10391,6 +10391,6 @@ TODO: delete them permanently from here
 </attr>
 
 <attr id="4102" name="zimbraAliasListToHide" type="email" max="256" immutable="1" cardinality="multi" optionalIn="mailRecipient" since="10.1.0">
-  <desc>aliases list to be hidden in autocomplete</desc>
+  <desc>Aliases list to be hidden in autocomplete results of  'compose email' page. Aliases get added in this when user opts to make an alias hidden in admin's aliases screen </desc>
 </attr>
 </attrs>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10390,4 +10390,7 @@ TODO: delete them permanently from here
   <desc>Whether retention policy feature is enabled</desc>
 </attr>
 
+<attr id="4102" name="zimbraAliasListToHide" type="email" max="256" immutable="1" cardinality="multi" optionalIn="mailRecipient" since="10.1.0">
+  <desc>aliases list to be hidden in autocomplete</desc>
+</attr>
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ProvUtil.java
+++ b/store/src/java/com/zimbra/cs/account/ProvUtil.java
@@ -519,7 +519,7 @@ public class ProvUtil implements HttpDebugListener {
     }
 
     public enum Command {
-        ADD_ACCOUNT_ALIAS("addAccountAlias", "aaa", "{name@domain|id} {alias@domain}", Category.ACCOUNT, 2, 2),
+        ADD_ACCOUNT_ALIAS("addAccountAlias", "aaa", "{name@domain|id} {alias@domain}", Category.ACCOUNT, 2, 3),
         ADD_ACCOUNT_LOGGER(
                 "addAccountLogger", "aal",
                 "[-s/--server hostname] {name@domain|id} {logging-category} {trace|debug|info|warn|error}",
@@ -1090,7 +1090,7 @@ public class ProvUtil implements HttpDebugListener {
         }
         switch (command) {
         case ADD_ACCOUNT_ALIAS:
-            prov.addAlias(lookupAccount(args[1]), args[2]);
+            prov.addAlias(lookupAccount(args[1]), args[2], Boolean.FALSE);
             break;
         case ADD_ACCOUNT_LOGGER:
             alo = parseAccountLoggerOptions(args);

--- a/store/src/java/com/zimbra/cs/account/Provisioning.java
+++ b/store/src/java/com/zimbra/cs/account/Provisioning.java
@@ -1316,6 +1316,8 @@ public abstract class Provisioning extends ZAttrProvisioning {
 
     public abstract void addAlias(Account acct, String alias) throws ServiceException;
 
+    public abstract void addAlias(Account acct, String alias, boolean aliasToBeHidden) throws ServiceException;
+
     public abstract void removeAlias(Account acct, String alias) throws ServiceException;
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -3924,7 +3924,9 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * aliases list to be hidden in autocomplete
+     * Aliases list to be hidden in autocomplete results of &#039;compose
+     * email&#039; page. Aliases get added in this when user opts to make an
+     * alias hidden in admin&#039;s aliases screen
      *
      * @return zimbraAliasListToHide, or empty array if unset
      *
@@ -3936,7 +3938,9 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * aliases list to be hidden in autocomplete
+     * Aliases list to be hidden in autocomplete results of &#039;compose
+     * email&#039; page. Aliases get added in this when user opts to make an
+     * alias hidden in admin&#039;s aliases screen
      *
      * @param zimbraAliasListToHide new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -3951,7 +3955,9 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * aliases list to be hidden in autocomplete
+     * Aliases list to be hidden in autocomplete results of &#039;compose
+     * email&#039; page. Aliases get added in this when user opts to make an
+     * alias hidden in admin&#039;s aliases screen
      *
      * @param zimbraAliasListToHide new value
      * @param attrs existing map to populate, or null to create a new map
@@ -3967,7 +3973,9 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * aliases list to be hidden in autocomplete
+     * Aliases list to be hidden in autocomplete results of &#039;compose
+     * email&#039; page. Aliases get added in this when user opts to make an
+     * alias hidden in admin&#039;s aliases screen
      *
      * @param zimbraAliasListToHide new to add to existing values
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -3982,7 +3990,9 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * aliases list to be hidden in autocomplete
+     * Aliases list to be hidden in autocomplete results of &#039;compose
+     * email&#039; page. Aliases get added in this when user opts to make an
+     * alias hidden in admin&#039;s aliases screen
      *
      * @param zimbraAliasListToHide new to add to existing values
      * @param attrs existing map to populate, or null to create a new map
@@ -3998,7 +4008,9 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * aliases list to be hidden in autocomplete
+     * Aliases list to be hidden in autocomplete results of &#039;compose
+     * email&#039; page. Aliases get added in this when user opts to make an
+     * alias hidden in admin&#039;s aliases screen
      *
      * @param zimbraAliasListToHide existing value to remove
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -4013,7 +4025,9 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * aliases list to be hidden in autocomplete
+     * Aliases list to be hidden in autocomplete results of &#039;compose
+     * email&#039; page. Aliases get added in this when user opts to make an
+     * alias hidden in admin&#039;s aliases screen
      *
      * @param zimbraAliasListToHide existing value to remove
      * @param attrs existing map to populate, or null to create a new map
@@ -4029,7 +4043,9 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * aliases list to be hidden in autocomplete
+     * Aliases list to be hidden in autocomplete results of &#039;compose
+     * email&#039; page. Aliases get added in this when user opts to make an
+     * alias hidden in admin&#039;s aliases screen
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -4043,7 +4059,9 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * aliases list to be hidden in autocomplete
+     * Aliases list to be hidden in autocomplete results of &#039;compose
+     * email&#039; page. Aliases get added in this when user opts to make an
+     * alias hidden in admin&#039;s aliases screen
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -3924,6 +3924,140 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * aliases list to be hidden in autocomplete
+     *
+     * @return zimbraAliasListToHide, or empty array if unset
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4102)
+    public String[] getAliasListToHide() {
+        return getMultiAttr(Provisioning.A_zimbraAliasListToHide, true, true);
+    }
+
+    /**
+     * aliases list to be hidden in autocomplete
+     *
+     * @param zimbraAliasListToHide new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4102)
+    public void setAliasListToHide(String[] zimbraAliasListToHide) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAliasListToHide, zimbraAliasListToHide);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * aliases list to be hidden in autocomplete
+     *
+     * @param zimbraAliasListToHide new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4102)
+    public Map<String,Object> setAliasListToHide(String[] zimbraAliasListToHide, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAliasListToHide, zimbraAliasListToHide);
+        return attrs;
+    }
+
+    /**
+     * aliases list to be hidden in autocomplete
+     *
+     * @param zimbraAliasListToHide new to add to existing values
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4102)
+    public void addAliasListToHide(String zimbraAliasListToHide) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraAliasListToHide, zimbraAliasListToHide);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * aliases list to be hidden in autocomplete
+     *
+     * @param zimbraAliasListToHide new to add to existing values
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4102)
+    public Map<String,Object> addAliasListToHide(String zimbraAliasListToHide, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraAliasListToHide, zimbraAliasListToHide);
+        return attrs;
+    }
+
+    /**
+     * aliases list to be hidden in autocomplete
+     *
+     * @param zimbraAliasListToHide existing value to remove
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4102)
+    public void removeAliasListToHide(String zimbraAliasListToHide) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraAliasListToHide, zimbraAliasListToHide);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * aliases list to be hidden in autocomplete
+     *
+     * @param zimbraAliasListToHide existing value to remove
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4102)
+    public Map<String,Object> removeAliasListToHide(String zimbraAliasListToHide, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraAliasListToHide, zimbraAliasListToHide);
+        return attrs;
+    }
+
+    /**
+     * aliases list to be hidden in autocomplete
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4102)
+    public void unsetAliasListToHide() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAliasListToHide, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * aliases list to be hidden in autocomplete
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4102)
+    public Map<String,Object> unsetAliasListToHide(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraAliasListToHide, "");
+        return attrs;
+    }
+
+    /**
      * Whether this account can use any from address. Not changeable by
      * domain admin to allow arbitrary addresses
      *

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -2344,6 +2344,10 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
         addAliasInternal(acct, alias);
     }
 
+    @Override public void addAlias(Account acct, String alias, boolean aliasToBeHidden) throws ServiceException {
+        addAliasInternal(acct, alias);
+    }
+
     @Override
     public void removeAlias(Account acct, String alias) throws ServiceException {
         accountCache.remove(acct);
@@ -2355,8 +2359,6 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
         addAliasInternal(dl, alias);
         allDLs.addGroup(dl);
     }
-
-
     public void addAliasHidingDetails(Account acct, String alias) throws ServiceException {
         addAliasHidingDetailsInternal(acct, alias);
     }
@@ -2364,7 +2366,8 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     private void addAliasHidingDetailsInternal(Account acct, String alias) throws ServiceException {
         ZLdapContext zlc = LdapClient.getContext(LdapServerType.MASTER, LdapUsage.ADD_ALIAS_ACCOUNT);
         HashMap<String, String> attrs = new HashMap<String, String>();
-        attrs.put("+" + Provisioning.A_zimbraAliasListToHide, alias);
+        //attrs.put("+" + Provisioning.A_zimbraAliasListToHide, alias);
+        attrs.put("+" + Provisioning.A_zimbraMailDeliveryAddress, alias);
         modifyAttrsInternal(acct, zlc, attrs);
     }
 

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -2356,6 +2356,18 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
         allDLs.addGroup(dl);
     }
 
+
+    public void addAliasHidingDetails(Account acct, String alias) throws ServiceException {
+        addAliasHidingDetailsInternal(acct, alias);
+    }
+
+    private void addAliasHidingDetailsInternal(Account acct, String alias) throws ServiceException {
+        ZLdapContext zlc = LdapClient.getContext(LdapServerType.MASTER, LdapUsage.ADD_ALIAS_ACCOUNT);
+        HashMap<String, String> attrs = new HashMap<String, String>();
+        attrs.put("+" + Provisioning.A_zimbraAliasListToHide, alias);
+        modifyAttrsInternal(acct, zlc, attrs);
+    }
+
     @Override
     public void removeAlias(DistributionList dl, String alias) throws ServiceException {
         groupCache.remove(dl);

--- a/store/src/java/com/zimbra/cs/account/soap/SoapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/soap/SoapProvisioning.java
@@ -827,9 +827,14 @@ public class SoapProvisioning extends Provisioning {
             }
         }
     }
-
     @Override
     public void addAlias(Account acct, String alias) throws ServiceException {
+        invokeJaxb(new AddAccountAliasRequest(acct.getId(), alias));
+        reload(acct);
+    }
+
+
+    public void addAlias(Account acct, String alias, boolean aliasToBeHidden) throws ServiceException {
         invokeJaxb(new AddAccountAliasRequest(acct.getId(), alias, false));
         reload(acct);
     }

--- a/store/src/java/com/zimbra/cs/account/soap/SoapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/soap/SoapProvisioning.java
@@ -830,7 +830,7 @@ public class SoapProvisioning extends Provisioning {
 
     @Override
     public void addAlias(Account acct, String alias) throws ServiceException {
-        invokeJaxb(new AddAccountAliasRequest(acct.getId(), alias));
+        invokeJaxb(new AddAccountAliasRequest(acct.getId(), alias, false));
         reload(acct);
     }
 

--- a/store/src/java/com/zimbra/cs/mailbox/util/AccountAliasUtil.java
+++ b/store/src/java/com/zimbra/cs/mailbox/util/AccountAliasUtil.java
@@ -1,0 +1,19 @@
+package com.zimbra.cs.mailbox.util;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.ldap.LdapProvisioning;
+
+public class AccountAliasUtil {
+
+    private final LdapProvisioning ldapProvisioning;
+
+    public AccountAliasUtil(LdapProvisioning prov) {
+        this.ldapProvisioning = prov;
+    }
+
+    public void addAliasHidingInfo(Account account, String alias) throws ServiceException {
+        ldapProvisioning.addAliasHidingDetails(account, alias);
+    }
+}

--- a/store/src/java/com/zimbra/cs/mailbox/util/AccountAliasUtil.java
+++ b/store/src/java/com/zimbra/cs/mailbox/util/AccountAliasUtil.java
@@ -6,9 +6,7 @@ import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.ldap.LdapProvisioning;
 
 public class AccountAliasUtil {
-
     private final LdapProvisioning ldapProvisioning;
-
     public AccountAliasUtil(LdapProvisioning prov) {
         this.ldapProvisioning = prov;
     }

--- a/store/src/java/com/zimbra/cs/service/admin/AddAccountAlias.java
+++ b/store/src/java/com/zimbra/cs/service/admin/AddAccountAlias.java
@@ -85,7 +85,7 @@ public class AddAccountAlias extends AdminDocumentHandler {
         checkDomainRightByEmail(zsc, alias, Admin.R_createAlias);
 
         prov.addAlias(account, alias);
-        if (aliasToBeHidden){
+        if (aliasToBeHidden) {
             util.addAliasHidingInfo(account, alias);
         }
         ZimbraLog.security.info(ZimbraLog.encodeAttrs(

--- a/store/src/java/com/zimbra/cs/service/admin/AddAccountAlias.java
+++ b/store/src/java/com/zimbra/cs/service/admin/AddAccountAlias.java
@@ -32,6 +32,8 @@ import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.accesscontrol.AdminRight;
 import com.zimbra.cs.account.accesscontrol.Rights.Admin;
+import com.zimbra.cs.account.ldap.LdapProvisioning;
+import com.zimbra.cs.mailbox.util.AccountAliasUtil;
 import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.admin.message.AddAccountAliasRequest;
@@ -68,9 +70,11 @@ public class AddAccountAlias extends AdminDocumentHandler {
         ZimbraSoapContext zsc = getZimbraSoapContext(context);
         Provisioning prov = Provisioning.getInstance();
         AddAccountAliasRequest req = zsc.elementToJaxb(request);
+        AccountAliasUtil util = new AccountAliasUtil((LdapProvisioning) prov);
 
         String id = req.getId();
         String alias = req.getAlias();
+        boolean aliasToBeHidden = req.isAliasToBeHidden();
 
         Account account = prov.get(AccountBy.id, id, zsc.getAuthToken());
 
@@ -81,6 +85,9 @@ public class AddAccountAlias extends AdminDocumentHandler {
         checkDomainRightByEmail(zsc, alias, Admin.R_createAlias);
 
         prov.addAlias(account, alias);
+        if (aliasToBeHidden){
+            util.addAliasHidingInfo(account, alias);
+        }
         ZimbraLog.security.info(ZimbraLog.encodeAttrs(
                 new String[] {"cmd", "AddAccountAlias","name", account.getName(), "alias", alias}));
 

--- a/store/src/java/com/zimbra/qa/unittest/TestDLMembership.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestDLMembership.java
@@ -140,7 +140,7 @@ public class TestDLMembership extends TestCase {
         try {
             transport = TestUtil.getAdminSoapTransport();
             //add an alias to the account
-            AddAccountAliasResponse addAliasResp = SoapTest.invokeJaxb(transport,new AddAccountAliasRequest(testUser.getId(),TestUtil.getAddress(TEST_ALIAS)));
+            AddAccountAliasResponse addAliasResp = SoapTest.invokeJaxb(transport,new AddAccountAliasRequest(testUser.getId(),TestUtil.getAddress(TEST_ALIAS), false));
             assertNotNull("AddAccountAliasResponse cannot be null", addAliasResp);
             Account acct = Provisioning.getInstance().getAccount(testUser.getId());
             assertNotNull(acct);
@@ -171,7 +171,7 @@ public class TestDLMembership extends TestCase {
         try {
             transport = TestUtil.getAdminSoapTransport();
             //add an alias to the account
-            AddAccountAliasResponse addAliasResp = SoapTest.invokeJaxb(transport,new AddAccountAliasRequest(testUser.getId(),TestUtil.getAddress(TEST_ALIAS)));
+            AddAccountAliasResponse addAliasResp = SoapTest.invokeJaxb(transport,new AddAccountAliasRequest(testUser.getId(),TestUtil.getAddress(TEST_ALIAS), false));
             assertNotNull("AddAccountAliasResponse cannot be null", addAliasResp);
             Account acct = Provisioning.getInstance().getAccount(testUser.getId());
             assertNotNull(acct);
@@ -216,7 +216,7 @@ public class TestDLMembership extends TestCase {
         try {
             transport = TestUtil.getAdminSoapTransport();
             //add an alias to the account
-            AddAccountAliasResponse addAliasResp = SoapTest.invokeJaxb(transport,new AddAccountAliasRequest(testUser.getId(),TestUtil.getAddress(TEST_ALIAS)));
+            AddAccountAliasResponse addAliasResp = SoapTest.invokeJaxb(transport,new AddAccountAliasRequest(testUser.getId(),TestUtil.getAddress(TEST_ALIAS),false));
             assertNotNull("AddAccountAliasResponse cannot be null", addAliasResp);
             Account acct = Provisioning.getInstance().getAccount(testUser.getId());
             assertNotNull(acct);

--- a/store/src/java/com/zimbra/qa/unittest/TestDLMembership.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestDLMembership.java
@@ -216,7 +216,7 @@ public class TestDLMembership extends TestCase {
         try {
             transport = TestUtil.getAdminSoapTransport();
             //add an alias to the account
-            AddAccountAliasResponse addAliasResp = SoapTest.invokeJaxb(transport,new AddAccountAliasRequest(testUser.getId(),TestUtil.getAddress(TEST_ALIAS),false));
+            AddAccountAliasResponse addAliasResp = SoapTest.invokeJaxb(transport, new AddAccountAliasRequest(testUser.getId(), TestUtil.getAddress(TEST_ALIAS), false));
             assertNotNull("AddAccountAliasResponse cannot be null", addAliasResp);
             Account acct = Provisioning.getInstance().getAccount(testUser.getId());
             assertNotNull(acct);

--- a/store/src/java/com/zimbra/qa/unittest/TestDLMembership.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestDLMembership.java
@@ -171,7 +171,7 @@ public class TestDLMembership extends TestCase {
         try {
             transport = TestUtil.getAdminSoapTransport();
             //add an alias to the account
-            AddAccountAliasResponse addAliasResp = SoapTest.invokeJaxb(transport,new AddAccountAliasRequest(testUser.getId(),TestUtil.getAddress(TEST_ALIAS), false));
+            AddAccountAliasResponse addAliasResp = SoapTest.invokeJaxb(transport, new AddAccountAliasRequest(testUser.getId(), TestUtil.getAddress(TEST_ALIAS), false));
             assertNotNull("AddAccountAliasResponse cannot be null", addAliasResp);
             Account acct = Provisioning.getInstance().getAccount(testUser.getId());
             assertNotNull(acct);

--- a/store/src/java/com/zimbra/qa/unittest/TestDomainAdmin.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestDomainAdmin.java
@@ -435,10 +435,10 @@ public class TestDomainAdmin extends TestCase {
         assertNotNull("GetMailboxResponse for " + TARGET_ACCT + " as domAdmin specifying target acct", gmResp);
 
         AddAccountAliasResponse aaaResp;
-        aaaResp = domAdminSoapProv.invokeJaxb( new AddAccountAliasRequest(acctId, ALIAS_FOR_TARGET_ACCT));
+        aaaResp = domAdminSoapProv.invokeJaxb( new AddAccountAliasRequest(acctId, ALIAS_FOR_TARGET_ACCT, false));
         assertNotNull("AddAccountAliasResponse for " + TARGET_ACCT + " simple as domAdmin", aaaResp);
         aaaResp = domAdminSoapProv.invokeJaxbOnTargetAccount(
-                new AddAccountAliasRequest(acctId, ALIAS_FOR_TARGET_ACCT2), acctId);
+                new AddAccountAliasRequest(acctId, ALIAS_FOR_TARGET_ACCT2, false), acctId);
         assertNotNull("AddAccountAliasResponse for " + TARGET_ACCT + " as domAdmin specifying target acct", aaaResp);
 
         RemoveAccountAliasResponse daaResp;
@@ -547,20 +547,20 @@ public class TestDomainAdmin extends TestCase {
 
         AddAccountAliasResponse aaaResp;
         try {
-            aaaResp = domAdminSoapProv.invokeJaxb(new AddAccountAliasRequest(acctId, ALIAS_FOR_TARGET_ACCT));
+            aaaResp = domAdminSoapProv.invokeJaxb(new AddAccountAliasRequest(acctId, ALIAS_FOR_TARGET_ACCT, false));
             fail("AddAccountAliasRequest succeeded for account in other domain!");
         } catch (SoapFaultException sfe) {
             checkSoapReason(sfe, "permission denied: can not access account ");
         }
         try {
             aaaResp = domAdminSoapProv.invokeJaxbOnTargetAccount(
-                    new AddAccountAliasRequest(acctId, ALIAS_FOR_TARGET_ACCT2), acctId);
+                    new AddAccountAliasRequest(acctId, ALIAS_FOR_TARGET_ACCT2, false), acctId);
             fail("AddAccountAliasRequest succeeded for account in other domain!");
         } catch (SoapFaultException sfe) {
             checkSoapReason(sfe, "permission denied: can not access account ");
         }
 
-        aaaResp = adminSoapProv.invokeJaxb(new AddAccountAliasRequest(acctId, ALIAS_FOR_TARGET_ACCT));
+        aaaResp = adminSoapProv.invokeJaxb(new AddAccountAliasRequest(acctId, ALIAS_FOR_TARGET_ACCT, false));
         assertNotNull("AddAccountAliasResponse for " + TARGET_ACCT + " as FULL ADMIN", aaaResp);
 
         try {


### PR DESCRIPTION
The new PR for this requirement is 

**https://github.com/Zimbra/zm-mailbox/pull/1505**














Problem: Requirement of ticket [[ZCS-13662](https://jira.corp.synacor.com/browse/ZCS-13662)]:
Create an LDAP attribute and modify AddAccountAlias API to save alias hiding details in LDAP value

Solution: added a new flag 'aliasToBeHidden' in the AddAccountAlias api and using that, saved the alias into the newly created LDAP attribute **zimbraAliasListToHide** list.

Test Done: Manual testing done locally by using SoapUI and verifying the alias getting added in  list values using CLI

[ZCS-13662]: https://synacor.atlassian.net/browse/ZCS-13662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ