### PR TITLE
ZCS-15392: REGEXP_ESCAPED['+']=true

### DIFF
--- a/store/src/java/com/zimbra/cs/imap/ImapHandler.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapHandler.java
@@ -221,7 +221,7 @@ public abstract class ImapHandler {
         REGEXP_ESCAPED['['] = REGEXP_ESCAPED[']'] = REGEXP_ESCAPED['|'] = true;
         REGEXP_ESCAPED['^'] = REGEXP_ESCAPED['$'] = REGEXP_ESCAPED['?'] = true;
         REGEXP_ESCAPED['{'] = REGEXP_ESCAPED['}'] = REGEXP_ESCAPED['*'] = true;
-        REGEXP_ESCAPED['\\'] = true;
+        REGEXP_ESCAPED['+'] = REGEXP_ESCAPED['\\'] = true;
     }
 
     protected ImapConfig config;
@@ -2160,7 +2160,7 @@ public abstract class ImapHandler {
         return true;
     }
 
-    private boolean doLIST(String tag, String referenceName, Set<String> mailboxNames,
+    protected boolean doLIST(String tag, String referenceName, Set<String> mailboxNames,
             byte selectOptions, byte returnOptions, byte status) throws ImapException, IOException {
         checkCommandThrottle(new ListCommand(referenceName, mailboxNames, selectOptions, returnOptions, status));
         if (!checkState(tag, State.AUTHENTICATED)) {
@@ -2632,7 +2632,7 @@ public abstract class ImapHandler {
         if (path.belongsTo(credentials)) {
             FolderStore folderStore = path.getFolder();
             if (folderStore != null) {
-            	return folderStore.isIMAPSubscribed();
+                return folderStore.isIMAPSubscribed();
             } else {
                 ZimbraLog.imap.info("Null FolderStore for path %s", path.asZimbraPath());
             }

--- a/store/src/java/com/zimbra/cs/imap/ImapPath.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapPath.java
@@ -58,8 +58,7 @@ public class ImapPath implements Comparable<ImapPath> {
             FOLDER_ENCODING_CHARSET = Charset.forName("imap-utf-7");
         } catch (Exception e) {
             ZimbraLog.imap.error(
-                "could not load imap-utf-7 charset (perhaps zimbra-charset.jar is not in the jetty endorsed directory)",
-                e);
+                "could not load imap-utf-7 charset (perhaps zimbra-charset.jar is not in the jetty endorsed directory)");
             FOLDER_ENCODING_CHARSET = Charset.forName("utf-8");
         }
     }


### PR DESCRIPTION
Mailboxes with a plus sign would not match any search filter. It seems we had not included '+' as a regexp character to be escaped when converting IMAP wildcards into regexp Patterns. This fixed that, so when you search for "BOB+ALICE" you'll find a literal "BOB+ALICE" but not "BOBBBBBBBBALICE" or nothing at all.

ImapHandlerTest intermittently fails, but it does that on develop, also. And it doesn't seem to fail on my new test, so I'm chalking it up to something wrong with the existing ones. I'll take a look, but this isn't the ideal place to fix them.