### PR TITLE
ZCS-14407: Added callback for zimbraTwoFactorScratchCodeLength and zimbraTwoFactorCodeLength

### DIFF
--- a/client/ivy.xml
+++ b/client/ivy.xml
@@ -5,7 +5,7 @@
  <info organisation="zimbra" module="zm-client" status="integration">
  </info>
  <dependencies>
-  <dependency org="junit" name="junit" rev="4.8.2" />
+  <dependency org="junit" name="junit" rev="4.13.2" />
   <dependency org="javax.mail" name="mail" rev="1.4.5" />
   <dependency org="jaxen" name="jaxen" rev="1.1-beta-10"/>
   <dependency org="org.dom4j" name="dom4j" rev="${dom4j.version}" />

--- a/common/ivy.xml
+++ b/common/ivy.xml
@@ -15,7 +15,7 @@
   <dependency org="org.apache.httpcomponents" name="httpcore-nio" rev="${httpclient.httpcore.version}"/>
   <dependency org="org.dom4j" name="dom4j" rev="${dom4j.version}" />
   <dependency org="ical4j" name="ical4j" rev="0.9.16-patched" />
-  <dependency org="junit" name="junit" rev="4.8.2" />
+  <dependency org="junit" name="junit" rev="4.13.2" />
   <dependency org="org.apache.logging.log4j" name="log4j-core" rev="${log4j.core.version}" />
   <dependency org="org.apache.logging.log4j" name="log4j-api" rev="${log4j.api.version}" />
   <dependency org="javax.mail" name="mail" rev="1.4.5" />

--- a/soap/ivy.xml
+++ b/soap/ivy.xml
@@ -4,7 +4,7 @@
  xsi:noNamespaceSchemaLocation="http://ant.apache.org/ivy/schemas/ivy.xsd">
  <info organisation="zimbra" module="zm-soap" status="integration" />
  <dependencies>
-  <dependency org="junit" name="junit" rev="4.8.2" />
+  <dependency org="junit" name="junit" rev="4.13.2" />
   <dependency org="xmlunit" name="xmlunit" rev="1.6"/>
   <dependency org="org.dom4j" name="dom4j" rev="${dom4j.version}" />
   <dependency org="com.google.guava" name="guava" rev="${com.google.guava.version}"/>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -8540,14 +8540,14 @@ TODO: delete them permanently from here
   <desc>Shared secret encoding. Keep at BASE32 for compatability with common TOTP clients.</desc>
 </attr>
 
-<attr id="1827" name="zimbraTwoFactorScratchCodeLength" type="integer" cardinality="single" optionalIn="globalConfig" since="8.7.0,9.0.0">
+<attr id="1827" name="zimbraTwoFactorScratchCodeLength" type="integer" cardinality="single" optionalIn="globalConfig" callback="TwoFactorScratchCode" since="8.7.0,9.0.0">
   <globalConfigValue>8</globalConfigValue>
-  <desc>length of scratch codes</desc>
+  <desc>Length of scratch codes. It must be different from zimbraTwoFactorCodeLength and zimbraTwoFactorAuthEmailCodeLength</desc>
 </attr>
 
-<attr id="1828" name="zimbraTwoFactorCodeLength" type="integer" cardinality="single" optionalIn="globalConfig" since="8.7.0,9.0.0">
+<attr id="1828" name="zimbraTwoFactorCodeLength" type="integer" cardinality="single" optionalIn="globalConfig" callback="TwoFactorCode" since="8.7.0,9.0.0">
   <globalConfigValue>6</globalConfigValue>
-  <desc>Length of TOTP code required for two-factor authentication. Keep at 6 for compatability with common TOTP clients.</desc>
+  <desc>Length of TOTP code required for two-factor authentication. Keep at 6 for compatibility with common TOTP clients, and it must be different from zimbraTwoFactorScratchCodeLength and zimbraTwoFactorAuthEmailCodeLength.</desc>
 </attr>
 
 <attr id="1829" name="zimbraTwoFactorTimeWindowLength" type="duration" cardinality="single" optionalIn="globalConfig" since="8.7.0,9.0.0">

--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -18,7 +18,9 @@
   <dependency org="org.slf4j" name="slf4j-api" rev="1.7.36"/>
   <dependency org="org.slf4j" name="slf4j-simple" rev="1.7.36"/>
   <dependency org="org.apache.logging.log4j" name="log4j-slf4j-impl" rev="2.17.1" />
-  <dependency org="junit" name="junit" rev="4.8.2" />
+  <dependency org="junit" name="junit" rev="4.13.2"/>
+  <dependency org="pl.pragmatists" name="JUnitParams" rev="1.1.1"/>
+  <dependency org="org.assertj" name="assertj-core" rev="3.8.0"/>
   <dependency org="javax.mail" name="mail" rev="1.4.5" />
   <dependency org="jaxen" name="jaxen" rev="1.1-beta-10"/>
   <dependency org="org.dom4j" name="dom4j" rev="${dom4j.version}" />

--- a/store/src/java-test/com/zimbra/cs/account/callback/CallbackUtilTest.java
+++ b/store/src/java-test/com/zimbra/cs/account/callback/CallbackUtilTest.java
@@ -1,0 +1,97 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2024 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.account.callback;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RunWith(JUnitParamsRunner.class)
+public class CallbackUtilTest {
+
+    private static Object[] validTestData() {
+        return new Object[] {
+                new Object[] {Provisioning.A_zimbraTwoFactorCodeLength, 7, createAttrsMap(Provisioning.A_zimbraTwoFactorCodeLength, 6, 8)},
+                new Object[] {Provisioning.A_zimbraTwoFactorCodeLength, 5, createAttrsMap(Provisioning.A_zimbraTwoFactorCodeLength, 6, 8)},
+                new Object[] {Provisioning.A_zimbraTwoFactorCodeLength, 9, createAttrsMap(Provisioning.A_zimbraTwoFactorCodeLength, 6, 8)},
+                new Object[] {Provisioning.A_zimbraTwoFactorCodeLength, 10, createAttrsMap(Provisioning.A_zimbraTwoFactorCodeLength, 6, 8)},
+                new Object[] {Provisioning.A_zimbraTwoFactorAuthEmailCodeLength, 7, createAttrsMap(Provisioning.A_zimbraTwoFactorAuthEmailCodeLength, 6, 8)},
+                new Object[] {Provisioning.A_zimbraTwoFactorAuthEmailCodeLength, 5, createAttrsMap(Provisioning.A_zimbraTwoFactorAuthEmailCodeLength, 6, 8)},
+                new Object[] {Provisioning.A_zimbraTwoFactorAuthEmailCodeLength, 9, createAttrsMap(Provisioning.A_zimbraTwoFactorAuthEmailCodeLength, 6, 8)},
+                new Object[] {Provisioning.A_zimbraTwoFactorAuthEmailCodeLength, 10, createAttrsMap(Provisioning.A_zimbraTwoFactorAuthEmailCodeLength, 6, 8)},
+                new Object[] {Provisioning.A_zimbraTwoFactorScratchCodeLength, 7, createAttrsMap(Provisioning.A_zimbraTwoFactorScratchCodeLength, 6, 8)},
+                new Object[] {Provisioning.A_zimbraTwoFactorScratchCodeLength, 5, createAttrsMap(Provisioning.A_zimbraTwoFactorScratchCodeLength, 6, 8)},
+                new Object[] {Provisioning.A_zimbraTwoFactorScratchCodeLength, 9, createAttrsMap(Provisioning.A_zimbraTwoFactorScratchCodeLength, 6, 8)},
+                new Object[] {Provisioning.A_zimbraTwoFactorScratchCodeLength, 10, createAttrsMap(Provisioning.A_zimbraTwoFactorScratchCodeLength, 6, 8)}
+        };
+    }
+
+    private static Object[] invalidTestData() {
+        return new Object[] {
+                new Object[] {Provisioning.A_zimbraTwoFactorCodeLength, 6, createAttrsMap(Provisioning.A_zimbraTwoFactorCodeLength, 6, 8)},
+                new Object[] {Provisioning.A_zimbraTwoFactorCodeLength, 8, createAttrsMap(Provisioning.A_zimbraTwoFactorCodeLength, 6, 8)},
+                new Object[] {Provisioning.A_zimbraTwoFactorAuthEmailCodeLength, 6, createAttrsMap(Provisioning.A_zimbraTwoFactorAuthEmailCodeLength, 6, 8)},
+                new Object[] {Provisioning.A_zimbraTwoFactorAuthEmailCodeLength, 8, createAttrsMap(Provisioning.A_zimbraTwoFactorAuthEmailCodeLength, 6, 8)},
+                new Object[] {Provisioning.A_zimbraTwoFactorScratchCodeLength, 6, createAttrsMap(Provisioning.A_zimbraTwoFactorScratchCodeLength, 6, 8)},
+                new Object[] {Provisioning.A_zimbraTwoFactorScratchCodeLength, 8, createAttrsMap(Provisioning.A_zimbraTwoFactorScratchCodeLength, 6, 8)}
+        };
+    }
+
+    private static Map<String, Integer> createAttrsMap(String attrName, int value1, int value2) {
+        Map<String, Integer> attrs = new HashMap<>();
+        switch (attrName) {
+            case Provisioning.A_zimbraTwoFactorCodeLength:
+                attrs.put(Provisioning.A_zimbraTwoFactorScratchCodeLength, value1);
+                attrs.put(Provisioning.A_zimbraTwoFactorAuthEmailCodeLength, value2);
+                break;
+            case Provisioning.A_zimbraTwoFactorAuthEmailCodeLength:
+                attrs.put(Provisioning.A_zimbraTwoFactorCodeLength, value1);
+                attrs.put(Provisioning.A_zimbraTwoFactorScratchCodeLength, value2);
+                break;
+            case Provisioning.A_zimbraTwoFactorScratchCodeLength:
+                attrs.put(Provisioning.A_zimbraTwoFactorCodeLength, value1);
+                attrs.put(Provisioning.A_zimbraTwoFactorAuthEmailCodeLength, value2);
+                break;
+        }
+        return attrs;
+    }
+
+    @BeforeClass
+    public static void init() throws Exception {
+        MailboxTestUtil.initProvisioning();
+    }
+
+    @Test
+    @Parameters(method = "validTestData")
+    public void validateAttributeValueTest(String attrName, int attrValue, Map<String, Integer> attrs) throws ServiceException {
+        CallbackUtil.validateTwoFactorAuthAttributeValue(attrName, attrValue, attrs, 10);
+    }
+
+    @Test(expected = ServiceException.class)
+    @Parameters(method = "invalidTestData")
+    public void validateAttributeValueThrowsExceptionTest(String attrName, int attrValue, Map<String, Integer> attrs) throws ServiceException {
+        CallbackUtil.validateTwoFactorAuthAttributeValue(attrName, attrValue, attrs, 10);
+    }
+}

--- a/store/src/java-test/com/zimbra/cs/mailbox/calendar/ZAttendeeTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/calendar/ZAttendeeTest.java
@@ -25,7 +25,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.internal.matchers.StringContains;
 import org.junit.rules.MethodRule;
 import org.junit.rules.TestName;
 
@@ -45,6 +44,8 @@ import com.zimbra.cs.mailbox.MailboxTestUtil;
 import com.zimbra.cs.mime.ParsedMessage;
 import com.zimbra.cs.mime.ParsedMessage.CalendarPartInfo;
 import com.zimbra.cs.util.ZTestWatchman;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ZAttendeeTest {
 
@@ -130,6 +131,6 @@ public class ZAttendeeTest {
         TimeZoneMap tzMap = new TimeZoneMap(WellKnownTimeZones.getTimeZoneById("JST"));
         Invite inv = new Invite(MailItem.Type.APPOINTMENT, ICalTok.ACCEPTED.toString(),
                 tzMap, false);
-        Assert.assertThat(inv.toString(), StringContains.containsString("rsvp: (not specified)"));
+        assertThat(inv.toString()).contains("rsvp: (not specified)");
     }
 }

--- a/store/src/java/com/zimbra/cs/account/callback/CallbackUtil.java
+++ b/store/src/java/com/zimbra/cs/account/callback/CallbackUtil.java
@@ -19,6 +19,7 @@ package com.zimbra.cs.account.callback;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
@@ -110,5 +111,26 @@ public class CallbackUtil {
     public static boolean isLocalServer (Server server) throws ServiceException {
         Server local = Provisioning.getInstance().getLocalServer();
         return server.getId().equals(local.getId());
+    }
+
+    /**
+     * This method is used to validate attribute value
+     * @param attrName
+     * @param attrValue
+     * @param attrs
+     * @throws ServiceException
+     */
+    public static void validateTwoFactorAuthAttributeValue(String attrName, int attrValue, Map<String, Integer> attrs, int maxCodeLength) throws ServiceException {
+        if (attrValue > maxCodeLength) {
+            throw ServiceException.INVALID_REQUEST(attrName + " cannot set above " + maxCodeLength, null);
+        }
+        if (attrs == null || attrs.size() < 2) {
+            throw ServiceException.INVALID_REQUEST(attrs + " cannot be null or size less than 2", null);
+
+        }
+        String[] keys = attrs.keySet().stream().toArray(String[]::new);
+        if ((attrValue == attrs.get(keys[0])) || (attrValue == attrs.get(keys[1]))) {
+            throw ServiceException.INVALID_REQUEST(attrName + " must be different from " + keys[0] + " and " + keys[1], null);
+        }
     }
 }

--- a/store/src/java/com/zimbra/cs/account/callback/TwoFactorCode.java
+++ b/store/src/java/com/zimbra/cs/account/callback/TwoFactorCode.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2023 Synacor, Inc.
+ * Copyright (C) 2024 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -25,18 +25,17 @@ import com.zimbra.cs.account.Provisioning;
 import java.util.HashMap;
 import java.util.Map;
 
-public class TwoFactorAuthEmailCode extends AttributeCallback {
-
+public class TwoFactorCode extends AttributeCallback {
     @Override
     public void preModify(CallbackContext context, String attrName, Object attrValue, Map attrsToModify, Entry entry) throws ServiceException {
         String value = (String) attrValue;
         if (StringUtil.isNullOrEmpty(value)) {
-            throw ServiceException.INVALID_REQUEST(Provisioning.A_zimbraTwoFactorAuthEmailCodeLength + " cannot set to empty.", null);
+            throw ServiceException.INVALID_REQUEST(Provisioning.A_zimbraTwoFactorCodeLength + " cannot set to empty.", null);
         }
         Provisioning prov = Provisioning.getInstance();
         Map<String, Integer> attrs = new HashMap<String, Integer>() {{
-            put(Provisioning.A_zimbraTwoFactorCodeLength, prov.getConfig().getTwoFactorCodeLength());
             put(Provisioning.A_zimbraTwoFactorScratchCodeLength, prov.getConfig().getTwoFactorScratchCodeLength());
+            put(Provisioning.A_zimbraTwoFactorAuthEmailCodeLength, prov.getConfig().getTwoFactorAuthEmailCodeLength());
         }};
         CallbackUtil.validateTwoFactorAuthAttributeValue(attrName, Integer.valueOf(value), attrs, 10);
     }

--- a/store/src/java/com/zimbra/cs/account/callback/TwoFactorScratchCode.java
+++ b/store/src/java/com/zimbra/cs/account/callback/TwoFactorScratchCode.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2023 Synacor, Inc.
+ * Copyright (C) 2024 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -25,18 +25,17 @@ import com.zimbra.cs.account.Provisioning;
 import java.util.HashMap;
 import java.util.Map;
 
-public class TwoFactorAuthEmailCode extends AttributeCallback {
-
+public class TwoFactorScratchCode extends AttributeCallback {
     @Override
     public void preModify(CallbackContext context, String attrName, Object attrValue, Map attrsToModify, Entry entry) throws ServiceException {
         String value = (String) attrValue;
         if (StringUtil.isNullOrEmpty(value)) {
-            throw ServiceException.INVALID_REQUEST(Provisioning.A_zimbraTwoFactorAuthEmailCodeLength + " cannot set to empty.", null);
+            throw ServiceException.INVALID_REQUEST(Provisioning.A_zimbraTwoFactorScratchCodeLength + " cannot set to empty.", null);
         }
         Provisioning prov = Provisioning.getInstance();
         Map<String, Integer> attrs = new HashMap<String, Integer>() {{
             put(Provisioning.A_zimbraTwoFactorCodeLength, prov.getConfig().getTwoFactorCodeLength());
-            put(Provisioning.A_zimbraTwoFactorScratchCodeLength, prov.getConfig().getTwoFactorScratchCodeLength());
+            put(Provisioning.A_zimbraTwoFactorAuthEmailCodeLength, prov.getConfig().getTwoFactorAuthEmailCodeLength());
         }};
         CallbackUtil.validateTwoFactorAuthAttributeValue(attrName, Integer.valueOf(value), attrs, 10);
     }

--- a/store/src/java/com/zimbra/qa/unittest/TestUtil.java
+++ b/store/src/java/com/zimbra/qa/unittest/TestUtil.java
@@ -1636,7 +1636,7 @@ public class TestUtil extends Assert {
         try {
             org.junit.Assume.assumeTrue(testVal);
         } catch (AssumptionViolatedException ave) {
-            throw new AssumptionViolatedException(missive, null);
+            throw new AssumptionViolatedException(missive);
         }
     }
 


### PR DESCRIPTION
**Description**
A value of `zimbraTwoFactorCodeLength`, `zimbraTwoFactorScratchCodeLength` and `zimbraTwoFactorAuthEmailCodeLength` must be different each other.

**Scrope**
Add callbacks for `zimbraTwoFactorCodeLength` and `zimbraTwoFactorScratchCodeLength`

**Solution**
A callback has been added for same.
