### PR TITLE
ZBUG-4613: Added soft quota for IMAP copy for Trash folder instead of unlimited quota

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -10315,6 +10315,14 @@ public class ZAttrProvisioning {
     public static final String A_zimbraMailQuota = "zimbraMailQuota";
 
     /**
+     * Soft quota limit percentage applied over zimbraMailQuota
+     *
+     * @since ZCS 10.1.17
+     */
+    @ZAttr(id=4151)
+    public static final String A_zimbraMailQuotaSoftLimitPercent = "zimbraMailQuotaSoftLimitPercent";
+
+    /**
      * If TRUE, the envelope sender of a message redirected by mail filters
      * will be set to the users address. If FALSE, the envelope sender will
      * be set to the From address of the redirected message.

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10639,4 +10639,9 @@ TODO: delete them permanently from here
   <desc>Attribute to check whether we need to reset the CSD backup if there  </desc>
 </attr>
 
+<attr id="4151" name="zimbraMailQuotaSoftLimitPercent" type="integer" min="100" cardinality="single" optionalIn="account,cos" flags="accountInherited,accountInfo" since="10.1.17" callback="MailQuotaSoftLimitCallback">
+  <defaultCOSValue>100</defaultCOSValue>
+  <desc>Soft quota limit percentage applied over zimbraMailQuota</desc>
+</attr>
+
 </attrs>

--- a/store/src/java-test/com/zimbra/cs/mailbox/MailboxTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/MailboxTest.java
@@ -26,7 +26,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -42,6 +41,7 @@ import com.zimbra.common.mailbox.ContactConstants;
 import com.zimbra.common.mime.InternetAddress;
 import com.zimbra.common.util.ArrayUtil;
 import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Domain;
 import com.zimbra.cs.account.MockProvisioning;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.index.BrowseTerm;
@@ -710,6 +710,80 @@ public final class MailboxTest {
 
         Assert.assertEquals(10L, mbox.getSize());
     }
+
+    @Test
+    public void testTrashAllowsSoftQuotaBuffer() throws Exception {
+        Provisioning prov = Provisioning.getInstance();
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put(Provisioning.A_zimbraMailQuota, "100");
+        attrs.put(Provisioning.A_zimbraMailQuotaSoftLimitPercent, "110");
+        Account acct = prov.createAccount("trashbuffer@zimbra.com", "secret", attrs);
+
+        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+
+        // Simulate mailbox already near quota
+        mbox.updateSize(95, false);  // force size without quota check
+        Assert.assertEquals(95, mbox.getSize());
+
+        // Trash path: allow up to 110
+        mbox.checkSizeChangeForTrash(105);
+
+        // No exception = PASS
+    }
+
+    @Test(expected = MailServiceException.class)
+    public void testTrashBlocksBeyondSoftQuota() throws Exception {
+        Provisioning prov = Provisioning.getInstance();
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put(Provisioning.A_zimbraMailQuota, "100");
+        attrs.put(Provisioning.A_zimbraMailQuotaSoftLimitPercent, "110");
+        Account acct = prov.createAccount("trashoverflow@zimbra.com", "secret", attrs);
+
+        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+
+        mbox.updateSize(100, false);
+        mbox.checkSizeChangeForTrash(111);
+    }
+
+    @Test(expected = MailServiceException.class)
+    public void testNonTrashStillEnforcesHardQuota() throws Exception {
+        Provisioning prov = Provisioning.getInstance();
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put(Provisioning.A_zimbraMailQuota, "100");
+        attrs.put(Provisioning.A_zimbraMailQuotaSoftLimitPercent, "110");
+        Account acct = prov.createAccount("nontrash@zimbra.com", "secret", attrs);
+
+        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+
+        mbox.updateSize(100, false);
+        mbox.checkSizeChange(101);
+    }
+
+    @Test(expected = MailServiceException.class)
+    public void testDomainQuotaBlocksTrash() throws Exception {
+        Provisioning prov = Provisioning.getInstance();
+
+        // Create domain with aggregate quota
+        Map<String, Object> domainAttrs = new HashMap<>();
+        domainAttrs.put(Provisioning.A_zimbraDomainAggregateQuota, "100");
+        domainAttrs.put(Provisioning.A_zimbraDomainAggregateQuotaPolicy, "reject");
+        domainAttrs.put(Provisioning.A_zimbraAggregateQuotaLastUsage, "200");
+        domainAttrs.put(Provisioning.A_zimbraDomainAggregateQuotaPolicy, "BLOCKSENDRECEIVE");
+        Domain domain = prov.createDomain("trashdomain.com", domainAttrs);
+
+
+        // Unlimited account
+        Map<String, Object> acctAttrs = new HashMap<>();
+        acctAttrs.put(Provisioning.A_zimbraMailQuota, "0");
+        acctAttrs.put(Provisioning.A_zimbraMailQuotaSoftLimitPercent, "110");
+        Account acct = prov.createAccount("user@trashdomain.com", "secret", acctAttrs);
+
+        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+
+        // This must now fail due to domain quota
+        mbox.checkSizeChangeForTrash(1);
+    }
+
 
     /**
      * @throws java.lang.Exception

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -30807,6 +30807,78 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * Soft quota limit percentage applied over zimbraMailQuota
+     *
+     * @return zimbraMailQuotaSoftLimitPercent, or 100 if unset
+     *
+     * @since ZCS 10.1.17
+     */
+    @ZAttr(id=4151)
+    public int getMailQuotaSoftLimitPercent() {
+        return getIntAttr(Provisioning.A_zimbraMailQuotaSoftLimitPercent, 100, true);
+    }
+
+    /**
+     * Soft quota limit percentage applied over zimbraMailQuota
+     *
+     * @param zimbraMailQuotaSoftLimitPercent new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.17
+     */
+    @ZAttr(id=4151)
+    public void setMailQuotaSoftLimitPercent(int zimbraMailQuotaSoftLimitPercent) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailQuotaSoftLimitPercent, Integer.toString(zimbraMailQuotaSoftLimitPercent));
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Soft quota limit percentage applied over zimbraMailQuota
+     *
+     * @param zimbraMailQuotaSoftLimitPercent new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.17
+     */
+    @ZAttr(id=4151)
+    public Map<String,Object> setMailQuotaSoftLimitPercent(int zimbraMailQuotaSoftLimitPercent, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailQuotaSoftLimitPercent, Integer.toString(zimbraMailQuotaSoftLimitPercent));
+        return attrs;
+    }
+
+    /**
+     * Soft quota limit percentage applied over zimbraMailQuota
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.17
+     */
+    @ZAttr(id=4151)
+    public void unsetMailQuotaSoftLimitPercent() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailQuotaSoftLimitPercent, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Soft quota limit percentage applied over zimbraMailQuota
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.17
+     */
+    @ZAttr(id=4151)
+    public Map<String,Object> unsetMailQuotaSoftLimitPercent(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailQuotaSoftLimitPercent, "");
+        return attrs;
+    }
+
+    /**
      * sieve script generated from user filter rules
      *
      * @return zimbraMailSieveScript, or null if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -23380,6 +23380,78 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * Soft quota limit percentage applied over zimbraMailQuota
+     *
+     * @return zimbraMailQuotaSoftLimitPercent, or 100 if unset
+     *
+     * @since ZCS 10.1.17
+     */
+    @ZAttr(id=4151)
+    public int getMailQuotaSoftLimitPercent() {
+        return getIntAttr(Provisioning.A_zimbraMailQuotaSoftLimitPercent, 100, true);
+    }
+
+    /**
+     * Soft quota limit percentage applied over zimbraMailQuota
+     *
+     * @param zimbraMailQuotaSoftLimitPercent new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.17
+     */
+    @ZAttr(id=4151)
+    public void setMailQuotaSoftLimitPercent(int zimbraMailQuotaSoftLimitPercent) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailQuotaSoftLimitPercent, Integer.toString(zimbraMailQuotaSoftLimitPercent));
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Soft quota limit percentage applied over zimbraMailQuota
+     *
+     * @param zimbraMailQuotaSoftLimitPercent new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.17
+     */
+    @ZAttr(id=4151)
+    public Map<String,Object> setMailQuotaSoftLimitPercent(int zimbraMailQuotaSoftLimitPercent, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailQuotaSoftLimitPercent, Integer.toString(zimbraMailQuotaSoftLimitPercent));
+        return attrs;
+    }
+
+    /**
+     * Soft quota limit percentage applied over zimbraMailQuota
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.17
+     */
+    @ZAttr(id=4151)
+    public void unsetMailQuotaSoftLimitPercent() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailQuotaSoftLimitPercent, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Soft quota limit percentage applied over zimbraMailQuota
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.17
+     */
+    @ZAttr(id=4151)
+    public Map<String,Object> unsetMailQuotaSoftLimitPercent(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraMailQuotaSoftLimitPercent, "");
+        return attrs;
+    }
+
+    /**
      * Maximum size in bytes for sieve script attributes. When it is set to
      * 0, the size is not limited.
      *

--- a/store/src/java/com/zimbra/cs/account/callback/MailQuotaSoftLimitCallback.java
+++ b/store/src/java/com/zimbra/cs/account/callback/MailQuotaSoftLimitCallback.java
@@ -1,0 +1,24 @@
+package com.zimbra.cs.account.callback;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.AttributeCallback;
+import com.zimbra.cs.account.Entry;
+
+import java.util.Map;
+
+public class MailQuotaSoftLimitCallback extends AttributeCallback {
+    @Override
+    public void preModify(CallbackContext context, String attrName, Object attrValue, Map attrsToModify, Entry entry) throws ServiceException {
+
+        int value = Integer.parseInt((String) attrValue);
+
+        if (value > 120) {
+            throw ServiceException.INVALID_REQUEST("Soft limit cannot be more than 120% of the mail quota", null);
+       }
+    }
+
+    @Override
+    public void postModify(CallbackContext context, String attrName, Entry entry) {
+
+    }
+}

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -1500,6 +1500,36 @@ public class Mailbox implements MailboxStore {
         }
     }
 
+    /**
+     * Validates whether moving data to Trash would exceed account or domain quota limits.
+     *
+     * <p>The method checks the effective account quota and applies the configured
+     * soft limit percentage. If the resulting allowed quota is exceeded by the
+     * provided size, a {@link MailServiceException#QUOTA_EXCEEDED(long)} is thrown.</p>
+     *
+     * <p>It also verifies the domain aggregate quota. If the domain is already
+     * over its aggregate limit and receiving data over the limit is not allowed,
+     * a {@link MailServiceException#DOMAIN_QUOTA_EXCEEDED(long)} is thrown.</p>
+     *
+     * @param newSize the expected mailbox size after the Trash size change
+     * @throws ServiceException if the account or domain quota restrictions are violated
+     */
+    public void checkSizeChangeForTrash(long newSize) throws ServiceException {
+        Account acct = getAccount();
+        long acctQuota = AccountUtil.getEffectiveQuota(acct);
+
+        long allowedQuota = acctQuota * acct.getMailQuotaSoftLimitPercent() / 100;
+        if (allowedQuota != 0 && newSize > allowedQuota) {
+            throw MailServiceException.QUOTA_EXCEEDED(allowedQuota);
+        }
+
+        Domain domain = Provisioning.getInstance().getDomain(acct);
+        if (domain != null && AccountUtil.isOverAggregateQuota(domain)
+                && !AccountUtil.isReceiveAllowedOverAggregateQuota(domain)) {
+            throw MailServiceException.DOMAIN_QUOTA_EXCEEDED(domain.getDomainAggregateQuota());
+        }
+    }
+
     long getEffectiveSize(long delta) {
         // if we go negative, that's OK! just pretend we're at 0.
         return Math.max(0, (currentChange().size == MailboxChange.NO_CHANGE ? mData.size : currentChange().size)
@@ -7378,10 +7408,15 @@ public class Mailbox implements MailboxStore {
             }
 
             // check if mailbox has enough quota available to copy all the item.
-            // ZBUG-1375 : exclude check for Trash Folder , so that messages can be deleted even when quota is full
-            if (requiredQuota > 0 && folderId != FolderConstants.ID_FOLDER_TRASH) {
+            if (requiredQuota > 0) {
                 ZimbraLog.mailbox.info("total space required to copy items = %d", requiredQuota);
-                checkSizeChange(getEffectiveSize(requiredQuota));
+                if (folderId != FolderConstants.ID_FOLDER_TRASH) {
+                    checkSizeChange(getEffectiveSize(requiredQuota));
+                } else {
+                    // ZBUG-4613 : Allow soft quota buffer when copying into Trash.
+                    // this enables cleanup workflows near quota.
+                    checkSizeChangeForTrash(getEffectiveSize(requiredQuota));
+                }
             }
 
             List<MailItem> result = new ArrayList<MailItem>();


### PR DESCRIPTION
Two issues (move to trash):

Scenario 1 : Mailbox size almost near to quota → COPY to trash → mailbox size exceeds the quota → Copy fails. This issue is currently fixed by not including trash folder for quota check.

Scenario 2 : COPY to trash → NO EXPUNGE due to some error → Mailbox size keeps on increasing way beyond Quota. 

We need Scenario 1 to work (quota bypass for deletes) while preventing Scenario 2 (unbounded growth).

Solution: Have a configurable Soft Quota Limit for Trash Folder(100-120%)

Instead of enforcing hard quota (100%) on trash, use a soft limit as a safety buffer.