### PR TITLE
ZCS-13219:Add an LDAP attribute to hide aliases in GAL

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -8505,6 +8505,14 @@ public class ZAttrProvisioning {
     public static final String A_zimbraHelpStandardURL = "zimbraHelpStandardURL";
 
     /**
+     * When set to True, all aliases will be hidden for particular account
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4110)
+    public static final String A_zimbraHideAliasesInGal = "zimbraHideAliasesInGal";
+
+    /**
      * hide entry in Global Address List
      */
     @ZAttr(id=353)

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10454,4 +10454,9 @@ TODO: delete them permanently from here
 <attr id="4115" name="zimbraTwoFactorCodeEmailBodyHtml" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited" since="10.1.0">
   <desc>Define body: field for 2FA email in html format</desc>
 </attr>
+
+<attr id="4110" name="zimbraHideAliasesInGal" type="boolean" cardinality="single" optionalIn="account" flags="accountInfo" since="10.1.0">
+  <desc>When set to True, all aliases will be hidden for particular account</desc>
+</attr>
+
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -25552,6 +25552,78 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * When set to True, all aliases will be hidden for particular account
+     *
+     * @return zimbraHideAliasesInGal, or false if unset
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4110)
+    public boolean isHideAliasesInGal() {
+        return getBooleanAttr(Provisioning.A_zimbraHideAliasesInGal, false, true);
+    }
+
+    /**
+     * When set to True, all aliases will be hidden for particular account
+     *
+     * @param zimbraHideAliasesInGal new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4110)
+    public void setHideAliasesInGal(boolean zimbraHideAliasesInGal) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHideAliasesInGal, zimbraHideAliasesInGal ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * When set to True, all aliases will be hidden for particular account
+     *
+     * @param zimbraHideAliasesInGal new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4110)
+    public Map<String,Object> setHideAliasesInGal(boolean zimbraHideAliasesInGal, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHideAliasesInGal, zimbraHideAliasesInGal ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * When set to True, all aliases will be hidden for particular account
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4110)
+    public void unsetHideAliasesInGal() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHideAliasesInGal, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * When set to True, all aliases will be hidden for particular account
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4110)
+    public Map<String,Object> unsetHideAliasesInGal(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraHideAliasesInGal, "");
+        return attrs;
+    }
+
+    /**
      * hide entry in Global Address List
      *
      * @return zimbraHideInGal, or false if unset


### PR DESCRIPTION
Requirement of ticket [[ZCS-13219](https://synacor.atlassian.net/browse/ZCS-13219)]

Requirements:
Add a new LDAP attribute **zimbraHideAliasesInGal** of type boolean to hide only the aliases from GAL without affecting the user.

Solution:
Added a new LDAP attribute **zimbraHideAliasesInGal** of type boolean in _zimbra-attrs.xml_ class and its setters/getters are generated.

Testing:
Tested by installing the custom build on remote machine.

Link to ZimbraOS Repo PR:https://github.com/ZimbraOS/zm-mailbox/pull/608

[ZCS-13219]: https://synacor-sandbox-512.atlassian.net/browse/ZCS-13219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ