### PR TITLE
ZBUG-3130: Modified zimbraAttachmentsScanEnabled with requiresRestart as mailbox

### DIFF
--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -1392,7 +1392,7 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
   <desc>whether list of well known time zones is displayed in calendar UI</desc>
 </attr>
 
-<attr id="237" name="zimbraAttachmentsScanEnabled" type="boolean" cardinality="single" optionalIn="server,globalConfig">
+<attr id="237" name="zimbraAttachmentsScanEnabled" type="boolean" cardinality="single" optionalIn="server,globalConfig" requiresRestart="mailbox">
   <globalConfigValue>FALSE</globalConfigValue>
   <desc>Whether to scan attachments during compose</desc>
 </attr>


### PR DESCRIPTION
**Issue**: Description of zimbraAttachmentsScanEnabled requiresRestart was not showing mailbox

**Fix**: zimbraAttachmentsScanEnabled is updated with requiresRestart with mailbox

**Test Case**: Installed updated zimbra on VM and checked the requiresRestart by trigerring zmprov desc -a zimbraAttachmentsScanEnabled following is the  [comment id](https://synacor.atlassian.net/browse/ZBUG-3130?focusedCommentId=332021)