### PR TITLE
ZCS-14369: Defined action and status as Element instead of attribute

### DIFF
--- a/soap/src/java/com/zimbra/soap/account/message/SendTwoFactorAuthCodeRequest.java
+++ b/soap/src/java/com/zimbra/soap/account/message/SendTwoFactorAuthCodeRequest.java
@@ -21,7 +21,6 @@ package com.zimbra.soap.account.message;
 import com.zimbra.common.soap.AccountConstants;
 import com.zimbra.soap.account.type.AuthToken;
 
-import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
@@ -46,7 +45,7 @@ public class SendTwoFactorAuthCodeRequest {
         this.action = action;
     }
 
-    @XmlAttribute(name=AccountConstants.E_ACTION)
+    @XmlElement(name=AccountConstants.E_ACTION)
     private SendTwoFactorAuthCodeAction action;
 
 

--- a/soap/src/java/com/zimbra/soap/account/message/SendTwoFactorAuthCodeResponse.java
+++ b/soap/src/java/com/zimbra/soap/account/message/SendTwoFactorAuthCodeResponse.java
@@ -24,7 +24,7 @@ import com.zimbra.common.soap.AccountConstants;
 import com.google.common.base.MoreObjects;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
 import javax.xml.bind.annotation.XmlRootElement;
@@ -67,7 +67,7 @@ public class SendTwoFactorAuthCodeResponse {
         setStatus(status);
     }
 
-    @XmlAttribute(name=AccountConstants.A_STATUS /* status */, required=true)
+    @XmlElement(name=AccountConstants.A_STATUS /* status */, required=true)
     private SendTwoFactorAuthCodeStatus status;
 
     public SendTwoFactorAuthCodeStatus getStatus() {


### PR DESCRIPTION
**Description**
`action` and `status` of `SendTwoFactorAuthCodeRequest` should be an element, not an attribute 

**Soap request  and response expectation** 
```
<SendTwoFactorAuthCodeRequest> 
   <action>[email, reset]</action> (sms or other method might be added in the future) 
</SendTwoFactorAuthCodeRequest> 

<SendTwoFactorAuthCodeResponse>
   <status>[sent, not sent]</status>
</SendTwoFactorAuthCodeResponse>
```

**Solution**
Defined action and status as Element instead of attribute

<img width="1155" alt="Screenshot 2023-12-19 at 6 38 25 PM" src="https://github.com/ZimbraOS/zm-mailbox/assets/38309486/3be5fd1c-66dc-4e0d-834f-aea574266f15">
