### PR TITLE
ZCS-14424: Limit attribute restriction with LDAP Counter: LdapCounter

### DIFF
--- a/soap/src/java/com/zimbra/soap/admin/type/CountObjectsType.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/CountObjectsType.java
@@ -37,7 +37,10 @@ public enum CountObjectsType {
     // for license counting
     internalUserAccount(true, false),
     internalArchivingAccount(true, false),
-    internalUserAccountX(true, false);
+    internalUserAccountX(true, false),
+    internalUserAccountWithMobileSync(false, false),
+    internalUserAccountWithSmime(false, false),
+    internalUserAccountWithEws(false, false);
     
     private boolean allowsDomain;
     private boolean allowsUCService;

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -9352,6 +9352,18 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
                 types.add(ObjectType.domains);
                 filter = filterFactory.domainsOnUCService(ucService.getId());
                 break;
+            case internalUserAccountWithSmime:
+                types.add(ObjectType.accounts);
+                filter = filterFactory.accountsWithSmime();
+                break;
+            case internalUserAccountWithEws:
+                types.add(ObjectType.accounts);
+                filter = filterFactory.accountsWithEws();
+                break;
+            case internalUserAccountWithMobileSync:
+                types.add(ObjectType.accounts);
+                filter = filterFactory.accountsWithMobileSync();
+                break;
             default:
                 throw ServiceException.INVALID_REQUEST("unsupported counting type:" + type.toString(), null);
         }

--- a/store/src/java/com/zimbra/cs/ldap/ZLdapFilterFactory.java
+++ b/store/src/java/com/zimbra/cs/ldap/ZLdapFilterFactory.java
@@ -185,7 +185,14 @@ public abstract class ZLdapFilterFactory extends ZLdapElement {
         LDAP_UPGRADE("LDAP_UPGRADE"),
         ZMCONFIGD("ZMCONFIGD"),
 
-        TODO("TODO");
+        TODO("TODO"),
+
+        /*
+         * Licensing
+         */
+        ACCOUNTS_WITH_MOBILE_SYNC("Filter in " + Provisioning.A_zimbraFeatureMobileSyncEnabled),
+        ACCOUNTS_WITH_EWS("Filter in " + Provisioning.A_zimbraFeatureEwsEnabled),
+        ACCOUNTS_WITH_SMIME("Filter in " + Provisioning.A_zimbraFeatureSMIMEEnabled);
 
         private final String template;
 
@@ -354,6 +361,13 @@ public abstract class ZLdapFilterFactory extends ZLdapElement {
     public abstract ZLdapFilter CMBSearchAccountsOnly();
     public abstract ZLdapFilter CMBSearchAccountsOnlyWithArchive();
     public abstract ZLdapFilter CMBSearchNonSystemResourceAccountsOnly();
+
+    /*
+     * account licensing
+     */
+    public abstract ZLdapFilter accountsWithSmime();
+    public abstract ZLdapFilter accountsWithEws();
+    public abstract ZLdapFilter accountsWithMobileSync();
 
     /*
      * alias

--- a/store/src/java/com/zimbra/cs/ldap/unboundid/UBIDLdapFilterFactory.java
+++ b/store/src/java/com/zimbra/cs/ldap/unboundid/UBIDLdapFilterFactory.java
@@ -83,6 +83,9 @@ public class UBIDLdapFilterFactory extends ZLdapFilterFactory {
     private static Filter FILTER_WITH_ARCHIVE;
     private static Filter FILTER_ALL_INTERNAL_ACCOUNTS;
     private static Filter FILTER_ALL_ADDRESS_LISTS;
+    private static Filter FILTER_ACCOUNTS_WITH_SMIME;
+    private static Filter FILTER_ACCOUNTS_WITH_EWS;
+    private static Filter FILTER_ACCOUNTS_WITH_MOBILE_SYNC;
 
 
     private static boolean initialized = false;
@@ -274,6 +277,15 @@ public class UBIDLdapFilterFactory extends ZLdapFilterFactory {
 
         FILTER_ALL_ADDRESS_LISTS = Filter.createEqualityFilter(
                 LdapConstants.ATTR_objectClass, AttributeClass.OC_zimbraAddressList);
+
+        FILTER_ACCOUNTS_WITH_EWS = Filter.createEqualityFilter(
+                Provisioning.A_zimbraFeatureEwsEnabled, LdapConstants.LDAP_TRUE);
+
+        FILTER_ACCOUNTS_WITH_MOBILE_SYNC = Filter.createEqualityFilter(
+                Provisioning.A_zimbraFeatureMobileSyncEnabled, LdapConstants.LDAP_TRUE);
+
+        FILTER_ACCOUNTS_WITH_SMIME = Filter.createEqualityFilter(
+                Provisioning.A_zimbraFeatureSMIMEEnabled, LdapConstants.LDAP_TRUE);
     }
 
     @Override
@@ -590,6 +602,40 @@ public class UBIDLdapFilterFactory extends ZLdapFilterFactory {
                         FILTER_ALL_ACCOUNTS_ONLY,
                         FILTER_NOT_SYSTEM_RESOURCE,
                         FILTER_NOT_EXCLUDED_FROM_CMB_SEARCH));
+    }
+
+    /*
+     * account licensing
+     */
+    @Override
+    public ZLdapFilter accountsWithSmime() {
+        return new UBIDLdapFilter(
+                FilterId.ACCOUNTS_WITH_SMIME,
+                Filter.createANDFilter(
+                        FILTER_ALL_ACCOUNTS_ONLY,
+                        FILTER_NOT_SYSTEM_RESOURCE,
+                        FILTER_ACCOUNTS_WITH_SMIME));
+
+    }
+    @Override
+    public ZLdapFilter accountsWithEws() {
+        return new UBIDLdapFilter(
+                FilterId.ACCOUNTS_WITH_EWS,
+                Filter.createANDFilter(
+                        FILTER_ALL_ACCOUNTS_ONLY,
+                        FILTER_NOT_SYSTEM_RESOURCE,
+                        FILTER_ACCOUNTS_WITH_EWS));
+
+    }
+    @Override
+    public ZLdapFilter accountsWithMobileSync() {
+        return new UBIDLdapFilter(
+                FilterId.ACCOUNTS_WITH_MOBILE_SYNC,
+                Filter.createANDFilter(
+                        FILTER_ALL_ACCOUNTS_ONLY,
+                        FILTER_NOT_SYSTEM_RESOURCE,
+                        FILTER_ACCOUNTS_WITH_MOBILE_SYNC));
+
     }
 
 


### PR DESCRIPTION
add required functionality for [ZCS-14424. ](https://github.com/Zimbra/zm-license-tools/compare/feature/ZCS-14424)
adding ability to count individual ldap feature seats with paging. 

