### PR TITLE
ZCS-15708: eml file Import is not working with Zimbra10 server

### DIFF
--- a/store/src/java/com/zimbra/cs/service/UserServlet.java
+++ b/store/src/java/com/zimbra/cs/service/UserServlet.java
@@ -907,7 +907,7 @@ public class UserServlet extends ZimbraServlet {
         if (context.formatter == null) {
             context.formatter = FormatterFactory.mFormatters.get(context.format);
             // check if its native formatter, and if onlyoffice formatter is available
-            if (context.formatter.getType().equals(FormatType.HTML_CONVERTED)) {
+            if (context.formatter.getType().equals(FormatType.HTML_CONVERTED) && context.req != null && "GET".equals(context.req.getMethod())) {
                 try {
                     Provisioning prov = Provisioning.getInstance();
                     Server server = prov.getServer(context.getAuthAccount());


### PR DESCRIPTION
Issue: eml file Import is not working with Zimbra10 server
Fix: Modified the code so that server uses nativeFormatter instead of onlyOffice Formatter in case of POST Requests.