### PR TITLE
ZCS-13779: Added implementation for other external volumes in in-plac…

### DIFF
--- a/store/src/java-test/com/zimbra/util/ExternalVolumeInfoHandlerTest.java
+++ b/store/src/java-test/com/zimbra/util/ExternalVolumeInfoHandlerTest.java
@@ -35,6 +35,10 @@ public class ExternalVolumeInfoHandlerTest {
     private static final String TEST_SERVER_CONFIG = "{\"server/stores\":[{\"volumePrefix\":\"vp_11471\",\"globalBucketConfigId\":\"glb_8\",\"useIntelligentTiering\":\"false\",\"volumeId\":\"3\",\"useInFrequentAccessThreshold\":\"65536\",\"storageType\":\"S3\",\"useInFrequentAccess\":\"false\"}]}";
 
     private static final String TEST_SERVER_CONFIG_OPENIO = "{\"server/stores\":[{\"volumePrefix\":\"TEST_CONTAINER\", \"storageType\":\"OPENIO\", \"volumeId\":\"3\", \"url\":\"http://10.139.28.32\", \"proxyPort\":\"6006\", \"accountPort\":\"6000\", \"account\":\"SM_ACCOUNT\", \"nameSpace\":\"OPENIO\"}]}";
+    // storeType is local
+    private static final String TEST_SERVER_CONFIG_MODIFY = "{\"server/stores\":[{\"volumePrefix\":\"aws_volume1-71cdee9c-250c-4dd4-b67e-7725c5b65061\",\"globalBucketConfigId\":\"4d7c308e-a42f-4a12-8708-521f9d2e6fe6\",\"useIntelligentTiering\":\"false\",\"unified\":\"false\",\"volumeId\":\"4\",\"useInFrequentAccessThreshold\":\"65536\",\"storageType\":\"LOCAL\",\"useInFrequentAccess\":\"false\"},{\"volumePrefix\":\"EMC_Volume-71cdee9c-250c-4dd4-b67e-7725c5b65061\",\"globalBucketConfigId\":\"695bca5e-0d9e-44ad-aa0f-b59c59c5cb6f\",\"useIntelligentTiering\":\"false\",\"unified\":\"false\",\"volumeId\":\"5\",\"useInFrequentAccessThreshold\":\"65536\",\"storageType\":\"S3\",\"useInFrequentAccess\":\"false\"},{\"accountPort\":\"6000\",\"proxyPort\":\"6006\",\"volumeId\":\"6\",\"storageType\":\"OPENIO\",\"nameSpace\":\"OPENIO\",\"url\":\"http://10.139.28.32\",\"account\":\"SM_ACCOUNT\"}]}";
+    // storeType is S3
+    private static final String TEST_SERVER_CONFIG_MODIFY_1 = "{\"server/stores\":[{\"volumePrefix\":\"aws_volume1-71cdee9c-250c-4dd4-b67e-7725c5b65061\",\"globalBucketConfigId\":\"4d7c308e-a42f-4a12-8708-521f9d2e6fe6\",\"useIntelligentTiering\":\"false\",\"unified\":\"false\",\"volumeId\":\"4\",\"useInFrequentAccessThreshold\":\"65536\",\"storageType\":\"S3\",\"useInFrequentAccess\":\"false\"},{\"volumePrefix\":\"EMC_Volume-71cdee9c-250c-4dd4-b67e-7725c5b65061\",\"globalBucketConfigId\":\"695bca5e-0d9e-44ad-aa0f-b59c59c5cb6f\",\"useIntelligentTiering\":\"false\",\"unified\":\"false\",\"volumeId\":\"5\",\"useInFrequentAccessThreshold\":\"65536\",\"storageType\":\"S3\",\"useInFrequentAccess\":\"false\"},{\"accountPort\":\"6000\",\"proxyPort\":\"6006\",\"volumeId\":\"6\",\"storageType\":\"OPENIO\",\"nameSpace\":\"OPENIO\",\"url\":\"http://10.139.28.32\",\"account\":\"SM_ACCOUNT\"}]}";
 
     private MockProvisioning mockProvisioning;
     private ExternalVolumeInfoHandler externalVolumeInfoHandler = null;
@@ -200,6 +204,37 @@ public class ExternalVolumeInfoHandlerTest {
 
         actualServerExternalStoreConfigJson = externalVolumeInfoHandler.readServerProperties(4);
         Assert.assertFalse(actualServerExternalStoreConfigJson.length() > 0);
+    }
+
+    /**
+     * Modify server config details
+     * @throws ServiceException
+     * @throws JSONException
+     */
+    @Test
+    public void testServerConfig_ModifyExternalVolume() throws ServiceException, JSONException {
+        VolumeInfo volInfo = mockModifyVolumeInfo();
+        mockProvisioning.getLocalServer().setServerExternalStoreConfig(TEST_SERVER_CONFIG_MODIFY);
+        externalVolumeInfoHandler.modifyServerProperties(volInfo);
+        String serverExternalStoreConfigJson = mockProvisioning.getLocalServer().getServerExternalStoreConfig();
+        Assert.assertEquals(TEST_SERVER_CONFIG_MODIFY_1, serverExternalStoreConfigJson);
+    }
+
+    private VolumeInfo mockModifyVolumeInfo() {
+        VolumeInfo volInfo = new VolumeInfo();
+        volInfo.setId((short) 4);
+        volInfo.setName("JunitTest");
+        volInfo.setRootPath("/junit/");
+        volInfo.setType((short) 2);
+
+        VolumeExternalInfo volumeExternalInfo = new VolumeExternalInfo();
+        volumeExternalInfo.setGlobalBucketConfigurationId("4d7c308e-a42f-4a12-8708-521f9d2e6fe6");
+        volumeExternalInfo.setVolumePrefix("aws_volume1-71cdee9c-250c-4dd4-b67e-7725c5b65061");
+        volumeExternalInfo.setStorageType("S3");
+        volumeExternalInfo.setUseInFrequentAccess(false);
+
+        volInfo.setVolumeExternalInfo(volumeExternalInfo);
+        return volInfo;
     }
 
 }

--- a/store/src/java/com/zimbra/cs/db/DbVolume.java
+++ b/store/src/java/com/zimbra/cs/db/DbVolume.java
@@ -124,7 +124,7 @@ public final class DbVolume {
             } else {
                 stmt = conn.prepareStatement("UPDATE volume SET type = ?, name = ?, path = ?, " +
                         "mailbox_group_bits = ?, mailbox_bits = ?, file_group_bits = ?, file_bits = ?, " +
-                        "compress_blobs = ?, compression_threshold = ? , metadata = ? , store_manager_class = ? WHERE id = ?");
+                        "compress_blobs = ?, compression_threshold = ? , metadata = ?, store_type = ? , store_manager_class = ? WHERE id = ?");
             }
 
             int pos = 1;
@@ -139,6 +139,7 @@ public final class DbVolume {
             stmt.setLong(pos++, volume.getCompressionThreshold());
             stmt.setString(pos++, volume.getMetadata().toString());
             if (smClass != null) {
+                stmt.setShort(pos++, (short) (volume.getStoreType().getStoreType()));
                 stmt.setString(pos++, smClass);
             }
             stmt.setShort(pos++, volume.getId());

--- a/store/src/java/com/zimbra/util/ExternalVolumeInfoHandler.java
+++ b/store/src/java/com/zimbra/util/ExternalVolumeInfoHandler.java
@@ -290,8 +290,7 @@ public class ExternalVolumeInfoHandler {
 
     /**
      * Modify server level external volume properties
-     * @param volumeId
-     * @param server
+     * @param volInfo
      * @throws JSONException, ServiceException
      */
     public void modifyServerProperties(VolumeInfo volInfo) throws ServiceException, JSONException {
@@ -300,6 +299,17 @@ public class ExternalVolumeInfoHandler {
             String serverExternalStoreConfigJson = provisioning.getLocalServer().getServerExternalStoreConfig();
             JSONObject currentJsonObject = new JSONObject(serverExternalStoreConfigJson);
             JSONArray currentJsonArray = currentJsonObject.getJSONArray("server/stores");
+
+            VolumeExternalInfo volExtInfo = volInfo.getVolumeExternalInfo();
+            VolumeExternalOpenIOInfo volExtOpenIoInfo = volInfo.getVolumeExternalOpenIOInfo();
+
+            JSONObject volExtInfoObj = new JSONObject();
+            if (volExtInfo != null && AdminConstants.A_VOLUME_S3.equalsIgnoreCase(volExtInfo.getStorageType())) {
+                volExtInfoObj = volExtInfo.toJSON(volInfo);
+            } else if (volExtOpenIoInfo != null
+                    && AdminConstants.A_VOLUME_OPEN_IO.equalsIgnoreCase(volExtOpenIoInfo.getStorageType())) {
+                volExtInfoObj = volExtOpenIoInfo.toJSON(volInfo);
+            }
 
             // step 2: Create new/empty updated JSON state array
             JSONArray updatedJsonArray = new JSONArray();
@@ -310,8 +320,7 @@ public class ExternalVolumeInfoHandler {
                 if (volInfo.getId() != tempJsonObj.getInt(AdminConstants.A_VOLUME_ID)) {
                     updatedJsonArray.put(tempJsonObj);
                 } else {
-                    tempJsonObj.put(AdminConstants.A_VOLUME_NAME, volInfo.getName());
-                    updatedJsonArray.put(tempJsonObj);
+                    updatedJsonArray.put(volExtInfoObj);
                 }
             }
 


### PR DESCRIPTION
**Issue:** In-place upgrade is not updating LDAP details for external volumes except AWS.
**Solution:** StorageType is coming 1 for external volumes except AWS so those were not treated as an external volume. So changed the logic for StorageType as per volume type.