### PR TITLE
ZCS-19018: Improve Ehcache handling - implement large folder skip logic and logging for monitoring

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/DebugConfig.java
+++ b/common/src/java/com/zimbra/common/localconfig/DebugConfig.java
@@ -179,6 +179,8 @@ public final class DebugConfig {
     public static final boolean enableThisAndFuture = value("debug_enable_calendar_thisandfuture", false);
     public static final boolean caldavAllowAttendeeForOrganizer =
             value("debug_caldav_allow_attendee_for_organizer", false);
+    public static final boolean enableImapCacheReport = value("enable_imap_cache_report", false);
+    public static final int imapCacheReportInterval = value("imap_cache_report_interval_in_seconds", 300);
 
     /** TODO: Replace/remove when support persistence of DavName to DB instead of in memory cache.
      *        In memory cache version developed to enable a test mode which is more compatible with

--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -721,6 +721,10 @@ public final class LC {
     @Reloadable
     public static final KnownKey imap_ehcache_heap_size = KnownKey.newKey(1);
 
+    public static final KnownKey imap_ehcache_skip_large_folder = KnownKey.newKey(false);
+
+    public static final KnownKey imap_ehcache_folder_max_message_count = KnownKey.newKey(80000);
+
     @Supported
     public static final KnownKey imapd_keystore = KnownKey.newKey("/opt/zimbra/conf/imapd.keystore");
     @Supported

--- a/store/src/java/com/zimbra/cs/imap/ImapSessionManager.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapSessionManager.java
@@ -25,8 +25,9 @@ import java.util.TimerTask;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-
+import java.util.concurrent.atomic.LongAdder;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
@@ -88,6 +89,18 @@ final class ImapSessionManager {
     private final Cache<String, ImapFolder> activeSessionCache; // not LRU'ed
     private final Cache<String, ImapFolder> inactiveSessionCache; // LRU'ed
 
+    private static final String THREAD_NAME = "CacheStatsLogger";
+
+    private final ScheduledExecutorService statsLogger = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = new Thread(r, THREAD_NAME);
+        t.setDaemon(true);
+        return t;
+    });
+
+    private final LongAdder windowSkipped = new LongAdder();
+
+    private final LongAdder windowUnloaded = new LongAdder();
+
     private static final ImapSessionManager SINGLETON = new ImapSessionManager();
 
     private static final ExecutorService CLOSER = Executors.newSingleThreadExecutor(
@@ -110,6 +123,11 @@ final class ImapSessionManager {
                 new EhcacheImapCache(EhcacheManager.IMAP_INACTIVE_SESSION_CACHE, false) :
                 activeSessionCache);
         Preconditions.checkState(inactiveSessionCache != null);
+
+        if (DebugConfig.enableImapCacheReport) {
+            statsLogger.scheduleAtFixedRate(this::printStats, DebugConfig.imapCacheReportInterval,
+                    DebugConfig.imapCacheReportInterval, TimeUnit.SECONDS);
+        }
     }
 
     protected static ImapSessionManager getInstance() {
@@ -668,7 +686,24 @@ final class ImapSessionManager {
             try {
                 // could use session.serialize() if we want to leave it in memory...
                 ZimbraLog.imap.debug("Paging session during close: %s", session);
-                session.unload(false);
+                int actualMsgCount = session.mFolder.getSize();
+                // skip folders where imapFolder message count exceeds the imap_ehcache_folder_max_message_count
+                // to reduce load on Ehcache
+                if (LC.imap_ehcache_skip_large_folder.booleanValue() &&
+                        actualMsgCount > LC.imap_ehcache_folder_max_message_count.intValue()) {
+                    windowSkipped.increment();
+                    ZimbraLog.imap.debug(
+                            "Skipping IMAP folder cache storage: message count (%d) exceeds threshold (%d). " +
+                                    "FolderId: %d. CacheKey: %s",
+                            actualMsgCount,
+                            LC.imap_ehcache_folder_max_message_count.intValue(),
+                            session.mFolder.getId(),
+                            cacheKey(session, false)
+                    );
+                } else {
+                    windowUnloaded.increment();
+                    session.unload(false);
+                }
             } catch (MailboxInMaintenanceException miMe) {
                 if (ZimbraLog.imap.isDebugEnabled()) {
                     ZimbraLog.imap.info("Mailbox in maintenance detected during close - will detach %s", session, miMe);
@@ -823,6 +858,28 @@ final class ImapSessionManager {
 
     public static boolean isActiveKey(String key) {
         return key.contains("_");
+    }
+
+    /**
+     * Prints cache statistics for large folder handling.
+     *
+     * <p>This method logs the number of folders that were skipped or unloaded
+     * during the current window. The log is emitted only when cache reporting
+     * is enabled via configuration (DebugConfig.enableImapCacheReport flag).</p>
+     *
+     * <p>Logging is performed at INFO level to avoid excessive DEBUG log noise.</p>
+     */
+    private void printStats() {
+        long winSkipped = windowSkipped.sumThenReset();
+        long winUnloaded = windowUnloaded.sumThenReset();
+
+        if (winSkipped > 0 || winUnloaded > 0) {
+            ZimbraLog.imap.info(
+                    "[CACHE REPORT] Large folder handling: {Unloaded: %d, Skipped: %d}",
+                    winUnloaded,
+                    winSkipped
+            );
+        }
     }
 
     static interface Cache<String, ImapFolder> {


### PR DESCRIPTION
https://synacor.atlassian.net/browse/ZCS-19018

Changes introduced
Added logic to skip large folders from being unloaded into Ehcache
Large folder handling is made configurable via local configuration
Introduced cache reporting logs for monitoring purposes

Configuration changes :
Debug configuration (default values)
enable_imap_cache_report → false
imap_cache_report_interval_in_seconds → 300 seconds

Local configuration (LC)
imap_ehcache_skip_large_folder → false
imap_ehcache_folder_max_message_count → 80000

Cache reporting behavior
When enable_cache_report is set to true, a dedicated daemon thread is started
The thread logs cache statistics at configured intervals
Logs are written at INFO level to avoid flooding DEBUG logs and impacting troubleshooting
The thread runs as a daemon to ensure it does not block shutdown

Sample log output
2026-04-27 07:44:01,269 INFO  [CacheStatsLogger] [] imap - [CACHE REPORT] Large folder handling: {Unloaded: 1, Skipped: 0}

Notes
 INFO level logging is used intentionally to prevent debug log congestion during issue investigation 
 Feature is fully controlled via configuration flags