### PR TITLE
ZCS-14704 Manual Cache refresh command for license cache

### DIFF
--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -1639,4 +1639,11 @@ public final class AdminConstants {
             "com_zimbra_docs_modern", "com_zimbra_drive_modern", "com_zextras_drive", "com_zextras_drive_open",
             "com_zextras_chat_open", "com_zextras_talk", "zimbra-zimlet-briefcase-edit-lool");
 
+    public static final String LICENSE_CACHE_REFRESHED = "cacheRefreshed";
+
+    public static final String E_LICENSE_CACHE_SOAP_SERVICE_REQUEST = "LicenseCacheSoapServiceRequest";
+    public static final String E_LICENSE_CACHE_SOAP_SERVICE_RESPONSE = "LicenseCacheSoapServiceResponse";
+    public static final QName LICENSE_CACHE_SOAP_SERVICE_REQUEST = QName.get(E_LICENSE_CACHE_SOAP_SERVICE_REQUEST, NAMESPACE);
+    public static final QName LICENSE_CACHE_SOAP_SERVICE_RESPONSE = QName.get(E_LICENSE_CACHE_SOAP_SERVICE_RESPONSE, NAMESPACE);
+
 }

--- a/soap/src/java/com/zimbra/soap/admin/message/LicenseCacheSoapServiceRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/LicenseCacheSoapServiceRequest.java
@@ -1,0 +1,40 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2024 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import com.zimbra.common.soap.AdminConstants;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * request class for LicenseCacheService
+ */
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name=AdminConstants.E_LICENSE_CACHE_SOAP_SERVICE_REQUEST)
+public class LicenseCacheSoapServiceRequest {
+
+    /**
+     * no-argument constructor wanted by JAXB
+     */
+    @SuppressWarnings("unused")
+    private LicenseCacheSoapServiceRequest() {}
+
+
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/LicenseCacheSoapServiceResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/LicenseCacheSoapServiceResponse.java
@@ -1,0 +1,60 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2024 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.soap.type.ZmBoolean;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * response class for LicenseCacheService
+ */
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name=AdminConstants.E_LICENSE_CACHE_SOAP_SERVICE_RESPONSE)
+public class LicenseCacheSoapServiceResponse {
+
+    /**
+     * no-argument constructor wanted by JAXB
+     */
+    private LicenseCacheSoapServiceResponse() {
+        new LicenseCacheSoapServiceResponse((Boolean) null);
+    }
+    public LicenseCacheSoapServiceResponse(Boolean cacheRefreshed) {
+        this.cacheRefreshed = ZmBoolean.fromBool(cacheRefreshed);
+
+    }
+
+    /**
+     * @zm-api-field-tag cacheRefreshed
+     * @zm-api-field-description flag for is Cache Refreshed
+     */
+    @XmlAttribute(name=AdminConstants.LICENSE_CACHE_REFRESHED /* cacheRefreshed */, required=true)
+    public ZmBoolean cacheRefreshed;
+
+    public ZmBoolean getCacheRefreshed() {
+        return cacheRefreshed;
+    }
+
+    public void setCacheRefreshed(ZmBoolean cacheRefreshed) {
+        this.cacheRefreshed = cacheRefreshed;
+    }
+}


### PR DESCRIPTION
I would like to provide a provision to manually refresh the license cache that is created in the license to provide a fast response for license-related APIs.

Tech Notes
The command for flush cache would be 
```
# with long option
>zmlicense --refreshCache
# with short option
>zmlicense -rc
```
It should remove existing records and reload records.