### PR TITLE
ZCS-16703 Logic for handling external storage in secondary volume for mailboxmove from 9.0 to 10.0

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1438,6 +1438,8 @@ public final class LC {
 
     public static final KnownKey enable_delegated_admin_ldap_access = KnownKey.newKey(true);
 
+    public static final KnownKey primary_store_manager_class = KnownKey.newKey("");
+    public static final KnownKey secondary_store_manager_class = KnownKey.newKey("");
     // OAuth2 Social
     public static final KnownKey zm_oauth_classes_handlers_yahoo = KnownKey.newKey("com.zimbra.oauth.handlers.impl.YahooOAuth2Handler");
     public static final KnownKey zm_oauth_classes_handlers_google = KnownKey.newKey("com.zimbra.oauth.handlers.impl.GoogleOAuth2Handler");

--- a/common/src/java/com/zimbra/common/soap/BackupConstants.java
+++ b/common/src/java/com/zimbra/common/soap/BackupConstants.java
@@ -55,6 +55,8 @@ public final class BackupConstants {
     public static final String E_UNREGISTER_MAILBOX_MOVE_OUT_RESPONSE = "UnregisterMailboxMoveOutResponse";
     public static final String E_QUERY_MAILBOX_MOVE_REQUEST = "QueryMailboxMoveRequest";
     public static final String E_QUERY_MAILBOX_MOVE_RESPONSE = "QueryMailboxMoveResponse";
+    public static final String E_GET_MAILBOX_CURRENT_VOLUMES_REQUEST = "GetMailboxCurrentVolumesRequest";
+    public static final String E_GET_MAILBOX_CURRENT_VOLUMES_RESPONSE = "GetMailboxCurrentVolumesResponse";
 
     public static final QName EXPORTMAILBOX_REQUEST = QName.get(E_EXPORTMAILBOX_REQUEST, NAMESPACE);
     public static final QName EXPORTMAILBOX_RESPONSE = QName.get(E_EXPORTMAILBOX_RESPONSE, NAMESPACE);
@@ -92,6 +94,8 @@ public final class BackupConstants {
     public static final QName UNREGISTER_MAILBOX_MOVE_OUT_RESPONSE = QName.get(E_UNREGISTER_MAILBOX_MOVE_OUT_RESPONSE, NAMESPACE);
     public static final QName QUERY_MAILBOX_MOVE_REQUEST = QName.get(E_QUERY_MAILBOX_MOVE_REQUEST, NAMESPACE);
     public static final QName QUERY_MAILBOX_MOVE_RESPONSE = QName.get(E_QUERY_MAILBOX_MOVE_RESPONSE, NAMESPACE);
+    public static final QName GET_MAILBOX_CURRENT_VOLUMES_REQUEST = QName.get(E_GET_MAILBOX_CURRENT_VOLUMES_REQUEST, NAMESPACE);
+    public static final QName GET_MAILBOX_CURRENT_VOLUMES_RESPONSE = QName.get(E_GET_MAILBOX_CURRENT_VOLUMES_RESPONSE, NAMESPACE);
 
     public static final String ZM_SCHEDULE_BACKUP = "zmschedulebackup";
 

--- a/soap/src/java/com/zimbra/soap/admin/message/GetMailboxCurrentVolumesRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/GetMailboxCurrentVolumesRequest.java
@@ -1,0 +1,55 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite, Network Edition.
+ * Copyright (C) 2022 Zimbra, Inc.  All Rights Reserved.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.google.common.base.MoreObjects;
+import com.zimbra.common.soap.BackupConstants;
+import com.zimbra.soap.admin.type.Name;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name = BackupConstants.E_GET_MAILBOX_CURRENT_VOLUMES_REQUEST)
+public class GetMailboxCurrentVolumesRequest {
+    /**
+     * @zm-api-field-tag account-email-address
+     * @zm-api-field-description Account email address
+     */
+    @XmlElement(name=BackupConstants.E_ACCOUNT /* account */, required=true)
+    private Name account;
+
+    private GetMailboxCurrentVolumesRequest() {
+    }
+
+    private GetMailboxCurrentVolumesRequest(Name account) {
+        setAccount(account);
+    }
+
+    public static GetMailboxCurrentVolumesRequest create(Name account) {
+        return new GetMailboxCurrentVolumesRequest(account);
+    }
+
+    public void setAccount(Name account) { this.account = account; }
+    public Name getAccount() { return account; }
+
+    public MoreObjects.ToStringHelper addToStringInfo(
+            MoreObjects.ToStringHelper helper) {
+        return helper
+                .add("account", account);
+    }
+
+    @Override
+    public String toString() {
+        return addToStringInfo(MoreObjects.toStringHelper(this))
+                .toString();
+    }
+
+
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/GetMailboxCurrentVolumesResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/GetMailboxCurrentVolumesResponse.java
@@ -1,0 +1,56 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite, Network Edition.
+ * Copyright (C) 2022 Zimbra, Inc.  All Rights Reserved.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+import com.google.common.base.MoreObjects;
+import com.zimbra.common.soap.BackupConstants;
+import com.zimbra.soap.admin.type.MailboxVolumesInfo;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name=BackupConstants.E_GET_MAILBOX_CURRENT_VOLUMES_RESPONSE)
+@XmlType(propOrder = {})
+public class GetMailboxCurrentVolumesResponse {
+    /**
+     * @zm-api-field-description Mailbox Volume Information
+     */
+    @XmlElement(name=BackupConstants.E_ACCOUNT /* account */, required=true)
+    private MailboxVolumesInfo account;
+
+    private GetMailboxCurrentVolumesResponse() {
+    }
+
+    private GetMailboxCurrentVolumesResponse(MailboxVolumesInfo account) {
+        setAccount(account);
+    }
+
+    public static GetMailboxCurrentVolumesResponse create(MailboxVolumesInfo account) {
+        return new GetMailboxCurrentVolumesResponse(account);
+    }
+
+    public void setAccount(MailboxVolumesInfo account) { this.account = account; }
+    public MailboxVolumesInfo getAccount() { return account; }
+
+    public MoreObjects.ToStringHelper addToStringInfo(
+            MoreObjects.ToStringHelper helper) {
+        return helper
+                .add("account", account);
+    }
+
+    @Override
+    public String toString() {
+        return addToStringInfo(MoreObjects.toStringHelper(this))
+                .toString();
+    }
+
+
+}

--- a/store/src/java/com/zimbra/cs/mailbox/util/MailItemHelper.java
+++ b/store/src/java/com/zimbra/cs/mailbox/util/MailItemHelper.java
@@ -1,0 +1,41 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.mailbox.util;
+
+import org.apache.commons.lang.StringUtils;
+
+import java.util.Optional;
+
+public class MailItemHelper {
+
+    public static final String VOL_ID_LOCATOR_SEPARATOR = "@@";
+
+    public static Optional<Short> findMyVolumeId(String locator) {
+
+        if (StringUtils.isNumeric(locator)) {
+            return Optional.of(Short.valueOf(locator));
+        }
+
+        if (locator.contains(VOL_ID_LOCATOR_SEPARATOR)) {
+            String[] parts = locator.split(VOL_ID_LOCATOR_SEPARATOR, 2);
+            if (parts.length ==  2 && StringUtils.isNumeric(parts[0])) {
+                return Optional.of(Short.valueOf(parts[0]));
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/store/src/java/com/zimbra/cs/store/CacheEnabledStoreManagerProvider.java
+++ b/store/src/java/com/zimbra/cs/store/CacheEnabledStoreManagerProvider.java
@@ -1,0 +1,98 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.store;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.zimbra.common.localconfig.LC;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.store.helper.ClassHelper;
+import com.zimbra.cs.volume.Volume;
+import com.zimbra.cs.volume.VolumeManager;
+
+import java.io.IOException;
+
+/**
+ * Cache enable store manager provier
+ */
+public class CacheEnabledStoreManagerProvider {
+
+    private static final String FILE_BLOB_STORE = "FileBlobStore";
+    private static final String DEFAULT_CLASS_NAME = "com.zimbra.cs.store.file.FileBlobStore";
+
+    /**
+     * StoreManager cache
+     */
+    private static final LoadingCache<Short, StoreManager> volumeStoreManagerCacheLoader = CacheBuilder.newBuilder()
+            .build(new CacheLoader<Short, StoreManager>() {
+                @Override
+                public StoreManager load(final Short volumeId) throws Exception {
+                    return getStoreManagerForVolume(volumeId);
+                }
+            });
+
+    /**
+     * Return StoreManager from cache if skiCache false otherwise cache object will be returned
+     * @param volumeId
+     * @param skipCache
+     * @return
+     * @throws Exception
+     */
+    public static StoreManager getStoreManagerForVolume(Short volumeId, boolean skipCache) throws Exception {
+        if (!skipCache) {
+            ZimbraLog.store.trace("Store Manager cached for %s", volumeId);
+            return volumeStoreManagerCacheLoader.get(volumeId);
+        }
+        return getStoreManagerForVolume(volumeId);
+    }
+
+    private static StoreManager getStoreManagerForVolume(Short volumeId) throws ServiceException {
+        // load volume
+        Volume volume = VolumeManager.getInstance().getVolume(volumeId);
+        String className = DEFAULT_CLASS_NAME;
+        if (volume.getType() == Volume.TYPE_MESSAGE) {
+            className = LC.primary_store_manager_class.value();
+        } else if (volume.getType() == Volume.TYPE_MESSAGE_SECONDARY) {
+            className = LC.secondary_store_manager_class.value();
+        }
+        if (!className.contains(FILE_BLOB_STORE)) {
+            return StoreManager.getInstance(className);
+        }
+        StoreManager storeManager = null;
+        try {
+            ZimbraLog.store.debug("loading Store Manager: %s for %s", className, volumeId);
+            storeManager = (StoreManager) ClassHelper.getZimbraClassInstanceBy(className);
+            ZimbraLog.store.debug("StoreManager loaded, starting up");
+            storeManager.startup();
+        } catch (ReflectiveOperationException e) {
+            String msg = "error while loading StoreManager class: " + className;
+            ZimbraLog.store.error(msg, e);
+            throw ServiceException.FAILURE(msg, e);
+        } catch (IOException e) {
+            String msg = "error while StoreManager.startup() for class: " + className;
+            ZimbraLog.store.error(msg, e);
+            throw ServiceException.FAILURE(msg, e);
+        }
+        return storeManager;
+    }
+
+    protected static void refreshCache(short volumeId) {
+        volumeStoreManagerCacheLoader.refresh(volumeId);
+    }
+}

--- a/store/src/java/com/zimbra/cs/store/StoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/StoreManager.java
@@ -18,9 +18,11 @@ package com.zimbra.cs.store;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Optional;
 
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.Server;
@@ -28,17 +30,32 @@ import com.zimbra.cs.extension.ExtensionUtil;
 import com.zimbra.cs.imap.ImapDaemon;
 import com.zimbra.cs.mailbox.MailItem;
 import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.util.MailItemHelper;
 import com.zimbra.cs.store.file.FileBlobStore;
+import com.zimbra.cs.store.helper.ClassHelper;
 import com.zimbra.cs.util.Zimbra;
+import com.zimbra.cs.volume.VolumeManager;
 
 public abstract class StoreManager {
 
     private static StoreManager sInstance;
     private static Integer diskStreamingThreshold;
+    private static String currentZimbraClassStore = LC.zimbra_class_store.value();
+
 
     public static StoreManager getInstance () {
         if(ImapDaemon.isRunningImapInsideMailboxd()) {
-            return getInstance(LC.zimbra_class_store.value());
+            ZimbraLog.store.debug("Actual StoreManager currentZimbraClassStore:%s, zimbra_class_store:%s", currentZimbraClassStore, LC.zimbra_class_store.value());
+            // if it's different from current set in localConfig
+            synchronized (StoreManager.class) {
+                if (!LC.zimbra_class_store.value().equals(currentZimbraClassStore)) {
+                    ZimbraLog.store.warn("currentZimbraClassStore:%s, is different than zimbra_class_store:%s", currentZimbraClassStore, LC.zimbra_class_store.value());
+                    sInstance = null;
+                }
+            }
+            StoreManager instance = getInstance(LC.zimbra_class_store.value());
+            ZimbraLog.store.trace("StorageManager actualInstance:%s,  Thread: %s", instance.getClass().getName(), Thread.currentThread().getName());
+            return instance;
         } else {
             return getInstance(LC.imapd_class_store.value());
         }
@@ -52,12 +69,10 @@ public abstract class StoreManager {
                 }
 
                 try {
-                    if (className != null && !className.equals("")) {
-                        try {
-                            sInstance = (StoreManager) Class.forName(className).newInstance();
-                        } catch (ClassNotFoundException e) {
-                            sInstance = (StoreManager) ExtensionUtil.findClass(className).newInstance();
-                        }
+                    if (!StringUtil.isNullOrEmpty(className)) {
+                        sInstance = (StoreManager) ClassHelper.getZimbraClassInstanceBy(className);
+                        currentZimbraClassStore = className;
+                        ZimbraLog.store.debug("currentZimbraClassStore set to: %s", className);
                     } else {
                         sInstance = new FileBlobStore();
                     }
@@ -423,5 +438,51 @@ public abstract class StoreManager {
      */
     public IncomingBlob newIncomingBlob(String id, Object ctxt) throws IOException, ServiceException {
         return new BufferingIncomingBlob(id, getBlobBuilder(), ctxt);
+    }
+
+    /**
+     * Get StoreManager instance from locator, in case locator have that information
+     * @param locator
+     * @return
+     */
+    public static StoreManager getReaderSMInstance(String locator) {
+        try {
+            if (!StringUtil.isNullOrEmpty(locator)) {
+                Optional<Short> volumeId = MailItemHelper.findMyVolumeId(locator);
+                if (volumeId.isPresent()) {
+                    return getReaderSMInstance(volumeId.get());
+                }
+            }
+        } catch (Exception e) {
+            ZimbraLog.store.error("Error while loading StoreManager for locator %s", locator, e);
+        }
+        ZimbraLog.store.info("Fallback: master StoreManager will be used for reading");
+        return getInstance();
+    }
+
+    /**
+     * In order to support multiple stores of different types, sometimes it required to write multiple store managers as well.
+     * Imagine a case where blobs were written to respective volume using storeManager1(aware of R/W operations)
+     * And months later, primary volume changed and storeManager2 introduced to work with new volume(storeManager2 awareR/W with new volume)
+     * Here, system should support older blobs which are in inbox where storeManager1 know how to read and
+     * storeManager2 aware of how to write/read new blobs in new volume.
+     * Now in this heterogeneous situation, there can be multiple reader(for reading older blobs from multiple old primary volumes
+     * and secondary volumes) and single writer(for writing and reading current primary volume)
+     * Following method returns respective reader StoreManager instance based on locator.
+     * @param volumeId
+     * @return
+     */
+    public static StoreManager getReaderSMInstance(short volumeId) {
+        try {
+            StoreManager storeManager = CacheEnabledStoreManagerProvider.getStoreManagerForVolume(volumeId, false);
+            if (storeManager != null) {
+                ZimbraLog.store.trace("StoreManager for %s Volume: %s ", storeManager.getClass().getSimpleName(), volumeId);
+                return storeManager;
+            }
+        } catch(Exception e){
+            ZimbraLog.store.error("Error while loading StoreManager for volumeId %s", volumeId, e);
+        }
+        ZimbraLog.store.trace("Fallback: master StoreManager will be used for reading");
+        return getInstance();
     }
 }

--- a/store/src/java/com/zimbra/cs/store/helper/ClassHelper.java
+++ b/store/src/java/com/zimbra/cs/store/helper/ClassHelper.java
@@ -1,0 +1,62 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.store.helper;
+
+import com.zimbra.common.util.StringUtil;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.extension.ExtensionUtil;
+
+/**
+ * Class helper
+ */
+public class ClassHelper {
+
+    /**
+     * Check if the class exist on class path
+     * @param classPath
+     * @return
+     */
+    public static boolean isClassExist(String classPath) {
+        if (!StringUtil.isNullOrEmpty(classPath)) {
+            try {
+                try {
+                    Class.forName(classPath);
+                } catch (ClassNotFoundException e) {
+                    ExtensionUtil.findClass(classPath);
+                }
+                return true;
+            } catch (Exception e) {
+                ZimbraLog.store.error("unable to initialize blob store", e);
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Get Class instance by className
+     * @param className
+     * @return
+     * @throws Throwable
+     */
+    public static Object getZimbraClassInstanceBy(String className) throws ReflectiveOperationException {
+        try {
+            return Class.forName(className).newInstance();
+        } catch (Exception e) {
+            return ExtensionUtil.findClass(className).newInstance();
+        }
+    }
+}


### PR DESCRIPTION
Mailbox move from 9.0 to 10.1.6 is not compatible because there are major updates made in 10 version release for handling external storage and backup.
When mbox move starts:

First an API is fired to source to check if external storage exists “GetMailboxCurrentVolumes”. This API is not available in 9.0 and I tried with other API’s but those are not returning data for secondary volumes(external storage). Added this API in 9.0 with default value 2 for storage_type , storage_type variable in unavailable in version 9(this external volume flag in response is required to run the importExternalBlobs() flow in 10 version)

For storing data in the same volume as of source to the destination, while taking the backup “volume id” is added to the path of the blob folder. While extracting the blobs in 10.0, the same “volume id” is extracted and the data get stored into the respective volume of destination server. This code to add volume id info into the blob path is missing in version 9.0 . So without volume id its not possible to map the data in the destination server to primary or secondary volumes. I have added code changes in version 9 for the same but with multiple workarounds.

9.0 misses few columns that were added in 10.0 to handle the external storage flow(also the zm-store-manager repo added in 10.0 for externalStorage management). Adding new columns to the 9 version TABLE would not be appropriate approach as this will be a one time change and we will revert back to the previous jars. As a workaround, I have added 2 LC attribute to handle the store_manager_class value that comes out of volume table in 10.0 for finding out the StorageManager instance. This Store Manager class is further used in the code for extracting the file from internal or external storage.

This code has the multithreading changes too for performance improvement while taking the backup in movemailbox flow. So LC attribute for thread count also needs to be configured(by default its 5)

These changes will only handle the MOVEMAILBOX flow. It will not be handle any other flow like restore.