### PR TITLE
ZCS-14412: change default value false for ldap attributes

### DIFF
--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -1822,7 +1822,7 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
 </attr>
 
 <attr id="335" name="zimbraFeatureSharingEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited">
-  <defaultCOSValue>TRUE</defaultCOSValue>
+  <defaultCOSValue>FALSE</defaultCOSValue>
   <defaultExternalCOSValue>FALSE</defaultExternalCOSValue>
   <desc>enabled sharing</desc>
 </attr>
@@ -2618,7 +2618,7 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
 </attr>
 
 <attr id="498" name="zimbraFeatureBriefcasesEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited">
-  <defaultCOSValue>TRUE</defaultCOSValue>
+  <defaultCOSValue>FALSE</defaultCOSValue>
   <defaultExternalCOSValue>FALSE</defaultExternalCOSValue>
   <desc>whether to allow use of briefcase feature</desc>
 </attr>
@@ -6250,7 +6250,7 @@ TODO: delete them permanently from here
 </attr>
 
 <attr id="1261" name="zimbraExternalSharingEnabled" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountInfo,accountCosDomainInherited,domainAdminModifiable" since="8.0.0">
-  <defaultCOSValue>TRUE</defaultCOSValue>
+  <defaultCOSValue>FALSE</defaultCOSValue>
   <defaultExternalCOSValue>FALSE</defaultExternalCOSValue>
   <desc>switch for turning external user sharing on/off</desc>
 </attr>
@@ -6798,7 +6798,7 @@ TODO: delete them permanently from here
 </attr>
 
 <attr id="1351" name="zimbraPublicSharingEnabled" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountInfo,accountCosDomainInherited,domainAdminModifiable" since="8.0.0">
-  <defaultCOSValue>TRUE</defaultCOSValue>
+  <defaultCOSValue>FALSE</defaultCOSValue>
   <defaultExternalCOSValue>FALSE</defaultExternalCOSValue>
   <desc>switch for turning public sharing on/off</desc>
 </attr>
@@ -9882,7 +9882,7 @@ TODO: delete them permanently from here
  </attr>
 
 <attr id="9016" name="zimbraFeatureDocumentEditingEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="10.0.0">
-  <defaultCOSValue>TRUE</defaultCOSValue>
+  <defaultCOSValue>FALSE</defaultCOSValue>
   <desc>Whether or not document editing feature is enabled within briefcase</desc>
 </attr>
 <attr id="3098" name="zimbraDocumentServerHost" type="string" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="10.0.0">

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -13262,13 +13262,13 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * switch for turning external user sharing on/off
      *
-     * @return zimbraExternalSharingEnabled, or true if unset
+     * @return zimbraExternalSharingEnabled, or false if unset
      *
      * @since ZCS 8.0.0
      */
     @ZAttr(id=1261)
     public boolean isExternalSharingEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraExternalSharingEnabled, true, true);
+        return getBooleanAttr(Provisioning.A_zimbraExternalSharingEnabled, false, true);
     }
 
     /**
@@ -14491,11 +14491,11 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * whether to allow use of briefcase feature
      *
-     * @return zimbraFeatureBriefcasesEnabled, or true if unset
+     * @return zimbraFeatureBriefcasesEnabled, or false if unset
      */
     @ZAttr(id=498)
     public boolean isFeatureBriefcasesEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraFeatureBriefcasesEnabled, true, true);
+        return getBooleanAttr(Provisioning.A_zimbraFeatureBriefcasesEnabled, false, true);
     }
 
     /**
@@ -16070,13 +16070,13 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * Whether or not document editing feature is enabled within briefcase
      *
-     * @return zimbraFeatureDocumentEditingEnabled, or true if unset
+     * @return zimbraFeatureDocumentEditingEnabled, or false if unset
      *
      * @since ZCS 10.0.0
      */
     @ZAttr(id=9016)
     public boolean isFeatureDocumentEditingEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraFeatureDocumentEditingEnabled, true, true);
+        return getBooleanAttr(Provisioning.A_zimbraFeatureDocumentEditingEnabled, false, true);
     }
 
     /**
@@ -20518,11 +20518,11 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * enabled sharing
      *
-     * @return zimbraFeatureSharingEnabled, or true if unset
+     * @return zimbraFeatureSharingEnabled, or false if unset
      */
     @ZAttr(id=335)
     public boolean isFeatureSharingEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraFeatureSharingEnabled, true, true);
+        return getBooleanAttr(Provisioning.A_zimbraFeatureSharingEnabled, false, true);
     }
 
     /**
@@ -60452,13 +60452,13 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * switch for turning public sharing on/off
      *
-     * @return zimbraPublicSharingEnabled, or true if unset
+     * @return zimbraPublicSharingEnabled, or false if unset
      *
      * @since ZCS 8.0.0
      */
     @ZAttr(id=1351)
     public boolean isPublicSharingEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraPublicSharingEnabled, true, true);
+        return getBooleanAttr(Provisioning.A_zimbraPublicSharingEnabled, false, true);
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -7931,13 +7931,13 @@ public abstract class ZAttrCos extends NamedEntry {
     /**
      * switch for turning external user sharing on/off
      *
-     * @return zimbraExternalSharingEnabled, or true if unset
+     * @return zimbraExternalSharingEnabled, or false if unset
      *
      * @since ZCS 8.0.0
      */
     @ZAttr(id=1261)
     public boolean isExternalSharingEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraExternalSharingEnabled, true, true);
+        return getBooleanAttr(Provisioning.A_zimbraExternalSharingEnabled, false, true);
     }
 
     /**
@@ -8880,11 +8880,11 @@ public abstract class ZAttrCos extends NamedEntry {
     /**
      * whether to allow use of briefcase feature
      *
-     * @return zimbraFeatureBriefcasesEnabled, or true if unset
+     * @return zimbraFeatureBriefcasesEnabled, or false if unset
      */
     @ZAttr(id=498)
     public boolean isFeatureBriefcasesEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraFeatureBriefcasesEnabled, true, true);
+        return getBooleanAttr(Provisioning.A_zimbraFeatureBriefcasesEnabled, false, true);
     }
 
     /**
@@ -10459,13 +10459,13 @@ public abstract class ZAttrCos extends NamedEntry {
     /**
      * Whether or not document editing feature is enabled within briefcase
      *
-     * @return zimbraFeatureDocumentEditingEnabled, or true if unset
+     * @return zimbraFeatureDocumentEditingEnabled, or false if unset
      *
      * @since ZCS 10.0.0
      */
     @ZAttr(id=9016)
     public boolean isFeatureDocumentEditingEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraFeatureDocumentEditingEnabled, true, true);
+        return getBooleanAttr(Provisioning.A_zimbraFeatureDocumentEditingEnabled, false, true);
     }
 
     /**
@@ -14907,11 +14907,11 @@ public abstract class ZAttrCos extends NamedEntry {
     /**
      * enabled sharing
      *
-     * @return zimbraFeatureSharingEnabled, or true if unset
+     * @return zimbraFeatureSharingEnabled, or false if unset
      */
     @ZAttr(id=335)
     public boolean isFeatureSharingEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraFeatureSharingEnabled, true, true);
+        return getBooleanAttr(Provisioning.A_zimbraFeatureSharingEnabled, false, true);
     }
 
     /**
@@ -47038,13 +47038,13 @@ public abstract class ZAttrCos extends NamedEntry {
     /**
      * switch for turning public sharing on/off
      *
-     * @return zimbraPublicSharingEnabled, or true if unset
+     * @return zimbraPublicSharingEnabled, or false if unset
      *
      * @since ZCS 8.0.0
      */
     @ZAttr(id=1351)
     public boolean isPublicSharingEnabled() {
-        return getBooleanAttr(Provisioning.A_zimbraPublicSharingEnabled, true, true);
+        return getBooleanAttr(Provisioning.A_zimbraPublicSharingEnabled, false, true);
     }
 
     /**


### PR DESCRIPTION
**Implementation:** Change the default value to FALSE for the below LDAP attributes. It will help disable the feature for the new account.

1. zimbraFeatureSharingEnabled
2. zimbraFeatureBriefcasesEnabled
3. zimbraFeatureDocumentEditingEnabled
4. zimbraExternalSharingEnabled
5. zimbraPublicSharingEnabled