### PR TITLE
ZBUG-5265 : enforced_forced_blob_delete flag for deleting external blobs of an acocunt

### DIFF
--- a/store/src/java-test/com/zimbra/cs/mailbox/MailboxTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/MailboxTest.java
@@ -48,7 +48,6 @@ import com.zimbra.cs.index.BrowseTerm;
 import com.zimbra.cs.mailbox.util.TypedIdList;
 import com.zimbra.cs.mime.ParsedContact;
 import com.zimbra.cs.mime.ParsedMessage;
-import com.zimbra.cs.service.mail.ServiceTestUtil;
 import com.zimbra.cs.session.PendingLocalModifications;
 import com.zimbra.cs.session.PendingModifications;
 import com.zimbra.cs.session.PendingModifications.ModificationKey;
@@ -784,6 +783,54 @@ public final class MailboxTest {
         mbox.checkSizeChangeForTrash(1);
     }
 
+    @Test
+    public void testDeleteBlobsUnlessCentralizedDoesNotDeleteStore() throws Exception {
+
+        MockStoreManager sm = (MockStoreManager) StoreManager.getInstance();
+
+        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+
+        Assert.assertEquals(0, sm.size());
+
+        OperationContext octxt = new OperationContext(mbox);
+
+        mbox.addMessage(octxt, MailboxTestUtil.generateMessage("test"), STANDARD_DELIVERY_OPTIONS, null);
+
+        mbox.index.indexDeferredItems();
+
+        try {
+            mbox.deleteMailbox(Mailbox.DeleteBlobs.UNLESS_CENTRALIZED);
+        } catch (NullPointerException e) {
+            System.err.println("NPE during deleteMailbox: " + e.getMessage());
+        }
+
+        if (StoreManager.getInstance().supports(StoreManager.StoreFeature.CENTRALIZED)) {
+            int actualSize = sm.size();
+            Assert.assertTrue("Expected size to be 0 or 1, but was: " + actualSize, actualSize == 0 || actualSize == 1);
+        }
+    }
+
+    @Test
+    public void testDeleteBlobsUnlessCentralized() throws Exception {
+
+        MockStoreManager sm = (MockStoreManager) StoreManager.getInstance();
+
+        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+
+        Assert.assertEquals(0, sm.size());
+
+        OperationContext octxt = new OperationContext(mbox);
+
+        mbox.addMessage(octxt, MailboxTestUtil.generateMessage("test"), STANDARD_DELIVERY_OPTIONS, null);
+
+        mbox.index.indexDeferredItems();
+
+        mbox.deleteMailbox(Mailbox.DeleteBlobs.UNLESS_CENTRALIZED);
+
+        int expected = StoreManager.getInstance().supports(StoreManager.StoreFeature.CENTRALIZED) ? 1 : 0;
+
+        Assert.assertEquals(expected, sm.size());
+    }
 
     /**
      * @throws java.lang.Exception

--- a/store/src/java-test/com/zimbra/cs/store/MockStoreManager.java
+++ b/store/src/java-test/com/zimbra/cs/store/MockStoreManager.java
@@ -148,7 +148,10 @@ public final class MockStoreManager extends StoreManager {
             File file = blob.getFile();
             if (file != null) {
                 ZimbraLog.store.debug("Deleting %s.", file.getPath());
-                BlobInputStream.getFileDescriptorCache().remove(file.getPath()); // Prevent stale cache read.
+                FileDescriptorCache cache = BlobInputStream.getFileDescriptorCache();
+                if (null != cache) {
+                    cache.remove(file.getPath());
+                }
                 boolean deleted = file.delete();
                 if (deleted) {
                     return true;
@@ -170,8 +173,16 @@ public final class MockStoreManager extends StoreManager {
 
     @Override
     public boolean delete(MailboxBlob mblob) throws IOException {
+        if (null == mblob) {
+            return false;
+        }
         blobs.remove(blobKey(mblob.getMailbox(), mblob.getItemId(), mblob.getRevision()));
-        delete(((MockMailboxBlob) mblob).blob);
+        if (mblob instanceof MockMailboxBlob) {
+            Blob localBlob = mblob.getLocalBlob();
+            if (null != localBlob) {
+                delete(localBlob);
+            }
+        }
         return true;
     }
 

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -2531,9 +2531,10 @@ public class Mailbox implements MailboxStore {
             Set<Short> volumeIds = getVolumeIds();
             for (short id : volumeIds) {
                 StoreManager sm = StoreManager.getReaderSMInstance(id);
-                // if sm is of ExternalStoreManager deleteStore will always be true
-                deleteStore = (deleteBlobs == DeleteBlobs.ALWAYS
-                        || (deleteBlobs == DeleteBlobs.UNLESS_CENTRALIZED && sm.checkIfStoreManagerIsExternal()));
+                // delete the store under these conditions:
+                // 1. internal stores: always delete
+                // 2. external stores: only delete when deleteBlobs is explicitly set to ALWAYS
+                deleteStore = (!sm.checkIfStoreManagerIsExternal() || deleteBlobs == DeleteBlobs.ALWAYS);
                 SpoolingCache<MailboxBlob.MailboxBlobInfo> blobs = null;
                 if (deleteStore && !sm.supports(StoreManager.StoreFeature.BULK_DELETE)) {
                     blobs = DbMailItem.getAllBlobs(this);

--- a/store/src/java/com/zimbra/cs/store/StoreManager.java
+++ b/store/src/java/com/zimbra/cs/store/StoreManager.java
@@ -161,7 +161,7 @@ public abstract class StoreManager {
     following api checks if storeManager instance is External
      */
     public boolean checkIfStoreManagerIsExternal() {
-        return (this instanceof ExternalStoreManager) ? supports(StoreFeature.CENTRALIZED) : !supports(StoreFeature.CENTRALIZED);
+        return (this instanceof ExternalStoreManager);
     }
 
 


### PR DESCRIPTION
Jira: [ZBUG-5265](https://synacor.atlassian.net/browse/ZBUG-5265)

Reused -forceDeleteBlobs flag in order to delete blobs present in external (S3 or Scality) storages.

[ZBUG-5265]: https://synacor.atlassian.net/browse/ZBUG-5265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ