### PR TITLE
ZCS-15319: Exiting command execution after completion

### DIFF
--- a/store/src/java/com/zimbra/cs/redolog/util/PlaybackUtil.java
+++ b/store/src/java/com/zimbra/cs/redolog/util/PlaybackUtil.java
@@ -375,6 +375,7 @@ public class PlaybackUtil {
             player.playback();
         } finally {
             teardown();
+            System.exit(0);
         }
     }
 


### PR DESCRIPTION
**Problem**
zmplayredo utility is not exiting after execution

**Solution**
Command was not getting terminated after successful execution so added `System.exit(0)`.