### PR TITLE
ZCS-14435: Added request and response classes for DisableTwoFactorAuth for admin namespace

### DIFF
--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -52,6 +52,8 @@ public final class AdminConstants {
     public static final String E_DELEGATE_AUTH_RESPONSE = "DelegateAuthResponse";
     public static final String E_DELETE_GAL_SYNC_ACCOUNT_REQUEST = "DeleteGalSyncAccountRequest";
     public static final String E_DELETE_GAL_SYNC_ACCOUNT_RESPONSE = "DeleteGalSyncAccountResponse";
+    public static final String E_DISABLE_TWO_FACTOR_AUTH_REQUEST = "DisableTwoFactorAuthRequest";
+    public static final String E_DISABLE_TWO_FACTOR_AUTH_RESPONSE = "DisableTwoFactorAuthResponse";
     public static final String E_GET_ACCOUNT_REQUEST = "GetAccountRequest";
     public static final String E_GET_ACCOUNT_RESPONSE = "GetAccountResponse";
     public static final String E_GET_ACCOUNT_INFO_REQUEST = "GetAccountInfoRequest";
@@ -563,6 +565,8 @@ public final class AdminConstants {
     public static final QName DELEGATE_AUTH_RESPONSE = QName.get(E_DELEGATE_AUTH_RESPONSE, NAMESPACE);
     public static final QName DELETE_GAL_SYNC_ACCOUNT_REQUEST = QName.get(E_DELETE_GAL_SYNC_ACCOUNT_REQUEST, NAMESPACE);
     public static final QName DELETE_GAL_SYNC_ACCOUNT_RESPONSE = QName.get(E_DELETE_GAL_SYNC_ACCOUNT_RESPONSE, NAMESPACE);
+    public static final QName DISABLE_TWO_FACTOR_AUTH_REQUEST = QName.get(E_DISABLE_TWO_FACTOR_AUTH_REQUEST, NAMESPACE);
+    public static final QName DISABLE_TWO_FACTOR_AUTH_RESPONSE = QName.get(E_DISABLE_TWO_FACTOR_AUTH_RESPONSE, NAMESPACE);
     public static final QName GET_ACCOUNT_REQUEST = QName.get(E_GET_ACCOUNT_REQUEST, NAMESPACE);
     public static final QName GET_ACCOUNT_RESPONSE = QName.get(E_GET_ACCOUNT_RESPONSE, NAMESPACE);
     public static final QName GET_ACCOUNT_INFO_REQUEST = QName.get(E_GET_ACCOUNT_INFO_REQUEST, NAMESPACE);

--- a/soap/src/java/com/zimbra/soap/JaxbUtil.java
+++ b/soap/src/java/com/zimbra/soap/JaxbUtil.java
@@ -354,6 +354,8 @@ public final class JaxbUtil {
             com.zimbra.soap.admin.message.DeleteDomainResponse.class,
             com.zimbra.soap.admin.message.DeleteGalSyncAccountRequest.class,
             com.zimbra.soap.admin.message.DeleteGalSyncAccountResponse.class,
+            com.zimbra.soap.admin.message.DisableTwoFactorAuthRequest.class,
+            com.zimbra.soap.admin.message.DisableTwoFactorAuthResponse.class,
             com.zimbra.soap.admin.message.DeleteLDAPEntryRequest.class,
             com.zimbra.soap.admin.message.DeleteLDAPEntryResponse.class,
             com.zimbra.soap.admin.message.DeleteMailboxRequest.class,

--- a/soap/src/java/com/zimbra/soap/admin/message/DisableTwoFactorAuthRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/DisableTwoFactorAuthRequest.java
@@ -1,0 +1,53 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ *
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2024 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.soap.admin.message;
+
+import com.zimbra.common.soap.AccountConstants;
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.soap.type.AccountSelector;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlRootElement(name= AdminConstants.E_DISABLE_TWO_FACTOR_AUTH_REQUEST)
+@XmlType(propOrder = {})
+public class DisableTwoFactorAuthRequest {
+    @XmlElement(name= AccountConstants.E_ACCOUNT, required=false)
+    private AccountSelector account;
+
+    @XmlElement(name=AccountConstants.E_METHOD, required=false)
+    private String method;
+
+    public AccountSelector getAccount() {
+        return account;
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public void setAccount(AccountSelector account) {
+        this.account = account;
+    }
+
+    public void setMethod(String method) {
+        this.method = method;
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/DisableTwoFactorAuthResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/DisableTwoFactorAuthResponse.java
@@ -1,0 +1,29 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ *
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2024 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.soap.admin.message;
+
+import com.zimbra.common.soap.AdminConstants;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlRootElement(name= AdminConstants.E_DISABLE_TWO_FACTOR_AUTH_RESPONSE)
+@XmlType(propOrder = {})
+public class DisableTwoFactorAuthResponse {
+}


### PR DESCRIPTION
**Description**

We are adding new 2FA-related attributes to admin console on https://synacor.atlassian.net/browse/ZCS-14111.

Regarding `zimbraTwoFactorAuthMethodEnabled` , it is configured via EnableTwoFactorAuthRequest.
`zimbraTwoFactorAuthEnabled` and `zimbraPrefPrimaryTwoFactorAuthMethod` are configured during the process.
These attributes are automatically configured in the process of DisableTwoFactorAuthRequest as well.

It means that `zimbraTwoFactorAuthMethodEnabled` should not be configured directly via ModifyAccountRequest but should always be configured via Enable|DisableTwoFactorAuthRequest.

To disable a TFA method on admin console, from the viewpoint of UI, DisableTwoFactorAuthRequest must be called using admin authtoken, specifying `urn:zimbraAdmin` and a target account, via admin port (proxy 9071 => mailbox 7071 by default.)
DisableTwoFactorAuthRequest called by administrator needs to address a target account.

i.e.

**current implementation (See PREAPPS-7487)**
```
urn:zimbraAccount
<DisableTwoFactorAuthRequest>
   <method>{app|email}</method>
</DisableTwoFactorAuthRequest>
```

**Need to add**
```
urn:zimbraAdmin
<DisableTwoFactorAuthRequest>
   <account by={name|id}>{value}</account>
   <method>{app|email}</method>
</DisableTwoFactorAuthRequest>
```

**Requirements:**

add DisableTwoFactorAuthRequest in urn:zimbraAdmin . It can address account element as target account to disable a TFA method.
It can be called via admin port (7071 by default) only. It cannot be called by end user in any case.
it can be addressed with admin authtoken only.