### PR TITLE
Revert "ZBUG-4023:Upgraded jetty to 9.4.57.v20241219"

### DIFF
--- a/build-ivysettings.xml
+++ b/build-ivysettings.xml
@@ -3,7 +3,7 @@
   <property name="httpclient.version" value="4.5.8"/>
   <property name="httpclient.httpcore.version" value="4.4.11"/>
   <property name="httpclient.async.version" value="4.1.4"/>
-  <property name="jetty.version" value="9.4.57.v20241219"/>
+  <property name="jetty.version" value="9.4.46.v20220331"/>
   <property name="dom4j.version" value="2.1.1"/>  
   <property name="log4j.core.version" value="2.17.1" />
   <property name="log4j.api.version" value="2.17.1" />

--- a/store/WebRoot/WEB-INF/jetty-env.xml
+++ b/store/WebRoot/WEB-INF/jetty-env.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
 <!--
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server

--- a/store/build.xml
+++ b/store/build.xml
@@ -337,8 +337,8 @@
     <ivy:install organisation="com.graphql-java" module="graphql-java" revision="9.0" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.reactivestreams" module="reactive-streams" revision="1.0.2" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.antlr" module="antlr4-runtime" revision="4.7.1" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
-    <ivy:install organisation="org.eclipse.jetty" module="jetty-servlets" revision="9.4.57.v20241219" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
-    <ivy:install organisation="org.eclipse.jetty" module="jetty-servlet" revision="9.4.57.v20241219" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
+    <ivy:install organisation="org.eclipse.jetty" module="jetty-servlets" revision="9.4.46.v20220331" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
+    <ivy:install organisation="org.eclipse.jetty" module="jetty-servlet" revision="9.4.46.v20220331" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.tukaani" module="xz" revision="1.8" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     <ivy:install organisation="org.apache.commons" module="commons-compress" revision="1.20" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
     


### PR DESCRIPTION
Reverts Zimbra/zm-mailbox#1707
Reverting Above changes for now because, **zimbra-jetty-distribution package** involves changes in another zimbra-repositories also (zm-build, zm-zcs-lib, zm-mailbox, zm-jetty-conf)
merging this changes will result into **failure/installation of dev-builds because new Jetty packages not present in package repository.**
will raise New-PR for this changes while upcoming patch release..