### PR TITLE
ZCS-14379: Sanitized attribute zimbraTwoFactorCodeForEmail value to VALUE_BLOCKED

### DIFF
--- a/store/src/java/com/zimbra/cs/account/Provisioning.java
+++ b/store/src/java/com/zimbra/cs/account/Provisioning.java
@@ -459,7 +459,8 @@ public abstract class Provisioning extends ZAttrProvisioning {
             name.equalsIgnoreCase(Provisioning.A_zimbraTwoFactorAuthTrustedDevices) ||
             name.equalsIgnoreCase(Provisioning.A_zimbraDataSourceOAuthToken) ||
             name.equalsIgnoreCase(Provisioning.A_zimbraDataSourceOAuthClientSecret) ||
-            name.equalsIgnoreCase(Provisioning.A_zimbraDataSourceOAuthRefreshToken)) {
+            name.equalsIgnoreCase(Provisioning.A_zimbraDataSourceOAuthRefreshToken) ||
+            name.equalsIgnoreCase(Provisioning.A_zimbraTwoFactorCodeForEmail)) {
             return "VALUE-BLOCKED";
         }
         return realValue;


### PR DESCRIPTION
**Description**
zimbraTwoFactorCodeForEmail needs to be shown as VALUE-BLOCKED at zmprov ga

**Current behavior:**

```
zmprov ga ACCOUNT zimbraTwoFactorCodeForEmail
zimbraTwoFactorCodeForEmail: AWilsMFsd8EO2a9sWoAOpuMdomKlNvf/9p9gEgKmn9zw3HbNawRctLLP2Wfxxbk2aA==
```
**Expected behavior:**
```
zmprov ga ACCOUNT zimbraTwoFactorCodeForEmail
zimbraTwoFactorCodeForEmail: VALUE-BLOCKED
```
**Solution**
Sanitised attribute value to VALUE-BLOCKED

<img width="809" alt="Screenshot 2023-12-19 at 6 20 32 PM" src="https://github.com/ZimbraOS/zm-mailbox/assets/38309486/4cd7b816-a426-4bda-85d4-2ceccfd1384b">

