### PR TITLE
Bugfix/zbug 3254

### DIFF
--- a/store/src/java/com/zimbra/cs/dav/DavContext.java
+++ b/store/src/java/com/zimbra/cs/dav/DavContext.java
@@ -113,6 +113,7 @@ public class DavContext {
     private String mCollectionPath;
     private RequestProp mResponseProp;
     private String mDavCompliance;
+    public static boolean noFileExtension;
     /**
      * "actingAsDelegateFor" is used to form part of the scheduling inbox or scheduling outbox URL used
      * for scheduling on behalf of another user (the principal we are acting as a delegate for).
@@ -254,6 +255,11 @@ public class DavContext {
                 URI uri = HttpUtil.getUriFromFragments(fragments, req.getQueryString(), true, false);
                 mUri = uri.getPath();
             }
+            int lastDot = mUri.lastIndexOf(".");
+            noFileExtension = mUri.endsWith("/")
+                    || !(lastDot > 0
+                    && lastDot < mUri.length() - 1
+                    && mUri.substring(lastDot + 1).matches("[a-zA-Z0-9]+"));
 
             int index = mUri.indexOf('/', 1);
             if (index > 0) {
@@ -363,7 +369,6 @@ public class DavContext {
         }
         return null;
     }
-
     public String getActingAsDelegateFor() {
         return actingAsDelegateFor;
     }

--- a/store/src/java/com/zimbra/cs/dav/carddav/CustomXmlDetector.java
+++ b/store/src/java/com/zimbra/cs/dav/carddav/CustomXmlDetector.java
@@ -1,0 +1,66 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023,2024 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.dav.carddav;
+
+import com.zimbra.common.mime.MimeConstants;
+import org.apache.commons.fileupload.FileItem;
+import org.apache.tika.detect.Detector;
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.mime.MediaType;
+
+import java.io.InputStream;
+import java.io.IOException;
+
+/**
+ * Custom detector for XML content types .
+ * Extends Apache Tika's Detector interface to provide specialized XML detection.
+ */
+public class CustomXmlDetector implements Detector {
+
+    private final Detector defaultDetector;
+    private final FileItem file;
+    private String cType;
+
+    /**
+     * Constructs a new CustomXmlDetector with a default detector and file .
+     *
+     * @param defaultDetector The fallback detector to use if content is not XML
+     * @param attachment The FileItem attachment to analyze
+     */
+    public CustomXmlDetector(Detector defaultDetector, FileItem attachment) {
+        this.defaultDetector = defaultDetector;
+        this.file = attachment;
+    }
+
+    /**
+     * Detects the media type of the input stream, specifically handling XML content.
+     *
+     * @param input The input stream to analyze
+     * @param metadata Additional metadata about the content
+     * @return MediaType.APPLICATION_XML if content type is "text/xml",
+     *         otherwise delegates to default detector
+     * @throws IOException If an error occurs while reading the input stream
+     */
+    @Override
+    public MediaType detect(InputStream input, Metadata metadata) throws IOException {
+        cType = file.getContentType();
+        if (cType != null && (cType.equalsIgnoreCase(MimeConstants.CT_TEXT_XML) || cType.equalsIgnoreCase(MimeConstants.CT_TEXT_XML_LEGACY))) {
+            return MediaType.APPLICATION_XML;
+        }
+        return defaultDetector.detect(input, metadata);
+    }
+}

--- a/store/src/java/com/zimbra/cs/service/FileUploadServlet.java
+++ b/store/src/java/com/zimbra/cs/service/FileUploadServlet.java
@@ -41,6 +41,8 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.zimbra.cs.dav.DavContext;
+import com.zimbra.cs.dav.carddav.CustomXmlDetector;
 import org.apache.commons.fileupload.DefaultFileItem;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileUploadBase;
@@ -216,7 +218,11 @@ public class FileUploadServlet extends ZimbraServlet {
             MediaType mediaType = null;
             try {
                 TikaInputStream stream = TikaInputStream.get(fileItem.getInputStream());
-                if (new File(customMimeTypesPath).isFile()) {
+                if (DavContext.noFileExtension) {
+                    Detector customXmlDetector = new CustomXmlDetector(detector, fileItem);
+                    mediaType = customXmlDetector.detect(stream, metadata);
+                    DavContext.noFileExtension=false;
+                } else if (new File(customMimeTypesPath).isFile()) {
                     MimeTypes customMimeTypes = MimeTypesFactory.create(new URL("file://" + customMimeTypesPath));
                     mediaType = new CompositeDetector(customMimeTypes, detector).detect(stream, metadata);
                 } else {


### PR DESCRIPTION
issue is  - dav - Request: requested content-type: text/xml, actual content-type: text/plain

we are getting text/plain because of filename is not ending with any extension
so we have added custom detector for this spacial case .

<img width="461" alt="image" src="https://github.com/user-attachments/assets/91a0e1e2-6df7-446e-92b0-7e11eb9af7e5">
