### PR TITLE
ZCS-14781: Add ldap attributes to reset TFA setting

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -7417,6 +7417,15 @@ public class ZAttrProvisioning {
     public static final String A_zimbraFeatureResetPasswordSuspensionTime = "zimbraFeatureResetPasswordSuspensionTime";
 
     /**
+     * Whether to enable a function to reconfigure two-factor authentication
+     * without disabling the existing one
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4123)
+    public static final String A_zimbraFeatureResetTwoFactorAuthEnabled = "zimbraFeatureResetTwoFactorAuthEnabled";
+
+    /**
      * Whether retention policy feature is enabled
      *
      * @since ZCS 10.1.0
@@ -18102,6 +18111,14 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=1824)
     public static final String A_zimbraTwoFactorAuthSecretLength = "zimbraTwoFactorAuthSecretLength";
+
+    /**
+     * Temporary data to update two-factor authentication settings
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4124)
+    public static final String A_zimbraTwoFactorAuthTemporaryData = "zimbraTwoFactorAuthTemporaryData";
 
     /**
      * Lifetime of auth tokens provisioned for completing the 2nd stage of

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10483,4 +10483,12 @@ TODO: delete them permanently from here
   <desc>Attribute to allow IP/IP Range to access email for Zimbra Desktop</desc>
 </attr>
 
+<attr id="4123" name="zimbraFeatureResetTwoFactorAuthEnabled" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited" since="10.1.0">
+  <desc>Whether to enable a function to reconfigure two-factor authentication without disabling the existing one</desc>
+</attr>
+
+<attr id="4124" name="zimbraTwoFactorAuthTemporaryData" type="string" cardinality="multi" optionalIn="account" since="10.1.0">
+  <desc>Temporary data to update two-factor authentication settings</desc>
+</attr>
+
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -20325,6 +20325,83 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * Whether to enable a function to reconfigure two-factor authentication
+     * without disabling the existing one
+     *
+     * @return zimbraFeatureResetTwoFactorAuthEnabled, or false if unset
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4123)
+    public boolean isFeatureResetTwoFactorAuthEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureResetTwoFactorAuthEnabled, false, true);
+    }
+
+    /**
+     * Whether to enable a function to reconfigure two-factor authentication
+     * without disabling the existing one
+     *
+     * @param zimbraFeatureResetTwoFactorAuthEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4123)
+    public void setFeatureResetTwoFactorAuthEnabled(boolean zimbraFeatureResetTwoFactorAuthEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureResetTwoFactorAuthEnabled, zimbraFeatureResetTwoFactorAuthEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to enable a function to reconfigure two-factor authentication
+     * without disabling the existing one
+     *
+     * @param zimbraFeatureResetTwoFactorAuthEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4123)
+    public Map<String,Object> setFeatureResetTwoFactorAuthEnabled(boolean zimbraFeatureResetTwoFactorAuthEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureResetTwoFactorAuthEnabled, zimbraFeatureResetTwoFactorAuthEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether to enable a function to reconfigure two-factor authentication
+     * without disabling the existing one
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4123)
+    public void unsetFeatureResetTwoFactorAuthEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureResetTwoFactorAuthEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to enable a function to reconfigure two-factor authentication
+     * without disabling the existing one
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4123)
+    public Map<String,Object> unsetFeatureResetTwoFactorAuthEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureResetTwoFactorAuthEnabled, "");
+        return attrs;
+    }
+
+    /**
      * Whether retention policy feature is enabled
      *
      * @return zimbraFeatureRetentionPolicyEnabled, or true if unset
@@ -65895,6 +65972,140 @@ public abstract class ZAttrAccount  extends MailTarget {
     public Map<String,Object> unsetTwoFactorAuthSecret(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraTwoFactorAuthSecret, "");
+        return attrs;
+    }
+
+    /**
+     * Temporary data to update two-factor authentication settings
+     *
+     * @return zimbraTwoFactorAuthTemporaryData, or empty array if unset
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4124)
+    public String[] getTwoFactorAuthTemporaryData() {
+        return getMultiAttr(Provisioning.A_zimbraTwoFactorAuthTemporaryData, true, true);
+    }
+
+    /**
+     * Temporary data to update two-factor authentication settings
+     *
+     * @param zimbraTwoFactorAuthTemporaryData new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4124)
+    public void setTwoFactorAuthTemporaryData(String[] zimbraTwoFactorAuthTemporaryData) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorAuthTemporaryData, zimbraTwoFactorAuthTemporaryData);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Temporary data to update two-factor authentication settings
+     *
+     * @param zimbraTwoFactorAuthTemporaryData new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4124)
+    public Map<String,Object> setTwoFactorAuthTemporaryData(String[] zimbraTwoFactorAuthTemporaryData, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorAuthTemporaryData, zimbraTwoFactorAuthTemporaryData);
+        return attrs;
+    }
+
+    /**
+     * Temporary data to update two-factor authentication settings
+     *
+     * @param zimbraTwoFactorAuthTemporaryData new to add to existing values
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4124)
+    public void addTwoFactorAuthTemporaryData(String zimbraTwoFactorAuthTemporaryData) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraTwoFactorAuthTemporaryData, zimbraTwoFactorAuthTemporaryData);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Temporary data to update two-factor authentication settings
+     *
+     * @param zimbraTwoFactorAuthTemporaryData new to add to existing values
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4124)
+    public Map<String,Object> addTwoFactorAuthTemporaryData(String zimbraTwoFactorAuthTemporaryData, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraTwoFactorAuthTemporaryData, zimbraTwoFactorAuthTemporaryData);
+        return attrs;
+    }
+
+    /**
+     * Temporary data to update two-factor authentication settings
+     *
+     * @param zimbraTwoFactorAuthTemporaryData existing value to remove
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4124)
+    public void removeTwoFactorAuthTemporaryData(String zimbraTwoFactorAuthTemporaryData) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraTwoFactorAuthTemporaryData, zimbraTwoFactorAuthTemporaryData);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Temporary data to update two-factor authentication settings
+     *
+     * @param zimbraTwoFactorAuthTemporaryData existing value to remove
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4124)
+    public Map<String,Object> removeTwoFactorAuthTemporaryData(String zimbraTwoFactorAuthTemporaryData, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraTwoFactorAuthTemporaryData, zimbraTwoFactorAuthTemporaryData);
+        return attrs;
+    }
+
+    /**
+     * Temporary data to update two-factor authentication settings
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4124)
+    public void unsetTwoFactorAuthTemporaryData() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorAuthTemporaryData, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Temporary data to update two-factor authentication settings
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4124)
+    public Map<String,Object> unsetTwoFactorAuthTemporaryData(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraTwoFactorAuthTemporaryData, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -14714,6 +14714,83 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * Whether to enable a function to reconfigure two-factor authentication
+     * without disabling the existing one
+     *
+     * @return zimbraFeatureResetTwoFactorAuthEnabled, or false if unset
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4123)
+    public boolean isFeatureResetTwoFactorAuthEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureResetTwoFactorAuthEnabled, false, true);
+    }
+
+    /**
+     * Whether to enable a function to reconfigure two-factor authentication
+     * without disabling the existing one
+     *
+     * @param zimbraFeatureResetTwoFactorAuthEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4123)
+    public void setFeatureResetTwoFactorAuthEnabled(boolean zimbraFeatureResetTwoFactorAuthEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureResetTwoFactorAuthEnabled, zimbraFeatureResetTwoFactorAuthEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to enable a function to reconfigure two-factor authentication
+     * without disabling the existing one
+     *
+     * @param zimbraFeatureResetTwoFactorAuthEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4123)
+    public Map<String,Object> setFeatureResetTwoFactorAuthEnabled(boolean zimbraFeatureResetTwoFactorAuthEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureResetTwoFactorAuthEnabled, zimbraFeatureResetTwoFactorAuthEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether to enable a function to reconfigure two-factor authentication
+     * without disabling the existing one
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4123)
+    public void unsetFeatureResetTwoFactorAuthEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureResetTwoFactorAuthEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to enable a function to reconfigure two-factor authentication
+     * without disabling the existing one
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4123)
+    public Map<String,Object> unsetFeatureResetTwoFactorAuthEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureResetTwoFactorAuthEnabled, "");
+        return attrs;
+    }
+
+    /**
      * Whether retention policy feature is enabled
      *
      * @return zimbraFeatureRetentionPolicyEnabled, or true if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -11419,6 +11419,83 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
+     * Whether to enable a function to reconfigure two-factor authentication
+     * without disabling the existing one
+     *
+     * @return zimbraFeatureResetTwoFactorAuthEnabled, or false if unset
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4123)
+    public boolean isFeatureResetTwoFactorAuthEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureResetTwoFactorAuthEnabled, false, true);
+    }
+
+    /**
+     * Whether to enable a function to reconfigure two-factor authentication
+     * without disabling the existing one
+     *
+     * @param zimbraFeatureResetTwoFactorAuthEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4123)
+    public void setFeatureResetTwoFactorAuthEnabled(boolean zimbraFeatureResetTwoFactorAuthEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureResetTwoFactorAuthEnabled, zimbraFeatureResetTwoFactorAuthEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to enable a function to reconfigure two-factor authentication
+     * without disabling the existing one
+     *
+     * @param zimbraFeatureResetTwoFactorAuthEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4123)
+    public Map<String,Object> setFeatureResetTwoFactorAuthEnabled(boolean zimbraFeatureResetTwoFactorAuthEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureResetTwoFactorAuthEnabled, zimbraFeatureResetTwoFactorAuthEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether to enable a function to reconfigure two-factor authentication
+     * without disabling the existing one
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4123)
+    public void unsetFeatureResetTwoFactorAuthEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureResetTwoFactorAuthEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to enable a function to reconfigure two-factor authentication
+     * without disabling the existing one
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4123)
+    public Map<String,Object> unsetFeatureResetTwoFactorAuthEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureResetTwoFactorAuthEnabled, "");
+        return attrs;
+    }
+
+    /**
      * internal social features
      *
      * @return zimbraFeatureSocialEnabled, or false if unset


### PR DESCRIPTION
Add ldap attributes to achieve ZCS-14317; reset (reconfigure) an enabled 2FA method without disabling it.