### PR TITLE
ZBUG-4936: Fix autocomplete to include local contacts regardless of zimbraHideInGal

### DIFF
--- a/store/src/java-test/com/zimbra/cs/mailbox/ContactAutoCompleteTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/ContactAutoCompleteTest.java
@@ -381,7 +381,7 @@ public final class ContactAutoCompleteTest {
     }
 
     @Test
-    public void testAutoComplete_localContactReturned_whenHideInGalTrue() throws Exception {
+    public void testAutoCompleteLocalContactReturnedWhenHideInGalTrue() throws Exception {
         Account account = Provisioning.getInstance().getAccountByName("test3@zimbra.com");
         Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
         Map<String, Object> fields = new HashMap<>();
@@ -396,7 +396,7 @@ public final class ContactAutoCompleteTest {
     }
 
     @Test
-    public void testAutoComplete_localContactReturned_whenHideInGalFalse() throws Exception {
+    public void testAutoCompleteLocalContactReturnedWhenHideInGalFalse() throws Exception {
         Account account = Provisioning.getInstance().getAccountByName("test3@zimbra.com");
         Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
         Map<String, Object> fields = new HashMap<>();

--- a/store/src/java-test/com/zimbra/cs/mailbox/ContactAutoCompleteTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/ContactAutoCompleteTest.java
@@ -22,8 +22,6 @@ import java.util.HashMap;
 import java.util.Set;
 import java.util.Map;
 import javax.mail.internet.InternetAddress;
-
-import com.zimbra.common.account.ProvisioningConstants;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -34,6 +32,7 @@ import org.junit.Test;
 import org.junit.rules.MethodRule;
 import org.junit.rules.TestName;
 import com.google.common.collect.ImmutableMap;
+import com.zimbra.common.account.ProvisioningConstants;
 import com.zimbra.common.mailbox.ContactConstants;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.MockProvisioning;
@@ -60,21 +59,21 @@ public final class ContactAutoCompleteTest {
 
     @Before
     public void setUp() throws Exception {
-       System.out.println(testName.getMethodName());
-       Provisioning prov = Provisioning.getInstance();
-       prov.createAccount("testContAC@zimbra.com", "secret", new HashMap<String, Object>());
-       prov.createAccount("test2@zimbra.com", "secret", new HashMap<String, Object>());
-       prov.createAccount("test3@zimbra.com", "secret", new HashMap<String, Object>());
+        System.out.println(testName.getMethodName());
+        Provisioning prov = Provisioning.getInstance();
+        prov.createAccount("testContAC@zimbra.com", "secret", new HashMap<String, Object>());
+        prov.createAccount("test2@zimbra.com", "secret", new HashMap<String, Object>());
+        prov.createAccount("test3@zimbra.com", "secret", new HashMap<String, Object>());
 
-       Map<String, Object> attrs = new HashMap<>();
-       attrs.put(Provisioning.A_zimbraHideInGal, ProvisioningConstants.TRUE);
-       prov.createAccount("testAccountWithGalHideTrue@zimbra.com", "secret", attrs);
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put(Provisioning.A_zimbraHideInGal, ProvisioningConstants.TRUE);
+        prov.createAccount("testAccountWithGalHideTrue@zimbra.com", "secret", attrs);
 
-       Map<String, Object> attrs1 = new HashMap<>();
-       attrs1.put(Provisioning.A_zimbraHideInGal, ProvisioningConstants.FALSE);
-       prov.createAccount("testAccountWithGalHideFalse@zimbra.com", "secret", attrs1);
+        Map<String, Object> attrs1 = new HashMap<>();
+        attrs1.put(Provisioning.A_zimbraHideInGal, ProvisioningConstants.FALSE);
+        prov.createAccount("testAccountWithGalHideFalse@zimbra.com", "secret", attrs1);
 
-       Provisioning.setInstance(prov);
+        Provisioning.setInstance(prov);
     }
 
     @Test
@@ -446,8 +445,9 @@ public final class ContactAutoCompleteTest {
         ContactAutoComplete.AutoCompleteResult result = new ContactAutoComplete.AutoCompleteResult(10);
         result.rankings = new ContactRankings(MockProvisioning.DEFAULT_ACCOUNT_ID);
 
-        // Account without zimbraHideInGal attribute
-        Provisioning.getInstance().createAccount("testAccountWithGalHideNotSet@zimbra.com", "secret", new HashMap<String, Object>());
+        // account without zimbraHideInGal attribute
+        Provisioning.getInstance().createAccount("testAccountWithGalHideNotSet@zimbra.com",
+                "secret", new HashMap<String, Object>());
 
         Map<String, Object> attrs = ImmutableMap.<String, Object>of(
                 ContactConstants.A_firstName, "First",

--- a/store/src/java-test/com/zimbra/cs/mailbox/ContactAutoCompleteTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/ContactAutoCompleteTest.java
@@ -22,6 +22,8 @@ import java.util.HashMap;
 import java.util.Set;
 import java.util.Map;
 import javax.mail.internet.InternetAddress;
+
+import com.zimbra.common.account.ProvisioningConstants;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -62,6 +64,16 @@ public final class ContactAutoCompleteTest {
        Provisioning prov = Provisioning.getInstance();
        prov.createAccount("testContAC@zimbra.com", "secret", new HashMap<String, Object>());
        prov.createAccount("test2@zimbra.com", "secret", new HashMap<String, Object>());
+       prov.createAccount("test3@zimbra.com", "secret", new HashMap<String, Object>());
+
+       Map<String, Object> attrs = new HashMap<>();
+       attrs.put(Provisioning.A_zimbraHideInGal, ProvisioningConstants.TRUE);
+       prov.createAccount("testAccountWithGalHideTrue@zimbra.com", "secret", attrs);
+
+       Map<String, Object> attrs1 = new HashMap<>();
+       attrs1.put(Provisioning.A_zimbraHideInGal, ProvisioningConstants.FALSE);
+       prov.createAccount("testAccountWithGalHideFalse@zimbra.com", "secret", attrs1);
+
        Provisioning.setInstance(prov);
     }
 
@@ -187,31 +199,31 @@ public final class ContactAutoCompleteTest {
                 ContactConstants.A_middleName, "Middle",
                 ContactConstants.A_lastName, "Last",
                 ContactConstants.A_email, "first.last@zimbra.com");
-        comp.addMatchedContacts("first f", attrs, Mailbox.ID_FOLDER_CONTACTS, null, result);
+        comp.addMatchedContacts("first f", attrs, Mailbox.ID_FOLDER_CONTACTS, null, result, true);
         Assert.assertEquals(0, result.entries.size());
         result.clear();
 
-        comp.addMatchedContacts("first mid", attrs, Mailbox.ID_FOLDER_CONTACTS, null, result);
+        comp.addMatchedContacts("first mid", attrs, Mailbox.ID_FOLDER_CONTACTS, null, result, true);
         Assert.assertEquals(1, result.entries.size());
         result.clear();
 
-        comp.addMatchedContacts("first la", attrs, Mailbox.ID_FOLDER_CONTACTS, null, result);
+        comp.addMatchedContacts("first la", attrs, Mailbox.ID_FOLDER_CONTACTS, null, result, true);
         Assert.assertEquals(1, result.entries.size());
         result.clear();
 
-        comp.addMatchedContacts("middle last", attrs, Mailbox.ID_FOLDER_CONTACTS, null, result);
+        comp.addMatchedContacts("middle last", attrs, Mailbox.ID_FOLDER_CONTACTS, null, result, true);
         Assert.assertEquals(1, result.entries.size());
         result.clear();
 
-        comp.addMatchedContacts("middle la", attrs, Mailbox.ID_FOLDER_CONTACTS, null, result);
+        comp.addMatchedContacts("middle la", attrs, Mailbox.ID_FOLDER_CONTACTS, null, result, true);
         Assert.assertEquals(1, result.entries.size());
         result.clear();
 
-        comp.addMatchedContacts("ddle last", attrs, Mailbox.ID_FOLDER_CONTACTS, null, result);
+        comp.addMatchedContacts("ddle last", attrs, Mailbox.ID_FOLDER_CONTACTS, null, result, true);
         Assert.assertEquals(0, result.entries.size());
         result.clear();
 
-        comp.addMatchedContacts("first mid la", attrs, Mailbox.ID_FOLDER_CONTACTS, null, result);
+        comp.addMatchedContacts("first mid la", attrs, Mailbox.ID_FOLDER_CONTACTS, null, result, true);
         Assert.assertEquals(1, result.entries.size());
         result.clear();
 
@@ -220,15 +232,15 @@ public final class ContactAutoCompleteTest {
                 ContactConstants.A_lastName, "test.server-vmware - dash",
                 ContactConstants.A_email, "conf-hillview@zimbra.com");
 
-        comp.addMatchedContacts("test.server-vmware -", attrs, Mailbox.ID_FOLDER_CONTACTS, null, result);
+        comp.addMatchedContacts("test.server-vmware -", attrs, Mailbox.ID_FOLDER_CONTACTS, null, result, true);
         Assert.assertEquals(1, result.entries.size());
         result.clear();
 
-        comp.addMatchedContacts("test.server-vmware - d", attrs, Mailbox.ID_FOLDER_CONTACTS, null, result);
+        comp.addMatchedContacts("test.server-vmware - d", attrs, Mailbox.ID_FOLDER_CONTACTS, null, result, true);
         Assert.assertEquals(1, result.entries.size());
         result.clear();
 
-        comp.addMatchedContacts("conf - h", attrs, Mailbox.ID_FOLDER_CONTACTS, null, result);
+        comp.addMatchedContacts("conf - h", attrs, Mailbox.ID_FOLDER_CONTACTS, null, result, true);
         Assert.assertEquals(1, result.entries.size());
         result.clear();
     }
@@ -245,7 +257,7 @@ public final class ContactAutoCompleteTest {
                 ContactConstants.A_lastName, "\u0441\u043a\u0438 \u0411\u043e\u0441\u043d\u0430 \u0438 \u0425\u0435\u0440\u0446\u0435\u0433\u043e\u0432\u0438\u043d\u0430",
                 ContactConstants.A_email, "sr_BA@i18n.com");
         comp.addMatchedContacts("\u0421\u0440\u043f\u0441\u043a\u0438 \u0411\u043e\u0441\u043d\u0430 \u0438 \u0425\u0435\u0440\u0446\u0435\u0433\u043e\u0432\u0438\u043d\u0430",
-                attrs, Mailbox.ID_FOLDER_CONTACTS, null, result);
+                attrs, Mailbox.ID_FOLDER_CONTACTS, null, result, true);
         Assert.assertEquals(1, result.entries.size());
         result.clear();
     }
@@ -307,7 +319,7 @@ public final class ContactAutoCompleteTest {
         attrs.put(ContactConstants.A_email, "first.last@zimbra.com");
         attrs.put(ContactConstants.A_email2, "alias1@zimbra.com");
         Provisioning.getInstance().createAccount("first.last@zimbra.com", "secret", new HashMap<String, Object>());
-        contactAutoComplete.addMatchedContacts("first mid", attrs, Mailbox.ID_FOLDER_CONTACTS, null, result);
+        contactAutoComplete.addMatchedContacts("first mid", attrs, Mailbox.ID_FOLDER_CONTACTS, null, result, true);
         Assert.assertEquals(2, result.entries.size());
         result.clear();
     }
@@ -327,7 +339,7 @@ public final class ContactAutoCompleteTest {
         attrs.put(ContactConstants.A_email2, "alias1@zimbra.com");
         attrs.put(ContactConstants.A_email3, "alias2@zimbra.com");
         Provisioning.getInstance().createAccount("first.last@zimbra.com", "secret", new HashMap<String, Object>());
-        contactAutoComplete.addMatchedContacts("first mid", attrs, Mailbox.ID_FOLDER_CONTACTS, null, result);
+        contactAutoComplete.addMatchedContacts("first mid", attrs, Mailbox.ID_FOLDER_CONTACTS, null, result, true);
         Assert.assertEquals(3, result.entries.size());
         result.clear();
     }
@@ -347,7 +359,7 @@ public final class ContactAutoCompleteTest {
         attrs.put(ContactConstants.A_email2, "alias1@zimbra.com");
         attrs.put(ContactConstants.A_email3, "alias2@zimbra.com");
         Provisioning.getInstance().createAccount("first.last@zimbra.com", "secret", new HashMap<String, Object>());
-        contactAutoComplete.addMatchedContacts("first mid", attrs, Mailbox.ID_FOLDER_CONTACTS, null, result);
+        contactAutoComplete.addMatchedContacts("first mid", attrs, Mailbox.ID_FOLDER_CONTACTS, null, result, true);
         Assert.assertEquals(3, result.entries.size());
         result.clear();
     }
@@ -365,7 +377,85 @@ public final class ContactAutoCompleteTest {
         Account account = Provisioning.getInstance().getAccountByName("testContAC@zimbra.com");
         Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
         ContactAutoComplete contactAutoComplete = new ContactAutoComplete(account, new OperationContext(mbox));
-        Set<String> eligibleEmails = contactAutoComplete.extractEligibleEmailsListForAccount(attrs);
+        Set<String> eligibleEmails = contactAutoComplete.extractEligibleEmailsListForAccount(attrs, true);
         Assert.assertEquals(3, eligibleEmails.size());
+    }
+
+    @Test
+    public void testAutoComplete_localContactReturned_whenHideInGalTrue() throws Exception {
+        Account account = Provisioning.getInstance().getAccountByName("test3@zimbra.com");
+        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
+        Map<String, Object> fields = new HashMap<>();
+        fields.put(ContactConstants.A_firstName, "First");
+        fields.put(ContactConstants.A_lastName, "Last");
+        fields.put(ContactConstants.A_email, "testAccountWithGalHideTrue@zimbra.com");
+        mbox.createContact(null, new ParsedContact(fields), Mailbox.ID_FOLDER_CONTACTS, null);
+
+        Thread.sleep(500);
+        ContactAutoComplete autocomplete = new ContactAutoComplete(mbox.getAccount(), new OperationContext(mbox));
+        Assert.assertEquals(1, autocomplete.query("first last", null, 100).entries.size());
+    }
+
+    @Test
+    public void testAutoComplete_localContactReturned_whenHideInGalFalse() throws Exception {
+        Account account = Provisioning.getInstance().getAccountByName("test3@zimbra.com");
+        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
+        Map<String, Object> fields = new HashMap<>();
+        fields.put(ContactConstants.A_firstName, "First");
+        fields.put(ContactConstants.A_lastName, "Last");
+        fields.put(ContactConstants.A_email, "testAccountWithGalHideFalse@zimbra.com");
+        mbox.createContact(null, new ParsedContact(fields), Mailbox.ID_FOLDER_CONTACTS, null);
+
+        Thread.sleep(500);
+        ContactAutoComplete autocomplete = new ContactAutoComplete(mbox.getAccount(), new OperationContext(mbox));
+        Assert.assertEquals(1, autocomplete.query("first last", null, 100).entries.size());
+    }
+
+    @Test
+    public void testGalEntryReturnedWhenHideInGalFalse() throws Exception {
+        Account account = Provisioning.getInstance().getAccountByName("test3@zimbra.com");
+        ContactAutoComplete comp = new ContactAutoComplete(account, null);
+        ContactAutoComplete.AutoCompleteResult result = new ContactAutoComplete.AutoCompleteResult(10);
+        result.rankings = new ContactRankings(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        Map<String, Object> attrs = ImmutableMap.<String, Object>of(
+                ContactConstants.A_firstName, "First",
+                ContactConstants.A_lastName, "Last",
+                ContactConstants.A_email, "testAccountWithGalHideFalse@zimbra.com");
+        comp.addMatchedContacts("first last", attrs, ContactAutoComplete.FOLDER_ID_GAL, null, result, false);
+        Assert.assertEquals(1, result.entries.size());
+    }
+
+    @Test
+    public void testGalEntryNotReturnedWhenHideInGalTrue() throws Exception {
+        Account account = Provisioning.getInstance().getAccountByName("test3@zimbra.com");
+        ContactAutoComplete comp = new ContactAutoComplete(account, null);
+        ContactAutoComplete.AutoCompleteResult result = new ContactAutoComplete.AutoCompleteResult(10);
+        result.rankings = new ContactRankings(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        Map<String, Object> attrs = ImmutableMap.<String, Object>of(
+                ContactConstants.A_firstName, "First",
+                ContactConstants.A_lastName, "Last",
+                ContactConstants.A_email, "testAccountWithGalHideTrue@zimbra.com");
+        comp.addMatchedContacts("first last", attrs, ContactAutoComplete.FOLDER_ID_GAL, null, result, false);
+        Assert.assertEquals(0, result.entries.size());
+    }
+
+    @Test
+    public void testGalEntryReturnedWhenHideInGalNotSet() throws Exception {
+        Account account = Provisioning.getInstance().getAccountByName("test3@zimbra.com");
+        ContactAutoComplete comp = new ContactAutoComplete(account, null);
+        ContactAutoComplete.AutoCompleteResult result = new ContactAutoComplete.AutoCompleteResult(10);
+        result.rankings = new ContactRankings(MockProvisioning.DEFAULT_ACCOUNT_ID);
+
+        // Account without zimbraHideInGal attribute
+        Provisioning.getInstance().createAccount("testAccountWithGalHideNotSet@zimbra.com", "secret", new HashMap<String, Object>());
+
+        Map<String, Object> attrs = ImmutableMap.<String, Object>of(
+                ContactConstants.A_firstName, "First",
+                ContactConstants.A_lastName, "Last",
+                ContactConstants.A_email, "testAccountWithGalHideNotSet@zimbra.com"
+        );
+
+        comp.addMatchedContacts("first last", attrs, ContactAutoComplete.FOLDER_ID_GAL, null, result, false);
+        Assert.assertEquals(1, result.entries.size());
     }
 }

--- a/store/src/java/com/zimbra/cs/mailbox/ContactAutoComplete.java
+++ b/store/src/java/com/zimbra/cs/mailbox/ContactAutoComplete.java
@@ -754,7 +754,7 @@ public class ContactAutoComplete {
      * @param attrs
      * @param isFromContactFolder true if the entry originates from a local/shared contact folder,
      *                            false if the entry originates from GAL
-     * @return
+     * @return a set of email addresses that are eligible for autocomplete suggestions
      * @throws ServiceException
      */
     protected Set<String> extractEligibleEmailsListForAccount(Map<String, ?> attrs,
@@ -782,7 +782,8 @@ public class ContactAutoComplete {
             if (null != account) {
                 // apply zimbraHideInGal restriction only to GAL results.
                 // local contacts should still be suggested regardless of the zimbraHideInGal setting.
-                if (!isFromContactFolder && ContactConstants.A_email.equalsIgnoreCase(emailKey) && account.isHideInGal()) {
+                if (!isFromContactFolder
+                        && ContactConstants.A_email.equalsIgnoreCase(emailKey) && account.isHideInGal()) {
                     ZimbraLog.gal.debug("Skipping account %s from autocomplete", getFieldAsString(attrs, emailKey));
                     continue;
                 }

--- a/store/src/java/com/zimbra/cs/mailbox/ContactAutoComplete.java
+++ b/store/src/java/com/zimbra/cs/mailbox/ContactAutoComplete.java
@@ -752,10 +752,13 @@ public class ContactAutoComplete {
     /**
      * Identifies the eligible results for GAL Autocomplete for an account
      * @param attrs
+     * @param isFromContactFolder true if the entry originates from a local/shared contact folder,
+     *                            false if the entry originates from GAL
      * @return
      * @throws ServiceException
      */
-    protected Set<String> extractEligibleEmailsListForAccount(Map<String, ?> attrs, boolean isFromContactFolder) throws ServiceException {
+    protected Set<String> extractEligibleEmailsListForAccount(Map<String, ?> attrs,
+                                                              boolean isFromContactFolder) throws ServiceException {
         Set<String> eligibleEmailsForAccount = new HashSet<>();
         String primaryEmail = getFieldAsString(attrs, ContactConstants.A_email);
         Account account = Provisioning.getInstance().get(Key.AccountBy.name, primaryEmail);
@@ -768,15 +771,17 @@ public class ContactAutoComplete {
      * @param attrs
      * @param eligibleEmailsForAccount
      * @param account
+     * @param isFromContactFolder true if the entry originates from a local/shared contact folder,
+     *                            false if the entry originates from GAL
      * @throws ServiceException
      */
-    private void populateEligibleEmails(Map<String, ?> attrs, Set<String> eligibleEmailsForAccount, Account account, boolean isFromContactFolder)
-            throws ServiceException {
+    private void populateEligibleEmails(Map<String, ?> attrs, Set<String> eligibleEmailsForAccount, Account account,
+                                        boolean isFromContactFolder) throws ServiceException {
         for (String emailKey : mEmailKeys) {
             // when account is null, its external contact.Below alias logic is not applicable.
             if (null != account) {
-                // Apply zimbraHideInGal restriction only to GAL results.
-                // Local contacts should still be suggested regardless of the zimbraHideInGal setting.
+                // apply zimbraHideInGal restriction only to GAL results.
+                // local contacts should still be suggested regardless of the zimbraHideInGal setting.
                 if (!isFromContactFolder && ContactConstants.A_email.equalsIgnoreCase(emailKey) && account.isHideInGal()) {
                     ZimbraLog.gal.debug("Skipping account %s from autocomplete", getFieldAsString(attrs, emailKey));
                     continue;

--- a/store/src/java/com/zimbra/cs/mailbox/ContactAutoComplete.java
+++ b/store/src/java/com/zimbra/cs/mailbox/ContactAutoComplete.java
@@ -505,7 +505,7 @@ public class ContactAutoComplete {
         }
 
         public void handleContactAttrs(Map<String, ? extends Object> attrs) throws ServiceException {
-            addMatchedContacts(str, attrs, FOLDER_ID_GAL, null, result);
+            addMatchedContacts(str, attrs, FOLDER_ID_GAL, null, result, false);
         }
 
         @Override
@@ -668,7 +668,7 @@ public class ContactAutoComplete {
     }
 
     public void addMatchedContacts(String query, Map<String, ? extends Object> attrs, int folderId, ItemId id,
-            AutoCompleteResult result) throws ServiceException {
+            AutoCompleteResult result, boolean isFromContactFolder) throws ServiceException {
         if (!result.canBeCached) {
             return;
         }
@@ -701,7 +701,7 @@ public class ContactAutoComplete {
             if (Strings.isNullOrEmpty(displayName)) {
                 displayName = Joiner.on(' ').skipNulls().join(first, middle, last);
             }
-            Set<String> eligibleEmailsForAccount = extractEligibleEmailsListForAccount(attrs);
+            Set<String> eligibleEmailsForAccount = extractEligibleEmailsListForAccount(attrs, isFromContactFolder);
             for (String email : eligibleEmailsForAccount) {
                 if (email != null && (nameMatches || matchesEmail(tokens, email))) {
                     ContactEntry entry = new ContactEntry();
@@ -755,11 +755,11 @@ public class ContactAutoComplete {
      * @return
      * @throws ServiceException
      */
-    protected Set<String> extractEligibleEmailsListForAccount(Map<String, ?> attrs) throws ServiceException {
+    protected Set<String> extractEligibleEmailsListForAccount(Map<String, ?> attrs, boolean isFromContactFolder) throws ServiceException {
         Set<String> eligibleEmailsForAccount = new HashSet<>();
         String primaryEmail = getFieldAsString(attrs, ContactConstants.A_email);
         Account account = Provisioning.getInstance().get(Key.AccountBy.name, primaryEmail);
-        populateEligibleEmails(attrs, eligibleEmailsForAccount, account);
+        populateEligibleEmails(attrs, eligibleEmailsForAccount, account, isFromContactFolder);
         return eligibleEmailsForAccount;
     }
 
@@ -770,13 +770,14 @@ public class ContactAutoComplete {
      * @param account
      * @throws ServiceException
      */
-    private void populateEligibleEmails(Map<String, ?> attrs, Set<String> eligibleEmailsForAccount, Account account)
+    private void populateEligibleEmails(Map<String, ?> attrs, Set<String> eligibleEmailsForAccount, Account account, boolean isFromContactFolder)
             throws ServiceException {
         for (String emailKey : mEmailKeys) {
             // when account is null, its external contact.Below alias logic is not applicable.
             if (null != account) {
-                // check if account needs to be hidden in autocomplete
-                if (ContactConstants.A_email.equalsIgnoreCase(emailKey) && account.isHideInGal()) {
+                // Apply zimbraHideInGal restriction only to GAL results.
+                // Local contacts should still be suggested regardless of the zimbraHideInGal setting.
+                if (!isFromContactFolder && ContactConstants.A_email.equalsIgnoreCase(emailKey) && account.isHideInGal()) {
                     ZimbraLog.gal.debug("Skipping account %s from autocomplete", getFieldAsString(attrs, emailKey));
                     continue;
                 }
@@ -886,7 +887,7 @@ public class ContactAutoComplete {
                     continue;
                 }
 
-                addMatchedContacts(str, fields, fid, id, result);
+                addMatchedContacts(str, fields, fid, id, result, true);
                 if (!result.canBeCached) {
                     return;
                 }


### PR DESCRIPTION
**Ticket:** 
https://synacor.atlassian.net/browse/ZBUG-4936

**Issue:**
Autocomplete incorrectly excluded local contacts when the corresponding account had zimbraHideInGal=TRUE.
The zimbraHideInGal attribute is intended to control visibility in the Global Address List (GAL), but it was also being applied to local contact results, leading to unintended filtering.

**Fix:**
Updated the autocomplete filtering logic to apply zimbraHideInGal only to GAL results.
- Introduced context awareness using **isFromContactFolder**.
- Skipped filtering for entries originating from local contact folders.
- Retained existing behaviour for GAL and alias filtering.