### PR TITLE
ZCS-14667: User is able to access email present in external storage w…

### DIFF
--- a/store/src/java/com/zimbra/cs/store/file/FileBlobStore.java
+++ b/store/src/java/com/zimbra/cs/store/file/FileBlobStore.java
@@ -367,12 +367,17 @@ public final class FileBlobStore extends StoreManager {
 
     @Override
     public MailboxBlob getMailboxBlob(Mailbox mbox, int itemId, int revision, String locator, boolean validate) throws ServiceException {
-        short volumeId = Short.valueOf(locator);
-        File file = getMailboxBlobFile(mbox, itemId, revision, volumeId, validate);
-        if (file == null) {
-            return null;
+        try {
+            short volumeId = Short.valueOf(locator);
+            File file = getMailboxBlobFile(mbox, itemId, revision, volumeId, validate);
+            if (file == null) {
+                return null;
+            }
+            return new VolumeMailboxBlob(mbox, itemId, revision, locator, new VolumeBlob(file, volumeId));
+        } catch (NumberFormatException e) {
+            ZimbraLog.store.info("NumberFormatException:", e);
+            throw ServiceException.FAILURE("Operation can not be completed because store is not accessible", null);
         }
-        return new VolumeMailboxBlob(mbox, itemId, revision, locator, new VolumeBlob(file, volumeId));
     }
 
     @Override


### PR DESCRIPTION
Ticket : [ZCS-14667](https://synacor.atlassian.net/browse/ZCS-14667)
We are getting NumberFormatException, while reading the messages when primary is internal and secondary is external when license is expired. Also, we should block user reading external blobs from S3 volume, so to handle this we are providing a custom exception message for it.

Solution :
to handle this we are providing a custom exception message for it.

Testing:
Tested the changes remotely.


[ZCS-14667]: https://synacor.atlassian.net/browse/ZCS-14667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ