### PR TITLE
feature/ZCS-17569:Provisioning Bulk Delete Capability in S3

### DIFF
--- a/store/src/java/com/zimbra/cs/store/external/ExternalBlobIO.java
+++ b/store/src/java/com/zimbra/cs/store/external/ExternalBlobIO.java
@@ -18,6 +18,7 @@ package com.zimbra.cs.store.external;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collection;
 
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.mailbox.Mailbox;
@@ -70,4 +71,6 @@ public interface ExternalBlobIO {
      * @throws IOException
      */
     boolean deleteFromStore(String locator, Mailbox mbox) throws IOException;
+
+    void deleteFromStoreInBulk(Collection<String> locators, Mailbox mbox);
 }

--- a/store/src/java/com/zimbra/cs/store/external/ExternalStoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/external/ExternalStoreManager.java
@@ -24,7 +24,9 @@ import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.zimbra.common.localconfig.LC;
@@ -43,7 +45,6 @@ import com.zimbra.cs.store.IncomingDirectory;
 import com.zimbra.cs.store.MailboxBlob;
 import com.zimbra.cs.store.StagedBlob;
 import com.zimbra.cs.store.StoreManager;
-import com.zimbra.cs.store.file.VolumeMailboxBlob;
 import com.zimbra.cs.volume.Volume;
 
 /**
@@ -146,32 +147,54 @@ public abstract class ExternalStoreManager extends StoreManager implements Exter
     }
 
     @Override
-    public boolean deleteStore(Mailbox mbox, Iterable<MailboxBlob.MailboxBlobInfo> blobs) throws IOException, ServiceException {
-        // the default implementation iterates through the mailbox's blobs and deletes them one by one
-        IOException ioException = null;
-        int consecutiveIoExceptions = 0;
-        for (MailboxBlob.MailboxBlobInfo mbinfo : blobs) {
-            try {
-                delete(getMailboxBlob(mbox, mbinfo.itemId, mbinfo.revision, mbinfo.locator, false));
-                consecutiveIoExceptions = 0;
-            } catch (IOException ioe) {
-                if (ioException == null) {
-                    ioException = ioe;
-                }
-                consecutiveIoExceptions++;
-                ZimbraLog.store.warn("IOException during deleteStore() for mbox [%d] item [%d] revision [%d] locator [%s]"
-                    , mbox.getId(), mbinfo.itemId, mbinfo.revision, mbinfo.locator, ioe);
-                if (consecutiveIoExceptions > LC.external_store_delete_max_ioexceptions.intValue()) {
-                    ZimbraLog.store.error("too many consecutive IOException during delete store, bailing");
-                    break;
-                }
+    public boolean deleteStore(Mailbox mbox, Iterable<MailboxBlob.MailboxBlobInfo> blobs)
+            throws IOException, ServiceException {
+        List<MailboxBlob.MailboxBlobInfo> blobList = new ArrayList<>();
+        Set<String> locators = new HashSet<>();
+        for (MailboxBlob.MailboxBlobInfo blob : blobs) {
+            blobList.add(blob);
+            if (blob.locator != null) {
+                locators.add(blob.locator);
             }
         }
-        if (ioException != null) {
-            throw new IOException("deleteStore failed due to IOException", ioException);
+        try {
+            // try bulk delete first
+            deleteFromStoreInBulk(locators, mbox);
+            return true;
+        } catch (Exception bulkEx) {
+            // fallback to deleting one by one
+            IOException firstIoException = null;
+            int consecutiveIoExceptions = 0;
+            int maxIoExceptions = LC.external_store_delete_max_ioexceptions.intValue();
+
+            for (MailboxBlob.MailboxBlobInfo mbinfo : blobList) {
+                try {
+                    delete(getMailboxBlob(mbox, mbinfo.itemId, mbinfo.revision, mbinfo.locator, false));
+                    consecutiveIoExceptions = 0; // reset on success
+                } catch (IOException ioe) {
+                    if (firstIoException == null) {
+                        firstIoException = ioe; // capture the first
+                    }
+                    consecutiveIoExceptions++;
+
+                    ZimbraLog.store.warn(
+                            "IOException during deleteStore() for mbox [{}] item [{}] revision [{}] locator [{}]",
+                            mbox.getId(), mbinfo.itemId, mbinfo.revision, mbinfo.locator, ioe);
+
+                    if (consecutiveIoExceptions > maxIoExceptions) {
+                        ZimbraLog.store.error("Too many consecutive IOExceptions during deleteStore, bailing");
+                        break;
+                    }
+                }
+            }
+
+            if (firstIoException != null) {
+                throw new IOException("deleteStore failed due to IOException", firstIoException);
+            }
+            return true;
         }
-        return true;
     }
+
 
     @Override
     public BlobBuilder getBlobBuilder() throws IOException, ServiceException {

--- a/store/src/java/com/zimbra/cs/store/external/ImapTransientStoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/external/ImapTransientStoreManager.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collection;
 
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
@@ -73,6 +74,10 @@ public class ImapTransientStoreManager extends ExternalStoreManager {
     public boolean deleteFromStore(String locator, Mailbox mbox) throws IOException {
         File deleteFile = new File(locator);
         return deleteFile.delete();
+    }
+
+    @Override
+    public void deleteFromStoreInBulk(Collection<String> locators, Mailbox mbox) {
     }
 
     @Override

--- a/store/src/java/com/zimbra/cs/store/external/SimpleStoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/external/SimpleStoreManager.java
@@ -23,6 +23,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.io.filefilter.FileFileFilter;
@@ -99,6 +100,11 @@ public class SimpleStoreManager extends ExternalStoreManager {
     public boolean deleteFromStore(String locator, Mailbox mbox) throws IOException {
         File deleteFile = new File(locator);
         return deleteFile.delete();
+    }
+
+    @Override
+    public void deleteFromStoreInBulk(Collection<String> locators, Mailbox mbox) {
+
     }
 
     @Override

--- a/store/src/java/com/zimbra/cs/store/triton/TritonBlobStoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/triton/TritonBlobStoreManager.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Collection;
 
 import org.apache.commons.codec.binary.Hex;
 import org.apache.http.HttpException;
@@ -232,6 +233,11 @@ public class TritonBlobStoreManager extends SisStore implements ExternalResumabl
         } finally {
             delete.releaseConnection();
         }
+    }
+
+    @Override
+    public void deleteFromStoreInBulk(Collection<String> locators, Mailbox mbox) {
+
     }
 
     @Override


### PR DESCRIPTION
Issue: [ZCS-17569](https://synacor.atlassian.net/browse/ZCS-17569)

Fix: Deleting blobs in bulk (1000 blobs at once) using aws sdk api (deleteObjects)

Test Case: Create zimbra account add some data having more than 8k or 10k blobs, configure s3 bucket as primary or secondary storage, move data to it then trigger zmprov da "accountName" command

Results: This will delete the blobs from the bucket in bulk instead of one at a time.


[ZCS-17569]: https://synacor.atlassian.net/browse/ZCS-17569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ