### PR TITLE
ZBUG-5144: Added MathML MIME type handling and defanger to prevent script execution

### DIFF
--- a/common/src/java/com/zimbra/common/mime/MimeConstants.java
+++ b/common/src/java/com/zimbra/common/mime/MimeConstants.java
@@ -82,6 +82,7 @@ public class MimeConstants {
     public static final String CT_SMIME_TYPE_ENVELOPED_DATA = "enveloped-data";
     public static final String CT_SMIME_TYPE_SIGNED_DATA = "signed-data";
     public static final String CT_IMAGE = "image/";
+
     public static final String CT_APPLICATION_MATHML = "application/mathml+xml";
 
     // encodings

--- a/common/src/java/com/zimbra/common/mime/MimeConstants.java
+++ b/common/src/java/com/zimbra/common/mime/MimeConstants.java
@@ -82,6 +82,7 @@ public class MimeConstants {
     public static final String CT_SMIME_TYPE_ENVELOPED_DATA = "enveloped-data";
     public static final String CT_SMIME_TYPE_SIGNED_DATA = "signed-data";
     public static final String CT_IMAGE = "image/";
+    public static final String CT_APPLICATION_MATHML = "application/mathml+xml";
 
     // encodings
     public static final String ET_7BIT = "7bit";

--- a/store/src/java/com/zimbra/cs/html/DefangFactory.java
+++ b/store/src/java/com/zimbra/cs/html/DefangFactory.java
@@ -71,10 +71,11 @@ public class DefangFactory {
             return htmlDefang;
         }
 
-        if(contentTypeLowerCase.startsWith(MimeConstants.CT_TEXT_XML) ||
-           contentTypeLowerCase.startsWith(MimeConstants.CT_APPLICATION_XHTML) ||
-           contentTypeLowerCase.startsWith(MimeConstants.CT_IMAGE_SVG) ||
-           contentTypeLowerCase.startsWith(MimeConstants.CT_TEXT_XML_LEGACY)) {
+        if (contentTypeLowerCase.startsWith(MimeConstants.CT_TEXT_XML) ||
+                contentTypeLowerCase.startsWith(MimeConstants.CT_APPLICATION_XHTML) ||
+                contentTypeLowerCase.startsWith(MimeConstants.CT_IMAGE_SVG) ||
+                contentTypeLowerCase.startsWith(MimeConstants.CT_TEXT_XML_LEGACY) ||
+                contentTypeLowerCase.startsWith(MimeConstants.CT_APPLICATION_MATHML)) {
             return xhtmlDefang;
         }
         return noopDefang;


### PR DESCRIPTION
Issue: since application/mathml+xml content type is not included in onlyoffice SCRIPTABLE_CONTENT_TYPES therefore it was not sanitizing file having application/mathml+xml content type.

Fix: I added the extension "application/mathml+xml" in DefangFactory.getDefanger and also in MimeConstants.java.
