### PR TITLE
bugfix/ZCS-14930 : Used Limit not updated in "zmlicense -p and LDAP Attribute" after upgrading to 10.1.0 Beta when feature was overused in 8.8.15/9.0 

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -6652,6 +6652,14 @@ public class ZAttrProvisioning {
     public static final String A_zimbraExternalUserMailAddress = "zimbraExternalUserMailAddress";
 
     /**
+     * Zimbra feature actual usage count
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4133)
+    public static final String A_zimbraFeatureActualUsageCount = "zimbraFeatureActualUsageCount";
+
+    /**
      * RFC822 email address under verification for an account
      *
      * @since ZCS 8.8.5

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10519,6 +10519,7 @@ TODO: delete them permanently from here
   <desc>Zimbra offline network license code</desc>
 </attr>
 
+
 <attr id="4130" name="zimbraFeatureAdvancedChatEnabled" type="boolean" cardinality="single" optionalIn="domain,cos,account" flags="accountInfo,domainInfo,domainAdminModifiable,accountCosDomainInherited" since="10.1.0">
   <defaultCOSValue>FALSE</defaultCOSValue>
   <desc>When true, users can access all chat features, including private chats, group chats, and sending attachments</desc>
@@ -10531,6 +10532,10 @@ TODO: delete them permanently from here
 
 <attr id="4132" name="zimbraLicenseNotificationEmail" type="email" cardinality="single" optionalIn="globalConfig" since="10.1.0">
   <desc>Email address for receiving Zimbra license notifications</desc>
+</attr>
+
+<attr id="4133" name="zimbraFeatureActualUsageCount" type="string" cardinality="single" optionalIn="globalConfig" immutable="1" requiresRestart="mailbox" since="10.1.0">
+  <desc>Zimbra feature actual usage count</desc>
 </attr>
 
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -18378,6 +18378,78 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Zimbra feature actual usage count
+     *
+     * @return zimbraFeatureActualUsageCount, or null if unset
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4133)
+    public String getFeatureActualUsageCount() {
+        return getAttr(Provisioning.A_zimbraFeatureActualUsageCount, null, true);
+    }
+
+    /**
+     * Zimbra feature actual usage count
+     *
+     * @param zimbraFeatureActualUsageCount new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4133)
+    public void setFeatureActualUsageCount(String zimbraFeatureActualUsageCount) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureActualUsageCount, zimbraFeatureActualUsageCount);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Zimbra feature actual usage count
+     *
+     * @param zimbraFeatureActualUsageCount new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4133)
+    public Map<String,Object> setFeatureActualUsageCount(String zimbraFeatureActualUsageCount, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureActualUsageCount, zimbraFeatureActualUsageCount);
+        return attrs;
+    }
+
+    /**
+     * Zimbra feature actual usage count
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4133)
+    public void unsetFeatureActualUsageCount() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureActualUsageCount, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Zimbra feature actual usage count
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4133)
+    public Map<String,Object> unsetFeatureActualUsageCount(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureActualUsageCount, "");
+        return attrs;
+    }
+
+    /**
      * Deprecated since: 8.8.6. No longer used by ContactBackupRequest SOAP
      * handler. Orig desc: Sleep time between subsequent contact backups. 0
      * means that contact backup is disabled. . Must be in valid duration


### PR DESCRIPTION
Ticket : [ZCS-14930](https://synacor.atlassian.net/browse/ZCS-14930)
- Created an LDAP Attribute to store Feature with Actual Usage Limits : zimbraFeatureActualUsageLimits

[ZCS-14930]: https://synacor.atlassian.net/browse/ZCS-14930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ