### PR TITLE
 ZCS-13464-1: Changed log level to debug for java.lang.IllegalArgumentException

### DIFF
--- a/common/src/java/com/zimbra/common/soap/Element.java
+++ b/common/src/java/com/zimbra/common/soap/Element.java
@@ -261,7 +261,7 @@ public abstract class Element implements Cloneable {
         try {
             returnValue = (uri == null) ? QName.get(mName) : QName.get(getQualifiedName(), uri);
         } catch (IllegalArgumentException e) {
-            ZimbraLog.soap.error("Caught IllegalArgumentException: %s", e.getMessage());
+            ZimbraLog.soap.debug("Caught IllegalArgumentException: %s", e.getMessage());
         }
         return returnValue;
     }


### PR DESCRIPTION
Ticket - [ZCS-13464](https://synacor.atlassian.net/browse/ZCS-13464)
This PR includes changes to log java.lang.IllegalArgumentException as debug.



Tested:
Changes has been validated on Remote VM

[ZCS-13464]: https://synacor.atlassian.net/browse/ZCS-13464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ