### PR TITLE
ZCS-16704 added functionality to handle secondary as internal for mailboxmove

### DIFF
--- a/store/src/java/com/zimbra/cs/store/StoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/StoreManager.java
@@ -263,6 +263,18 @@ public abstract class StoreManager {
     public abstract BlobBuilder getBlobBuilder() throws IOException, ServiceException;
 
     /**
+     * Returns a 'BlobBuilder' which can be used to store a blob in incoming
+     * directory asynchronously one chunk at a time. Blob will be compressed
+     * if volume supports compression and blob size is over the compression
+     * threshold.
+     * @param volume
+     * @return the BlobBuilder to use to construct the Blob
+     * @throws IOException if an I/O error occurred
+     * @throws ServiceException if a service exception occurred
+     */
+    public abstract BlobBuilder getBlobBuilder(Volume volume) throws IOException, ServiceException;
+
+    /**
      * Store a blob in incoming directory.  Blob will be compressed if volume supports compression
      * and blob size is over the compression threshold.
      * @param data
@@ -278,6 +290,22 @@ public abstract class StoreManager {
     }
 
     /**
+     * Store a blob in incoming directory.  Blob will be compressed if volume supports compression
+     * and blob size is over the compression threshold.
+     * @param data
+     * @param sizeHint used for determining whether data should be compressed
+     * @param digest
+     * @param vol
+     * @return
+     * @throws IOException
+     * @throws ServiceException
+     */
+    public Blob storeIncoming(InputStream data, Volume vol)
+            throws IOException, ServiceException {
+        return storeIncoming(data, false, vol);
+    }
+
+    /**
      * Store a blob in incoming directory.
      * @param data
      * @param callback
@@ -288,6 +316,19 @@ public abstract class StoreManager {
      */
     public abstract Blob storeIncoming(InputStream data, boolean storeAsIs)
     throws IOException, ServiceException;
+
+    /**
+     * Store a blob in incoming directory.
+     * @param data
+     * @param callback
+     * @param storeAsIs if true, store the blob as is even if volume supports compression
+     * @param volume
+     * @return
+     * @throws IOException
+     * @throws ServiceException
+     */
+    public abstract Blob storeIncoming(InputStream data, boolean storeAsIs, Volume volume)
+            throws IOException, ServiceException;
 
     /**
      * Stage an incoming <code>InputStream</code> to an
@@ -401,6 +442,21 @@ public abstract class StoreManager {
      */
     public abstract MailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destMsgId, int destRevision)
     throws IOException, ServiceException;
+
+    /**
+     * Rename a blob to a blob in mailbox directory.
+     * This effectively makes the StagedBlob permanent, implementations may not need to do anything if the stage operation creates permanent items
+     * @param src
+     * @param destMbox
+     * @param destMsgId mail_item.id value for message in destMbox
+     * @param destRevision mail_item.mod_content value for message in destMbox
+     * @param volume volume info
+     * @return MailboxBlob object representing the renamed blob
+     * @throws IOException
+     * @throws ServiceException
+     */
+    public abstract MailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destMsgId, int destRevision, Volume volume)
+            throws IOException, ServiceException;
 
     /**
      * Deletes a blob from incoming directory.  If blob doesn't exist, no exception is

--- a/store/src/java/com/zimbra/cs/store/external/ExternalStoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/external/ExternalStoreManager.java
@@ -179,6 +179,11 @@ public abstract class ExternalStoreManager extends StoreManager implements Exter
     }
 
     @Override
+    public BlobBuilder getBlobBuilder(Volume volume) throws IOException, ServiceException {
+        throw new UnsupportedOperationException("method not supported");
+    }
+
+    @Override
     public InputStream getContent(MailboxBlob mblob) throws IOException {
         if (mblob == null) {
             return null;
@@ -242,6 +247,12 @@ public abstract class ExternalStoreManager extends StoreManager implements Exter
 
         MailboxBlob mblob = new ExternalMailboxBlob(destMbox, destMsgId, destRevision, staged.getLocator());
         return mblob.setSize(staged.getSize()).setDigest(staged.getDigest());
+    }
+
+    @Override
+    public MailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destMsgId, int destRevision, Volume volume) throws IOException,
+            ServiceException {
+       throw new UnsupportedOperationException("method not supported");
     }
 
     @Override
@@ -367,6 +378,12 @@ public abstract class ExternalStoreManager extends StoreManager implements Exter
         // if the blob is already compressed, *don't* calculate a digest/size from what we write
         builder.disableCompression(storeAsIs).disableDigest(storeAsIs);
         return builder.init().append(data).finish();
+    }
+
+    @Override
+    public Blob storeIncoming(InputStream data, boolean storeAsIs, Volume volume) throws IOException,
+            ServiceException {
+        throw new UnsupportedOperationException("method not supported");
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/store/file/FileBlobStore.java
+++ b/store/src/java/com/zimbra/cs/store/file/FileBlobStore.java
@@ -19,6 +19,8 @@ package com.zimbra.cs.store.file;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Objects;
+import java.util.Optional;
 
 import com.zimbra.common.localconfig.DebugConfig;
 import com.zimbra.common.localconfig.LC;
@@ -84,7 +86,12 @@ public final class FileBlobStore extends StoreManager {
     }
 
     private Blob getUniqueIncomingBlob() throws IOException, ServiceException {
-        Volume volume = MANAGER.getCurrentMessageVolume();
+        return getUniqueIncomingBlob(null);
+    }
+
+    private Blob getUniqueIncomingBlob(Volume volume) throws IOException, ServiceException {
+        volume = Optional.ofNullable(volume)
+                .orElseGet(MANAGER::getCurrentMessageVolume);
         IncomingDirectory incdir = volume.getIncomingDirectory();
         if (incdir == null) {
             throw ServiceException.FAILURE("storing blob to volume without incoming directory: " + volume.getName(), null);
@@ -96,17 +103,27 @@ public final class FileBlobStore extends StoreManager {
 
     @Override
     public BlobBuilder getBlobBuilder() throws IOException, ServiceException {
-        Blob blob = getUniqueIncomingBlob();
+        return getBlobBuilder(null);
+    }
+
+    @Override
+    public BlobBuilder getBlobBuilder(Volume volume) throws IOException, ServiceException {
+        Blob blob = (Objects.isNull(volume)) ? getUniqueIncomingBlob() : getUniqueIncomingBlob(volume);
         return new VolumeBlobBuilder(blob);
     }
 
     @Override
     public Blob storeIncoming(InputStream in, boolean storeAsIs)
     throws IOException, ServiceException {
-        BlobBuilder builder = getBlobBuilder();
+        return storeIncoming(in, storeAsIs, null);
+    }
+
+    @Override
+    public Blob storeIncoming(InputStream in, boolean storeAsIs, Volume volume)
+            throws IOException, ServiceException {
+        BlobBuilder builder = (Objects.isNull(volume)) ? getBlobBuilder() : getBlobBuilder(volume);
         // if the blob is already compressed, *don't* calculate a digest/size from what we write
         builder.disableCompression(storeAsIs).disableDigest(storeAsIs);
-
         return builder.init().append(in).finish();
     }
 
@@ -114,14 +131,14 @@ public final class FileBlobStore extends StoreManager {
     public VolumeStagedBlob stage(InputStream in, long actualSize, Mailbox mbox)
     throws IOException, ServiceException {
         // mailbox store is on the same volume as incoming directory, so just storeIncoming() and wrap it
-        Blob blob = storeIncoming(in);
-        return new VolumeStagedBlob(mbox, (VolumeBlob) blob).markStagedDirectly();
+        return new VolumeStagedBlob(mbox, (VolumeBlob) storeIncoming(in))
+                .markStagedDirectly();
     }
 
     @Override
     public StagedBlob stage(InputStream data, long actualSize, Mailbox mbox, Volume volume) throws IOException, ServiceException {
-        // mailbox store is on the same volume as incoming directory, so no need to stage the blob
-        throw ServiceException.FAILURE("Operation can not be completed because the required StoreManager is not available", null);
+        return new VolumeStagedBlob(mbox, (VolumeBlob) storeIncoming(data, volume))
+                .markStagedDirectly();
     }
 
     @Override
@@ -284,7 +301,14 @@ public final class FileBlobStore extends StoreManager {
     @Override
     public VolumeMailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destItemId, int destRevision)
     throws IOException, ServiceException {
-        Volume volume = MANAGER.getCurrentMessageVolume();
+        return renameTo(src, destMbox, destItemId, destRevision, null);
+    }
+
+    @Override
+    public VolumeMailboxBlob renameTo(StagedBlob src, Mailbox destMbox, int destItemId, int destRevision, Volume volume)
+            throws IOException, ServiceException {
+        volume = Optional.ofNullable(volume)
+                .orElseGet(MANAGER::getCurrentMessageVolume);
         VolumeBlob blob = ((VolumeStagedBlob) src).getLocalBlob();
         File srcFile = blob.getFile();
         String srcPath = srcFile.getAbsolutePath();
@@ -301,22 +325,23 @@ public final class FileBlobStore extends StoreManager {
             long srcSize = srcFile.length();
             long srcRawSize = blob.getRawSize();
             ZimbraLog.store.debug("Renaming %s (size=%d, raw size=%d) to %s for mailbox %d, id %d.",
-                srcPath, srcSize, srcRawSize, destPath, destMbox.getId(), destItemId);
+                    srcPath, srcSize, srcRawSize, destPath, destMbox.getId(), destItemId);
         }
 
         short srcVolumeId = blob.getVolumeId();
         if (srcVolumeId == volume.getId()) {
             boolean renamed = srcFile.renameTo(destFile);
             if (SystemUtil.ON_WINDOWS) {
-                // On Windows renameTo fails if the dest already exists.  So delete
+                // on Windows renameTo fails if the dest already exists.  So delete
                 // the destination and try the rename again
                 if (!renamed && destFile.exists()) {
                     destFile.delete();
                     renamed = srcFile.renameTo(destFile);
                 }
             }
-            if (!renamed)
+            if (!renamed) {
                 throw new IOException("Unable to rename " + srcPath + " to " + destPath);
+            }
         } else {
             // Can't rename across volumes.  Copy then delete instead.
             FileUtil.copy(srcFile, destFile, !DebugConfig.disableMessageStoreFsync);


### PR DESCRIPTION
Secondary volume data on External S3 is moved to Primary volume when moving mailbox from 10.1.6 to 10.1.6