### PR TITLE
ZBUG-5011 Restrict exportDir from web-exposed jetty paths

### DIFF
--- a/store/src/java/com/zimbra/cs/service/admin/ExportAndDeleteItems.java
+++ b/store/src/java/com/zimbra/cs/service/admin/ExportAndDeleteItems.java
@@ -18,6 +18,7 @@
 package com.zimbra.cs.service.admin;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -26,6 +27,7 @@ import com.google.common.collect.Multimap;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AdminConstants;
 import com.zimbra.common.soap.Element;
+import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.AccountServiceException;
 import com.zimbra.cs.account.accesscontrol.AdminRight;
 import com.zimbra.cs.db.DbBlobConsistency;
@@ -72,6 +74,7 @@ public class ExportAndDeleteItems extends AdminDocumentHandler {
                 conn = DbPool.getConnection();
                 if (dirPath != null) {
                     File exportDir = new File(dirPath);
+                    validateExportDirPath(exportDir);
                     if (!exportDir.isDirectory()) {
                         DbPool.quietClose(conn);
                         throw ServiceException.INVALID_REQUEST(dirPath + " is not a directory", null);
@@ -151,6 +154,30 @@ public class ExportAndDeleteItems extends AdminDocumentHandler {
             prefix = "";
         }
         return dirPath + "/" + prefix + tableName + ".txt";
+    }
+
+    private void validateExportDirPath(File exportDir) throws ServiceException {
+        try {
+            String canonicalPath = exportDir.getCanonicalPath();
+            final List<String> restrictedPaths = Arrays.asList(
+                    "/opt/zimbra/jetty/webapps",
+                    "/opt/zimbra/jetty_base/webapps"
+            );
+            for (String directory : restrictedPaths) {
+                if (canonicalPath.equals(directory) || canonicalPath.startsWith(directory + File.separator)) {
+                    ZimbraLog.security.warn(
+                            "Export denied: attempted access to restricted directory. "
+                                    + "Export to the location %s is not allowed",
+                            canonicalPath);
+                    throw ServiceException.PERM_DENIED(
+                            "Export request denied: directory not permitted", null);
+                }
+            }
+        } catch (ServiceException se) {
+            throw se;
+        } catch (Exception e) {
+            throw ServiceException.INVALID_REQUEST(e.getMessage(), e);
+        }
     }
 
     @Override


### PR DESCRIPTION
**Problem**: The ExportAndDeleteItemsRequest SOAP API currently accepts arbitrary filesystem paths via the exportDir parameter, without adequate validation.Allow users to provide any exportDir path, but strictly restrict it from pointing to /opt/zimbra/jetty/webapps or any subdirectory that may be web-exposed.

**Solution**:

Reject if canonical path starts with:

/opt/zimbra/jetty/webapps/
/opt/zimbra/jetty_base/webapps/