### PR TITLE
ZCS-16610: Ldap for DSN to store user preference

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -14613,6 +14613,15 @@ public class ZAttrProvisioning {
     public static final String A_zimbraPrefMailDefaultCharset = "zimbraPrefMailDefaultCharset";
 
     /**
+     * whether web UI should always request delivery status notification for
+     * outgoing messages
+     *
+     * @since ZCS 10.1.7
+     */
+    @ZAttr(id=4140)
+    public static final String A_zimbraPrefMailDeliveryStatusNotification = "zimbraPrefMailDeliveryStatusNotification";
+
+    /**
      * Flash icon when a new email arrives
      *
      * @since ZCS 5.0.7

--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1520,9 +1520,6 @@ public final class LC {
     @Supported
     public static final KnownKey zimbra_remote_cmd_channel_timeout_min = KnownKey.newKey(10);
 
-    @Supported
-    public static final KnownKey delivery_report_enabled = KnownKey.newKey(true);
-
     public static final KnownKey invite_ignore_x_alt_description = KnownKey.newKey(true);
 
     // TODO: ZCS-11319 move the following from LC to LDAP property.

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10560,4 +10560,9 @@ TODO: delete them permanently from here
   <defaultCOSValue>FALSE</defaultCOSValue>
   <desc>Feature to enable delivery status notification</desc>
 </attr>
+
+<attr id="4140" name="zimbraPrefMailDeliveryStatusNotification" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInherited" since="10.1.7">
+  <defaultCOSValue>FALSE</defaultCOSValue>
+  <desc>whether web UI should always request delivery status notification for outgoing messages</desc>
+</attr>
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -52993,6 +52993,83 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * whether web UI should always request delivery status notification for
+     * outgoing messages
+     *
+     * @return zimbraPrefMailDeliveryStatusNotification, or false if unset
+     *
+     * @since ZCS 10.1.7
+     */
+    @ZAttr(id=4140)
+    public boolean isPrefMailDeliveryStatusNotification() {
+        return getBooleanAttr(Provisioning.A_zimbraPrefMailDeliveryStatusNotification, false, true);
+    }
+
+    /**
+     * whether web UI should always request delivery status notification for
+     * outgoing messages
+     *
+     * @param zimbraPrefMailDeliveryStatusNotification new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.7
+     */
+    @ZAttr(id=4140)
+    public void setPrefMailDeliveryStatusNotification(boolean zimbraPrefMailDeliveryStatusNotification) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefMailDeliveryStatusNotification, zimbraPrefMailDeliveryStatusNotification ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * whether web UI should always request delivery status notification for
+     * outgoing messages
+     *
+     * @param zimbraPrefMailDeliveryStatusNotification new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.7
+     */
+    @ZAttr(id=4140)
+    public Map<String,Object> setPrefMailDeliveryStatusNotification(boolean zimbraPrefMailDeliveryStatusNotification, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefMailDeliveryStatusNotification, zimbraPrefMailDeliveryStatusNotification ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * whether web UI should always request delivery status notification for
+     * outgoing messages
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.7
+     */
+    @ZAttr(id=4140)
+    public void unsetPrefMailDeliveryStatusNotification() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefMailDeliveryStatusNotification, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * whether web UI should always request delivery status notification for
+     * outgoing messages
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.7
+     */
+    @ZAttr(id=4140)
+    public Map<String,Object> unsetPrefMailDeliveryStatusNotification(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefMailDeliveryStatusNotification, "");
+        return attrs;
+    }
+
+    /**
      * Flash icon when a new email arrives
      *
      * @return zimbraPrefMailFlashIcon, or false if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -42181,6 +42181,83 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * whether web UI should always request delivery status notification for
+     * outgoing messages
+     *
+     * @return zimbraPrefMailDeliveryStatusNotification, or false if unset
+     *
+     * @since ZCS 10.1.7
+     */
+    @ZAttr(id=4140)
+    public boolean isPrefMailDeliveryStatusNotification() {
+        return getBooleanAttr(Provisioning.A_zimbraPrefMailDeliveryStatusNotification, false, true);
+    }
+
+    /**
+     * whether web UI should always request delivery status notification for
+     * outgoing messages
+     *
+     * @param zimbraPrefMailDeliveryStatusNotification new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.7
+     */
+    @ZAttr(id=4140)
+    public void setPrefMailDeliveryStatusNotification(boolean zimbraPrefMailDeliveryStatusNotification) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefMailDeliveryStatusNotification, zimbraPrefMailDeliveryStatusNotification ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * whether web UI should always request delivery status notification for
+     * outgoing messages
+     *
+     * @param zimbraPrefMailDeliveryStatusNotification new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.7
+     */
+    @ZAttr(id=4140)
+    public Map<String,Object> setPrefMailDeliveryStatusNotification(boolean zimbraPrefMailDeliveryStatusNotification, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefMailDeliveryStatusNotification, zimbraPrefMailDeliveryStatusNotification ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * whether web UI should always request delivery status notification for
+     * outgoing messages
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.7
+     */
+    @ZAttr(id=4140)
+    public void unsetPrefMailDeliveryStatusNotification() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefMailDeliveryStatusNotification, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * whether web UI should always request delivery status notification for
+     * outgoing messages
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.7
+     */
+    @ZAttr(id=4140)
+    public Map<String,Object> unsetPrefMailDeliveryStatusNotification(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPrefMailDeliveryStatusNotification, "");
+        return attrs;
+    }
+
+    /**
      * Flash icon when a new email arrives
      *
      * @return zimbraPrefMailFlashIcon, or false if unset

--- a/store/src/java/com/zimbra/cs/mailbox/AutoSendDraftTask.java
+++ b/store/src/java/com/zimbra/cs/mailbox/AutoSendDraftTask.java
@@ -47,7 +47,6 @@ public class AutoSendDraftTask extends ScheduledTask<Object> {
     private Element request;
     public static final String ZIMBRA_MAILBOX_APP = "ZIMBRA_MAILBOX_APP";
     public static final String ZIMBRA_CONSTANT_VERSION = "1.0";
-    public static final String DELIVERY_RECEIPT_ENABLED = "1";
 
 
     public Server getServerName() {
@@ -123,7 +122,7 @@ public class AutoSendDraftTask extends ScheduledTask<Object> {
         boolean deliveryReport = false;
         if (null != delegatorAccount) {
             if (delegatorAccount.getBooleanAttr(Provisioning.A_zimbraFeatureDeliveryStatusNotificationEnabled, false)) {
-                deliveryReport = DELIVERY_RECEIPT_ENABLED.equals(msg.getMimeMessage().getHeader(MailConstants.A_DELIVERY_RECEIPT_NOTIFICATION, null));
+                deliveryReport = Boolean.parseBoolean(msg.getMimeMessage().getHeader(MailConstants.A_DELIVERY_RECEIPT_NOTIFICATION, null));
             }
             if (Provisioning.onLocalServer(delegatorAccount)) {
                 delegatorMbox = MailboxManager.getInstance().getMailboxByAccount(delegatorAccount);

--- a/store/src/java/com/zimbra/cs/service/mail/SaveDraft.java
+++ b/store/src/java/com/zimbra/cs/service/mail/SaveDraft.java
@@ -159,7 +159,7 @@ public class SaveDraft extends MailDocumentHandler {
                 Date d = new Date();
                 mm.setSentDate(d);
                 date = d.getTime();
-                mm.setHeader(MailConstants.A_DELIVERY_RECEIPT_NOTIFICATION, msgElem.getAttribute(MailConstants.A_DELIVERY_RECEIPT_NOTIFICATION, "0"));
+                mm.setHeader(MailConstants.A_DELIVERY_RECEIPT_NOTIFICATION, String.valueOf(msgElem.getAttributeBool(MailConstants.A_DELIVERY_RECEIPT_NOTIFICATION, false)));
             } catch (Exception ignored) {
             }
 

--- a/store/src/java/com/zimbra/cs/service/mail/ToXML.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ToXML.java
@@ -1594,10 +1594,8 @@ public final class ToXML {
                     m.addAttribute(MailConstants.E_IN_REPLY_TO, StringUtil.stripControlCharacters(inReplyTo),
                             Element.Disposition.CONTENT);
                 }
-                String deliveryReport = mm.getHeader(MailConstants.A_DELIVERY_RECEIPT_NOTIFICATION, null);
-                if (!StringUtil.isNullOrEmpty(deliveryReport)) {
-                    m.addAttribute(MailConstants.A_DELIVERY_RECEIPT_NOTIFICATION, StringUtil.stripControlCharacters(deliveryReport));
-                }
+                boolean deliveryReport = Boolean.parseBoolean(mm.getHeader(MailConstants.A_DELIVERY_RECEIPT_NOTIFICATION, null));
+                    m.addAttribute(MailConstants.A_DELIVERY_RECEIPT_NOTIFICATION, deliveryReport);
                 if (msg.getDraftAutoSendTime() != 0) {
                     m.addAttribute(MailConstants.A_AUTO_SEND_TIME, msg.getDraftAutoSendTime());
                 }


### PR DESCRIPTION
[ZCS-16610](https://synacor.atlassian.net/browse/ZCS-16610)

Problem: Add boolean LDAP attribute for user preference to always request delivery status notification. deliveryReport attribute in Request and response should be boolean.

Solution: Created LDAP attribute, parsed deliveryReport to boolean.

[ZCS-16610]: https://synacor.atlassian.net/browse/ZCS-16610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ