### PR TITLE
ZCS-14364: Provided default template for zimbraTwoFactorCodeEmailBody|Subject

### DIFF
--- a/common/src/java/com/zimbra/common/util/L10nUtil.java
+++ b/common/src/java/com/zimbra/common/util/L10nUtil.java
@@ -312,7 +312,12 @@ public class L10nUtil {
         // two-factor email address verification
         twoFactorAuthEmailSubject,
         twoFactorAuthEmailBodyText,
-        twoFactorAuthEmailBodyHtml
+        twoFactorAuthEmailBodyHtml,
+
+        // send Two Factor Auth Code for email method
+        twoFactorAuthCodeEmailSubject,
+        twoFactorAuthCodeEmailBodyText,
+        twoFactorAuthCodeEmailBodyHtml
 
         // add other messages in the future...
     }

--- a/store-conf/conf/msgs/ZsMsg.properties
+++ b/store-conf/conf/msgs/ZsMsg.properties
@@ -959,6 +959,19 @@ twoFactorAuthEmailBodyHtml =\
   The code expires by {1}\
   </div>
 
+# send Two Factor Auth Code for email method
+twoFactorAuthCodeEmailSubject = Two-factor authentication code
+twoFactorAuthCodeEmailBodyText =\
+  Your two-factor authentication code is: {0}\n\
+  The code expires by: {1}\n\
+  *~*~*~*~*~*~*~*~*~*\n
+twoFactorAuthCodeEmailBodyHtml =\
+  <div style="font-family:sans-serif;">\
+  <hr>\
+  Your two-factor authentication code is: {0}<br>\
+  The code expires by {1}\
+  </div>
+
 # password reset code verification
 sendPasswordRecoveryEmailSubject = Reset your {0} password
 sendPasswordRecoveryEmailBodyText =\


### PR DESCRIPTION
**Description**
default values of `From`, `Subject` and `Body` should be defined in case `zimbraTwoFactorCodeEmailFrom|Body|Subject` is empty

**Solution**
Provided default template for zimbraTwoFactorCodeEmailBody|Subject in ZsMsg.properties