### PR TITLE
ZCS-16660: Update SOAP API Documentation for SendMsg, SaveDraft and SecureSendMsg

### DIFF
--- a/common/src/java/com/zimbra/common/gql/GqlConstants.java
+++ b/common/src/java/com/zimbra/common/gql/GqlConstants.java
@@ -710,4 +710,5 @@ public class GqlConstants {
 
     // GetAccount - admin api
     public static final String APPLY_COS = "applyCos";
+    public static final String DELIVERY_RECEIPT_NOTIFICATION = "deliveryReport";
 }

--- a/soap/src/java/com/zimbra/soap/mail/message/SendMsgRequest.java
+++ b/soap/src/java/com/zimbra/soap/mail/message/SendMsgRequest.java
@@ -105,13 +105,6 @@ public class SendMsgRequest {
     @XmlElement(name=MailConstants.E_MSG /* m */, required=false)
     private MsgToSend msg;
 
-    /**
-     * @zm-api-field-tag delivery-receipt-notification
-     * @zm-api-field-description If set, delivery receipt notification will be sent.
-     */
-    @XmlAttribute(name=MailConstants.A_DELIVERY_RECEIPT_NOTIFICATION /* deliveryReport */, required=false)
-    private ZmBoolean deliveryReport;
-
     public SendMsgRequest() {
     }
 
@@ -131,10 +124,6 @@ public class SendMsgRequest {
         this.fetchSavedMsg = ZmBoolean.fromBool(fetchSavedMsg);
     }
 
-    public void setDeliveryReport(Boolean deliveryReport) {
-        this.deliveryReport = ZmBoolean.fromBool(deliveryReport);
-    }
-
     public void setSendUid(String sendUid) { this.sendUid = sendUid; }
     public void setMsg(MsgToSend msg) { this.msg = msg; }
 
@@ -143,7 +132,6 @@ public class SendMsgRequest {
     public Boolean getNoSaveToSent() { return ZmBoolean.toBool(noSaveToSent); }
     public Boolean getFetchSavedMsg() { return ZmBoolean.toBool(fetchSavedMsg); }
     public String getSendUid() { return sendUid; }
-    public Boolean getDeliveryReport() { return ZmBoolean.toBool(deliveryReport); }
     public MsgToSend getMsg() { return msg; }
 
     public MoreObjects.ToStringHelper addToStringInfo(MoreObjects.ToStringHelper helper) {
@@ -153,7 +141,6 @@ public class SendMsgRequest {
             .add("noSaveToSent", noSaveToSent)
             .add("fetchSavedMsg", fetchSavedMsg)
             .add("sendUid", sendUid)
-            .add("deliveryReport", deliveryReport)
             .add("msg", msg);
     }
 

--- a/soap/src/java/com/zimbra/soap/mail/type/MsgToSend.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/MsgToSend.java
@@ -56,6 +56,13 @@ extends Msg {
     @XmlAttribute(name=MailConstants.A_DATASOURCE_ID /* dsId */, required=false)
     private String dataSourceId;
 
+    /**
+     * @zm-api-field-tag delivery-receipt-notification
+     * @zm-api-field-description If set, delivery receipt notification will be sent.
+     */
+    @XmlAttribute(name=MailConstants.A_DELIVERY_RECEIPT_NOTIFICATION /* deliveryReport */, required=false)
+    private ZmBoolean deliveryReport;
+
     public MsgToSend() {
     }
 
@@ -73,13 +80,18 @@ extends Msg {
     public void setDataSourceId(String dsId) { this.dataSourceId = dsId; }
     public String getDataSourceId() { return dataSourceId; }
 
+    @GraphQLInputField(name=GqlConstants.DELIVERY_RECEIPT_NOTIFICATION, description="Whether to enable DSN for the outgoing message")
+    public void setDeliveryReport(Boolean deliveryReport) { this.deliveryReport = ZmBoolean.fromBool(deliveryReport); }
+    public Boolean getDeliveryReport() { return ZmBoolean.toBool(deliveryReport); }
+
     @Override
     public MoreObjects.ToStringHelper addToStringInfo(MoreObjects.ToStringHelper helper) {
         helper = super.addToStringInfo(helper);
         return helper
             .add("draftId", draftId)
             .add("sendFromDraft", sendFromDraft)
-            .add("dataSourceId", dataSourceId);
+            .add("dataSourceId", dataSourceId)
+            .add("deliveryReport", deliveryReport);
     }
 
     @Override

--- a/soap/src/java/com/zimbra/soap/mail/type/SaveDraftMsg.java
+++ b/soap/src/java/com/zimbra/soap/mail/type/SaveDraftMsg.java
@@ -23,6 +23,7 @@ import javax.xml.bind.annotation.XmlAttribute;
 
 import com.google.common.base.MoreObjects;
 import com.zimbra.common.soap.MailConstants;
+import com.zimbra.soap.type.ZmBoolean;
 
 @XmlAccessorType(XmlAccessType.NONE)
 public class SaveDraftMsg extends Msg {
@@ -77,6 +78,13 @@ public class SaveDraftMsg extends Msg {
     @XmlAttribute(name=MailConstants.A_AUTO_SEND_TIME /* autoSendTime */, required=false)
     private Long autoSendTime;
 
+    /**
+     * @zm-api-field-tag delivery-receipt-notification
+     * @zm-api-field-description If set, delivery receipt notification will be sent.
+     */
+    @XmlAttribute(name=MailConstants.A_DELIVERY_RECEIPT_NOTIFICATION /* deliveryReport */, required=false)
+    private ZmBoolean deliveryReport;
+
     public SaveDraftMsg() {
     }
 
@@ -92,6 +100,9 @@ public class SaveDraftMsg extends Msg {
     public void setAutoSendTime(Long autoSendTime) {
         this.autoSendTime = autoSendTime;
     }
+    public void setDeliveryReport(Boolean deliveryReport) {
+        this.deliveryReport = ZmBoolean.fromBool(deliveryReport);
+    }
 
     public Integer getId() { return id; }
     public String getDraftAccountId() { return draftAccountId; }
@@ -101,6 +112,7 @@ public class SaveDraftMsg extends Msg {
     public String getRgb() { return rgb; }
     public Byte getColor() { return color; }
     public Long getAutoSendTime() { return autoSendTime; }
+    public Boolean getDeliveryReport() { return ZmBoolean.toBool(deliveryReport); }
 
     @Override
     public MoreObjects.ToStringHelper addToStringInfo(MoreObjects.ToStringHelper helper) {
@@ -112,7 +124,8 @@ public class SaveDraftMsg extends Msg {
             .add("tagNames", tagNames)
             .add("rgb", rgb)
             .add("color", color)
-            .add("autoSendTime", autoSendTime);
+            .add("autoSendTime", autoSendTime)
+            .add("deliveryReport", deliveryReport);
     }
 
     @Override


### PR DESCRIPTION
[ZCS-16660](https://synacor.atlassian.net/browse/ZCS-16660)

Problem: The SOAP API Documentation needs to be updated to show "deliveryReport" attribute in msgElem of the requests.

Solution: Updated the documentation.

[ZCS-16660]: https://synacor.atlassian.net/browse/ZCS-16660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ