### PR TITLE
ZCS-16289 : SaveDraft request not failing on exceeding zimbraMtaMaxMessageSize

### DIFF
--- a/store/src/java/com/zimbra/cs/service/mail/ParseMimeMessage.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ParseMimeMessage.java
@@ -284,7 +284,7 @@ public final class ParseMimeMessage {
                 long mailAttachmentMaxSize = account.getMailAttachmentMaxSize();
                 Config config = Provisioning.getInstance().getConfig();
                 long mtaMaxMsgSize = config.getLongAttr(Provisioning.A_zimbraMtaMaxMessageSize, -1);
-                if (mailAttachmentMaxSize > mtaMaxMsgSize) {
+                if (mailAttachmentMaxSize > mtaMaxMsgSize || mailAttachmentMaxSize == 0) {
                     maxSize = mtaMaxMsgSize;
                 } else {
                     maxSize = mailAttachmentMaxSize;


### PR DESCRIPTION
https://synacor.atlassian.net/browse/ZCS-16289

Problem:- On Modern/Classic, SaveDraftRequest does not fail on exceeding message size limit of zimbraMtaMaxMessageSize.

Solution:- Modified the condition such that when the mailAttachmentMaxSize is not set, it will consider mtaMaxMsgSize as the limit.