### PR TITLE
ZCS-14368: Configured email code length by adding a ldap attribute

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -17889,6 +17889,16 @@ public class ZAttrProvisioning {
     public static final String A_zimbraTrialExpirationDate = "zimbraTrialExpirationDate";
 
     /**
+     * Length of TOTP code required for two-factor authentication for email.
+     * It must be different from zimbraTwoFactorCodeLength and
+     * zimbraTwoFactorScratchCodeLength.
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4110)
+    public static final String A_zimbraTwoFactorAuthEmailCodeLength = "zimbraTwoFactorAuthEmailCodeLength";
+
+    /**
      * whether two-factor authentication is enabled by the user
      *
      * @since ZCS 8.7.0,9.0.0

--- a/common/src/java/com/zimbra/common/auth/twofactor/AuthenticatorConfig.java
+++ b/common/src/java/com/zimbra/common/auth/twofactor/AuthenticatorConfig.java
@@ -22,6 +22,7 @@ package com.zimbra.common.auth.twofactor;
 public class AuthenticatorConfig {
     private TwoFactorOptions.HashAlgorithm hashAlgorithm;
     private TwoFactorOptions.CodeLength codeLength;
+    private TwoFactorOptions.EmailCodeLength emailCodeLength;
     private long secondsInTimeWindow;
     private int allowedOffset;
 
@@ -36,6 +37,11 @@ public class AuthenticatorConfig {
 
     public AuthenticatorConfig setNumCodeDigits(TwoFactorOptions.CodeLength length) {
         this.codeLength = length;
+        return this;
+    }
+
+    public AuthenticatorConfig setNumCodeDigits(TwoFactorOptions.EmailCodeLength emailCodeLength) {
+        this.emailCodeLength = emailCodeLength;
         return this;
     }
 
@@ -63,7 +69,7 @@ public class AuthenticatorConfig {
     }
 
     public int getNumCodeDigits() {
-        return codeLength.getValue();
+        return codeLength != null ? codeLength.getValue() : emailCodeLength.getValue();
     }
 
     public int getWindowRange() {

--- a/common/src/java/com/zimbra/common/auth/twofactor/TwoFactorOptions.java
+++ b/common/src/java/com/zimbra/common/auth/twofactor/TwoFactorOptions.java
@@ -61,6 +61,29 @@ public class TwoFactorOptions {
         }
     }
 
+    public enum EmailCodeLength {
+        FIVE(5), SIX(6), SEVEN(7), EIGHT(8), NINE(9);
+
+        private int num;
+
+        private EmailCodeLength(int n) {
+            this.num = n;
+        }
+
+        public int getValue() {
+            return num;
+        }
+
+        public static EmailCodeLength valueOf(int n) throws ServiceException {
+            for (EmailCodeLength l: EmailCodeLength.values()) {
+                if (l.getValue() == n) {
+                    return l;
+                }
+            }
+            throw ServiceException.FAILURE(String.format("%s is not a valid two-factor email code length. Possible values are %s", n, EmailCodeLength.values()), new Throwable());
+        }
+    }
+
     public enum Encoding {
         BASE32, BASE64;
     }

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10424,4 +10424,9 @@ TODO: delete them permanently from here
 <attr id="4109" name="zimbraTwoFactorCodeEmailBody" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited" since="11.0.0">
   <desc>Define body: field for 2FA email</desc>
 </attr>
+
+<attr id="4110" name="zimbraTwoFactorAuthEmailCodeLength" type="integer" min="5" cardinality="single" optionalIn="globalConfig" callback="TwoFactorAuthEmailCode" since="11.0.0">
+  <globalConfigValue>7</globalConfigValue>
+  <desc>Length of TOTP code required for two-factor authentication for email. It must be different from zimbraTwoFactorCodeLength and zimbraTwoFactorScratchCodeLength.</desc>
+</attr>
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -77891,6 +77891,88 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Length of TOTP code required for two-factor authentication for email.
+     * It must be different from zimbraTwoFactorCodeLength and
+     * zimbraTwoFactorScratchCodeLength.
+     *
+     * @return zimbraTwoFactorAuthEmailCodeLength, or 7 if unset
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4110)
+    public int getTwoFactorAuthEmailCodeLength() {
+        return getIntAttr(Provisioning.A_zimbraTwoFactorAuthEmailCodeLength, 7, true);
+    }
+
+    /**
+     * Length of TOTP code required for two-factor authentication for email.
+     * It must be different from zimbraTwoFactorCodeLength and
+     * zimbraTwoFactorScratchCodeLength.
+     *
+     * @param zimbraTwoFactorAuthEmailCodeLength new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4110)
+    public void setTwoFactorAuthEmailCodeLength(int zimbraTwoFactorAuthEmailCodeLength) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorAuthEmailCodeLength, Integer.toString(zimbraTwoFactorAuthEmailCodeLength));
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Length of TOTP code required for two-factor authentication for email.
+     * It must be different from zimbraTwoFactorCodeLength and
+     * zimbraTwoFactorScratchCodeLength.
+     *
+     * @param zimbraTwoFactorAuthEmailCodeLength new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4110)
+    public Map<String,Object> setTwoFactorAuthEmailCodeLength(int zimbraTwoFactorAuthEmailCodeLength, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorAuthEmailCodeLength, Integer.toString(zimbraTwoFactorAuthEmailCodeLength));
+        return attrs;
+    }
+
+    /**
+     * Length of TOTP code required for two-factor authentication for email.
+     * It must be different from zimbraTwoFactorCodeLength and
+     * zimbraTwoFactorScratchCodeLength.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4110)
+    public void unsetTwoFactorAuthEmailCodeLength() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorAuthEmailCodeLength, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Length of TOTP code required for two-factor authentication for email.
+     * It must be different from zimbraTwoFactorCodeLength and
+     * zimbraTwoFactorScratchCodeLength.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 11.0.0
+     */
+    @ZAttr(id=4110)
+    public Map<String,Object> unsetTwoFactorAuthEmailCodeLength(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorAuthEmailCodeLength, "");
+        return attrs;
+    }
+
+    /**
      * Hash algorithm used in TOTP generation. SHA1 is the current accepted
      * standard per RFC 6238. Only consider changing this to another hashing
      * function when working with authenticators that deviate from this

--- a/store/src/java/com/zimbra/cs/account/callback/TwoFactorAuthEmailCode.java
+++ b/store/src/java/com/zimbra/cs/account/callback/TwoFactorAuthEmailCode.java
@@ -1,0 +1,53 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2023 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.account.callback;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.StringUtil;
+import com.zimbra.cs.account.AttributeCallback;
+import com.zimbra.cs.account.Entry;
+import com.zimbra.cs.account.Provisioning;
+
+import java.util.Map;
+
+public class TwoFactorAuthEmailCode extends AttributeCallback {
+    public static final int MAX_CODE_LENGTH = 10;
+
+    @Override
+    public void preModify(CallbackContext context, String attrName, Object attrValue, Map attrsToModify, Entry entry) throws ServiceException {
+        String value = (String) attrValue;
+        if (StringUtil.isNullOrEmpty(value)) {
+            throw ServiceException.INVALID_REQUEST(Provisioning.A_zimbraTwoFactorAuthEmailCodeLength + " cannot set to empty.", null);
+        }
+        validateAttributeValue(attrName, Integer.valueOf(value) );
+    }
+
+    @Override
+    public void postModify(CallbackContext context, String attrName, Entry entry) {
+
+    }
+
+    private void validateAttributeValue(String attrName, int attrValue) throws ServiceException {
+        if (attrValue > MAX_CODE_LENGTH) {
+            throw ServiceException.INVALID_REQUEST(Provisioning.A_zimbraTwoFactorAuthEmailCodeLength + " cannot set above " + MAX_CODE_LENGTH, null);
+        }
+        if ((attrValue == Provisioning.getInstance().getConfig().getTwoFactorCodeLength()) ||
+                (attrValue == Provisioning.getInstance().getConfig().getTwoFactorScratchCodeLength())) {
+            throw ServiceException.INVALID_REQUEST(Provisioning.A_zimbraTwoFactorAuthEmailCodeLength + " must be different from zimbraTwoFactorCodeLength and zimbraTwoFactorScratchCodeLength", null);
+        }
+    }
+}


### PR DESCRIPTION
**Description**
2FA code sent by email must not match a code generated by authentication app

**Expectation**
Add a new ldap attribute and also add a callback that must verify that values of `zimbraTwoFactorCodeLength`, `zimbraTwoFactorScratchCodeLength` and the new one are different each other.

**Solution**
Added a ldap attribute as well as callback for same.