### PR TITLE
ZBUG-4620: Fix login issue by resolving domain on backend using serverName

### DIFF
--- a/store/src/java/com/zimbra/cs/account/Provisioning.java
+++ b/store/src/java/com/zimbra/cs/account/Provisioning.java
@@ -1086,6 +1086,13 @@ public abstract class Provisioning extends ZAttrProvisioning {
         return get(acctSel.getBy().toKeyAccountBy(), acctSel.getKey());
     }
 
+    public Account get(AccountSelector acctSel, String serverName)
+            throws ServiceException {
+        String key = acctSel.getKey();
+        key = resolveDomainForUsername(key, serverName);
+        return get(acctSel.getBy().toKeyAccountBy(), key);
+    }
+
     public static interface EagerAutoProvisionScheduler {
         // returns whether a shutdown has been request to the scheduler
         public boolean isShutDownRequested();
@@ -2798,4 +2805,21 @@ public abstract class Provisioning extends ZAttrProvisioning {
     }
     
     public abstract String sendMdmEmail(String status, String timeInterval) throws ServiceException;
+
+    public String resolveDomainForUsername(String username, String virtualHostname) throws ServiceException {
+        if (username == null) {
+            throw ServiceException.INVALID_REQUEST("Username cannot be null", null);
+        }
+        if (username.contains("@")) {
+            return username;
+        }
+        if (virtualHostname == null) {
+            throw ServiceException.INVALID_REQUEST("Server name cannot be null for domain resolution", null);
+        }
+        Domain domain = get(Key.DomainBy.virtualHostname, virtualHostname.toLowerCase());
+        if (domain != null) {
+            return username + "@" + domain.getName();
+        }
+        return username;
+    }
 }


### PR DESCRIPTION
Issue:
Login was failing when users entered only their username without a domain while the "password must change" policy was enforced.

Fix Implemented:
Updated the UI to call a backend method, passing the server name.
On the server side, the domain is retrieved using the provided serverName.
The backend constructs the complete username.
