### PR TITLE
ZCS-15617 Implementation & testing of Hide alias in GAL

### DIFF
--- a/store/src/java/com/zimbra/cs/gal/GalSearchConfig.java
+++ b/store/src/java/com/zimbra/cs/gal/GalSearchConfig.java
@@ -182,8 +182,11 @@ public class GalSearchConfig {
 		if (dnSubtreeMatchFilter == null) {
 		    dnSubtreeMatchFilter = "";
 		}
-		mFilter = "(&" + filter + "(!(zimbraHideInGal=TRUE))(!(zimbraIsSystemResource=TRUE))" + dnSubtreeMatchFilter + ")";
-
+		if (GalOp.autocomplete.equals(op)) {
+			mFilter = "(&" + filter + "(!(&(zimbraIsAdminGroup=TRUE)(zimbraHideInGal=TRUE)))(!(zimbraIsSystemResource=TRUE))" + dnSubtreeMatchFilter + ")";
+		} else {
+			mFilter = "(&" + filter + "(!(zimbraHideInGal=TRUE))(!(zimbraIsSystemResource=TRUE))" + dnSubtreeMatchFilter + ")";
+		}
 		mSearchBase = ZimbraGalSearchBase.getSearchBase(domain, op);
 		mGalType = GalType.zimbra;
 		mTimestampFormat = LdapDateUtil.ZIMBRA_LDAP_GENERALIZED_TIME_FORMAT_LEGACY;


### PR DESCRIPTION
**Description:**

Implementation & testing of Hide alias in GAL. 

As an admin, I want a way to hide only the aliases from GAL without affecting the user.

Setting the attribute zimbraHideAliasesInGal value to true should hide all the aliases for that user. This means all the aliases for the account should not be displayed in the autocomplete.

Current functionality is when clicking on Hide in GAL, the user as well as aliases both are hidden.

Current Hide in GAL should be renamed to Hide User in GAL([ZCS-13220](https://synacor.atlassian.net/browse/ZCS-13220)) and the behavior should be modified to hide just the user but not the aliases.

**Solution Provided:**
Modified the implementation to show/hide aliases for an account based on attribute value of zimbraHideAliasesInGal
Modified the existing 'Hide User In Gal' by modifiying the LDAP query for autocomplete

[ZCS-13220]: https://synacor.atlassian.net/browse/ZCS-13220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ