### PR TITLE
ZCS-17462: Able to change zimbraExternalEmailWarningMessage even when zimbraFeatureExternalEmailWarningEnabled is set to FALSE.

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -6523,7 +6523,7 @@ public class ZAttrProvisioning {
     /**
      * Sets the base warning text for External Email Warning (EEW)
      *
-     * @since ZCS 10.1.9
+     * @since ZCS 10.1.12
      */
     @ZAttr(id=4139)
     public static final String A_zimbraExternalEmailWarningMessage = "zimbraExternalEmailWarningMessage";
@@ -7074,7 +7074,7 @@ public class ZAttrProvisioning {
     /**
      * Feature to enable/disable External Email Warning (EEW)
      *
-     * @since ZCS 10.1.9
+     * @since ZCS 10.1.12
      */
     @ZAttr(id=4138)
     public static final String A_zimbraFeatureExternalEmailWarningEnabled = "zimbraFeatureExternalEmailWarningEnabled";

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10571,12 +10571,12 @@ TODO: delete them permanently from here
   </desc>
 </attr>
 
-<attr id="4138" name="zimbraFeatureExternalEmailWarningEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.9">
+<attr id="4138" name="zimbraFeatureExternalEmailWarningEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.12">
   <globalConfigValue>FALSE</globalConfigValue>
   <desc>Feature to enable/disable External Email Warning (EEW)</desc>
 </attr>
 
-<attr id="4139" name="zimbraExternalEmailWarningMessage" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.9">
+<attr id="4139" name="zimbraExternalEmailWarningMessage" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" callback="ExternalEmailWarningCallBack" since="10.1.12">
   <desc>Sets the base warning text for External Email Warning (EEW)</desc>
   <globalConfigValue>This message originated outside of your organization.</globalConfigValue>
 </attr>

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -18413,7 +18413,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @return zimbraExternalEmailWarningMessage, or "This message originated outside of your organization." if unset
      *
-     * @since ZCS 10.1.9
+     * @since ZCS 10.1.12
      */
     @ZAttr(id=4139)
     public String getExternalEmailWarningMessage() {
@@ -18426,7 +18426,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param zimbraExternalEmailWarningMessage new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 10.1.9
+     * @since ZCS 10.1.12
      */
     @ZAttr(id=4139)
     public void setExternalEmailWarningMessage(String zimbraExternalEmailWarningMessage) throws com.zimbra.common.service.ServiceException {
@@ -18442,7 +18442,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 10.1.9
+     * @since ZCS 10.1.12
      */
     @ZAttr(id=4139)
     public Map<String,Object> setExternalEmailWarningMessage(String zimbraExternalEmailWarningMessage, Map<String,Object> attrs) {
@@ -18456,7 +18456,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 10.1.9
+     * @since ZCS 10.1.12
      */
     @ZAttr(id=4139)
     public void unsetExternalEmailWarningMessage() throws com.zimbra.common.service.ServiceException {
@@ -18471,7 +18471,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 10.1.9
+     * @since ZCS 10.1.12
      */
     @ZAttr(id=4139)
     public Map<String,Object> unsetExternalEmailWarningMessage(Map<String,Object> attrs) {
@@ -18977,7 +18977,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @return zimbraFeatureExternalEmailWarningEnabled, or false if unset
      *
-     * @since ZCS 10.1.9
+     * @since ZCS 10.1.12
      */
     @ZAttr(id=4138)
     public boolean isFeatureExternalEmailWarningEnabled() {
@@ -18990,7 +18990,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param zimbraFeatureExternalEmailWarningEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 10.1.9
+     * @since ZCS 10.1.12
      */
     @ZAttr(id=4138)
     public void setFeatureExternalEmailWarningEnabled(boolean zimbraFeatureExternalEmailWarningEnabled) throws com.zimbra.common.service.ServiceException {
@@ -19006,7 +19006,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 10.1.9
+     * @since ZCS 10.1.12
      */
     @ZAttr(id=4138)
     public Map<String,Object> setFeatureExternalEmailWarningEnabled(boolean zimbraFeatureExternalEmailWarningEnabled, Map<String,Object> attrs) {
@@ -19020,7 +19020,7 @@ public abstract class ZAttrConfig extends Entry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 10.1.9
+     * @since ZCS 10.1.12
      */
     @ZAttr(id=4138)
     public void unsetFeatureExternalEmailWarningEnabled() throws com.zimbra.common.service.ServiceException {
@@ -19035,7 +19035,7 @@ public abstract class ZAttrConfig extends Entry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 10.1.9
+     * @since ZCS 10.1.12
      */
     @ZAttr(id=4138)
     public Map<String,Object> unsetFeatureExternalEmailWarningEnabled(Map<String,Object> attrs) {

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -9275,7 +9275,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @return zimbraExternalEmailWarningMessage, or "This message originated outside of your organization." if unset
      *
-     * @since ZCS 10.1.9
+     * @since ZCS 10.1.12
      */
     @ZAttr(id=4139)
     public String getExternalEmailWarningMessage() {
@@ -9288,7 +9288,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param zimbraExternalEmailWarningMessage new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 10.1.9
+     * @since ZCS 10.1.12
      */
     @ZAttr(id=4139)
     public void setExternalEmailWarningMessage(String zimbraExternalEmailWarningMessage) throws com.zimbra.common.service.ServiceException {
@@ -9304,7 +9304,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 10.1.9
+     * @since ZCS 10.1.12
      */
     @ZAttr(id=4139)
     public Map<String,Object> setExternalEmailWarningMessage(String zimbraExternalEmailWarningMessage, Map<String,Object> attrs) {
@@ -9318,7 +9318,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 10.1.9
+     * @since ZCS 10.1.12
      */
     @ZAttr(id=4139)
     public void unsetExternalEmailWarningMessage() throws com.zimbra.common.service.ServiceException {
@@ -9333,7 +9333,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 10.1.9
+     * @since ZCS 10.1.12
      */
     @ZAttr(id=4139)
     public Map<String,Object> unsetExternalEmailWarningMessage(Map<String,Object> attrs) {
@@ -11451,7 +11451,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @return zimbraFeatureExternalEmailWarningEnabled, or false if unset
      *
-     * @since ZCS 10.1.9
+     * @since ZCS 10.1.12
      */
     @ZAttr(id=4138)
     public boolean isFeatureExternalEmailWarningEnabled() {
@@ -11464,7 +11464,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param zimbraFeatureExternalEmailWarningEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 10.1.9
+     * @since ZCS 10.1.12
      */
     @ZAttr(id=4138)
     public void setFeatureExternalEmailWarningEnabled(boolean zimbraFeatureExternalEmailWarningEnabled) throws com.zimbra.common.service.ServiceException {
@@ -11480,7 +11480,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 10.1.9
+     * @since ZCS 10.1.12
      */
     @ZAttr(id=4138)
     public Map<String,Object> setFeatureExternalEmailWarningEnabled(boolean zimbraFeatureExternalEmailWarningEnabled, Map<String,Object> attrs) {
@@ -11494,7 +11494,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 10.1.9
+     * @since ZCS 10.1.12
      */
     @ZAttr(id=4138)
     public void unsetFeatureExternalEmailWarningEnabled() throws com.zimbra.common.service.ServiceException {
@@ -11509,7 +11509,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 10.1.9
+     * @since ZCS 10.1.12
      */
     @ZAttr(id=4138)
     public Map<String,Object> unsetFeatureExternalEmailWarningEnabled(Map<String,Object> attrs) {

--- a/store/src/java/com/zimbra/cs/account/callback/ExternalEmailWarningCallBack.java
+++ b/store/src/java/com/zimbra/cs/account/callback/ExternalEmailWarningCallBack.java
@@ -1,0 +1,24 @@
+package com.zimbra.cs.account.callback;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.AttributeCallback;
+import com.zimbra.cs.account.Entry;
+
+import java.util.Map;
+
+public class ExternalEmailWarningCallBack extends AttributeCallback {
+    @Override
+    public void preModify(CallbackContext context, String attrName, Object attrValue, Map attrsToModify, Entry entry) throws ServiceException {
+
+        boolean eewEnabled = entry.getBooleanAttr("zimbraFeatureExternalEmailWarningEnabled", false);
+
+        if(!eewEnabled)  {
+            throw ServiceException.INVALID_REQUEST("Warning Message cannot be modified if the feature is disabled", null);
+        }
+    }
+
+    @Override
+    public void postModify(CallbackContext context, String attrName, Entry entry) {
+
+    }
+}


### PR DESCRIPTION
Problem: User is able to change zimbraExternalEmailWarningMessage LDAP attribute from backend even when zimbraFeatureExternalEmailWarningEnabled is set to FALSE. No restrictions on LDAP attributes.

Solution: Added callback for zimbraExternalEmailWarningMessage to check if the feature is enabled or not before modifying the attribute.