### PR TITLE
ZCS-16138: Add LDAP Attribute for DSN

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -6991,6 +6991,14 @@ public class ZAttrProvisioning {
     public static final String A_zimbraFeatureDelayedIndexEnabled = "zimbraFeatureDelayedIndexEnabled";
 
     /**
+     * Feature to enable delivery status notification
+     *
+     * @since ZCS 10.1.4
+     */
+    @ZAttr(id=4135)
+    public static final String A_zimbraFeatureDeliveryStatusNotificationEnabled = "zimbraFeatureDeliveryStatusNotificationEnabled";
+
+    /**
      * enable end-user mail discarding defined in mail filters features
      *
      * @since ZCS 6.0.0_BETA1
@@ -7508,9 +7516,9 @@ public class ZAttrProvisioning {
     public static final String A_zimbraFeatureSearchHistoryEnabled = "zimbraFeatureSearchHistoryEnabled";
 
     /**
-     * Feature to enable/disable the mobile sync for shared folders. Default 
-     * value is TRUE. The option to sync the shared folders to the Mobile 
-     * will be enabled for the users in the webclient. The option will only 
+     * Feature to enable/disable the mobile sync for shared folders. Default
+     * value is TRUE. The option to sync the shared folders to the Mobile
+     * will be enabled for the users in the webclient. The option will only
      * be enabled for shared folders having Admin or Manager permission
      *
      * @since ZCS 10.1.0

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10555,4 +10555,9 @@ TODO: delete them permanently from here
   <defaultCOSValue>TRUE</defaultCOSValue>
   <desc>Feature to enable/disable the mobile sync for shared folders. Default value is TRUE. The option to sync the shared folders to the Mobile will be enabled for the users in the webclient. The option will only be enabled for shared folders having Admin or Manager permission</desc>
 </attr>
+
+<attr id="4135" name="zimbraFeatureDeliveryStatusNotificationEnabled" type="boolean" cardinality="single" optionalIn="cos,account" flags="accountInherited,accountInfo" since="10.1.4">
+  <defaultCOSValue>FALSE</defaultCOSValue>
+  <desc>Feature to enable delivery status notification</desc>
+</attr>
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -16165,6 +16165,78 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * Feature to enable delivery status notification
+     *
+     * @return zimbraFeatureDeliveryStatusNotificationEnabled, or false if unset
+     *
+     * @since ZCS 10.1.4
+     */
+    @ZAttr(id=4135)
+    public boolean isFeatureDeliveryStatusNotificationEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureDeliveryStatusNotificationEnabled, false, true);
+    }
+
+    /**
+     * Feature to enable delivery status notification
+     *
+     * @param zimbraFeatureDeliveryStatusNotificationEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.4
+     */
+    @ZAttr(id=4135)
+    public void setFeatureDeliveryStatusNotificationEnabled(boolean zimbraFeatureDeliveryStatusNotificationEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureDeliveryStatusNotificationEnabled, zimbraFeatureDeliveryStatusNotificationEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Feature to enable delivery status notification
+     *
+     * @param zimbraFeatureDeliveryStatusNotificationEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.4
+     */
+    @ZAttr(id=4135)
+    public Map<String,Object> setFeatureDeliveryStatusNotificationEnabled(boolean zimbraFeatureDeliveryStatusNotificationEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureDeliveryStatusNotificationEnabled, zimbraFeatureDeliveryStatusNotificationEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Feature to enable delivery status notification
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.4
+     */
+    @ZAttr(id=4135)
+    public void unsetFeatureDeliveryStatusNotificationEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureDeliveryStatusNotificationEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Feature to enable delivery status notification
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.4
+     */
+    @ZAttr(id=4135)
+    public Map<String,Object> unsetFeatureDeliveryStatusNotificationEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureDeliveryStatusNotificationEnabled, "");
+        return attrs;
+    }
+
+    /**
      * enable end-user mail discarding defined in mail filters features
      *
      * @return zimbraFeatureDiscardInFiltersEnabled, or true if unset
@@ -21018,9 +21090,9 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * Feature to enable/disable the mobile sync for shared folders. Default 
-     * value is TRUE. The option to sync the shared folders to the Mobile 
-     * will be enabled for the users in the webclient. The option will only 
+     * Feature to enable/disable the mobile sync for shared folders. Default
+     * value is TRUE. The option to sync the shared folders to the Mobile
+     * will be enabled for the users in the webclient. The option will only
      * be enabled for shared folders having Admin or Manager permission
      *
      * @return zimbraFeatureSharedFolderMobileSyncEnabled, or true if unset
@@ -21033,9 +21105,9 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * Feature to enable/disable the mobile sync for shared folders. Default 
-     * value is TRUE. The option to sync the shared folders to the Mobile 
-     * will be enabled for the users in the webclient. The option will only 
+     * Feature to enable/disable the mobile sync for shared folders. Default
+     * value is TRUE. The option to sync the shared folders to the Mobile
+     * will be enabled for the users in the webclient. The option will only
      * be enabled for shared folders having Admin or Manager permission
      *
      * @param zimbraFeatureSharedFolderMobileSyncEnabled new value
@@ -21051,9 +21123,9 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * Feature to enable/disable the mobile sync for shared folders. Default 
-     * value is TRUE. The option to sync the shared folders to the Mobile 
-     * will be enabled for the users in the webclient. The option will only 
+     * Feature to enable/disable the mobile sync for shared folders. Default
+     * value is TRUE. The option to sync the shared folders to the Mobile
+     * will be enabled for the users in the webclient. The option will only
      * be enabled for shared folders having Admin or Manager permission
      *
      * @param zimbraFeatureSharedFolderMobileSyncEnabled new value
@@ -21070,9 +21142,9 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * Feature to enable/disable the mobile sync for shared folders. Default 
-     * value is TRUE. The option to sync the shared folders to the Mobile 
-     * will be enabled for the users in the webclient. The option will only 
+     * Feature to enable/disable the mobile sync for shared folders. Default
+     * value is TRUE. The option to sync the shared folders to the Mobile
+     * will be enabled for the users in the webclient. The option will only
      * be enabled for shared folders having Admin or Manager permission
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -21087,9 +21159,9 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * Feature to enable/disable the mobile sync for shared folders. Default 
-     * value is TRUE. The option to sync the shared folders to the Mobile 
-     * will be enabled for the users in the webclient. The option will only 
+     * Feature to enable/disable the mobile sync for shared folders. Default
+     * value is TRUE. The option to sync the shared folders to the Mobile
+     * will be enabled for the users in the webclient. The option will only
      * be enabled for shared folders having Admin or Manager permission
      *
      * @param attrs existing map to populate, or null to create a new map

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -10554,6 +10554,78 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * Feature to enable delivery status notification
+     *
+     * @return zimbraFeatureDeliveryStatusNotificationEnabled, or false if unset
+     *
+     * @since ZCS 10.1.4
+     */
+    @ZAttr(id=4135)
+    public boolean isFeatureDeliveryStatusNotificationEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeatureDeliveryStatusNotificationEnabled, false, true);
+    }
+
+    /**
+     * Feature to enable delivery status notification
+     *
+     * @param zimbraFeatureDeliveryStatusNotificationEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.4
+     */
+    @ZAttr(id=4135)
+    public void setFeatureDeliveryStatusNotificationEnabled(boolean zimbraFeatureDeliveryStatusNotificationEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureDeliveryStatusNotificationEnabled, zimbraFeatureDeliveryStatusNotificationEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Feature to enable delivery status notification
+     *
+     * @param zimbraFeatureDeliveryStatusNotificationEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.4
+     */
+    @ZAttr(id=4135)
+    public Map<String,Object> setFeatureDeliveryStatusNotificationEnabled(boolean zimbraFeatureDeliveryStatusNotificationEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureDeliveryStatusNotificationEnabled, zimbraFeatureDeliveryStatusNotificationEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Feature to enable delivery status notification
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.4
+     */
+    @ZAttr(id=4135)
+    public void unsetFeatureDeliveryStatusNotificationEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureDeliveryStatusNotificationEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Feature to enable delivery status notification
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.4
+     */
+    @ZAttr(id=4135)
+    public Map<String,Object> unsetFeatureDeliveryStatusNotificationEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeatureDeliveryStatusNotificationEnabled, "");
+        return attrs;
+    }
+
+    /**
      * enable end-user mail discarding defined in mail filters features
      *
      * @return zimbraFeatureDiscardInFiltersEnabled, or true if unset
@@ -15407,9 +15479,9 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Feature to enable/disable the mobile sync for shared folders. Default 
-     * value is TRUE. The option to sync the shared folders to the Mobile 
-     * will be enabled for the users in the webclient. The option will only 
+     * Feature to enable/disable the mobile sync for shared folders. Default
+     * value is TRUE. The option to sync the shared folders to the Mobile
+     * will be enabled for the users in the webclient. The option will only
      * be enabled for shared folders having Admin or Manager permission
      *
      * @return zimbraFeatureSharedFolderMobileSyncEnabled, or true if unset
@@ -15422,9 +15494,9 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Feature to enable/disable the mobile sync for shared folders. Default 
-     * value is TRUE. The option to sync the shared folders to the Mobile 
-     * will be enabled for the users in the webclient. The option will only 
+     * Feature to enable/disable the mobile sync for shared folders. Default
+     * value is TRUE. The option to sync the shared folders to the Mobile
+     * will be enabled for the users in the webclient. The option will only
      * be enabled for shared folders having Admin or Manager permission
      *
      * @param zimbraFeatureSharedFolderMobileSyncEnabled new value
@@ -15440,9 +15512,9 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Feature to enable/disable the mobile sync for shared folders. Default 
-     * value is TRUE. The option to sync the shared folders to the Mobile 
-     * will be enabled for the users in the webclient. The option will only 
+     * Feature to enable/disable the mobile sync for shared folders. Default
+     * value is TRUE. The option to sync the shared folders to the Mobile
+     * will be enabled for the users in the webclient. The option will only
      * be enabled for shared folders having Admin or Manager permission
      *
      * @param zimbraFeatureSharedFolderMobileSyncEnabled new value
@@ -15459,9 +15531,9 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Feature to enable/disable the mobile sync for shared folders. Default 
-     * value is TRUE. The option to sync the shared folders to the Mobile 
-     * will be enabled for the users in the webclient. The option will only 
+     * Feature to enable/disable the mobile sync for shared folders. Default
+     * value is TRUE. The option to sync the shared folders to the Mobile
+     * will be enabled for the users in the webclient. The option will only
      * be enabled for shared folders having Admin or Manager permission
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -15476,9 +15548,9 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Feature to enable/disable the mobile sync for shared folders. Default 
-     * value is TRUE. The option to sync the shared folders to the Mobile 
-     * will be enabled for the users in the webclient. The option will only 
+     * Feature to enable/disable the mobile sync for shared folders. Default
+     * value is TRUE. The option to sync the shared folders to the Mobile
+     * will be enabled for the users in the webclient. The option will only
      * be enabled for shared folders having Admin or Manager permission
      *
      * @param attrs existing map to populate, or null to create a new map

--- a/store/src/java/com/zimbra/cs/service/mail/SendMsg.java
+++ b/store/src/java/com/zimbra/cs/service/mail/SendMsg.java
@@ -132,7 +132,7 @@ public class SendMsg extends MailDocumentHandler {
                boolean noSaveToSent = request.getAttributeBool(MailConstants.A_NO_SAVE_TO_SENT, false);
                boolean fetchSavedMsg = request.getAttributeBool(MailConstants.A_FETCH_SAVED_MSG, false);
                boolean deliveryReport = false;
-               if (LC.delivery_report_enabled.booleanValue()) {
+               if (authAcct.getBooleanAttr(Provisioning.A_zimbraFeatureDeliveryStatusNotificationEnabled, false)) {
                    deliveryReport = request.getAttributeBool(MailConstants.A_DELIVERY_RECEIPT_NOTIFICATION, false);
                }
 


### PR DESCRIPTION
https://synacor.atlassian.net/browse/ZCS-16138

Problem:- Admin should be able to enable/disable DSN feature on COS/Account to have better control over the feature.

Fix:- Added boolean LDAP attribute zimbraFeatureDeliveryStatusNotificationEnabled with default value as FALSE.