### PR TITLE
ZCS-16353 Created new property for autosend time and skipped logging

### DIFF
--- a/store/src/java/com/zimbra/cs/mailclient/smtp/SmtpTransport.java
+++ b/store/src/java/com/zimbra/cs/mailclient/smtp/SmtpTransport.java
@@ -113,6 +113,7 @@ public class SmtpTransport extends Transport {
     private SmtpConnection connection;
     private final boolean ssl;
     private final String protocol;
+    private static final String MAIL_AUTOSEND_TIME = "mail.autosend.time";
 
     /**
      * Constructs a new {@link SmtpTransport}.
@@ -241,7 +242,11 @@ public class SmtpTransport extends Transport {
                 connection.sendMessage(rcpts, (MimeMessage) msg);
             }
         } catch (MessagingException e) {
-            ZimbraLog.smtp.warn("Failed to send message", e);
+            // after receipt validation , messaging exception is always thrown while scheduling msg
+            // skipping warning as it is known exception, nothing to do with sending actual msg
+            if (null == session.getProperty(MAIL_AUTOSEND_TIME)) {
+                ZimbraLog.smtp.warn("Failed to send message", e);
+            }
             notify(e, msg, rcpts);
         } catch (IOException e) {
             ZimbraLog.smtp.warn("Failed to send message", e);

--- a/store/src/java/com/zimbra/cs/service/mail/SaveDraft.java
+++ b/store/src/java/com/zimbra/cs/service/mail/SaveDraft.java
@@ -28,7 +28,6 @@ import javax.mail.Session;
 import javax.mail.internet.MimeMessage;
 
 import com.zimbra.common.account.Key.AccountBy;
-import com.zimbra.common.account.ZAttrProvisioning;
 import com.zimbra.common.mailbox.Color;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
@@ -71,6 +70,7 @@ public class SaveDraft extends MailDocumentHandler {
     public static final String IS_DELEGATED_REQUEST = "isDelegatedReq";
     public static final String DELEGATEE_ACCOUNT_ID = "delegateeAccountId";
     private static final String MAIL_SMTP_FROM = "mail.smtp.from";
+    private static final String MAIL_AUTOSEND_TIME = "mail.autosend.time";
 
     @Override
     protected String[] getProxiedIdPath(Element request) {
@@ -178,6 +178,7 @@ public class SaveDraft extends MailDocumentHandler {
                     if (null != mailAddress) {
                         mSession.getProperties().setProperty(MAIL_SMTP_FROM, mailAddress);
                     }
+                    mSession.getProperties().setProperty(MAIL_AUTOSEND_TIME, String.valueOf(autoSendTime));
                     // always throws MessagingException. The api call here is checking if MessagingException is an instance of SendFailedException
                     // then get the list of invalid e-mail addresses.
                     MailUtil.validateRcptAddresses(mSession, mm.getAllRecipients());


### PR DESCRIPTION
Send Later: "Failed to send message - No MimeMessage content" error appears immediately upon scheduling, but email is sent successfully at the scheduled time.

Created a new Property for autsend time, and used it to skip looging warning message as it is a known exception thrown everytime after receipt validation.