### PR TITLE
ZCS-14337: Fetching StoreManager classes from DB to handle blobcheck utility issue

### DIFF
--- a/store/src/java/com/zimbra/cs/service/admin/CheckBlobConsistency.java
+++ b/store/src/java/com/zimbra/cs/service/admin/CheckBlobConsistency.java
@@ -18,12 +18,14 @@
 package com.zimbra.cs.service.admin;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AdminConstants;
 import com.zimbra.common.soap.Element;
+import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.accesscontrol.AdminRight;
 import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.MailboxManager;
@@ -65,63 +67,96 @@ public final class CheckBlobConsistency extends AdminDocumentHandler {
 
         // Check blobs and assemble response.
         Element response = zsc.createElement(AdminConstants.CHECK_BLOB_CONSISTENCY_RESPONSE);
-
-        StoreManager sm = StoreManager.getInstance();
-        if (sm instanceof ExternalStoreManager) {
-
-            for (int mboxId : mailboxIds) {
-                ExternalBlobConsistencyChecker checker = new ExternalBlobConsistencyChecker();
-                BlobConsistencyChecker.Results results = checker.check(null, mboxId, checkSize, reportUsedBlobs);
-                if (results.hasInconsistency() || reportUsedBlobs) { //or checking used blobs
-                    Element mboxEl = response.addElement(AdminConstants.E_MAILBOX).addAttribute(AdminConstants.A_ID, mboxId);
-                    results.toElement(mboxEl);
+        List<Element> volumeElementList = request.listElements(AdminConstants.E_VOLUME);
+        List<Short> volumeIds = new ArrayList<Short>();
+        if (!volumeElementList.isEmpty()) {
+            for (Element volumeEl : volumeElementList) {
+                short volumeId = (short) volumeEl.getAttributeLong(AdminConstants.A_ID);
+                Volume vol = VolumeManager.getInstance().getVolume(volumeId);
+                if (vol.getType() == Volume.TYPE_INDEX) {
+                    throw ServiceException.INVALID_REQUEST("Index volume " + volumeId + " is not supported", null);
+                } else {
+                    volumeIds.add(volumeId);
                 }
             }
-        } else if (sm instanceof FileBlobStore) {
+        }
 
-            // Assemble the list of volumes.
-            List<Short> volumeIds = new ArrayList<Short>();
-            List<Element> volumeElementList = request.listElements(AdminConstants.E_VOLUME);
-            if (volumeElementList.isEmpty()) {
-                // Get all message volume id's.
-                for (Volume vol : VolumeManager.getInstance().getAllVolumes()) {
-                    switch (vol.getType()) {
-                        case Volume.TYPE_MESSAGE:
-                        case Volume.TYPE_MESSAGE_SECONDARY:
-                            volumeIds.add(vol.getId());
-                            break;
-                    }
+        List<Volume> vols = VolumeManager.getInstance().getAllVolumes();
+        Map<StoreType, StoreManager> storeManagerMap = new HashMap<>();
+        for (Volume volume: vols) {
+            StoreManager sm = StoreManager.getReaderSMInstance(volume.getId());
+            if (sm instanceof FileBlobStore && volumeElementList.isEmpty()) {
+                storeManagerMap.putIfAbsent(StoreType.INTERNAL, sm);
+                switch (volume.getType()) {
+                    case Volume.TYPE_MESSAGE:
+                    case Volume.TYPE_MESSAGE_SECONDARY:
+                        volumeIds.add(volume.getId());
+                        break;
+                }
+            } else if (sm instanceof ExternalStoreManager) {
+                storeManagerMap.putIfAbsent(StoreType.EXTERNAL, sm);
+            } else {
+                storeManagerMap.putIfAbsent(StoreType.NOT_SUPPORTED, sm);
+            }
+        }
+        for (StoreManager sm : storeManagerMap.values()) {
+            if (sm instanceof ExternalStoreManager && volumeElementList.isEmpty()) {
+                for (int mboxId : mailboxIds) {
+                    blobCheckProcessor(null, mboxId, checkSize, reportUsedBlobs, sm, response);
+                }
+            } else if (sm instanceof FileBlobStore) {
+                for (int mboxId : mailboxIds) {
+                    blobCheckProcessor(volumeIds, mboxId, checkSize, reportUsedBlobs, sm, response);
                 }
             } else {
-                // Read volume id's from the request.
-                for (Element volumeEl : volumeElementList) {
-                    short volumeId = (short) volumeEl.getAttributeLong(AdminConstants.A_ID);
-                    Volume vol = VolumeManager.getInstance().getVolume(volumeId);
-                    if (vol.getType() == Volume.TYPE_INDEX) {
-                        throw ServiceException.INVALID_REQUEST("Index volume " + volumeId + " is not supported", null);
-                    } else {
-                        volumeIds.add(volumeId);
-                    }
-                }
+                ZimbraLog.store.warn(sm.getClass().getName() + " is not supported");
             }
-
-            for (int mboxId : mailboxIds) {
-                BlobConsistencyChecker checker = new BlobConsistencyChecker();
-                BlobConsistencyChecker.Results results = checker.check(volumeIds, mboxId, checkSize, reportUsedBlobs);
-                if (results.hasInconsistency() || reportUsedBlobs) {
-                    Element mboxEl = response.addElement(AdminConstants.E_MAILBOX).addAttribute(AdminConstants.A_ID, mboxId);
-                    results.toElement(mboxEl);
-                }
-            }
-        } else {
-            //neither ExternalStoreManager nor FileBlobStore..some third type we haven't coded for
-            throw ServiceException.INVALID_REQUEST(sm.getClass().getName() + " is not supported", null);
         }
+
         return response;
+    }
+
+    /**
+     * This method is used to check internal and external blobs
+     * Also process result and add in response
+     * @param volumeIds
+     * @param mboxId
+     * @param checkSize
+     * @param reportUsedBlobs
+     * @param sm
+     * @param response
+     * @throws ServiceException
+     */
+    private void blobCheckProcessor(List<Short> volumeIds, int mboxId, boolean checkSize, boolean reportUsedBlobs, StoreManager sm, Element response) throws ServiceException {
+        BlobConsistencyChecker checker = null;
+        if (sm instanceof ExternalStoreManager) {
+            checker = new ExternalBlobConsistencyChecker();
+        } else {
+            checker = new BlobConsistencyChecker();
+        }
+        checker.setStoreManager(sm);
+        BlobConsistencyChecker.Results results = checker.check(volumeIds, mboxId, checkSize, reportUsedBlobs);
+        if (results.hasInconsistency() || reportUsedBlobs) {
+            Element mboxEl = response.addElement(AdminConstants.E_MAILBOX).addAttribute(AdminConstants.A_ID, mboxId);
+            results.toElement(mboxEl);
+        }
     }
 
     @Override
     public void docRights(List<AdminRight> relatedRights, List<String> notes) {
         notes.add(AdminRightCheckPoint.Notes.SYSTEM_ADMINS_ONLY);
     }
+
+    public enum StoreType {
+        INTERNAL(1),
+        EXTERNAL(2),
+        NOT_SUPPORTED(3);
+
+        private final int storeType;
+
+        StoreType(final int storeType) {
+            this.storeType = storeType;
+        }
+    }
+
 }

--- a/store/src/java/com/zimbra/cs/store/external/ExternalBlobConsistencyChecker.java
+++ b/store/src/java/com/zimbra/cs/store/external/ExternalBlobConsistencyChecker.java
@@ -51,8 +51,7 @@ public class ExternalBlobConsistencyChecker extends BlobConsistencyChecker {
         results = new Results();
         Mailbox mbox = MailboxManager.getInstance().getMailboxById(mailboxId);
         DbConnection conn = null;
-        assert(StoreManager.getInstance() instanceof ExternalStoreManager);
-        ExternalStoreManager sm = (ExternalStoreManager) StoreManager.getInstance();
+        ExternalStoreManager sm = (ExternalStoreManager) getStoreManager();
         try {
             unexpectedBlobPaths = sm.getAllBlobPaths(mbox);
         } catch (IOException ioe) {
@@ -126,7 +125,10 @@ public class ExternalBlobConsistencyChecker extends BlobConsistencyChecker {
                 }
             } catch (Exception e) {
                 blobInfo.fetchException = e instanceof IOException ? (IOException) e : new IOException("Exception fetching blob", e);
-                results.missingBlobs.put(blobInfo.itemId, blobInfo);
+                StoreManager storeManager = StoreManager.getReaderSMInstance(mblob.getLocator());
+                if (storeManager instanceof ExternalStoreManager) {
+                    results.missingBlobs.put(blobInfo.itemId, blobInfo);
+                }
             }
         }
     }

--- a/store/src/java/com/zimbra/cs/store/file/BlobConsistencyChecker.java
+++ b/store/src/java/com/zimbra/cs/store/file/BlobConsistencyChecker.java
@@ -235,12 +235,22 @@ public class BlobConsistencyChecker {
     protected boolean checkSize = true;
     protected boolean reportUsedBlobs = false;
 
+    public StoreManager getStoreManager() {
+        return storeManager;
+    }
+
+    public void setStoreManager(StoreManager storeManager) {
+        this.storeManager = storeManager;
+    }
+
+    private StoreManager storeManager;
+
     public BlobConsistencyChecker() {
     }
 
     public Results check(Collection<Short> volumeIds, int mboxId, boolean checkSize, boolean reportUsedBlobs)
     throws ServiceException {
-        StoreManager sm = StoreManager.getInstance();
+        StoreManager sm = getStoreManager();
         if (!(sm instanceof FileBlobStore)) {
             throw ServiceException.INVALID_REQUEST(sm.getClass().getSimpleName() + " is not supported", null);
         }


### PR DESCRIPTION
**Issue**
If a customer is using S3 external storage for secondary volume or primary volume and the customer wants to check the consistency of a mailbox by running zmblobchk, then zmblobchk reports the “blob not found“ for the messages which are on the external storage.

**Reason**
1 - This issue only comes when external volume is configured but local config is set to FileBlobStore as zimbra_class_store.
2 - Due to this, code skipped external case and consider blobs are on local volumes and see mentioned errors.

**Solution**
As we have separate implementation of internal and external so fetching volumes information from data base and provided implementation for both Storage classes ie FileBlobStore and ExternalStoreManager.