### PR TITLE
ZCS-14416:Date filter payload modification due to timezone issue

### DIFF
--- a/common/src/java/com/zimbra/common/util/DateParser.java
+++ b/common/src/java/com/zimbra/common/util/DateParser.java
@@ -19,6 +19,7 @@ package com.zimbra.common.util;
 import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
 /**
  * Wrapper around {@link SimpleDateFormat} that allows it to be used in a
@@ -30,6 +31,7 @@ public class DateParser {
 
     private ThreadLocal<SimpleDateFormat> mFormatterHolder = new ThreadLocal<SimpleDateFormat>();
     private String mDatePattern;
+    private String timezone;
     
     public DateParser(String datePattern) {
         mDatePattern = datePattern;
@@ -38,17 +40,27 @@ public class DateParser {
     public Date parse(String s) {
         return getFormatter().parse(s, new ParsePosition(0));
     }
-    
+
     public String format(Date date) {
         return getFormatter().format(date);
     }
-    
+
     private SimpleDateFormat getFormatter() {
         SimpleDateFormat formatter = mFormatterHolder.get();
         if (formatter == null) {
             formatter = new SimpleDateFormat(mDatePattern);
             mFormatterHolder.set(formatter);
         }
+
+        formatter.setTimeZone(TimeZone.getTimeZone(timezone));
         return formatter;
+    }
+
+    public String getTimezone() {
+        return timezone;
+    }
+
+    public void setTimezone(String timezone) {
+        this.timezone = timezone;
     }
 }

--- a/store/src/java/com/zimbra/cs/filter/RuleManager.java
+++ b/store/src/java/com/zimbra/cs/filter/RuleManager.java
@@ -17,9 +17,11 @@
 
 package com.zimbra.cs.filter;
 
+import com.zimbra.common.filter.Sieve;
 import com.zimbra.common.service.DeliveryServiceException;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.Pair;
+import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.Cos;
@@ -27,8 +29,8 @@ import com.zimbra.cs.account.Domain;
 import com.zimbra.cs.account.Entry;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.Server;
-import com.zimbra.cs.filter.jsieve.ErejectException;
 import com.zimbra.cs.filter.ZimbraMailAdapter.KeepType;
+import com.zimbra.cs.filter.jsieve.ErejectException;
 import com.zimbra.cs.lmtpserver.LmtpEnvelope;
 import com.zimbra.cs.mailbox.DeliveryContext;
 import com.zimbra.cs.mailbox.Mailbox;
@@ -38,7 +40,6 @@ import com.zimbra.cs.mime.ParsedMessage;
 import com.zimbra.cs.service.util.ItemId;
 import com.zimbra.cs.service.util.SpamHandler;
 import com.zimbra.soap.mail.type.FilterRule;
-
 import org.apache.jsieve.ConfigurationManager;
 import org.apache.jsieve.SieveFactory;
 import org.apache.jsieve.exception.SieveException;
@@ -55,6 +56,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -351,6 +353,8 @@ public final class RuleManager {
     private static void setXMLRules(Account account,List<FilterRule> rules, String sieveScriptAttrName,
             String rulesCacheKey) throws ServiceException {
         SoapToSieve soapToSieve = new SoapToSieve(rules);
+        String tzId = account.getAttr(Provisioning.A_zimbraPrefTimeZoneId);
+        Sieve.DATE_PARSER.setTimezone((StringUtil.isNullOrEmpty(tzId) ? TimeZone.getDefault().getID() : tzId));
         String script = soapToSieve.getSieveScript();
         setRules(account, script, sieveScriptAttrName, rulesCacheKey);
     }


### PR DESCRIPTION
Requirement of ticket: ZCS-14416

Requirements:
Now Zimbra UI is sending only _Date_ in timestamp so, in the backend we have to use `zimbraPrefTimeZoneId` to handle the **timezone issue** for parsing and formatting the _Date_.

Solution:
Modified the _DateParser_ class and _RuleManger_ class to handle timezone changes according to the `zimbraPrefTimeZoneId` value for the **formatter**.

Testing:
Tested on custom build with all the filters.
