### PR TITLE
ZBUG-5144: Add support for sanitizing all +xml content types in defang logic

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1544,6 +1544,11 @@ public final class LC {
 
     public static final KnownKey zimbra_two_factor_auth_resend_email_wait_seconds = KnownKey.newKey(1); // 1 sec
     public static final KnownKey proxy_web_map_hash_bucket_size = KnownKey.newKey(64);
+
+    public static final KnownKey DEFANG_XML_CONTENT_TYPES = KnownKey.newKey("application/rss+xml," +
+            "application/atom+xml,application/svg+xml,application/mathml+xml,application/xhtml+xml," +
+            "application/xslt+xml,application/xsd+xml,application/gml+xml,application/rdf+xml");
+            
     @Supported
     public static final KnownKey proxy_chat_config_enabled = KnownKey.newKey(true);
 

--- a/store/src/java/com/zimbra/cs/html/DefangFactory.java
+++ b/store/src/java/com/zimbra/cs/html/DefangFactory.java
@@ -16,9 +16,15 @@
  */
 package com.zimbra.cs.html;
 
+import com.google.common.base.Splitter;
+import com.zimbra.common.localconfig.KnownKey;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.mime.MimeConstants;
 import com.zimbra.cs.html.owasp.OwaspDefang;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * This factory is used to determine the proper defanger based on content type for
@@ -49,6 +55,13 @@ public class DefangFactory {
      */
     private static OwaspDefang owaspDefang = new OwaspDefang();
     
+    private static Set<String> defangXmlContentTypes;
+
+    static {
+        List<String> extensions = Splitter.on(",").omitEmptyStrings().splitToList(LC.DEFANG_XML_CONTENT_TYPES.value());
+        defangXmlContentTypes = new HashSet<>(extensions);
+    }
+
     /**
      * if content type is null, returns noopDefang which does nothing
      * 
@@ -74,9 +87,14 @@ public class DefangFactory {
         if(contentTypeLowerCase.startsWith(MimeConstants.CT_TEXT_XML) ||
            contentTypeLowerCase.startsWith(MimeConstants.CT_APPLICATION_XHTML) ||
            contentTypeLowerCase.startsWith(MimeConstants.CT_IMAGE_SVG) ||
-           contentTypeLowerCase.startsWith(MimeConstants.CT_TEXT_XML_LEGACY)) {
+           contentTypeLowerCase.startsWith(MimeConstants.CT_TEXT_XML_LEGACY) ||
+                isDefangXmlContentType(contentType)) {
             return xhtmlDefang;
         }
         return noopDefang;
+    }
+
+    public static boolean isDefangXmlContentType(String contentType) {
+        return  defangXmlContentTypes.contains(contentType);
     }
 }


### PR DESCRIPTION
**Merge ZBUG-5144 to develop**

Issue:
Files with +xml content types were not being sanitized, allowing potential script execution.

Fix:
Extended the defang logic to cover all +xml content types and introduced a new LC key (DEFANG_XML_CONTENT_TYPES) containing all known +xml MIME types. This list is configurable, allowing additional content types to be added in the future if needed.
