### PR TITLE
ZBUG-5063 :handling_zimbraFeatureMailForwardingInFiltersEnabled_flag_at_account_level

### DIFF
--- a/store/src/java-test/com/zimbra/cs/filter/FilterUtilTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/FilterUtilTest.java
@@ -16,17 +16,16 @@
  */
 package com.zimbra.cs.filter;
 
+import static com.zimbra.cs.filter.JsieveConfigMapHandler.CAPABILITY_VARIABLES;
 import static org.junit.Assert.fail;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.StringUtil;
 import com.zimbra.cs.account.Account;
@@ -37,10 +36,11 @@ import com.zimbra.cs.mailbox.DeliveryContext;
 import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.MailboxManager;
 import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.mailbox.Message;
 import com.zimbra.cs.mailbox.OperationContext;
 import com.zimbra.cs.mime.ParsedMessage;
-
-import static com.zimbra.cs.filter.JsieveConfigMapHandler.CAPABILITY_VARIABLES;
+import com.zimbra.cs.service.util.ItemId;
+import java.lang.reflect.Method;
 
 /**
  * Unit tests for {@link FilterUtil}.
@@ -253,5 +253,290 @@ public class FilterUtilTest {
         ParsedMessage parsedMessage = new ParsedMessage(content.getBytes(), false);
         String result = FilterUtil.getExtendedInfo(parsedMessage.getMimeMessage());
         Assert.assertEquals(", sender=xxx>xxx@yyyyyh<, MsgId=null", result);
+    }
+
+    @Test
+    public void testApplyRulesToIncomingMessageFeatureFlagTrue() throws Exception {
+        // setup - enable the feature flag
+        Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        account.setFeatureMailForwardingInFiltersEnabled(true);
+
+        // Set filter rules using account's modify method
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put(Provisioning.A_zimbraMailSieveScript,
+                "require [\"fileinto\"];\n" + "if header :contains \"Subject\" " +
+                        "\"Test\" {\n" + "    fileinto \"Junk\";\n" + "    stop;\n" + "}");
+
+        account.modify(attrs);
+
+        // clear cached rules to force reload
+        RuleManager.clearCachedRules(account);
+
+        Mailbox mailbox = MailboxManager.getInstance().getMailboxByAccount(account);
+
+        // create a test message
+        String content = "From: sender@example.com\r\n" + "To: test@zimbra.com\r\n" +
+                "Subject: Test Message\r\n" + "Content-Type: text/plain\r\n\r\n" + "This is a test message.";
+
+        ParsedMessage parsedMessage = new ParsedMessage(content.getBytes(), false);
+
+        // create IncomingMessageHandler
+        IncomingMessageHandler handler = new IncomingMessageHandler(new OperationContext(mailbox),
+                new DeliveryContext(), mailbox, "test@zimbra.com", parsedMessage, content.length(),
+                Mailbox.ID_FOLDER_INBOX, false);
+
+        // create ZimbraMailAdapter
+        ZimbraMailAdapter mailAdapter = new ZimbraMailAdapter(mailbox, handler);
+
+        // simulate the applyRulesToIncomingMessage logic
+        boolean applyRules = account.isFeatureMailForwardingInFiltersEnabled();
+
+        if (applyRules) {
+            String script = RuleManager.getIncomingRules(account);
+            if (script != null && !script.isEmpty()) {
+                mailAdapter.setUserScriptExecuting(true);
+                // Use reflection to call private evaluateScript method
+                boolean proceed = invokeEvaluateScript(mailAdapter, script);
+                if (proceed && !mailAdapter.isStop()) {
+                    mailAdapter.executeAllActions();
+                }
+            }
+        }
+
+        // get the added message IDs
+        List<ItemId> result = mailAdapter.getAddedMessageIds();
+        if (result == null || result.isEmpty()) {
+            // Implicit keep - pass IMPLICIT_KEEP parameter
+            mailAdapter.keep(ZimbraMailAdapter.KeepType.IMPLICIT_KEEP);
+            result = mailAdapter.getAddedMessageIds();
+        }
+
+        // verify results
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.isEmpty());
+
+        // get the message
+        Message msg = mailbox.getMessageById(null, result.get(0).getId());
+        Assert.assertNotNull(msg);
+    }
+
+    @Test
+    public void testApplyRulesToIncomingMessageFeatureFlagFalse() throws Exception {
+        // setup - disable the feature flag
+        Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        account.setFeatureMailForwardingInFiltersEnabled(false);
+
+        // set filter rules
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put(Provisioning.A_zimbraMailSieveScript,
+                "require [\"fileinto\"];\n" + "if header :contains \"Subject\" \"Test\" " +
+                        "{\n" + "    fileinto \"Junk\";\n" + "    stop;\n" + "}");
+
+        account.modify(attrs);
+        RuleManager.clearCachedRules(account);
+
+        Mailbox mailbox = MailboxManager.getInstance().getMailboxByAccount(account);
+
+        // create a test message
+        String content = "From: sender@example.com\r\n" + "To: test@zimbra.com\r\n" +
+                "Subject: Test Message\r\n" + "Content-Type: text/plain\r\n\r\n" + "This is a test message.";
+
+        ParsedMessage parsedMessage = new ParsedMessage(content.getBytes(), false);
+
+        // create IncomingMessageHandler
+        IncomingMessageHandler handler = new IncomingMessageHandler(new OperationContext(mailbox),
+                new DeliveryContext(), mailbox, "test@zimbra.com", parsedMessage, content.length(),
+                Mailbox.ID_FOLDER_INBOX, false);
+
+        // create ZimbraMailAdapter
+        ZimbraMailAdapter mailAdapter = new ZimbraMailAdapter(mailbox, handler);
+
+        // simulate the applyRulesToIncomingMessage logic with feature flag false
+        boolean applyRules = account.isFeatureMailForwardingInFiltersEnabled();
+
+        if (applyRules) {
+            // This block won't execute because applyRules is false
+            String script = RuleManager.getIncomingRules(account);
+            if (script != null && !script.isEmpty()) {
+                mailAdapter.setUserScriptExecuting(true);
+                boolean proceed = invokeEvaluateScript(mailAdapter, script);
+                if (proceed && !mailAdapter.isStop()) {
+                    mailAdapter.executeAllActions();
+                }
+            }
+        }
+
+        // get the added message IDs (will be null because we didn't apply rules)
+        List<ItemId> result = mailAdapter.getAddedMessageIds();
+        if (result == null || result.isEmpty()) {
+            // Implicit keep - this is what should happen when feature flag is false
+            mailAdapter.keep(ZimbraMailAdapter.KeepType.IMPLICIT_KEEP);
+            result = mailAdapter.getAddedMessageIds();
+        }
+
+        // verify results - message should be in Inbox
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.isEmpty());
+
+        // get the message and verify it was filed to Inbox
+        Message msg = mailbox.getMessageById(null, result.get(0).getId());
+        Assert.assertNotNull(msg);
+        Assert.assertEquals(Mailbox.ID_FOLDER_INBOX, msg.getFolderId());
+    }
+
+    @Test
+    public void testApplyRulesToIncomingMessageFeatureFlagTrueNoRules() throws Exception {
+        // setup - enable the feature flag but no rules
+        Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        account.setFeatureMailForwardingInFiltersEnabled(true);
+
+        // clear any existing rules
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put(Provisioning.A_zimbraMailSieveScript, "");
+        account.modify(attrs);
+        RuleManager.clearCachedRules(account);
+
+        Mailbox mailbox = MailboxManager.getInstance().getMailboxByAccount(account);
+
+        // create a test message
+        String content = "From: sender@example.com\r\n" + "To: test@zimbra.com\r\n" +
+                "Subject: Test Message\r\n" + "Content-Type: text/plain\r\n\r\n" + "This is a test message.";
+
+        ParsedMessage parsedMessage = new ParsedMessage(content.getBytes(), false);
+
+        // create IncomingMessageHandler
+        IncomingMessageHandler handler = new IncomingMessageHandler(new OperationContext(mailbox),
+                new DeliveryContext(), mailbox, "test@zimbra.com", parsedMessage, content.length(),
+                Mailbox.ID_FOLDER_INBOX, false);
+
+        // create ZimbraMailAdapter
+        ZimbraMailAdapter mailAdapter = new ZimbraMailAdapter(mailbox, handler);
+
+        // simulate the applyRulesToIncomingMessage logic
+        boolean applyRules = account.isFeatureMailForwardingInFiltersEnabled();
+
+        if (applyRules) {
+            String script = RuleManager.getIncomingRules(account);
+            if (script != null && !script.isEmpty()) {
+                mailAdapter.setUserScriptExecuting(true);
+                boolean proceed = invokeEvaluateScript(mailAdapter, script);
+                if (proceed && !mailAdapter.isStop()) {
+                    mailAdapter.executeAllActions();
+                }
+            }
+        }
+
+        // get the added message IDs
+        List<ItemId> result = mailAdapter.getAddedMessageIds();
+        if (result == null || result.isEmpty()) {
+            // implicit keep
+            mailAdapter.keep(ZimbraMailAdapter.KeepType.IMPLICIT_KEEP);
+            result = mailAdapter.getAddedMessageIds();
+        }
+
+        // verify results - message should be in Inbox since no rules applied
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.isEmpty());
+
+        Message msg = mailbox.getMessageById(null, result.get(0).getId());
+        Assert.assertNotNull(msg);
+        Assert.assertEquals(Mailbox.ID_FOLDER_INBOX, msg.getFolderId());
+    }
+
+    @Test
+    public void testApplyRulesToIncomingMessageFeatureFlagTrueWithSpamApplyUserFilters() throws Exception {
+        // setup - enable the feature flag and configure to apply user filters to spam
+        Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        account.setFeatureMailForwardingInFiltersEnabled(true);
+
+        // Set spam apply user filters to true and set filter rules
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put(Provisioning.A_zimbraSpamApplyUserFilters, "TRUE");
+        attrs.put(Provisioning.A_zimbraMailSieveScript,
+                "require [\"fileinto\"];\n" + "if header :contains \"Subject\" \"Test\" " +
+                        "{\n" + "    fileinto \"Junk\";\n" + "    stop;\n" + "}");
+        account.modify(attrs);
+        RuleManager.clearCachedRules(account);
+
+        Mailbox mailbox = MailboxManager.getInstance().getMailboxByAccount(account);
+
+        // create a test message that appears to be spam
+        String content = "X-Spam-Flag: YES\r\n" + "X-Spam-Score: 15.0\r\n" + "From: " +
+                "sender@example.com\r\n" + "To: test@zimbra.com\r\n" + "Subject: Test " +
+                "Message\r\n" + "Content-Type: text/plain\r\n\r\n" + "This is a test message.";
+
+        ParsedMessage parsedMessage = new ParsedMessage(content.getBytes(), false);
+
+        // create IncomingMessageHandler
+        IncomingMessageHandler handler = new IncomingMessageHandler(new OperationContext(mailbox),
+                new DeliveryContext(), mailbox, "test@zimbra.com", parsedMessage, content.length(),
+                Mailbox.ID_FOLDER_INBOX, false);
+
+        // create ZimbraMailAdapter
+        ZimbraMailAdapter mailAdapter = new ZimbraMailAdapter(mailbox, handler);
+
+        // apply rules even for spam since applyUserFiltersToSpam is true
+        boolean applyRules = account.isFeatureMailForwardingInFiltersEnabled();
+
+        // check if it's spam
+        boolean isSpam = false;
+        String[] spamFlags = parsedMessage.getMimeMessage().getHeader("X-Spam-Flag");
+        if (spamFlags != null && spamFlags.length > 0 && "YES".equalsIgnoreCase(spamFlags[0])) {
+            isSpam = true;
+        }
+
+        boolean applyUserFiltersToSpam = account.getBooleanAttr(Provisioning.A_zimbraSpamApplyUserFilters, false);
+
+        if (applyRules && (!isSpam || applyUserFiltersToSpam)) {
+            String script = RuleManager.getIncomingRules(account);
+            if (script != null && !script.isEmpty()) {
+                mailAdapter.setUserScriptExecuting(true);
+                boolean proceed = invokeEvaluateScript(mailAdapter, script);
+                if (proceed && !mailAdapter.isStop()) {
+                    mailAdapter.executeAllActions();
+                }
+            }
+        }
+
+        // get the added message IDs
+        List<ItemId> result = mailAdapter.getAddedMessageIds();
+        if (result == null || result.isEmpty()) {
+            // implicit keep
+            mailAdapter.keep(ZimbraMailAdapter.KeepType.IMPLICIT_KEEP);
+            result = mailAdapter.getAddedMessageIds();
+        }
+
+        // verify results
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.isEmpty());
+        Message msg = mailbox.getMessageById(null, result.get(0).getId());
+        Assert.assertNotNull(msg);
+    }
+
+    // helper method to invoke private evaluateScript method using reflection
+    private boolean invokeEvaluateScript(ZimbraMailAdapter mailAdapter, String script) throws Exception {
+        try {
+            // get the private method from RuleManager class
+            Method evaluateScriptMethod = RuleManager.class.getDeclaredMethod("evaluateScript", ZimbraMailAdapter.class,
+                    String.class);
+            evaluateScriptMethod.setAccessible(true);
+
+            // invoke the static method (null as first parameter since it's static)
+            return (boolean) evaluateScriptMethod.invoke(null, mailAdapter, script);
+        } catch (NoSuchMethodException e) {
+            // try alternative method signature
+            try {
+                Method evaluateScriptMethod = RuleManager.class.getDeclaredMethod("evaluateScript",
+                        ZimbraMailAdapter.class, String.class, boolean.class);
+                evaluateScriptMethod.setAccessible(true);
+                return (boolean) evaluateScriptMethod.invoke(null, mailAdapter, script, true);
+            } catch (NoSuchMethodException e2) {
+                // ff both fail, try FilterUtil's evaluateScript
+                Method filterUtilMethod = FilterUtil.class.getDeclaredMethod("evaluateScript", ZimbraMailAdapter.class,
+                        String.class);
+                filterUtilMethod.setAccessible(true);
+                return (boolean) filterUtilMethod.invoke(null, mailAdapter, script);
+            }
+        }
     }
 }

--- a/store/src/java/com/zimbra/cs/filter/RuleManager.java
+++ b/store/src/java/com/zimbra/cs/filter/RuleManager.java
@@ -495,8 +495,8 @@ public final class RuleManager {
         };
 
         try {
-            boolean applyRules = true;
             Account account = mailbox.getAccount();
+            boolean applyRules = account.isFeatureMailForwardingInFiltersEnabled();
             for (String filter : filters) {
                 // Determine whether to apply rules
                 Node node = getRulesNode(account, filter);


### PR DESCRIPTION
This PR is regarding utilizing zimbraFeatureMailForwardingInFiltersEnabled filter at account level to enable filters 

Jira: [ZBUG-5063](https://synacor.atlassian.net/browse/ZBUG-5063)


[ZBUG-5063]: https://synacor.atlassian.net/browse/ZBUG-5063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ