### PR TITLE
ZCS-16181 : Password expiry reminder via. email

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -7402,6 +7402,14 @@ public class ZAttrProvisioning {
     public static final String A_zimbraFeatureOutOfOfficeReplyEnabled = "zimbraFeatureOutOfOfficeReplyEnabled";
 
     /**
+     * Feature to enable password expiry reminder
+     *
+     * @since ZCS 10.1.4
+     */
+    @ZAttr(id=4136)
+    public static final String A_zimbraFeaturePasswordExpiryReminderEnabled = "zimbraFeaturePasswordExpiryReminderEnabled";
+
+    /**
      * Deprecated since: 8.0.0. Deprecated per bug 56924. Orig desc: whether
      * people search feature is enabled
      *

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -7402,7 +7402,8 @@ public class ZAttrProvisioning {
     public static final String A_zimbraFeatureOutOfOfficeReplyEnabled = "zimbraFeatureOutOfOfficeReplyEnabled";
 
     /**
-     * Feature to enable password expiry reminder
+     * Feature to enable/disable password expiry reminder. The default value
+     * is FALSE.
      *
      * @since ZCS 10.1.4
      */

--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1548,6 +1548,8 @@ public final class LC {
 
     public final static KnownKey zimbra_10_locator_upgrade_thread_count = KnownKey.newKey(5);
 
+    public final static KnownKey zimbra_password_expiry_reminder_thread_count = KnownKey.newKey(5);
+
     // ZBUG-2547 : zimbra_strict_unclosed_comment_tag if this is false we relax rule
     // of allowing unclosed tag based on zimbra_skip_tags_with_unclosed_cdata value
     // zimbra_skip_tags_with_unclosed_cdata : Set values , based on this tags would be checked for closed comment

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10560,4 +10560,9 @@ TODO: delete them permanently from here
   <defaultCOSValue>FALSE</defaultCOSValue>
   <desc>Feature to enable delivery status notification</desc>
 </attr>
+
+<attr id="4136" name="zimbraFeaturePasswordExpiryReminderEnabled" type="boolean" cardinality="single" optionalIn="cos,account" flags="accountInherited,accountInfo" since="10.1.4">
+  <defaultCOSValue>FALSE</defaultCOSValue>
+  <desc>Feature to enable password expiry reminder</desc>
+</attr>
 </attrs>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10563,6 +10563,6 @@ TODO: delete them permanently from here
 
 <attr id="4136" name="zimbraFeaturePasswordExpiryReminderEnabled" type="boolean" cardinality="single" optionalIn="cos,account" flags="accountInherited,accountInfo" since="10.1.4">
   <defaultCOSValue>FALSE</defaultCOSValue>
-  <desc>Feature to enable password expiry reminder</desc>
+  <desc>Feature to enable/disable password expiry reminder. The default value is FALSE.</desc>
 </attr>
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -19916,6 +19916,78 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * Feature to enable password expiry reminder
+     *
+     * @return zimbraFeaturePasswordExpiryReminderEnabled, or false if unset
+     *
+     * @since ZCS 10.1.4
+     */
+    @ZAttr(id=4136)
+    public boolean isFeaturePasswordExpiryReminderEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeaturePasswordExpiryReminderEnabled, false, true);
+    }
+
+    /**
+     * Feature to enable password expiry reminder
+     *
+     * @param zimbraFeaturePasswordExpiryReminderEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.4
+     */
+    @ZAttr(id=4136)
+    public void setFeaturePasswordExpiryReminderEnabled(boolean zimbraFeaturePasswordExpiryReminderEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeaturePasswordExpiryReminderEnabled, zimbraFeaturePasswordExpiryReminderEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Feature to enable password expiry reminder
+     *
+     * @param zimbraFeaturePasswordExpiryReminderEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.4
+     */
+    @ZAttr(id=4136)
+    public Map<String,Object> setFeaturePasswordExpiryReminderEnabled(boolean zimbraFeaturePasswordExpiryReminderEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeaturePasswordExpiryReminderEnabled, zimbraFeaturePasswordExpiryReminderEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Feature to enable password expiry reminder
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.4
+     */
+    @ZAttr(id=4136)
+    public void unsetFeaturePasswordExpiryReminderEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeaturePasswordExpiryReminderEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Feature to enable password expiry reminder
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.4
+     */
+    @ZAttr(id=4136)
+    public Map<String,Object> unsetFeaturePasswordExpiryReminderEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeaturePasswordExpiryReminderEnabled, "");
+        return attrs;
+    }
+
+    /**
      * Deprecated since: 8.0.0. Deprecated per bug 56924. Orig desc: whether
      * people search feature is enabled
      *

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -19916,7 +19916,8 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * Feature to enable password expiry reminder
+     * Feature to enable/disable password expiry reminder. The default value
+     * is FALSE.
      *
      * @return zimbraFeaturePasswordExpiryReminderEnabled, or false if unset
      *
@@ -19928,7 +19929,8 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * Feature to enable password expiry reminder
+     * Feature to enable/disable password expiry reminder. The default value
+     * is FALSE.
      *
      * @param zimbraFeaturePasswordExpiryReminderEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -19943,7 +19945,8 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * Feature to enable password expiry reminder
+     * Feature to enable/disable password expiry reminder. The default value
+     * is FALSE.
      *
      * @param zimbraFeaturePasswordExpiryReminderEnabled new value
      * @param attrs existing map to populate, or null to create a new map
@@ -19959,7 +19962,8 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * Feature to enable password expiry reminder
+     * Feature to enable/disable password expiry reminder. The default value
+     * is FALSE.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -19973,7 +19977,8 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * Feature to enable password expiry reminder
+     * Feature to enable/disable password expiry reminder. The default value
+     * is FALSE.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -14305,6 +14305,78 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * Feature to enable password expiry reminder
+     *
+     * @return zimbraFeaturePasswordExpiryReminderEnabled, or false if unset
+     *
+     * @since ZCS 10.1.4
+     */
+    @ZAttr(id=4136)
+    public boolean isFeaturePasswordExpiryReminderEnabled() {
+        return getBooleanAttr(Provisioning.A_zimbraFeaturePasswordExpiryReminderEnabled, false, true);
+    }
+
+    /**
+     * Feature to enable password expiry reminder
+     *
+     * @param zimbraFeaturePasswordExpiryReminderEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.4
+     */
+    @ZAttr(id=4136)
+    public void setFeaturePasswordExpiryReminderEnabled(boolean zimbraFeaturePasswordExpiryReminderEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeaturePasswordExpiryReminderEnabled, zimbraFeaturePasswordExpiryReminderEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Feature to enable password expiry reminder
+     *
+     * @param zimbraFeaturePasswordExpiryReminderEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.4
+     */
+    @ZAttr(id=4136)
+    public Map<String,Object> setFeaturePasswordExpiryReminderEnabled(boolean zimbraFeaturePasswordExpiryReminderEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeaturePasswordExpiryReminderEnabled, zimbraFeaturePasswordExpiryReminderEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Feature to enable password expiry reminder
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.4
+     */
+    @ZAttr(id=4136)
+    public void unsetFeaturePasswordExpiryReminderEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeaturePasswordExpiryReminderEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Feature to enable password expiry reminder
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.4
+     */
+    @ZAttr(id=4136)
+    public Map<String,Object> unsetFeaturePasswordExpiryReminderEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraFeaturePasswordExpiryReminderEnabled, "");
+        return attrs;
+    }
+
+    /**
      * Deprecated since: 8.0.0. Deprecated per bug 56924. Orig desc: whether
      * people search feature is enabled
      *

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -14305,7 +14305,8 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Feature to enable password expiry reminder
+     * Feature to enable/disable password expiry reminder. The default value
+     * is FALSE.
      *
      * @return zimbraFeaturePasswordExpiryReminderEnabled, or false if unset
      *
@@ -14317,7 +14318,8 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Feature to enable password expiry reminder
+     * Feature to enable/disable password expiry reminder. The default value
+     * is FALSE.
      *
      * @param zimbraFeaturePasswordExpiryReminderEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -14332,7 +14334,8 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Feature to enable password expiry reminder
+     * Feature to enable/disable password expiry reminder. The default value
+     * is FALSE.
      *
      * @param zimbraFeaturePasswordExpiryReminderEnabled new value
      * @param attrs existing map to populate, or null to create a new map
@@ -14348,7 +14351,8 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Feature to enable password expiry reminder
+     * Feature to enable/disable password expiry reminder. The default value
+     * is FALSE.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -14362,7 +14366,8 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Feature to enable password expiry reminder
+     * Feature to enable/disable password expiry reminder. The default value
+     * is FALSE.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/java/com/zimbra/cs/service/mail/PasswordExpiryNotifier.java
+++ b/store/src/java/com/zimbra/cs/service/mail/PasswordExpiryNotifier.java
@@ -1,0 +1,191 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2024 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.service.mail;
+
+import com.zimbra.common.localconfig.LC;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.Constants;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.NamedEntry;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.SearchAccountsOptions;
+import com.zimbra.cs.account.ldap.LdapProv;
+import com.zimbra.cs.ldap.ZLdapFilter;
+import com.zimbra.cs.ldap.ZLdapFilterFactory;
+import com.zimbra.cs.util.JMSession;
+
+import javax.mail.Message;
+import javax.mail.Multipart;
+import javax.mail.Session;
+import javax.mail.Transport;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeBodyPart;
+import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+
+public class PasswordExpiryNotifier implements Runnable {
+
+    private static final int PASSWORD_REMINDER_THREAD_COUNT = LC.zimbra_password_expiry_reminder_thread_count.intValue();
+    private static final int PASSWORD_REMINDER_BATCH_SIZE = 500;
+    private static final DateFormat formatter = new SimpleDateFormat("MM/dd/yyyy");
+
+    public static void main(String[] args) {
+        Thread thread = new Thread(new PasswordExpiryNotifier());
+        thread.start();
+    }
+
+    /**
+     * Sending password reminder emails to user accounts based on the following conditions:
+     * - Accounts with passwords approaching their maximum age
+     * - Accounts where password reminder notifications are enabled
+     *
+     * If an error occurs during the reminder sending process, it is logged for further analysis.
+     */
+    protected static void sendReminder() {
+        try {
+            LdapProv ldapProv = LdapProv.getInst();
+            List<NamedEntry> accounts = findAccountsWithMaxAgePasswordAndReminderEnabled(ldapProv);
+            ExecutorService emailSenderExecutor = Executors.newFixedThreadPool(PASSWORD_REMINDER_THREAD_COUNT);
+            for (int i = 0; i < accounts.size(); i += PASSWORD_REMINDER_BATCH_SIZE) {
+                final List<NamedEntry> batch = accounts.subList(i, Math.min(i + PASSWORD_REMINDER_BATCH_SIZE, accounts.size()));
+                emailSenderExecutor.submit(() -> filterAccountsAndSendMail(batch));
+            }
+            emailSenderExecutor.shutdown();
+        } catch (ServiceException e) {
+            ZimbraLog.store.error("Failed to send reminder", e);
+        }
+    }
+
+    /**
+     * Finding accounts that meet the following conditions:
+     * - The account has the password expiry reminder feature enabled
+     * - The account's password is not set to never expire (i.e., max age is not zero)
+     *
+     * @param ldapProv The instance of the LdapProv used to perform the LDAP search.
+     * @return A list of {@link NamedEntry} objects representing the accounts that meet the conditions.
+     * @throws ServiceException If there is an issue during the LDAP search.
+     */
+    private static List<NamedEntry> findAccountsWithMaxAgePasswordAndReminderEnabled(LdapProv ldapProv) throws ServiceException {
+        SearchAccountsOptions searchOpts = new SearchAccountsOptions(
+                new String[]{
+                        Provisioning.A_zimbraPasswordMaxAge,
+                        Provisioning.A_zimbraFeaturePasswordExpiryReminderEnabled,
+                        Provisioning.A_zimbraPasswordModifiedTime,
+                        Provisioning.A_zimbraMailDeliveryAddress,
+                        Provisioning.A_cn});
+        ZLdapFilterFactory filterFactory = ZLdapFilterFactory.getInstance();
+        ZLdapFilter filterPasswordExpiryReminderEnabled = filterFactory.accountsWithLdapFeatureCheck(Provisioning.A_zimbraFeaturePasswordExpiryReminderEnabled, "TRUE");
+        ZLdapFilter filterPasswordMaxAge = filterFactory.negate(filterFactory.accountsWithLdapFeatureCheck(Provisioning.A_zimbraPasswordMaxAge, "0"));
+        searchOpts.setFilter(filterFactory.andWith(filterPasswordExpiryReminderEnabled, filterPasswordMaxAge));
+        searchOpts.setIncludeType(SearchAccountsOptions.IncludeType.ACCOUNTS_ONLY);
+        return ldapProv.searchDirectory(searchOpts);
+    }
+
+    /**
+     * Filtering accounts in a given batch and sending password expiry reminder emails to those
+     * that meet the following conditions:
+     * - The account's password was modified recently.
+     * - The password is approaching expiration (i.e., within the next 10 days).
+     *
+     * @param batch A list of {@link NamedEntry} objects representing the accounts to be processed.
+     */
+    private static void filterAccountsAndSendMail(List<NamedEntry> batch) {
+        for (NamedEntry ne : batch) {
+            Account account = (Account) ne;
+            int maxAge = account.getIntAttr(Provisioning.A_zimbraPasswordMaxAge, 0);
+            Date lastChange = account.getGeneralizedTimeAttr(Provisioning.A_zimbraPasswordModifiedTime, null);
+            if (lastChange != null) {
+                long last = lastChange.getTime();
+                long curr = System.currentTimeMillis();
+                long expires = last + (Constants.MILLIS_PER_DAY * maxAge);
+                String expiresOn = formatter.format(new Date(expires));
+                long deadline = Math.round((float) (curr - expires) / -86400000);
+                if (deadline > 0 && deadline <= 10) {
+                    sendMail(account, deadline, expiresOn);
+                }
+            }
+        }
+    }
+
+    /**
+     * Sending a password expiry reminder email to the user account.
+     *
+     * The email contains information about the following:
+     * - The number of days remaining before the account's password expires.
+     * - The expiration date of the password.
+     * - A reminder to reset the password to maintain access to the account.
+     *
+     * @param account The {@link Account} object representing the user account to which the reminder will be sent.
+     * @param deadline The number of days remaining until the account's password expires.
+     * @param expiresOn A string representing the exact expiration date of the account's password.
+     *
+     * @throws RuntimeException If there is an error while sending the email (e.g., failure in setting up the SMTP session, message creation, or transport).
+     */
+    private static void sendMail(Account account, long deadline, String expiresOn) {
+        try {
+            Session session = JMSession.getSmtpSession(account);
+            MimeMessage mimeMessage = new MimeMessage(session);
+            mimeMessage.setFrom(new InternetAddress("no-reply", "Password Expiration Notification"));
+            mimeMessage.addRecipient(Message.RecipientType.TO, new InternetAddress(account.getAttr(Provisioning.A_zimbraMailDeliveryAddress)));
+            mimeMessage.setSubject("Your password expires in " + deadline + " Days");
+            String userName = account.getAttr(Provisioning.A_cn);
+            String textContent = "Dear " + userName + ",\n" +
+                    "\n" +
+                    "Your account password expires in " + deadline + " Days, on " + expiresOn + ".\n" +
+                    "\n" +
+                    "To maintain access to your account, please reset your password before the expiration date.\n" +
+                    "\n" +
+                    "You will continue to receive the notifications daily until the password is changed or expires.\n" +
+                    "\n" +
+                    "This is an automated email notification.";
+            String htmlContent = "<html>" +
+                    "<body>" +
+                    "<p>Dear " + userName + ",</p>" +
+                    "<p>Your account password expires in <strong>" + deadline + " Days</strong>, on <strong>" + expiresOn + "</strong>.</p>" +
+                    "<p>To maintain access to your account, please reset your password before the expiration date.</p>" +
+                    "<p>You will continue to receive the notifications daily until the password is changed or expires.</p>" +
+                    "<p>This is an automated email notification.</p>" +
+                    "</body>" +
+                    "</html>";
+            Multipart multipart = new MimeMultipart();
+            MimeBodyPart textPart = new MimeBodyPart();
+            textPart.setText(textContent);
+            MimeBodyPart htmlPart = new MimeBodyPart();
+            htmlPart.setContent(htmlContent, "text/html");
+            multipart.addBodyPart(textPart);
+            multipart.addBodyPart(htmlPart);
+            mimeMessage.setContent(multipart);
+            Transport.send(mimeMessage);
+        } catch (Exception e) {
+            ZimbraLog.store.error("Failed to send email for account %s ", account.getName(), e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void run() {
+        sendReminder();
+    }
+}


### PR DESCRIPTION
https://synacor.atlassian.net/browse/ZCS-16181

Problem: Admin should be able to set password reminders for the users so that they are informed about the upcoming password expiry of their account and accordingly can take the required action.

Solution: 

1.  Added zimbraFeaturePasswordExpiryReminderEnabled LDAP attribute to enable the email reminder.
2. Created Notifier to fetch all the accounts with reminder enabled and whose password is about expire and then send the reminder emails.