### PR TITLE
ZBUG-5116:Ignore mailbox exception when deleting the mailbox on server crashes

### DIFF
--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -2485,6 +2485,15 @@ public class Mailbox implements MailboxStore {
             // first, throw the mailbox into maintenance mode
             // (so anyone else with a cached reference to the Mailbox can't use it)
             maint = MailboxManager.getInstance().beginMaintenance(mData.accountId, mId);
+        } catch (MailServiceException e) {
+            // ignore wrong mailbox exception.  It may be thrown if we're redoing a DeleteMailbox that was interrupted
+            // when server crashed in the middle of the operation.  Database says the mailbox has been deleted, but
+            // there may be other files that still need to be cleaned up.
+            if (!MailServiceException.WRONG_MAILBOX.equals(e.getCode())) {
+                throw e;
+            }
+        }
+        try {
             DeleteMailbox redoRecorder = new DeleteMailbox(mId);
             beginTransaction("deleteMailbox", null, redoRecorder);
             boolean needRedo = needRedo(null, redoRecorder);
@@ -2565,13 +2574,6 @@ public class Mailbox implements MailboxStore {
                         MailboxManager.getInstance().endMaintenance(maint, success, true);
                     }
                 }
-            }
-        } catch (MailServiceException e) {
-            // Ignore wrong mailbox exception.  It may be thrown if we're redoing a DeleteMailbox that was interrupted
-            // when server crashed in the middle of the operation.  Database says the mailbox has been deleted, but
-            // there may be other files that still need to be cleaned up.
-            if (!MailServiceException.WRONG_MAILBOX.equals(e.getCode())) {
-                throw e;
             }
         } finally {
             lock.release();


### PR DESCRIPTION
**Issue**: [ZBUG-5116](https://synacor.atlassian.net/browse/ZBUG-5116)

**Fix**: Relocated the catch block during mailbox maintenance initialization to properly handle exceptions; previously, this could have caused orphan account deletions.

**Test Case**: Verified by deliberately causing the beginMaintenance method to fail and observing the functional flow of the changes.

**Results**: When the server crashes, the deleteMailbox method now stops gracefully without affecting orphan accounts.

[ZBUG-5116]: https://synacor.atlassian.net/browse/ZBUG-5116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ