### PR TITLE
ZCS-13783 : Part 1- Update locator for external storage | In-place up…

### DIFF
--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -1622,5 +1622,12 @@ public final class AdminConstants {
             "com_zextras_client", "com_zimbra_connect_classic", "com_zimbra_connect_modern", "com_zextras_docs",
             "com_zimbra_docs_modern", "com_zimbra_drive_modern", "com_zextras_drive", "com_zextras_drive_open",
             "com_zextras_chat_open", "com_zextras_talk", "zimbra-zimlet-briefcase-edit-lool");
-
+    public static final String E_ACCOUNT_NAME = "accounts";
+    public static final String E_MAIL_BOXES = "mboxNumbers";
+    public static final String E_IS_UPDATE_ALL = "isUpdateAllMailBoxes";
+    public static final String E_ZIMBRA10_LOCATOR_UPGRADE_REQUEST = "Zimbra10LocatorUpgradeRequest";
+    public static final String E_STATUS_NAME = "status";
+    public static final String E_ZIMBRA10_LOCATOR_UPGRADE_RESPONSE = "Zimbra10LocatorUpgradeResponse";
+    public static final QName LOCATOR_UPDATE_ZIMBRA10_REQUEST = QName.get(E_ZIMBRA10_LOCATOR_UPGRADE_REQUEST, NAMESPACE);
+    public static final QName LOCATOR_UPDATE_ZIMBRA10_RESPONSE = QName.get(E_ZIMBRA10_LOCATOR_UPGRADE_RESPONSE, NAMESPACE);
 }

--- a/common/src/java/com/zimbra/common/util/Constants.java
+++ b/common/src/java/com/zimbra/common/util/Constants.java
@@ -49,5 +49,6 @@ public class Constants {
     public static final String AUTH_HEADER = "Authorization";
     public static final String BEARER= "Bearer";
     public static final String JWT_SALT_SEPARATOR = "|";
+    public static final Integer LOCATOR_UPDATE_THREAD_COUNT  = 10;
 
 }

--- a/soap/src/java/com/zimbra/soap/admin/message/Zimbra10LocatorUpgradeRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/Zimbra10LocatorUpgradeRequest.java
@@ -1,0 +1,57 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2023 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.soap.admin.type.MailboxByAccountIdSelector;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@XmlAccessorType(XmlAccessType.NONE) @XmlRootElement(name = AdminConstants.E_ZIMBRA10_LOCATOR_UPGRADE_REQUEST)
+public final class Zimbra10LocatorUpgradeRequest {
+    @XmlElement(name = AdminConstants.E_ACCOUNT_NAME, required = false)
+    private List<String> accounts = new ArrayList<>();
+    @XmlElement(name = AdminConstants.E_MAIL_BOXES, required = false)
+    private List<Integer> mboxNumbers = new ArrayList<>();
+    @XmlElement(name = AdminConstants.E_IS_UPDATE_ALL, required = false)
+    private boolean isUpdateAllMailBoxes;
+    private Zimbra10LocatorUpgradeRequest() {
+        this((List<String>) null, (List<Integer>) null, Boolean.FALSE);
+    }
+    public Zimbra10LocatorUpgradeRequest(List<String> accounts, List<Integer> mboxNumbers,
+            boolean isUpdateAllMailBoxes) {
+        this.accounts = accounts;
+        this.mboxNumbers = mboxNumbers;
+        this.isUpdateAllMailBoxes = isUpdateAllMailBoxes;
+    }
+    public List<String> getAccounts() {
+        return accounts;
+    }
+    public List<Integer> getMboxNumbers() {
+        return mboxNumbers;
+    }
+    public boolean isUpdateAllMailBoxes() {
+        return isUpdateAllMailBoxes;
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/Zimbra10LocatorUpgradeResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/Zimbra10LocatorUpgradeResponse.java
@@ -29,13 +29,14 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-@XmlAccessorType(XmlAccessType.NONE) @XmlRootElement(name = AdminConstants.E_ZIMBRA10_LOCATOR_UPGRADE_RESPONSE)
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name = AdminConstants.E_ZIMBRA10_LOCATOR_UPGRADE_RESPONSE)
 public final class Zimbra10LocatorUpgradeResponse {
 
     /**
      * @zm-api-field-description Information about the execution status
      */
-    @XmlElement(name = AdminConstants.E_STAT_NAME, required = true)
+    @XmlElement(name = AdminConstants.E_STATUS_NAME, required = true)
     private final boolean status;
     private Zimbra10LocatorUpgradeResponse() {
         this(false);

--- a/soap/src/java/com/zimbra/soap/admin/message/Zimbra10LocatorUpgradeResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/Zimbra10LocatorUpgradeResponse.java
@@ -1,0 +1,49 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2023 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import com.google.common.collect.Lists;
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.soap.admin.type.VolumeInfo;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+@XmlAccessorType(XmlAccessType.NONE) @XmlRootElement(name = AdminConstants.E_ZIMBRA10_LOCATOR_UPGRADE_RESPONSE)
+public final class Zimbra10LocatorUpgradeResponse {
+
+    /**
+     * @zm-api-field-description Information about the execution status
+     */
+    @XmlElement(name = AdminConstants.E_STAT_NAME, required = true)
+    private final boolean status;
+    private Zimbra10LocatorUpgradeResponse() {
+        this(false);
+    }
+    public Zimbra10LocatorUpgradeResponse(boolean status) {
+        this.status = status;
+    }
+    public boolean isStatus() {
+        return status;
+    }
+}

--- a/store/src/java/com/zimbra/cs/db/LocatorUpdateExecutor.java
+++ b/store/src/java/com/zimbra/cs/db/LocatorUpdateExecutor.java
@@ -1,0 +1,37 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2023 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.db;
+
+import com.zimbra.common.util.Constants;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * class for LocatorUpdateExecutor initiation in static context.
+ */
+public class LocatorUpdateExecutor {
+    public static ExecutorService executor;
+    public static ThreadPoolExecutor pool;
+    static {
+        executor = Executors.newFixedThreadPool(Constants.LOCATOR_UPDATE_THREAD_COUNT);
+        pool = (ThreadPoolExecutor) executor;
+        ((ThreadPoolExecutor) executor).prestartAllCoreThreads();
+    }
+}

--- a/store/src/java/com/zimbra/cs/db/LocatorUpgradeDaoWorker.java
+++ b/store/src/java/com/zimbra/cs/db/LocatorUpgradeDaoWorker.java
@@ -1,0 +1,64 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2023 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.db;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.index.query.InQuery;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailbox.OperationContext;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+/**
+ * Thread class to complete DB locator update per account
+ */
+public class LocatorUpgradeDaoWorker implements Callable<Boolean> {
+    private final String accountPrimaryEmail;
+
+    public LocatorUpgradeDaoWorker(String accountid) {
+        this.accountPrimaryEmail = accountid;
+    }
+
+    /**
+     * completes the locator update in DB for an account
+     * @return
+     * @throws Exception
+     */
+    @Override public Boolean call() throws Exception {
+        try {
+            Account account = Provisioning.getInstance().getAccountByName(this.accountPrimaryEmail.split("@")[0]);
+            Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(account.getId(), true);
+            OperationContext ctx = new OperationContext(account, true);
+            List<Integer> sentRAndRecievedToBeUpdated = mbox.getAllRecordsForSentAndRecieved(ctx, mbox,
+                    this.accountPrimaryEmail, false);
+            mbox.updateLocatorFieldZimbra10(ctx, sentRAndRecievedToBeUpdated);
+            List<Integer> recordNumbersPending = mbox.getAllRecordsForSentAndRecieved(ctx, mbox,
+                    this.accountPrimaryEmail, true);
+            if (recordNumbersPending.size() == 0) {
+                return true;
+            } else {
+                return false;
+            }
+        } catch (ServiceException e) {
+            return false;
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/db/Zimbra10MailItemLocatorUpgradeExec.java
+++ b/store/src/java/com/zimbra/cs/db/Zimbra10MailItemLocatorUpgradeExec.java
@@ -1,0 +1,84 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2023 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.db;
+
+import com.zimbra.client.ZMailbox;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.index.query.InQuery;
+import com.zimbra.cs.mailbox.MailItem;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailbox.OperationContext;
+import com.zimbra.cs.util.Zimbra;
+import com.zimbra.soap.admin.message.Zimbra10LocatorUpgradeRequest;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+/**
+ * central class for updating the locator in mail_item
+ */
+public class Zimbra10MailItemLocatorUpgradeExec {
+    /**
+     * recieves the request from porter application
+     * @param locatorUpdateRequestequest
+     * @return
+     * @throws ServiceException
+     */
+    public boolean upgrade(Zimbra10LocatorUpgradeRequest locatorUpdateRequestequest) throws ServiceException {
+        if (locatorUpdateRequestequest.isUpdateAllMailBoxes()) {
+            //TODO placeholder forallmailboxes
+
+        } else if (null != locatorUpdateRequestequest.getMboxNumbers() && locatorUpdateRequestequest.getMboxNumbers()
+                .size() > 1) {
+            List<Integer> mboxNumbers = locatorUpdateRequestequest.getMboxNumbers();
+            for (Integer mboxNumber : mboxNumbers) {
+                Mailbox mbox = MailboxManager.getInstance().getMailboxById(mboxNumber);
+                OperationContext ctx = new OperationContext(mbox);
+                return upgrade(mbox.getAllSendersList(ctx));
+            }
+        } else if (null != locatorUpdateRequestequest.getAccounts() && locatorUpdateRequestequest.getAccounts()
+                .size() > 1) {
+            return upgrade(locatorUpdateRequestequest.getAccounts());
+        }
+        return false;
+    }
+    private boolean upgrade(List<String> accounts) throws ServiceException {
+        try {
+            List<Future<Boolean>> resultFlags = new ArrayList<Future<Boolean>>();
+            for (String accountId : accounts) {
+                LocatorUpgradeDaoWorker daoWorker = new LocatorUpgradeDaoWorker(accountId);
+                Future<Boolean> resultFlag = LocatorUpdateExecutor.executor.submit(daoWorker);
+                resultFlags.add(resultFlag);
+            }
+            for (Future<Boolean> resultFlag : resultFlags) {
+                if (!resultFlag.get()) {
+                    return false;
+                }
+            }
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -10957,6 +10957,63 @@ public class Mailbox implements MailboxStore {
         }
     }
 
+    /**
+     * get all records for an account
+     * @param octxt
+     * @param mbox
+     * @param accountId
+     * @param isUpdated
+     * @return
+     * @throws ServiceException
+     */
+    public List<Integer> getAllRecordsForSentAndRecieved(OperationContext octxt, Mailbox mbox, String accountId, boolean isUpdated)
+            throws ServiceException {
+        boolean success = false;
+        try {
+            beginReadTransaction("getAllRecordsForSender", octxt);
+            List<Integer> allRecords = DbMailItem.getAllRecordsForSentAndRecieved(mbox, accountId, isUpdated);
+            success = true;
+            return allRecords;
+        } finally {
+            endTransaction(success);
+        }
+    }
+
+    /**
+     * updates the locator for the seleted records
+     * @param ctx
+     * @param recordNumbers
+     * @throws ServiceException
+     */
+    public void updateLocatorFieldZimbra10(OperationContext ctx, List<Integer> recordNumbers)
+            throws ServiceException {
+        boolean success = false;
+        try {
+            beginTransaction("getAllRecordsForSender", ctx);
+            DbMailItem.updateLocatorFieldZimbra10(this, recordNumbers);
+            success = true;
+        } finally {
+            endTransaction(success);
+        }
+    }
+
+    /**
+     * gets all senders in a mailbox
+     * @param ctx
+     * @return
+     * @throws ServiceException
+     */
+    public List<String> getAllSendersList(OperationContext ctx) throws ServiceException {
+        boolean success = false;
+        try {
+            beginReadTransaction("getAllSendersList", ctx);
+            List<String> allDistinctSenders = DbMailItem.getAllSendersList(this);
+            success = true;
+            return allDistinctSenders;
+        } finally {
+            endTransaction(success);
+        }
+    }
     public static void logDebugXML(Element e) {
         ZimbraLog.sync.debug(e.prettyPrint());
     }

--- a/store/src/java/com/zimbra/cs/service/admin/Zimbra10DBLocatorUpgrade.java
+++ b/store/src/java/com/zimbra/cs/service/admin/Zimbra10DBLocatorUpgrade.java
@@ -1,0 +1,67 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2005, 2006, 2007, 2009, 2010, 2011, 2013, 2014, 2015, 2016 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.service.admin;
+
+import com.zimbra.common.account.Key.DistributionListBy;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.DistributionList;
+import com.zimbra.cs.account.Group;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.ShareInfo;
+import com.zimbra.cs.account.accesscontrol.AdminRight;
+import com.zimbra.cs.account.accesscontrol.Rights.Admin;
+import com.zimbra.cs.db.Zimbra10MailItemLocatorUpgradeExec;
+import com.zimbra.cs.mailbox.OperationContext;
+import com.zimbra.soap.ZimbraSoapContext;
+import com.zimbra.soap.admin.message.AddAccountAliasResponse;
+import com.zimbra.soap.admin.message.AddDistributionListMemberResponse;
+import com.zimbra.soap.admin.message.Zimbra10LocatorUpgradeRequest;
+import com.zimbra.soap.admin.message.Zimbra10LocatorUpgradeResponse;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * handler class for recieving request from porter for zimbra10 locator upgrade
+ */
+public class Zimbra10DBLocatorUpgrade extends AdminDocumentHandler {
+    /**
+     * handles the request for locator update
+     * @param request
+     * @param context
+     * @return
+     * @throws ServiceException
+     */
+    @Override
+    public Element handle(Element request, Map<String, Object> context) throws ServiceException {
+        ZimbraSoapContext zsc = getZimbraSoapContext(context);
+        Zimbra10LocatorUpgradeRequest req = zsc.elementToJaxb(request);
+        Zimbra10MailItemLocatorUpgradeExec locatorUpgradeExec = new Zimbra10MailItemLocatorUpgradeExec();
+        return zsc.jaxbToElement(new Zimbra10LocatorUpgradeResponse(locatorUpgradeExec.upgrade(req)));
+    }
+
+    @Override
+    public void docRights(List<AdminRight> relatedRights, List<String> notes) {
+        relatedRights.add(Admin.R_addDistributionListMember);
+        relatedRights.add(Admin.R_addGroupMember);
+    }
+}

--- a/store/src/java/com/zimbra/cs/service/admin/Zimbra10DBLocatorUpgrade.java
+++ b/store/src/java/com/zimbra/cs/service/admin/Zimbra10DBLocatorUpgrade.java
@@ -58,7 +58,6 @@ public class Zimbra10DBLocatorUpgrade extends AdminDocumentHandler {
         Zimbra10MailItemLocatorUpgradeExec locatorUpgradeExec = new Zimbra10MailItemLocatorUpgradeExec();
         return zsc.jaxbToElement(new Zimbra10LocatorUpgradeResponse(locatorUpgradeExec.upgrade(req)));
     }
-
     @Override
     public void docRights(List<AdminRight> relatedRights, List<String> notes) {
         relatedRights.add(Admin.R_addDistributionListMember);


### PR DESCRIPTION
Problem : AFter the zimbra 10 in place upgrade, When we try to read those mail stored on external storage we are getting missing blob because according to Zimbra 10 Storage Management locator values format should be volume_id@@mailbox_id/file_name for external volume but there is only external volume id present in the locator, according to zimbra9 standard.


Solution: 
We update locators in the mail_item table for external volumes only to read blobs from external storage according to Zimbra 10 Storage Management implementation.  
This utility will work with having the below argument. 
**Update locator based on account**

Link to another PR: [#44](https://github.com/Zimbra/zm-modules-porter/pull/44)