### PR TITLE
ZCS-13934: updated soap apis to match new license deployment

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -14785,6 +14785,14 @@ public class ZAttrProvisioning {
     public static final String A_zimbraPrefPowerPasteEnabled = "zimbraPrefPowerPasteEnabled";
 
     /**
+     * what method is primary for 2FA on an account: app or email
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4104)
+    public static final String A_zimbraPrefPrimaryTwoFactorAuthMethod = "zimbraPrefPrimaryTwoFactorAuthMethod";
+
+    /**
      * quick command encoded by the client
      *
      * @since ZCS 8.0.0
@@ -17941,6 +17949,22 @@ public class ZAttrProvisioning {
     public static final String A_zimbraTwoFactorAuthLockoutMaxFailures = "zimbraTwoFactorAuthLockoutMaxFailures";
 
     /**
+     * Methods allowed for 2FA: app and/or email
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4102)
+    public static final String A_zimbraTwoFactorAuthMethodAllowed = "zimbraTwoFactorAuthMethodAllowed";
+
+    /**
+     * What 2FA method is enabled by user: app and/or email
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4103)
+    public static final String A_zimbraTwoFactorAuthMethodEnabled = "zimbraTwoFactorAuthMethodEnabled";
+
+    /**
      * number of scratch codes to generate for two-factor auth
      *
      * @since ZCS 8.7.0,9.0.0
@@ -18029,6 +18053,38 @@ public class ZAttrProvisioning {
     public static final String A_zimbraTwoFactorAuthTrustedDeviceTokenLifetime = "zimbraTwoFactorAuthTrustedDeviceTokenLifetime";
 
     /**
+     * Define body: field for 2FA email
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4109)
+    public static final String A_zimbraTwoFactorCodeEmailBody = "zimbraTwoFactorCodeEmailBody";
+
+    /**
+     * Define from: field for 2FA email
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4107)
+    public static final String A_zimbraTwoFactorCodeEmailFrom = "zimbraTwoFactorCodeEmailFrom";
+
+    /**
+     * Define subject: field for 2FA email
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4108)
+    public static final String A_zimbraTwoFactorCodeEmailSubject = "zimbraTwoFactorCodeEmailSubject";
+
+    /**
+     * 2FA code for email
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4106)
+    public static final String A_zimbraTwoFactorCodeForEmail = "zimbraTwoFactorCodeForEmail";
+
+    /**
      * Length of TOTP code required for two-factor authentication. Keep at 6
      * for compatability with common TOTP clients.
      *
@@ -18036,6 +18092,17 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=1828)
     public static final String A_zimbraTwoFactorCodeLength = "zimbraTwoFactorCodeLength";
+
+    /**
+     * Duration of 2FA code for email. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4105)
+    public static final String A_zimbraTwoFactorCodeLifetimeForEmail = "zimbraTwoFactorCodeLifetimeForEmail";
 
     /**
      * length of scratch codes

--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -502,6 +502,8 @@ public final class AdminConstants {
     public static final String E_INSTALL_LICENSE_REQUEST = "InstallLicenseRequest";
     public static final String E_INSTALL_LICENSE_RESPONSE = "InstallLicenseResponse";
     public static final String E_ACTIVATE_LICENSE_REQUEST = "ActivateLicenseRequest";
+    public static final String E_GET_OFFLINE_LICENSE_CERTIFICATE_REQUEST = "GetOfflineLicenseCertificateRequest";
+    public static final String E_GET_OFFLINE_LICENSE_CERTIFICATE_RESPONSE = "GetOfflineLicenseCertificateResponse";
     public static final String E_ACTIVATE_LICENSE_RESPONSE = "ActivateLicenseResponse";
     public static final String E_GET_LICENSE_REQUEST = "GetLicenseRequest";
     public static final String E_GET_LICENSE_RESPONSE = "GetLicenseResponse";
@@ -1015,6 +1017,8 @@ public final class AdminConstants {
     public static final QName ACTIVATE_LICENSE_RESPONSE = QName.get(E_ACTIVATE_LICENSE_RESPONSE, NAMESPACE);
     public static final QName GET_LICENSE_REQUEST = QName.get(E_GET_LICENSE_REQUEST, NAMESPACE);
     public static final QName GET_LICENSE_RESPONSE = QName.get(E_GET_LICENSE_RESPONSE, NAMESPACE);
+    public static final QName GET_OFFLINE_LICENSE_CERTIFICATE_REQUEST = QName.get(E_GET_OFFLINE_LICENSE_CERTIFICATE_REQUEST, NAMESPACE);
+    public static final QName GET_OFFLINE_LICENSE_CERTIFICATE_RESPONSE = QName.get(E_GET_OFFLINE_LICENSE_CERTIFICATE_RESPONSE, NAMESPACE);
 
     // Auto provision
     public static final QName AUTO_PROV_ACCOUNT_REQUEST = QName.get(E_AUTO_PROV_ACCOUNT_REQUEST, NAMESPACE);
@@ -1537,6 +1541,8 @@ public final class AdminConstants {
     public static final String E_CONTENT = "content";
     public static final String A_ATTACHMENT_ID = "aid";
     public static final String E_LICENSE = "license";
+    public static final String E_LICENSE_CODE = "licenseCode";
+    public static final String E_OFFLINE_LICENSE_ACTIVATION_REQUEST_CERTIFICATE = "activationRequestCertificate";
     public static final String E_ACTIVATION = "activation";
     public static final String E_INFO = "info";
     public static final String A_VALID_FROM = "validFrom";

--- a/soap/src/java/com/zimbra/soap/JaxbUtil.java
+++ b/soap/src/java/com/zimbra/soap/JaxbUtil.java
@@ -536,6 +536,8 @@ public final class JaxbUtil {
             com.zimbra.soap.admin.message.GetMailboxVolumesResponse.class,
             com.zimbra.soap.admin.message.GetMemcachedClientConfigRequest.class,
             com.zimbra.soap.admin.message.GetMemcachedClientConfigResponse.class,
+            com.zimbra.soap.admin.message.GetOfflineLicenseCertificateRequest.class,
+            com.zimbra.soap.admin.message.GetOfflineLicenseCertificateResponse.class,
             com.zimbra.soap.admin.message.GetOutgoingFilterRulesRequest.class,
             com.zimbra.soap.admin.message.GetOutgoingFilterRulesResponse.class,
             com.zimbra.soap.admin.message.GetQuotaUsageRequest.class,

--- a/soap/src/java/com/zimbra/soap/admin/message/ActivateLicenseRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/ActivateLicenseRequest.java
@@ -39,27 +39,31 @@ public class ActivateLicenseRequest {
     /**
      * @zm-api-field-description Content
      */
-    @XmlElement(name=AdminConstants.E_CONTENT /* content */, required=true)
+    @XmlElement(name=AdminConstants.E_CONTENT /* content */, required=false)
     private final AttachmentIdAttrib content;
+
+    @XmlElement(name=AdminConstants.E_LICENSE_CODE /* content */, required=false)
+    private final String licenseCode;
 
     /**
      * no-argument constructor wanted by JAXB
      */
     @SuppressWarnings("unused")
     private ActivateLicenseRequest() {
-        this((AttachmentIdAttrib) null);
+        this((AttachmentIdAttrib) null, null);
     }
 
-    public ActivateLicenseRequest(AttachmentIdAttrib content) {
+    public ActivateLicenseRequest(AttachmentIdAttrib content, String licenseCode) {
         this.content = content;
+        this.licenseCode = licenseCode;
     }
 
     public AttachmentIdAttrib getContent() { return content; }
 
     public MoreObjects.ToStringHelper addToStringInfo(
-                MoreObjects.ToStringHelper helper) {
+            MoreObjects.ToStringHelper helper) {
         return helper
-            .add("content", content);
+                .add("content", content);
     }
 
     @Override

--- a/soap/src/java/com/zimbra/soap/admin/message/GetOfflineLicenseCertificateRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/GetOfflineLicenseCertificateRequest.java
@@ -1,0 +1,51 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2023 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.soap.admin.message;
+
+
+import com.zimbra.common.soap.AdminConstants;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @zm-api-command-network-edition
+ * @zm-api-command-auth-required true
+ * @zm-api-command-admin-auth-required true
+ * @zm-api-command-description Get Offline License Certificate
+ */
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name= AdminConstants.E_GET_OFFLINE_LICENSE_CERTIFICATE_REQUEST)
+public class GetOfflineLicenseCertificateRequest {
+
+    /**
+     * @zm-api-field-description licenseCode
+     */
+    @XmlElement(name=AdminConstants.E_LICENSE_CODE /* licenseCode */, required=true)
+    private final String licenseCode;
+
+    public GetOfflineLicenseCertificateRequest() {
+        this.licenseCode = null;
+    }
+
+
+    public String getLicenseCode() {
+        return licenseCode;
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/GetOfflineLicenseCertificateResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/GetOfflineLicenseCertificateResponse.java
@@ -1,0 +1,50 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2023 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.soap.admin.message;
+
+
+import com.zimbra.common.soap.AdminConstants;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @zm-api-command-network-edition
+ * @zm-api-command-auth-required true
+ * @zm-api-command-admin-auth-required true
+ * @zm-api-command-description gets offline request license request certificate
+ */
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name= AdminConstants.E_GET_OFFLINE_LICENSE_CERTIFICATE_RESPONSE)
+public class GetOfflineLicenseCertificateResponse {
+
+    /**
+     * @zm-api-field-description licenseCode
+     */
+    @XmlElement(name=AdminConstants.E_OFFLINE_LICENSE_ACTIVATION_REQUEST_CERTIFICATE /* activationRequestCertificate */, required=true)
+    private final String activationRequestCertificate;
+
+    public GetOfflineLicenseCertificateResponse() {
+        this.activationRequestCertificate = null;
+    }
+
+    public String getActivationRequestCertificate() {
+        return activationRequestCertificate;
+    }
+}

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10391,4 +10391,37 @@ TODO: delete them permanently from here
   <desc>Whether retention policy feature is enabled</desc>
 </attr>
 
+<attr id="4102" name="zimbraTwoFactorAuthMethodAllowed" type="string" cardinality="multi" optionalIn="domain,cos,account" flags="accountCosDomainInherited,accountInfo" since="11.0.0">
+  <defaultCOSValue>app</defaultCOSValue>
+  <desc>Methods allowed for 2FA: app and/or email</desc>
+</attr>
+
+<attr id="4103" name="zimbraTwoFactorAuthMethodEnabled" type="string" cardinality="multi" optionalIn="account" flags="accountInfo" since="11.0.0">
+  <desc>What 2FA method is enabled by user: app and/or email</desc>
+</attr>
+
+<attr id="4104" name="zimbraPrefPrimaryTwoFactorAuthMethod" type="string" cardinality="single" optionalIn="domain,cos,account" flags="accountCosDomainInherited,accountInfo" since="11.0.0">
+  <desc>what method is primary for 2FA on an account: app or email</desc>
+</attr>
+
+<attr id="4105" name="zimbraTwoFactorCodeLifetimeForEmail" type="duration" cardinality="single" optionalIn="globalConfig,domain,cos,account" flags="domainInherited,accountCosDomainInherited" since="11.0.0">
+  <defaultCOSValue>120s</defaultCOSValue>
+  <desc>Duration of 2FA code for email</desc>
+</attr>
+
+<attr id="4106" name="zimbraTwoFactorCodeForEmail" type="string" cardinality="single" optionalIn="account" since="11.0.0">
+  <desc>2FA code for email</desc>
+</attr>
+
+<attr id="4107" name="zimbraTwoFactorCodeEmailFrom" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited" since="11.0.0">
+  <desc>Define from: field for 2FA email</desc>
+</attr>
+
+<attr id="4108" name="zimbraTwoFactorCodeEmailSubject" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited" since="11.0.0">
+  <desc>Define subject: field for 2FA email</desc>
+</attr>
+
+<attr id="4109" name="zimbraTwoFactorCodeEmailBody" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited" since="11.0.0">
+  <desc>Define body: field for 2FA email</desc>
+</attr>
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -55679,6 +55679,78 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * what method is primary for 2FA on an account: app or email
+     *
+     * @return zimbraPrefPrimaryTwoFactorAuthMethod, or null if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4104)
+    public String getPrefPrimaryTwoFactorAuthMethod() {
+        return getAttr(Provisioning.A_zimbraPrefPrimaryTwoFactorAuthMethod, null, true);
+    }
+
+    /**
+     * what method is primary for 2FA on an account: app or email
+     *
+     * @param zimbraPrefPrimaryTwoFactorAuthMethod new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4104)
+    public void setPrefPrimaryTwoFactorAuthMethod(String zimbraPrefPrimaryTwoFactorAuthMethod) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefPrimaryTwoFactorAuthMethod, zimbraPrefPrimaryTwoFactorAuthMethod);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * what method is primary for 2FA on an account: app or email
+     *
+     * @param zimbraPrefPrimaryTwoFactorAuthMethod new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4104)
+    public Map<String,Object> setPrefPrimaryTwoFactorAuthMethod(String zimbraPrefPrimaryTwoFactorAuthMethod, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefPrimaryTwoFactorAuthMethod, zimbraPrefPrimaryTwoFactorAuthMethod);
+        return attrs;
+    }
+
+    /**
+     * what method is primary for 2FA on an account: app or email
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4104)
+    public void unsetPrefPrimaryTwoFactorAuthMethod() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefPrimaryTwoFactorAuthMethod, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * what method is primary for 2FA on an account: app or email
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4104)
+    public Map<String,Object> unsetPrefPrimaryTwoFactorAuthMethod(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefPrimaryTwoFactorAuthMethod, "");
+        return attrs;
+    }
+
+    /**
      * quick command encoded by the client
      *
      * @return zimbraPrefQuickCommand, or empty array if unset
@@ -64403,6 +64475,274 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * Methods allowed for 2FA: app and/or email
+     *
+     * @return zimbraTwoFactorAuthMethodAllowed, or empty array if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4102)
+    public String[] getTwoFactorAuthMethodAllowed() {
+        String[] value = getMultiAttr(Provisioning.A_zimbraTwoFactorAuthMethodAllowed, true, true); return value.length > 0 ? value : new String[] {"app"};
+    }
+
+    /**
+     * Methods allowed for 2FA: app and/or email
+     *
+     * @param zimbraTwoFactorAuthMethodAllowed new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4102)
+    public void setTwoFactorAuthMethodAllowed(String[] zimbraTwoFactorAuthMethodAllowed) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorAuthMethodAllowed, zimbraTwoFactorAuthMethodAllowed);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Methods allowed for 2FA: app and/or email
+     *
+     * @param zimbraTwoFactorAuthMethodAllowed new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4102)
+    public Map<String,Object> setTwoFactorAuthMethodAllowed(String[] zimbraTwoFactorAuthMethodAllowed, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorAuthMethodAllowed, zimbraTwoFactorAuthMethodAllowed);
+        return attrs;
+    }
+
+    /**
+     * Methods allowed for 2FA: app and/or email
+     *
+     * @param zimbraTwoFactorAuthMethodAllowed new to add to existing values
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4102)
+    public void addTwoFactorAuthMethodAllowed(String zimbraTwoFactorAuthMethodAllowed) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraTwoFactorAuthMethodAllowed, zimbraTwoFactorAuthMethodAllowed);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Methods allowed for 2FA: app and/or email
+     *
+     * @param zimbraTwoFactorAuthMethodAllowed new to add to existing values
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4102)
+    public Map<String,Object> addTwoFactorAuthMethodAllowed(String zimbraTwoFactorAuthMethodAllowed, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraTwoFactorAuthMethodAllowed, zimbraTwoFactorAuthMethodAllowed);
+        return attrs;
+    }
+
+    /**
+     * Methods allowed for 2FA: app and/or email
+     *
+     * @param zimbraTwoFactorAuthMethodAllowed existing value to remove
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4102)
+    public void removeTwoFactorAuthMethodAllowed(String zimbraTwoFactorAuthMethodAllowed) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraTwoFactorAuthMethodAllowed, zimbraTwoFactorAuthMethodAllowed);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Methods allowed for 2FA: app and/or email
+     *
+     * @param zimbraTwoFactorAuthMethodAllowed existing value to remove
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4102)
+    public Map<String,Object> removeTwoFactorAuthMethodAllowed(String zimbraTwoFactorAuthMethodAllowed, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraTwoFactorAuthMethodAllowed, zimbraTwoFactorAuthMethodAllowed);
+        return attrs;
+    }
+
+    /**
+     * Methods allowed for 2FA: app and/or email
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4102)
+    public void unsetTwoFactorAuthMethodAllowed() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorAuthMethodAllowed, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Methods allowed for 2FA: app and/or email
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4102)
+    public Map<String,Object> unsetTwoFactorAuthMethodAllowed(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorAuthMethodAllowed, "");
+        return attrs;
+    }
+
+    /**
+     * What 2FA method is enabled by user: app and/or email
+     *
+     * @return zimbraTwoFactorAuthMethodEnabled, or empty array if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4103)
+    public String[] getTwoFactorAuthMethodEnabled() {
+        return getMultiAttr(Provisioning.A_zimbraTwoFactorAuthMethodEnabled, true, true);
+    }
+
+    /**
+     * What 2FA method is enabled by user: app and/or email
+     *
+     * @param zimbraTwoFactorAuthMethodEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4103)
+    public void setTwoFactorAuthMethodEnabled(String[] zimbraTwoFactorAuthMethodEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorAuthMethodEnabled, zimbraTwoFactorAuthMethodEnabled);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * What 2FA method is enabled by user: app and/or email
+     *
+     * @param zimbraTwoFactorAuthMethodEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4103)
+    public Map<String,Object> setTwoFactorAuthMethodEnabled(String[] zimbraTwoFactorAuthMethodEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorAuthMethodEnabled, zimbraTwoFactorAuthMethodEnabled);
+        return attrs;
+    }
+
+    /**
+     * What 2FA method is enabled by user: app and/or email
+     *
+     * @param zimbraTwoFactorAuthMethodEnabled new to add to existing values
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4103)
+    public void addTwoFactorAuthMethodEnabled(String zimbraTwoFactorAuthMethodEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraTwoFactorAuthMethodEnabled, zimbraTwoFactorAuthMethodEnabled);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * What 2FA method is enabled by user: app and/or email
+     *
+     * @param zimbraTwoFactorAuthMethodEnabled new to add to existing values
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4103)
+    public Map<String,Object> addTwoFactorAuthMethodEnabled(String zimbraTwoFactorAuthMethodEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraTwoFactorAuthMethodEnabled, zimbraTwoFactorAuthMethodEnabled);
+        return attrs;
+    }
+
+    /**
+     * What 2FA method is enabled by user: app and/or email
+     *
+     * @param zimbraTwoFactorAuthMethodEnabled existing value to remove
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4103)
+    public void removeTwoFactorAuthMethodEnabled(String zimbraTwoFactorAuthMethodEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraTwoFactorAuthMethodEnabled, zimbraTwoFactorAuthMethodEnabled);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * What 2FA method is enabled by user: app and/or email
+     *
+     * @param zimbraTwoFactorAuthMethodEnabled existing value to remove
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4103)
+    public Map<String,Object> removeTwoFactorAuthMethodEnabled(String zimbraTwoFactorAuthMethodEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraTwoFactorAuthMethodEnabled, zimbraTwoFactorAuthMethodEnabled);
+        return attrs;
+    }
+
+    /**
+     * What 2FA method is enabled by user: app and/or email
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4103)
+    public void unsetTwoFactorAuthMethodEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorAuthMethodEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * What 2FA method is enabled by user: app and/or email
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4103)
+    public Map<String,Object> unsetTwoFactorAuthMethodEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorAuthMethodEnabled, "");
+        return attrs;
+    }
+
+    /**
      * number of scratch codes to generate for two-factor auth
      *
      * @return zimbraTwoFactorAuthNumScratchCodes, or 10 if unset
@@ -64967,6 +65307,184 @@ public abstract class ZAttrAccount  extends MailTarget {
     public Map<String,Object> unsetTwoFactorAuthTrustedDevices(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraTwoFactorAuthTrustedDevices, "");
+        return attrs;
+    }
+
+    /**
+     * 2FA code for email
+     *
+     * @return zimbraTwoFactorCodeForEmail, or null if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4106)
+    public String getTwoFactorCodeForEmail() {
+        return getAttr(Provisioning.A_zimbraTwoFactorCodeForEmail, null, true);
+    }
+
+    /**
+     * 2FA code for email
+     *
+     * @param zimbraTwoFactorCodeForEmail new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4106)
+    public void setTwoFactorCodeForEmail(String zimbraTwoFactorCodeForEmail) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeForEmail, zimbraTwoFactorCodeForEmail);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * 2FA code for email
+     *
+     * @param zimbraTwoFactorCodeForEmail new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4106)
+    public Map<String,Object> setTwoFactorCodeForEmail(String zimbraTwoFactorCodeForEmail, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeForEmail, zimbraTwoFactorCodeForEmail);
+        return attrs;
+    }
+
+    /**
+     * 2FA code for email
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4106)
+    public void unsetTwoFactorCodeForEmail() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeForEmail, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * 2FA code for email
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4106)
+    public Map<String,Object> unsetTwoFactorCodeForEmail(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeForEmail, "");
+        return attrs;
+    }
+
+    /**
+     * Duration of 2FA code for email. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * <p>Use getTwoFactorCodeLifetimeForEmailAsString to access value as a string.
+     *
+     * @see #getTwoFactorCodeLifetimeForEmailAsString()
+     *
+     * @return zimbraTwoFactorCodeLifetimeForEmail in millseconds, or 120000 (120s)  if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4105)
+    public long getTwoFactorCodeLifetimeForEmail() {
+        return getTimeInterval(Provisioning.A_zimbraTwoFactorCodeLifetimeForEmail, 120000L, true);
+    }
+
+    /**
+     * Duration of 2FA code for email. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @return zimbraTwoFactorCodeLifetimeForEmail, or "120s" if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4105)
+    public String getTwoFactorCodeLifetimeForEmailAsString() {
+        return getAttr(Provisioning.A_zimbraTwoFactorCodeLifetimeForEmail, "120s", true);
+    }
+
+    /**
+     * Duration of 2FA code for email. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @param zimbraTwoFactorCodeLifetimeForEmail new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4105)
+    public void setTwoFactorCodeLifetimeForEmail(String zimbraTwoFactorCodeLifetimeForEmail) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeLifetimeForEmail, zimbraTwoFactorCodeLifetimeForEmail);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Duration of 2FA code for email. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @param zimbraTwoFactorCodeLifetimeForEmail new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4105)
+    public Map<String,Object> setTwoFactorCodeLifetimeForEmail(String zimbraTwoFactorCodeLifetimeForEmail, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeLifetimeForEmail, zimbraTwoFactorCodeLifetimeForEmail);
+        return attrs;
+    }
+
+    /**
+     * Duration of 2FA code for email. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4105)
+    public void unsetTwoFactorCodeLifetimeForEmail() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeLifetimeForEmail, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Duration of 2FA code for email. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4105)
+    public Map<String,Object> unsetTwoFactorCodeLifetimeForEmail(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeLifetimeForEmail, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -78522,6 +78522,222 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Define body: field for 2FA email
+     *
+     * @return zimbraTwoFactorCodeEmailBody, or null if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4109)
+    public String getTwoFactorCodeEmailBody() {
+        return getAttr(Provisioning.A_zimbraTwoFactorCodeEmailBody, null, true);
+    }
+
+    /**
+     * Define body: field for 2FA email
+     *
+     * @param zimbraTwoFactorCodeEmailBody new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4109)
+    public void setTwoFactorCodeEmailBody(String zimbraTwoFactorCodeEmailBody) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeEmailBody, zimbraTwoFactorCodeEmailBody);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Define body: field for 2FA email
+     *
+     * @param zimbraTwoFactorCodeEmailBody new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4109)
+    public Map<String,Object> setTwoFactorCodeEmailBody(String zimbraTwoFactorCodeEmailBody, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeEmailBody, zimbraTwoFactorCodeEmailBody);
+        return attrs;
+    }
+
+    /**
+     * Define body: field for 2FA email
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4109)
+    public void unsetTwoFactorCodeEmailBody() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeEmailBody, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Define body: field for 2FA email
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4109)
+    public Map<String,Object> unsetTwoFactorCodeEmailBody(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeEmailBody, "");
+        return attrs;
+    }
+
+    /**
+     * Define from: field for 2FA email
+     *
+     * @return zimbraTwoFactorCodeEmailFrom, or null if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4107)
+    public String getTwoFactorCodeEmailFrom() {
+        return getAttr(Provisioning.A_zimbraTwoFactorCodeEmailFrom, null, true);
+    }
+
+    /**
+     * Define from: field for 2FA email
+     *
+     * @param zimbraTwoFactorCodeEmailFrom new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4107)
+    public void setTwoFactorCodeEmailFrom(String zimbraTwoFactorCodeEmailFrom) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeEmailFrom, zimbraTwoFactorCodeEmailFrom);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Define from: field for 2FA email
+     *
+     * @param zimbraTwoFactorCodeEmailFrom new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4107)
+    public Map<String,Object> setTwoFactorCodeEmailFrom(String zimbraTwoFactorCodeEmailFrom, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeEmailFrom, zimbraTwoFactorCodeEmailFrom);
+        return attrs;
+    }
+
+    /**
+     * Define from: field for 2FA email
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4107)
+    public void unsetTwoFactorCodeEmailFrom() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeEmailFrom, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Define from: field for 2FA email
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4107)
+    public Map<String,Object> unsetTwoFactorCodeEmailFrom(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeEmailFrom, "");
+        return attrs;
+    }
+
+    /**
+     * Define subject: field for 2FA email
+     *
+     * @return zimbraTwoFactorCodeEmailSubject, or null if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4108)
+    public String getTwoFactorCodeEmailSubject() {
+        return getAttr(Provisioning.A_zimbraTwoFactorCodeEmailSubject, null, true);
+    }
+
+    /**
+     * Define subject: field for 2FA email
+     *
+     * @param zimbraTwoFactorCodeEmailSubject new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4108)
+    public void setTwoFactorCodeEmailSubject(String zimbraTwoFactorCodeEmailSubject) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeEmailSubject, zimbraTwoFactorCodeEmailSubject);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Define subject: field for 2FA email
+     *
+     * @param zimbraTwoFactorCodeEmailSubject new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4108)
+    public Map<String,Object> setTwoFactorCodeEmailSubject(String zimbraTwoFactorCodeEmailSubject, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeEmailSubject, zimbraTwoFactorCodeEmailSubject);
+        return attrs;
+    }
+
+    /**
+     * Define subject: field for 2FA email
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4108)
+    public void unsetTwoFactorCodeEmailSubject() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeEmailSubject, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Define subject: field for 2FA email
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4108)
+    public Map<String,Object> unsetTwoFactorCodeEmailSubject(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeEmailSubject, "");
+        return attrs;
+    }
+
+    /**
      * Length of TOTP code required for two-factor authentication. Keep at 6
      * for compatability with common TOTP clients.
      *
@@ -78595,6 +78811,112 @@ public abstract class ZAttrConfig extends Entry {
     public Map<String,Object> unsetTwoFactorCodeLength(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraTwoFactorCodeLength, "");
+        return attrs;
+    }
+
+    /**
+     * Duration of 2FA code for email. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * <p>Use getTwoFactorCodeLifetimeForEmailAsString to access value as a string.
+     *
+     * @see #getTwoFactorCodeLifetimeForEmailAsString()
+     *
+     * @return zimbraTwoFactorCodeLifetimeForEmail in millseconds, or -1 if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4105)
+    public long getTwoFactorCodeLifetimeForEmail() {
+        return getTimeInterval(Provisioning.A_zimbraTwoFactorCodeLifetimeForEmail, -1L, true);
+    }
+
+    /**
+     * Duration of 2FA code for email. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @return zimbraTwoFactorCodeLifetimeForEmail, or null if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4105)
+    public String getTwoFactorCodeLifetimeForEmailAsString() {
+        return getAttr(Provisioning.A_zimbraTwoFactorCodeLifetimeForEmail, null, true);
+    }
+
+    /**
+     * Duration of 2FA code for email. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @param zimbraTwoFactorCodeLifetimeForEmail new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4105)
+    public void setTwoFactorCodeLifetimeForEmail(String zimbraTwoFactorCodeLifetimeForEmail) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeLifetimeForEmail, zimbraTwoFactorCodeLifetimeForEmail);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Duration of 2FA code for email. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @param zimbraTwoFactorCodeLifetimeForEmail new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4105)
+    public Map<String,Object> setTwoFactorCodeLifetimeForEmail(String zimbraTwoFactorCodeLifetimeForEmail, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeLifetimeForEmail, zimbraTwoFactorCodeLifetimeForEmail);
+        return attrs;
+    }
+
+    /**
+     * Duration of 2FA code for email. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4105)
+    public void unsetTwoFactorCodeLifetimeForEmail() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeLifetimeForEmail, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Duration of 2FA code for email. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4105)
+    public Map<String,Object> unsetTwoFactorCodeLifetimeForEmail(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeLifetimeForEmail, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -43280,6 +43280,78 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * what method is primary for 2FA on an account: app or email
+     *
+     * @return zimbraPrefPrimaryTwoFactorAuthMethod, or null if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4104)
+    public String getPrefPrimaryTwoFactorAuthMethod() {
+        return getAttr(Provisioning.A_zimbraPrefPrimaryTwoFactorAuthMethod, null, true);
+    }
+
+    /**
+     * what method is primary for 2FA on an account: app or email
+     *
+     * @param zimbraPrefPrimaryTwoFactorAuthMethod new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4104)
+    public void setPrefPrimaryTwoFactorAuthMethod(String zimbraPrefPrimaryTwoFactorAuthMethod) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefPrimaryTwoFactorAuthMethod, zimbraPrefPrimaryTwoFactorAuthMethod);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * what method is primary for 2FA on an account: app or email
+     *
+     * @param zimbraPrefPrimaryTwoFactorAuthMethod new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4104)
+    public Map<String,Object> setPrefPrimaryTwoFactorAuthMethod(String zimbraPrefPrimaryTwoFactorAuthMethod, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefPrimaryTwoFactorAuthMethod, zimbraPrefPrimaryTwoFactorAuthMethod);
+        return attrs;
+    }
+
+    /**
+     * what method is primary for 2FA on an account: app or email
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4104)
+    public void unsetPrefPrimaryTwoFactorAuthMethod() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefPrimaryTwoFactorAuthMethod, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * what method is primary for 2FA on an account: app or email
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4104)
+    public Map<String,Object> unsetPrefPrimaryTwoFactorAuthMethod(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefPrimaryTwoFactorAuthMethod, "");
+        return attrs;
+    }
+
+    /**
      * Deprecated since: 6.0.0_BETA2. deprecated in favor of
      * zimbraPrefReadingPaneLocation and zimbraPrefConvReadingPaneLocation.
      * Orig desc: whether reading pane is shown by default
@@ -50065,6 +50137,140 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * Methods allowed for 2FA: app and/or email
+     *
+     * @return zimbraTwoFactorAuthMethodAllowed, or empty array if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4102)
+    public String[] getTwoFactorAuthMethodAllowed() {
+        String[] value = getMultiAttr(Provisioning.A_zimbraTwoFactorAuthMethodAllowed, true, true); return value.length > 0 ? value : new String[] {"app"};
+    }
+
+    /**
+     * Methods allowed for 2FA: app and/or email
+     *
+     * @param zimbraTwoFactorAuthMethodAllowed new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4102)
+    public void setTwoFactorAuthMethodAllowed(String[] zimbraTwoFactorAuthMethodAllowed) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorAuthMethodAllowed, zimbraTwoFactorAuthMethodAllowed);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Methods allowed for 2FA: app and/or email
+     *
+     * @param zimbraTwoFactorAuthMethodAllowed new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4102)
+    public Map<String,Object> setTwoFactorAuthMethodAllowed(String[] zimbraTwoFactorAuthMethodAllowed, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorAuthMethodAllowed, zimbraTwoFactorAuthMethodAllowed);
+        return attrs;
+    }
+
+    /**
+     * Methods allowed for 2FA: app and/or email
+     *
+     * @param zimbraTwoFactorAuthMethodAllowed new to add to existing values
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4102)
+    public void addTwoFactorAuthMethodAllowed(String zimbraTwoFactorAuthMethodAllowed) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraTwoFactorAuthMethodAllowed, zimbraTwoFactorAuthMethodAllowed);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Methods allowed for 2FA: app and/or email
+     *
+     * @param zimbraTwoFactorAuthMethodAllowed new to add to existing values
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4102)
+    public Map<String,Object> addTwoFactorAuthMethodAllowed(String zimbraTwoFactorAuthMethodAllowed, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraTwoFactorAuthMethodAllowed, zimbraTwoFactorAuthMethodAllowed);
+        return attrs;
+    }
+
+    /**
+     * Methods allowed for 2FA: app and/or email
+     *
+     * @param zimbraTwoFactorAuthMethodAllowed existing value to remove
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4102)
+    public void removeTwoFactorAuthMethodAllowed(String zimbraTwoFactorAuthMethodAllowed) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraTwoFactorAuthMethodAllowed, zimbraTwoFactorAuthMethodAllowed);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Methods allowed for 2FA: app and/or email
+     *
+     * @param zimbraTwoFactorAuthMethodAllowed existing value to remove
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4102)
+    public Map<String,Object> removeTwoFactorAuthMethodAllowed(String zimbraTwoFactorAuthMethodAllowed, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraTwoFactorAuthMethodAllowed, zimbraTwoFactorAuthMethodAllowed);
+        return attrs;
+    }
+
+    /**
+     * Methods allowed for 2FA: app and/or email
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4102)
+    public void unsetTwoFactorAuthMethodAllowed() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorAuthMethodAllowed, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Methods allowed for 2FA: app and/or email
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4102)
+    public Map<String,Object> unsetTwoFactorAuthMethodAllowed(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorAuthMethodAllowed, "");
+        return attrs;
+    }
+
+    /**
      * number of scratch codes to generate for two-factor auth
      *
      * @return zimbraTwoFactorAuthNumScratchCodes, or 10 if unset
@@ -50351,6 +50557,112 @@ public abstract class ZAttrCos extends NamedEntry {
     public Map<String,Object> unsetTwoFactorAuthTrustedDeviceTokenLifetime(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraTwoFactorAuthTrustedDeviceTokenLifetime, "");
+        return attrs;
+    }
+
+    /**
+     * Duration of 2FA code for email. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * <p>Use getTwoFactorCodeLifetimeForEmailAsString to access value as a string.
+     *
+     * @see #getTwoFactorCodeLifetimeForEmailAsString()
+     *
+     * @return zimbraTwoFactorCodeLifetimeForEmail in millseconds, or 120000 (120s)  if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4105)
+    public long getTwoFactorCodeLifetimeForEmail() {
+        return getTimeInterval(Provisioning.A_zimbraTwoFactorCodeLifetimeForEmail, 120000L, true);
+    }
+
+    /**
+     * Duration of 2FA code for email. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @return zimbraTwoFactorCodeLifetimeForEmail, or "120s" if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4105)
+    public String getTwoFactorCodeLifetimeForEmailAsString() {
+        return getAttr(Provisioning.A_zimbraTwoFactorCodeLifetimeForEmail, "120s", true);
+    }
+
+    /**
+     * Duration of 2FA code for email. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @param zimbraTwoFactorCodeLifetimeForEmail new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4105)
+    public void setTwoFactorCodeLifetimeForEmail(String zimbraTwoFactorCodeLifetimeForEmail) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeLifetimeForEmail, zimbraTwoFactorCodeLifetimeForEmail);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Duration of 2FA code for email. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @param zimbraTwoFactorCodeLifetimeForEmail new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4105)
+    public Map<String,Object> setTwoFactorCodeLifetimeForEmail(String zimbraTwoFactorCodeLifetimeForEmail, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeLifetimeForEmail, zimbraTwoFactorCodeLifetimeForEmail);
+        return attrs;
+    }
+
+    /**
+     * Duration of 2FA code for email. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4105)
+    public void unsetTwoFactorCodeLifetimeForEmail() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeLifetimeForEmail, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Duration of 2FA code for email. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4105)
+    public Map<String,Object> unsetTwoFactorCodeLifetimeForEmail(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeLifetimeForEmail, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -20391,6 +20391,78 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
+     * what method is primary for 2FA on an account: app or email
+     *
+     * @return zimbraPrefPrimaryTwoFactorAuthMethod, or null if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4104)
+    public String getPrefPrimaryTwoFactorAuthMethod() {
+        return getAttr(Provisioning.A_zimbraPrefPrimaryTwoFactorAuthMethod, null, true);
+    }
+
+    /**
+     * what method is primary for 2FA on an account: app or email
+     *
+     * @param zimbraPrefPrimaryTwoFactorAuthMethod new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4104)
+    public void setPrefPrimaryTwoFactorAuthMethod(String zimbraPrefPrimaryTwoFactorAuthMethod) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefPrimaryTwoFactorAuthMethod, zimbraPrefPrimaryTwoFactorAuthMethod);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * what method is primary for 2FA on an account: app or email
+     *
+     * @param zimbraPrefPrimaryTwoFactorAuthMethod new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4104)
+    public Map<String,Object> setPrefPrimaryTwoFactorAuthMethod(String zimbraPrefPrimaryTwoFactorAuthMethod, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefPrimaryTwoFactorAuthMethod, zimbraPrefPrimaryTwoFactorAuthMethod);
+        return attrs;
+    }
+
+    /**
+     * what method is primary for 2FA on an account: app or email
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4104)
+    public void unsetPrefPrimaryTwoFactorAuthMethod() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefPrimaryTwoFactorAuthMethod, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * what method is primary for 2FA on an account: app or email
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4104)
+    public Map<String,Object> unsetPrefPrimaryTwoFactorAuthMethod(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefPrimaryTwoFactorAuthMethod, "");
+        return attrs;
+    }
+
+    /**
      * Show Chats folder even if zimbraFeatureIMEnabled is false
      *
      * @return zimbraPrefShowChatsFolderInMail, or false if unset
@@ -26380,6 +26452,462 @@ public abstract class ZAttrDomain extends NamedEntry {
     public Map<String,Object> unsetTrialExpirationDate(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraTrialExpirationDate, "");
+        return attrs;
+    }
+
+    /**
+     * Methods allowed for 2FA: app and/or email
+     *
+     * @return zimbraTwoFactorAuthMethodAllowed, or empty array if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4102)
+    public String[] getTwoFactorAuthMethodAllowed() {
+        return getMultiAttr(Provisioning.A_zimbraTwoFactorAuthMethodAllowed, true, true);
+    }
+
+    /**
+     * Methods allowed for 2FA: app and/or email
+     *
+     * @param zimbraTwoFactorAuthMethodAllowed new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4102)
+    public void setTwoFactorAuthMethodAllowed(String[] zimbraTwoFactorAuthMethodAllowed) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorAuthMethodAllowed, zimbraTwoFactorAuthMethodAllowed);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Methods allowed for 2FA: app and/or email
+     *
+     * @param zimbraTwoFactorAuthMethodAllowed new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4102)
+    public Map<String,Object> setTwoFactorAuthMethodAllowed(String[] zimbraTwoFactorAuthMethodAllowed, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorAuthMethodAllowed, zimbraTwoFactorAuthMethodAllowed);
+        return attrs;
+    }
+
+    /**
+     * Methods allowed for 2FA: app and/or email
+     *
+     * @param zimbraTwoFactorAuthMethodAllowed new to add to existing values
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4102)
+    public void addTwoFactorAuthMethodAllowed(String zimbraTwoFactorAuthMethodAllowed) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraTwoFactorAuthMethodAllowed, zimbraTwoFactorAuthMethodAllowed);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Methods allowed for 2FA: app and/or email
+     *
+     * @param zimbraTwoFactorAuthMethodAllowed new to add to existing values
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4102)
+    public Map<String,Object> addTwoFactorAuthMethodAllowed(String zimbraTwoFactorAuthMethodAllowed, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraTwoFactorAuthMethodAllowed, zimbraTwoFactorAuthMethodAllowed);
+        return attrs;
+    }
+
+    /**
+     * Methods allowed for 2FA: app and/or email
+     *
+     * @param zimbraTwoFactorAuthMethodAllowed existing value to remove
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4102)
+    public void removeTwoFactorAuthMethodAllowed(String zimbraTwoFactorAuthMethodAllowed) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraTwoFactorAuthMethodAllowed, zimbraTwoFactorAuthMethodAllowed);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Methods allowed for 2FA: app and/or email
+     *
+     * @param zimbraTwoFactorAuthMethodAllowed existing value to remove
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4102)
+    public Map<String,Object> removeTwoFactorAuthMethodAllowed(String zimbraTwoFactorAuthMethodAllowed, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraTwoFactorAuthMethodAllowed, zimbraTwoFactorAuthMethodAllowed);
+        return attrs;
+    }
+
+    /**
+     * Methods allowed for 2FA: app and/or email
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4102)
+    public void unsetTwoFactorAuthMethodAllowed() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorAuthMethodAllowed, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Methods allowed for 2FA: app and/or email
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4102)
+    public Map<String,Object> unsetTwoFactorAuthMethodAllowed(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorAuthMethodAllowed, "");
+        return attrs;
+    }
+
+    /**
+     * Define body: field for 2FA email
+     *
+     * @return zimbraTwoFactorCodeEmailBody, or null if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4109)
+    public String getTwoFactorCodeEmailBody() {
+        return getAttr(Provisioning.A_zimbraTwoFactorCodeEmailBody, null, true);
+    }
+
+    /**
+     * Define body: field for 2FA email
+     *
+     * @param zimbraTwoFactorCodeEmailBody new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4109)
+    public void setTwoFactorCodeEmailBody(String zimbraTwoFactorCodeEmailBody) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeEmailBody, zimbraTwoFactorCodeEmailBody);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Define body: field for 2FA email
+     *
+     * @param zimbraTwoFactorCodeEmailBody new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4109)
+    public Map<String,Object> setTwoFactorCodeEmailBody(String zimbraTwoFactorCodeEmailBody, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeEmailBody, zimbraTwoFactorCodeEmailBody);
+        return attrs;
+    }
+
+    /**
+     * Define body: field for 2FA email
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4109)
+    public void unsetTwoFactorCodeEmailBody() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeEmailBody, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Define body: field for 2FA email
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4109)
+    public Map<String,Object> unsetTwoFactorCodeEmailBody(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeEmailBody, "");
+        return attrs;
+    }
+
+    /**
+     * Define from: field for 2FA email
+     *
+     * @return zimbraTwoFactorCodeEmailFrom, or null if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4107)
+    public String getTwoFactorCodeEmailFrom() {
+        return getAttr(Provisioning.A_zimbraTwoFactorCodeEmailFrom, null, true);
+    }
+
+    /**
+     * Define from: field for 2FA email
+     *
+     * @param zimbraTwoFactorCodeEmailFrom new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4107)
+    public void setTwoFactorCodeEmailFrom(String zimbraTwoFactorCodeEmailFrom) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeEmailFrom, zimbraTwoFactorCodeEmailFrom);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Define from: field for 2FA email
+     *
+     * @param zimbraTwoFactorCodeEmailFrom new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4107)
+    public Map<String,Object> setTwoFactorCodeEmailFrom(String zimbraTwoFactorCodeEmailFrom, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeEmailFrom, zimbraTwoFactorCodeEmailFrom);
+        return attrs;
+    }
+
+    /**
+     * Define from: field for 2FA email
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4107)
+    public void unsetTwoFactorCodeEmailFrom() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeEmailFrom, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Define from: field for 2FA email
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4107)
+    public Map<String,Object> unsetTwoFactorCodeEmailFrom(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeEmailFrom, "");
+        return attrs;
+    }
+
+    /**
+     * Define subject: field for 2FA email
+     *
+     * @return zimbraTwoFactorCodeEmailSubject, or null if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4108)
+    public String getTwoFactorCodeEmailSubject() {
+        return getAttr(Provisioning.A_zimbraTwoFactorCodeEmailSubject, null, true);
+    }
+
+    /**
+     * Define subject: field for 2FA email
+     *
+     * @param zimbraTwoFactorCodeEmailSubject new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4108)
+    public void setTwoFactorCodeEmailSubject(String zimbraTwoFactorCodeEmailSubject) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeEmailSubject, zimbraTwoFactorCodeEmailSubject);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Define subject: field for 2FA email
+     *
+     * @param zimbraTwoFactorCodeEmailSubject new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4108)
+    public Map<String,Object> setTwoFactorCodeEmailSubject(String zimbraTwoFactorCodeEmailSubject, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeEmailSubject, zimbraTwoFactorCodeEmailSubject);
+        return attrs;
+    }
+
+    /**
+     * Define subject: field for 2FA email
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4108)
+    public void unsetTwoFactorCodeEmailSubject() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeEmailSubject, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Define subject: field for 2FA email
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4108)
+    public Map<String,Object> unsetTwoFactorCodeEmailSubject(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeEmailSubject, "");
+        return attrs;
+    }
+
+    /**
+     * Duration of 2FA code for email. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * <p>Use getTwoFactorCodeLifetimeForEmailAsString to access value as a string.
+     *
+     * @see #getTwoFactorCodeLifetimeForEmailAsString()
+     *
+     * @return zimbraTwoFactorCodeLifetimeForEmail in millseconds, or -1 if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4105)
+    public long getTwoFactorCodeLifetimeForEmail() {
+        return getTimeInterval(Provisioning.A_zimbraTwoFactorCodeLifetimeForEmail, -1L, true);
+    }
+
+    /**
+     * Duration of 2FA code for email. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @return zimbraTwoFactorCodeLifetimeForEmail, or null if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4105)
+    public String getTwoFactorCodeLifetimeForEmailAsString() {
+        return getAttr(Provisioning.A_zimbraTwoFactorCodeLifetimeForEmail, null, true);
+    }
+
+    /**
+     * Duration of 2FA code for email. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @param zimbraTwoFactorCodeLifetimeForEmail new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4105)
+    public void setTwoFactorCodeLifetimeForEmail(String zimbraTwoFactorCodeLifetimeForEmail) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeLifetimeForEmail, zimbraTwoFactorCodeLifetimeForEmail);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Duration of 2FA code for email. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @param zimbraTwoFactorCodeLifetimeForEmail new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4105)
+    public Map<String,Object> setTwoFactorCodeLifetimeForEmail(String zimbraTwoFactorCodeLifetimeForEmail, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeLifetimeForEmail, zimbraTwoFactorCodeLifetimeForEmail);
+        return attrs;
+    }
+
+    /**
+     * Duration of 2FA code for email. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4105)
+    public void unsetTwoFactorCodeLifetimeForEmail() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeLifetimeForEmail, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Duration of 2FA code for email. Must be in valid duration format:
+     * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -
+     * minutes, s - seconds, d - days, ms - milliseconds. If time unit is not
+     * specified, the default is s(seconds).
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4105)
+    public Map<String,Object> unsetTwoFactorCodeLifetimeForEmail(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorCodeLifetimeForEmail, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/soap/RemovableDocumentService.java
+++ b/store/src/java/com/zimbra/soap/RemovableDocumentService.java
@@ -1,0 +1,22 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2023 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap;
+
+public interface RemovableDocumentService extends DocumentService{
+    void deregisterHandlers(DocumentDispatcher dispatcher);
+}

--- a/store/src/java/com/zimbra/soap/SoapServlet.java
+++ b/store/src/java/com/zimbra/soap/SoapServlet.java
@@ -17,22 +17,6 @@
 
 package com.zimbra.soap;
 
-import java.io.EOFException;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-
-import javax.servlet.ServletException;
-import javax.servlet.UnavailableException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import org.apache.http.HttpVersion;
-import org.apache.http.ParseException;
-import org.apache.http.ProtocolVersion;
-import org.apache.http.message.BasicLineParser;
-
 import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 import com.google.common.cache.CacheBuilder;
@@ -56,6 +40,20 @@ import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.servlet.ZimbraServlet;
 import com.zimbra.cs.stats.ZimbraPerf;
 import com.zimbra.cs.util.Zimbra;
+import org.apache.http.HttpVersion;
+import org.apache.http.ParseException;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.message.BasicLineParser;
+
+import javax.servlet.ServletException;
+import javax.servlet.UnavailableException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 
 /**
  * The soap service servlet
@@ -204,9 +202,25 @@ public class SoapServlet extends ZimbraServlet {
         }
     }
 
+    public static void removeService(String servletName, RemovableDocumentService service) {
+        synchronized (sExtraServices) {
+            ZimbraServlet servlet = ZimbraServlet.getServlet(servletName);
+            if (servlet != null) {
+                ((SoapServlet) servlet).removeService(service);
+            } else {
+                sLog.info("No servlet found with name: %s", servletName);
+            }
+        }
+    }
+
     private void addService(DocumentService service) {
         ZimbraLog.soap.info("Adding service %s to %s", service.getClass().getSimpleName(), getServletName());
         service.registerHandlers(mEngine.getDocumentDispatcher());
+    }
+
+    private void removeService(RemovableDocumentService service) {
+        ZimbraLog.soap.info("Removing service %s to %s", service.getClass().getSimpleName(), getServletName());
+        service.deregisterHandlers(mEngine.getDocumentDispatcher());
     }
 
     @Override public void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {


### PR DESCRIPTION
This SOAP API will fetch the `offline activation request` from daemon service. The `offline activation request` is passed along with license code to activate license in offline mode and fetch the license certificate. 