### PR TITLE
ZBUG-4620:Fix login issue by resolving domain on backend side using serverName

### DIFF
--- a/store/src/java/com/zimbra/cs/account/Provisioning.java
+++ b/store/src/java/com/zimbra/cs/account/Provisioning.java
@@ -2798,4 +2798,16 @@ public abstract class Provisioning extends ZAttrProvisioning {
     }
     
     public abstract String sendMdmEmail(String status, String timeInterval) throws ServiceException;
+
+
+    public String expandWithDomain(String username, String virtualHostname) throws ServiceException {
+        if (username == null || virtualHostname == null) {
+            throw ServiceException.INVALID_REQUEST("must be valid email address: "+ username, null);
+        }
+        Domain domain = get(Key.DomainBy.virtualHostname, virtualHostname.toLowerCase());
+        if (domain == null)
+            throw ServiceException.INVALID_REQUEST("must be valid email address: "+ username, null);
+
+        return username + "@" + domain.getName();
+    }
 }

--- a/store/src/java/com/zimbra/cs/service/PreAuthServlet.java
+++ b/store/src/java/com/zimbra/cs/service/PreAuthServlet.java
@@ -116,7 +116,6 @@ public class PreAuthServlet extends ZimbraServlet {
             Provisioning prov = Provisioning.getInstance();
             Server server = prov.getLocalServer();
             String referMode = server.getAttr(Provisioning.A_zimbraMailReferMode, "wronghost");
-
             boolean isRedirect = getOptionalParam(req, PARAM_ISREDIRECT, "0").equals("1");
             String rawAuthToken = getOptionalParam(req, PARAM_AUTHTOKEN, null);
             AuthToken authToken = null;
@@ -201,6 +200,9 @@ public class PreAuthServlet extends ZimbraServlet {
                             EmailAddress email = new EmailAddress(account, false);
                             String domainName = email.getDomain();
                             Domain domain = domainName == null ? null : prov.get(Key.DomainBy.name, domainName);
+                            if (domain == null) {
+                                throw AccountServiceException.NO_SUCH_DOMAIN(domainName);
+                            }
                             prov.preAuthAccount(domain, account, accountBy, timestamp, expires, preAuth, authCtxt);
                             acct = prov.autoProvAccountLazy(domain, account, null, AutoProvAuthMech.PREAUTH);
 
@@ -261,9 +263,11 @@ public class PreAuthServlet extends ZimbraServlet {
                     redirectToCorrectServer(req, resp, acct, null);
                 }
             }
-        } catch (ServiceException e) {
+        }catch (NumberFormatException e) {
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST,"Invalid numeric parameter");
+        }catch (ServiceException e) {
             resp.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
-        } catch (AuthTokenException e) {
+        }catch (AuthTokenException e) {
             resp.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
         }
     }


### PR DESCRIPTION
Issue:
Login was failing when users entered only their username without a domain.

Fix Implemented:
Updated the UI to call a backend method, passing the username and server name.
On the server side, the domain is retrieved using the serverName.
The backend then constructs the complete username in the format [username@domain.com](mailto:username@domain.com) and returns it to the UI.