### PR TITLE
ZBUG-4951: Junk Characters showing in ActiveSync

### DIFF
--- a/store/src/java-test/com/zimbra/cs/service/mail/ExternalEmailWarningTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/mail/ExternalEmailWarningTest.java
@@ -79,4 +79,79 @@ public class ExternalEmailWarningTest extends TestCase{
         Domain domain1 = prov.getDomain(account1);
         Assert.assertEquals("This message originated outside of your organization.", domain1.getExternalEmailWarningMessage());
     }
+
+    public void testGetUpdatedContentWithBase64PlainText() throws Exception {
+        Account account1 = prov.get(Key.AccountBy.name, rcptEmail1);
+
+        // base warning configured on the domain
+        Domain domain1 = prov.getDomain(account1);
+        domain1.setExternalEmailWarningMessage("This message originated outside of your organization.");
+
+        // original plain text body
+        String originalBody = "Hello, this is a test email.";
+        String base64Body = java.util.Base64.getMimeEncoder(76, "\r\n".getBytes())
+                .encodeToString(originalBody.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+        // RFC822-compliant MIME message (simplified)
+        String content =
+                "Content-Type: text/plain; charset=\"UTF-8\"\r\n" +
+                        "Content-Transfer-Encoding: base64\r\n" +
+                        "\r\n" +
+                        base64Body + "\r\n";
+
+        // call the method under test
+        String updatedContent = externalEmailWarning.getUpdatedContent(content, account1);
+
+        // extract the re-encoded Base64 body
+        String encodedPart = updatedContent.substring(updatedContent.indexOf("\r\n\r\n") + 4).trim();
+        String decodedBody = new String(
+                java.util.Base64.getMimeDecoder().decode(encodedPart),
+                java.nio.charset.StandardCharsets.UTF_8
+        );
+
+        // assert the warning comes before the original message
+        Assert.assertTrue("Updated body should contain warning",
+                decodedBody.startsWith("This message originated outside of your organization."));
+
+        Assert.assertTrue("Updated body should still contain original text",
+                decodedBody.contains(originalBody));
+    }
+
+    public void testGetUpdatedContentWithBase64Html() throws Exception {
+        Account account1 = prov.get(Key.AccountBy.name, rcptEmail1);
+
+        // base warning configured on the domain
+        Domain domain1 = prov.getDomain(account1);
+        domain1.setExternalEmailWarningMessage("This message originated outside of your organization.");
+
+        // original HTML body
+        String originalHtml = "<html><body><p>Hello HTML world</p></body></html>";
+        String base64Body = java.util.Base64.getMimeEncoder(76, "\r\n".getBytes())
+                .encodeToString(originalHtml.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+        // RFC822-compliant MIME message
+        String content =
+                "Content-Type: text/html; charset=\"UTF-8\"\r\n" +
+                        "Content-Transfer-Encoding: base64\r\n" +
+                        "\r\n" +
+                        base64Body + "\r\n";
+
+        // call the method under test
+        String updatedContent = externalEmailWarning.getUpdatedContent(content, account1);
+
+        // extract the re-encoded Base64 body
+        String encodedPart = updatedContent.substring(updatedContent.indexOf("\r\n\r\n") + 4).trim();
+        String decodedBody = new String(
+                java.util.Base64.getMimeDecoder().decode(encodedPart),
+                java.nio.charset.StandardCharsets.UTF_8
+        );
+
+        // assert warning was inserted into HTML
+        Assert.assertTrue("Updated HTML should contain warning div",
+                decodedBody.contains("<div") && decodedBody.contains("This message originated outside of your organization."));
+
+        Assert.assertTrue("Updated HTML should still contain original HTML text",
+                decodedBody.contains("Hello HTML world"));
+    }
+
 }

--- a/store/src/java/com/zimbra/cs/lmtpserver/ExternalEmailWarning.java
+++ b/store/src/java/com/zimbra/cs/lmtpserver/ExternalEmailWarning.java
@@ -16,6 +16,7 @@
  */
 package com.zimbra.cs.lmtpserver;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashSet;
@@ -35,7 +36,7 @@ import org.apache.commons.lang.StringEscapeUtils;
 /**
  * ExternalEmailWarning is a singleton class that provides assorted utilities
  * for the External Email Warning functionality.
- * 
+ *
  * @author telus
  *
  */
@@ -65,7 +66,7 @@ public class ExternalEmailWarning {
 
     /**
      * Get whether External Email Warning feature is enabled.
-     * 
+     *
      * @return true if EEW feature is enabled.
      */
     public boolean isEnabled(Account account) throws ServiceException {
@@ -75,7 +76,7 @@ public class ExternalEmailWarning {
     /**
      * Checks if each recipient in the list has External Email Warning (EEW) enabled.
      * If a recipient has EEW enabled, their account is added to the {@code eewEnabledAccountsSet}.
-     * 
+     *
      * @param recipients a list of recipients to check
      */
     public void findRecipientsWithEEWEnabled(List<LmtpAddress> recipients) {
@@ -105,7 +106,7 @@ public class ExternalEmailWarning {
 
     /**
      * Get configured warning to be used on text/html mime message parts.
-     * 
+     *
      * @return string with warning note.
      */
     public String getTextHtmlWarning() {
@@ -114,7 +115,7 @@ public class ExternalEmailWarning {
 
     /**
      * Get configured warning to be used on text/plain mime message parts.
-     * 
+     *
      * @return string with warning note.
      */
     public String getTextPlainWarning() {
@@ -132,25 +133,25 @@ public class ExternalEmailWarning {
     /**
      * Finds whether a originator is external to a receiver's organization based on
      * the string representation of their addresses.
-     * 
+     *
      * If their domains are equal or at least one is sub-domain to the other, then
      * the addresses are considered as intra-organization; otherwise, the addresses
      * are considered as extra-organization.
-     * 
+     *
      * This method works under an optimistic behavior: shall any of the arguments
      * represent an invalid email address, or shall anything goes wrong in any other
      * aspect with the analysis, it will assume that the originator is not external
      * and thus return false.
-     * 
+     *
      * Please note that no actual directory (LDAP) validations are done here, just
      * analysis of two independent as-is strings.
-     * 
+     *
      * @param receiverAddress
      *            receiver's email address in RFC5322 format: name@domain.tld
-     * 
+     *
      * @param originatorAddress
      *            originator's email address in RFC5322 format: name@domain.tld
-     * 
+     *
      * @return true if originatorAddress is external to receiverAddress domain
      */
     public boolean isExternal(String receiverAddress, String originatorAddress) {
@@ -207,66 +208,125 @@ public class ExternalEmailWarning {
     private static final String CONTENT_TYPE_TEXT_HTML_WITHOUT_BODY_TAG_REGEX = "Content-Type: text/html.*?\\r\\n\\r\\n";
     private static final Pattern CONTENT_TYPE_TEXT_HTML_WIHOUT_BODY_TAG_PATTERN = Pattern.compile(CONTENT_TYPE_TEXT_HTML_WITHOUT_BODY_TAG_REGEX,
             Pattern.CASE_INSENSITIVE + Pattern.DOTALL);
+    private static final Pattern CONTENT_TYPE_TEXT_HTML_WITHOUT_BODY_TAG_PATTERN = Pattern.compile(
+            "Content-Type: text/html.*?\\r\\n\\r\\n",
+            Pattern.CASE_INSENSITIVE + Pattern.DOTALL);
     /**
      * Updates the string representation of a mime message in RFC822 format with the
      * warning note for text/plain and text/html parts.
-     * 
+     *
      * This method requires the content to be RFC822 compliant, including that CRLF
      * characters are used as line separators as established in the standard.
      * Similarly, each part header should start with Content-Type and end with
      * CRLFCRLF as established in the standard, in order for this method to properly
      * parse and update the content.
-     * 
+     *
      * @param content
      *            string representation of mime message in RFC822 format
      * @return updated string with warning note
      */
     public String getUpdatedContent(String content, Account account) {
-        if (content != null) {
-            try {
-                baseWarningMessage = Provisioning.getInstance().getDomain(account).getExternalEmailWarningMessage();
-            } catch (ServiceException e) {
-                ZimbraLog.lmtp.warn("Error while retrieving external email warning message", e);
+        if (content == null) {
+            return null;
+        }
+
+        try {
+            baseWarningMessage = Provisioning.getInstance().getDomain(account).getExternalEmailWarningMessage();
+        } catch (ServiceException e) {
+            ZimbraLog.lmtp.warn("Error while retrieving external email warning message", e);
+        }
+
+        textPlainWarning = StringEscapeUtils.escapeHtml(baseWarningMessage) + "\r\n";
+        textHtmlWarning = "<div>"
+                + "<p>" + baseWarningMessage + "</p><hr/></div>";
+
+        // handle text/plain
+        Matcher ctTextPlainMatcher = CONTENT_TYPE_TEXT_PLAIN_PATTERN.matcher(content);
+        Matcher ctBase64TextPlainMatcher = CONTENT_TRANSFER_BASE64_TEXT_PLAIN_PATTERN.matcher(content);
+
+        if (ctTextPlainMatcher.find()) {
+            int headerEnd = ctTextPlainMatcher.end();
+            if (ctTextPlainMatcher.group().contains(CONTENT_TRANSFER_BASE64_ENCODING)) {
+                content = decodeModifyEncodeContent(content, headerEnd, textPlainWarning, "text/plain");
+            } else if (ctBase64TextPlainMatcher.find()) {
+                content = decodeModifyEncodeContent(content, ctBase64TextPlainMatcher.end(), textPlainWarning, "text/plain");
+            } else {
+                content = appendWarning(content, headerEnd, textPlainWarning);
             }
-            textPlainWarning = StringEscapeUtils.escapeHtml(baseWarningMessage) + "\r\n";
-            textHtmlWarning = "<div><p>" + baseWarningMessage + "</p><hr/></div>";
-            encodedTextPlainWarning = Base64.getEncoder().encodeToString(textPlainWarning.getBytes());
-            encodedTextHtmlWarning = Base64.getEncoder().encodeToString(textHtmlWarning.getBytes());
-            final Matcher ctTextPlainMatcher = CONTENT_TYPE_TEXT_PLAIN_PATTERN.matcher(content);
-            final Matcher ctBase64TextPlainMatcher = CONTENT_TRANSFER_BASE64_TEXT_PLAIN_PATTERN.matcher(content);
-            if (ctTextPlainMatcher.find()) {
-                String textPlainHeader = ctTextPlainMatcher.group();
-                final int end = ctTextPlainMatcher.end();
-                if (textPlainHeader != null && textPlainHeader.contains(CONTENT_TRANSFER_BASE64_ENCODING)) {
-                    content = appendWarning(content, end, getEncodedTextPlainWarning());
-                } else if (ctBase64TextPlainMatcher.find()) {
-                    final int endBase64TextPlain = ctBase64TextPlainMatcher.end();
-                    content = appendWarning(content, endBase64TextPlain, getEncodedTextPlainWarning());
-                } else {
-                    content = appendWarning(content, end, getTextPlainWarning());
-                }
-            }
-            final Matcher ctTextHtmlMatcher = CONTENT_TYPE_TEXT_HTML_PATTERN.matcher(content);
-            final Matcher ctTextHtmlWithoutBodyTagMatcher = CONTENT_TYPE_TEXT_HTML_WIHOUT_BODY_TAG_PATTERN.matcher(content);
-            final Matcher ctBase64TextHtmlMatcher = CONTENT_TRANSFER_BASE64_TEXT_HTML_PATTERN.matcher(content);
-            if (ctTextHtmlMatcher.find()) {
-                final int end = ctTextHtmlMatcher.end();
-                content = appendWarning(content, end, getTextHtmlWarning());
-            } else if (ctTextHtmlWithoutBodyTagMatcher.find()) {
-                String textHtmlHeader = ctTextHtmlWithoutBodyTagMatcher.group();
-                final int end = ctTextHtmlWithoutBodyTagMatcher.end();
-                if (textHtmlHeader != null && textHtmlHeader.contains(CONTENT_TRANSFER_BASE64_ENCODING)) {
-                    content = appendWarning(content, end, getEncodedTextHtmlWarning());
-                } else if (ctBase64TextHtmlMatcher.find()) {
-                    final int endBase64TextHtml = ctBase64TextHtmlMatcher.end();
-                    content = appendWarning(content, endBase64TextHtml, getEncodedTextHtmlWarning());
-                } else {
-                    content = appendWarning(content, end, getTextHtmlWarning());
-                }
+        }
+
+        // handle text/html
+        final Matcher ctTextHtmlMatcher = CONTENT_TYPE_TEXT_HTML_PATTERN.matcher(content);
+        final Matcher ctTextHtmlWithoutBodyTagMatcher = CONTENT_TYPE_TEXT_HTML_WITHOUT_BODY_TAG_PATTERN.matcher(content);
+        final Matcher ctBase64TextHtmlMatcher = CONTENT_TRANSFER_BASE64_TEXT_HTML_PATTERN.matcher(content);
+
+        if (ctTextHtmlMatcher.find()) {
+            content = insertHtmlWarning(content, ctTextHtmlMatcher.end(), textHtmlWarning);
+        } else if (ctTextHtmlWithoutBodyTagMatcher.find()) {
+            int headerEnd = ctTextHtmlWithoutBodyTagMatcher.end();
+            if (ctTextHtmlWithoutBodyTagMatcher.group().contains(CONTENT_TRANSFER_BASE64_ENCODING)) {
+                content = decodeModifyEncodeContent(content, headerEnd, textHtmlWarning, "text/html");
+            } else if (ctBase64TextHtmlMatcher.find()) {
+                content = decodeModifyEncodeContent(content, ctBase64TextHtmlMatcher.end(), textHtmlWarning, "text/html");
+            } else {
+                content = insertHtmlWarning(content, headerEnd, textHtmlWarning);
             }
         }
         return content;
     }
+
+    /**
+     * Decode base64, insert warning, re-encode.
+     */
+    private String decodeModifyEncodeContent(String content, int bodyStart, String warning, String contentType) {
+        try {
+            String headers = content.substring(0, bodyStart);
+
+            // original body until boundary
+            int boundaryIndex = content.indexOf("--", bodyStart);
+            String body;
+            String remainder = "";
+            if (boundaryIndex > 0) {
+                body = content.substring(bodyStart, boundaryIndex);
+                remainder = content.substring(boundaryIndex);
+            } else {
+                body = content.substring(bodyStart);
+            }
+
+            boolean isBase64 = headers.toLowerCase().contains("content-transfer-encoding: base64");
+
+            String decoded = isBase64 ? new String(Base64.getMimeDecoder().decode(body), StandardCharsets.UTF_8) : body;
+
+            String modified = warning + "\r\n" + decoded;
+
+            String reEncoded = isBase64
+                    ? Base64.getMimeEncoder(76, "\r\n".getBytes()).encodeToString(modified.getBytes(StandardCharsets.UTF_8)) + "\r\n"
+                    : modified;
+
+            return headers + reEncoded + remainder;
+
+        } catch (Exception e) {
+            ZimbraLog.lmtp.warn("Base64 decode/encode failed, falling back", e);
+            return appendWarning(content, bodyStart, warning);
+        }
+    }
+
+    /**
+     * Insert warning for non-base64 HTML.
+     */
+    private String insertHtmlWarning(String content, int insertPosition, String htmlWarning) {
+        String beforeInsert = content.substring(0, insertPosition);
+        String afterInsert = content.substring(insertPosition);
+        Matcher bodyMatcher = Pattern.compile("(<body[^>]*>)", Pattern.CASE_INSENSITIVE).matcher(afterInsert);
+
+        if (bodyMatcher.find()) {
+            String beforeBody = afterInsert.substring(0, bodyMatcher.end());
+            String afterBody = afterInsert.substring(bodyMatcher.end());
+            return beforeInsert + beforeBody + htmlWarning + afterBody;
+        }
+        return beforeInsert + htmlWarning + afterInsert;
+    }
+
     public String appendWarning(String content, int index, String warning) {
         final StringBuilder sb = new StringBuilder();
         sb.append(content.substring(0, index));


### PR DESCRIPTION
Problem: The ExternalEmailWarning message is being appended after the original email content has already been base64-encoded. The warning message is independently base64-encoded and then concatenated with the previously encoded message content. This results in a malformed final base64 string.

Solution: Decoded the original base64 content, appended warning message to the original content and then re-encoded the whole message.