### PR TITLE
ZBUG-3254: Thunderbird CalDAV Sync Fail

### DIFF
--- a/store/src/java/com/zimbra/cs/dav/DavContext.java
+++ b/store/src/java/com/zimbra/cs/dav/DavContext.java
@@ -424,9 +424,14 @@ public class DavContext {
     /* Returns true if the DAV request contains a message. */
     public boolean hasRequestMessage() {
         try {
-            String ct = getUpload().getContentType();
-            return getUpload().getSize() > 0; // && ct != null && (ct.startsWith(DavProtocol.XML_CONTENT_TYPE) || ct.startsWith(DavProtocol.XML_CONTENT_TYPE2));
+            /*
+             Previously, we rejected any Content-Type that was not a variant
+             of XML, but sometimes the client doesn't send the right
+             Content-Type, so we decided to be liberal in what we receive.
+            */
+            return getUpload().getSize() > 0;
         } catch (Exception e) {
+            ZimbraLog.dav.debug("error getting upload", e);
         }
         return false;
     }

--- a/store/src/java/com/zimbra/cs/dav/DavContext.java
+++ b/store/src/java/com/zimbra/cs/dav/DavContext.java
@@ -425,7 +425,7 @@ public class DavContext {
     public boolean hasRequestMessage() {
         try {
             String ct = getUpload().getContentType();
-            return getUpload().getSize() > 0 && ct != null && (ct.startsWith(DavProtocol.XML_CONTENT_TYPE) || ct.startsWith(DavProtocol.XML_CONTENT_TYPE2));
+            return getUpload().getSize() > 0; // && ct != null && (ct.startsWith(DavProtocol.XML_CONTENT_TYPE) || ct.startsWith(DavProtocol.XML_CONTENT_TYPE2));
         } catch (Exception e) {
         }
         return false;


### PR DESCRIPTION
When one attempts to Sync a Zimbra CalDAV contacts folder from Thunderbird, nothing happens. The Zimbra server logs the request, but is sending back "empty request body", even though it clearly logs the request just before. Looking into the code, it seems we enforce that the Content-Type of the multipart that contains the request be of some XML type. When I remove that restriction, the synchronization works as expected.

Not sure if this is the right approach. Is it important that we enforce the type? Is it a security issue? Shouldn't we be liberal in what we receive?