### PR TITLE
Revert ZBUG-2956 - Send email button does not work in modern UI with Undo send enable - delegate sender Send as

### DIFF
--- a/store/src/java/com/zimbra/cs/service/mail/SaveDraft.java
+++ b/store/src/java/com/zimbra/cs/service/mail/SaveDraft.java
@@ -101,9 +101,8 @@ public class SaveDraft extends MailDocumentHandler {
         Mailbox delegatorMbox = null;
         if (mailAddress != null) {
             delegatorAccount = prov.get(AccountBy.name, mailAddress, zsc.getAuthToken());
-            if (delegatorAccount != null) {
-                delegatorMbox = MailboxManager.getInstance().getMailboxByAccountId(delegatorAccount.getId(), true);
-            }
+            String mRequestedAccountId = delegatorAccount.getId();
+            delegatorMbox = MailboxManager.getInstance().getMailboxByAccountId(mRequestedAccountId, true);
         }
         if (delegatorMbox != null && !mbox.getAccountId().equals(delegatorMbox.getAccountId())) {
             ZimbraLog.soap.info("Draft is delegated to be sent from " + mailAddress);

--- a/store/src/java/com/zimbra/cs/service/mail/SaveDraft.java
+++ b/store/src/java/com/zimbra/cs/service/mail/SaveDraft.java
@@ -104,7 +104,7 @@ public class SaveDraft extends MailDocumentHandler {
             String mRequestedAccountId = delegatorAccount.getId();
             delegatorMbox = MailboxManager.getInstance().getMailboxByAccountId(mRequestedAccountId, true);
         }
-        if (delegatorMbox != null && !mbox.getAccountId().equals(delegatorMbox.getAccountId())) {
+        if (!mbox.getAccountId().equals(delegatorMbox.getAccountId())) {
             ZimbraLog.soap.info("Draft is delegated to be sent from " + mailAddress);
         }
         String mId = msgElem.getAttribute(MailConstants.A_ID, String.valueOf(Mailbox.ID_AUTO_INCREMENT));


### PR DESCRIPTION
Reverted the following Commits from the ticket :

46d7423173 Revert "ZCS-14474: ZBUG-2956 - Send email button does not work in modern UI with Undo send enable - delegate sender Send as"
bf2d2775dc: Revert "ZCS-14643 Adding Check for Null Pointer Exception."
0b5c6c16d6 Revert "ZCS-14653: Add null Pointer check for delegatorAccount variable."

