### PR TITLE
ZCS-15671: Ignore Conversation feature

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/Flag.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Flag.java
@@ -56,6 +56,7 @@ public final class Flag extends Tag {
         HIGH_PRIORITY(-11, "\\Urgent", '!'),
         LOW_PRIORITY(-12, "\\Bulk", '?'),
         VERSIONED(-13, "\\Versioned", '/'),
+        MUTED(-19, "\\Muted", '('),
         /**
          * @deprecated Use indexId = 0
          */
@@ -65,7 +66,6 @@ public final class Flag extends Tag {
         NOTE(-16, "\\Note", 't'),
         PRIORITY(-17, "\\Priority", '+'),
         POST(-18, "\\Post", '^'),
-        MUTED(-19, "\\Muted", '('),
         SUBSCRIBED(-20, "\\Subscribed", '*'),
         EXCLUDE_FREEBUSY(-21, "\\ExcludeFB", 'b'),
         CHECKED(-22, "\\Checked", '#'),


### PR DESCRIPTION
Description of the feature

1. Ignore Conversation: This will trigger ConvAction API with operation as “mute” and Conversation Id. On the Backend we just need to mute this conversation. (Mute is just a type of flag).
2. Since Mute functionality was already present in the Backend, we just removed mute flag from list of Deprecated Flags and moved it to normal one.