### PR TITLE
ZCS-17678: Forward invitation does not work properly for outlook IOS if attendee accepts the event before forwarding ActiveSync

### DIFF
--- a/store/src/java/com/zimbra/cs/service/mail/ForwardCalendarItem.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ForwardCalendarItem.java
@@ -391,6 +391,13 @@ public class ForwardCalendarItem extends CalendarRequest {
         Address sender = null;
         sender = AccountUtil.getFriendlyEmailAddress(senderAcct);
         ZOrganizer org = inv.getOrganizer();
+
+        // we need to treat the incoming object as a new REQUEST instead of a REPLY for forwarded message,
+        // otherwise it won’t be processed correctly in our system.
+        ZProperty method = cal.getProperty(ICalTok.METHOD);
+        if (method != null && ICalTok.REPLY.toString().equals(method.getValue()))
+            method.setValue(ICalTok.REQUEST.toString());
+
         if (org != null) {
             if (org.hasCn())
                 from = new JavaMailInternetAddress(org.getAddress(), org.getCn(), MimeConstants.P_CHARSET_UTF8);


### PR DESCRIPTION
Problem: If attendee accepts a meeting invitation from mobile device and then forwards the event to another user, the new attendee receives the invitation as plain mail without the calendar.

Solution: Modified the header from REPLY to REQUEST while creating the forwarded message.