### PR TITLE
ZCS-17622:Apache mina version update

### DIFF
--- a/store/build.xml
+++ b/store/build.xml
@@ -278,7 +278,7 @@
     <ivy:install organisation="org.apache.lucene" module="lucene-analyzers" revision="3.5.0" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
   	<ivy:install organisation="org.apache.lucene" module="lucene-smartcn" revision="3.5.0" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="ant-tar-patched" module="ant-tar-patched" revision="1.0" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
-    <ivy:install organisation="org.apache.mina" module="mina-core" revision="2.1.6" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
+    <ivy:install organisation="org.apache.mina" module="mina-core" revision="2.1.10" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="zimbra" module="zm-ews-stub" revision="4.0" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.apache.zookeeper" module="zookeeper" revision="3.4.5" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="com.101tec" module="zkclient" revision="0.1.0" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>

--- a/store/ivy.xml
+++ b/store/ivy.xml
@@ -74,7 +74,7 @@
   <dependency org="org.apache.httpcomponents" name="httpcore-nio" rev="${httpclient.httpcore.version}"/>
   <dependency org="org.apache.httpcomponents" name="httpmime" rev="${httpclient.version}"/>
   <dependency org="org.apache.commons" name="commons-compress" rev="1.20" />
-  <dependency org="org.apache.mina" name="mina-core" rev="2.1.6"/>
+  <dependency org="org.apache.mina" name="mina-core" rev="2.1.10"/>
   <dependency org="org.apache.curator" name="curator-recipes" rev="2.0.1-incubating" />
   <dependency org="org.apache.curator" name="curator-client" rev="2.0.1-incubating" />
   <dependency org="org.apache.curator" name="curator-x-discovery" rev="2.0.1-incubating" />


### PR DESCRIPTION
As part of **ZBUG-4636** fix & as a precautionary measures, although Zimbra is not directly impacted by any vulnerabilities, we will update **Apache MINA** to it's latest version to mitigate any future risks.