### PR TITLE
ZBUG-3863 Gracefully handling OOM for reindex account

### DIFF
--- a/store/src/java/com/zimbra/cs/mime/MimeHandler.java
+++ b/store/src/java/com/zimbra/cs/mime/MimeHandler.java
@@ -177,11 +177,14 @@ public abstract class MimeHandler {
      */
     public final String getContent() throws MimeHandlerException {
         if (!DebugConfig.disableMimePartExtraction) {
-            String toRet = getContentImpl();
-            if (toRet == null)
-                return "";
-            else
-                return toRet;
+            String toRet = "";
+            try {
+                toRet = getContentImpl();
+            } catch (OutOfMemoryError e) {
+                // java.lang.OutOfMemoryError: Java heap space handled here
+                ZimbraLog.index.warn("File %s is corrupted causing OOM", filename);
+            }
+            return toRet;
         } else {
             if (dataSource != null && !mDrainedContent) {
                 InputStream is = null;

--- a/store/src/java/com/zimbra/cs/mime/MimeHandler.java
+++ b/store/src/java/com/zimbra/cs/mime/MimeHandler.java
@@ -27,6 +27,7 @@ import java.util.Locale;
 import javax.activation.DataSource;
 import javax.mail.internet.MimeUtility;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.lucene.document.Document;
 
 import com.google.common.base.Strings;
@@ -177,7 +178,7 @@ public abstract class MimeHandler {
      */
     public final String getContent() throws MimeHandlerException {
         if (!DebugConfig.disableMimePartExtraction) {
-            String toRet = "";
+            String toRet = StringUtils.EMPTY;
             try {
                 toRet = getContentImpl();
             } catch (OutOfMemoryError e) {


### PR DESCRIPTION
**Problem:** 
OOM on reindexing account having corrupted file.

**Fix:**
The file cannot be fixed if corrupted, so only handling it here to stop mailbox crash.