### PR TITLE
ZCS-15691 Analysis |  Deleting alias entry from contact ranking table if Hide alias in GAL is true

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -1930,6 +1930,33 @@ public class Mailbox implements MailboxStore {
         }
     }
 
+
+
+    public Set<String> getAllIds(OperationContext octxt, Set<String> aliases) throws ServiceException {
+        if (aliases.size() == 0) {
+            return null;
+        }
+        // note: defaulting to true, not false...
+        boolean success = true;
+        Set<String> ids = null;
+        try {
+            beginTransaction("getAllIds", octxt, null);
+            // make sure they have sufficient rights to view the config
+            if (!hasFullAccess()) {
+                return null;
+            }
+            ids = DbMailbox.getAllIds(this, aliases);
+            if (ids.size() == 0) {
+                return null;
+            }
+
+        }
+         finally {
+            endTransaction(success);
+        }
+        return ids;
+    }
+
     public String getConfig(OperationContext octxt, Pattern pattern) throws ServiceException {
 
         String previousDeviceId = null;

--- a/store/src/java/com/zimbra/cs/service/admin/ModifyAccount.java
+++ b/store/src/java/com/zimbra/cs/service/admin/ModifyAccount.java
@@ -20,10 +20,7 @@
  */
 package com.zimbra.cs.service.admin;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import com.zimbra.common.account.Key;
 import com.zimbra.common.account.Key.AccountBy;
@@ -345,11 +342,12 @@ public class ModifyAccount extends AdminDocumentHandler {
         } catch (ServiceException e) {
             throw new RuntimeException(e);
         }
-        /*for(String mailBoxId: mailBoxIds) {
+
+        for(String mailBoxId: mailBoxIds) {
             for(String alias:aliases) {
                 ContactRankings.remove(MailboxManager.getInstance().getAccountIdByMailboxId(Integer.parseInt(mailBoxId)), alias);
             }
-        }*/
+        }
         removeEntryFromLucene(mailBoxIds, aliases);
     }
 
@@ -362,13 +360,16 @@ public class ModifyAccount extends AdminDocumentHandler {
 
                 for (MailItem item : mbox.getItemList(ctx, MailItem.Type.CONTACT, FolderConstants.ID_FOLDER_AUTO_CONTACTS)) {
                     Contact contact = (Contact) item;
-                    contact.getEmailAddresses().retainAll(aliases);
-                    for(String address : aliases) {
-                        if(contact.getEmailAddresses().contains(address)) {
-                            contact.getEmailAddresses().remove(address);
+                    List<String> emailAddresses = contact.getEmailAddresses();
+                    Map<String, String> hm = new HashMap<>();
+                    for (String address : aliases) {
+                        if (emailAddresses.contains(address)) {
+                            hm = contact.getAllFields();
+                            hm.clear();
+                            hm.put("EMPTY","EMPTY");
+                            mbox.modifyContact(ctx, contact.getId(), new ParsedContact(hm));
                         }
                     }
-                    mbox.modifyContact(ctx, contact.getId(), new ParsedContact(contact));
 
                 }
             } catch (ServiceException e) {


### PR DESCRIPTION
Analysis  and impact of deleting alias entry from contact ranking table if Hide alias in GAL is true.

Issue: After sending an email to alias/es of any user, and then enable option Hide alias in GAL, we still get that alias/es in autocomplete while composing a new email as the results of auto complete gets populated from Contact ranking table.

Note: This is a PR for the Analysis ticket, https://synacor.atlassian.net/browse/ZCS-15691. The analysis is complete and will be implemented as part of future tickets. Hence closing this PR

