### PR TITLE
ZCS-14933: Prevent access of classic ui when zimbraClassicWebClientDisabled is TRUE

### DIFF
--- a/store/src/java/com/zimbra/cs/service/account/ClientInfo.java
+++ b/store/src/java/com/zimbra/cs/service/account/ClientInfo.java
@@ -59,6 +59,7 @@ public class ClientInfo extends AccountDocumentHandler {
             ToXML.encodeAttr(parent, Provisioning.A_zimbraWebClientLogoutURL, webClientLogoutURL);
             ToXML.encodeAttr(parent, Provisioning.A_zimbraWebClientStaySignedInDisabled, String.valueOf(domain.isWebClientStaySignedInDisabled()));
             ToXML.encodeAttr(parent, Provisioning.A_zimbraHelpModernURL, domain.getHelpModernURL());
+            ToXML.encodeAttr(parent, Provisioning.A_zimbraClassicWebClientDisabled, String.valueOf(domain.isClassicWebClientDisabled()));
             // TODO: ZCS-11319 update this line to read from LDAP property once this is moved out of LC.
             // e.g. change the `split(LC.web_client_logoff_..)` -> `domain.getWebClientLogoffURLs()`
             encodeAttrSkipLogoff(parent, webClientLogoutURL, StringUtils.split(LC.zimbra_web_client_logoff_urls.value()));


### PR DESCRIPTION
- Change in clientInfo API to get value of zimbraClassicWebClientDisabled attribute.