### PR TITLE
ZBUG-4934: Spam Reports contain a null returnpath header

### DIFF
--- a/store/src/java/com/zimbra/cs/lmtpserver/LmtpHandler.java
+++ b/store/src/java/com/zimbra/cs/lmtpserver/LmtpHandler.java
@@ -20,6 +20,8 @@ package com.zimbra.cs.lmtpserver;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.mail.internet.MailDateFormat;
 import javax.mail.internet.MimeUtility;
@@ -485,11 +487,17 @@ public abstract class LmtpHandler extends ProtocolHandler {
         StringBuilder headers = new StringBuilder();
 
         // Assemble Return-Path header
-        String sender = "";
-        if (mEnvelope.hasSender()) {
-            sender = mEnvelope.getSender().getEmailAddress();
+        if (null != mEnvelope.getRecipients()) {
+            List<String> recipients = mEnvelope.getRecipients().stream().map(LmtpAddress::getEmailAddress).collect(Collectors.toList());
+            String recipientsStr = String.join(",", recipients);
+            headers.append(String.format("Return-Path: <%s>\r\n", recipientsStr));
+        } else {
+            String sender = "";
+            if (mEnvelope.hasSender()) {
+                sender = mEnvelope.getSender().getEmailAddress();
+            }
+            headers.append(String.format("Return-Path: <%s>\r\n", sender));
         }
-        headers.append(String.format("Return-Path: <%s>\r\n", sender));
 
         // Assemble Received header
         String localHostname = "unknown";


### PR DESCRIPTION
**Issue**: [ZBUG-4934](https://synacor.atlassian.net/browse/ZBUG-4934) - Return Path was showcasing empty (null)

**Fix**: Return Path is showcasing corresponding spam test account.

**Test Case**: 
Created spam test account - [spamtest@autodisc.zimbradev.com](mailto:spamtest@autodisc.zimbradev.com)

zmprov mcf zimbraSpamIsSpamAccount [spamtest@autodisc.zimbradev.com](mailto:spamtest@autodisc.zimbradev.com)
Created test accounts - [pa1@autodisc.zimbradev.com](mailto:pa1@autodisc.zimbradev.com) and [pa2@autodisc.zimbradev.com](mailto:pa2@autodisc.zimbradev.com)
Sent email from pa2 to pa1.
Login Classic ZWC as [pa1@autodisc.zimbradev.com](mailto:pa1@autodisc.zimbradev.com). Right click received email and "Mark as spam". Spam report will be sent to [spamtest@autodisc.zimbradev.com](mailto:spamtest@autodisc.zimbradev.com)
Login Classic ZWC as [spamtest@autodisc.zimbradev.com](mailto:spamtest@autodisc.zimbradev.com). Right click received spam report email and check Show Original.

Show Original shows Return-Path: <> at the top

**Results**: Show Original will show Return-Path with the spam test account mail address.

[ZBUG-4934]: https://synacor.atlassian.net/browse/ZBUG-4934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ