### PR TITLE
ZCS-14294:Social filter is not working with latest URL's of social pl…

### DIFF
--- a/store/src/java-test/com/zimbra/cs/filter/FacebookTestTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/FacebookTestTest.java
@@ -16,14 +16,6 @@
  */
 package com.zimbra.cs.filter;
 
-import java.util.HashMap;
-import java.util.List;
-
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import com.zimbra.common.util.ArrayUtil;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.MockProvisioning;
@@ -37,6 +29,13 @@ import com.zimbra.cs.mailbox.Message;
 import com.zimbra.cs.mailbox.OperationContext;
 import com.zimbra.cs.mime.ParsedMessage;
 import com.zimbra.cs.service.util.ItemId;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
 
 /**
  * Unit test for {@link FacebookTest}.
@@ -74,11 +73,12 @@ public final class FacebookTestTest {
 
         // deals
         ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox), mbox,
-                new ParsedMessage("From: \"Facebook Deals\" <deals+mhw1-ivm@facebookmail.com>\n".getBytes(), false),
+                new ParsedMessage("From: \"Facebook Deals\" <deals+mhw1-ivm@xfacebookmail.com>\n".getBytes(), false),
                 0, account.getName(), new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
         Assert.assertEquals(1, ids.size());
         msg = mbox.getMessageById(null, ids.get(0).getId());
         Assert.assertTrue(msg.getTags().length == 0);
+
     }
 
 }

--- a/store/src/java-test/com/zimbra/cs/filter/LinkedInTestTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/LinkedInTestTest.java
@@ -16,14 +16,6 @@
  */
 package com.zimbra.cs.filter;
 
-import java.util.HashMap;
-import java.util.List;
-
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import com.zimbra.common.util.ArrayUtil;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.MockProvisioning;
@@ -37,6 +29,13 @@ import com.zimbra.cs.mailbox.Message;
 import com.zimbra.cs.mailbox.OperationContext;
 import com.zimbra.cs.mime.ParsedMessage;
 import com.zimbra.cs.service.util.ItemId;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
 
 /**
  * Unit test for {@link LinkedInTest}.
@@ -76,7 +75,25 @@ public final class LinkedInTestTest {
         // deals
         ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox), mbox,
                 new ParsedMessage(("Sender: messages-noreply@bounce.linkedin.com\n" +
-                    "From: Yuichi Sasaki via LinkedIn <member@linkedin.com>").getBytes(), false),
+                    "From: Yuichi Sasaki via LinkedIn <member@cs.linkedin.com>").getBytes(), false),
+                0, account.getName(), new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
+        Assert.assertEquals(1, ids.size());
+        msg = mbox.getMessageById(null, ids.get(0).getId());
+        Assert.assertEquals("linkedin", ArrayUtil.getFirstElement(msg.getTags()));
+
+        // connections@e.linkedin.com
+        ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox), mbox,
+                new ParsedMessage(("Sender: messages-noreply@bounce.linkedin.com\n" +
+                        "From: LinkedIn Connections <connections@e.linkedin.com>").getBytes(), false),
+                0, account.getName(), new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
+        Assert.assertEquals(1, ids.size());
+        msg = mbox.getMessageById(null, ids.get(0).getId());
+        Assert.assertEquals("linkedin", ArrayUtil.getFirstElement(msg.getTags()));
+
+        // connections@el.linkedin.com
+        ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox), mbox,
+                new ParsedMessage(("Sender: messages-noreply@bounce.linkedin.com\n" +
+                        "From: LinkedIn Connections <connections@el.linkedin.com>").getBytes(), false),
                 0, account.getName(), new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
         Assert.assertEquals(1, ids.size());
         msg = mbox.getMessageById(null, ids.get(0).getId());

--- a/store/src/java-test/com/zimbra/cs/filter/TwitterTestTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/TwitterTestTest.java
@@ -16,14 +16,6 @@
  */
 package com.zimbra.cs.filter;
 
-import java.util.HashMap;
-import java.util.List;
-
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import com.zimbra.common.util.ArrayUtil;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.MockProvisioning;
@@ -37,6 +29,13 @@ import com.zimbra.cs.mailbox.Message;
 import com.zimbra.cs.mailbox.OperationContext;
 import com.zimbra.cs.mime.ParsedMessage;
 import com.zimbra.cs.service.util.ItemId;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
 
 /**
  * Unit test for {@link TwitterTest}.
@@ -66,7 +65,7 @@ public final class TwitterTestTest {
 
         // direct message email: the old way the filter worked
         List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox), mbox, new ParsedMessage(
-                "From: Twitter <dm-lfnfnxv=mvzoen.pbz-4fa92@postmaster.twitter.com>\n".getBytes(), false),
+                "From: Twitter <dm-lfnfnxv=mvzoen.pbz-4fa92@yx.com>\n".getBytes(), false),
                 0, account.getName(), new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
         Assert.assertEquals(1, ids.size());
         Message msg = mbox.getMessageById(null, ids.get(0).getId());
@@ -74,7 +73,7 @@ public final class TwitterTestTest {
 
         // mention email : the old way the filter worked
         ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox), mbox, new ParsedMessage(
-                "From: Twitter <mention-lfnfnxv=mvzoen.pbz-4fa92@postmaster.twitter.com>\n".getBytes(), false),
+                "From: Twitter <mention-lfnfnxv=mvzoen.pbz-4fa92@e-x.com>\n".getBytes(), false),
                 0, account.getName(), new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
         Assert.assertEquals(1, ids.size());
         msg = mbox.getMessageById(null, ids.get(0).getId());
@@ -82,7 +81,7 @@ public final class TwitterTestTest {
         
         
         ids = RuleManager.applyRulesToIncomingMessage(new OperationContext(mbox), mbox, new ParsedMessage(
-                "From: sharuki2 (via Twitter) <notify@twitter.com>\n".getBytes(), false),
+                "From: sharuki2 (via Twitter) <notify@x.com>\n".getBytes(), false),
                 0, account.getName(), new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
         Assert.assertEquals(1, ids.size());
         msg = mbox.getMessageById(null, ids.get(0).getId());

--- a/store/src/java/com/zimbra/cs/filter/jsieve/FacebookTest.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/FacebookTest.java
@@ -56,7 +56,7 @@ public final class FacebookTest extends AbstractTest {
         ParsedAddress sender = adapter.getParsedMessage().getParsedSender();
         if (!Strings.isNullOrEmpty(sender.emailPart)) {
             String email = sender.emailPart.toLowerCase();
-            if (email.endsWith("@facebookmail.com") && email.startsWith("notification+")) {
+            if (email.endsWith("@facebookmail.com")) {
                 return true;
             }
         }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/LinkedInTest.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/LinkedInTest.java
@@ -16,19 +16,15 @@
  */
 package com.zimbra.cs.filter.jsieve;
 
-import java.util.Set;
-
+import com.google.common.base.Strings;
+import com.zimbra.cs.filter.DummyMailAdapter;
+import com.zimbra.cs.filter.ZimbraMailAdapter;
+import com.zimbra.cs.mime.ParsedAddress;
 import org.apache.jsieve.Arguments;
 import org.apache.jsieve.SieveContext;
 import org.apache.jsieve.exception.SieveException;
 import org.apache.jsieve.mail.MailAdapter;
 import org.apache.jsieve.tests.AbstractTest;
-
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableSet;
-import com.zimbra.cs.filter.DummyMailAdapter;
-import com.zimbra.cs.filter.ZimbraMailAdapter;
-import com.zimbra.cs.mime.ParsedAddress;
 
 /**
  * SIEVE test for LinkedIn notifications.
@@ -42,8 +38,6 @@ import com.zimbra.cs.mime.ParsedAddress;
  * @author ysasaki
  */
 public final class LinkedInTest extends AbstractTest {
-    private static final Set<String> ADDRESSES = ImmutableSet.of("connections@linkedin.com", "member@linkedin.com", "hit-reply@linkedin.com");
-
     @Override
     protected boolean executeBasic(MailAdapter mail, Arguments args, SieveContext ctx) throws SieveException {
         if (mail instanceof DummyMailAdapter) {
@@ -55,8 +49,12 @@ public final class LinkedInTest extends AbstractTest {
         ZimbraMailAdapter adapter = (ZimbraMailAdapter) mail;
 
         ParsedAddress sender = adapter.getParsedMessage().getParsedSender();
-        if (!Strings.isNullOrEmpty(sender.emailPart) && ADDRESSES.contains(sender.emailPart.toLowerCase())) {
-            return true;
+        if (!Strings.isNullOrEmpty(sender.emailPart)) {
+            String email = sender.emailPart.toLowerCase();
+            if (email.endsWith("@linkedin.com") || email.endsWith("@e.linkedin.com") || email.endsWith(
+                    "@cs.linkedin.com") || email.endsWith("@el.linkedin.com")) {
+                return true;
+            }
         }
         return false;
     }

--- a/store/src/java/com/zimbra/cs/filter/jsieve/TwitterTest.java
+++ b/store/src/java/com/zimbra/cs/filter/jsieve/TwitterTest.java
@@ -53,7 +53,7 @@ public final class TwitterTest extends AbstractTest {
         ParsedAddress sender = adapter.getParsedMessage().getParsedSender();
         if (!Strings.isNullOrEmpty(sender.emailPart)) {
             String email = sender.emailPart.toLowerCase();
-            if (email.equals("notify@twitter.com")) {
+            if (email.endsWith("@x.com")) {
                 return true;
             }
         }


### PR DESCRIPTION
Requirements:
The social filter is not working with the latest URLs of social platforms such as the following:

- [notifications@facebook.com](mailto:notifications@facebook.com)
- [X.com](http://x.com/)
- alerts for @linkedin.com

Solution:
Update the existing URLs with the latest **domain names** of social platforms _facebook.com_, _x.com_ and _linkedin.com_.

Testing:
Tested by installing the custom build on the remote machine & by Junits.

[ZCS-13731]: https://synacor.atlassian.net/browse/ZCS-13731?

[ZCS-14294]: https://synacor.atlassian.net/browse/ZCS-14294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ