### PR TITLE
ZBUG-4317: Autocomplete failure after updating to 10.1.1

### DIFF
--- a/store/src/java/com/zimbra/cs/account/Provisioning.java
+++ b/store/src/java/com/zimbra/cs/account/Provisioning.java
@@ -634,7 +634,9 @@ public abstract class Provisioning extends ZAttrProvisioning {
      */
     public String getEmailAddrByDomainAlias(String emailAddress) throws ServiceException {
         String addr = null;
-
+        if (StringUtil.isNullOrEmpty(emailAddress)) {
+            return null;
+        }
         String parts[] = emailAddress.split("@");
         if (parts.length == 2) {
             Domain domain = getDomain(Key.DomainBy.name, parts[1], true);

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -1163,6 +1163,9 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     }
 
     private String fixupAccountName(String emailAddress) throws ServiceException {
+        if (StringUtil.isNullOrEmpty(emailAddress)) {
+            return null;
+        }
         int index = emailAddress.indexOf('@');
         String domain = null;
         if (index == -1) {
@@ -1205,7 +1208,9 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     private Account getAccountByNameInternal(String emailAddress, boolean loadFromMaster)
     throws ServiceException {
-
+        if (StringUtil.isNullOrEmpty(emailAddress)) {
+            return null;
+        }
         emailAddress = fixupAccountName(emailAddress);
 
         Account account = accountCache.getByName(emailAddress);


### PR DESCRIPTION
Ticket : [ZBUG-4317](https://synacor.atlassian.net/browse/ZBUG-4317)

* The code changes have avoided the NullPointerException (NPE) issue

Testing:
Tested on local setup

[ZBUG-4317]: https://synacor.atlassian.net/browse/ZBUG-4317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ