### PR TITLE
ZCS-16427: Resolve heap memory issue for Password Expiry Reminder Emails

### DIFF
--- a/store/src/java/com/zimbra/cs/account/SearchDirectoryOptions.java
+++ b/store/src/java/com/zimbra/cs/account/SearchDirectoryOptions.java
@@ -140,6 +140,8 @@ public class SearchDirectoryOptions {
     private final boolean useConnPool = true; // TODO: retire this
     private int maxResults = ALL_RESULTS;
     private int resultPageSize = DEFAULT_LIMIT;
+    private int limit = 0;
+    private int offset = 0;
 
     /*
      * search base
@@ -506,4 +508,19 @@ public class SearchDirectoryOptions {
         this.habRootGroupDn = baseDn;
     }
 
+    public int getLimit() {
+        return limit;
+    }
+
+    public void setLimit(int limit) {
+        this.limit = limit;
+    }
+
+    public int getOffset() {
+        return offset;
+    }
+
+    public void setOffset(int offset) {
+        this.offset = offset;
+    }
 }

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -2304,6 +2304,12 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
             } else {
                 searchObjectsOptions.setUseControl(opts.isUseControl());
             }
+            if (opts.getLimit() != 0) {
+                searchObjectsOptions.setLimit(opts.getLimit());
+            }
+            if (opts.getOffset() != 0) {
+                searchObjectsOptions.setOffset(opts.getOffset());
+            }
             searchObjectsOptions.setManageDSAit(opts.isManageDSAit());
             zlc.searchPaged(searchObjectsOptions);
         } catch (LdapSizeLimitExceededException e) {

--- a/store/src/java/com/zimbra/cs/ldap/SearchLdapOptions.java
+++ b/store/src/java/com/zimbra/cs/ldap/SearchLdapOptions.java
@@ -111,6 +111,8 @@ public class SearchLdapOptions {
     private boolean isManageDSAit = false;
     private SearchGalResult searchGalResult;
     private GalOp galOp;
+    private int limit = 0;
+    private int offset = 0;
 
     // TODO: retire this
     public SearchLdapOptions(String searchbase, String filterStr,
@@ -243,5 +245,21 @@ public class SearchLdapOptions {
 
     public void setSearchGalResult(SearchGalResult result) {
         this.searchGalResult = result;
+    }
+
+    public int getLimit() {
+        return limit;
+    }
+
+    public void setLimit(int limit) {
+        this.limit = limit;
+    }
+
+    public int getOffset() {
+        return offset;
+    }
+
+    public void setOffset(int offset) {
+        this.offset = offset;
     }
 }

--- a/store/src/java/com/zimbra/cs/ldap/unboundid/UBIDLdapContext.java
+++ b/store/src/java/com/zimbra/cs/ldap/unboundid/UBIDLdapContext.java
@@ -546,6 +546,12 @@ public class UBIDLdapContext extends ZLdapContext {
         int pageOffset = 0;
         int currentPage = 0;
         int index = 0;
+        if (searchOptions.getLimit() != 0) {
+            limit = searchOptions.getLimit();
+        }
+        if (searchOptions.getOffset() != 0){
+            offset = searchOptions.getOffset();
+        }
         if (offset > 0) {
             pageCount = offset / pageSize;
             pageOffset = offset % pageSize;

--- a/store/src/java/com/zimbra/cs/service/mail/EmailTracker.java
+++ b/store/src/java/com/zimbra/cs/service/mail/EmailTracker.java
@@ -1,0 +1,91 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2024 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.service.mail;
+
+import com.zimbra.common.util.ZimbraLog;
+
+import java.io.*;
+import java.util.HashSet;
+import java.util.Set;
+
+public class EmailTracker {
+    private static final String SENT_EMAILS_FILE = "/tmp/sent_emails.txt";
+    private static final Set<String> sentEmails = new HashSet<>();
+
+    static {
+        loadSentEmails();
+    }
+
+    /**
+     * Loads the list of previously sent email addresses from the file specified by the constant
+     * `SENT_EMAILS_FILE`. If the file does not exist, it is created. The method reads each email
+     * address from the file and adds it to the `sentEmails` set to keep track of emails that have
+     * already been sent.
+     *
+     * @throws IOException If an error occurs while reading the file or creating the file.
+     */
+    private static void loadSentEmails() {
+        File file = new File(SENT_EMAILS_FILE);
+        try {
+        if (!file.exists()) {
+            file.createNewFile();
+        }
+        BufferedReader reader = new BufferedReader(new FileReader(SENT_EMAILS_FILE));
+            String email;
+            while ((email = reader.readLine()) != null) {
+                sentEmails.add(email);
+            }
+        } catch (IOException e) {
+            ZimbraLog.store.error("Failed to load sent emails: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Checks if an email has already been sent by verifying its presence in the `sentEmails` set.
+     *
+     * @param email The email address to be checked.
+     * @return `true` if the email has already been sent (i.e., exists in the `sentEmails` set),
+     *         otherwise `false`.
+     */
+    public static boolean isEmailSent(String email) {
+        return sentEmails.contains(email);
+    }
+
+    /**
+     * Marks the specified email address as sent by adding it to the `sentEmails` set and
+     * appending it to the `SENT_EMAILS_FILE`. The method ensures that an email is only marked
+     * once to avoid duplicates.
+     *
+     * @param email The email address to be marked as sent.
+     *
+     * @throws IOException If an error occurs while writing to the file.
+     */
+    public static synchronized void markEmailAsSent(String email) {
+        if (sentEmails.add(email)) {
+            try (BufferedWriter writer = new BufferedWriter(new FileWriter(SENT_EMAILS_FILE, true))) {
+                writer.write(email);
+                writer.newLine();
+            } catch (IOException e) {
+                ZimbraLog.store.error("Failed to mark email as sent: " + e.getMessage());
+            }
+        }
+    }
+
+    public static String getSentEmailsFile() {
+        return SENT_EMAILS_FILE;
+    }
+}

--- a/store/src/java/com/zimbra/cs/service/mail/PasswordExpiryNotifier.java
+++ b/store/src/java/com/zimbra/cs/service/mail/PasswordExpiryNotifier.java
@@ -45,6 +45,9 @@ import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -76,45 +79,86 @@ public class PasswordExpiryNotifier implements Runnable {
     protected static void sendReminder() {
         try {
             LdapProv ldapProv = LdapProv.getInst();
-            List<NamedEntry> accounts = findAccountsWithMaxAgePasswordAndReminderEnabled(ldapProv);
-            ExecutorService emailSenderExecutor = Executors.newFixedThreadPool(PASSWORD_REMINDER_THREAD_COUNT);
-            for (int i = 0; i < accounts.size(); i += PASSWORD_REMINDER_BATCH_SIZE) {
-                final List<NamedEntry> batch = accounts.subList(i, Math.min(i + PASSWORD_REMINDER_BATCH_SIZE, accounts.size()));
-                emailSenderExecutor.submit(() -> filterAccountsAndSendMail(batch));
-            }
-            emailSenderExecutor.shutdown();
+            findAccountsWithMaxAgePasswordAndReminderInheritedFromCos(ldapProv);
+            findAccountsWithMaxAgePasswordAndReminderSet(ldapProv);
         } catch (ServiceException e) {
             ZimbraLog.store.error("Failed to send reminder", e);
         }
     }
 
     /**
-     * Finding accounts that meet the following conditions:
-     * - The account has the password expiry reminder feature enabled
-     * - The account's password is not set to never expire (i.e., max age is not zero)
+     * Finds accounts that meet the following conditions:
+     * - The account has the password expiry reminder feature explicitly enabled.
+     * - The account's password is not set to never expire (i.e., the maximum password age is not zero).
      *
-     * @param ldapProv The instance of the LdapProv used to perform the LDAP search.
-     * @return A list of {@link NamedEntry} objects representing the accounts that meet the conditions.
-     * @throws ServiceException If there is an issue during the LDAP search.
+     * This method searches for accounts that have the password expiry reminder feature enabled and also have
+     * a non-zero password max age. It processes the results in batches and, for each batch, a task is created
+     * for sending notifications.
+     *
+     * @param ldapProv The instance of the LdapProv used to perform the LDAP search and handle directory operations.
+     * @throws ServiceException If there is an issue during the LDAP search or processing of the accounts.
      */
-    private static List<NamedEntry> findAccountsWithMaxAgePasswordAndReminderEnabled(LdapProv ldapProv) throws ServiceException {
+    private static void findAccountsWithMaxAgePasswordAndReminderSet(LdapProv ldapProv) throws ServiceException {
         SearchAccountsOptions searchAcctOpts = new SearchAccountsOptions(
                 new String[]{
-                Provisioning.A_zimbraPasswordMaxAge,
-                Provisioning.A_zimbraFeaturePasswordExpiryReminderEnabled,
-                Provisioning.A_zimbraPasswordModifiedTime,
-                Provisioning.A_zimbraMailDeliveryAddress,
-                Provisioning.A_cn,
-                Provisioning.A_zimbraPrefLocale});
+                        Provisioning.A_zimbraPasswordMaxAge,
+                        Provisioning.A_zimbraFeaturePasswordExpiryReminderEnabled,
+                        Provisioning.A_zimbraPasswordModifiedTime,
+                        Provisioning.A_zimbraMailDeliveryAddress,
+                        Provisioning.A_cn,
+                        Provisioning.A_zimbraPrefLocale});
+        ZLdapFilterFactory filterFactory = ZLdapFilterFactory.getInstance();
+        // filtering accounts with set attributes
+        ZLdapFilter filterServer = filterFactory.accountsWithLdapFeatureCheck(Provisioning.A_zimbraMailHost, LC.zimbra_server_hostname.value());
+        ZLdapFilter filterPasswordExpiryReminderEnabled = filterFactory.accountsWithLdapFeatureCheck(Provisioning.A_zimbraFeaturePasswordExpiryReminderEnabled, "TRUE");
+        ZLdapFilter filterPasswordMaxAge = filterFactory.negate(filterFactory.accountsWithLdapFeatureCheck(Provisioning.A_zimbraPasswordMaxAge, "0"));
+        ZLdapFilter filterReminderAndMaxAgeEnabled = filterFactory.andWith(filterPasswordExpiryReminderEnabled, filterPasswordMaxAge);
+        searchAcctOpts.setFilter(filterFactory.andWith(filterServer, filterReminderAndMaxAgeEnabled));
+        searchAcctOpts.setResultPageSize(PASSWORD_REMINDER_BATCH_SIZE);
+        searchAcctOpts.setUseControl(true);
+        searchAcctOpts.setLimit(PASSWORD_REMINDER_BATCH_SIZE);
+        int offset = 0;
+        List<NamedEntry> accountsWithAttributesSet;
+        ExecutorService emailSenderExecutor = Executors.newFixedThreadPool(PASSWORD_REMINDER_THREAD_COUNT);
+        do {
+            searchAcctOpts.setOffset(offset);
+            accountsWithAttributesSet = ldapProv.searchDirectory(searchAcctOpts);
+            final List<NamedEntry> batch = accountsWithAttributesSet;
+            emailSenderExecutor.submit(() -> filterAccountsAndSendMail(batch));
+            offset += PASSWORD_REMINDER_BATCH_SIZE;
+        } while (!accountsWithAttributesSet.isEmpty());
+        emailSenderExecutor.shutdown();
+        // wait for the executor to finish processing all tasks
+        while (!emailSenderExecutor.isTerminated()) {
+        }
+        // after all emails are processed and sent, clear the file
+        clearSentEmailsFile();
+    }
+
+    /**
+     * Finds accounts that meet the following conditions:
+     * - The account has the password expiry reminder feature enabled.
+     * - The account's password is not set to never expire (i.e., max password age is not zero).
+     *
+     * This method first filters the Classes of Service (COS) that have the password expiry reminder feature enabled
+     * and ensure their password max age is not set to zero. Then, it retrieves accounts that inherit these attributes
+     * from their COS and have the corresponding feature enabled.
+     *
+     * The results are processed in batches, and for each batch, a thread is created to send notifications.
+     *
+     * @param ldapProv The instance of the LdapProv used to perform the LDAP search and manage the directory operations.
+     * @throws ServiceException If there is an issue during the LDAP search or processing of the accounts.
+     */
+    private static void findAccountsWithMaxAgePasswordAndReminderInheritedFromCos(LdapProv ldapProv) throws ServiceException {
         SearchAccountsOptions searchAccFromCosOpts = new SearchAccountsOptions(
                 new String[]{
-                Provisioning.A_zimbraPasswordMaxAge,
-                Provisioning.A_zimbraFeaturePasswordExpiryReminderEnabled,
-                Provisioning.A_zimbraPasswordModifiedTime,
-                Provisioning.A_zimbraMailDeliveryAddress,
-                Provisioning.A_cn,
-                Provisioning.A_zimbraPrefLocale,
-                Provisioning.A_zimbraCOSId});
+                        Provisioning.A_zimbraPasswordMaxAge,
+                        Provisioning.A_zimbraFeaturePasswordExpiryReminderEnabled,
+                        Provisioning.A_zimbraPasswordModifiedTime,
+                        Provisioning.A_zimbraMailDeliveryAddress,
+                        Provisioning.A_cn,
+                        Provisioning.A_zimbraPrefLocale,
+                        Provisioning.A_zimbraCOSId});
         SearchDirectoryOptions searchCosOpts = new SearchDirectoryOptions(
                 new String[]{
                         Provisioning.A_zimbraPasswordMaxAge,
@@ -134,15 +178,43 @@ public class PasswordExpiryNotifier implements Runnable {
         ZLdapFilter filterServer = filterFactory.accountsWithLdapFeatureCheck(Provisioning.A_zimbraMailHost, LC.zimbra_server_hostname.value());
         ZLdapFilter filterReminderEnabledAtCos = filterFactory.accountsByCosesAndFeatureCheck(cosIds,Provisioning.A_zimbraFeaturePasswordExpiryReminderEnabled);
         searchAccFromCosOpts.setFilter(filterFactory.andWith(filterServer, filterReminderEnabledAtCos));
-        List<NamedEntry> accountsWithAttributesInherited = ldapProv.searchDirectory(searchAccFromCosOpts);
-        // filtering accounts with set attributes
-        ZLdapFilter filterPasswordExpiryReminderEnabled = filterFactory.accountsWithLdapFeatureCheck(Provisioning.A_zimbraFeaturePasswordExpiryReminderEnabled, "TRUE");
-        ZLdapFilter filterPasswordMaxAge = filterFactory.negate(filterFactory.accountsWithLdapFeatureCheck(Provisioning.A_zimbraPasswordMaxAge, "0"));
-        ZLdapFilter filterReminderAndMaxAgeEnabled = filterFactory.andWith(filterPasswordExpiryReminderEnabled, filterPasswordMaxAge);
-        searchAcctOpts.setFilter(filterFactory.andWith(filterServer, filterReminderAndMaxAgeEnabled));
-        List<NamedEntry> accountsWithAttributesSet = ldapProv.searchDirectory(searchAcctOpts);
-        accountsWithAttributesInherited.addAll(accountsWithAttributesSet);
-        return accountsWithAttributesInherited;
+        searchAccFromCosOpts.setResultPageSize(PASSWORD_REMINDER_BATCH_SIZE);
+        searchAccFromCosOpts.setUseControl(true);
+        searchAccFromCosOpts.setLimit(PASSWORD_REMINDER_BATCH_SIZE);
+        int offset = 0;
+        List<NamedEntry> accountsWithAttributesInherited;
+        ExecutorService emailSenderExecutor = Executors.newFixedThreadPool(PASSWORD_REMINDER_THREAD_COUNT);
+        do {
+            searchAccFromCosOpts.setOffset(offset);
+            accountsWithAttributesInherited = ldapProv.searchDirectory(searchAccFromCosOpts);
+            final List<NamedEntry> batch = accountsWithAttributesInherited;
+            emailSenderExecutor.submit(() -> filterAccountsAndSendMail(batch));
+            offset += PASSWORD_REMINDER_BATCH_SIZE;
+        } while (!accountsWithAttributesInherited.isEmpty());
+        emailSenderExecutor.shutdown();
+        // wait for the executor to finish processing all tasks
+        while (!emailSenderExecutor.isTerminated()) {
+        }
+        // after all emails are processed and sent, clear the file
+        clearSentEmailsFile();
+    }
+
+    /**
+     * Clears the contents of the file specified by the constant `SENT_EMAILS_FILE` by truncating it.
+     * This method is used to empty the file after all emails have been successfully sent, ensuring
+     * that the list of sent emails is reset for future operations.
+     *
+     * @throws IOException If an error occurs while writing to the file.
+     */
+    private static void clearSentEmailsFile() {
+        try {
+            // create a new FileWriter with append=false to truncate the file
+            try (BufferedWriter writer = new BufferedWriter(new FileWriter(EmailTracker.getSentEmailsFile(), false))) {
+                writer.write(""); // writing an empty string to truncate the file
+            }
+        } catch (IOException e) {
+            ZimbraLog.store.error("Failed to clear the sent emails file: " + e.getMessage());
+        }
     }
 
     /**
@@ -187,6 +259,9 @@ public class PasswordExpiryNotifier implements Runnable {
      */
     private static void sendMail(Account account, long deadline, String expiresOn) {
         try {
+            if (EmailTracker.isEmailSent(account.getAttr(Provisioning.A_zimbraMailDeliveryAddress))) {
+                return;
+            }
             MimeMultipart mmp = new ZMimeMultipart("alternative");
             Session session = JMSession.getSmtpSession(account);
             MimeMessage mimeMessage = new Mime.FixedMimeMessage(session);
@@ -208,6 +283,7 @@ public class PasswordExpiryNotifier implements Runnable {
             mimeMessage.setContent(mmp);
             mimeMessage.saveChanges();
             Transport.send(mimeMessage);
+            EmailTracker.markEmailAsSent(account.getAttr(Provisioning.A_zimbraMailDeliveryAddress));
         } catch (Exception e) {
             ZimbraLog.store.error("Failed to send email for account %s ", account.getName(), e);
             throw new RuntimeException(e);


### PR DESCRIPTION
Problem:- While executing script for large number of accounts, it is failing with heap memory issue.

Solution:- Instead of fetching all the accounts at once and then process them in batches, fetched the accounts in batches and process them before searching for the next batch. Added offset and limit in searchDirectoryOptions and searchLdapOptions.