### PR TITLE
ZBUG-1769: mailbox.log flooded with EWS Soap Payload #58

### DIFF
--- a/store/src/java/com/zimbra/cs/service/AutoDiscoverServlet.java
+++ b/store/src/java/com/zimbra/cs/service/AutoDiscoverServlet.java
@@ -286,7 +286,7 @@ public class AutoDiscoverServlet extends ZimbraServlet {
             return;
         }
 
-        log.info("Response: %s", respDoc);
+        log.debug("Response: %s", respDoc);
         log.debug("response length: %d", respDoc.length());
 
         try {


### PR DESCRIPTION
Issue:
mailbox.log is getting flooded with EWS Soap Payload as below

2020-08-15 09:26:19,284 INFO  [qtp366590980-498311:https://mail.zimbrasupportlab.com/ews/Exchange.asmx] [] ExchangeServicePortType - Outbound Message
---------------------------
ID: 6458
Response-Code: 200
Encoding: UTF-8
Content-Type: text/xml
Headers: {}
Payload: <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Header><ns2:ServerVersionInfo xmlns:ns2="http://schemas.microsoft.com/exchange/services/2006/types" xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" MajorVersion="14" MinorVersion="3" MajorBuildNumber="158" MinorBuildNumber="11" Version="Exchange2010_SP2"/></soap:Header><soap:Body><GetStreamingEventsResponse xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:ns2="http://schemas.microsoft.com/exchange/services/2006/types"><ResponseMessages><GetStreamingEventsResponseMessage ResponseClass="Success"><ConnectionStatus>OK</ConnectionStatus></GetStreamingEventsResponseMessage></ResponseMessages></GetStreamingEventsResponse></soap:Body></soap:Envelope>
Issue is reproducible in our environment by configuring EWS account in Mac Outlook.

Tested on mail.zimbrasupportlab.com, attached mailbox.log.

Release 8.8.15_GA_3829.RHEL6_64_20190718141144 RHEL6_64 NETWORK edition, Patch 8.8.15_P11.

Solution :

The logging into mailbox.log is happening due to automatic soap outbound logging mechanism using in LoggingOutInterceptor which is a part of apache-cxf framework.

As part of this ticket, LogOutZInterceptor.java wil handle logging the outbound responses into ews.log.