### PR TITLE
ZCS-18656 : Fix volume ID extraction from locator to prevent backup failures

### DIFF
--- a/store/src/java-test/com/zimbra/cs/volume/VolumeManagerTest.java
+++ b/store/src/java-test/com/zimbra/cs/volume/VolumeManagerTest.java
@@ -1,0 +1,97 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite, Network Edition.
+ * Copyright (C) 2026 Zimbra, Inc.  All Rights Reserved.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.volume;
+
+import com.zimbra.common.service.ServiceException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({VolumeManager.class})
+public class VolumeManagerTest {
+
+    private VolumeManager volumeManager;
+
+    @Before
+    public void setup() throws Exception {
+        volumeManager = PowerMockito.spy(VolumeManager.getInstance());
+    }
+
+    @Test
+    public void testPureNumericId() throws Exception {
+        PowerMockito.doReturn(null)
+                .when(volumeManager)
+                .getVolume((short) 1);
+
+        volumeManager.getVolume("1");
+
+        Mockito.verify(volumeManager).getVolume((short) 1);
+    }
+
+    @Test
+    public void testLocatorWithSeparator() throws Exception {
+        PowerMockito.doReturn(null)
+                .when(volumeManager)
+                .getVolume((short) 3);
+
+        volumeManager.getVolume("3@@abc-def");
+
+        Mockito.verify(volumeManager).getVolume((short) 3);
+    }
+
+    @Test(expected = ServiceException.class)
+    public void testInvalidNumericPrefix() throws Exception {
+        volumeManager.getVolume("abc@@123");
+    }
+
+    @Test(expected = ServiceException.class)
+    public void testEmptyString() throws Exception {
+        volumeManager.getVolume("");
+    }
+
+    @Test(expected = ServiceException.class)
+    public void testNullId() throws Exception {
+        volumeManager.getVolume(null);
+    }
+
+    @Test(expected = ServiceException.class)
+    public void testNonNumericNoSeparator() throws Exception {
+        volumeManager.getVolume("foo");
+    }
+
+    @Test
+    public void testNumberFormatExceptionOutOfRange() {
+        String largeNumber = String.valueOf((long) Short.MAX_VALUE + 1);
+
+        try {
+            volumeManager.getVolume(largeNumber);
+            fail("Expected ServiceException");
+        } catch (ServiceException e) {
+            assertTrue(e.getMessage().contains("out of range"));
+        }
+    }
+
+    @Test
+    public void testSeparatorWithOutOfRangeNumber() {
+        String largeNumber = String.valueOf((long) Short.MAX_VALUE + 1) + "@@abc";
+
+        try {
+            volumeManager.getVolume(largeNumber);
+            fail("Expected ServiceException");
+        } catch (ServiceException e) {
+            assertTrue(e.getMessage().contains("out of range"));
+        }
+    }
+}

--- a/store/src/java-test/com/zimbra/cs/volume/package-info.java
+++ b/store/src/java-test/com/zimbra/cs/volume/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite, Network Edition.
+ * Copyright (C) 2026 Zimbra, Inc.  All Rights Reserved.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.volume;

--- a/store/src/java/com/zimbra/cs/volume/VolumeManager.java
+++ b/store/src/java/com/zimbra/cs/volume/VolumeManager.java
@@ -37,6 +37,7 @@ import com.zimbra.cs.redolog.op.SetCurrentVolume;
 import com.zimbra.cs.store.IncomingDirectory;
 import com.zimbra.cs.store.StoreManager;
 import com.zimbra.cs.store.external.ExternalStoreManager;
+import org.apache.commons.lang.StringUtils;
 
 public final class VolumeManager {
 
@@ -251,11 +252,65 @@ public final class VolumeManager {
         }
     }
 
+    /**
+     * Returns the {@link Volume} corresponding to the given identifier.
+     *
+     * <p>The input {@code id} can be either:
+     * <ul>
+     *   <li>A pure numeric volume ID (e.g., {@code "3"})</li>
+     *   <li>A locator string prefixed with the volume ID followed by a separator
+     *       (e.g., {@code "3@@fbvdfbdfb"})</li>
+     * </ul>
+     *
+     * <p>If the input contains the locator separator ({@code "@@"}),
+     * the method extracts and parses the numeric prefix as the volume ID.
+     *
+     * <p>Validation rules:
+     * <ul>
+     *   <li>{@code id} must not be {@code null} or empty</li>
+     *   <li>The extracted volume ID must be numeric</li>
+     *   <li>The numeric value must be within the valid {@code short} range</li>
+     * </ul>
+     *
+     * @param id the volume identifier or locator string containing the volume ID
+     * @return the corresponding {@link Volume} instance
+     * @throws ServiceException if:
+     *         <ul>
+     *           <li>The input is {@code null} or empty</li>
+     *           <li>The ID format is invalid</li>
+     *           <li>The numeric value is out of {@code short} range</li>
+     *           <li>An unexpected error occurs while retrieving the volume</li>
+     *         </ul>
+     */
     public Volume getVolume(String id) throws ServiceException {
+        if (id == null || id.isEmpty()) {
+            throw ServiceException.INVALID_REQUEST("volume ID cannot be null or empty", null);
+        }
+        String volIdLocatorSeparator = "@@";
         try {
-            return getVolume(Short.parseShort(id));
+            short volumeId;
+
+            if (StringUtils.isNumeric(id)) {
+                volumeId = Short.parseShort(id);
+            } else {
+                if (id.contains(volIdLocatorSeparator)) {
+                    String[] parts = id.split(volIdLocatorSeparator, 2);
+                    if (parts.length >= 1 && StringUtils.isNumeric(parts[0])) {
+                        volumeId = Short.parseShort(parts[0]);
+                    } else {
+                        throw ServiceException.INVALID_REQUEST("invalid volume ID: " + id, null);
+                    }
+                } else {
+                    throw ServiceException.INVALID_REQUEST("invalid locator ID: " + id, null);
+                }
+            }
+
+            return getVolume(volumeId);
+
         } catch (NumberFormatException e) {
-            throw ServiceException.INVALID_REQUEST("invalid volume ID: " + id, e);
+            throw ServiceException.INVALID_REQUEST("volume ID out of range: " + id, e);
+        } catch (Exception e) {
+            throw ServiceException.FAILURE("unexpected error while retrieving volume for ID: " + id, e);
         }
     }
 


### PR DESCRIPTION
https://synacor.atlassian.net/browse/ZCS-18656

Issue:
The backup failure occurs in getVolume(mblob.getLocator()). The getVolume method attempts to parse the locator string as a Short. However, in some cases, the locator has a format like 3@@adkhbcadhkbc, which causes a NumberFormatException.
This issue was introduced in version 10.1.7 and only occurs under a specific scenario: when the primary volume is S3 and new blobs are created or modified while a backup process is running. In these cases, the locator contains a non-numeric component, leading to the failure.

Solution:
Updated getVolume(String id) to correctly handle locators in external or object storage formats. The change:
Extracts the numeric volume ID from the locator string before calling getVolume(short).
Adds proper exception handling to manage invalid or out-of-range volume IDs.
This ensures that backups proceed successfully even when the locator contains a non-numeric portion.