### PR TITLE
ZBUG-4554: Issue with Calendar Synchronization Post Upgrade

### DIFF
--- a/store/src/java/com/zimbra/cs/index/Fragment.java
+++ b/store/src/java/com/zimbra/cs/index/Fragment.java
@@ -176,7 +176,7 @@ public class Fragment {
     }
 
     public static String getFragment(String content, Source item) {
-        String remainder = content.trim();
+        String remainder = content == null ? "" : content.trim();
         String backup    = remainder;
         StringBuilder fragment = new StringBuilder();
         String result;


### PR DESCRIPTION
Problem: When modifying a calendar event on an iOS device results in Null pointer exception.

Solution: Added null check for description in getFragment.