### PR TITLE
ZCS-15982: zimbraMailAttachmentMaxSize should not exceed zimbraMtaMaxMessageSize while modifying account cos

### DIFF
--- a/store/src/java-test/com/zimbra/cs/service/admin/ModifyAccountTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/admin/ModifyAccountTest.java
@@ -1,0 +1,76 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2024 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.service.admin;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ModifyAccountTest {
+
+    private Map<String, Object> attrs = new HashMap<>();
+    private ModifyAccount modifyAccount = new ModifyAccount();
+
+    @Before
+    public void setUp() throws Exception {
+        MailboxTestUtil.initServer();
+        Provisioning prov = Provisioning.getInstance();
+    }
+
+    @Test
+    public void testValidateMailAttachmentMaxSize_WithinLimit() {
+        attrs.put(Provisioning.A_zimbraMailAttachmentMaxSize, "10000");
+        try {
+            modifyAccount.validateMailAttachmentMaxSize(attrs);
+        } catch (ServiceException e) {
+            fail("No exception should be thrown");
+        }
+    }
+
+    @Test
+    public void testValidateMailAttachmentMaxSize_ExceedingLimit() {
+        attrs.put(Provisioning.A_zimbraMailAttachmentMaxSize, "100000000");
+        try {
+            modifyAccount.validateMailAttachmentMaxSize(attrs);
+            fail("Exception should be thrown");
+        } catch (ServiceException e) {
+            assertEquals("account.INVALID_ATTR_VALUE", e.getCode());
+            assertTrue(e.getMessage().contains("larger than max allowed"));
+        }
+    }
+
+    @Test
+    public void testValidateMailAttachmentMaxSize_InvalidLong() {
+        attrs.put(Provisioning.A_zimbraMailAttachmentMaxSize, "19999abc");
+        try {
+            modifyAccount.validateMailAttachmentMaxSize(attrs);
+            fail("Exception should be thrown");
+        } catch (ServiceException e) {
+            assertEquals("account.INVALID_ATTR_VALUE", e.getCode());
+            assertTrue(e.getMessage().contains("must be a valid long"));
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/service/admin/AdminDocumentHandler.java
+++ b/store/src/java/com/zimbra/cs/service/admin/AdminDocumentHandler.java
@@ -119,6 +119,26 @@ public abstract class AdminDocumentHandler extends DocumentHandler implements Ad
         return acct;
     }
 
+    public void validateMailAttachmentMaxSize(Map<String, Object> attrs) throws ServiceException {
+
+        if (!attrs.containsKey(Provisioning.A_zimbraMailAttachmentMaxSize)) {
+            return;
+        }
+
+        String name = Provisioning.A_zimbraMailAttachmentMaxSize;
+        String value = attrs.get(name).toString();
+        long mtaMaxMessageSize = Provisioning.getInstance().getConfig().getMtaMaxMessageSize();
+
+        try {
+            long zimbraMailAttachmentMaxSize = Long.parseLong(value);
+            if (zimbraMailAttachmentMaxSize > mtaMaxMessageSize) {
+                throw AccountServiceException.INVALID_ATTR_VALUE(name + " value(" + zimbraMailAttachmentMaxSize + ") larger than max allowed: " + mtaMaxMessageSize, null);
+            }
+        } catch (NumberFormatException e) {
+            throw AccountServiceException.INVALID_ATTR_VALUE(name + " must be a valid long: " + value, e);
+        }
+    }
+
     private CalendarResource getCalendarResource(Provisioning prov, Key.CalendarResourceBy crBy, String value)
             throws ServiceException {
         CalendarResource cr = null;

--- a/store/src/java/com/zimbra/cs/service/admin/ModifyAccount.java
+++ b/store/src/java/com/zimbra/cs/service/admin/ModifyAccount.java
@@ -132,6 +132,10 @@ public class ModifyAccount extends AdminDocumentHandler {
         boolean rollbackOnFailure = LC.rollback_on_account_listener_failure.booleanValue();
 
         String oldSuspendReason = account.getAccountSuspensionReason();
+
+        // zimbraMailAttachmentMaxSize should not be more than mtaMessageMaxSize
+        validateMailAttachmentMaxSize(attrs);
+
         if (attrs.containsKey(Provisioning.A_zimbraAccountStatus)) {
             String newStatus = (String) attrs.get(Provisioning.A_zimbraAccountStatus);
             //clearing account suspension reason if new status is active and old status other than active.

--- a/store/src/java/com/zimbra/cs/service/admin/ModifyCos.java
+++ b/store/src/java/com/zimbra/cs/service/admin/ModifyCos.java
@@ -55,6 +55,9 @@ public class ModifyCos extends AdminDocumentHandler {
 
         checkRight(zsc, context, cos, attrs);
 
+        // zimbraMailAttachmentMaxSize should not be more than mtaMessageMaxSize
+        validateMailAttachmentMaxSize(attrs);
+
         // pass in true to checkImmutable
         prov.modifyAttrs(cos, attrs, true);
 


### PR DESCRIPTION
[ZCS-15982 ](https://synacor.atlassian.net/browse/ZCS-15982)

Problem:- On modifying account/cos  value for zimbraMailAttachmentMaxSize using command line/soap api(ModifyAccountRequest) should not exceed zimbraMtaMaxMessageSize limit.

Fix:- validation added for zimbraMailAttachmentMaxSize to compare with zimbraMtaMaxMessageSize.