### PR TITLE
ZCS-13692: Modify Search API to get CC and BCC in response

### DIFF
--- a/soap/src/java/com/zimbra/soap/type/WantRecipsSetting.java
+++ b/soap/src/java/com/zimbra/soap/type/WantRecipsSetting.java
@@ -30,6 +30,7 @@ public enum WantRecipsSetting {
     @XmlEnumValue("0") PUT_SENDERS,
     @XmlEnumValue("1") PUT_RECIPIENTS,
     @XmlEnumValue("2") PUT_BOTH,
+    @XmlEnumValue("3") PUT_ALL,
     @Deprecated @XmlEnumValue("false") LEGACY_PUT_SENDERS,
     @Deprecated @XmlEnumValue("true") LEGACY_PUT_RECIPS;
 
@@ -44,6 +45,8 @@ public enum WantRecipsSetting {
             return PUT_SENDERS;
         } else if (WantRecipsSetting.LEGACY_PUT_RECIPS.equals(setting)) {
             return PUT_RECIPIENTS;
+        } else if (WantRecipsSetting.PUT_ALL.equals(setting)) {
+            return PUT_ALL;
         }
         return setting;
     }

--- a/store/src/java/com/zimbra/cs/index/SearchParams.java
+++ b/store/src/java/com/zimbra/cs/index/SearchParams.java
@@ -419,6 +419,8 @@ public final class SearchParams implements Cloneable, ZimbraSearchParams {
             recipients = OutputParticipants.PUT_BOTH;
         } else if (1 == value) {
             recipients = OutputParticipants.PUT_RECIPIENTS;
+        } else if (3 == value) {
+            recipients = OutputParticipants.PUT_ALL;
         } else {
             recipients = OutputParticipants.PUT_SENDERS;
         }


### PR DESCRIPTION
Ticket: [ZCS-13692](https://jira.corp.synacor.com/browse/ZCS-13692)
Problem: In the Search API we use to get _TO_ and _FROM_ fields, we require the _CC_ and _BCC_ values additionally in case of message view in the sent folder.

Solution: For Message type search, on the basis of the _recip_ value parameter we are fetching and returning _CC_ and _BCC_ values. If _recip_ value is _3_, add _CC_ and _BCC_ into the response.

Fix: Modified code while creating the search response.
