### PR TITLE
ZCS-16428: Implementation for DSN support for Save Draft and Send Later

### DIFF
--- a/store/src/java-test/com/zimbra/cs/service/mail/SaveDraftTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/mail/SaveDraftTest.java
@@ -126,4 +126,68 @@ public class SaveDraftTest {
         Assert.assertEquals("picked up modified content", MODIFIED_CONTENT, response.getElement(MailConstants.E_MSG).getElement(MailConstants.E_MIMEPART).getAttribute(MailConstants.E_CONTENT));
     }
 
+    @Test
+    public void deliveryReportEnabled() throws Exception {
+        Account acct = Provisioning.getInstance().getAccountByName("test@zimbra.com");
+
+        // create a draft via SOAP
+        Element request = new Element.JSONElement(MailConstants.SAVE_DRAFT_REQUEST);
+        Element m = request.addNonUniqueElement(MailConstants.E_MSG).addAttribute(MailConstants.E_SUBJECT, "dinner appt");
+        m.addUniqueElement(MailConstants.E_MIMEPART).addAttribute(MailConstants.A_CONTENT_TYPE, "text/plain").addAttribute(MailConstants.E_CONTENT, ORIGINAL_CONTENT);
+        m.addAttribute(MailConstants.A_DELIVERY_RECEIPT_NOTIFICATION, "1");
+
+        Element response = new SaveDraft() {
+            @Override
+            protected Element generateResponse(ZimbraSoapContext zsc, ItemIdFormatter ifmt, OperationContext octxt,
+                    Mailbox mbox, Message msg, boolean wantImapUid, boolean wantModSeq) {
+
+                return super.generateResponse(zsc, ifmt, octxt, mbox, msg, wantImapUid, wantModSeq);
+            }
+        }.handle(request, ServiceTestUtil.getRequestContext(acct));
+
+        Assert.assertTrue(response.getElement(MailConstants.E_MSG).getAttributeBool(MailConstants.A_DELIVERY_RECEIPT_NOTIFICATION, false));
+    }
+
+    @Test
+    public void deliveryReportDisabled() throws Exception {
+        Account acct = Provisioning.getInstance().getAccountByName("test@zimbra.com");
+
+        // create a draft via SOAP
+        Element request = new Element.JSONElement(MailConstants.SAVE_DRAFT_REQUEST);
+        Element m = request.addNonUniqueElement(MailConstants.E_MSG).addAttribute(MailConstants.E_SUBJECT, "dinner appt");
+        m.addUniqueElement(MailConstants.E_MIMEPART).addAttribute(MailConstants.A_CONTENT_TYPE, "text/plain").addAttribute(MailConstants.E_CONTENT, ORIGINAL_CONTENT);
+        m.addAttribute(MailConstants.A_DELIVERY_RECEIPT_NOTIFICATION, "0");
+
+        Element response = new SaveDraft() {
+            @Override
+            protected Element generateResponse(ZimbraSoapContext zsc, ItemIdFormatter ifmt, OperationContext octxt,
+                                               Mailbox mbox, Message msg, boolean wantImapUid, boolean wantModSeq) {
+
+                return super.generateResponse(zsc, ifmt, octxt, mbox, msg, wantImapUid, wantModSeq);
+            }
+        }.handle(request, ServiceTestUtil.getRequestContext(acct));
+
+        Assert.assertFalse(response.getElement(MailConstants.E_MSG).getAttributeBool(MailConstants.A_DELIVERY_RECEIPT_NOTIFICATION, false));
+    }
+
+    @Test
+    public void deliveryReportNotSet() throws Exception {
+        Account acct = Provisioning.getInstance().getAccountByName("test@zimbra.com");
+
+        // create a draft via SOAP
+        Element request = new Element.JSONElement(MailConstants.SAVE_DRAFT_REQUEST);
+        Element m = request.addNonUniqueElement(MailConstants.E_MSG).addAttribute(MailConstants.E_SUBJECT, "dinner appt");
+        m.addUniqueElement(MailConstants.E_MIMEPART).addAttribute(MailConstants.A_CONTENT_TYPE, "text/plain").addAttribute(MailConstants.E_CONTENT, ORIGINAL_CONTENT);
+
+        Element response = new SaveDraft() {
+            @Override
+            protected Element generateResponse(ZimbraSoapContext zsc, ItemIdFormatter ifmt, OperationContext octxt,
+                                               Mailbox mbox, Message msg, boolean wantImapUid, boolean wantModSeq) {
+
+                return super.generateResponse(zsc, ifmt, octxt, mbox, msg, wantImapUid, wantModSeq);
+            }
+        }.handle(request, ServiceTestUtil.getRequestContext(acct));
+
+        Assert.assertFalse(response.getElement(MailConstants.E_MSG).getAttributeBool(MailConstants.A_DELIVERY_RECEIPT_NOTIFICATION, false));
+    }
 }

--- a/store/src/java/com/zimbra/cs/mailbox/AutoSendDraftTask.java
+++ b/store/src/java/com/zimbra/cs/mailbox/AutoSendDraftTask.java
@@ -17,6 +17,7 @@
 package com.zimbra.cs.mailbox;
 
 import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.MailConstants;
 import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.common.soap.SoapHttpTransport;
@@ -46,6 +47,7 @@ public class AutoSendDraftTask extends ScheduledTask<Object> {
     private Element request;
     public static final String ZIMBRA_MAILBOX_APP = "ZIMBRA_MAILBOX_APP";
     public static final String ZIMBRA_CONSTANT_VERSION = "1.0";
+    public static final String DELIVERY_RECEIPT_ENABLED = "1";
 
 
     public Server getServerName() {
@@ -118,12 +120,16 @@ public class AutoSendDraftTask extends ScheduledTask<Object> {
         mailSender.setIdentity(StringUtil.isNullOrEmpty(msg.getDraftIdentityId()) ? null : mbox.getAccount().getIdentityById(msg.getDraftIdentityId()));
         Provisioning provisioning = Provisioning.getInstance();
         Account delegatorAccount = provisioning.getAccountById(getDelegatorAccountId());
+        boolean deliveryReport = false;
         if (null != delegatorAccount) {
+            if (delegatorAccount.getBooleanAttr(Provisioning.A_zimbraFeatureDeliveryStatusNotificationEnabled, false)) {
+                deliveryReport = DELIVERY_RECEIPT_ENABLED.equals(msg.getMimeMessage().getHeader(MailConstants.A_DELIVERY_RECEIPT_NOTIFICATION, null));
+            }
             if (Provisioning.onLocalServer(delegatorAccount)) {
                 delegatorMbox = MailboxManager.getInstance().getMailboxByAccount(delegatorAccount);
             /* if delegator is on same server, just fetch the delegatorMbox object
             and use it for sending the Mime. */
-                mailSender.sendMimeMessage(new OperationContext(mbox), delegatorMbox, msg.getMimeMessage());
+                mailSender.sendMimeMessage(new OperationContext(mbox), delegatorMbox, msg.getMimeMessage(), deliveryReport);
             } else {
                 /* if delegator is on different server, invoke the saveDraft request on that server. */
                 Element reqForDelegatorAccount = getRequest();

--- a/store/src/java/com/zimbra/cs/mailbox/MailSender.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailSender.java
@@ -535,6 +535,11 @@ public class MailSender {
         return sendMimeMessage(octxt, mbox, mm);
     }
 
+    public ItemId sendMimeMessage(OperationContext operationContext, Mailbox delegatorMbox, MimeMessage mimeMessage, boolean deliveryReport) throws ServiceException {
+        mDeliveryReport = deliveryReport;
+        return sendMimeMessage(operationContext, delegatorMbox, mimeMessage);
+    }
+
     /**
      * Sends a message.
      */

--- a/store/src/java/com/zimbra/cs/service/mail/SaveDraft.java
+++ b/store/src/java/com/zimbra/cs/service/mail/SaveDraft.java
@@ -159,6 +159,7 @@ public class SaveDraft extends MailDocumentHandler {
                 Date d = new Date();
                 mm.setSentDate(d);
                 date = d.getTime();
+                mm.setHeader(MailConstants.A_DELIVERY_RECEIPT_NOTIFICATION, msgElem.getAttribute(MailConstants.A_DELIVERY_RECEIPT_NOTIFICATION, "0"));
             } catch (Exception ignored) {
             }
 
@@ -210,8 +211,12 @@ public class SaveDraft extends MailDocumentHandler {
                 }
                 if (oct != null && delegatorMbox != null) {
                     mm = ParseMimeMessage.parseMimeMsgSoap(zsc, oct, delegatorMbox, msgElem, null, mimeData);
+                    boolean deliveryReport = false;
+                    if (delegatorAccount.getBooleanAttr(Provisioning.A_zimbraFeatureDeliveryStatusNotificationEnabled, false)) {
+                        deliveryReport = msgElem.getAttributeBool(MailConstants.A_DELIVERY_RECEIPT_NOTIFICATION, false);
+                    }
                     SendMsg.doSendMessage(oct, delegatorMbox, mm, mimeData.uploads, null, "r", null, null, false,
-                            false, false, false);
+                            false, false, deliveryReport);
                 }
                 Element response = zsc.createElement(MailConstants.SAVE_DRAFT_RESPONSE);
                 response.addElement(MailConstants.E_MSG);

--- a/store/src/java/com/zimbra/cs/service/mail/SendMsg.java
+++ b/store/src/java/com/zimbra/cs/service/mail/SendMsg.java
@@ -132,8 +132,8 @@ public class SendMsg extends MailDocumentHandler {
                boolean noSaveToSent = request.getAttributeBool(MailConstants.A_NO_SAVE_TO_SENT, false);
                boolean fetchSavedMsg = request.getAttributeBool(MailConstants.A_FETCH_SAVED_MSG, false);
                boolean deliveryReport = false;
-               if (authAcct.getBooleanAttr(Provisioning.A_zimbraFeatureDeliveryStatusNotificationEnabled, false)) {
-                   deliveryReport = request.getAttributeBool(MailConstants.A_DELIVERY_RECEIPT_NOTIFICATION, false);
+               if (mbox.getAccount().getBooleanAttr(Provisioning.A_zimbraFeatureDeliveryStatusNotificationEnabled, false)) {
+                   deliveryReport = msgElem.getAttributeBool(MailConstants.A_DELIVERY_RECEIPT_NOTIFICATION, false);
                }
 
                String origId = msgElem.getAttribute(MailConstants.A_ORIG_ID, null);

--- a/store/src/java/com/zimbra/cs/service/mail/ToXML.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ToXML.java
@@ -1594,6 +1594,10 @@ public final class ToXML {
                     m.addAttribute(MailConstants.E_IN_REPLY_TO, StringUtil.stripControlCharacters(inReplyTo),
                             Element.Disposition.CONTENT);
                 }
+                String deliveryReport = mm.getHeader(MailConstants.A_DELIVERY_RECEIPT_NOTIFICATION, null);
+                if (!StringUtil.isNullOrEmpty(deliveryReport)) {
+                    m.addAttribute(MailConstants.A_DELIVERY_RECEIPT_NOTIFICATION, StringUtil.stripControlCharacters(deliveryReport));
+                }
                 if (msg.getDraftAutoSendTime() != 0) {
                     m.addAttribute(MailConstants.A_AUTO_SEND_TIME, msg.getDraftAutoSendTime());
                 }


### PR DESCRIPTION
[ZCS-16428](https://synacor.atlassian.net/browse/ZCS-16428)
Problem: Just like the deliveryReport attribute in the sendMsg request, we need a similar flag for the saveDraft request. This will help to save the draft state when user enabling or disabling email delivery status notifications from composer window (from 3 dot).

Solution: Fetch the attribute for deliveryReport from SaveDraftRequest (similar to SendMsg), then save it in Message Data. The deliveryReport then can be sent with the response and also is stored in Message. GetMsgRequest will fetch the attribute from Msg and send it as response. This can be read from UI to store the attribute in SendMsgRequest or when Re-using the same draft.

After storing the deliveryReport, it can be sent while scheduling messages. Before calling SendMimeMessage, check for the zimbraFeatureDeliveryStatusNotificationEnabled for the account. 

[ZCS-16428]: https://synacor.atlassian.net/browse/ZCS-16428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ