### PR TITLE
ZCS-15382: Implementation| Realtime licensing: Meaningful CLI/UI outpu…

### DIFF
--- a/store/src/java/com/zimbra/cs/account/Provisioning.java
+++ b/store/src/java/com/zimbra/cs/account/Provisioning.java
@@ -2630,6 +2630,7 @@ public abstract class Provisioning extends ZAttrProvisioning {
         static final String DELETE_ACCOUNT = "deleteAccount";
         static final String CREATE_COS = "createCos";
         static final String DELETE_COS = "deleteCos";
+        static final String DELETE_COS_SUCCEEDED = "deleteCosSucceeded";
 
         void validate(Provisioning prov, String action, Object... args) throws ServiceException;
         void refresh();

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -1576,7 +1576,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
             throw e;
         } catch (ServiceException e) {
             StringBuilder errorMsg = new StringBuilder();
-            errorMsg.append(String.format("unable to create account: %s", emailAddress));
+            errorMsg.append(String.format("Unable to create account: %s", emailAddress));
             if (!restoring && ServiceException.LICENSE_ERROR.equalsIgnoreCase(e.getCode())
                     && null != acct) {
                 modifyAccountStatus(acct, AccountStatus.maintenance.name());
@@ -3933,12 +3933,17 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
         // TODO: should we go through all accounts with this cos and remove the zimbraCOSId attr?
         ZLdapContext zlc = null;
         try {
+            validate(ProvisioningValidator.DELETE_COS, c);
             zlc = LdapClient.getContext(LdapServerType.MASTER, LdapUsage.DELETE_COS);
             zlc.deleteEntry(c.getDN());
-            validate(ProvisioningValidator.DELETE_COS, c);
+            validate(ProvisioningValidator.DELETE_COS_SUCCEEDED, c);
             cosCache.remove(c);
         } catch (ServiceException e) {
-            throw ServiceException.FAILURE("unable to purge cos: "+zimbraId, e);
+            String errorMsg = String.format("unable to purge cos: %s", zimbraId);
+            if (ServiceException.LICENSE_ERROR.equalsIgnoreCase(e.getCode())) {
+                errorMsg = e.getMessage();
+            }
+            throw ServiceException.FAILURE(errorMsg, e);
         } finally {
             LdapClient.closeContext(zlc);
         }


### PR DESCRIPTION
Ticket - [ZCS-15382](https://synacor.atlassian.net/browse/ZCS-15382)

- Changes related to realtime licensing for meaningful CLI/UI output massage.
- To keep consistency in error messages.

Link to related PR: https://github.com/Zimbra/zm-license-tools/pull/140



[ZCS-15382]: https://synacor.atlassian.net/browse/ZCS-15382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ