### PR TITLE
ZCS-13783 : Update locator for external storage

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1536,6 +1536,8 @@ public final class LC {
     public final static KnownKey zimbra_sm_blob_mover_parallelism_level = KnownKey.newKey(5);
     public final static KnownKey zimbra_s3_connection_request_timeout_ms = KnownKey.newKey(20000);
 
+    public final static KnownKey zimbra_10_locator_upgrade_thread_count = KnownKey.newKey(5);
+
     // ZBUG-2547 : zimbra_strict_unclosed_comment_tag if this is false we relax rule
     // of allowing unclosed tag based on zimbra_skip_tags_with_unclosed_cdata value
     // zimbra_skip_tags_with_unclosed_cdata : Set values , based on this tags would be checked for closed comment


### PR DESCRIPTION
Problem: After the Zimbra 10 in-place upgrade, When we try to read those mail stored on external storage we are getting missing blob because according to Zimbra 10 Storage Management locator values format should be volume_id@@mailbox_id/file_name for external volume but there is only external volume id present in the locator, according to zimbra9 standard.

Solution:
We update locators in the mail_item table for external volumes only to read blobs from external storage according to Zimbra 10 Storage Management implementation. The porter application calls the newly created soap api for this.

This LC attribute defines the number of threads the executor uses for running parallel tasks

Link to another PR: [zm-modules-porter](https://github.com/Zimbra/zm-modules-porter/pull/44)