### PR TITLE
ZCS-15063: Add LDAP attribute to control the mobile sync feature

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -7506,6 +7506,16 @@ public class ZAttrProvisioning {
     public static final String A_zimbraFeatureSearchHistoryEnabled = "zimbraFeatureSearchHistoryEnabled";
 
     /**
+     * Whether to enable/disable the mobile sync for shared folders. Default
+     * value is TRUE. Which makes shared folders sync enabled for mobile
+     * devices
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4133)
+    public static final String A_zimbraFeatureSharedFolderMobileSyncEnabled = "zimbraFeatureSharedFolderMobileSyncEnabled";
+
+    /**
      * enabled sharing
      */
     @ZAttr(id=335)

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -7506,13 +7506,14 @@ public class ZAttrProvisioning {
     public static final String A_zimbraFeatureSearchHistoryEnabled = "zimbraFeatureSearchHistoryEnabled";
 
     /**
-     * Whether to enable/disable the mobile sync for shared folders. Default
-     * value is TRUE. Which makes shared folders sync enabled for mobile
-     * devices
+     * Feature to enable/disable the mobile sync for shared folders. Default 
+     * value is TRUE. The option to sync the shared folders to the Mobile 
+     * will be enabled for the users in the webclient. The option will only 
+     * be enabled for shared folders having Admin or Manager permission
      *
      * @since ZCS 10.1.0
      */
-    @ZAttr(id=4133)
+    @ZAttr(id=4134)
     public static final String A_zimbraFeatureSharedFolderMobileSyncEnabled = "zimbraFeatureSharedFolderMobileSyncEnabled";
 
     /**

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10540,6 +10540,6 @@ TODO: delete them permanently from here
 
 <attr id="4134" name="zimbraFeatureSharedFolderMobileSyncEnabled" type="boolean" cardinality="single" optionalIn="cos,account" flags="accountInherited,accountInfo" since="10.1.0">
   <defaultCOSValue>TRUE</defaultCOSValue>
-  <desc>Whether to enable/disable the mobile sync for shared folders. Default value is TRUE. Which makes shared folders sync enabled for mobile devices</desc>
+  <desc>Feature to enable/disable the mobile sync for shared folders. Default value is TRUE. The option to sync the shared folders to the Mobile will be enabled for the users in the webclient. The option will only be enabled for shared folders having Admin or Manager permission</desc>
 </attr>
 </attrs>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10538,4 +10538,8 @@ TODO: delete them permanently from here
   <desc>Zimbra feature actual usage count</desc>
 </attr>
 
+<attr id="4134" name="zimbraFeatureSharedFolderMobileSyncEnabled" type="boolean" cardinality="single" optionalIn="cos,account" flags="accountInherited,accountInfo" since="10.1.0">
+  <defaultCOSValue>TRUE</defaultCOSValue>
+  <desc>Whether to enable/disable the mobile sync for shared folders. Default value is TRUE. Which makes shared folders sync enabled for mobile devices</desc>
+</attr>
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -21013,6 +21013,88 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * Whether to enable/disable the mobile sync for shared folders. Default
+     * value is TRUE. Which makes shared folders sync enabled for mobile
+     * devices
+     *
+     * @return zimbraFeatureSharedFolderMobileSyncEnabled, or true if unset
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4133)
+    public boolean isFeatureSharedFolderMobileSyncEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureSharedFolderMobileSyncEnabled, true, true);
+    }
+
+    /**
+     * Whether to enable/disable the mobile sync for shared folders. Default
+     * value is TRUE. Which makes shared folders sync enabled for mobile
+     * devices
+     *
+     * @param zimbraFeatureSharedFolderMobileSyncEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4133)
+    public void setFeatureSharedFolderMobileSyncEnabled(boolean zimbraFeatureSharedFolderMobileSyncEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureSharedFolderMobileSyncEnabled, zimbraFeatureSharedFolderMobileSyncEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to enable/disable the mobile sync for shared folders. Default
+     * value is TRUE. Which makes shared folders sync enabled for mobile
+     * devices
+     *
+     * @param zimbraFeatureSharedFolderMobileSyncEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4133)
+    public Map<String,Object> setFeatureSharedFolderMobileSyncEnabled(boolean zimbraFeatureSharedFolderMobileSyncEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureSharedFolderMobileSyncEnabled, zimbraFeatureSharedFolderMobileSyncEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether to enable/disable the mobile sync for shared folders. Default
+     * value is TRUE. Which makes shared folders sync enabled for mobile
+     * devices
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4133)
+    public void unsetFeatureSharedFolderMobileSyncEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureSharedFolderMobileSyncEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to enable/disable the mobile sync for shared folders. Default
+     * value is TRUE. Which makes shared folders sync enabled for mobile
+     * devices
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4133)
+    public Map<String,Object> unsetFeatureSharedFolderMobileSyncEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureSharedFolderMobileSyncEnabled, "");
+        return attrs;
+    }
+
+    /**
      * enabled sharing
      *
      * @return zimbraFeatureSharingEnabled, or true if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -21013,30 +21013,32 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * Whether to enable/disable the mobile sync for shared folders. Default
-     * value is TRUE. Which makes shared folders sync enabled for mobile
-     * devices
+     * Feature to enable/disable the mobile sync for shared folders. Default 
+     * value is TRUE. The option to sync the shared folders to the Mobile 
+     * will be enabled for the users in the webclient. The option will only 
+     * be enabled for shared folders having Admin or Manager permission
      *
      * @return zimbraFeatureSharedFolderMobileSyncEnabled, or true if unset
      *
      * @since ZCS 10.1.0
      */
-    @ZAttr(id=4133)
+    @ZAttr(id=4134)
     public boolean isFeatureSharedFolderMobileSyncEnabled() {
         return getBooleanAttr(Provisioning.A_zimbraFeatureSharedFolderMobileSyncEnabled, true, true);
     }
 
     /**
-     * Whether to enable/disable the mobile sync for shared folders. Default
-     * value is TRUE. Which makes shared folders sync enabled for mobile
-     * devices
+     * Feature to enable/disable the mobile sync for shared folders. Default 
+     * value is TRUE. The option to sync the shared folders to the Mobile 
+     * will be enabled for the users in the webclient. The option will only 
+     * be enabled for shared folders having Admin or Manager permission
      *
      * @param zimbraFeatureSharedFolderMobileSyncEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
      * @since ZCS 10.1.0
      */
-    @ZAttr(id=4133)
+    @ZAttr(id=4134)
     public void setFeatureSharedFolderMobileSyncEnabled(boolean zimbraFeatureSharedFolderMobileSyncEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureSharedFolderMobileSyncEnabled, zimbraFeatureSharedFolderMobileSyncEnabled ? TRUE : FALSE);
@@ -21044,9 +21046,10 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * Whether to enable/disable the mobile sync for shared folders. Default
-     * value is TRUE. Which makes shared folders sync enabled for mobile
-     * devices
+     * Feature to enable/disable the mobile sync for shared folders. Default 
+     * value is TRUE. The option to sync the shared folders to the Mobile 
+     * will be enabled for the users in the webclient. The option will only 
+     * be enabled for shared folders having Admin or Manager permission
      *
      * @param zimbraFeatureSharedFolderMobileSyncEnabled new value
      * @param attrs existing map to populate, or null to create a new map
@@ -21054,7 +21057,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 10.1.0
      */
-    @ZAttr(id=4133)
+    @ZAttr(id=4134)
     public Map<String,Object> setFeatureSharedFolderMobileSyncEnabled(boolean zimbraFeatureSharedFolderMobileSyncEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureSharedFolderMobileSyncEnabled, zimbraFeatureSharedFolderMobileSyncEnabled ? TRUE : FALSE);
@@ -21062,15 +21065,16 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * Whether to enable/disable the mobile sync for shared folders. Default
-     * value is TRUE. Which makes shared folders sync enabled for mobile
-     * devices
+     * Feature to enable/disable the mobile sync for shared folders. Default 
+     * value is TRUE. The option to sync the shared folders to the Mobile 
+     * will be enabled for the users in the webclient. The option will only 
+     * be enabled for shared folders having Admin or Manager permission
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
      * @since ZCS 10.1.0
      */
-    @ZAttr(id=4133)
+    @ZAttr(id=4134)
     public void unsetFeatureSharedFolderMobileSyncEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureSharedFolderMobileSyncEnabled, "");
@@ -21078,16 +21082,17 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * Whether to enable/disable the mobile sync for shared folders. Default
-     * value is TRUE. Which makes shared folders sync enabled for mobile
-     * devices
+     * Feature to enable/disable the mobile sync for shared folders. Default 
+     * value is TRUE. The option to sync the shared folders to the Mobile 
+     * will be enabled for the users in the webclient. The option will only 
+     * be enabled for shared folders having Admin or Manager permission
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
      * @since ZCS 10.1.0
      */
-    @ZAttr(id=4133)
+    @ZAttr(id=4134)
     public Map<String,Object> unsetFeatureSharedFolderMobileSyncEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureSharedFolderMobileSyncEnabled, "");

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -15402,6 +15402,88 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * Whether to enable/disable the mobile sync for shared folders. Default
+     * value is TRUE. Which makes shared folders sync enabled for mobile
+     * devices
+     *
+     * @return zimbraFeatureSharedFolderMobileSyncEnabled, or true if unset
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4133)
+    public boolean isFeatureSharedFolderMobileSyncEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureSharedFolderMobileSyncEnabled, true, true);
+    }
+
+    /**
+     * Whether to enable/disable the mobile sync for shared folders. Default
+     * value is TRUE. Which makes shared folders sync enabled for mobile
+     * devices
+     *
+     * @param zimbraFeatureSharedFolderMobileSyncEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4133)
+    public void setFeatureSharedFolderMobileSyncEnabled(boolean zimbraFeatureSharedFolderMobileSyncEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureSharedFolderMobileSyncEnabled, zimbraFeatureSharedFolderMobileSyncEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to enable/disable the mobile sync for shared folders. Default
+     * value is TRUE. Which makes shared folders sync enabled for mobile
+     * devices
+     *
+     * @param zimbraFeatureSharedFolderMobileSyncEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4133)
+    public Map<String,Object> setFeatureSharedFolderMobileSyncEnabled(boolean zimbraFeatureSharedFolderMobileSyncEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureSharedFolderMobileSyncEnabled, zimbraFeatureSharedFolderMobileSyncEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether to enable/disable the mobile sync for shared folders. Default
+     * value is TRUE. Which makes shared folders sync enabled for mobile
+     * devices
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4133)
+    public void unsetFeatureSharedFolderMobileSyncEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureSharedFolderMobileSyncEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether to enable/disable the mobile sync for shared folders. Default
+     * value is TRUE. Which makes shared folders sync enabled for mobile
+     * devices
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.0
+     */
+    @ZAttr(id=4133)
+    public Map<String,Object> unsetFeatureSharedFolderMobileSyncEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureSharedFolderMobileSyncEnabled, "");
+        return attrs;
+    }
+
+    /**
      * enabled sharing
      *
      * @return zimbraFeatureSharingEnabled, or true if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -15402,30 +15402,32 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Whether to enable/disable the mobile sync for shared folders. Default
-     * value is TRUE. Which makes shared folders sync enabled for mobile
-     * devices
+     * Feature to enable/disable the mobile sync for shared folders. Default 
+     * value is TRUE. The option to sync the shared folders to the Mobile 
+     * will be enabled for the users in the webclient. The option will only 
+     * be enabled for shared folders having Admin or Manager permission
      *
      * @return zimbraFeatureSharedFolderMobileSyncEnabled, or true if unset
      *
      * @since ZCS 10.1.0
      */
-    @ZAttr(id=4133)
+    @ZAttr(id=4134)
     public boolean isFeatureSharedFolderMobileSyncEnabled() {
         return getBooleanAttr(Provisioning.A_zimbraFeatureSharedFolderMobileSyncEnabled, true, true);
     }
 
     /**
-     * Whether to enable/disable the mobile sync for shared folders. Default
-     * value is TRUE. Which makes shared folders sync enabled for mobile
-     * devices
+     * Feature to enable/disable the mobile sync for shared folders. Default 
+     * value is TRUE. The option to sync the shared folders to the Mobile 
+     * will be enabled for the users in the webclient. The option will only 
+     * be enabled for shared folders having Admin or Manager permission
      *
      * @param zimbraFeatureSharedFolderMobileSyncEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
      * @since ZCS 10.1.0
      */
-    @ZAttr(id=4133)
+    @ZAttr(id=4134)
     public void setFeatureSharedFolderMobileSyncEnabled(boolean zimbraFeatureSharedFolderMobileSyncEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureSharedFolderMobileSyncEnabled, zimbraFeatureSharedFolderMobileSyncEnabled ? TRUE : FALSE);
@@ -15433,9 +15435,10 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Whether to enable/disable the mobile sync for shared folders. Default
-     * value is TRUE. Which makes shared folders sync enabled for mobile
-     * devices
+     * Feature to enable/disable the mobile sync for shared folders. Default 
+     * value is TRUE. The option to sync the shared folders to the Mobile 
+     * will be enabled for the users in the webclient. The option will only 
+     * be enabled for shared folders having Admin or Manager permission
      *
      * @param zimbraFeatureSharedFolderMobileSyncEnabled new value
      * @param attrs existing map to populate, or null to create a new map
@@ -15443,7 +15446,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 10.1.0
      */
-    @ZAttr(id=4133)
+    @ZAttr(id=4134)
     public Map<String,Object> setFeatureSharedFolderMobileSyncEnabled(boolean zimbraFeatureSharedFolderMobileSyncEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureSharedFolderMobileSyncEnabled, zimbraFeatureSharedFolderMobileSyncEnabled ? TRUE : FALSE);
@@ -15451,15 +15454,16 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Whether to enable/disable the mobile sync for shared folders. Default
-     * value is TRUE. Which makes shared folders sync enabled for mobile
-     * devices
+     * Feature to enable/disable the mobile sync for shared folders. Default 
+     * value is TRUE. The option to sync the shared folders to the Mobile 
+     * will be enabled for the users in the webclient. The option will only 
+     * be enabled for shared folders having Admin or Manager permission
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
      * @since ZCS 10.1.0
      */
-    @ZAttr(id=4133)
+    @ZAttr(id=4134)
     public void unsetFeatureSharedFolderMobileSyncEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureSharedFolderMobileSyncEnabled, "");
@@ -15467,16 +15471,17 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Whether to enable/disable the mobile sync for shared folders. Default
-     * value is TRUE. Which makes shared folders sync enabled for mobile
-     * devices
+     * Feature to enable/disable the mobile sync for shared folders. Default 
+     * value is TRUE. The option to sync the shared folders to the Mobile 
+     * will be enabled for the users in the webclient. The option will only 
+     * be enabled for shared folders having Admin or Manager permission
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
      * @since ZCS 10.1.0
      */
-    @ZAttr(id=4133)
+    @ZAttr(id=4134)
     public Map<String,Object> unsetFeatureSharedFolderMobileSyncEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraFeatureSharedFolderMobileSyncEnabled, "");


### PR DESCRIPTION
Adding new ldap attribute `zimbraFeatureSharedFolderMobileSyncEnabled`