### PR TITLE
ZBUG-5063: Allow redirection from zimbraAdminSieveScriptBefore when zimbraFeatureMailForwardingInFiltersEnabled is FALSE

### DIFF
--- a/store/src/java-test/com/zimbra/cs/filter/FilterUtilTest.java
+++ b/store/src/java-test/com/zimbra/cs/filter/FilterUtilTest.java
@@ -14,9 +14,15 @@
  * If not, see <https://www.gnu.org/licenses/>.
  * ***** END LICENSE BLOCK *****
  */
+
 package com.zimbra.cs.filter;
 
-import static org.junit.Assert.fail;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.mailbox.Message;
+import com.zimbra.cs.service.util.ItemId;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -26,7 +32,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.StringUtil;
 import com.zimbra.cs.account.Account;
@@ -34,13 +39,11 @@ import com.zimbra.cs.account.MockProvisioning;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.Server;
 import com.zimbra.cs.mailbox.DeliveryContext;
-import com.zimbra.cs.mailbox.Mailbox;
-import com.zimbra.cs.mailbox.MailboxManager;
-import com.zimbra.cs.mailbox.MailboxTestUtil;
 import com.zimbra.cs.mailbox.OperationContext;
 import com.zimbra.cs.mime.ParsedMessage;
 
 import static com.zimbra.cs.filter.JsieveConfigMapHandler.CAPABILITY_VARIABLES;
+import static org.junit.Assert.fail;
 
 /**
  * Unit tests for {@link FilterUtil}.
@@ -71,13 +74,9 @@ public class FilterUtilTest {
     @Test
     public void noBody() throws Exception {
         Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
-        String content =
-                "From: user1@example.com\r\n"
-                + "To: user2@example.com\r\n"
-                + "Subject: test\r\n"
-                + "Content-Type: application/octet-stream;name=\"test.pdf\"\r\n"
-                + "Content-Transfer-Encoding: base64\r\n\r\n"
-                + "R0a1231312ad124svsdsal=="; //obviously not a real pdf
+        String content = "From: user1@example.com\r\n" + "To: user2@example.com\r\n" + "Subject: test\r\n" 
+                + "Content-Type: application/octet-stream;name=\"test.pdf\"\r\n" 
+                + "Content-Transfer-Encoding: base64\r\n\r\n" + "R0a1231312ad124svsdsal=="; //obviously not a real pdf
         ParsedMessage parsedMessage = new ParsedMessage(content.getBytes(), false);
         Map<String, String> vars = FilterUtil.getVarsMap(mbox, parsedMessage, parsedMessage.getMimeMessage());
     }
@@ -92,20 +91,18 @@ public class FilterUtilTest {
     }
 
     /*
-     * Create and initialize the ZimbraMailAdapter object 
+     * Create and initialize the ZimbraMailAdapter object
      */
     private ZimbraMailAdapter initZimbraMailAdapter() throws ServiceException {
         Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
         RuleManager.clearCachedRules(account);
         Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
-        IncomingMessageHandler handler = new IncomingMessageHandler(
-                new OperationContext(mbox), new DeliveryContext(),
-                mbox, "test@zimbra.com",
-                new ParsedMessage("From: test1@zimbra.com".getBytes(), false),
-                0, Mailbox.ID_FOLDER_INBOX, true);
+        IncomingMessageHandler handler = new IncomingMessageHandler(new OperationContext(mbox), new DeliveryContext(),
+                mbox, "test@zimbra.com", new ParsedMessage("From: test1@zimbra.com".getBytes(), false), 0,
+                Mailbox.ID_FOLDER_INBOX, true);
         ZimbraMailAdapter mailAdapter = new ZimbraMailAdapter(mbox, handler);
-        
+
         // Set various variables
         mailAdapter.addVariable("var", "hello");
         List<String> matchedValues = new ArrayList<String>();
@@ -188,7 +185,7 @@ public class FilterUtilTest {
             fail("No exception should be thrown: " + e);
         }
     }
-    
+
     @Test
     public void testVariableReplacementQutdAndEncoded() {
         try {
@@ -221,17 +218,11 @@ public class FilterUtilTest {
 
     @Test
     public void testGetExtendedInfo() throws Exception {
-        String content =
-                "Return-Path: <dummy@dev.zimbra.com>\n"
-                + "Date: Tue, 29 Oct 2024 10:15:47 +0900 (JST)\n"
-                + "From: Dummy <dummy@dev.zimbra.com>\n"
-                + "To: user1@dev.zimbra.com\n"
-                + "Subject: ZBUG-4479: valid From header\n"
-                + "MIME-Version: 1.0\n"
-                + "Content-Type: text/plain; charset=utf-8\n"
-                + "Content-Transfer-Encoding: 7bit\n"
-                + "\n"
-                + "test message";
+        String content = "Return-Path: <dummy@dev.zimbra.com>\n" + "Date: Tue, 29 Oct 2024 10:15:47 +0900 (JST)\n" 
+                + "From: Dummy <dummy@dev.zimbra.com>\n" + "To: user1@dev.zimbra.com\n" 
+                + "Subject: ZBUG-4479: valid From header\n" + "MIME-Version: 1.0\n" 
+                + "Content-Type: text/plain; charset=utf-8\n" + "Content-Transfer-Encoding: 7bit\n" 
+                + "\n" + "test message";
         ParsedMessage parsedMessage = new ParsedMessage(content.getBytes(), false);
         String result = FilterUtil.getExtendedInfo(parsedMessage.getMimeMessage());
         Assert.assertEquals(", sender=dummy@dev.zimbra.com, MsgId=null", result);
@@ -239,19 +230,879 @@ public class FilterUtilTest {
 
     @Test
     public void testGetExtendedInfoExceptionCase() throws Exception {
-        String content =
-                "Return-Path: <dummy@dev.zimbra.com>\n"
-                + "Date: Tue, 29 Oct 2024 10:15:47 +0900 (JST)\n"
-                + "From: xxx>xxx@yyyyyh<\n"
-                + "To: user1@dev.zimbra.com\n"
-                + "Subject: ZBUG-4479: invalid From header\n"
-                + "MIME-Version: 1.0\n"
-                + "Content-Type: text/plain; charset=utf-8\n"
-                + "Content-Transfer-Encoding: 7bit\n"
-                + "\n"
-                + "test message";
+        String content = "Return-Path: <dummy@dev.zimbra.com>\n" + "Date: Tue, 29 Oct 2024 10:15:47 +0900 (JST)\n" 
+                + "From: xxx>xxx@yyyyyh<\n" + "To: user1@dev.zimbra.com\n" 
+                + "Subject: ZBUG-4479: invalid From header\n" + "MIME-Version: 1.0\n" 
+                + "Content-Type: text/plain; charset=utf-8\n" + "Content-Transfer-Encoding: 7bit\n" 
+                + "\n" + "test message";
         ParsedMessage parsedMessage = new ParsedMessage(content.getBytes(), false);
         String result = FilterUtil.getExtendedInfo(parsedMessage.getMimeMessage());
         Assert.assertEquals(", sender=xxx>xxx@yyyyyh<, MsgId=null", result);
+    }
+
+    @Test
+    public void testApplyRulesToIncomingMessageFeatureFlagTrue() throws Exception {
+        // setup - enable the feature flag
+        Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        account.setFeatureMailForwardingInFiltersEnabled(true);
+
+        // Set filter rules using account's modify method
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put(Provisioning.A_zimbraMailSieveScript,
+                "require [\"fileinto\"];\n" + "if header :contains \"Subject\" " 
+                        + "\"Test\" {\n" + "    fileinto \"Junk\";\n" + "    stop;\n" + "}");
+
+        account.modify(attrs);
+
+        // clear cached rules to force reload
+        RuleManager.clearCachedRules(account);
+
+        Mailbox mailbox = MailboxManager.getInstance().getMailboxByAccount(account);
+
+        // create a test message
+        String content = "From: sender@example.com\r\n" + "To: test@zimbra.com\r\n" + "Subject: Test Message\r\n" 
+                + "Content-Type: text/plain\r\n\r\n" + "This is a test message.";
+
+        ParsedMessage parsedMessage = new ParsedMessage(content.getBytes(), false);
+
+        // create IncomingMessageHandler
+        IncomingMessageHandler handler = new IncomingMessageHandler(new OperationContext(mailbox),
+                new DeliveryContext(), mailbox, "test@zimbra.com", parsedMessage, content.length(),
+                Mailbox.ID_FOLDER_INBOX, false);
+
+        // create ZimbraMailAdapter
+        ZimbraMailAdapter mailAdapter = new ZimbraMailAdapter(mailbox, handler);
+
+        // simulate the applyRulesToIncomingMessage logic
+        boolean applyRules = account.isFeatureMailForwardingInFiltersEnabled();
+
+        if (applyRules) {
+            String script = RuleManager.getIncomingRules(account);
+            if (script != null && !script.isEmpty()) {
+                mailAdapter.setUserScriptExecuting(true);
+                // Use reflection to call private evaluateScript method
+                boolean proceed = invokeEvaluateScript(mailAdapter, script);
+                if (proceed && !mailAdapter.isStop()) {
+                    mailAdapter.executeAllActions();
+                }
+            }
+        }
+
+        // get the added message IDs
+        List<ItemId> result = mailAdapter.getAddedMessageIds();
+        if (result == null || result.isEmpty()) {
+            // Implicit keep - pass IMPLICIT_KEEP parameter
+            mailAdapter.keep(ZimbraMailAdapter.KeepType.IMPLICIT_KEEP);
+            result = mailAdapter.getAddedMessageIds();
+        }
+
+        // verify results
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.isEmpty());
+
+        // get the message
+        Message msg = mailbox.getMessageById(null, result.get(0).getId());
+        Assert.assertNotNull(msg);
+    }
+
+    @Test
+    public void testApplyRulesToIncomingMessageFeatureFlagFalse() throws Exception {
+        // setup - disable the feature flag
+        Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        account.setFeatureMailForwardingInFiltersEnabled(false);
+
+        // set filter rules
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put(Provisioning.A_zimbraMailSieveScript,
+                "require [\"fileinto\"];\n" + "if header :contains \"Subject\" \"Test\" " 
+                        + "{\n" + "    fileinto \"Junk\";\n" + "    stop;\n" + "}");
+
+        account.modify(attrs);
+        RuleManager.clearCachedRules(account);
+
+        Mailbox mailbox = MailboxManager.getInstance().getMailboxByAccount(account);
+
+        // create a test message
+        String content = "From: sender@example.com\r\n" + "To: test@zimbra.com\r\n" + "Subject: Test Message\r\n" 
+                + "Content-Type: text/plain\r\n\r\n" + "This is a test message.";
+
+        ParsedMessage parsedMessage = new ParsedMessage(content.getBytes(), false);
+
+        // create IncomingMessageHandler
+        IncomingMessageHandler handler = new IncomingMessageHandler(new OperationContext(mailbox),
+                new DeliveryContext(), mailbox, "test@zimbra.com", parsedMessage, content.length(),
+                Mailbox.ID_FOLDER_INBOX, false);
+
+        // create ZimbraMailAdapter
+        ZimbraMailAdapter mailAdapter = new ZimbraMailAdapter(mailbox, handler);
+
+        // simulate the applyRulesToIncomingMessage logic with feature flag false
+        boolean applyRules = account.isFeatureMailForwardingInFiltersEnabled();
+
+        if (applyRules) {
+            // This block won't execute because applyRules is false
+            String script = RuleManager.getIncomingRules(account);
+            if (script != null && !script.isEmpty()) {
+                mailAdapter.setUserScriptExecuting(true);
+                boolean proceed = invokeEvaluateScript(mailAdapter, script);
+                if (proceed && !mailAdapter.isStop()) {
+                    mailAdapter.executeAllActions();
+                }
+            }
+        }
+
+        // get the added message IDs (will be null because we didn't apply rules)
+        List<ItemId> result = mailAdapter.getAddedMessageIds();
+        if (result == null || result.isEmpty()) {
+            // Implicit keep - this is what should happen when feature flag is false
+            mailAdapter.keep(ZimbraMailAdapter.KeepType.IMPLICIT_KEEP);
+            result = mailAdapter.getAddedMessageIds();
+        }
+
+        // verify results - message should be in Inbox
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.isEmpty());
+
+        // get the message and verify it was filed to Inbox
+        Message msg = mailbox.getMessageById(null, result.get(0).getId());
+        Assert.assertNotNull(msg);
+        Assert.assertEquals(Mailbox.ID_FOLDER_INBOX, msg.getFolderId());
+    }
+
+    @Test
+    public void testApplyRulesToIncomingMessageFeatureFlagTrueNoRules() throws Exception {
+        // setup - enable the feature flag but no rules
+        Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        account.setFeatureMailForwardingInFiltersEnabled(true);
+
+        // clear any existing rules
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put(Provisioning.A_zimbraMailSieveScript, "");
+        account.modify(attrs);
+        RuleManager.clearCachedRules(account);
+
+        Mailbox mailbox = MailboxManager.getInstance().getMailboxByAccount(account);
+
+        // create a test message
+        String content = "From: sender@example.com\r\n" + "To: test@zimbra.com\r\n" + "Subject: Test Message\r\n" 
+                + "Content-Type: text/plain\r\n\r\n" + "This is a test message.";
+
+        ParsedMessage parsedMessage = new ParsedMessage(content.getBytes(), false);
+
+        // create IncomingMessageHandler
+        IncomingMessageHandler handler = new IncomingMessageHandler(new OperationContext(mailbox),
+                new DeliveryContext(), mailbox, "test@zimbra.com", parsedMessage, content.length(),
+                Mailbox.ID_FOLDER_INBOX, false);
+
+        // create ZimbraMailAdapter
+        ZimbraMailAdapter mailAdapter = new ZimbraMailAdapter(mailbox, handler);
+
+        // simulate the applyRulesToIncomingMessage logic
+        boolean applyRules = account.isFeatureMailForwardingInFiltersEnabled();
+
+        if (applyRules) {
+            String script = RuleManager.getIncomingRules(account);
+            if (script != null && !script.isEmpty()) {
+                mailAdapter.setUserScriptExecuting(true);
+                boolean proceed = invokeEvaluateScript(mailAdapter, script);
+                if (proceed && !mailAdapter.isStop()) {
+                    mailAdapter.executeAllActions();
+                }
+            }
+        }
+
+        // get the added message IDs
+        List<ItemId> result = mailAdapter.getAddedMessageIds();
+        if (result == null || result.isEmpty()) {
+            // implicit keep
+            mailAdapter.keep(ZimbraMailAdapter.KeepType.IMPLICIT_KEEP);
+            result = mailAdapter.getAddedMessageIds();
+        }
+
+        // verify results - message should be in Inbox since no rules applied
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.isEmpty());
+
+        Message msg = mailbox.getMessageById(null, result.get(0).getId());
+        Assert.assertNotNull(msg);
+        Assert.assertEquals(Mailbox.ID_FOLDER_INBOX, msg.getFolderId());
+    }
+
+    @Test
+    public void testApplyRulesToIncomingMessageFeatureFlagTrueWithSpamApplyUserFilters() throws Exception {
+        // setup - enable the feature flag and configure to apply user filters to spam
+        Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        account.setFeatureMailForwardingInFiltersEnabled(true);
+
+        // Set spam apply user filters to true and set filter rules
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put(Provisioning.A_zimbraSpamApplyUserFilters, "TRUE");
+        attrs.put(Provisioning.A_zimbraMailSieveScript,
+                "require [\"fileinto\"];\n" + "if header :contains \"Subject\" \"Test\" " 
+                        + "{\n" + "    fileinto \"Junk\";\n" + "    stop;\n" + "}");
+        account.modify(attrs);
+        RuleManager.clearCachedRules(account);
+
+        Mailbox mailbox = MailboxManager.getInstance().getMailboxByAccount(account);
+
+        // create a test message that appears to be spam
+        String content = "X-Spam-Flag: YES\r\n" + "X-Spam-Score: 15.0\r\n" + "From: " 
+                + "sender@example.com\r\n" + "To: test@zimbra.com\r\n" + "Subject: Test " 
+                + "Message\r\n" + "Content-Type: text/plain\r\n\r\n" + "This is a test message.";
+
+        ParsedMessage parsedMessage = new ParsedMessage(content.getBytes(), false);
+
+        // create IncomingMessageHandler
+        IncomingMessageHandler handler = new IncomingMessageHandler(new OperationContext(mailbox),
+                new DeliveryContext(), mailbox, "test@zimbra.com", parsedMessage, content.length(),
+                Mailbox.ID_FOLDER_INBOX, false);
+
+        // create ZimbraMailAdapter
+        ZimbraMailAdapter mailAdapter = new ZimbraMailAdapter(mailbox, handler);
+
+        // apply rules even for spam since applyUserFiltersToSpam is true
+        boolean applyRules = account.isFeatureMailForwardingInFiltersEnabled();
+
+        // check if it's spam
+        boolean isSpam = false;
+        String[] spamFlags = parsedMessage.getMimeMessage().getHeader("X-Spam-Flag");
+        if (spamFlags != null && spamFlags.length > 0 && "YES".equalsIgnoreCase(spamFlags[0])) {
+            isSpam = true;
+        }
+
+        boolean applyUserFiltersToSpam = account.getBooleanAttr(Provisioning.A_zimbraSpamApplyUserFilters, false);
+
+        if (applyRules && (!isSpam || applyUserFiltersToSpam)) {
+            String script = RuleManager.getIncomingRules(account);
+            if (script != null && !script.isEmpty()) {
+                mailAdapter.setUserScriptExecuting(true);
+                boolean proceed = invokeEvaluateScript(mailAdapter, script);
+                if (proceed && !mailAdapter.isStop()) {
+                    mailAdapter.executeAllActions();
+                }
+            }
+        }
+
+        // get the added message IDs
+        List<ItemId> result = mailAdapter.getAddedMessageIds();
+        if (result == null || result.isEmpty()) {
+            // implicit keep
+            mailAdapter.keep(ZimbraMailAdapter.KeepType.IMPLICIT_KEEP);
+            result = mailAdapter.getAddedMessageIds();
+        }
+
+        // verify results
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.isEmpty());
+        Message msg = mailbox.getMessageById(null, result.get(0).getId());
+        Assert.assertNotNull(msg);
+    }
+
+    @Test
+    public void testRedirectActionFeatureFlagEnabled() throws Exception {
+        // setup - enable the feature flag
+        Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        account.setFeatureMailForwardingInFiltersEnabled(true);
+
+        // Set filter rules with redirect action
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put(Provisioning.A_zimbraMailSieveScript,
+                "require [\"redirect\"];\n" + "if header :contains \"Subject\" " 
+                        + "\"Test\" {\n" + "    redirect \"redirect@example.com\";\n" + "    stop;\n" + "}");
+
+        account.modify(attrs);
+        RuleManager.clearCachedRules(account);
+
+        Mailbox mailbox = MailboxManager.getInstance().getMailboxByAccount(account);
+
+        // create a test message
+        String content = "From: sender@example.com\r\n" + "To: test@zimbra.com\r\n" + "Subject: Test Message\r\n" 
+                + "Content-Type: text/plain\r\n\r\n" + "This is a test message.";
+
+        ParsedMessage parsedMessage = new ParsedMessage(content.getBytes(), false);
+
+        // create IncomingMessageHandler
+        IncomingMessageHandler handler = new IncomingMessageHandler(new OperationContext(mailbox),
+                new DeliveryContext(), mailbox, "test@zimbra.com", parsedMessage, content.length(),
+                Mailbox.ID_FOLDER_INBOX, false);
+
+        // create ZimbraMailAdapter
+        ZimbraMailAdapter mailAdapter = new ZimbraMailAdapter(mailbox, handler);
+
+        // simulate the applyRulesToIncomingMessage logic
+        boolean applyRules = account.isFeatureMailForwardingInFiltersEnabled();
+
+        if (applyRules) {
+            String script = RuleManager.getIncomingRules(account);
+            if (script != null && !script.isEmpty()) {
+                mailAdapter.setUserScriptExecuting(true);
+                boolean proceed = invokeEvaluateScript(mailAdapter, script);
+                if (proceed && !mailAdapter.isStop()) {
+                    mailAdapter.executeAllActions();
+                }
+            }
+        }
+
+        // get the added message IDs
+        List<ItemId> result = mailAdapter.getAddedMessageIds();
+        if (result == null || result.isEmpty()) {
+            // Implicit keep
+            mailAdapter.keep(ZimbraMailAdapter.KeepType.IMPLICIT_KEEP);
+            result = mailAdapter.getAddedMessageIds();
+        }
+
+        // verify results - message should be processed (redirect should work since feature flag is enabled)
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.isEmpty());
+    }
+
+    @Test
+    public void testRedirectActionFeatureFlagDisabled() throws Exception {
+        // setup - disable the feature flag
+        Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        account.setFeatureMailForwardingInFiltersEnabled(false);
+
+        // Set filter rules with redirect action
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put(Provisioning.A_zimbraMailSieveScript,
+                "require [\"redirect\"];\n" + "if header :contains \"Subject\" \"Test\" " 
+                        + "{\n" + "    redirect \"redirect@example.com\";\n" + "    stop;\n" + "}");
+
+        account.modify(attrs);
+        RuleManager.clearCachedRules(account);
+
+        Mailbox mailbox = MailboxManager.getInstance().getMailboxByAccount(account);
+
+        // create a test message
+        String content = "From: sender@example.com\r\n" + "To: test@zimbra.com\r\n" + "Subject: Test Message\r\n" 
+                + "Content-Type: text/plain\r\n\r\n" + "This is a test message.";
+
+        ParsedMessage parsedMessage = new ParsedMessage(content.getBytes(), false);
+
+        // create IncomingMessageHandler
+        IncomingMessageHandler handler = new IncomingMessageHandler(new OperationContext(mailbox),
+                new DeliveryContext(), mailbox, "test@zimbra.com", parsedMessage, content.length(),
+                Mailbox.ID_FOLDER_INBOX, false);
+
+        // create ZimbraMailAdapter
+        ZimbraMailAdapter mailAdapter = new ZimbraMailAdapter(mailbox, handler);
+
+        // simulate the applyRulesToIncomingMessage logic - even with feature flag false, 
+        // rules should still be applied, but redirect actions from user scripts will be rejected
+        boolean applyRules = account.isFeatureMailForwardingInFiltersEnabled();
+
+        if (applyRules) {
+            String script = RuleManager.getIncomingRules(account);
+            if (script != null && !script.isEmpty()) {
+                mailAdapter.setUserScriptExecuting(true);
+                boolean proceed = invokeEvaluateScript(mailAdapter, script);
+                if (proceed && !mailAdapter.isStop()) {
+                    mailAdapter.executeAllActions();
+                }
+            }
+        }
+
+        // get the added message IDs - should be empty since redirect from user script is rejected
+        List<ItemId> result = mailAdapter.getAddedMessageIds();
+        if (result == null || result.isEmpty()) {
+            // Implicit keep - this is what should happen when redirect is rejected
+            mailAdapter.keep(ZimbraMailAdapter.KeepType.IMPLICIT_KEEP);
+            result = mailAdapter.getAddedMessageIds();
+        }
+
+        // verify results - message should be in Inbox since redirect from user script is rejected
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.isEmpty());
+
+        Message msg = mailbox.getMessageById(null, result.get(0).getId());
+        Assert.assertNotNull(msg);
+        Assert.assertEquals(Mailbox.ID_FOLDER_INBOX, msg.getFolderId());
+    }
+
+    @Test
+    public void testRedirectActionWithCopyFeatureFlagEnabled() throws Exception {
+        // setup - enable the feature flag
+        Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        account.setFeatureMailForwardingInFiltersEnabled(true);
+
+        // Set filter rules with redirect action and copy
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put(Provisioning.A_zimbraMailSieveScript,
+                "require [\"redirect\"];\n" + "if header :contains \"Subject\" " 
+                        + "\"Test\" {\n" + "    redirect :copy \"redirect@example.com\";\n" + "    stop;\n" + "}");
+
+        account.modify(attrs);
+        RuleManager.clearCachedRules(account);
+
+        Mailbox mailbox = MailboxManager.getInstance().getMailboxByAccount(account);
+
+        // create a test message
+        String content = "From: sender@example.com\r\n" + "To: test@zimbra.com\r\n" + "Subject: Test Message\r\n" 
+                + "Content-Type: text/plain\r\n\r\n" + "This is a test message.";
+
+        ParsedMessage parsedMessage = new ParsedMessage(content.getBytes(), false);
+
+        // create IncomingMessageHandler
+        IncomingMessageHandler handler = new IncomingMessageHandler(new OperationContext(mailbox),
+                new DeliveryContext(), mailbox, "test@zimbra.com", parsedMessage, content.length(),
+                Mailbox.ID_FOLDER_INBOX, false);
+
+        // create ZimbraMailAdapter
+        ZimbraMailAdapter mailAdapter = new ZimbraMailAdapter(mailbox, handler);
+
+        // simulate the applyRulesToIncomingMessage logic
+        boolean applyRules = account.isFeatureMailForwardingInFiltersEnabled();
+
+        if (applyRules) {
+            String script = RuleManager.getIncomingRules(account);
+            if (script != null && !script.isEmpty()) {
+                mailAdapter.setUserScriptExecuting(true);
+                boolean proceed = invokeEvaluateScript(mailAdapter, script);
+                if (proceed && !mailAdapter.isStop()) {
+                    mailAdapter.executeAllActions();
+                }
+            }
+        }
+
+        // get the added message IDs - should have message since redirect has :copy and feature flag is enabled
+        List<ItemId> result = mailAdapter.getAddedMessageIds();
+        if (result == null || result.isEmpty()) {
+            // Implicit keep
+            mailAdapter.keep(ZimbraMailAdapter.KeepType.IMPLICIT_KEEP);
+            result = mailAdapter.getAddedMessageIds();
+        }
+
+        // verify results - message should be kept since redirect has :copy and feature flag is enabled
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.isEmpty());
+
+        Message msg = mailbox.getMessageById(null, result.get(0).getId());
+        Assert.assertNotNull(msg);
+        Assert.assertEquals(Mailbox.ID_FOLDER_INBOX, msg.getFolderId());
+    }
+
+    @Test
+    public void testRedirectActionWithCopyFeatureFlagDisabled() throws Exception {
+        // setup - disable the feature flag
+        Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        account.setFeatureMailForwardingInFiltersEnabled(false);
+
+        // Set filter rules with redirect action and copy
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put(Provisioning.A_zimbraMailSieveScript,
+                "require [\"redirect\"];\n" + "if header :contains \"Subject\" \"Test\" " 
+                        + "{\n" + "    redirect :copy \"redirect@example.com\";\n" + "    stop;\n" + "}");
+
+        account.modify(attrs);
+        RuleManager.clearCachedRules(account);
+
+        Mailbox mailbox = MailboxManager.getInstance().getMailboxByAccount(account);
+
+        // create a test message
+        String content = "From: sender@example.com\r\n" + "To: test@zimbra.com\r\n" + "Subject: Test Message\r\n" 
+                + "Content-Type: text/plain\r\n\r\n" + "This is a test message.";
+
+        ParsedMessage parsedMessage = new ParsedMessage(content.getBytes(), false);
+
+        // create IncomingMessageHandler
+        IncomingMessageHandler handler = new IncomingMessageHandler(new OperationContext(mailbox),
+                new DeliveryContext(), mailbox, "test@zimbra.com", parsedMessage, content.length(),
+                Mailbox.ID_FOLDER_INBOX, false);
+
+        // create ZimbraMailAdapter
+        ZimbraMailAdapter mailAdapter = new ZimbraMailAdapter(mailbox, handler);
+
+        // simulate the applyRulesToIncomingMessage logic - even with feature flag false, 
+        // rules should still be applied, but redirect actions from user scripts will be rejected
+        boolean applyRules = account.isFeatureMailForwardingInFiltersEnabled();
+
+        if (applyRules) {
+            String script = RuleManager.getIncomingRules(account);
+            if (script != null && !script.isEmpty()) {
+                mailAdapter.setUserScriptExecuting(true);
+                boolean proceed = invokeEvaluateScript(mailAdapter, script);
+                if (proceed && !mailAdapter.isStop()) {
+                    mailAdapter.executeAllActions();
+                }
+            }
+        }
+
+        // get the added message IDs - should be empty since redirect from user script is rejected
+        List<ItemId> result = mailAdapter.getAddedMessageIds();
+        if (result == null || result.isEmpty()) {
+            // Implicit keep - this is what should happen when redirect is rejected
+            mailAdapter.keep(ZimbraMailAdapter.KeepType.IMPLICIT_KEEP);
+            result = mailAdapter.getAddedMessageIds();
+        }
+
+        // verify results - message should be in Inbox since redirect from user script is rejected
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.isEmpty());
+
+        Message msg = mailbox.getMessageById(null, result.get(0).getId());
+        Assert.assertNotNull(msg);
+        Assert.assertEquals(Mailbox.ID_FOLDER_INBOX, msg.getFolderId());
+    }
+
+    @Test
+    public void testAdminSieveScriptBeforeRedirectFeatureFlagEnabled() throws Exception {
+        // setup - enable the feature flag
+        Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        account.setFeatureMailForwardingInFiltersEnabled(true);
+
+        // Set admin sieve script before with redirect action
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put(Provisioning.A_zimbraAdminSieveScriptBefore,
+                "require [\"redirect\"];\n" + "if header :contains \"Subject\" " 
+                        + "\"Test\" {\n" + "    redirect \"adminredirect@example.com\";\n" + "    stop;\n" + "}");
+
+        account.modify(attrs);
+        RuleManager.clearCachedRules(account);
+
+        Mailbox mailbox = MailboxManager.getInstance().getMailboxByAccount(account);
+
+        // create a test message
+        String content = "From: sender@example.com\r\n" + "To: test@zimbra.com\r\n" + "Subject: Test Message\r\n" 
+                + "Content-Type: text/plain\r\n\r\n" + "This is a test message.";
+
+        ParsedMessage parsedMessage = new ParsedMessage(content.getBytes(), false);
+
+        // create IncomingMessageHandler
+        IncomingMessageHandler handler = new IncomingMessageHandler(new OperationContext(mailbox),
+                new DeliveryContext(), mailbox, "test@zimbra.com", parsedMessage, content.length(),
+                Mailbox.ID_FOLDER_INBOX, false);
+
+        // create ZimbraMailAdapter
+        ZimbraMailAdapter mailAdapter = new ZimbraMailAdapter(mailbox, handler);
+
+        // simulate admin script execution (before user scripts)
+        String script = account.getAttr(Provisioning.A_zimbraAdminSieveScriptBefore);
+        if (script != null && !script.isEmpty()) {
+            // admin scripts are NOT user scripts, so userScriptExecuting should be false
+            boolean proceed = invokeEvaluateScript(mailAdapter, script);
+            if (proceed && !mailAdapter.isStop()) {
+                mailAdapter.executeAllActions();
+            }
+        }
+
+        // get the added message IDs - should be empty since redirect should happen
+        List<ItemId> result = mailAdapter.getAddedMessageIds();
+        if (result == null || result.isEmpty()) {
+            // Implicit keep - this is what should happen when redirect happens (no message kept)
+            mailAdapter.keep(ZimbraMailAdapter.KeepType.IMPLICIT_KEEP);
+            result = mailAdapter.getAddedMessageIds();
+        }
+
+        // verify results - message should be processed (admin redirect should work since it's not user script)
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.isEmpty());
+    }
+
+    @Test
+    public void testAdminSieveScriptBeforeRedirectFeatureFlagDisabled() throws Exception {
+        // setup - disable the feature flag
+        Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        account.setFeatureMailForwardingInFiltersEnabled(false);
+
+        // Set admin sieve script before with redirect action
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put(Provisioning.A_zimbraAdminSieveScriptBefore,
+                "require [\"redirect\"];\n" + "if header :contains \"Subject\" \"Test\" " 
+                        + "{\n" + "    redirect \"adminredirect@example.com\";\n" + "    stop;\n" + "}");
+
+        account.modify(attrs);
+        RuleManager.clearCachedRules(account);
+
+        Mailbox mailbox = MailboxManager.getInstance().getMailboxByAccount(account);
+
+        // create a test message
+        String content = "From: sender@example.com\r\n" + "To: test@zimbra.com\r\n" + "Subject: Test Message\r\n" 
+                + "Content-Type: text/plain\r\n\r\n" + "This is a test message.";
+
+        ParsedMessage parsedMessage = new ParsedMessage(content.getBytes(), false);
+
+        // create IncomingMessageHandler
+        IncomingMessageHandler handler = new IncomingMessageHandler(new OperationContext(mailbox),
+                new DeliveryContext(), mailbox, "test@zimbra.com", parsedMessage, content.length(),
+                Mailbox.ID_FOLDER_INBOX, false);
+
+        // create ZimbraMailAdapter
+        ZimbraMailAdapter mailAdapter = new ZimbraMailAdapter(mailbox, handler);
+
+        // simulate admin script execution (before user scripts)
+        String script = account.getAttr(Provisioning.A_zimbraAdminSieveScriptBefore);
+        if (script != null && !script.isEmpty()) {
+            // admin scripts are NOT user scripts, so userScriptExecuting should be false
+            boolean proceed = invokeEvaluateScript(mailAdapter, script);
+            if (proceed && !mailAdapter.isStop()) {
+                mailAdapter.executeAllActions();
+            }
+        }
+
+        // get the added message IDs - should be empty since redirect should happen
+        List<ItemId> result = mailAdapter.getAddedMessageIds();
+        if (result == null || result.isEmpty()) {
+            // Implicit keep - this is what should happen when redirect happens (no message kept)
+            mailAdapter.keep(ZimbraMailAdapter.KeepType.IMPLICIT_KEEP);
+            result = mailAdapter.getAddedMessageIds();
+        }
+
+        // verify results - message should be processed (admin redirect should work even with feature flag disabled 
+        // since it's not user script)
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.isEmpty());
+    }
+
+    @Test
+    public void testAdminSieveScriptAfterRedirectFeatureFlagEnabled() throws Exception {
+        // setup - enable the feature flag
+        Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        account.setFeatureMailForwardingInFiltersEnabled(true);
+
+        // Set admin sieve script after with redirect action
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put(Provisioning.A_zimbraAdminSieveScriptAfter,
+                "require [\"redirect\"];\n" + "if header :contains \"Subject\" " 
+                        + "\"Test\" {\n" + "    redirect \"adminredirect@example.com\";\n" + "    stop;\n" + "}");
+
+        account.modify(attrs);
+        RuleManager.clearCachedRules(account);
+
+        Mailbox mailbox = MailboxManager.getInstance().getMailboxByAccount(account);
+
+        // create a test message
+        String content = "From: sender@example.com\r\n" + "To: test@zimbra.com\r\n" + "Subject: Test Message\r\n" 
+                + "Content-Type: text/plain\r\n\r\n" + "This is a test message.";
+
+        ParsedMessage parsedMessage = new ParsedMessage(content.getBytes(), false);
+
+        // create IncomingMessageHandler
+        IncomingMessageHandler handler = new IncomingMessageHandler(new OperationContext(mailbox),
+                new DeliveryContext(), mailbox, "test@zimbra.com", parsedMessage, content.length(),
+                Mailbox.ID_FOLDER_INBOX, false);
+
+        // create ZimbraMailAdapter
+        ZimbraMailAdapter mailAdapter = new ZimbraMailAdapter(mailbox, handler);
+
+        // simulate admin script execution (after user scripts)
+        String script = account.getAttr(Provisioning.A_zimbraAdminSieveScriptAfter);
+        if (script != null && !script.isEmpty()) {
+            // admin scripts are NOT user scripts, so userScriptExecuting should be false
+            boolean proceed = invokeEvaluateScript(mailAdapter, script);
+            if (proceed && !mailAdapter.isStop()) {
+                mailAdapter.executeAllActions();
+            }
+        }
+
+        // get the added message IDs - should be empty since redirect should happen
+        List<ItemId> result = mailAdapter.getAddedMessageIds();
+        if (result == null || result.isEmpty()) {
+            // Implicit keep - this is what should happen when redirect happens (no message kept)
+            mailAdapter.keep(ZimbraMailAdapter.KeepType.IMPLICIT_KEEP);
+            result = mailAdapter.getAddedMessageIds();
+        }
+
+        // verify results - message should be processed (admin redirect should work since it's not user script)
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.isEmpty());
+    }
+
+    @Test
+    public void testAdminSieveScriptAfterRedirectFeatureFlagDisabled() throws Exception {
+        // setup - disable the feature flag
+        Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        account.setFeatureMailForwardingInFiltersEnabled(false);
+
+        // Set admin sieve script after with redirect action
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put(Provisioning.A_zimbraAdminSieveScriptAfter,
+                "require [\"redirect\"];\n" + "if header :contains \"Subject\" \"Test\" " 
+                        + "{\n" + "    redirect \"adminredirect@example.com\";\n" + "    stop;\n" + "}");
+
+        account.modify(attrs);
+        RuleManager.clearCachedRules(account);
+
+        Mailbox mailbox = MailboxManager.getInstance().getMailboxByAccount(account);
+
+        // create a test message
+        String content = "From: sender@example.com\r\n" + "To: test@zimbra.com\r\n" + "Subject: Test Message\r\n" 
+                + "Content-Type: text/plain\r\n\r\n" + "This is a test message.";
+
+        ParsedMessage parsedMessage = new ParsedMessage(content.getBytes(), false);
+
+        // create IncomingMessageHandler
+        IncomingMessageHandler handler = new IncomingMessageHandler(new OperationContext(mailbox),
+                new DeliveryContext(), mailbox, "test@zimbra.com", parsedMessage, content.length(),
+                Mailbox.ID_FOLDER_INBOX, false);
+
+        // create ZimbraMailAdapter
+        ZimbraMailAdapter mailAdapter = new ZimbraMailAdapter(mailbox, handler);
+
+        // simulate admin script execution (after user scripts)
+        String script = account.getAttr(Provisioning.A_zimbraAdminSieveScriptAfter);
+        if (script != null && !script.isEmpty()) {
+            // admin scripts are NOT user scripts, so userScriptExecuting should be false
+            boolean proceed = invokeEvaluateScript(mailAdapter, script);
+            if (proceed && !mailAdapter.isStop()) {
+                mailAdapter.executeAllActions();
+            }
+        }
+
+        // get the added message IDs - should be empty since redirect should happen
+        List<ItemId> result = mailAdapter.getAddedMessageIds();
+        if (result == null || result.isEmpty()) {
+            // Implicit keep - this is what should happen when redirect happens (no message kept)
+            mailAdapter.keep(ZimbraMailAdapter.KeepType.IMPLICIT_KEEP);
+            result = mailAdapter.getAddedMessageIds();
+        }
+
+        // verify results - message should be processed (admin redirect should work even with feature flag disabled 
+        // since it's not user script)
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.isEmpty());
+    }
+
+    @Test
+    public void testAdminSieveScriptBeforeRedirectWithCopyFeatureFlagEnabled() throws Exception {
+        // setup - enable the feature flag
+        Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        account.setFeatureMailForwardingInFiltersEnabled(true);
+
+        // Set admin sieve script before with redirect action and copy
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put(Provisioning.A_zimbraAdminSieveScriptBefore,
+                "require [\"redirect\"];\n" + "if header :contains \"Subject\" " 
+                        + "\"Test\" {\n" + "    redirect :copy \"adminredirect@example.com\";\n" + "    stop;\n" + "}");
+
+        account.modify(attrs);
+        RuleManager.clearCachedRules(account);
+
+        Mailbox mailbox = MailboxManager.getInstance().getMailboxByAccount(account);
+
+        // create a test message
+        String content = "From: sender@example.com\r\n" + "To: test@zimbra.com\r\n" + "Subject: Test Message\r\n" 
+                + "Content-Type: text/plain\r\n\r\n" + "This is a test message.";
+
+        ParsedMessage parsedMessage = new ParsedMessage(content.getBytes(), false);
+
+        // create IncomingMessageHandler
+        IncomingMessageHandler handler = new IncomingMessageHandler(new OperationContext(mailbox),
+                new DeliveryContext(), mailbox, "test@zimbra.com", parsedMessage, content.length(),
+                Mailbox.ID_FOLDER_INBOX, false);
+
+        // create ZimbraMailAdapter
+        ZimbraMailAdapter mailAdapter = new ZimbraMailAdapter(mailbox, handler);
+
+        // simulate admin script execution (before user scripts)
+        String script = account.getAttr(Provisioning.A_zimbraAdminSieveScriptBefore);
+        if (script != null && !script.isEmpty()) {
+            // admin scripts are NOT user scripts, so userScriptExecuting should be false
+            boolean proceed = invokeEvaluateScript(mailAdapter, script);
+            if (proceed && !mailAdapter.isStop()) {
+                mailAdapter.executeAllActions();
+            }
+        }
+
+        // get the added message IDs - should have message since redirect has :copy
+        List<ItemId> result = mailAdapter.getAddedMessageIds();
+        if (result == null || result.isEmpty()) {
+            // Implicit keep
+            mailAdapter.keep(ZimbraMailAdapter.KeepType.IMPLICIT_KEEP);
+            result = mailAdapter.getAddedMessageIds();
+        }
+
+        // verify results - message should be kept since redirect has :copy and it's admin script
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.isEmpty());
+
+        Message msg = mailbox.getMessageById(null, result.get(0).getId());
+        Assert.assertNotNull(msg);
+        Assert.assertEquals(Mailbox.ID_FOLDER_INBOX, msg.getFolderId());
+    }
+
+    @Test
+    public void testAdminSieveScriptBeforeRedirectWithCopyFeatureFlagDisabled() throws Exception {
+        // setup - disable the feature flag
+        Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        account.setFeatureMailForwardingInFiltersEnabled(false);
+
+        // Set admin sieve script before with redirect action and copy
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put(Provisioning.A_zimbraAdminSieveScriptBefore,
+                "require [\"redirect\"];\n" + "if header :contains \"Subject\" \"Test\" " 
+                        + "{\n" + "    redirect :copy \"adminredirect@example.com\";\n" + "    stop;\n" + "}");
+
+        account.modify(attrs);
+        RuleManager.clearCachedRules(account);
+
+        Mailbox mailbox = MailboxManager.getInstance().getMailboxByAccount(account);
+
+        // create a test message
+        String content = "From: sender@example.com\r\n" + "To: test@zimbra.com\r\n" + "Subject: Test Message\r\n" 
+                + "Content-Type: text/plain\r\n\r\n" + "This is a test message.";
+
+        ParsedMessage parsedMessage = new ParsedMessage(content.getBytes(), false);
+
+        // create IncomingMessageHandler
+        IncomingMessageHandler handler = new IncomingMessageHandler(new OperationContext(mailbox),
+                new DeliveryContext(), mailbox, "test@zimbra.com", parsedMessage, content.length(),
+                Mailbox.ID_FOLDER_INBOX, false);
+
+        // create ZimbraMailAdapter
+        ZimbraMailAdapter mailAdapter = new ZimbraMailAdapter(mailbox, handler);
+
+        // simulate admin script execution (before user scripts)
+        String script = account.getAttr(Provisioning.A_zimbraAdminSieveScriptBefore);
+        if (script != null && !script.isEmpty()) {
+            // admin scripts are NOT user scripts, so userScriptExecuting should be false
+            boolean proceed = invokeEvaluateScript(mailAdapter, script);
+            if (proceed && !mailAdapter.isStop()) {
+                mailAdapter.executeAllActions();
+            }
+        }
+
+        // get the added message IDs - should have message since redirect has :copy
+        List<ItemId> result = mailAdapter.getAddedMessageIds();
+        if (result == null || result.isEmpty()) {
+            // Implicit keep
+            mailAdapter.keep(ZimbraMailAdapter.KeepType.IMPLICIT_KEEP);
+            result = mailAdapter.getAddedMessageIds();
+        }
+
+        // verify results - message should be kept since redirect has :copy and it's admin script 
+        // (feature flag doesn't matter)
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.isEmpty());
+
+        Message msg = mailbox.getMessageById(null, result.get(0).getId());
+        Assert.assertNotNull(msg);
+        Assert.assertEquals(Mailbox.ID_FOLDER_INBOX, msg.getFolderId());
+    }
+
+    // helper method to invoke private evaluateScript method using reflection
+    private boolean invokeEvaluateScript(ZimbraMailAdapter mailAdapter, String script) throws Exception {
+        try {
+            // get the private method from RuleManager class
+            Method evaluateScriptMethod = RuleManager.class.getDeclaredMethod("evaluateScript", ZimbraMailAdapter.class,
+                    String.class);
+            evaluateScriptMethod.setAccessible(true);
+
+            // invoke the static method (null as first parameter since it's static)
+            return (boolean) evaluateScriptMethod.invoke(null, mailAdapter, script);
+        } catch (NoSuchMethodException e) {
+            // try alternative method signature
+            try {
+                Method evaluateScriptMethod = RuleManager.class.getDeclaredMethod("evaluateScript",
+                        ZimbraMailAdapter.class, String.class, boolean.class);
+                evaluateScriptMethod.setAccessible(true);
+                return (boolean) evaluateScriptMethod.invoke(null, mailAdapter, script, true);
+            } catch (NoSuchMethodException e2) {
+                // ff both fail, try FilterUtil's evaluateScript
+                Method filterUtilMethod = FilterUtil.class.getDeclaredMethod("evaluateScript", ZimbraMailAdapter.class,
+                        String.class);
+                filterUtilMethod.setAccessible(true);
+                return (boolean) filterUtilMethod.invoke(null, mailAdapter, script);
+            }
+        }
     }
 }

--- a/store/src/java-test/com/zimbra/cs/filter/package-info.java
+++ b/store/src/java-test/com/zimbra/cs/filter/package-info.java
@@ -1,0 +1,21 @@
+
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Web Client
+ * Copyright (C) 2026 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+/**
+ * CS filter package.
+ */
+package com.zimbra.cs.filter;

--- a/store/src/java/com/zimbra/cs/filter/ZimbraMailAdapter.java
+++ b/store/src/java/com/zimbra/cs/filter/ZimbraMailAdapter.java
@@ -103,6 +103,8 @@ public class ZimbraMailAdapter implements MailAdapter, EnvelopeAccessors {
     private List<String> matchedValues = new ArrayList<String>();
     private boolean parsedMessageCloned = false;
 
+    private final Set<Action> userScriptActions = new HashSet<>();
+
     public enum VARIABLEFEATURETYPE { UNKNOWN, OFF, AVAILABLE};
     private VARIABLEFEATURETYPE variablesExtAvailable = VARIABLEFEATURETYPE.UNKNOWN;
 
@@ -262,6 +264,9 @@ public class ZimbraMailAdapter implements MailAdapter, EnvelopeAccessors {
                 }
             }
         }
+        if (isUserScriptExecuting) {
+            userScriptActions.add(action);
+        }
     }
 
     @Override
@@ -397,7 +402,8 @@ public class ZimbraMailAdapter implements MailAdapter, EnvelopeAccessors {
         } else {
             ZimbraLog.filter.info("Redirecting message to %s.", addr);
         }
-        if (!account.isFeatureMailForwardingInFiltersEnabled()) {
+        if (userScriptActions.contains(redirect) &&
+                !account.isFeatureMailForwardingInFiltersEnabled()) {
             ZimbraLog.filter.warn("Redirection to %s is rejected as attribute mailForwarding is disabled.  Filing message to %s.",
                     addr, handler.getDefaultFolderPath());
             keep(KeepType.EXPLICIT_KEEP);


### PR DESCRIPTION
This PR is related to redirection use case of zimbra when zimbraFeatureMailForwardingInFiltersEnabled flag is set as true or false for any user the filter script added using zimbraAdminSieveScriptBefore flag do not workj 

**Fix**: Even if the zimbraFeatureMailForwardingInFiltersEnabled is true or false filters or any redirection conditions applied in filter will work

Jira: [ZBUG-5063](https://synacor.atlassian.net/browse/ZBUG-5063)


[ZBUG-5063]: https://synacor.atlassian.net/browse/ZBUG-5063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ