### PR TITLE
ZCS-14020: Returing 2FA attribute from Auth response

### DIFF
--- a/common/src/java/com/zimbra/common/soap/AccountConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AccountConstants.java
@@ -453,6 +453,7 @@ public class AccountConstants {
     public static final String A_LOCAL_NAME = "localName";
     public static final String A_MEMBER_OF = "memberOf";
     public static final String A_MORE = "more";
+    public static final String E_METHOD = "method";
     public static final String A_NEED_IS_OWNER = "needIsOwner";
     public static final String A_NEED_IS_MEMBER = "needIsMember";
     public static final String A_NEED_OWNERS = "needOwners";
@@ -652,4 +653,10 @@ public class AccountConstants {
     public static final String E_SKIN_SELECTION_COLOR = "zimbraSkinSelectionColor";
     public static final String E_SKIN_FAVICON = "zimbraSkinFavicon";
     public static final String E_HOSTNAME = "hostname";
+
+    // 2FA attributes
+    public static final String E_TWO_FACTOR_AUTH_METHOD_ALLOWED = "zimbraTwoFactorAuthMethodAllowed";
+    public static final String E_TWO_FACTOR_AUTH_METHOD_ENABLED = "zimbraTwoFactorAuthMethodEnabled";
+    public static final String E_PREF_PRIMARY_TWO_FACTOR_AUTH_METHOD = "zimbraPrefPrimaryTwoFactorAuthMethod";
+    public static final String E_PREF_PASSWORD_RECOVERY_ADDRESS = "zimbraPrefPasswordRecoveryAddress";
 }

--- a/soap/src/java/com/zimbra/soap/account/message/AuthResponse.java
+++ b/soap/src/java/com/zimbra/soap/account/message/AuthResponse.java
@@ -28,12 +28,15 @@ import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.zimbra.common.soap.AccountConstants;
 import com.zimbra.common.soap.HeaderConstants;
 import com.zimbra.soap.account.type.Attr;
 import com.zimbra.soap.account.type.Pref;
 import com.zimbra.soap.account.type.Session;
+import com.zimbra.soap.json.jackson.annotate.ZimbraJsonArrayForWrapper;
 import com.zimbra.soap.json.jackson.annotate.ZimbraJsonAttribute;
 import com.zimbra.soap.json.jackson.annotate.ZimbraKeyValuePairs;
 import com.zimbra.soap.type.ZmBoolean;
@@ -152,6 +155,20 @@ public class AuthResponse {
     @XmlElement(name=AccountConstants.E_TRUSTED_DEVICES_ENABLED, required=false)
     private ZmBoolean trustedDevicesEnabled;
 
+    @XmlElementWrapper(name=AccountConstants.E_TWO_FACTOR_AUTH_METHOD_ALLOWED)
+    @XmlElement(name=AccountConstants.E_METHOD, required=false)
+    private List<String> twoFactorAuthMethodAllowed = Lists.newArrayList();
+
+    @XmlElementWrapper(name=AccountConstants.E_TWO_FACTOR_AUTH_METHOD_ENABLED)
+    @XmlElement(name=AccountConstants.E_METHOD, required=false)
+    private List<String> twoFactorAuthMethodEnabled = Lists.newArrayList();
+
+    @XmlElement(name=AccountConstants.E_PREF_PRIMARY_TWO_FACTOR_AUTH_METHOD, required=false)
+    private String prefPrimaryTwoFactorAuthMethod;
+
+    @XmlElement(name=AccountConstants.E_PREF_PASSWORD_RECOVERY_ADDRESS, required=false)
+    private String prefPasswordRecoveryAddress;
+
     public AuthResponse() {
     }
 
@@ -262,4 +279,52 @@ public class AuthResponse {
     @GraphQLQuery(name="trustedDevicesEnabled", description="Denotes if trusted devices are enabled")
     public ZmBoolean getTrustedDevicesEnabled() { return trustedDevicesEnabled; }
     public AuthResponse setTrustedDevicesEnabled(boolean bool) { this.trustedDevicesEnabled = ZmBoolean.fromBool(bool); return this; }
+
+    public AuthResponse addTwoFactorAuthMethodAllowed(String method) {
+        this.twoFactorAuthMethodAllowed.add(method);
+        return this;
+    }
+
+    public void setTwoFactorAuthMethodAllowed(Iterable <String> twoFactorAuthMethodAllowed) {
+        this.twoFactorAuthMethodAllowed.clear();
+        if (twoFactorAuthMethodAllowed != null) {
+            Iterables.addAll(this.twoFactorAuthMethodAllowed, twoFactorAuthMethodAllowed);
+        }
+    }
+
+    public List<String> getTwoFactorAuthMethodAllowed() {
+        return Collections.unmodifiableList(twoFactorAuthMethodAllowed);
+    }
+
+    public AuthResponse addTwoFactorAuthMethodEnabled(String method) {
+        this.twoFactorAuthMethodEnabled.add(method);
+        return this;
+    }
+
+    public void setTwoFactorAuthMethodEnabled(Iterable <String> twoFactorAuthMethodEnabled) {
+        this.twoFactorAuthMethodEnabled.clear();
+        if (twoFactorAuthMethodEnabled != null) {
+            Iterables.addAll(this.twoFactorAuthMethodEnabled, twoFactorAuthMethodEnabled);
+        }
+    }
+
+    public List<String> getTwoFactorAuthMethodEnabled() {
+        return Collections.unmodifiableList(twoFactorAuthMethodEnabled);
+    }
+
+    public String getPrefPrimaryTwoFactorAuthMethod() {
+        return prefPrimaryTwoFactorAuthMethod;
+    }
+
+    public void setPrefPrimaryTwoFactorAuthMethod(String prefPrimaryTwoFactorAuthMethod) {
+        this.prefPrimaryTwoFactorAuthMethod = prefPrimaryTwoFactorAuthMethod;
+    }
+
+    public String getPrefPasswordRecoveryAddress() {
+        return prefPasswordRecoveryAddress;
+    }
+
+    public void setPrefPasswordRecoveryAddress(String prefPasswordRecoveryAddress) {
+        this.prefPasswordRecoveryAddress = prefPasswordRecoveryAddress;
+    }
 }

--- a/store/src/java/com/zimbra/cs/service/account/Auth.java
+++ b/store/src/java/com/zimbra/cs/service/account/Auth.java
@@ -22,10 +22,13 @@ package com.zimbra.cs.service.account;
 
 import io.jsonwebtoken.Claims;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
@@ -42,6 +45,7 @@ import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.HeaderConstants;
 import com.zimbra.common.util.Constants;
 import com.zimbra.common.util.Pair;
+import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.UUIDUtil;
 import com.zimbra.common.util.ZimbraCookie;
 import com.zimbra.common.util.ZimbraLog;
@@ -480,6 +484,7 @@ public class Auth extends AccountDocumentHandler {
                 authToken.encode(httpReq, httpResp, false, ZimbraCookie.secureCookie(httpReq), rememberMe);
             }
             response.addUniqueElement(AccountConstants.E_TRUSTED_DEVICES_ENABLED).setText(account.isFeatureTrustedDevicesEnabled() ? "true" : "false");
+            addTwoFactorAttributes(response, account);
             return response;
         }
     }
@@ -588,4 +593,27 @@ public class Auth extends AccountDocumentHandler {
             AccountUtil.addAccountToLogContext(prov, aid, ZimbraLog.C_ANAME, ZimbraLog.C_AID, null);
     }
 
+    /**
+     * This method is used to add Two Factor Attributes in response
+     * @param response
+     * @param acct
+     */
+    private void addTwoFactorAttributes(Element response, Account acct) {
+        String[] twoFactorAuthMethodAllowedArray = acct.getTwoFactorAuthMethodAllowed();
+        String[] twoFactorAuthMethodEnabledArray =  acct.getTwoFactorAuthMethodEnabled();
+        String prefPwdRecoveryAddressStatus = acct.getPrefPasswordRecoveryAddressStatusAsString();
+        Element twoFactorAuthMethodAllowed = response.addUniqueElement(AccountConstants.E_TWO_FACTOR_AUTH_METHOD_ALLOWED);
+        ToXML.encodeTFAResponse(twoFactorAuthMethodAllowed, twoFactorAuthMethodAllowedArray);
+        Element twoFactorAuthMethodEnabled = response.addUniqueElement(AccountConstants.E_TWO_FACTOR_AUTH_METHOD_ENABLED);
+        ToXML.encodeTFAResponse(twoFactorAuthMethodEnabled, twoFactorAuthMethodEnabledArray);
+        response.addUniqueElement(AccountConstants.E_PREF_PRIMARY_TWO_FACTOR_AUTH_METHOD).setText(acct.getPrefPrimaryTwoFactorAuthMethod());
+        String recoveryAddress = acct.getPrefPasswordRecoveryAddress();
+        if ((twoFactorAuthMethodAllowedArray != null && Arrays.asList(twoFactorAuthMethodAllowedArray).contains(AccountConstants.E_EMAIL))
+                && (twoFactorAuthMethodEnabledArray != null && Arrays.asList(twoFactorAuthMethodEnabledArray).contains(AccountConstants.E_EMAIL))
+                && (!StringUtil.isNullOrEmpty(prefPwdRecoveryAddressStatus) && prefPwdRecoveryAddressStatus.equals(AccountConstants.E_VERIFIED))
+                && !StringUtil.isNullOrEmpty(recoveryAddress)) {
+            String prefPwdRecoveryAddress = Stream.of(recoveryAddress.split(",")).map(add -> StringUtil.maskEmail(add)).collect(Collectors.joining(","));
+            response.addUniqueElement(AccountConstants.E_PREF_PASSWORD_RECOVERY_ADDRESS).setText(prefPwdRecoveryAddress);
+        }
+    }
 }

--- a/store/src/java/com/zimbra/cs/service/account/ToXML.java
+++ b/store/src/java/com/zimbra/cs/service/account/ToXML.java
@@ -350,4 +350,18 @@ public class ToXML {
 
     }
 
+    public static void encodeTFAResponse(Element response, Object value) {
+        if (value instanceof String[]) {
+            String sa[] = (String[]) value;
+            for (int i = 0; i < sa.length; i++) {
+                if (!Strings.isNullOrEmpty(sa[i])) {
+                    response.addNonUniqueElement(AccountConstants.E_METHOD).setText(sa[i]);
+                }
+            }
+        } else if (value instanceof String) {
+            if (!Strings.isNullOrEmpty((String) value)) {
+                response.addNonUniqueElement(AccountConstants.E_METHOD).setText((String) value);
+            }
+        }
+    }
 }


### PR DESCRIPTION
**Feature scope** 

In the process of supporting 2FA authentication via email code current auth response needs modification to let UI know to trigger SendTFACodeRequest to send email with 2FA code.

Modify Authresponse to include zimbraTwoFactorAuthMethodAllowed, zimbraTwoFactorAuthMethodEnabled, zimbraPrefPrimaryTwoFactorAuthMethod and a masked zimbraPrefPasswordRecoveryAddress to be included.


**Implementation**
Added the required attribute in Auth response.

