### PR TITLE
ZBUG-4531 : Skip Imap UID range search

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -999,6 +999,7 @@ public final class LC {
     public static final KnownKey lds_client_max_connection = KnownKey.newKey(100);
     public static final KnownKey lds_client_max_per_route = KnownKey.newKey(20);
     public static final KnownKey lds_client_max_idle_time_seconds = KnownKey.newKey(20);
+    public static final KnownKey ignore_imap_uid_range_search = KnownKey.newKey(true);
 
     /**
      * Bug: 47051 Known key for the CLI utilities SOAP HTTP transport timeout.

--- a/store/src/java/com/zimbra/cs/imap/ImapSearch.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapSearch.java
@@ -22,8 +22,11 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import com.google.common.base.Joiner;
+import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.util.Constants;
 import com.zimbra.cs.imap.ImapFlagCache.ImapFlag;
 import com.zimbra.cs.imap.ImapMessage.ImapMessageSet;
@@ -33,6 +36,9 @@ abstract class ImapSearch {
     protected abstract String toZimbraSearch(ImapFolder i4folder) throws ImapParseException;
     protected abstract ImapMessageSet evaluate(ImapFolder i4folder) throws ImapParseException;
     protected boolean requiresMODSEQ()  { return false; }
+    // Pattern to match UID range search in the format "1:x,y:*", e.g., "1:100,200:*"
+    private static final String UID_SEARCH_PATTERN = "^1:(\\d+),(\\d+):\\*$";
+    private static boolean isUidRangeSearchIgnored = LC.ignore_imap_uid_range_search.booleanValue();
 
     protected static boolean isAllMessages(ImapFolder i4folder, Set<ImapMessage> i4set) {
         int size = i4set.size() - (i4set.contains(null) ? 1 : 0);
@@ -167,7 +173,14 @@ abstract class ImapSearch {
         @Override
         protected String toZimbraSearch(ImapFolder i4folder) throws ImapParseException {
             StringBuilder search = new StringBuilder("(");
+            Pattern compiledUidPattern = Pattern.compile(UID_SEARCH_PATTERN);
             for (ImapSearch i4search : mChildren) {
+                if (i4search instanceof SequenceSearch
+                        && isUidRangeSearchIgnored
+                        && null != ((SequenceSearch) i4search).mSubSequence
+                        && compiledUidPattern.matcher(((SequenceSearch) i4search).mSubSequence).find()) {
+                        continue;
+                }
                 search.append(search.length() == 1 ? "" : " ").append(i4search.toZimbraSearch(i4folder));
             }
             return search.append(')').toString();


### PR DESCRIPTION
[ZBUG-4531 ](https://synacor.atlassian.net/browse/ZBUG-4531)
The IMAP search query which includes a UID range (e.g., UID 1:x,y:*), results in the generation of long SQL queries and causing longer execution time for the search.

  Solution : Check if Sequence search's sub sequence contains UID range pattern; if it does, skip processing.
  Added a LC config to make this check configurable.