### PR TITLE
ZCS-13911: Refactor crossmailboxsearch code causing read timed out wi…

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1000,6 +1000,7 @@ public final class LC {
     public static final KnownKey lds_client_max_per_route = KnownKey.newKey(20);
     public static final KnownKey lds_client_max_idle_time_seconds = KnownKey.newKey(20);
     public static final KnownKey ignore_imap_uid_range_search = KnownKey.newKey(true);
+    public static final KnownKey cross_mailbox_max_thread_pool_size = KnownKey.newKey(20);
 
     /**
      * Bug: 47051 Known key for the CLI utilities SOAP HTTP transport timeout.


### PR DESCRIPTION
Requirement of ticket [[ZCS-13911](https://jira.corp.synacor.com/browse/ZCS-13911)]

To optimize search performance, we implemented a thread pool for parallel searching and utilized XMLStreamWriter with Marshaller for marshalling. This approach successfully reduced the marshalling time from an average of 80 seconds to below 20 seconds.

* This PR contains the LC changes for cross-mailbox-search 

Test:
Tested on remote VM with 1.2 TB setup.

Related PR link: https://github.com/Zimbra/zm-network-store/pull/50

[ZCS-13911]: https://synacor.atlassian.net/browse/ZCS-13911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ