### PR TITLE
ZCS-14405: added new LDAP attribute zimbraServerVersionChangeNotificationDisabled

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -16698,6 +16698,16 @@ public class ZAttrProvisioning {
     public static final String A_zimbraServerVersionBuild = "zimbraServerVersionBuild";
 
     /**
+     * whether to show a notification dialog to reload the page when server
+     * version is changed. FALSE is recommended to use server functions
+     * correctly.
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4113)
+    public static final String A_zimbraServerVersionChangeNotificationDisabled = "zimbraServerVersionChangeNotificationDisabled";
+
+    /**
      * Current major version of ZCS installed on this server
      *
      * @since ZCS 8.5.0

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10440,4 +10440,9 @@ TODO: delete them permanently from here
   <defaultCOSValue>0</defaultCOSValue>
   <desc>This numeric attribute defines the maximum number of participants a user can have in their meetings. For instance, if set to 5, the user can't host a meeting with more than five participants</desc>
 </attr>
+
+<attr id="4113" name="zimbraServerVersionChangeNotificationDisabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited,accountInfo" since="10.1.0">
+  <defaultCOSValue>FALSE</defaultCOSValue>
+  <desc>whether to show a notification dialog to reload the page when server version is changed. FALSE is recommended to use server functions correctly.</desc>
+</attr>
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -61963,6 +61963,88 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * whether to show a notification dialog to reload the page when server
+     * version is changed. FALSE is recommended to use server functions
+     * correctly.
+     *
+     * @return zimbraServerVersionChangeNotificationDisabled, or false if unset
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4113)
+    public boolean isServerVersionChangeNotificationDisabled() {
+        return getBooleanAttr(Provisioning.A_zimbraServerVersionChangeNotificationDisabled, false, true);
+    }
+
+    /**
+     * whether to show a notification dialog to reload the page when server
+     * version is changed. FALSE is recommended to use server functions
+     * correctly.
+     *
+     * @param zimbraServerVersionChangeNotificationDisabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4113)
+    public void setServerVersionChangeNotificationDisabled(boolean zimbraServerVersionChangeNotificationDisabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraServerVersionChangeNotificationDisabled, zimbraServerVersionChangeNotificationDisabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * whether to show a notification dialog to reload the page when server
+     * version is changed. FALSE is recommended to use server functions
+     * correctly.
+     *
+     * @param zimbraServerVersionChangeNotificationDisabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4113)
+    public Map<String,Object> setServerVersionChangeNotificationDisabled(boolean zimbraServerVersionChangeNotificationDisabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraServerVersionChangeNotificationDisabled, zimbraServerVersionChangeNotificationDisabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * whether to show a notification dialog to reload the page when server
+     * version is changed. FALSE is recommended to use server functions
+     * correctly.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4113)
+    public void unsetServerVersionChangeNotificationDisabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraServerVersionChangeNotificationDisabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * whether to show a notification dialog to reload the page when server
+     * version is changed. FALSE is recommended to use server functions
+     * correctly.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4113)
+    public Map<String,Object> unsetServerVersionChangeNotificationDisabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraServerVersionChangeNotificationDisabled, "");
+        return attrs;
+    }
+
+    /**
      * Subscriber/service account number. Custom attribute for account
      * identity.
      *

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -48205,6 +48205,88 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * whether to show a notification dialog to reload the page when server
+     * version is changed. FALSE is recommended to use server functions
+     * correctly.
+     *
+     * @return zimbraServerVersionChangeNotificationDisabled, or false if unset
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4113)
+    public boolean isServerVersionChangeNotificationDisabled() {
+        return getBooleanAttr(Provisioning.A_zimbraServerVersionChangeNotificationDisabled, false, true);
+    }
+
+    /**
+     * whether to show a notification dialog to reload the page when server
+     * version is changed. FALSE is recommended to use server functions
+     * correctly.
+     *
+     * @param zimbraServerVersionChangeNotificationDisabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4113)
+    public void setServerVersionChangeNotificationDisabled(boolean zimbraServerVersionChangeNotificationDisabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraServerVersionChangeNotificationDisabled, zimbraServerVersionChangeNotificationDisabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * whether to show a notification dialog to reload the page when server
+     * version is changed. FALSE is recommended to use server functions
+     * correctly.
+     *
+     * @param zimbraServerVersionChangeNotificationDisabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4113)
+    public Map<String,Object> setServerVersionChangeNotificationDisabled(boolean zimbraServerVersionChangeNotificationDisabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraServerVersionChangeNotificationDisabled, zimbraServerVersionChangeNotificationDisabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * whether to show a notification dialog to reload the page when server
+     * version is changed. FALSE is recommended to use server functions
+     * correctly.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4113)
+    public void unsetServerVersionChangeNotificationDisabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraServerVersionChangeNotificationDisabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * whether to show a notification dialog to reload the page when server
+     * version is changed. FALSE is recommended to use server functions
+     * correctly.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4113)
+    public Map<String,Object> unsetServerVersionChangeNotificationDisabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraServerVersionChangeNotificationDisabled, "");
+        return attrs;
+    }
+
+    /**
      * Maximum allowed lifetime of shares to internal users or groups. A
      * value of 0 indicates that there&#039;s no limit on an internal
      * share&#039;s lifetime. . Must be in valid duration format:


### PR DESCRIPTION
Adding a ldap attribute `zimbraServerVersionChangeNotificationDisabled` to suppress a dialog of server version change on Classic UI.