### PR TITLE
ZCS-16234-1: Fetch accounts whose LDAP attribute is getting inherited from COS

### DIFF
--- a/store/src/java/com/zimbra/cs/ldap/ZLdapFilterFactory.java
+++ b/store/src/java/com/zimbra/cs/ldap/ZLdapFilterFactory.java
@@ -94,6 +94,7 @@ public abstract class ZLdapFilterFactory extends ZLdapElement {
         COS_BY_ID(SINGLETON.cosById("{COS-ID}")),
         COSES_BY_MAILHOST_POOL(SINGLETON.cosesByMailHostPool("{SERVER-ID}")),
         COSES_ON_UCSERVICE(SINGLETON.cosesOnUCService("{UCSERVICE-ID}")),
+        COSES_WITH_LDAP_FEATURE_CHECK(SINGLETON.cosesWithLdapFeatureCheck("{LDAP_ATTRIBUTE}", "{LDAP_VALUE}")),
 
         CREATED_LATEROREQUAL(SINGLETON.createdLaterOrEqual("{GENERALIZED_TIME}")),
         DATA_SOURCE_BY_ID(SINGLETON.dataSourceById("{DATA-SOURCE-ID}")),
@@ -422,7 +423,7 @@ public abstract class ZLdapFilterFactory extends ZLdapElement {
     public abstract ZLdapFilter cosById(String id);
     public abstract ZLdapFilter cosesByMailHostPool(String serverId);
     public abstract ZLdapFilter cosesOnUCService(String ucServiceId);
-
+    public abstract ZLdapFilter cosesWithLdapFeatureCheck(String ldapAttribute, String ldapValue);
     /*
      * data source
      */

--- a/store/src/java/com/zimbra/cs/ldap/unboundid/UBIDLdapFilterFactory.java
+++ b/store/src/java/com/zimbra/cs/ldap/unboundid/UBIDLdapFilterFactory.java
@@ -420,7 +420,6 @@ public class UBIDLdapFilterFactory extends ZLdapFilterFactory {
     }
 
 
-
     /*
      * Mail target (accounts and groups)
      */
@@ -1013,6 +1012,16 @@ public class UBIDLdapFilterFactory extends ZLdapFilterFactory {
                 Filter.createANDFilter(
                         Filter.createEqualityFilter(Provisioning.A_zimbraUCServiceId, usServiceId),
                         FILTER_ALL_COSES));
+    }
+
+    @Override
+    public ZLdapFilter cosesWithLdapFeatureCheck(String ldapAttribute, String ldapValue) {
+        return new UBIDLdapFilter(
+                FilterId.COSES_WITH_LDAP_FEATURE_CHECK,
+                Filter.createANDFilter(
+                        FILTER_ALL_COSES,
+                        Filter.createEqualityFilter(ldapAttribute, ldapValue)
+                ));
     }
 
 

--- a/store/src/java/com/zimbra/cs/service/mail/PasswordExpiryNotifier.java
+++ b/store/src/java/com/zimbra/cs/service/mail/PasswordExpiryNotifier.java
@@ -29,6 +29,7 @@ import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.NamedEntry;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.SearchAccountsOptions;
+import com.zimbra.cs.account.SearchDirectoryOptions;
 import com.zimbra.cs.account.ldap.LdapProv;
 import com.zimbra.cs.ldap.ZLdapFilter;
 import com.zimbra.cs.ldap.ZLdapFilterFactory;
@@ -51,6 +52,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
 
 
 public class PasswordExpiryNotifier implements Runnable {
@@ -96,22 +98,51 @@ public class PasswordExpiryNotifier implements Runnable {
      * @throws ServiceException If there is an issue during the LDAP search.
      */
     private static List<NamedEntry> findAccountsWithMaxAgePasswordAndReminderEnabled(LdapProv ldapProv) throws ServiceException {
-        SearchAccountsOptions searchOpts = new SearchAccountsOptions(
+        SearchAccountsOptions searchAcctOpts = new SearchAccountsOptions(
+                new String[]{
+                Provisioning.A_zimbraPasswordMaxAge,
+                Provisioning.A_zimbraFeaturePasswordExpiryReminderEnabled,
+                Provisioning.A_zimbraPasswordModifiedTime,
+                Provisioning.A_zimbraMailDeliveryAddress,
+                Provisioning.A_cn,
+                Provisioning.A_zimbraPrefLocale});
+        SearchAccountsOptions searchAccFromCosOpts = new SearchAccountsOptions(
+                new String[]{
+                Provisioning.A_zimbraPasswordMaxAge,
+                Provisioning.A_zimbraFeaturePasswordExpiryReminderEnabled,
+                Provisioning.A_zimbraPasswordModifiedTime,
+                Provisioning.A_zimbraMailDeliveryAddress,
+                Provisioning.A_cn,
+                Provisioning.A_zimbraPrefLocale,
+                Provisioning.A_zimbraCOSId});
+        SearchDirectoryOptions searchCosOpts = new SearchDirectoryOptions(
                 new String[]{
                         Provisioning.A_zimbraPasswordMaxAge,
-                        Provisioning.A_zimbraFeaturePasswordExpiryReminderEnabled,
-                        Provisioning.A_zimbraPasswordModifiedTime,
-                        Provisioning.A_zimbraMailDeliveryAddress,
-                        Provisioning.A_cn,
-                        Provisioning.A_zimbraPrefLocale});
+                        Provisioning.A_zimbraFeaturePasswordExpiryReminderEnabled}
+        );
         ZLdapFilterFactory filterFactory = ZLdapFilterFactory.getInstance();
+        // filtering Coses
+        ZLdapFilter filterPasswordExpiryReminderEnabledCos = filterFactory.cosesWithLdapFeatureCheck(Provisioning.A_zimbraFeaturePasswordExpiryReminderEnabled, "TRUE");
+        ZLdapFilter filterPasswordMaxAgeCos = filterFactory.negate(filterFactory.cosesWithLdapFeatureCheck(Provisioning.A_zimbraPasswordMaxAge, "0"));
+        searchCosOpts.setFilter(filterFactory.andWith(filterPasswordExpiryReminderEnabledCos, filterPasswordMaxAgeCos));
+        searchCosOpts.addType(SearchDirectoryOptions.ObjectType.coses);
+        List<NamedEntry> coses=  ldapProv.searchDirectory(searchCosOpts);
+        List<String> cosIds = coses.stream()
+                .map(NamedEntry::getId)
+                .collect(Collectors.toList());
+        // filtering Accounts with inherited attributes
         ZLdapFilter filterServer = filterFactory.accountsWithLdapFeatureCheck(Provisioning.A_zimbraMailHost, LC.zimbra_server_hostname.value());
+        ZLdapFilter filterReminderEnabledAtCos = filterFactory.accountsByCosesAndFeatureCheck(cosIds,Provisioning.A_zimbraFeaturePasswordExpiryReminderEnabled);
+        searchAccFromCosOpts.setFilter(filterFactory.andWith(filterServer, filterReminderEnabledAtCos));
+        List<NamedEntry> accountsWithAttributesInherited = ldapProv.searchDirectory(searchAccFromCosOpts);
+        // filtering accounts with set attributes
         ZLdapFilter filterPasswordExpiryReminderEnabled = filterFactory.accountsWithLdapFeatureCheck(Provisioning.A_zimbraFeaturePasswordExpiryReminderEnabled, "TRUE");
         ZLdapFilter filterPasswordMaxAge = filterFactory.negate(filterFactory.accountsWithLdapFeatureCheck(Provisioning.A_zimbraPasswordMaxAge, "0"));
         ZLdapFilter filterReminderAndMaxAgeEnabled = filterFactory.andWith(filterPasswordExpiryReminderEnabled, filterPasswordMaxAge);
-        searchOpts.setFilter(filterFactory.andWith(filterServer, filterReminderAndMaxAgeEnabled));
-        searchOpts.setIncludeType(SearchAccountsOptions.IncludeType.ACCOUNTS_ONLY);
-        return ldapProv.searchDirectory(searchOpts);
+        searchAcctOpts.setFilter(filterFactory.andWith(filterServer, filterReminderAndMaxAgeEnabled));
+        List<NamedEntry> accountsWithAttributesSet = ldapProv.searchDirectory(searchAcctOpts);
+        accountsWithAttributesInherited.addAll(accountsWithAttributesSet);
+        return accountsWithAttributesInherited;
     }
 
     /**


### PR DESCRIPTION
Problem:- For LDAP attributes which are being inherited from COS and not set at account level. The LDAP query is not able to retrieve those accounts as it's looking for attributes and not defaults.

Solution:- Modified logic to fetch accounts in steps:-

1. First fetch the coses eligible.
2. Fetch the accounts linked to the eligible cos and not have those attributes set explicitly.
3. Finally fetch the accounts which are eligible with attributes set.