### PR TITLE
ZCS-14115 fix extension dispatcher unregistration issue

### DIFF
--- a/store/src/java-test/com/zimbra/cs/extension/ExtensionDispatcherServletTest.java
+++ b/store/src/java-test/com/zimbra/cs/extension/ExtensionDispatcherServletTest.java
@@ -1,0 +1,102 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2024 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.extension;
+
+import com.zimbra.common.service.ServiceException;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ExtensionDispatcherServletTest {
+
+    @Mock
+    private ZimbraExtension mockExtension1;
+    @Mock
+    private ZimbraExtension mockExtension2;
+    @Mock
+    private ZimbraExtension mockExtension3;
+
+    @Before
+    public void setup() {
+        Mockito.when(mockExtension1.getName()).thenReturn("mockExtension1");
+        Mockito.when(mockExtension2.getName()).thenReturn("mockExtension2");
+        Mockito.when(mockExtension3.getName()).thenReturn("mockExtension3");
+    }
+
+    @Test
+    public void testRegister() throws ServiceException {
+        ExtensionDispatcherServlet.register(mockExtension1, getExtensionHttpHandler("handlerPath1"));
+        ExtensionDispatcherServlet.register(mockExtension2, getExtensionHttpHandler("handlerPath2"));
+        ExtensionDispatcherServlet.register(mockExtension3, getExtensionHttpHandler("handlerPath3"));
+        Assert.assertNotNull(ExtensionDispatcherServlet.getHandler("handlerPath1"));
+        Assert.assertNotNull(ExtensionDispatcherServlet.getHandler("handlerPath2"));
+        Assert.assertNotNull(ExtensionDispatcherServlet.getHandler("handlerPath3"));
+    }
+
+    @Test(expected = ServiceException.class)
+    public void testDuplicatePathRegister() throws ServiceException {
+        ExtensionDispatcherServlet.register(mockExtension1, getExtensionHttpHandler("handlerPath1"));
+        ExtensionDispatcherServlet.register(mockExtension2, getExtensionHttpHandler("handlerPath1"));
+    }
+
+    @Test
+    public void testUnregister() throws ServiceException {
+        ExtensionDispatcherServlet.register(mockExtension1, getExtensionHttpHandler("handlerPath1"));
+        ExtensionDispatcherServlet.register(mockExtension2, getExtensionHttpHandler("handlerPath2"));
+        ExtensionDispatcherServlet.register(mockExtension3, getExtensionHttpHandler("handlerPath3"));
+        Assert.assertNotNull(ExtensionDispatcherServlet.getHandler("handlerPath1"));
+        Assert.assertNotNull(ExtensionDispatcherServlet.getHandler("handlerPath2"));
+        Assert.assertNotNull(ExtensionDispatcherServlet.getHandler("handlerPath3"));
+
+        ExtensionDispatcherServlet.unregister(mockExtension1);
+        Assert.assertNull(ExtensionDispatcherServlet.getHandler("handlerPath1"));
+        ExtensionDispatcherServlet.unregister(mockExtension2);
+        Assert.assertNull(ExtensionDispatcherServlet.getHandler("handlerPath2"));
+    }
+
+    @After
+    public void tearDown() throws IllegalAccessException, NoSuchFieldException {
+        Field fieldSHandlers = ExtensionDispatcherServlet.class.getDeclaredField("sHandlers");
+        fieldSHandlers.setAccessible(true);
+        fieldSHandlers.set(null, Collections.synchronizedMap(new HashMap()));
+
+        Field fieldExtensionHandlers = ExtensionDispatcherServlet.class.getDeclaredField("EXTENSION_HANDLERS");
+        fieldExtensionHandlers.setAccessible(true);
+        fieldExtensionHandlers.set(null, new ConcurrentHashMap<>());
+    }
+
+    private ExtensionHttpHandler getExtensionHttpHandler(String handlerPath) {
+        return new ExtensionHttpHandler() {
+            @Override
+            public String getPath() {
+                return handlerPath;
+            }
+        };
+    }
+}

--- a/store/src/java/com/zimbra/cs/extension/ExtensionDispatcherServlet.java
+++ b/store/src/java/com/zimbra/cs/extension/ExtensionDispatcherServlet.java
@@ -21,21 +21,21 @@
  */
 package com.zimbra.cs.extension;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.Server;
 import com.zimbra.cs.servlet.ZimbraServlet;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Registers {@link ExtensionHttpHandler} for extensions and dispatches HTTP requests to them.
@@ -48,6 +48,9 @@ import com.zimbra.cs.servlet.ZimbraServlet;
  */
 public class ExtensionDispatcherServlet extends ZimbraServlet {
     private static Map sHandlers = Collections.synchronizedMap(new HashMap());
+
+    private static Map<String, ArrayList<ExtensionHttpHandler>> EXTENSION_HANDLERS = new ConcurrentHashMap<>(new HashMap());
+
     public static final String EXTENSION_PATH = "/service/extension";
 
     /**
@@ -60,9 +63,14 @@ public class ExtensionDispatcherServlet extends ZimbraServlet {
         handler.init(ext);
         String name = handler.getPath();
         synchronized (sHandlers) {
-            if (sHandlers.containsKey(name))
+            if (sHandlers.containsKey(name)) {
                 throw ServiceException.FAILURE("HTTP handler already registered: " + name, null);
+            }
             sHandlers.put(name, handler);
+            if (!EXTENSION_HANDLERS.containsKey(ext.getName())) {
+                EXTENSION_HANDLERS.put(ext.getName(), new ArrayList<ExtensionHttpHandler>());
+            }
+            EXTENSION_HANDLERS.get(ext.getName()).add(handler);
             ZimbraLog.extensions.info("registered handler at " + name);
         }
     }
@@ -129,19 +137,20 @@ public class ExtensionDispatcherServlet extends ZimbraServlet {
      */
     public static void unregister(ZimbraExtension ext) {
         synchronized(sHandlers) {
-            for (Iterator it = sHandlers.keySet().iterator(); it.hasNext(); ) {
-                String path = (String) it.next();
-                if (path.startsWith("/" + ext.getName())) {
-                    ExtensionHttpHandler handler = (ExtensionHttpHandler) sHandlers.get(path);
+            String extName = ext.getName();
+            ArrayList<ExtensionHttpHandler> extensionHttpHandlers = EXTENSION_HANDLERS.get(extName);
+            if (extensionHttpHandlers != null) {
+                for (ExtensionHttpHandler extHandler : extensionHttpHandlers) {
                     try {
-                        handler.destroy();
+                        extHandler.destroy();
                     } catch (Exception e) {
-                        ZimbraLog.extensions.warn("Error in destroy for handler " + handler.getClass(), e);
+                        ZimbraLog.extensions.warn("Error in destroy for handler %s", extHandler.getClass(), e);
                     } finally {
-                        it.remove();
+                        sHandlers.remove(extHandler.getPath());
                     }
                 }
             }
+            EXTENSION_HANDLERS.remove(extName);
         }
     }
 
@@ -159,13 +168,13 @@ public class ExtensionDispatcherServlet extends ZimbraServlet {
             throw ServiceException.FAILURE(String.format("extension '%s' not supported on %d port", handler.mExtension.getName(), req.getServerPort()), null);
         }
         if (handler.hideFromDefaultPorts()) {
-        	Server server = Provisioning.getInstance().getLocalServer();
-        	int port = req.getLocalPort();
-        	int mailPort = server.getIntAttr(Provisioning.A_zimbraMailPort, 0);
-        	int mailSslPort = server.getIntAttr(Provisioning.A_zimbraMailSSLPort, 0);
-        	int adminPort = server.getIntAttr(Provisioning.A_zimbraAdminPort, 0);
-        	if (port == mailPort || port == mailSslPort || port == adminPort)
-        		throw ServiceException.FAILURE("extension not supported on this port", null);
+            Server server = Provisioning.getInstance().getLocalServer();
+            int port = req.getLocalPort();
+            int mailPort = server.getIntAttr(Provisioning.A_zimbraMailPort, 0);
+            int mailSslPort = server.getIntAttr(Provisioning.A_zimbraMailSSLPort, 0);
+            int adminPort = server.getIntAttr(Provisioning.A_zimbraAdminPort, 0);
+            if (port == mailPort || port == mailSslPort || port == adminPort)
+                throw ServiceException.FAILURE("extension not supported on this port", null);
         }
         return handler;
     }


### PR DESCRIPTION
Description
Extension’s HTTP handlers registered using method https://github.com/Zimbra/zm-mailbox/blob/develop/store/src/java/com/zimbra/cs/extension/ExtensionDispatcherServlet.java#L59 can not deregistered using the method https://github.com/Zimbra/zm-mailbox/blob/develop/store/src/java/com/zimbra/cs/extension/ExtensionDispatcherServlet.java#L130 since registration of handlers tracking is incorrect, while deregisterd code is not honoring correct key to remove handlers.

Solution
Define data structure that can keep tracking of handlers based on the extensions https://github.com/Zimbra/zm-mailbox/blob/develop/store/src/java/com/zimbra/cs/extension/ExtensionDispatcherServlet.java#L50 so while removing it will look for handlers with respect to the extensions