### PR TITLE
Zcs 13728 Part 2- Update locator for external storage | In-place upgrade

### DIFF
--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -1627,5 +1627,12 @@ public final class AdminConstants {
             "com_zextras_client", "com_zimbra_connect_classic", "com_zimbra_connect_modern", "com_zextras_docs",
             "com_zimbra_docs_modern", "com_zimbra_drive_modern", "com_zextras_drive", "com_zextras_drive_open",
             "com_zextras_chat_open", "com_zextras_talk", "zimbra-zimlet-briefcase-edit-lool");
-
+    public static final String E_ACCOUNT_NAME = "accounts";
+    public static final String E_MAIL_BOXES = "mboxNumbers";
+    public static final String E_IS_UPDATE_ALL = "isUpdateAllMailBoxes";
+    public static final String E_ZIMBRA10_LOCATOR_UPGRADE_REQUEST = "Zimbra10LocatorUpgradeRequest";
+    public static final String E_STATUS_NAME = "status";
+    public static final String E_ZIMBRA10_LOCATOR_UPGRADE_RESPONSE = "Zimbra10LocatorUpgradeResponse";
+    public static final QName LOCATOR_UPDATE_ZIMBRA10_REQUEST = QName.get(E_ZIMBRA10_LOCATOR_UPGRADE_REQUEST, NAMESPACE);
+    public static final QName LOCATOR_UPDATE_ZIMBRA10_RESPONSE = QName.get(E_ZIMBRA10_LOCATOR_UPGRADE_RESPONSE, NAMESPACE);
 }

--- a/common/src/java/com/zimbra/common/util/Constants.java
+++ b/common/src/java/com/zimbra/common/util/Constants.java
@@ -49,7 +49,7 @@ public class Constants {
     public static final String AUTH_HEADER = "Authorization";
     public static final String BEARER= "Bearer";
     public static final String JWT_SALT_SEPARATOR = "|";
-    public static final Integer LOCATOR_UPDATE_THREAD_COUNT  = 10;
+    public static final Integer LOCATOR_UPDATE_THREAD_COUNT  = 1;
 
 
 }

--- a/common/src/java/com/zimbra/common/util/Constants.java
+++ b/common/src/java/com/zimbra/common/util/Constants.java
@@ -49,5 +49,7 @@ public class Constants {
     public static final String AUTH_HEADER = "Authorization";
     public static final String BEARER= "Bearer";
     public static final String JWT_SALT_SEPARATOR = "|";
+    public static final Integer LOCATOR_UPDATE_THREAD_COUNT  = 10;
+
 
 }

--- a/soap/src/java/com/zimbra/soap/JaxbUtil.java
+++ b/soap/src/java/com/zimbra/soap/JaxbUtil.java
@@ -1173,7 +1173,9 @@ public final class JaxbUtil {
             com.zimbra.soap.admin.message.ValidateS3BucketReachableRequest.class,
             com.zimbra.soap.admin.message.ValidateS3BucketReachableResponse.class,
             com.zimbra.soap.admin.message.EditS3BucketConfigRequest.class,
-            com.zimbra.soap.admin.message.EditS3BucketConfigResponse.class
+            com.zimbra.soap.admin.message.EditS3BucketConfigResponse.class,
+            com.zimbra.soap.admin.message.Zimbra10LocatorUpgradeRequest.class,
+            com.zimbra.soap.admin.message.Zimbra10LocatorUpgradeResponse.class
         };
 
         try {

--- a/soap/src/java/com/zimbra/soap/admin/message/Zimbra10LocatorUpgradeRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/Zimbra10LocatorUpgradeRequest.java
@@ -1,0 +1,57 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2023 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.soap.admin.type.MailboxByAccountIdSelector;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@XmlAccessorType(XmlAccessType.NONE) @XmlRootElement(name = AdminConstants.E_ZIMBRA10_LOCATOR_UPGRADE_REQUEST)
+public final class Zimbra10LocatorUpgradeRequest {
+    @XmlElement(name = AdminConstants.E_ACCOUNT_NAME, required = false)
+    private List<String> accounts = new ArrayList<>();
+    @XmlElement(name = AdminConstants.E_MAIL_BOXES, required = false)
+    private List<Integer> mboxNumbers = new ArrayList<>();
+    @XmlElement(name = AdminConstants.E_IS_UPDATE_ALL, required = false)
+    private boolean isUpdateAllMailBoxes;
+    private Zimbra10LocatorUpgradeRequest() {
+        this((List<String>) null, (List<Integer>) null, Boolean.FALSE);
+    }
+    public Zimbra10LocatorUpgradeRequest(List<String> accounts, List<Integer> mboxNumbers,
+            boolean isUpdateAllMailBoxes) {
+        this.accounts = accounts;
+        this.mboxNumbers = mboxNumbers;
+        this.isUpdateAllMailBoxes = isUpdateAllMailBoxes;
+    }
+    public List<String> getAccounts() {
+        return accounts;
+    }
+    public List<Integer> getMboxNumbers() {
+        return mboxNumbers;
+    }
+    public boolean isUpdateAllMailBoxes() {
+        return isUpdateAllMailBoxes;
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/Zimbra10LocatorUpgradeResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/Zimbra10LocatorUpgradeResponse.java
@@ -1,0 +1,50 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2023 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import com.google.common.collect.Lists;
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.soap.admin.type.VolumeInfo;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name = AdminConstants.E_ZIMBRA10_LOCATOR_UPGRADE_RESPONSE)
+public final class Zimbra10LocatorUpgradeResponse {
+
+    /**
+     * @zm-api-field-description Information about the execution status
+     */
+    @XmlElement(name = AdminConstants.E_STATUS_NAME, required = true)
+    private final boolean status;
+    private Zimbra10LocatorUpgradeResponse() {
+        this(false);
+    }
+    public Zimbra10LocatorUpgradeResponse(boolean status) {
+        this.status = status;
+    }
+    public boolean isStatus() {
+        return status;
+    }
+}

--- a/store/src/java/com/zimbra/cs/db/DbMailItem.java
+++ b/store/src/java/com/zimbra/cs/db/DbMailItem.java
@@ -5496,17 +5496,17 @@ public class DbMailItem {
         ResultSet rs = null;
         DbConnection conn = null;
         try {
-             conn = mbox.getOperationConnection();
+            conn = mbox.getOperationConnection();
             List<Integer> recordIds = new ArrayList<>();
             String WHERE_CLAUSE_CHECK_UPDATED = "";
             if (isUpdated) {
                 WHERE_CLAUSE_CHECK_UPDATED = "AND LOCATOR NOT LIKE '%@@%'";
             }
-             preparedStatement = conn.prepareStatement(" SELECT id FROM " + getMailItemTableName(mbox,
+            preparedStatement = conn.prepareStatement(" SELECT id FROM " + getMailItemTableName(mbox,
                     false) + " where ((sender like concat('%',?,'%')) or (recipients like concat('%',?,'%')))  and folder_id in (2,3,4,5,6,9) " + WHERE_CLAUSE_CHECK_UPDATED);
             preparedStatement.setString(1, senderEmail);
             preparedStatement.setString(2, senderEmail);
-             rs = preparedStatement.executeQuery();
+            rs = preparedStatement.executeQuery();
             while (rs.next()) {
                 recordIds.add(rs.getInt(1));
             }
@@ -5515,8 +5515,7 @@ public class DbMailItem {
         } catch (Exception e) {
             ZimbraLog.mailbox.error("error occured while DB update");
             throw ServiceException.INTERRUPTED("not updated locator");
-        }
-        finally {
+        } finally {
             DbPool.closeStatement(preparedStatement);
             DbPool.closeResults(rs);
         }

--- a/store/src/java/com/zimbra/cs/db/LocatorUpdateExecutor.java
+++ b/store/src/java/com/zimbra/cs/db/LocatorUpdateExecutor.java
@@ -1,0 +1,37 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2023 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.db;
+
+import com.zimbra.common.util.Constants;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * class for LocatorUpdateExecutor initiation in static context.
+ */
+public class LocatorUpdateExecutor {
+    public static ExecutorService executor;
+    public static ThreadPoolExecutor pool;
+    static {
+        executor = Executors.newFixedThreadPool(Constants.LOCATOR_UPDATE_THREAD_COUNT);
+        pool = (ThreadPoolExecutor) executor;
+        ((ThreadPoolExecutor) executor).prestartAllCoreThreads();
+    }
+}

--- a/store/src/java/com/zimbra/cs/db/LocatorUpdateExecutor.java
+++ b/store/src/java/com/zimbra/cs/db/LocatorUpdateExecutor.java
@@ -32,6 +32,6 @@ public class LocatorUpdateExecutor {
     static {
         executor = Executors.newFixedThreadPool(Constants.LOCATOR_UPDATE_THREAD_COUNT);
         pool = (ThreadPoolExecutor) executor;
-        ((ThreadPoolExecutor) executor).prestartAllCoreThreads();
+        //((ThreadPoolExecutor) executor).prestartAllCoreThreads();
     }
 }

--- a/store/src/java/com/zimbra/cs/db/LocatorUpgradeDaoWorker.java
+++ b/store/src/java/com/zimbra/cs/db/LocatorUpgradeDaoWorker.java
@@ -54,23 +54,10 @@ public class LocatorUpgradeDaoWorker implements Callable<Boolean>{
                 ZimbraLog.account.warn("No records found for  %s ", accountPrimaryEmail);
                 return true;
             }
-
-            ZimbraLog.account.info("No records found for  %s ", accountPrimaryEmail);
-            mbox.updateLocatorFieldZimbra10(ctx, sentRAndRecievedToBeUpdated);
-            List<Integer> recordNumbersPending = mbox.getAllRecordsForSentAndRecieved(ctx, mbox,
-                    this.accountPrimaryEmail, true);
-
-            if (recordNumbersPending.size() == 0) {
-                ZimbraLog.account.info("succesfully updated  locator for  %s and record count is  %s ",
-                        accountPrimaryEmail, recordNumbersPending);
-                return true;
-            } else {
-                ZimbraLog.account.info("failed updating locator for %s ", accountPrimaryEmail);
-                return false;
-            }
         } catch (ServiceException e) {
             ZimbraLog.account.error("Exception occured while updating  %s and error is %s ", accountPrimaryEmail, e);
             return false;
         }
+        return null;
     }
 }

--- a/store/src/java/com/zimbra/cs/db/LocatorUpgradeDaoWorker.java
+++ b/store/src/java/com/zimbra/cs/db/LocatorUpgradeDaoWorker.java
@@ -1,0 +1,76 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2023 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.db;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailbox.OperationContext;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+/**
+ * Thread class to complete DB locator update per account
+ */
+public class LocatorUpgradeDaoWorker implements Callable<Boolean>{
+    private final String accountPrimaryEmail;
+    public LocatorUpgradeDaoWorker(String accountid) {
+        this.accountPrimaryEmail = accountid;
+    }
+
+    /**
+     * completes the locator update in DB for an account
+     *
+     * @return
+     */
+    @Override
+    public Boolean call() {
+        try {
+            Account account = Provisioning.getInstance().getAccountByName(this.accountPrimaryEmail.split("@")[0]);
+            Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(account.getId(), false);
+            OperationContext ctx = new OperationContext(account, true);
+            ZimbraLog.account.info("updating locator for %s ", accountPrimaryEmail);
+            List<Integer> sentRAndRecievedToBeUpdated = mbox.getAllRecordsForSentAndRecieved(ctx, mbox,
+                    this.accountPrimaryEmail, false);
+            if (sentRAndRecievedToBeUpdated.size() == 0) {
+                ZimbraLog.account.warn("No records found for  %s ", accountPrimaryEmail);
+                return true;
+            }
+
+            ZimbraLog.account.info("No records found for  %s ", accountPrimaryEmail);
+            mbox.updateLocatorFieldZimbra10(ctx, sentRAndRecievedToBeUpdated);
+            List<Integer> recordNumbersPending = mbox.getAllRecordsForSentAndRecieved(ctx, mbox,
+                    this.accountPrimaryEmail, true);
+
+            if (recordNumbersPending.size() == 0) {
+                ZimbraLog.account.info("succesfully updated  locator for  %s and record count is  %s ",
+                        accountPrimaryEmail, recordNumbersPending);
+                return true;
+            } else {
+                ZimbraLog.account.info("failed updating locator for %s ", accountPrimaryEmail);
+                return false;
+            }
+        } catch (ServiceException e) {
+            ZimbraLog.account.error("Exception occured while updating  %s and error is %s ", accountPrimaryEmail, e);
+            return false;
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/db/Zimbra10MailItemLocatorUpgradeExec.java
+++ b/store/src/java/com/zimbra/cs/db/Zimbra10MailItemLocatorUpgradeExec.java
@@ -1,0 +1,109 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2023 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.db;
+
+import com.google.common.collect.Lists;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailbox.OperationContext;
+import com.zimbra.soap.admin.message.Zimbra10LocatorUpgradeRequest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Future;
+
+/**
+ * central class for updating the locator in mail_item
+ */
+public class Zimbra10MailItemLocatorUpgradeExec {
+    /**
+     * recieves the request from porter application
+     *
+     * @param locatorUpdateRequest
+     * @return
+     * @throws ServiceException
+     */
+
+    public boolean upgrade(Zimbra10LocatorUpgradeRequest locatorUpdateRequest)
+            throws ServiceException {
+        if (locatorUpdateRequest.isUpdateAllMailBoxes()) {
+            ZimbraLog.account.info("updating locator for all mailboxes");
+            List<Mailbox> allLoadedMailboxes = MailboxManager.getInstance().getAllLoadedMailboxes();
+            boolean isAllMailboxesUpdated = upgradeMailboxes(allLoadedMailboxes);
+            ZimbraLog.account.info("updated locator for all mailboxes ");
+            return isAllMailboxesUpdated;
+        } else if (null != locatorUpdateRequest.getMboxNumbers()) {
+            ZimbraLog.account.info("updating locator for the mailboxes %s ", locatorUpdateRequest.getMboxNumbers());
+            List<Integer> mboxNumbers = locatorUpdateRequest.getMboxNumbers();
+            List<Mailbox> mailBoxes = Lists.newArrayList();
+            for (Integer mboxNumber : mboxNumbers) {
+                if (null != mboxNumber) {
+                    mailBoxes.add(MailboxManager.getInstance().getMailboxById(mboxNumber));
+                }
+            }
+            return upgradeMailboxes(mailBoxes);
+        } else if (null != locatorUpdateRequest.getAccounts()) {
+            return upgrade(locatorUpdateRequest.getAccounts());
+        }
+        return false;
+    }
+
+    boolean upgradeMailboxes(List<Mailbox> mailboxes) throws ServiceException {
+        Account account = Provisioning.getInstance().getAccount("admin");
+        for (Mailbox mbox : mailboxes) {
+            if (null != mbox) {
+                OperationContext ctx = new OperationContext(account, true);
+                ZimbraLog.account.info("updating locator for mailboxe %s ", mbox);
+                if (!upgrade(mbox.getAllSendersList(ctx))) {
+                    return false;
+                }
+                ZimbraLog.account.info("updated locator for mailbox %s ", mbox);
+
+            }
+        }
+        ZimbraLog.account.info("updated locator for mailboxes %s ", mailboxes);
+
+        return true;
+    }
+
+    public boolean upgrade(List<String> accounts) throws ServiceException {
+        try {
+            ZimbraLog.account.info("updating locator for accounts %s ", accounts);
+            List<Future<Boolean>> resultFlags = new ArrayList<Future<Boolean>>();
+            for (String accountId : accounts) {
+                if (null != accountId) {
+                    LocatorUpgradeDaoWorker daoWorker = new LocatorUpgradeDaoWorker(accountId);
+                    Future<Boolean> resultFlag = LocatorUpdateExecutor.executor.submit(daoWorker);
+                    resultFlags.add(resultFlag);
+                }
+            }
+            for (Future<Boolean> resultFlag : resultFlags) {
+                if (!resultFlag.get()) {
+                    return false;
+                }
+            }
+            return true;
+        } catch (Exception e) {
+            ZimbraLog.account.info("Failed updating locator  for accounts : %s ", accounts);
+
+            return false;
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/service/admin/AdminService.java
+++ b/store/src/java/com/zimbra/cs/service/admin/AdminService.java
@@ -120,7 +120,8 @@ public class AdminService implements DocumentService {
         dispatcher.registerHandler(AdminConstants.CREATE_VOLUME_REQUEST, new CreateVolume());
         dispatcher.registerHandler(AdminConstants.GET_VOLUME_REQUEST, new GetVolume());
         dispatcher.registerHandler(AdminConstants.GET_ALL_VOLUMES_REQUEST, new GetAllVolumes());
-        dispatcher.registerHandler(AdminConstants.GET_ALL_VOLUMES_INPLACE_UPGRADE_REQUEST, new GetAllVolumesInplaceUpgrade());
+        dispatcher.registerHandler(AdminConstants.LOCATOR_UPDATE_ZIMBRA10_REQUEST, new Zimbra10DBLocatorUpgrade());
+        dispatcher.registerHandler(AdminConstants.MODIFY_VOLUME_INPLACE_UPGRADE_REQUEST, new ModifyVolumeInplaceUpgrade());
         dispatcher.registerHandler(AdminConstants.MODIFY_VOLUME_REQUEST, new ModifyVolume());
         dispatcher.registerHandler(AdminConstants.MODIFY_VOLUME_INPLACE_UPGRADE_REQUEST, new ModifyVolumeInplaceUpgrade());
         dispatcher.registerHandler(AdminConstants.DELETE_VOLUME_REQUEST, new DeleteVolume());

--- a/store/src/java/com/zimbra/cs/service/admin/Zimbra10DBLocatorUpgrade.java
+++ b/store/src/java/com/zimbra/cs/service/admin/Zimbra10DBLocatorUpgrade.java
@@ -1,0 +1,66 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2005, 2006, 2007, 2009, 2010, 2011, 2013, 2014, 2015, 2016 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.service.admin;
+
+import com.zimbra.common.account.Key.DistributionListBy;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.DistributionList;
+import com.zimbra.cs.account.Group;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.ShareInfo;
+import com.zimbra.cs.account.accesscontrol.AdminRight;
+import com.zimbra.cs.account.accesscontrol.Rights.Admin;
+import com.zimbra.cs.db.Zimbra10MailItemLocatorUpgradeExec;
+import com.zimbra.cs.mailbox.OperationContext;
+import com.zimbra.soap.ZimbraSoapContext;
+import com.zimbra.soap.admin.message.AddAccountAliasResponse;
+import com.zimbra.soap.admin.message.AddDistributionListMemberResponse;
+import com.zimbra.soap.admin.message.Zimbra10LocatorUpgradeRequest;
+import com.zimbra.soap.admin.message.Zimbra10LocatorUpgradeResponse;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * handler class for recieving request from porter for zimbra10 locator upgrade
+ */
+public class Zimbra10DBLocatorUpgrade extends AdminDocumentHandler {
+    /**
+     * handles the request for locator update
+     *
+     * @param request
+     * @param context
+     * @return
+     * @throws ServiceException
+     */
+    @Override public Element handle(Element request, Map<String, Object> context) throws ServiceException {
+        ZimbraSoapContext zsc = getZimbraSoapContext(context);
+        Zimbra10LocatorUpgradeRequest req = zsc.elementToJaxb(request);
+        Zimbra10MailItemLocatorUpgradeExec locatorUpgradeExec = new Zimbra10MailItemLocatorUpgradeExec();
+        return zsc.jaxbToElement(new Zimbra10LocatorUpgradeResponse(locatorUpgradeExec.upgrade(req)));
+    }
+
+    @Override public void docRights(List<AdminRight> relatedRights, List<String> notes) {
+        relatedRights.add(Admin.R_addDistributionListMember);
+        relatedRights.add(Admin.R_addGroupMember);
+    }
+}


### PR DESCRIPTION
Problem : AFter the zimbra 10 in place upgrade, When we try to read those mail stored on external storage we are getting missing blob because according to Zimbra 10 Storage Management locator values format should be volume_id@@mailbox_id/file_name for external volume but there is only external volume id present in the locator, according to zimbra9 standard.

Solution:
We update locators in the mail_item table for external volumes only to read blobs from external storage according to Zimbra 10 Storage Management implementation.
This utility will work with having the below argument.
Update locator based on account, selected mailbox and all mailboxes

Link to another Part1 PR : https://github.com/Zimbra/zm-mailbox/pull/1512
