### PR TITLE
ZCS-12461: LC config for smtputf8_enable in postfix

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1563,6 +1563,9 @@ public final class LC {
     @Supported
     public static final KnownKey zimbra_license_election_leader_zimbraId = KnownKey.newKey("");
 
+    @Reloadable
+    public static final KnownKey zimbra_postfix_smtputf8 = KnownKey.newKey("no");
+
 
     static {
         // Automatically set the key name with the variable name.


### PR DESCRIPTION
https://github.com/Zimbra/packages/pull/209
https://github.com/Zimbra/zm-ldap-utilities/pull/18

This PR enables SMTPUTF8 support in Postfix. However, it requires changes in other components such as LDAP, LMTP, Mailbox, and Web Client UI.

