### PR TITLE
ZCS-14474: ZBUG-2956 - Send email button doesn't work in modernUI while using SendAs

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/AutoSendDraftTask.java
+++ b/store/src/java/com/zimbra/cs/mailbox/AutoSendDraftTask.java
@@ -30,6 +30,15 @@ public class AutoSendDraftTask extends ScheduledTask<Object> {
 
     private static final String TASK_NAME_PREFIX = "autoSendDraftTask";
     private static final String DRAFT_ID_PROP_NAME = "draftId";
+    private int delegatorMailboxId;
+
+    public int getDelegatorMailboxId() {
+        return delegatorMailboxId;
+    }
+
+    public void setDelegatorMailboxId(int delegatorMailboxId) {
+        this.delegatorMailboxId = delegatorMailboxId;
+    }
 
     /**
      * Returns the task name.
@@ -47,6 +56,10 @@ public class AutoSendDraftTask extends ScheduledTask<Object> {
     @Override public Void call() throws Exception {
         ZimbraLog.scheduler.debug("Running task %s", this);
         Mailbox mbox = MailboxManager.getInstance().getMailboxById(getMailboxId());
+        Mailbox delegatorMbox = mbox;
+        if (getDelegatorMailboxId() != 0) {
+            delegatorMbox = MailboxManager.getInstance().getMailboxById(getDelegatorMailboxId());
+        }
         if (mbox == null) {
             ZimbraLog.scheduler.error("Mailbox for id %s does not exist", getMailboxId());
             return null;
@@ -69,11 +82,11 @@ public class AutoSendDraftTask extends ScheduledTask<Object> {
             return null;
         }
         // send draft
-        MailSender mailSender = mbox.getMailSender();
+        MailSender mailSender = delegatorMbox.getMailSender();
         mailSender.setOriginalMessageId(StringUtil.isNullOrEmpty(msg.getDraftOrigId()) ? null : new ItemId(msg.getDraftOrigId(), mbox.getAccountId()));
         mailSender.setReplyType(StringUtil.isNullOrEmpty(msg.getDraftReplyType()) ? null : msg.getDraftReplyType());
         mailSender.setIdentity(StringUtil.isNullOrEmpty(msg.getDraftIdentityId()) ? null : mbox.getAccount().getIdentityById(msg.getDraftIdentityId()));
-        mailSender.sendMimeMessage(new OperationContext(mbox), mbox, msg.getMimeMessage());
+        mailSender.sendMimeMessage(new OperationContext(mbox), delegatorMbox, msg.getMimeMessage());
         // now delete the draft
         mbox.delete(null, draftId, MailItem.Type.MESSAGE);
         return null;
@@ -102,11 +115,16 @@ public class AutoSendDraftTask extends ScheduledTask<Object> {
      * @param autoSendTime
      * @throws ServiceException
      */
-    public static void scheduleTask(int draftId, int mailboxId, long autoSendTime) throws ServiceException {
+    public static void scheduleTask(int draftId, int mailboxId, int delegatorMailboxId, long autoSendTime) throws ServiceException {
         AutoSendDraftTask autoSendDraftTask = new AutoSendDraftTask();
         autoSendDraftTask.setMailboxId(mailboxId);
+        autoSendDraftTask.setDelegatorMailboxId(delegatorMailboxId);
         autoSendDraftTask.setExecTime(new Date(autoSendTime));
         autoSendDraftTask.setProperty(DRAFT_ID_PROP_NAME, Integer.toString(draftId));
         ScheduledTaskManager.schedule(autoSendDraftTask);
+    }
+
+    public static void scheduleTask(int draftId, int mailboxId, long autoSendTime) throws ServiceException {
+        scheduleTask(draftId, mailboxId, 0, autoSendTime);
     }
 }

--- a/store/src/java/com/zimbra/cs/service/mail/SaveDraft.java
+++ b/store/src/java/com/zimbra/cs/service/mail/SaveDraft.java
@@ -18,20 +18,26 @@ package com.zimbra.cs.service.mail;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Date;
 import java.util.Map;
 
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
+import com.zimbra.common.account.Key.AccountBy;
 import com.zimbra.common.mailbox.Color;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.HeaderConstants;
 import com.zimbra.common.soap.MailConstants;
 import com.zimbra.common.util.ArrayUtil;
 import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.mailbox.AutoSendDraftTask;
 import com.zimbra.cs.mailbox.MailItem;
+import com.zimbra.cs.mailbox.MailboxManager;
 import com.zimbra.cs.mailbox.MailServiceException;
 import com.zimbra.cs.mailbox.MailServiceException.NoSuchItemException;
 import com.zimbra.cs.mailbox.Mailbox;
@@ -81,7 +87,29 @@ public class SaveDraft extends MailDocumentHandler {
         boolean wantModSeq = request.getAttributeBool(MailConstants.A_WANT_MODIFIED_SEQUENCE, false);
         Element msgElem = request.getElement(MailConstants.E_MSG);
 
-        int id = (int) msgElem.getAttributeLong(MailConstants.A_ID, Mailbox.ID_AUTO_INCREMENT);
+        // fetching the Delegator Account
+        // if mail is not delegated to be Send As, then the delegator account is the same as the account of the mailbox
+        String mailAddress = null;
+        List<Element> elements = msgElem.listElements(MailConstants.E_EMAIL);
+        for (Element element : elements) {
+            if (element.getAttribute(MailConstants.A_ITEM_TYPE, null).equals(MailConstants.A_FLAGS)) {
+                mailAddress = element.getAttribute(MailConstants.A_ADDRESS, null);
+            }
+        }
+        Provisioning prov = Provisioning.getInstance();
+        Account delegatorAccount;
+        Mailbox delegatorMbox = null;
+        if (mailAddress != null) {
+            delegatorAccount = prov.get(AccountBy.name, mailAddress, zsc.getAuthToken());
+            String mRequestedAccountId = delegatorAccount.getId();
+            delegatorMbox = MailboxManager.getInstance().getMailboxByAccountId(mRequestedAccountId, true);
+        }
+        if (!mbox.getAccountId().equals(delegatorMbox.getAccountId())) {
+            ZimbraLog.soap.info("Draft is delegated to be sent from " + mailAddress);
+        }
+        String mId = msgElem.getAttribute(MailConstants.A_ID, String.valueOf(Mailbox.ID_AUTO_INCREMENT));
+        ItemId iidMsg = mId == null ? null : new ItemId(mId, zsc);
+        int id = iidMsg.getId();
         String originalId = msgElem.getAttribute(MailConstants.A_ORIG_ID, null);
         ItemId iidOrigid = originalId == null ? null : new ItemId(originalId, zsc);
         String replyType = msgElem.getAttribute(MailConstants.A_REPLY_TYPE, null);
@@ -170,7 +198,12 @@ public class SaveDraft extends MailDocumentHandler {
             }
             if (autoSendTime != 0) {
                 // schedule a new auto-send-draft task
-                AutoSendDraftTask.scheduleTask(msg.getId(), mbox.getId(), autoSendTime);
+                if (delegatorMbox != null) {
+                    AutoSendDraftTask.scheduleTask(msg.getId(), mbox.getId(), delegatorMbox.getId(), autoSendTime);
+                }
+                else {
+                    AutoSendDraftTask.scheduleTask(msg.getId(), mbox.getId(), autoSendTime);
+                }
             }
         }
 


### PR DESCRIPTION
Issue: Send email button doesn't work in modernUI while using SendAs Delegator and Undo Send Enabled
Fix: Updated the SaveDraft Method Call and AutoSendDraftTask Method Call.
Testing: Verified the SendAs Button is working when Undo Send is Enabled.