### PR TITLE
ZCS-15070 GetShareInfoRequest soap api require activesyncdisabled attribute in response

### DIFF
--- a/common/src/java/com/zimbra/common/gql/GqlConstants.java
+++ b/common/src/java/com/zimbra/common/gql/GqlConstants.java
@@ -697,6 +697,7 @@ public class GqlConstants {
     public static final String GRNATEE_NAME = "granteeName";
     public static final String GRANTEE_DISPLAY_NAME = "granteeDisplayName";
     public static final String MOUNTPOINT_ID = "mountpointId";
+    public static final String ACTIVESYNC_DISABLED = "activeSyncDisabled";
 
     // auth
     public static final String CLASS_ADMIN_AUTH_REQUEST = "AdminAuthRequest";

--- a/common/src/java/com/zimbra/common/soap/AccountConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AccountConstants.java
@@ -536,6 +536,7 @@ public class AccountConstants {
     public static final String A_OWNER_DISPLAY_NAME = "ownerName";
     public static final String A_RIGHTS = "rights";
     public static final String A_MOUNTPOINT_ID = "mid";
+    public static final String A_ACTIVESYNC_DISABLED = "activeSyncDisabled";
     // contact search
     public static final String A_DEPARTMENT = "department";
 

--- a/soap/src/java/com/zimbra/soap/type/ShareInfo.java
+++ b/soap/src/java/com/zimbra/soap/type/ShareInfo.java
@@ -33,7 +33,7 @@ import io.leangen.graphql.annotations.types.GraphQLType;
 
 @XmlAccessorType(XmlAccessType.NONE)
 @JsonPropertyOrder({ "ownerId", "ownerEmail", "ownerName", "folderId", "folderUuid", "folderPath", "view", "rights",
-    "granteeType", "granteeId", "granteeName", "granteeDisplayName", "mid" })
+    "granteeType", "granteeId", "granteeName", "granteeDisplayName", "mid", "activeSyncDisabled" })
 @GraphQLType(name=GqlConstants.CLASS_SHARE_INFO, description="share info")
 public class ShareInfo {
 
@@ -129,6 +129,13 @@ public class ShareInfo {
     @XmlAttribute(name=AccountConstants.A_MOUNTPOINT_ID /* mid */, required=false)
     private String mountpointId;
 
+    /**
+     * @zm-api-field-tag activeSyncDisabled
+     * @zm-api-field-description activesync is disabled
+     */
+    @XmlAttribute(name=AccountConstants.A_ACTIVESYNC_DISABLED /* granteeDisplayName */, required=true)
+    private boolean activeSyncDisabled;
+
     public ShareInfo() {
     }
 
@@ -223,7 +230,16 @@ public class ShareInfo {
     @GraphQLQuery(name=GqlConstants.MOUNTPOINT_ID, description="mountpoint id")
     public String getMountpointId() { return mountpointId; }
 
-    @Override
+    public void setActiveSyncDisabled(boolean activeSyncDisabled) {
+		this.activeSyncDisabled = activeSyncDisabled;
+	}
+
+    @GraphQLQuery(name=GqlConstants.ACTIVESYNC_DISABLED, description="disbale activesync")
+    public boolean isActiveSyncDisabled() {
+		return activeSyncDisabled;
+	}
+
+	@Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
             .add("ownerId", ownerId)
@@ -239,6 +255,8 @@ public class ShareInfo {
             .add("granteeName", granteeName)
             .add("granteeDisplayName", granteeDisplayName)
             .add("mountpointId", mountpointId)
+            .add("activeSyncDisabled", activeSyncDisabled)
             .toString();
     }
+
 }

--- a/store/src/java/com/zimbra/cs/account/ShareInfo.java
+++ b/store/src/java/com/zimbra/cs/account/ShareInfo.java
@@ -266,13 +266,41 @@ public class ShareInfo {
          *     key: {owner-acct-id}:{remote-folder-id}
          *     value: {local-folder-id}
          */
-        private final Map<String, Integer> mMountedFolders;
+
+        public class FolderMountpoint {
+
+            int id;
+            boolean activeSyncDisabled;
+
+            public FolderMountpoint(Integer id, boolean activeSyncDisabled) {
+                this.id = id;
+                this.activeSyncDisabled = activeSyncDisabled;
+            }
+
+            public int getId() {
+                return id;
+            }
+
+            public void setId(Integer id) {
+                this.id = id;
+            }
+
+            public boolean isActiveSyncDisabled() {
+                return activeSyncDisabled;
+            }
+
+            public void setActiveSyncDisabled(boolean activeSyncDisabled) {
+                this.activeSyncDisabled = activeSyncDisabled;
+            }
+
+        }
+        private final Map<String, FolderMountpoint> mMountedFolders;
 
         public MountedFolders(OperationContext octxt, Account acct) throws ServiceException {
             mMountedFolders = getLocalMountpoints(octxt, acct);
         }
 
-        public Integer getLocalFolderId(String ownerAcctId, int remoteFolderId) {
+        public FolderMountpoint getLocalFolderId(String ownerAcctId, int remoteFolderId) {
             if (mMountedFolders == null)
                 return null;
             else {
@@ -295,7 +323,7 @@ public class ShareInfo {
          * @return
          * @throws ServiceException
          */
-        private Map<String, Integer> getLocalMountpoints(OperationContext octxt, Account acct) throws ServiceException {
+        private Map<String, FolderMountpoint> getLocalMountpoints(OperationContext octxt, Account acct) throws ServiceException {
             if (octxt == null)
                 return null;
 
@@ -307,9 +335,9 @@ public class ShareInfo {
 
         }
 
-        private Map<String, Integer> getLocalMountpoints(OperationContext octxt, Mailbox mbox) throws ServiceException {
+        private Map<String, FolderMountpoint> getLocalMountpoints(OperationContext octxt, Mailbox mbox) throws ServiceException {
 
-            Map<String, Integer> mountpoints = new HashMap<String, Integer>();
+            Map<String, FolderMountpoint> mountpoints = new HashMap<String, FolderMountpoint>();
 
             mbox.lock.lock(false);
             try {
@@ -327,7 +355,7 @@ public class ShareInfo {
             return mountpoints;
         }
 
-        private void getLocalMountpoints(Folder folder, Set<Folder> visible, Map<String, Integer> mountpoints) throws ServiceException {
+        private void getLocalMountpoints(Folder folder, Set<Folder> visible, Map<String, FolderMountpoint> mountpoints) throws ServiceException {
             boolean isVisible = visible == null || visible.remove(folder);
             if (!isVisible)
                 return;
@@ -335,7 +363,8 @@ public class ShareInfo {
             if (folder instanceof Mountpoint) {
                 Mountpoint mpt = (Mountpoint)folder;
                 String mid =  getKey(mpt.getOwnerId(), mpt.getRemoteId());
-                mountpoints.put(mid, mpt.getId());
+                FolderMountpoint folderMountpoint = new FolderMountpoint(mpt.getId(), mpt.isActiveSyncDisabled());
+                mountpoints.put(mid, folderMountpoint);
             }
 
             // if this was the last visible folder overall, no need to look at children

--- a/store/src/java/com/zimbra/cs/account/ShareInfoData.java
+++ b/store/src/java/com/zimbra/cs/account/ShareInfoData.java
@@ -20,6 +20,7 @@ import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AccountConstants;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.MailConstants;
+import com.zimbra.cs.account.ShareInfo.MountedFolders.FolderMountpoint;
 import com.zimbra.cs.mailbox.ACL;
 import com.zimbra.cs.mailbox.MailItem;
 
@@ -295,14 +296,13 @@ public class ShareInfoData {
         sid.setGranteeId(eShare.getAttribute(AccountConstants.A_GRANTEE_ID, null));
         sid.setGranteeName(eShare.getAttribute(AccountConstants.A_GRANTEE_NAME, null));
         sid.setGranteeDisplayName(eShare.getAttribute(AccountConstants.A_GRANTEE_DISPLAY_NAME, null));
-
         // and this ugly thing
         sid.setMountpointId_zmprov_only(eShare.getAttribute(AccountConstants.A_MOUNTPOINT_ID, null));
 
         return sid;
     }
 
-    public com.zimbra.soap.type.ShareInfo toJAXB(Integer mptId) {
+    public com.zimbra.soap.type.ShareInfo toJAXB(FolderMountpoint mptId) {
         com.zimbra.soap.type.ShareInfo jaxb = new com.zimbra.soap.type.ShareInfo();
         jaxb.setOwnerId(getOwnerAcctId());
         jaxb.setOwnerEmail(getOwnerAcctEmail());
@@ -317,7 +317,8 @@ public class ShareInfoData {
         jaxb.setGranteeName(getGranteeName());
         jaxb.setGranteeDisplayName(getGranteeDisplayName());
         if (mptId != null) {
-            jaxb.setMountpointId(mptId.toString());
+            jaxb.setMountpointId(String.valueOf(mptId.getId()));
+            jaxb.setActiveSyncDisabled(mptId.isActiveSyncDisabled());
         }
         return jaxb;
     }

--- a/store/src/java/com/zimbra/cs/service/account/GetShareInfo.java
+++ b/store/src/java/com/zimbra/cs/service/account/GetShareInfo.java
@@ -31,11 +31,11 @@ import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.Provisioning.PublishedShareInfoVisitor;
 import com.zimbra.cs.account.ShareInfo;
+import com.zimbra.cs.account.ShareInfo.MountedFolders.FolderMountpoint;
 import com.zimbra.cs.account.ShareInfoData;
 import com.zimbra.cs.account.names.NameUtil;
 import com.zimbra.cs.mailbox.ACL;
 import com.zimbra.cs.mailbox.OperationContext;
-import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.account.message.GetShareInfoRequest;
 import com.zimbra.soap.account.message.GetShareInfoResponse;
@@ -361,8 +361,8 @@ public class GetShareInfo  extends AccountDocumentHandler {
             mResp.addShare(sid.toJAXB(getMountpointId(sid)));
         }
 
-        private Integer getMountpointId(ShareInfoData sid) throws ServiceException {
-            Integer mptId = null;
+        private FolderMountpoint getMountpointId(ShareInfoData sid) throws ServiceException {
+            FolderMountpoint mptId = null;
             if (mMountedFolders != null) {
                 mptId = mMountedFolders.getLocalFolderId(sid.getOwnerAcctId(), sid.getItemId());
             }


### PR DESCRIPTION
Problem: Classic UI implementation for shared folder synchronization used GetShareInfoRequest which does not retuen all require mounted folder attributes.

Fix:
GetShareInfoRequest soap api return activesyncdisabled attribute in response

Test-cases:
tested using soap api call 
`<GetShareInfoResponse xmlns="urn:zimbraAccount">
         <share folderPath="/_InternalGAL" view="contact" granteeId="800b3fbe-3057-4156-96fb-8046e3d62c5a" rights="r" ownerId="d276d02f-9181-48ed-b6a7-b0bd9346449d" folderUuid="1695aa7b-85ec-4529-ab67-1ded1348a67f" granteeType="dom" folderId="257" ownerEmail="galsync.zosigfojwy@platform-dev-activesync.zimbradev.com" granteeName="platform-dev-activesync.zimbradev.com" activeSyncDisabled="false"/>
         <share granteeId="97fc8b0c-6af3-4d63-b60f-3ae32a2df49a" mid="1121" ownerId="1ced6ce3-950f-4080-b0ae-35ef27bb2646" folderUuid="1c611936-52ba-4c7d-a13d-07283e8a1bbd" folderId="1539" ownerEmail="sh2@platform-dev-activesync.zimbradev.com" granteeName="sh3@platform-dev-activesync.zimbradev.com" activeSyncDisabled="true" folderPath="/i1" view="message" ownerName="sh2" rights="r" granteeType="usr"/>
      </GetShareInfoResponse>`