### PR TITLE
ZBUG-4316: zmpurgeoldmbox is broken with S3 HSM/Primary volume

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -45,6 +45,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import javax.mail.Address;
 import javax.mail.MessagingException;
@@ -270,12 +271,13 @@ import com.zimbra.cs.store.MailboxBlob;
 import com.zimbra.cs.store.MailboxBlobDataSource;
 import com.zimbra.cs.store.StagedBlob;
 import com.zimbra.cs.store.StoreManager;
-import com.zimbra.cs.store.StoreManager.StoreFeature;
 import com.zimbra.cs.store.external.ExternalBlob;
 import com.zimbra.cs.util.AccountUtil;
 import com.zimbra.cs.util.AccountUtil.AccountAddressMatcher;
 import com.zimbra.cs.util.SpoolingCache;
 import com.zimbra.cs.util.Zimbra;
+import com.zimbra.cs.volume.Volume;
+import com.zimbra.cs.volume.VolumeManager;
 import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.admin.type.DataSourceType;
 import com.zimbra.soap.mail.message.FileSharedWithMeRequest;
@@ -2472,41 +2474,46 @@ public class Mailbox implements MailboxStore {
         }
     }
 
-    public void deleteMailbox(DeleteBlobs deleteBlobs) throws ServiceException {
-        StoreManager sm = StoreManager.getInstance();
-        boolean deleteStore = deleteBlobs == DeleteBlobs.ALWAYS
-                        || (deleteBlobs == DeleteBlobs.UNLESS_CENTRALIZED && !sm.supports(StoreFeature.CENTRALIZED));
-        SpoolingCache<MailboxBlob.MailboxBlobInfo> blobs = null;
+    public Set<Short> getVolumeIds() {
+        return VolumeManager.getInstance().getAllVolumes().stream().map(Volume::getId).collect(Collectors.toSet());
+    }
 
+    public void deleteMailbox(DeleteBlobs deleteBlobs) throws ServiceException {
         lock.lock();
+        MailboxMaintenance maint = null;
         try {
             // first, throw the mailbox into maintenance mode
-            //   (so anyone else with a cached reference to the Mailbox can't use it)
-            MailboxMaintenance maint = null;
-            try {
-                maint = MailboxManager.getInstance().beginMaintenance(mData.accountId, mId);
-            } catch (MailServiceException e) {
-                // Ignore wrong mailbox exception.  It may be thrown if we're redoing a DeleteMailbox that was interrupted
-                // when server crashed in the middle of the operation.  Database says the mailbox has been deleted, but
-                // there may be other files that still need to be cleaned up.
-                if (!MailServiceException.WRONG_MAILBOX.equals(e.getCode())) {
-                    throw e;
-                }
-            }
-
+            // (so anyone else with a cached reference to the Mailbox can't use it)
+            maint = MailboxManager.getInstance().beginMaintenance(mData.accountId, mId);
             DeleteMailbox redoRecorder = new DeleteMailbox(mId);
+            beginTransaction("deleteMailbox", null, redoRecorder);
             boolean needRedo = needRedo(null, redoRecorder);
-            boolean success = false;
-            try {
-                beginTransaction("deleteMailbox", null, redoRecorder);
-                if (needRedo) {
-                    redoRecorder.log();
-                }
-
+            boolean success = false, deleteStore = false;
+            Set<Short> volumeIds = getVolumeIds();
+            for (short id : volumeIds) {
+                StoreManager sm = StoreManager.getReaderSMInstance(id);
+                // if sm is of ExternalStoreManager deleteStore will always be true
+                deleteStore = (deleteBlobs == DeleteBlobs.ALWAYS
+                        || (deleteBlobs == DeleteBlobs.UNLESS_CENTRALIZED && sm.checkIfStoreManagerIsExternal()));
+                SpoolingCache<MailboxBlob.MailboxBlobInfo> blobs = null;
                 if (deleteStore && !sm.supports(StoreManager.StoreFeature.BULK_DELETE)) {
                     blobs = DbMailItem.getAllBlobs(this);
                 }
-
+                if (deleteStore) {
+                    try {
+                        sm.deleteStore(this, blobs);
+                    } catch (IOException iox) {
+                        ZimbraLog.store.warn("Unable to delete message data", iox);
+                    }
+                }
+                if (blobs != null) {
+                    blobs.cleanup();
+                }
+            }
+            try {
+                if (needRedo) {
+                    redoRecorder.log();
+                }
                 try {
                     // Remove the mime messages from MessageCache
                     if (deleteStore) {
@@ -2538,14 +2545,6 @@ public class Mailbox implements MailboxStore {
                     } catch (IOException iox) {
                         ZimbraLog.store.warn("Unable to delete index data", iox);
                     }
-
-                    if (deleteStore) {
-                        try {
-                            sm.deleteStore(this, blobs);
-                        } catch (IOException iox) {
-                            ZimbraLog.store.warn("Unable to delete message data", iox);
-                        }
-                    }
                 }
             } finally {
                 if (needRedo) {
@@ -2566,10 +2565,13 @@ public class Mailbox implements MailboxStore {
                         MailboxManager.getInstance().endMaintenance(maint, success, true);
                     }
                 }
-
-                if (blobs != null) {
-                    blobs.cleanup();
-                }
+            }
+        } catch (MailServiceException e) {
+            // Ignore wrong mailbox exception.  It may be thrown if we're redoing a DeleteMailbox that was interrupted
+            // when server crashed in the middle of the operation.  Database says the mailbox has been deleted, but
+            // there may be other files that still need to be cleaned up.
+            if (!MailServiceException.WRONG_MAILBOX.equals(e.getCode())) {
+                throw e;
             }
         } finally {
             lock.release();

--- a/store/src/java/com/zimbra/cs/store/StoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/StoreManager.java
@@ -26,6 +26,7 @@ import com.zimbra.cs.imap.ImapDaemon;
 import com.zimbra.cs.mailbox.MailItem;
 import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.util.MailItemHelper;
+import com.zimbra.cs.store.external.ExternalStoreManager;
 import com.zimbra.cs.store.file.FileBlobStore;
 import com.zimbra.cs.store.helper.ClassHelper;
 import com.zimbra.cs.util.Zimbra;
@@ -154,6 +155,13 @@ public abstract class StoreManager {
         }
         ZimbraLog.store.info("Fallback: master StoreManager will be used for reading");
         return getInstance();
+    }
+
+    /*
+    following api checks if storeManager instance is External
+     */
+    public boolean checkIfStoreManagerIsExternal() {
+        return (this instanceof ExternalStoreManager) ? supports(StoreFeature.CENTRALIZED) : !supports(StoreFeature.CENTRALIZED);
     }
 
 

--- a/store/src/java/com/zimbra/cs/store/external/ExternalStoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/external/ExternalStoreManager.java
@@ -139,7 +139,9 @@ public abstract class ExternalStoreManager extends StoreManager implements Exter
         if (mblob == null) {
             return true;
         }
-        localCache.remove(mblob.getLocator());
+        if (localCache != null) {
+            localCache.remove(mblob.getLocator());
+        }
         return deleteFromStore(mblob.getLocator(), mblob.getMailbox());
     }
 


### PR DESCRIPTION
**Issue**: [ZBUG-4316](https://synacor.atlassian.net/browse/ZBUG-4316)

**Fix**: That particular mailbox id gets deleted from s3 bucket

**Test Case**: Created some accounts on one server, sent mail to them to create blogs, then triggered the zmmboxmove -a  zuser@zimbra.local --from <src> --to <dest> [sync] command to move the mailbox from one server to another server.
Then trigger zmpurgeoldmbox -a zuser@zimbra.local command to purge the metadata from the source server.

**Results**: Purged mailbox id 6 for account 13_may_six@platform-dev-omkar.zimbradev.com on server platform-dev-omkar.zimbradev.com, and this deletes data from s3 bucket

[ZBUG-4316]: https://synacor.atlassian.net/browse/ZBUG-4316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ