### PR TITLE
ZCS-14647: Added SendTwoFactorCodeRequest/Response APIs for admin namespace

### DIFF
--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -305,6 +305,9 @@ public final class AdminConstants {
     public static final String E_SEARCH_MULTIPLE_MAILBOXES_REQUEST = "SearchMultiMailboxRequest";
     public static final String E_SEARCH_MULTIPLE_MAILBOXES_RESPONSE = "SearchMultiMailboxResponse";
 
+    public static final String E_SEND_TWO_FACTOR_AUTH_CODE_REQUEST = "SendTwoFactorAuthCodeRequest";
+    public static final String E_SEND_TWO_FACTOR_AUTH_CODE_RESPONSE = "SendTwoFactorAuthCodeResponse";
+
     public static final String E_DUMP_SESSIONS_REQUEST = "DumpSessionsRequest";
     public static final String E_DUMP_SESSIONS_RESPONSE = "DumpSessionsResponse";
     public static final String E_GET_SESSIONS_REQUEST = "GetSessionsRequest";
@@ -817,6 +820,9 @@ public final class AdminConstants {
 
     public static final QName SEARCH_MULTIPLE_MAILBOXES_REQUEST = QName.get(E_SEARCH_MULTIPLE_MAILBOXES_REQUEST, NAMESPACE);
     public static final QName SEARCH_MULTIPLE_MAILBOXES_RESPONSE = QName.get(E_SEARCH_MULTIPLE_MAILBOXES_RESPONSE, NAMESPACE);
+
+    public static final QName SEND_TWO_FACTOR_AUTH_CODE_REQUEST = QName.get(E_SEND_TWO_FACTOR_AUTH_CODE_REQUEST, NAMESPACE);
+    public static final QName SEND_TWO_FACTOR_AUTH_CODE_RESPONSE = QName.get(E_SEND_TWO_FACTOR_AUTH_CODE_RESPONSE, NAMESPACE);
 
     public static final QName DUMP_SESSIONS_REQUEST = QName.get(E_DUMP_SESSIONS_REQUEST, NAMESPACE);
     public static final QName DUMP_SESSIONS_RESPONSE = QName.get(E_DUMP_SESSIONS_RESPONSE, NAMESPACE);

--- a/soap/src/java/com/zimbra/soap/JaxbUtil.java
+++ b/soap/src/java/com/zimbra/soap/JaxbUtil.java
@@ -734,6 +734,8 @@ public final class JaxbUtil {
             com.zimbra.soap.admin.message.SearchGalResponse.class,
             com.zimbra.soap.admin.message.SearchMultiMailboxRequest.class,
             com.zimbra.soap.admin.message.SearchMultiMailboxResponse.class,
+            com.zimbra.soap.admin.message.SendTwoFactorAuthCodeRequest.class,
+            com.zimbra.soap.admin.message.SendTwoFactorAuthCodeResponse.class,
             com.zimbra.soap.admin.message.SetCurrentVolumeRequest.class,
             com.zimbra.soap.admin.message.SetCurrentVolumeResponse.class,
             com.zimbra.soap.admin.message.SetLocalServerOnlineRequest.class,

--- a/soap/src/java/com/zimbra/soap/admin/message/SendTwoFactorAuthCodeRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/SendTwoFactorAuthCodeRequest.java
@@ -1,0 +1,78 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ *
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2024 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.soap.admin.message;
+
+import com.zimbra.common.soap.AccountConstants;
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.soap.type.AccountSelector;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name= AdminConstants.E_SEND_TWO_FACTOR_AUTH_CODE_REQUEST)
+public class SendTwoFactorAuthCodeRequest {
+
+    public SendTwoFactorAuthCodeRequest() {
+    }
+
+    public SendTwoFactorAuthCodeRequest(SendTwoFactorAuthCodeAction action) {
+        setAction(action);
+    }
+
+    @XmlElement(name=AdminConstants.E_ACTION)
+    private SendTwoFactorAuthCodeAction action;
+
+    @XmlElement(name= AccountConstants.E_AUTH_TOKEN /* authToken */, required=false)
+    private String authToken;
+
+    public void setAuthToken(String authToken) {
+        this.authToken = authToken;
+    }
+
+    public String getAuthToken() {
+        return authToken;
+    }
+
+    public SendTwoFactorAuthCodeAction getAction() {
+        return action;
+    }
+
+    public void setAction(SendTwoFactorAuthCodeAction action) {
+        this.action = action;
+    }
+
+    @XmlEnum
+    public enum SendTwoFactorAuthCodeAction {
+
+        @XmlEnumValue("email") EMAIL("email"),
+        @XmlEnumValue("reset") RESET("reset");
+        private final String action;
+
+        private SendTwoFactorAuthCodeAction(String action) {
+            this.action = action;
+        }
+
+        @Override
+        public String toString() {
+            return action;
+        }
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/SendTwoFactorAuthCodeResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/SendTwoFactorAuthCodeResponse.java
@@ -1,0 +1,92 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ *
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2024 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.soap.admin.message;
+
+import com.zimbra.common.service.ServiceException;
+
+import com.google.common.base.MoreObjects;
+import com.zimbra.common.soap.AdminConstants;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name= AdminConstants.E_SEND_TWO_FACTOR_AUTH_CODE_RESPONSE)
+public class SendTwoFactorAuthCodeResponse {
+
+    @XmlEnum
+    public enum SendTwoFactorAuthCodeStatus {
+
+        @XmlEnumValue("sent") SENT("sent"),
+        @XmlEnumValue("not sent") NOT_SENT("not sent"),
+        @XmlEnumValue("reset succeeded") RESET_SUCCEEDED("reset succeeded"),
+        @XmlEnumValue("reset failed") RESET_FAILED("reset failed");
+        private final String status;
+        private SendTwoFactorAuthCodeStatus(String status) {
+            this.status = status;
+        }
+
+        @Override
+        public String toString() {
+            return status;
+        }
+
+        public static SendTwoFactorAuthCodeStatus fromString(String s) throws ServiceException {
+            try {
+                return SendTwoFactorAuthCodeStatus.valueOf(s);
+            } catch (IllegalArgumentException e) {
+                throw ServiceException.INVALID_REQUEST("unknown operation: "+s, e);
+            }
+        }
+    }
+
+    public SendTwoFactorAuthCodeResponse() {
+        this((SendTwoFactorAuthCodeStatus) null);
+    }
+
+    public SendTwoFactorAuthCodeResponse(SendTwoFactorAuthCodeStatus status) {
+        setStatus(status);
+    }
+
+    @XmlElement(name=AdminConstants.A_STATUS /* status */, required=true)
+    private SendTwoFactorAuthCodeStatus status;
+
+    public SendTwoFactorAuthCodeStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(SendTwoFactorAuthCodeStatus status) {
+        this.status = status;
+    }
+
+    public MoreObjects.ToStringHelper addToStringInfo(MoreObjects.ToStringHelper helper) {
+        return helper
+                .add("status", status);
+    }
+
+    @Override
+    public String toString() {
+        return addToStringInfo(MoreObjects.toStringHelper(this))
+                .toString();
+    }
+}


### PR DESCRIPTION
**Description**

Admin console needs to support 2FA email method.
https://synacor.atlassian.net/browse/ZCS-14646 

SendTwoFactorAuthCodeRequest will be called in urn:zimbraAdmin as admin console is accessed via admin port.

Task:

add SendTwoFactorAuthCodeRequest in urn:zimbraAdmin

it will work in the same way as the one in urn:zimbraAccount - support the same elements and attributes in http request and response.