### PR TITLE
ZCS-14893 : added a new attribute instead of replacing older one

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -4906,7 +4906,9 @@ public class ZAttrProvisioning {
     public static final String A_zimbraClamAVSafeBrowsing = "zimbraClamAVSafeBrowsing";
 
     /**
-     * Whether to enable/disable classic ui option on the login screen.
+     * Whether to enable/disable the classic web client option on the login
+     * screen. Default value is FALSE, which makes the classic client option
+     * available.
      *
      * @since ZCS 10.1.0
      */
@@ -6747,7 +6749,7 @@ public class ZAttrProvisioning {
      *
      * @since ZCS 10.1.0
      */
-    @ZAttr(id=4031)
+    @ZAttr(id=4126)
     public static final String A_zimbraFeatureBasicOneToOneChatEnabled = "zimbraFeatureBasicOneToOneChatEnabled";
 
     /**
@@ -7287,6 +7289,16 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=347)
     public static final String A_zimbraFeatureMobileSyncEnabled = "zimbraFeatureMobileSyncEnabled";
+
+    /**
+     * Deprecated since: 10.1.0. Added zimbraFeatureBasicOneToOneChatEnabled
+     * attribute from 10.1.0 for same functionality. Orig desc: Whether Chat
+     * feature is enabled or not
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4031)
+    public static final String A_zimbraFeatureModernChatEnabled = "zimbraFeatureModernChatEnabled";
 
     /**
      * Whether to allow a user to access Zimbra modern desktop
@@ -18209,7 +18221,9 @@ public class ZAttrProvisioning {
 
     /**
      * Length of TOTP code required for two-factor authentication. Keep at 6
-     * for compatability with common TOTP clients.
+     * for compatibility with common TOTP clients, and it must be different
+     * from zimbraTwoFactorScratchCodeLength and
+     * zimbraTwoFactorAuthEmailCodeLength.
      *
      * @since ZCS 8.7.0,9.0.0
      */
@@ -18228,7 +18242,8 @@ public class ZAttrProvisioning {
     public static final String A_zimbraTwoFactorCodeLifetimeForEmail = "zimbraTwoFactorCodeLifetimeForEmail";
 
     /**
-     * length of scratch codes
+     * Length of scratch codes. It must be different from
+     * zimbraTwoFactorCodeLength and zimbraTwoFactorAuthEmailCodeLength
      *
      * @since ZCS 8.7.0,9.0.0
      */

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10064,9 +10064,10 @@ TODO: delete them permanently from here
         It is ignored when zimbraDomainLoginPageEnabled is not TRUE.
   </desc>
 </attr>
-<attr id="4031" name="zimbraFeatureBasicOneToOneChatEnabled" type="boolean" callback="ModernChatVideoEnabled" cardinality="single" optionalIn="account,cos,domain" flags="accountInfo,domainInfo,domainAdminModifiable,accountCosDomainInherited" since="10.1.0">
+<attr id="4031" name="zimbraFeatureModernChatEnabled" type="boolean" callback="ModernChatVideoEnabled" cardinality="single" optionalIn="account,cos,domain" flags="accountInfo,domainInfo,domainAdminModifiable,accountCosDomainInherited" since="10.1.0" deprecatedSince="10.1.0">
   <defaultCOSValue>FALSE</defaultCOSValue>
   <desc>Whether Chat feature is enabled or not</desc>
+  <deprecateDesc>Added zimbraFeatureBasicOneToOneChatEnabled attribute from 10.1.0 for same functionality</deprecateDesc>
 </attr>
 
 <attr id="4032" name="zimbraFeatureModernVideoEnabled" type="boolean" callback="ModernChatVideoEnabled" cardinality="single" optionalIn="account,cos,domain" flags="accountInfo,domainInfo,domainAdminModifiable,accountCosDomainInherited" since="10.1.0" deprecatedSince="10.1.0">
@@ -10494,6 +10495,11 @@ TODO: delete them permanently from here
 <attr id="4125" name="zimbraClassicWebClientDisabled" type="boolean" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainInfo,domainAdminModifiable" since="10.1.0">
   <globalConfigValue>FALSE</globalConfigValue>
   <desc>Whether to enable/disable the classic web client option on the login screen. Default value is FALSE, which makes the classic client option available.</desc>
+</attr>
+
+<attr id="4126" name="zimbraFeatureBasicOneToOneChatEnabled" type="boolean" callback="ModernChatVideoEnabled" cardinality="single" optionalIn="account,cos,domain" flags="accountInfo,domainInfo,domainAdminModifiable,accountCosDomainInherited" since="10.1.0">
+  <defaultCOSValue>FALSE</defaultCOSValue>
+  <desc>Whether Chat feature is enabled or not</desc>
 </attr>
 
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -14279,7 +14279,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 10.1.0
      */
-    @ZAttr(id=4031)
+    @ZAttr(id=4126)
     public boolean isFeatureBasicOneToOneChatEnabled() {
         return getBooleanAttr(Provisioning.A_zimbraFeatureBasicOneToOneChatEnabled, false, true);
     }
@@ -14292,7 +14292,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 10.1.0
      */
-    @ZAttr(id=4031)
+    @ZAttr(id=4126)
     public void setFeatureBasicOneToOneChatEnabled(boolean zimbraFeatureBasicOneToOneChatEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureBasicOneToOneChatEnabled, zimbraFeatureBasicOneToOneChatEnabled ? TRUE : FALSE);
@@ -14308,7 +14308,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 10.1.0
      */
-    @ZAttr(id=4031)
+    @ZAttr(id=4126)
     public Map<String,Object> setFeatureBasicOneToOneChatEnabled(boolean zimbraFeatureBasicOneToOneChatEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureBasicOneToOneChatEnabled, zimbraFeatureBasicOneToOneChatEnabled ? TRUE : FALSE);
@@ -14322,7 +14322,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 10.1.0
      */
-    @ZAttr(id=4031)
+    @ZAttr(id=4126)
     public void unsetFeatureBasicOneToOneChatEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureBasicOneToOneChatEnabled, "");
@@ -14337,7 +14337,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 10.1.0
      */
-    @ZAttr(id=4031)
+    @ZAttr(id=4126)
     public Map<String,Object> unsetFeatureBasicOneToOneChatEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureBasicOneToOneChatEnabled, "");
@@ -19018,6 +19018,88 @@ public abstract class ZAttrAccount  extends MailTarget {
     public Map<String,Object> unsetFeatureMobileSyncEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureMobileSyncEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * Deprecated since: 10.1.0. Added zimbraFeatureBasicOneToOneChatEnabled
+     * attribute from 10.1.0 for same functionality. Orig desc: Whether Chat
+     * feature is enabled or not
+     *
+     * @return zimbraFeatureModernChatEnabled, or false if unset
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4031)
+    public boolean isFeatureModernChatEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureModernChatEnabled, false, true);
+    }
+
+    /**
+     * Deprecated since: 10.1.0. Added zimbraFeatureBasicOneToOneChatEnabled
+     * attribute from 10.1.0 for same functionality. Orig desc: Whether Chat
+     * feature is enabled or not
+     *
+     * @param zimbraFeatureModernChatEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4031)
+    public void setFeatureModernChatEnabled(boolean zimbraFeatureModernChatEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernChatEnabled, zimbraFeatureModernChatEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Deprecated since: 10.1.0. Added zimbraFeatureBasicOneToOneChatEnabled
+     * attribute from 10.1.0 for same functionality. Orig desc: Whether Chat
+     * feature is enabled or not
+     *
+     * @param zimbraFeatureModernChatEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4031)
+    public Map<String,Object> setFeatureModernChatEnabled(boolean zimbraFeatureModernChatEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernChatEnabled, zimbraFeatureModernChatEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Deprecated since: 10.1.0. Added zimbraFeatureBasicOneToOneChatEnabled
+     * attribute from 10.1.0 for same functionality. Orig desc: Whether Chat
+     * feature is enabled or not
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4031)
+    public void unsetFeatureModernChatEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernChatEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Deprecated since: 10.1.0. Added zimbraFeatureBasicOneToOneChatEnabled
+     * attribute from 10.1.0 for same functionality. Orig desc: Whether Chat
+     * feature is enabled or not
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4031)
+    public Map<String,Object> unsetFeatureModernChatEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernChatEnabled, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -11077,6 +11077,88 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Whether to enable/disable the classic web client option on the login
+     * screen. Default value is FALSE, which makes the classic client option
+     * available.
+     *
+     * @return zimbraClassicWebClientDisabled, or false if unset
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4125)
+    public boolean isClassicWebClientDisabled() {
+        return getBooleanAttr(Provisioning.A_zimbraClassicWebClientDisabled, false, true);
+    }
+
+    /**
+     * Whether to enable/disable the classic web client option on the login
+     * screen. Default value is FALSE, which makes the classic client option
+     * available.
+     *
+     * @param zimbraClassicWebClientDisabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4125)
+    public void setClassicWebClientDisabled(boolean zimbraClassicWebClientDisabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraClassicWebClientDisabled, zimbraClassicWebClientDisabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to enable/disable the classic web client option on the login
+     * screen. Default value is FALSE, which makes the classic client option
+     * available.
+     *
+     * @param zimbraClassicWebClientDisabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4125)
+    public Map<String,Object> setClassicWebClientDisabled(boolean zimbraClassicWebClientDisabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraClassicWebClientDisabled, zimbraClassicWebClientDisabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether to enable/disable the classic web client option on the login
+     * screen. Default value is FALSE, which makes the classic client option
+     * available.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4125)
+    public void unsetClassicWebClientDisabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraClassicWebClientDisabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to enable/disable the classic web client option on the login
+     * screen. Default value is FALSE, which makes the classic client option
+     * available.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4125)
+    public Map<String,Object> unsetClassicWebClientDisabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraClassicWebClientDisabled, "");
+        return attrs;
+    }
+
+    /**
      * Regex for identifying client types
      *
      * @return zimbraClientTypeRegex, or empty array if unset
@@ -37955,88 +38037,6 @@ public abstract class ZAttrConfig extends Entry {
     public Map<String,Object> unsetModernWebClientDisabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraModernWebClientDisabled, "");
-        return attrs;
-    }
-
-    /**
-     * Whether to enable/disable the classic web client option on the login
-     * screen. Default value is FALSE, which makes the classic client option
-     * available.
-     *
-     * @return zimbraClassicWebClientDisabled, or false if unset
-     *
-     * @since ZCS 10.1.0
-     */
-    @ZAttr(id=4125)
-    public boolean isClassicWebClientDisabled() {
-        return getBooleanAttr(Provisioning.A_zimbraClassicWebClientDisabled, false, true);
-    }
-
-    /**
-     * Whether to enable/disable the classic web client option on the login
-     * screen. Default value is FALSE, which makes the classic client option
-     * available.
-     *
-     * @param zimbraClassicWebClientDisabled new value
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 10.1.0
-     */
-    @ZAttr(id=4125)
-    public void setClassicWebClientDisabled(boolean zimbraClassicWebClientDisabled) throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraClassicWebClientDisabled, zimbraClassicWebClientDisabled ? TRUE : FALSE);
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Whether to enable/disable the classic web client option on the login
-     * screen. Default value is FALSE, which makes the classic client option
-     * available.
-     *
-     * @param zimbraClassicWebClientDisabled new value
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 10.1.0
-     */
-    @ZAttr(id=4125)
-    public Map<String,Object> setClassicWebClientDisabled(boolean zimbraClassicWebClientDisabled, Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraClassicWebClientDisabled, zimbraClassicWebClientDisabled ? TRUE : FALSE);
-        return attrs;
-    }
-
-    /**
-     * Whether to enable/disable the classic web client option on the login
-     * screen. Default value is FALSE, which makes the classic client option
-     * available.
-     *
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 10.1.0
-     */
-    @ZAttr(id=4125)
-    public void unsetClassicWebClientDisabled() throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraClassicWebClientDisabled, "");
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Whether to enable/disable the classic web client option on the login
-     * screen. Default value is FALSE, which makes the classic client option
-     * available.
-     *
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 10.1.0
-     */
-    @ZAttr(id=4125)
-    public Map<String,Object> unsetClassicWebClientDisabled(Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraClassicWebClientDisabled, "");
         return attrs;
     }
 
@@ -78975,7 +78975,9 @@ public abstract class ZAttrConfig extends Entry {
 
     /**
      * Length of TOTP code required for two-factor authentication. Keep at 6
-     * for compatability with common TOTP clients.
+     * for compatibility with common TOTP clients, and it must be different
+     * from zimbraTwoFactorScratchCodeLength and
+     * zimbraTwoFactorAuthEmailCodeLength.
      *
      * @return zimbraTwoFactorCodeLength, or 6 if unset
      *
@@ -78988,7 +78990,9 @@ public abstract class ZAttrConfig extends Entry {
 
     /**
      * Length of TOTP code required for two-factor authentication. Keep at 6
-     * for compatability with common TOTP clients.
+     * for compatibility with common TOTP clients, and it must be different
+     * from zimbraTwoFactorScratchCodeLength and
+     * zimbraTwoFactorAuthEmailCodeLength.
      *
      * @param zimbraTwoFactorCodeLength new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -79004,7 +79008,9 @@ public abstract class ZAttrConfig extends Entry {
 
     /**
      * Length of TOTP code required for two-factor authentication. Keep at 6
-     * for compatability with common TOTP clients.
+     * for compatibility with common TOTP clients, and it must be different
+     * from zimbraTwoFactorScratchCodeLength and
+     * zimbraTwoFactorAuthEmailCodeLength.
      *
      * @param zimbraTwoFactorCodeLength new value
      * @param attrs existing map to populate, or null to create a new map
@@ -79021,7 +79027,9 @@ public abstract class ZAttrConfig extends Entry {
 
     /**
      * Length of TOTP code required for two-factor authentication. Keep at 6
-     * for compatability with common TOTP clients.
+     * for compatibility with common TOTP clients, and it must be different
+     * from zimbraTwoFactorScratchCodeLength and
+     * zimbraTwoFactorAuthEmailCodeLength.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -79036,7 +79044,9 @@ public abstract class ZAttrConfig extends Entry {
 
     /**
      * Length of TOTP code required for two-factor authentication. Keep at 6
-     * for compatability with common TOTP clients.
+     * for compatibility with common TOTP clients, and it must be different
+     * from zimbraTwoFactorScratchCodeLength and
+     * zimbraTwoFactorAuthEmailCodeLength.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
@@ -79157,7 +79167,8 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * length of scratch codes
+     * Length of scratch codes. It must be different from
+     * zimbraTwoFactorCodeLength and zimbraTwoFactorAuthEmailCodeLength
      *
      * @return zimbraTwoFactorScratchCodeLength, or 8 if unset
      *
@@ -79169,7 +79180,8 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * length of scratch codes
+     * Length of scratch codes. It must be different from
+     * zimbraTwoFactorCodeLength and zimbraTwoFactorAuthEmailCodeLength
      *
      * @param zimbraTwoFactorScratchCodeLength new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -79184,7 +79196,8 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * length of scratch codes
+     * Length of scratch codes. It must be different from
+     * zimbraTwoFactorCodeLength and zimbraTwoFactorAuthEmailCodeLength
      *
      * @param zimbraTwoFactorScratchCodeLength new value
      * @param attrs existing map to populate, or null to create a new map
@@ -79200,7 +79213,8 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * length of scratch codes
+     * Length of scratch codes. It must be different from
+     * zimbraTwoFactorCodeLength and zimbraTwoFactorAuthEmailCodeLength
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -79214,7 +79228,8 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * length of scratch codes
+     * Length of scratch codes. It must be different from
+     * zimbraTwoFactorCodeLength and zimbraTwoFactorAuthEmailCodeLength
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -8668,7 +8668,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 10.1.0
      */
-    @ZAttr(id=4031)
+    @ZAttr(id=4126)
     public boolean isFeatureBasicOneToOneChatEnabled() {
         return getBooleanAttr(Provisioning.A_zimbraFeatureBasicOneToOneChatEnabled, false, true);
     }
@@ -8681,7 +8681,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 10.1.0
      */
-    @ZAttr(id=4031)
+    @ZAttr(id=4126)
     public void setFeatureBasicOneToOneChatEnabled(boolean zimbraFeatureBasicOneToOneChatEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureBasicOneToOneChatEnabled, zimbraFeatureBasicOneToOneChatEnabled ? TRUE : FALSE);
@@ -8697,7 +8697,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 10.1.0
      */
-    @ZAttr(id=4031)
+    @ZAttr(id=4126)
     public Map<String,Object> setFeatureBasicOneToOneChatEnabled(boolean zimbraFeatureBasicOneToOneChatEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureBasicOneToOneChatEnabled, zimbraFeatureBasicOneToOneChatEnabled ? TRUE : FALSE);
@@ -8711,7 +8711,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 10.1.0
      */
-    @ZAttr(id=4031)
+    @ZAttr(id=4126)
     public void unsetFeatureBasicOneToOneChatEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureBasicOneToOneChatEnabled, "");
@@ -8726,7 +8726,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 10.1.0
      */
-    @ZAttr(id=4031)
+    @ZAttr(id=4126)
     public Map<String,Object> unsetFeatureBasicOneToOneChatEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureBasicOneToOneChatEnabled, "");
@@ -13407,6 +13407,88 @@ public abstract class ZAttrCos extends NamedEntry {
     public Map<String,Object> unsetFeatureMobileSyncEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureMobileSyncEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * Deprecated since: 10.1.0. Added zimbraFeatureBasicOneToOneChatEnabled
+     * attribute from 10.1.0 for same functionality. Orig desc: Whether Chat
+     * feature is enabled or not
+     *
+     * @return zimbraFeatureModernChatEnabled, or false if unset
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4031)
+    public boolean isFeatureModernChatEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureModernChatEnabled, false, true);
+    }
+
+    /**
+     * Deprecated since: 10.1.0. Added zimbraFeatureBasicOneToOneChatEnabled
+     * attribute from 10.1.0 for same functionality. Orig desc: Whether Chat
+     * feature is enabled or not
+     *
+     * @param zimbraFeatureModernChatEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4031)
+    public void setFeatureModernChatEnabled(boolean zimbraFeatureModernChatEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernChatEnabled, zimbraFeatureModernChatEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Deprecated since: 10.1.0. Added zimbraFeatureBasicOneToOneChatEnabled
+     * attribute from 10.1.0 for same functionality. Orig desc: Whether Chat
+     * feature is enabled or not
+     *
+     * @param zimbraFeatureModernChatEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4031)
+    public Map<String,Object> setFeatureModernChatEnabled(boolean zimbraFeatureModernChatEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernChatEnabled, zimbraFeatureModernChatEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Deprecated since: 10.1.0. Added zimbraFeatureBasicOneToOneChatEnabled
+     * attribute from 10.1.0 for same functionality. Orig desc: Whether Chat
+     * feature is enabled or not
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4031)
+    public void unsetFeatureModernChatEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernChatEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Deprecated since: 10.1.0. Added zimbraFeatureBasicOneToOneChatEnabled
+     * attribute from 10.1.0 for same functionality. Orig desc: Whether Chat
+     * feature is enabled or not
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4031)
+    public Map<String,Object> unsetFeatureModernChatEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernChatEnabled, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -5126,6 +5126,88 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
+     * Whether to enable/disable the classic web client option on the login
+     * screen. Default value is FALSE, which makes the classic client option
+     * available.
+     *
+     * @return zimbraClassicWebClientDisabled, or false if unset
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4125)
+    public boolean isClassicWebClientDisabled() {
+        return getBooleanAttr(Provisioning.A_zimbraClassicWebClientDisabled, false, true);
+    }
+
+    /**
+     * Whether to enable/disable the classic web client option on the login
+     * screen. Default value is FALSE, which makes the classic client option
+     * available.
+     *
+     * @param zimbraClassicWebClientDisabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4125)
+    public void setClassicWebClientDisabled(boolean zimbraClassicWebClientDisabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraClassicWebClientDisabled, zimbraClassicWebClientDisabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to enable/disable the classic web client option on the login
+     * screen. Default value is FALSE, which makes the classic client option
+     * available.
+     *
+     * @param zimbraClassicWebClientDisabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4125)
+    public Map<String,Object> setClassicWebClientDisabled(boolean zimbraClassicWebClientDisabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraClassicWebClientDisabled, zimbraClassicWebClientDisabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether to enable/disable the classic web client option on the login
+     * screen. Default value is FALSE, which makes the classic client option
+     * available.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4125)
+    public void unsetClassicWebClientDisabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraClassicWebClientDisabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to enable/disable the classic web client option on the login
+     * screen. Default value is FALSE, which makes the classic client option
+     * available.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4125)
+    public Map<String,Object> unsetClassicWebClientDisabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraClassicWebClientDisabled, "");
+        return attrs;
+    }
+
+    /**
      * API Client ID for accessing with Zimbra Community API
      *
      * @return zimbraCommunityAPIClientID, or null if unset
@@ -10509,7 +10591,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 10.1.0
      */
-    @ZAttr(id=4031)
+    @ZAttr(id=4126)
     public boolean isFeatureBasicOneToOneChatEnabled() {
         return getBooleanAttr(Provisioning.A_zimbraFeatureBasicOneToOneChatEnabled, false, true);
     }
@@ -10522,7 +10604,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 10.1.0
      */
-    @ZAttr(id=4031)
+    @ZAttr(id=4126)
     public void setFeatureBasicOneToOneChatEnabled(boolean zimbraFeatureBasicOneToOneChatEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureBasicOneToOneChatEnabled, zimbraFeatureBasicOneToOneChatEnabled ? TRUE : FALSE);
@@ -10538,7 +10620,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 10.1.0
      */
-    @ZAttr(id=4031)
+    @ZAttr(id=4126)
     public Map<String,Object> setFeatureBasicOneToOneChatEnabled(boolean zimbraFeatureBasicOneToOneChatEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureBasicOneToOneChatEnabled, zimbraFeatureBasicOneToOneChatEnabled ? TRUE : FALSE);
@@ -10552,7 +10634,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 10.1.0
      */
-    @ZAttr(id=4031)
+    @ZAttr(id=4126)
     public void unsetFeatureBasicOneToOneChatEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureBasicOneToOneChatEnabled, "");
@@ -10567,7 +10649,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @since ZCS 10.1.0
      */
-    @ZAttr(id=4031)
+    @ZAttr(id=4126)
     public Map<String,Object> unsetFeatureBasicOneToOneChatEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureBasicOneToOneChatEnabled, "");
@@ -11207,6 +11289,88 @@ public abstract class ZAttrDomain extends NamedEntry {
     public Map<String,Object> unsetFeatureMaxVideoParticipantsForUser(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureMaxVideoParticipantsForUser, "");
+        return attrs;
+    }
+
+    /**
+     * Deprecated since: 10.1.0. Added zimbraFeatureBasicOneToOneChatEnabled
+     * attribute from 10.1.0 for same functionality. Orig desc: Whether Chat
+     * feature is enabled or not
+     *
+     * @return zimbraFeatureModernChatEnabled, or false if unset
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4031)
+    public boolean isFeatureModernChatEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureModernChatEnabled, false, true);
+    }
+
+    /**
+     * Deprecated since: 10.1.0. Added zimbraFeatureBasicOneToOneChatEnabled
+     * attribute from 10.1.0 for same functionality. Orig desc: Whether Chat
+     * feature is enabled or not
+     *
+     * @param zimbraFeatureModernChatEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4031)
+    public void setFeatureModernChatEnabled(boolean zimbraFeatureModernChatEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernChatEnabled, zimbraFeatureModernChatEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Deprecated since: 10.1.0. Added zimbraFeatureBasicOneToOneChatEnabled
+     * attribute from 10.1.0 for same functionality. Orig desc: Whether Chat
+     * feature is enabled or not
+     *
+     * @param zimbraFeatureModernChatEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4031)
+    public Map<String,Object> setFeatureModernChatEnabled(boolean zimbraFeatureModernChatEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernChatEnabled, zimbraFeatureModernChatEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Deprecated since: 10.1.0. Added zimbraFeatureBasicOneToOneChatEnabled
+     * attribute from 10.1.0 for same functionality. Orig desc: Whether Chat
+     * feature is enabled or not
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4031)
+    public void unsetFeatureModernChatEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernChatEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Deprecated since: 10.1.0. Added zimbraFeatureBasicOneToOneChatEnabled
+     * attribute from 10.1.0 for same functionality. Orig desc: Whether Chat
+     * feature is enabled or not
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4031)
+    public Map<String,Object> unsetFeatureModernChatEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureModernChatEnabled, "");
         return attrs;
     }
 
@@ -19578,88 +19742,6 @@ public abstract class ZAttrDomain extends NamedEntry {
     public Map<String,Object> unsetModernWebClientDisabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraModernWebClientDisabled, "");
-        return attrs;
-    }
-
-    /**
-     * Whether to enable/disable the classic web client option on the login
-     * screen. Default value is FALSE, which makes the classic client option
-     * available.
-     *
-     * @return zimbraClassicWebClientDisabled, or false if unset
-     *
-     * @since ZCS 10.1.0
-     */
-    @ZAttr(id=4125)
-    public boolean isClassicWebClientDisabled() {
-        return getBooleanAttr(Provisioning.A_zimbraClassicWebClientDisabled, false, true);
-    }
-
-    /**
-     * Whether to enable/disable the classic web client option on the login
-     * screen. Default value is FALSE, which makes the classic client option
-     * available.
-     *
-     * @param zimbraClassicWebClientDisabled new value
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 10.1.0
-     */
-    @ZAttr(id=4125)
-    public void setClassicWebClientDisabled(boolean zimbraClassicWebClientDisabled) throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraClassicWebClientDisabled, zimbraClassicWebClientDisabled ? TRUE : FALSE);
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Whether to enable/disable the classic web client option on the login
-     * screen. Default value is FALSE, which makes the classic client option
-     * available.
-     *
-     * @param zimbraClassicWebClientDisabled new value
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 10.1.0
-     */
-    @ZAttr(id=4125)
-    public Map<String,Object> setClassicWebClientDisabled(boolean zimbraClassicWebClientDisabled, Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraClassicWebClientDisabled, zimbraClassicWebClientDisabled ? TRUE : FALSE);
-        return attrs;
-    }
-
-    /**
-     * Whether to enable/disable the classic web client option on the login
-     * screen. Default value is FALSE, which makes the classic client option
-     * available.
-     *
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 10.1.0
-     */
-    @ZAttr(id=4125)
-    public void unsetClassicWebClientDisabled() throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraClassicWebClientDisabled, "");
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Whether to enable/disable the classic web client option on the login
-     * screen. Default value is FALSE, which makes the classic client option
-     * available.
-     *
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 10.1.0
-     */
-    @ZAttr(id=4125)
-    public Map<String,Object> unsetClassicWebClientDisabled(Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraClassicWebClientDisabled, "");
         return attrs;
     }
 


### PR DESCRIPTION
Problem: zimbraFeatureModernChatEnabled is renamed to new attribute zimbraFeatureBasicOneToOneChatEnabled, though it's not used, having a default value at COS is causing issue while upgrading

Solution: Created a new attributed instead of renaming it. 