### PR TITLE
ZBUG-5011 Restrict exportDir from web-exposed jetty paths

### DIFF
--- a/common/src/java/com/zimbra/common/soap/W3cDomUtil.java
+++ b/common/src/java/com/zimbra/common/soap/W3cDomUtil.java
@@ -99,6 +99,17 @@ public class W3cDomUtil {
         dbf.setFeature(Constants.EXTERNAL_GENERAL_ENTITIES, false);
         return dbf;
     }
+    public static DocumentBuilder getSecureDocumentBuilder() throws ParserConfigurationException {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        dbf.setXIncludeAware(false);
+        dbf.setExpandEntityReferences(false);
+        return dbf.newDocumentBuilder();
+    }
 
     public static DocumentBuilder getBuilder() {
         return w3DomBuilderTL.get();

--- a/store/docs/soap.txt
+++ b/store/docs/soap.txt
@@ -45,7 +45,6 @@ urn:zimbra  -- top-level namespace for global attributes/elements
   <soap:Header>
     <context xmlns="urn:zimbra">
       [<authToken>...</authToken>]
-      [<csrfToken>...</csrfToken>]
       [<authTokenControl voidOnExpired="1"/>]
       [<session [id="{returned-from-server-in-last-response}" [seq="{highest_notification_received}"] [type="admin"]/>]
       [<account by="name|id">{account-name-or-id}</account>]

--- a/store/src/java/com/zimbra/cs/service/admin/ExportAndDeleteItems.java
+++ b/store/src/java/com/zimbra/cs/service/admin/ExportAndDeleteItems.java
@@ -18,14 +18,17 @@
 package com.zimbra.cs.service.admin;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AdminConstants;
 import com.zimbra.common.soap.Element;
+import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.AccountServiceException;
 import com.zimbra.cs.account.accesscontrol.AdminRight;
 import com.zimbra.cs.db.DbBlobConsistency;
@@ -72,6 +75,7 @@ public class ExportAndDeleteItems extends AdminDocumentHandler {
                 conn = DbPool.getConnection();
                 if (dirPath != null) {
                     File exportDir = new File(dirPath);
+                    validateExportDirPath(exportDir);
                     if (!exportDir.isDirectory()) {
                         DbPool.quietClose(conn);
                         throw ServiceException.INVALID_REQUEST(dirPath + " is not a directory", null);
@@ -151,6 +155,31 @@ public class ExportAndDeleteItems extends AdminDocumentHandler {
             prefix = "";
         }
         return dirPath + "/" + prefix + tableName + ".txt";
+    }
+
+    private void validateExportDirPath(File exportDir) throws ServiceException {
+        try {
+            String canonicalPath = exportDir.getCanonicalPath();
+            final List<String> restrictedPaths = Arrays.asList(
+                    "/opt/zimbra/jetty/webapps",
+                    "/opt/zimbra/jetty_base/webapps"
+            );
+            for (String directory : restrictedPaths) {
+                if (canonicalPath.equals(directory) || canonicalPath.startsWith(directory + File.separator)) {
+                    ZimbraLog.security.warn(
+                            "Export denied: attempted access to restricted directory. "
+                                    + "Export to the location %s is not allowed",
+                            canonicalPath);
+
+                    throw ServiceException.PERM_DENIED(
+                            "Export request denied: directory not permitted", null);
+                }
+            }
+        } catch (ServiceException se) {
+            throw se;
+        } catch (Exception e) {
+            throw ServiceException.INVALID_REQUEST(e.getMessage(), e);
+        }
     }
 
     @Override

--- a/store/src/java/com/zimbra/soap/SoapEngine.java
+++ b/store/src/java/com/zimbra/soap/SoapEngine.java
@@ -377,17 +377,15 @@ public class SoapEngine {
                 // Bug: 96167 SoapEngine should be able to read CSRF token from HTTP headers
                 String csrfToken = httpReq.getHeader(Constants.CSRF_TOKEN);
                 if (StringUtil.isNullOrEmpty(csrfToken)) {
-                    Element contextElmt = getSoapContextElement(soapProto, envelope);
-                    if (contextElmt != null) {
-                        csrfToken = contextElmt.getAttribute(HeaderConstants.E_CSRFTOKEN);
-                    }
+                    LOG.info("Missing CSRF token in header");
+                    return soapFaultEnv(soapProto, "cannot dispatch request", ServiceException.AUTH_REQUIRED());
                 }
                 AuthToken authToken = zsc.getAuthToken();
                 if (!CsrfUtil.isValidCsrfToken(csrfToken, authToken)) {
                     LOG.info("CSRF token validation failed for account");
                     return soapFaultEnv(soapProto, "cannot dispatch request", ServiceException.AUTH_REQUIRED());
                 }
-            } catch (ServiceException e) {
+            } catch (Exception e) {
                 // we came here which implies clients supports CSRF authorization
                 // and CSRF token is generated
                 LOG.info("Error during CSRF validation.", e);


### PR DESCRIPTION
**Problem:** The ExportAndDeleteItemsRequest SOAP API currently accepts arbitrary filesystem paths via the exportDir parameter, without adequate validation.Allow users to provide any exportDir path, but strictly restrict it from pointing to /opt/zimbra/jetty/webapps or any subdirectory that may be web-exposed.

**Solution:**

Reject if canonical path starts with:

/opt/zimbra/jetty/webapps/
/opt/zimbra/jetty_base/webapps/