### PR TITLE
ZCS-18009 : New Ldap attributes for Legacy BackupRestore 2.0

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -162,6 +162,22 @@ public class ZAttrProvisioning {
         public boolean isNoZip() { return this == noZip;}
     }
 
+    public static enum BackupDeduplication {
+        dedup("dedup"),
+        noDedup("noDedup");
+        private String mValue;
+        private BackupDeduplication(String value) { mValue = value; }
+        public String toString() { return mValue; }
+        public static BackupDeduplication fromString(String s) throws ServiceException {
+            for (BackupDeduplication value : values()) {
+                if (value.mValue.equals(s)) return value;
+             }
+             throw ServiceException.INVALID_REQUEST("invalid value: "+s+", valid values: "+ Arrays.asList(values()), null);
+        }
+        public boolean isDedup() { return this == dedup;}
+        public boolean isNoDedup() { return this == noDedup;}
+    }
+
     public static enum BackupMode {
         Standard("Standard"),
         Auto_Grouped("Auto-Grouped");
@@ -314,6 +330,22 @@ public class ZAttrProvisioning {
         }
         public boolean isCleartext() { return this == cleartext;}
         public boolean isSsl() { return this == ssl;}
+    }
+
+    public static enum DedupeBackupBlobsCompressType {
+        noZip("noZip"),
+        ZSTD("ZSTD");
+        private String mValue;
+        private DedupeBackupBlobsCompressType(String value) { mValue = value; }
+        public String toString() { return mValue; }
+        public static DedupeBackupBlobsCompressType fromString(String s) throws ServiceException {
+            for (DedupeBackupBlobsCompressType value : values()) {
+                if (value.mValue.equals(s)) return value;
+             }
+             throw ServiceException.INVALID_REQUEST("invalid value: "+s+", valid values: "+ Arrays.asList(values()), null);
+        }
+        public boolean isNoZip() { return this == noZip;}
+        public boolean isZSTD() { return this == ZSTD;}
     }
 
     public static enum DelayedIndexStatus {
@@ -4070,6 +4102,16 @@ public class ZAttrProvisioning {
     public static final String A_zimbraBackupCrontabConfig = "zimbraBackupCrontabConfig";
 
     /**
+     * Blob Deduplication enabled during Backup dedup - blobs deduplication
+     * is enabled during the backup. noDedup - blobs deduplication is
+     * disabled during the backup.
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4147)
+    public static final String A_zimbraBackupDeduplication = "zimbraBackupDeduplication";
+
+    /**
      * Whether or not account is eligible for backup If true on cos level
      * then backup accounts for cos. zimbraDomainDefaultCOSId is considered.
      * If unset on cos level but true on domain level then backup domains
@@ -5753,6 +5795,16 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=365)
     public static final String A_zimbraDebugInfo = "zimbraDebugInfo";
+
+    /**
+     * Blobs inside a backup are compressed by default in ZSTD format. noZip
+     * - blobs are backed up as individual files without compression. ZSTD -
+     * blobs are backed up with Zstandard compression.
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4148)
+    public static final String A_zimbraDedupeBackupBlobsCompressType = "zimbraDedupeBackupBlobsCompressType";
 
     /**
      * stop words for lucene text analyzer. This setting takes effect only
@@ -9543,14 +9595,6 @@ public class ZAttrProvisioning {
     public static final String A_zimbraLicensePreExpiryReminderSentDetails = "zimbraLicensePreExpiryReminderSentDetails";
 
     /**
-     * Package Usage Reporting Scheduler last successful run date
-     *
-     * @since ZCS 10.1.12
-     */
-    @ZAttr(id=4145)
-    public static final String A_zimbraPackageUsageReportingLastSuccessfulRunDetails = "zimbraPackageUsageReportingLastSuccessfulRunDetails";
-
-    /**
      * name to use in greeting and sign-off; if empty, uses hostname
      */
     @ZAttr(id=23)
@@ -13215,6 +13259,14 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=3012)
     public static final String A_zimbraOpenImapFolderRequestChunkSize = "zimbraOpenImapFolderRequestChunkSize";
+
+    /**
+     * Package Usage Reporting Scheduler last successful run date
+     *
+     * @since ZCS 10.1.12
+     */
+    @ZAttr(id=4145)
+    public static final String A_zimbraPackageUsageReportingLastSuccessfulRunDetails = "zimbraPackageUsageReportingLastSuccessfulRunDetails";
 
     /**
      * regex of allowed characters in password

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10613,4 +10613,20 @@ TODO: delete them permanently from here
   <desc>Flag to enable or disable the collection of domain details</desc>
 </attr>
 
+<attr id="4147" name="zimbraBackupDeduplication" type="enum" value="dedup,noDedup" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="10.1.13">
+  <globalConfigValue>dedup</globalConfigValue>
+  <desc>Blob Deduplication enabled during Backup
+    dedup - blobs deduplication is enabled during the backup.
+    noDedup - blobs deduplication is disabled during the backup.
+  </desc>
+</attr>
+
+<attr id="4148" name="zimbraDedupeBackupBlobsCompressType" type="enum" value="noZip,ZSTD" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="10.1.13" callback="DedupeBackupBlobsCompressTypeCallback">
+  <globalConfigValue>ZSTD</globalConfigValue>
+  <desc>Blobs inside a backup are compressed by default in ZSTD format.
+    noZip - blobs are backed up as individual files without compression.
+    ZSTD - blobs are backed up with Zstandard compression.
+  </desc>
+</attr>
+
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -5365,6 +5365,153 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Blob Deduplication enabled during Backup dedup - blobs deduplication
+     * is enabled during the backup. noDedup - blobs deduplication is
+     * disabled during the backup.
+     *
+     * <p>Valid values: [dedup, noDedup]
+     *
+     * @return zimbraBackupDeduplication, or ZAttrProvisioning.BackupDeduplication.dedup if unset and/or has invalid value
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4147)
+    public ZAttrProvisioning.BackupDeduplication getBackupDeduplication() {
+        try { String v = getAttr(Provisioning.A_zimbraBackupDeduplication, true, true); return v == null ? ZAttrProvisioning.BackupDeduplication.dedup : ZAttrProvisioning.BackupDeduplication.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.BackupDeduplication.dedup; }
+    }
+
+    /**
+     * Blob Deduplication enabled during Backup dedup - blobs deduplication
+     * is enabled during the backup. noDedup - blobs deduplication is
+     * disabled during the backup.
+     *
+     * <p>Valid values: [dedup, noDedup]
+     *
+     * @return zimbraBackupDeduplication, or "dedup" if unset
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4147)
+    public String getBackupDeduplicationAsString() {
+        return getAttr(Provisioning.A_zimbraBackupDeduplication, "dedup", true);
+    }
+
+    /**
+     * Blob Deduplication enabled during Backup dedup - blobs deduplication
+     * is enabled during the backup. noDedup - blobs deduplication is
+     * disabled during the backup.
+     *
+     * <p>Valid values: [dedup, noDedup]
+     *
+     * @param zimbraBackupDeduplication new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4147)
+    public void setBackupDeduplication(ZAttrProvisioning.BackupDeduplication zimbraBackupDeduplication) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupDeduplication, zimbraBackupDeduplication.toString());
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Blob Deduplication enabled during Backup dedup - blobs deduplication
+     * is enabled during the backup. noDedup - blobs deduplication is
+     * disabled during the backup.
+     *
+     * <p>Valid values: [dedup, noDedup]
+     *
+     * @param zimbraBackupDeduplication new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4147)
+    public Map<String,Object> setBackupDeduplication(ZAttrProvisioning.BackupDeduplication zimbraBackupDeduplication, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupDeduplication, zimbraBackupDeduplication.toString());
+        return attrs;
+    }
+
+    /**
+     * Blob Deduplication enabled during Backup dedup - blobs deduplication
+     * is enabled during the backup. noDedup - blobs deduplication is
+     * disabled during the backup.
+     *
+     * <p>Valid values: [dedup, noDedup]
+     *
+     * @param zimbraBackupDeduplication new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4147)
+    public void setBackupDeduplicationAsString(String zimbraBackupDeduplication) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupDeduplication, zimbraBackupDeduplication);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Blob Deduplication enabled during Backup dedup - blobs deduplication
+     * is enabled during the backup. noDedup - blobs deduplication is
+     * disabled during the backup.
+     *
+     * <p>Valid values: [dedup, noDedup]
+     *
+     * @param zimbraBackupDeduplication new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4147)
+    public Map<String,Object> setBackupDeduplicationAsString(String zimbraBackupDeduplication, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupDeduplication, zimbraBackupDeduplication);
+        return attrs;
+    }
+
+    /**
+     * Blob Deduplication enabled during Backup dedup - blobs deduplication
+     * is enabled during the backup. noDedup - blobs deduplication is
+     * disabled during the backup.
+     *
+     * <p>Valid values: [dedup, noDedup]
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4147)
+    public void unsetBackupDeduplication() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupDeduplication, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Blob Deduplication enabled during Backup dedup - blobs deduplication
+     * is enabled during the backup. noDedup - blobs deduplication is
+     * disabled during the backup.
+     *
+     * <p>Valid values: [dedup, noDedup]
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4147)
+    public Map<String,Object> unsetBackupDeduplication(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupDeduplication, "");
+        return attrs;
+    }
+
+    /**
      * Whether or not account is eligible for backup If true on cos level
      * then backup accounts for cos. zimbraDomainDefaultCOSId is considered.
      * If unset on cos level but true on domain level then backup domains
@@ -14718,6 +14865,153 @@ public abstract class ZAttrConfig extends Entry {
     public Map<String,Object> unsetDatabaseSlowSqlThreshold(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraDatabaseSlowSqlThreshold, "");
+        return attrs;
+    }
+
+    /**
+     * Blobs inside a backup are compressed by default in ZSTD format. noZip
+     * - blobs are backed up as individual files without compression. ZSTD -
+     * blobs are backed up with Zstandard compression.
+     *
+     * <p>Valid values: [noZip, ZSTD]
+     *
+     * @return zimbraDedupeBackupBlobsCompressType, or ZAttrProvisioning.DedupeBackupBlobsCompressType.ZSTD if unset and/or has invalid value
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4148)
+    public ZAttrProvisioning.DedupeBackupBlobsCompressType getDedupeBackupBlobsCompressType() {
+        try { String v = getAttr(Provisioning.A_zimbraDedupeBackupBlobsCompressType, true, true); return v == null ? ZAttrProvisioning.DedupeBackupBlobsCompressType.ZSTD : ZAttrProvisioning.DedupeBackupBlobsCompressType.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.DedupeBackupBlobsCompressType.ZSTD; }
+    }
+
+    /**
+     * Blobs inside a backup are compressed by default in ZSTD format. noZip
+     * - blobs are backed up as individual files without compression. ZSTD -
+     * blobs are backed up with Zstandard compression.
+     *
+     * <p>Valid values: [noZip, ZSTD]
+     *
+     * @return zimbraDedupeBackupBlobsCompressType, or "ZSTD" if unset
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4148)
+    public String getDedupeBackupBlobsCompressTypeAsString() {
+        return getAttr(Provisioning.A_zimbraDedupeBackupBlobsCompressType, "ZSTD", true);
+    }
+
+    /**
+     * Blobs inside a backup are compressed by default in ZSTD format. noZip
+     * - blobs are backed up as individual files without compression. ZSTD -
+     * blobs are backed up with Zstandard compression.
+     *
+     * <p>Valid values: [noZip, ZSTD]
+     *
+     * @param zimbraDedupeBackupBlobsCompressType new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4148)
+    public void setDedupeBackupBlobsCompressType(ZAttrProvisioning.DedupeBackupBlobsCompressType zimbraDedupeBackupBlobsCompressType) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDedupeBackupBlobsCompressType, zimbraDedupeBackupBlobsCompressType.toString());
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Blobs inside a backup are compressed by default in ZSTD format. noZip
+     * - blobs are backed up as individual files without compression. ZSTD -
+     * blobs are backed up with Zstandard compression.
+     *
+     * <p>Valid values: [noZip, ZSTD]
+     *
+     * @param zimbraDedupeBackupBlobsCompressType new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4148)
+    public Map<String,Object> setDedupeBackupBlobsCompressType(ZAttrProvisioning.DedupeBackupBlobsCompressType zimbraDedupeBackupBlobsCompressType, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDedupeBackupBlobsCompressType, zimbraDedupeBackupBlobsCompressType.toString());
+        return attrs;
+    }
+
+    /**
+     * Blobs inside a backup are compressed by default in ZSTD format. noZip
+     * - blobs are backed up as individual files without compression. ZSTD -
+     * blobs are backed up with Zstandard compression.
+     *
+     * <p>Valid values: [noZip, ZSTD]
+     *
+     * @param zimbraDedupeBackupBlobsCompressType new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4148)
+    public void setDedupeBackupBlobsCompressTypeAsString(String zimbraDedupeBackupBlobsCompressType) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDedupeBackupBlobsCompressType, zimbraDedupeBackupBlobsCompressType);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Blobs inside a backup are compressed by default in ZSTD format. noZip
+     * - blobs are backed up as individual files without compression. ZSTD -
+     * blobs are backed up with Zstandard compression.
+     *
+     * <p>Valid values: [noZip, ZSTD]
+     *
+     * @param zimbraDedupeBackupBlobsCompressType new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4148)
+    public Map<String,Object> setDedupeBackupBlobsCompressTypeAsString(String zimbraDedupeBackupBlobsCompressType, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDedupeBackupBlobsCompressType, zimbraDedupeBackupBlobsCompressType);
+        return attrs;
+    }
+
+    /**
+     * Blobs inside a backup are compressed by default in ZSTD format. noZip
+     * - blobs are backed up as individual files without compression. ZSTD -
+     * blobs are backed up with Zstandard compression.
+     *
+     * <p>Valid values: [noZip, ZSTD]
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4148)
+    public void unsetDedupeBackupBlobsCompressType() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDedupeBackupBlobsCompressType, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Blobs inside a backup are compressed by default in ZSTD format. noZip
+     * - blobs are backed up as individual files without compression. ZSTD -
+     * blobs are backed up with Zstandard compression.
+     *
+     * <p>Valid values: [noZip, ZSTD]
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4148)
+    public Map<String,Object> unsetDedupeBackupBlobsCompressType(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDedupeBackupBlobsCompressType, "");
         return attrs;
     }
 
@@ -29353,78 +29647,6 @@ public abstract class ZAttrConfig extends Entry {
     public Map<String,Object> unsetLicensePreExpiryReminderSentDetails(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraLicensePreExpiryReminderSentDetails, "");
-        return attrs;
-    }
-
-    /**
-     * Package Usage Reporting Scheduler last successful run date
-     *
-     * @return zimbraPackageUsageReportingLastSuccessfulRunDetails, or null if unset
-     *
-     * @since ZCS 10.1.12
-     */
-    @ZAttr(id=4145)
-    public String getPackageUsageReportingLastSuccessfulRunDetails() {
-        return getAttr(Provisioning.A_zimbraPackageUsageReportingLastSuccessfulRunDetails, null, true);
-    }
-
-    /**
-     * Package Usage Reporting Scheduler last successful run date
-     *
-     * @param zimbraPackageUsageReportingLastSuccessfulRunDetails new value
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 10.1.12
-     */
-    @ZAttr(id=4145)
-    public void setPackageUsageReportingLastSuccessfulRunDetails(String zimbraPackageUsageReportingLastSuccessfulRunDetails) throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraPackageUsageReportingLastSuccessfulRunDetails, zimbraPackageUsageReportingLastSuccessfulRunDetails);
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Package Usage Reporting Scheduler last successful run date
-     *
-     * @param zimbraPackageUsageReportingLastSuccessfulRunDetails new value
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 10.1.12
-     */
-    @ZAttr(id=4145)
-    public Map<String,Object> setPackageUsageReportingLastSuccessfulRunDetails(String zimbraPackageUsageReportingLastSuccessfulRunDetails, Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraPackageUsageReportingLastSuccessfulRunDetails, zimbraPackageUsageReportingLastSuccessfulRunDetails);
-        return attrs;
-    }
-
-    /**
-     * Package Usage Reporting Scheduler last successful run date
-     *
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 10.1.12
-     */
-    @ZAttr(id=4145)
-    public void unsetPackageUsageReportingLastSuccessfulRunDetails() throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraPackageUsageReportingLastSuccessfulRunDetails, "");
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * Package Usage Reporting Scheduler last successful run date
-     *
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 10.1.12
-     */
-    @ZAttr(id=4145)
-    public Map<String,Object> unsetPackageUsageReportingLastSuccessfulRunDetails(Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraPackageUsageReportingLastSuccessfulRunDetails, "");
         return attrs;
     }
 
@@ -56075,6 +56297,78 @@ public abstract class ZAttrConfig extends Entry {
     public Map<String,Object> unsetPURDomainDetailsCollectionEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraPURDomainDetailsCollectionEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * Package Usage Reporting Scheduler last successful run date
+     *
+     * @return zimbraPackageUsageReportingLastSuccessfulRunDetails, or null if unset
+     *
+     * @since ZCS 10.1.12
+     */
+    @ZAttr(id=4145)
+    public String getPackageUsageReportingLastSuccessfulRunDetails() {
+        return getAttr(Provisioning.A_zimbraPackageUsageReportingLastSuccessfulRunDetails, null, true);
+    }
+
+    /**
+     * Package Usage Reporting Scheduler last successful run date
+     *
+     * @param zimbraPackageUsageReportingLastSuccessfulRunDetails new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.12
+     */
+    @ZAttr(id=4145)
+    public void setPackageUsageReportingLastSuccessfulRunDetails(String zimbraPackageUsageReportingLastSuccessfulRunDetails) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPackageUsageReportingLastSuccessfulRunDetails, zimbraPackageUsageReportingLastSuccessfulRunDetails);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Package Usage Reporting Scheduler last successful run date
+     *
+     * @param zimbraPackageUsageReportingLastSuccessfulRunDetails new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.12
+     */
+    @ZAttr(id=4145)
+    public Map<String,Object> setPackageUsageReportingLastSuccessfulRunDetails(String zimbraPackageUsageReportingLastSuccessfulRunDetails, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPackageUsageReportingLastSuccessfulRunDetails, zimbraPackageUsageReportingLastSuccessfulRunDetails);
+        return attrs;
+    }
+
+    /**
+     * Package Usage Reporting Scheduler last successful run date
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.12
+     */
+    @ZAttr(id=4145)
+    public void unsetPackageUsageReportingLastSuccessfulRunDetails() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPackageUsageReportingLastSuccessfulRunDetails, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Package Usage Reporting Scheduler last successful run date
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.12
+     */
+    @ZAttr(id=4145)
+    public Map<String,Object> unsetPackageUsageReportingLastSuccessfulRunDetails(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraPackageUsageReportingLastSuccessfulRunDetails, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrServer.java
@@ -3330,6 +3330,153 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
+     * Blob Deduplication enabled during Backup dedup - blobs deduplication
+     * is enabled during the backup. noDedup - blobs deduplication is
+     * disabled during the backup.
+     *
+     * <p>Valid values: [dedup, noDedup]
+     *
+     * @return zimbraBackupDeduplication, or ZAttrProvisioning.BackupDeduplication.dedup if unset and/or has invalid value
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4147)
+    public ZAttrProvisioning.BackupDeduplication getBackupDeduplication() {
+        try { String v = getAttr(Provisioning.A_zimbraBackupDeduplication, true, true); return v == null ? ZAttrProvisioning.BackupDeduplication.dedup : ZAttrProvisioning.BackupDeduplication.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.BackupDeduplication.dedup; }
+    }
+
+    /**
+     * Blob Deduplication enabled during Backup dedup - blobs deduplication
+     * is enabled during the backup. noDedup - blobs deduplication is
+     * disabled during the backup.
+     *
+     * <p>Valid values: [dedup, noDedup]
+     *
+     * @return zimbraBackupDeduplication, or "dedup" if unset
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4147)
+    public String getBackupDeduplicationAsString() {
+        return getAttr(Provisioning.A_zimbraBackupDeduplication, "dedup", true);
+    }
+
+    /**
+     * Blob Deduplication enabled during Backup dedup - blobs deduplication
+     * is enabled during the backup. noDedup - blobs deduplication is
+     * disabled during the backup.
+     *
+     * <p>Valid values: [dedup, noDedup]
+     *
+     * @param zimbraBackupDeduplication new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4147)
+    public void setBackupDeduplication(ZAttrProvisioning.BackupDeduplication zimbraBackupDeduplication) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupDeduplication, zimbraBackupDeduplication.toString());
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Blob Deduplication enabled during Backup dedup - blobs deduplication
+     * is enabled during the backup. noDedup - blobs deduplication is
+     * disabled during the backup.
+     *
+     * <p>Valid values: [dedup, noDedup]
+     *
+     * @param zimbraBackupDeduplication new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4147)
+    public Map<String,Object> setBackupDeduplication(ZAttrProvisioning.BackupDeduplication zimbraBackupDeduplication, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupDeduplication, zimbraBackupDeduplication.toString());
+        return attrs;
+    }
+
+    /**
+     * Blob Deduplication enabled during Backup dedup - blobs deduplication
+     * is enabled during the backup. noDedup - blobs deduplication is
+     * disabled during the backup.
+     *
+     * <p>Valid values: [dedup, noDedup]
+     *
+     * @param zimbraBackupDeduplication new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4147)
+    public void setBackupDeduplicationAsString(String zimbraBackupDeduplication) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupDeduplication, zimbraBackupDeduplication);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Blob Deduplication enabled during Backup dedup - blobs deduplication
+     * is enabled during the backup. noDedup - blobs deduplication is
+     * disabled during the backup.
+     *
+     * <p>Valid values: [dedup, noDedup]
+     *
+     * @param zimbraBackupDeduplication new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4147)
+    public Map<String,Object> setBackupDeduplicationAsString(String zimbraBackupDeduplication, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupDeduplication, zimbraBackupDeduplication);
+        return attrs;
+    }
+
+    /**
+     * Blob Deduplication enabled during Backup dedup - blobs deduplication
+     * is enabled during the backup. noDedup - blobs deduplication is
+     * disabled during the backup.
+     *
+     * <p>Valid values: [dedup, noDedup]
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4147)
+    public void unsetBackupDeduplication() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupDeduplication, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Blob Deduplication enabled during Backup dedup - blobs deduplication
+     * is enabled during the backup. noDedup - blobs deduplication is
+     * disabled during the backup.
+     *
+     * <p>Valid values: [dedup, noDedup]
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4147)
+    public Map<String,Object> unsetBackupDeduplication(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraBackupDeduplication, "");
+        return attrs;
+    }
+
+    /**
      * Minimum percentage or TB/GB/MB/KB/bytes of free space on backup target
      * to allow a full or auto-grouped backup to start; 0 = no minimum is
      * enforced. Examples: 25%, 10GB
@@ -9136,6 +9283,153 @@ public abstract class ZAttrServer extends NamedEntry {
     public Map<String,Object> unsetDatabaseSlowSqlThreshold(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraDatabaseSlowSqlThreshold, "");
+        return attrs;
+    }
+
+    /**
+     * Blobs inside a backup are compressed by default in ZSTD format. noZip
+     * - blobs are backed up as individual files without compression. ZSTD -
+     * blobs are backed up with Zstandard compression.
+     *
+     * <p>Valid values: [noZip, ZSTD]
+     *
+     * @return zimbraDedupeBackupBlobsCompressType, or ZAttrProvisioning.DedupeBackupBlobsCompressType.ZSTD if unset and/or has invalid value
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4148)
+    public ZAttrProvisioning.DedupeBackupBlobsCompressType getDedupeBackupBlobsCompressType() {
+        try { String v = getAttr(Provisioning.A_zimbraDedupeBackupBlobsCompressType, true, true); return v == null ? ZAttrProvisioning.DedupeBackupBlobsCompressType.ZSTD : ZAttrProvisioning.DedupeBackupBlobsCompressType.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.DedupeBackupBlobsCompressType.ZSTD; }
+    }
+
+    /**
+     * Blobs inside a backup are compressed by default in ZSTD format. noZip
+     * - blobs are backed up as individual files without compression. ZSTD -
+     * blobs are backed up with Zstandard compression.
+     *
+     * <p>Valid values: [noZip, ZSTD]
+     *
+     * @return zimbraDedupeBackupBlobsCompressType, or "ZSTD" if unset
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4148)
+    public String getDedupeBackupBlobsCompressTypeAsString() {
+        return getAttr(Provisioning.A_zimbraDedupeBackupBlobsCompressType, "ZSTD", true);
+    }
+
+    /**
+     * Blobs inside a backup are compressed by default in ZSTD format. noZip
+     * - blobs are backed up as individual files without compression. ZSTD -
+     * blobs are backed up with Zstandard compression.
+     *
+     * <p>Valid values: [noZip, ZSTD]
+     *
+     * @param zimbraDedupeBackupBlobsCompressType new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4148)
+    public void setDedupeBackupBlobsCompressType(ZAttrProvisioning.DedupeBackupBlobsCompressType zimbraDedupeBackupBlobsCompressType) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDedupeBackupBlobsCompressType, zimbraDedupeBackupBlobsCompressType.toString());
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Blobs inside a backup are compressed by default in ZSTD format. noZip
+     * - blobs are backed up as individual files without compression. ZSTD -
+     * blobs are backed up with Zstandard compression.
+     *
+     * <p>Valid values: [noZip, ZSTD]
+     *
+     * @param zimbraDedupeBackupBlobsCompressType new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4148)
+    public Map<String,Object> setDedupeBackupBlobsCompressType(ZAttrProvisioning.DedupeBackupBlobsCompressType zimbraDedupeBackupBlobsCompressType, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDedupeBackupBlobsCompressType, zimbraDedupeBackupBlobsCompressType.toString());
+        return attrs;
+    }
+
+    /**
+     * Blobs inside a backup are compressed by default in ZSTD format. noZip
+     * - blobs are backed up as individual files without compression. ZSTD -
+     * blobs are backed up with Zstandard compression.
+     *
+     * <p>Valid values: [noZip, ZSTD]
+     *
+     * @param zimbraDedupeBackupBlobsCompressType new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4148)
+    public void setDedupeBackupBlobsCompressTypeAsString(String zimbraDedupeBackupBlobsCompressType) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDedupeBackupBlobsCompressType, zimbraDedupeBackupBlobsCompressType);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Blobs inside a backup are compressed by default in ZSTD format. noZip
+     * - blobs are backed up as individual files without compression. ZSTD -
+     * blobs are backed up with Zstandard compression.
+     *
+     * <p>Valid values: [noZip, ZSTD]
+     *
+     * @param zimbraDedupeBackupBlobsCompressType new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4148)
+    public Map<String,Object> setDedupeBackupBlobsCompressTypeAsString(String zimbraDedupeBackupBlobsCompressType, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDedupeBackupBlobsCompressType, zimbraDedupeBackupBlobsCompressType);
+        return attrs;
+    }
+
+    /**
+     * Blobs inside a backup are compressed by default in ZSTD format. noZip
+     * - blobs are backed up as individual files without compression. ZSTD -
+     * blobs are backed up with Zstandard compression.
+     *
+     * <p>Valid values: [noZip, ZSTD]
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4148)
+    public void unsetDedupeBackupBlobsCompressType() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDedupeBackupBlobsCompressType, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Blobs inside a backup are compressed by default in ZSTD format. noZip
+     * - blobs are backed up as individual files without compression. ZSTD -
+     * blobs are backed up with Zstandard compression.
+     *
+     * <p>Valid values: [noZip, ZSTD]
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.13
+     */
+    @ZAttr(id=4148)
+    public Map<String,Object> unsetDedupeBackupBlobsCompressType(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraDedupeBackupBlobsCompressType, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/callback/DedupeBackupBlobsCompressTypeCallback.java
+++ b/store/src/java/com/zimbra/cs/account/callback/DedupeBackupBlobsCompressTypeCallback.java
@@ -1,0 +1,45 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2025 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.account.callback;
+
+import com.zimbra.common.account.ZAttrProvisioning;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.AttributeCallback;
+import com.zimbra.cs.account.Entry;
+import com.zimbra.cs.account.Provisioning;
+
+import java.util.Map;
+
+/**
+ * @author GopalMoolchandani
+ * When zimbraBackupDeduplication is set as noDedup, it shouldn't allow to modify DedupeBackupBlobsCompressType
+ */
+public class DedupeBackupBlobsCompressTypeCallback extends AttributeCallback {
+    @Override
+    public void preModify(CallbackContext context, String attrName, Object attrValue, Map attrsToModify, Entry entry) throws ServiceException {
+        String backupDedup = entry.getAttr(Provisioning.A_zimbraBackupDeduplication, ZAttrProvisioning.BackupDeduplication.dedup.name());
+
+        if(backupDedup.equals(ZAttrProvisioning.BackupDeduplication.noDedup.name())) {
+            throw ServiceException.INVALID_REQUEST("DedupeBackupBlobsCompressType cannot be set if the zimbraBackupDeduplication is set as noDedup", null);
+        }
+    }
+
+    @Override
+    public void postModify(CallbackContext context, String attrName, Entry entry) {
+
+    }
+}


### PR DESCRIPTION
Added following new ldap attributes for the new legacy backup 2.0

Deduplication: zimbraBackupDeduplicationEnabled (default: TRUE).

Compression for Dedup Backup: zimbraDedupeBackupBlobsCompressType (default: ZSTD).