### PR TITLE
ZBUG-3468: Fetching name from Content-Type if it is invalid as per RFC-2231 in Content-Disposition

### DIFF
--- a/common/src/java-test/com/zimbra/common/mime/MimeCompoundHeaderTest.java
+++ b/common/src/java-test/com/zimbra/common/mime/MimeCompoundHeaderTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 public class MimeCompoundHeaderTest {
     private void test(boolean isContentType, String description, String raw, String value, String[] params) {
         MimeCompoundHeader mch = isContentType ? new ContentType(raw) : new ContentDisposition(raw);
-
         String primary = isContentType ? ((ContentType) mch).getContentType() : ((ContentDisposition) mch).getDisposition();
         Assert.assertEquals(description, value, primary);
         Assert.assertEquals(description, params.length, mch.getParameterCount() * 2);
@@ -125,7 +124,12 @@ public class MimeCompoundHeaderTest {
         test(false, "missing 2231 charset/language with subsequent param",
                 "Content-Disposition: attachment; \r\nfilename*=Jarrod_Stiles%7a_resume_5579615_10344909272010946044.pdf; foo=bar",
                 "attachment", new String[] { "filename", "Jarrod_Stilesz_resume_5579615_10344909272010946044.pdf", "foo", "bar" });
+        test(false, "value continuation",
+                "Content-Disposition: attachment; filename*0=\"foo.\"; filename*1=\"html\"",
+                "attachment", new String[] { "filename", "foo.html"});
+        test(false, "using RFC2231 encoded UTF-8, with double quotes around the parameter value.\n",
+                "Content-Disposition: attachment; filename*=\"UTF-8''foo-%c3%a4.html\"",
+                "attachment", new String[] {});
     }
-
     // FIXME: add tests for serialization (2231 or not, various charsets, quoting, folding, etc.)
 }

--- a/common/src/java/com/zimbra/common/mime/MimeCompoundHeader.java
+++ b/common/src/java/com/zimbra/common/mime/MimeCompoundHeader.java
@@ -174,6 +174,10 @@ public class MimeCompoundHeader extends MimeHeader {
                     } else if (b == ';') {
                         rfc2231.saveParameter(params);
                         rfc2231.setState(RFC2231State.PARAM);
+                    } else if (b == '"') {
+                        // invalid, double-quote not allowed here. ignore
+                        rfc2231.reset();
+                        rfc2231.setState(RFC2231State.SLOP);
                     } else {
                         rfc2231.addCharsetByte(b);
                     }
@@ -507,7 +511,7 @@ public class MimeCompoundHeader extends MimeHeader {
                             charset.reset();
                         }
                         try {
-                            URLCodec codec = new URLCodec(charset.isEmpty() ? "us-ascii" : charset.toString());
+                            URLCodec codec = new URLCodec(charset.isEmpty() ? "us-ascii" : charset.toString().trim());
                             pvalue = codec.decode(pvalue);
                         } catch (DecoderException ignore) {
                         }


### PR DESCRIPTION
**Issue**
Broken utf-8 encoding in the mail attachment filenames when sender uses Outlook for Mac

**Reason**
As per analysis, this issue was coming because the filename was on the same line as in  Content-Disposition statement. Due to this, it was considering the filename string from beginning to end the same as it is.

**Solution**
If the name is not valid as per RFC-2231 then ignoring it and falling back to Content-Type and fetching from here.
https://greenbytes.de/tech/webdav/rfc2231.html
