### PR TITLE
ZCS-17871 : Added new LDAP attribute for PUR

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -9543,6 +9543,14 @@ public class ZAttrProvisioning {
     public static final String A_zimbraLicensePreExpiryReminderSentDetails = "zimbraLicensePreExpiryReminderSentDetails";
 
     /**
+     * Package Usage Reporting Scheduler last successful run date
+     *
+     * @since ZCS 10.1.12
+     */
+    @ZAttr(id=4145)
+    public static final String A_zimbraPackageUsageReportingLastSuccessfulRunDetails = "zimbraPackageUsageReportingLastSuccessfulRunDetails";
+
+    /**
      * name to use in greeting and sign-off; if empty, uses hostname
      */
     @ZAttr(id=23)

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10604,4 +10604,8 @@ TODO: delete them permanently from here
   <desc>Email address for receiving Zimbra license notifications for License Pre Expiry</desc>
 </attr>
 
+<attr id="4145" name="zimbraPackageUsageReportingLastSuccessfulRunDetails" type="string" cardinality="single" optionalIn="globalConfig" immutable="1" since="10.1.12">
+  <desc>Package Usage Reporting Scheduler last successful run date</desc>
+</attr>
+
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -29357,6 +29357,78 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Package Usage Reporting Scheduler last successful run date
+     *
+     * @return zimbraPackageUsageReportingLastSuccessfulRunDetails, or null if unset
+     *
+     * @since ZCS 10.1.12
+     */
+    @ZAttr(id=4145)
+    public String getPackageUsageReportingLastSuccessfulRunDetails() {
+        return getAttr(Provisioning.A_zimbraPackageUsageReportingLastSuccessfulRunDetails, null, true);
+    }
+
+    /**
+     * Package Usage Reporting Scheduler last successful run date
+     *
+     * @param zimbraPackageUsageReportingLastSuccessfulRunDetails new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.12
+     */
+    @ZAttr(id=4145)
+    public void setPackageUsageReportingLastSuccessfulRunDetails(String zimbraPackageUsageReportingLastSuccessfulRunDetails) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPackageUsageReportingLastSuccessfulRunDetails, zimbraPackageUsageReportingLastSuccessfulRunDetails);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Package Usage Reporting Scheduler last successful run date
+     *
+     * @param zimbraPackageUsageReportingLastSuccessfulRunDetails new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.12
+     */
+    @ZAttr(id=4145)
+    public Map<String,Object> setPackageUsageReportingLastSuccessfulRunDetails(String zimbraPackageUsageReportingLastSuccessfulRunDetails, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPackageUsageReportingLastSuccessfulRunDetails, zimbraPackageUsageReportingLastSuccessfulRunDetails);
+        return attrs;
+    }
+
+    /**
+     * Package Usage Reporting Scheduler last successful run date
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.12
+     */
+    @ZAttr(id=4145)
+    public void unsetPackageUsageReportingLastSuccessfulRunDetails() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPackageUsageReportingLastSuccessfulRunDetails, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Package Usage Reporting Scheduler last successful run date
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.12
+     */
+    @ZAttr(id=4145)
+    public Map<String,Object> unsetPackageUsageReportingLastSuccessfulRunDetails(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPackageUsageReportingLastSuccessfulRunDetails, "");
+        return attrs;
+    }
+
+    /**
      * Whether to bind to port on startup irrespective of whether the server
      * is enabled. Useful when port to bind is privileged and must be bound
      * early.


### PR DESCRIPTION
ZCS-17871 : Added new LDAP attribute for PUR
The new attribute is added in order to hold the package usage reporting last successful run DATE. Internally it will used for managing the schedule run for package usage reporting.