### PR TITLE
ZCS-14787 Set zimbraMobileForceSamsungProtocol25 default to TRUE for activesync

### DIFF
--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -7912,7 +7912,7 @@ TODO: delete them permanently from here
 </attr>
 
 <attr id="1572" name="zimbraMobileForceSamsungProtocol25" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="8.0.7">
-  <defaultCOSValue>FALSE</defaultCOSValue>
+  <defaultCOSValue>TRUE</defaultCOSValue>
   <desc>Whether to force Samsung devices using Active Sync 2.5</desc>
 </attr>
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -32421,13 +32421,13 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * Whether to force Samsung devices using Active Sync 2.5
      *
-     * @return zimbraMobileForceSamsungProtocol25, or false if unset
+     * @return zimbraMobileForceSamsungProtocol25, or true if unset
      *
      * @since ZCS 8.0.7
      */
     @ZAttr(id=1572)
     public boolean isMobileForceSamsungProtocol25() {
-        return getBooleanAttr(Provisioning.A_zimbraMobileForceSamsungProtocol25, false, true);
+        return getBooleanAttr(Provisioning.A_zimbraMobileForceSamsungProtocol25, true, true);
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -24515,13 +24515,13 @@ public abstract class ZAttrCos extends NamedEntry {
     /**
      * Whether to force Samsung devices using Active Sync 2.5
      *
-     * @return zimbraMobileForceSamsungProtocol25, or false if unset
+     * @return zimbraMobileForceSamsungProtocol25, or true if unset
      *
      * @since ZCS 8.0.7
      */
     @ZAttr(id=1572)
     public boolean isMobileForceSamsungProtocol25() {
-        return getBooleanAttr(Provisioning.A_zimbraMobileForceSamsungProtocol25, false, true);
+        return getBooleanAttr(Provisioning.A_zimbraMobileForceSamsungProtocol25, true, true);
     }
 
     /**


### PR DESCRIPTION
**Problem:** 
While connecting on samsung mail app using activesync, by default zimbraMobileForceSamsungProtocol25 is FALSE and it gets connected with 16.0 version

**FIx:**
Setting zimbraMobileForceSamsungProtocol25 default to TRUE. It connects with 2.5 vesrion default and able to send emails from samsung mail app.

**Test-cases:**
Tested on various apps and verified the impact:
Outlook iOS
iPhone mail
Android gmail
Samsung mail app