### PR TITLE
ZCS-16669: Mobile devices stop working until mailbox service restart

### DIFF
--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -18,6 +18,7 @@
 package com.zimbra.client;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -41,6 +42,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.UUID;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -3508,7 +3510,16 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
 
             // parse the response
             if (statusCode == HttpServletResponse.SC_OK) {
-                return new GetMethodInputStream(response.getEntity().getContent());
+                // copy the response content to a ByteArrayInputStream to allow multiple reads even after the connection is released
+                try (InputStream inputStream = new GetMethodInputStream(response.getEntity().getContent())) {
+                    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+                    byte[] buffer = new byte[1024];
+                    int bytesRead;
+                    while ((bytesRead = inputStream.read(buffer)) != -1) {
+                        byteArrayOutputStream.write(buffer, 0, bytesRead);
+                    }
+                    return new ByteArrayInputStream(byteArrayOutputStream.toByteArray());
+                }
             } else {
                 String msg = String.format("GET from %s failed, status=%d.  %s", uri, statusCode, response.getStatusLine().getReasonPhrase());
                 throw ServiceException.FAILURE(msg, null);
@@ -3516,6 +3527,9 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
         } catch (IOException | HttpException e) {
             String msg = String.format("Unable to get resource from '%s' : %s", uri, e.getMessage());
             throw ZClientException.IO_ERROR(msg, e);
+        } finally {
+            // release the connection to the connection manager
+            Optional.ofNullable(get).ifPresent(HttpGet::releaseConnection);
         }
     }
 


### PR DESCRIPTION
[ZCS-16669](https://synacor.atlassian.net/browse/ZCS-16669)

Problem: When we try to sync multiple shared folders with large amount of emails to mobile devices, the syncing gets stuck after few folders and the mailbox is also stuck until we restart the mailbox.

Solution: While fetching the email content from the shared mailbox, the connection did not get released back to the connection pool resulting in exhaustion of the pool and not further requests gets processed. 

Added the logic to release the connection after getting the response.

[ZCS-16669]: https://synacor.atlassian.net/browse/ZCS-16669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ