### PR TITLE
ZCS-13071:  Drive module with shared files loss on sharee end if it is later moved to 10.0 and sharer has already been moved

### DIFF
--- a/client/src/java/com/zimbra/client/ZDocument.java
+++ b/client/src/java/com/zimbra/client/ZDocument.java
@@ -16,16 +16,15 @@
  */
 package com.zimbra.client;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
 import org.json.JSONException;
 
-import com.zimbra.client.event.ZModifyEvent;
 import com.zimbra.common.mime.MimeConstants;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.MailConstants;
-
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 
 public class ZDocument implements ZItem, ToZJSONObject {
 
@@ -42,6 +41,7 @@ public class ZDocument implements ZItem, ToZJSONObject {
     private final long modifiedDate; /* content last modified - millis since 1970-01-01 00:00 UTC. */
     private final long metadataChangeDate; /* metadata &/or content last modified - millis since 1970-01-01 00:00 UTC */
     private final long size;
+    private Element acl;
     private String contentType;
     private final String tagIds;
     private final String flags;
@@ -68,6 +68,12 @@ public class ZDocument implements ZItem, ToZJSONObject {
         }
         tagIds = e.getAttribute(MailConstants.A_TAGS, null);
         flags = e.getAttribute(MailConstants.A_FLAGS, null);
+        try {
+            acl = e.getElement(MailConstants.E_ACL);
+        } catch (ServiceException se) {
+            // acl not present on doc
+            acl = null;
+        }
     }
 
     @Override
@@ -172,5 +178,13 @@ public class ZDocument implements ZItem, ToZJSONObject {
 
     public String getFlags() {
         return flags;
+    }
+
+    public Element getAcl() {
+        return acl;
+    }
+
+    public void setAcl(Element acl) {
+        this.acl = acl;
     }
 }

--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -5221,6 +5221,15 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
         return new ZDocument(e);
     }
 
+    // used only for migration
+    public ZDocument getDocumentByUuid(String nodeId) throws ServiceException {
+        Element req = newRequestElement(MailConstants.GET_ITEM_REQUEST);
+        Element item = req.addUniqueElement(MailConstants.E_ITEM);
+        item.addAttribute(MailConstants.E_NODE_ID, nodeId);
+        Element e = invoke(req).getElement(MailConstants.E_DOC);
+        return new ZDocument(e);
+    }
+
     /**
      * modify prefs. The key in the map is the pref name, and the value should be a String[],
      * a Collection of String objects, or a single String/Object.toString.

--- a/common/src/java/com/zimbra/common/soap/MailConstants.java
+++ b/common/src/java/com/zimbra/common/soap/MailConstants.java
@@ -748,6 +748,7 @@ public final class MailConstants {
     public static final String E_GRANT = "grant";
     public static final String E_NOTES = "notes";
     public static final String E_SHARE = "share";
+    public static final String E_NODE_ID = "nodeId";
     public static final String E_REVOKE = "revoke";
     public static final String A_EXPIRE = "expire";
     public static final String A_ZIMBRA_ID = "zid";

--- a/soap/src/java/com/zimbra/soap/mail/type/DocumentSpec.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/DocumentSpec.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2012, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2012, 2013, 2014, 2016, 2023 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -113,6 +113,13 @@ public class DocumentSpec {
     @XmlElement(name=MailConstants.E_DOC /* doc */, required=false)
     private IdVersion docRevision;
 
+    /**
+     * @zm-api-field-tag node-id
+     * @zm-api-field-description Node ID for zExtras drive migration
+     */
+    @XmlAttribute(name=MailConstants.E_NODE_ID /* nodeId */, required=false)
+    private String nodeId;
+
     public DocumentSpec() {
     }
 
@@ -142,6 +149,7 @@ public class DocumentSpec {
     public void setDocRevision(IdVersion docRevision) { this.docRevision = docRevision; }
     public void setAction(String action) { this.action = action; }
     public void setType(NewFileCreationTypes type) { this.type = type; }
+    public void setNodeId(String nodeId) { this.nodeId = nodeId; }
     public String getName() { return name; }
     public String getContentType() { return contentType; }
     public String getDescription() { return description; }
@@ -156,6 +164,7 @@ public class DocumentSpec {
     public IdVersion getDocRevision() { return docRevision; }
     public String getAction() { return action; }
     public NewFileCreationTypes getType() { return type; }
+    public String getNodeId() { return nodeId; }
 
     public MoreObjects.ToStringHelper addToStringInfo(MoreObjects.ToStringHelper helper) {
         return helper

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -147,10 +147,8 @@ import com.zimbra.cs.mailbox.ACL.Grant;
 import com.zimbra.cs.mailbox.CalendarItem.AlarmData;
 import com.zimbra.cs.mailbox.CalendarItem.Callback;
 import com.zimbra.cs.mailbox.CalendarItem.ReplyInfo;
-import com.zimbra.cs.mailbox.Flag.FlagInfo;
 import com.zimbra.cs.mailbox.FoldersTagsCache.FoldersTags;
 import com.zimbra.cs.mailbox.MailItem.CustomMetadata;
-import com.zimbra.cs.mailbox.MailItem.CustomMetadata.CustomMetadataList;
 import com.zimbra.cs.mailbox.MailItem.PendingDelete;
 import com.zimbra.cs.mailbox.MailItem.TargetConstraint;
 import com.zimbra.cs.mailbox.MailItem.Type;
@@ -9498,6 +9496,12 @@ public class Mailbox implements MailboxStore {
     public Document createDocument(OperationContext octxt, int folderId, ParsedDocument pd, MailItem.Type type,
             int flags, MailItem parent, CustomMetadata custom, boolean indexing)
     throws IOException, ServiceException {
+        return createDocument(octxt, folderId, pd, type, flags, parent, custom, indexing, null);
+    }
+
+    public Document createDocument(OperationContext octxt, int folderId, ParsedDocument pd, MailItem.Type type,
+            int flags, MailItem parent, CustomMetadata custom, boolean indexing, String nodeId)
+    throws IOException, ServiceException {
         StoreManager sm = StoreManager.getInstance();
         StagedBlob staged = sm.stage(pd.getBlob(), this);
 
@@ -9511,7 +9515,7 @@ public class Mailbox implements MailboxStore {
 
             SaveDocument redoPlayer = (octxt == null ? null : (SaveDocument) octxt.getPlayer());
             int itemId = getNextItemId(redoPlayer == null ? ID_AUTO_INCREMENT : redoPlayer.getMessageId());
-            String uuid = redoPlayer == null ? UUIDUtil.generateUUID() : redoPlayer.getUuid();
+            String uuid = redoPlayer == null ? (nodeId == null ? UUIDUtil.generateUUID() : nodeId) : redoPlayer.getUuid();
 
             Document doc;
             switch (type) {

--- a/store/src/java/com/zimbra/cs/service/doc/SaveDocument.java
+++ b/store/src/java/com/zimbra/cs/service/doc/SaveDocument.java
@@ -51,6 +51,7 @@ import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.MailConstants;
 import com.zimbra.common.util.ByteUtil;
 import com.zimbra.common.util.Pair;
+import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraHttpConnectionManager;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
@@ -378,16 +379,19 @@ public class SaveDocument extends DocDocumentHandler {
         }
         boolean descEnabled = false;
         String flags = "";
+        String nodeId = null;
         if (docElem != null) {
             descEnabled = docElem.getAttributeBool(MailConstants.A_DESC_ENABLED, true);
             flags = docElem.getAttribute(MailConstants.A_FLAGS, null);
+            nodeId = docElem.getAttribute(MailConstants.E_NODE_ID, null);
         }
 
         try {
             ParsedDocument pd = new ParsedDocument(is, doc.name, doc.contentType, System.currentTimeMillis(),
                 getAuthor(zsc), doc.description, descEnabled);
 
-            docItem = mbox.createDocument(octxt, folderId, pd, type, Flag.toBitmask(flags), parent, custom, index);
+            docItem = mbox.createDocument(octxt, folderId, pd, type, Flag.toBitmask(flags), parent, custom, index, nodeId);
+
         } catch (IOException e) {
             throw ServiceException.FAILURE("unable to create document", e);
         }

--- a/store/src/java/com/zimbra/cs/service/mail/GetItem.java
+++ b/store/src/java/com/zimbra/cs/service/mail/GetItem.java
@@ -55,6 +55,7 @@ public class GetItem extends MailDocumentHandler {
         String id = target.getAttribute(MailConstants.A_ID, null);
         String folderStr = target.getAttribute(MailConstants.A_FOLDER, null);
         String path = target.getAttribute(MailConstants.A_PATH, target.getAttribute(MailConstants.A_NAME, null));
+        String nodeId = target.getAttribute(MailConstants.E_NODE_ID, null);
 
         if (folderStr != null && path == null)
             throw ServiceException.INVALID_REQUEST("missing required attribute: " + MailConstants.A_PATH, null);
@@ -77,6 +78,8 @@ public class GetItem extends MailDocumentHandler {
                 }
                 throw nsie;
             }
+        } else if (nodeId != null) {
+            item = mbox.getDocumentByUuid(octxt, nodeId);
         } else {
             throw ServiceException.INVALID_REQUEST("must specify 'id' or 'path'", null);
         }


### PR DESCRIPTION
**Problem:**
Drive module with shared files loss on sharee end if it is later moved to 10.0 and sharer has already been moved

**Fix:**
While exporting the sharee data, also export data of its remote shares from other users.
while importing sharee data, process these remote shares data on sharer end.

**Test-cases:**

1. sharer is moved first to 10.0 (all export and import done) and then sharee is moved to 10.0.
2. sharee is moved first to 10.0 (all export and import done) and then sharer is moved to 10.0.
3. sharer and sharee both moved to 10.0, but first sharer data is imported and then sharee data is imported.
4. sharer and sharee both moved to 10.0, but first sharee data is imported and then sharer data is imported.
In all the above cases, sharee remote files data is restored.
