### PR TITLE
ZCS-14422 Added inviteId on invite instance

### DIFF
--- a/client/src/java/com/zimbra/client/ZInvite.java
+++ b/client/src/java/com/zimbra/client/ZInvite.java
@@ -40,6 +40,7 @@ public class ZInvite implements ToZJSONObject {
     private List<ZTimeZone> mTimeZones;
     private List<ZComponent> mComponents;
     private ZInviteType mType;
+    private int invId;
 
     public ZInvite() {
         mTimeZones = new ArrayList<ZTimeZone>();
@@ -49,6 +50,11 @@ public class ZInvite implements ToZJSONObject {
     public ZInvite(Element e) throws ServiceException {
         mTimeZones = new ArrayList<ZTimeZone>();
         mType = ZInviteType.fromString(e.getAttribute(MailConstants.A_TYPE, ZInviteType.appt.name()));
+        try {
+            invId = e.getAttributeInt(MailConstants.A_ID);
+        } catch (ServiceException se) {
+            // missing invite id
+        }
         for (Element tzEl : e.listElements(MailConstants.E_CAL_TZ)) {
             mTimeZones.add(new ZTimeZone(tzEl));
         }
@@ -72,6 +78,14 @@ public class ZInvite implements ToZJSONObject {
     
     public ZInviteType getType() {
         return mType;
+    }
+
+    public int getInvId() {
+        return invId;
+    }
+
+    public void setInvId(int invId) {
+        this.invId = invId;
     }
 
     public void setComponents(List<ZComponent> components) {


### PR DESCRIPTION
**Problem:**
InviteId is missing on invite instance

**Fix:**
Added inviteId on invite instance

**Test-cases:**
InviteId is needed for remote orphan invite.
To Sync on mobile using activesync, inviteId is added in format `<ServerId>277-271</ServerId>`
Please refer https://synacor.atlassian.net/browse/ZCS-14422 for the use-case