### PR TITLE
ZCS-17455: Mail showing external message even when zimbraFeatureExternalEmailWarningEnabled is set to FALSE

### DIFF
--- a/store/src/java/com/zimbra/cs/lmtpserver/ExternalEmailWarning.java
+++ b/store/src/java/com/zimbra/cs/lmtpserver/ExternalEmailWarning.java
@@ -92,6 +92,9 @@ public class ExternalEmailWarning {
                         if (!eewEnabledDomainsSet.contains(domain) && domain.isFeatureExternalEmailWarningEnabled()) {
                             eewEnabledDomainsSet.add(domain);
                         }
+                        else if (eewEnabledDomainsSet.contains(domain) && !domain.isFeatureExternalEmailWarningEnabled()) {
+                            eewEnabledDomainsSet.remove(domain);
+                        }
                     }
                 }
             } catch (ServiceException e) {


### PR DESCRIPTION
Problem: External Email Warning was still getting sent after the feature was disabled after enabling it.

Solution: Removed the domain from the list of domains with feature enabled after it got disabled.