### PR TITLE
ZBUG-3987: Set AllowConcurrentSocketFactoryUse to true for LDAP connections

### DIFF
--- a/store/src/java/com/zimbra/cs/ldap/unboundid/LdapConnUtil.java
+++ b/store/src/java/com/zimbra/cs/ldap/unboundid/LdapConnUtil.java
@@ -44,6 +44,9 @@ public class LdapConnUtil {
     static LDAPConnectionOptions getConnectionOptions(LdapServerConfig ldapConfig) {
         LDAPConnectionOptions connOpts = new LDAPConnectionOptions();
 
+        // allowConcurrentSocketFactoryUse indicates whether to allow a socket factory
+        // instance to be used to create multiple sockets concurrently
+        connOpts.setAllowConcurrentSocketFactoryUse(true);
         connOpts.setUseSynchronousMode(true); // TODO: expose in LC?
         connOpts.setFollowReferrals(true);   // TODO: expose in LC?
         connOpts.setConnectTimeoutMillis(ldapConfig.getConnectTimeoutMillis());


### PR DESCRIPTION
Issue
External LDAP is unreachable, threads keep building up without closing existing ones

Fix
Set allowConcurrentSocketFactoryUse to true for LDAP connection