### PR TITLE
zcs:17569

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -2493,15 +2493,20 @@ public class Mailbox implements MailboxStore {
             for (short id : volumeIds) {
                 StoreManager sm = StoreManager.getReaderSMInstance(id);
                 // if sm is of ExternalStoreManager deleteStore will always be true
+                boolean ifSMisExternal = sm.checkIfStoreManagerIsExternal();
                 deleteStore = (deleteBlobs == DeleteBlobs.ALWAYS
-                        || (deleteBlobs == DeleteBlobs.UNLESS_CENTRALIZED && sm.checkIfStoreManagerIsExternal()));
+                        || (deleteBlobs == DeleteBlobs.UNLESS_CENTRALIZED && ifSMisExternal));
                 SpoolingCache<MailboxBlob.MailboxBlobInfo> blobs = null;
                 if (deleteStore && !sm.supports(StoreManager.StoreFeature.BULK_DELETE)) {
                     blobs = DbMailItem.getAllBlobs(this);
                 }
                 if (deleteStore) {
                     try {
-                        sm.deleteStore(this, blobs);
+                        if(ifSMisExternal){
+                            sm.deleteBucketObjects(this, blobs);
+                        } else {
+                            sm.deleteStore(this, blobs);
+                        }
                     } catch (IOException iox) {
                         ZimbraLog.store.warn("Unable to delete message data", iox);
                     }

--- a/store/src/java/com/zimbra/cs/store/StoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/StoreManager.java
@@ -572,4 +572,6 @@ public abstract class StoreManager {
     public IncomingBlob newIncomingBlob(String id, Object ctxt) throws IOException, ServiceException {
         return new BufferingIncomingBlob(id, getBlobBuilder(), ctxt);
     }
+
+    public abstract boolean deleteBucketObjects(Mailbox mbox, Iterable<MailboxBlob.MailboxBlobInfo> blobs) throws ServiceException;
 }

--- a/store/src/java/com/zimbra/cs/store/external/ExternalBlobIO.java
+++ b/store/src/java/com/zimbra/cs/store/external/ExternalBlobIO.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.store.MailboxBlob;
 
 /**
  * Interface for the simplest blob store integration possible
@@ -70,4 +71,8 @@ public interface ExternalBlobIO {
      * @throws IOException
      */
     boolean deleteFromStore(String locator, Mailbox mbox) throws IOException;
+
+     String returnS3BucketName(String locator);
+
+     boolean deleteBlobsInBulk(Iterable<MailboxBlob.MailboxBlobInfo> blobs, Integer mailboxId);
 }

--- a/store/src/java/com/zimbra/cs/store/external/ExternalStoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/external/ExternalStoreManager.java
@@ -43,7 +43,6 @@ import com.zimbra.cs.store.IncomingDirectory;
 import com.zimbra.cs.store.MailboxBlob;
 import com.zimbra.cs.store.StagedBlob;
 import com.zimbra.cs.store.StoreManager;
-import com.zimbra.cs.store.file.VolumeMailboxBlob;
 import com.zimbra.cs.volume.Volume;
 
 /**

--- a/store/src/java/com/zimbra/cs/store/external/ImapTransientStoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/external/ImapTransientStoreManager.java
@@ -26,6 +26,7 @@ import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.FileUtil;
 import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.store.MailboxBlob;
 
 /**
  * Simple ExternalStoreManager implementation that is intended for use in storing
@@ -76,8 +77,23 @@ public class ImapTransientStoreManager extends ExternalStoreManager {
     }
 
     @Override
+    public String returnS3BucketName(String locator) {
+        return null;
+    }
+
+    @Override
+    public boolean deleteBlobsInBulk(Iterable<MailboxBlob.MailboxBlobInfo> blobs, Integer mailboxId) {
+        return false;
+    }
+
+    @Override
     public boolean supports(StoreFeature feature) {
         return feature == StoreFeature.CENTRALIZED ? false : super.supports(feature);
+    }
+
+    @Override
+    public boolean deleteBucketObjects(Mailbox mbox, Iterable<MailboxBlob.MailboxBlobInfo> blobs) throws ServiceException {
+        return false;
     }
 
     private File createBlobFile(Mailbox mbox) throws IOException {

--- a/store/src/java/com/zimbra/cs/store/external/SimpleStoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/external/SimpleStoreManager.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.zimbra.cs.store.MailboxBlob;
 import org.apache.commons.io.filefilter.FileFileFilter;
 import com.zimbra.common.localconfig.LC;
 
@@ -102,6 +103,16 @@ public class SimpleStoreManager extends ExternalStoreManager {
     }
 
     @Override
+    public String returnS3BucketName(String locator) {
+        return null;
+    }
+
+    @Override
+    public boolean deleteBlobsInBulk(Iterable<MailboxBlob.MailboxBlobInfo> blobs, Integer mailboxId) {
+        return false;
+    }
+
+    @Override
     public List<String> getAllBlobPaths(Mailbox mbox) throws IOException {
         File dir = new File(dirName(mbox));
         if (dir.exists()) {
@@ -123,5 +134,10 @@ public class SimpleStoreManager extends ExternalStoreManager {
         } else {
             return super.supports(feature);
         }
+    }
+
+    @Override
+    public boolean deleteBucketObjects(Mailbox mbox, Iterable<MailboxBlob.MailboxBlobInfo> blobs) throws ServiceException {
+        return false;
     }
 }

--- a/store/src/java/com/zimbra/cs/store/file/FileBlobStore.java
+++ b/store/src/java/com/zimbra/cs/store/file/FileBlobStore.java
@@ -411,6 +411,11 @@ public final class FileBlobStore extends StoreManager {
         return true;
     }
 
+    @Override
+    public boolean deleteBucketObjects(Mailbox mbox, Iterable<MailboxBlob.MailboxBlobInfo> blobs) throws ServiceException {
+        return false;
+    }
+
     private File getMailboxBlobFile(Mailbox mbox, int itemId, int revision, short volumeId, boolean check)
     throws ServiceException {
         File file = new File(getBlobPath(mbox, itemId, revision, volumeId));

--- a/store/src/java/com/zimbra/cs/store/triton/TritonBlobStoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/triton/TritonBlobStoreManager.java
@@ -23,6 +23,7 @@ import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
+import com.zimbra.cs.store.MailboxBlob;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.http.HttpException;
 import org.apache.http.HttpResponse;
@@ -235,8 +236,23 @@ public class TritonBlobStoreManager extends SisStore implements ExternalResumabl
     }
 
     @Override
+    public String returnS3BucketName(String locator) {
+        return null;
+    }
+
+    @Override
+    public boolean deleteBlobsInBulk(Iterable<MailboxBlob.MailboxBlobInfo> blobs, Integer mailboxId) {
+        return false;
+    }
+
+    @Override
     public ExternalResumableIncomingBlob newIncomingBlob(String id, Object ctxt) throws IOException, ServiceException {
         return new TritonIncomingBlob(id, url, getBlobBuilder(), ctxt, newDigest(), hashType);
+    }
+
+    @Override
+    public boolean deleteBucketObjects(Mailbox mbox, Iterable<MailboxBlob.MailboxBlobInfo> blobs) throws ServiceException {
+        return false;
     }
 
     @Override


### PR DESCRIPTION
**Issue**: [ZCS-17569](https://synacor.atlassian.net/browse/ZCS-17569)

**Fix**:  Deleting blobs in bulk (1000 blobs at once) using aws sdk api (deleteObjects)

**Test Case**: Create zimbra account add some data having more than 8k or 10k blobs, configure s3 bucket as primary or secondary storage, move data to it then trigger zmprov da "accountName" command 

**Results**: This will delete the blobs from the bucket in bulk instead of one at a time.

**Additional Jar requirements**: aws-java-sdk-core, aws-java-sdk-s3 and  joda-time  in /opt/zimbra/lib/ext/zimbrahsm/ path

[ZCS-17569]: https://synacor.atlassian.net/browse/ZCS-17569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ