### PR TITLE
ZCS-13306: changed to allow derefGroupMember in GetContactsRequest even when id is not set for print contacts

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1094,6 +1094,7 @@ public final class LC {
     @Supported
     public static final KnownKey contact_ranking_enabled = KnownKey.newKey(true);
 
+    public static final KnownKey contact_allow_deref_group_member = KnownKey.newKey(true);
 
     public static final KnownKey jdbc_results_streaming_enabled = KnownKey.newKey(true);
 

--- a/soap/src/java/com/zimbra/soap/mail/message/GetContactsRequest.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/GetContactsRequest.java
@@ -45,6 +45,7 @@ import com.zimbra.soap.type.ZmBoolean;
  * <br />
  * If derefGroupMember is set, group members are returned ordered by the "key" of member.
  * <br />
+ * Note that enabling derefGroupMember may cause a problem on performance.
  * Key is:
  * <ul>
  * <li> for contact ref (type="C"): the fileAs field of the Contact

--- a/store/src/java/com/zimbra/cs/service/mail/GetContacts.java
+++ b/store/src/java/com/zimbra/cs/service/mail/GetContacts.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.MailConstants;
@@ -190,10 +191,13 @@ public final class GetContacts extends MailDocumentHandler  {
                 }
             }
         } else {
+            boolean isDerefGroupMemberAllowed = LC.contact_allow_deref_group_member.booleanValue();
             for (Contact con : mbox.getContactList(octxt, folderId, sort)) {
                 if (con != null) {
                     ContactGroup contactGroup = null;
-                    if (derefContactGroupMember) {
+                    // derefContactGroupMember with no ids may cause performance issue.
+                    // It can be blocked using localconfig contact_allow_deref_group_member
+                    if (derefContactGroupMember && isDerefGroupMemberAllowed) {
                         contactGroup = ContactGroup.init(con, false);
                         if (contactGroup != null) {
                             contactGroup.derefAllMembers(con.getMailbox(), octxt,


### PR DESCRIPTION
**Issue:**
When "Print Contacts" is clicked on Classic UI, the detail (name, email etc.) of contact group member(s) is not shown in the print page. Only contact id is shown.
When "Print selected contact(s) is clicked, the detail is shown.

**Root cause:**
When "Print Contacts" is clicked, the access URL is `https://HOST/h/printcontacts?sfi=[folder_id]`. In this case, a member of contact group is not derefed.
When "Print selected contact(s) is clicked the access URL is `https://HOST/h/printcontacts?id=[id1,id2,...]`. `derefGroupMember true` is set through taglib and ZMailbox class. Then a member is derefed and the detail is shown in Print page.

**Fix:**
* `store/src/java/com/zimbra/cs/service/mail/GetContacts.java`
   * change to pass `derefGroupMember` for searching contacts without `id` parameter as well.
   * Note that `derefGroupMember` was not allowed when `id` was not specified in GetContactsRequest. The logic was added when derefGroupMember parameter was added. According to the comment in the code, it was for performance reason.
      https://bugzilla.zimbra.com/show_bug.cgi?id=56772
    * `derefGroupMember` without specifying `id` can be blocked by setting `contact_allow_deref_group_member` to `false` in case the performance issue occurs. In that case, the detail of a contact group member is not shown in Print page.

* `common/src/java/com/zimbra/common/localconfig/LC.java`
    * added new localconfig key `contact_allow_deref_group_member`. Default value is `true`.

* `soap/src/java/com/zimbra/soap/mail/message/GetContactsRequest.java`
    * add a note about the performance 

* `client/src/java/com/zimbra/client/ZMailbox.java`
    * add `boolean forceDerefGroupMember` to `getContactsForFolder`.
    * add an overloading function for backward compatibility

**Related PRs:**
* https://github.com/Zimbra/zm-taglib/pull/49
* https://github.com/Zimbra/zm-web-client/pull/832