### PR TITLE
ZBUG-4950 Prevent self-forwarding in mail forwarding configuration

### DIFF
--- a/store/src/java-test/com/zimbra/cs/account/MailForwardingUtilTest.java
+++ b/store/src/java-test/com/zimbra/cs/account/MailForwardingUtilTest.java
@@ -1,0 +1,99 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite, Network Edition.
+ * Copyright (C) 2026 Synacor, Inc.  All Rights Reserved.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.account;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import java.util.HashMap;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MailForwardingUtilTest {
+
+    private Account account;
+
+    @Before
+    public void setUp() throws Exception {
+        MailboxTestUtil.initServer();
+
+        Provisioning prov = Provisioning.getInstance();
+
+        account = prov.createAccount(
+                "user@test.com",
+                "secret",
+                new HashMap<String, Object>());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        MailboxTestUtil.clearData();
+    }
+
+    @Test(expected = ServiceException.class)
+    public void testSelfForwardingShouldThrowException() throws Exception {
+
+        MailForwardingUtil.validateSelfForwarding(
+                account,
+                "user@test.com");
+    }
+
+    @Test(expected = ServiceException.class)
+    public void testSelfForwardingCaseInsensitiveShouldThrowException()
+            throws Exception {
+
+        MailForwardingUtil.validateSelfForwarding(
+                account,
+                "USER@TEST.COM");
+    }
+
+    @Test
+    public void testValidForwardingShouldNotThrowException()
+            throws Exception {
+
+        MailForwardingUtil.validateSelfForwarding(
+                account,
+                "other@test.com");
+    }
+
+    @Test
+    public void testMultipleValidForwardingAddressesShouldNotThrowException()
+            throws Exception {
+
+        MailForwardingUtil.validateSelfForwarding(
+                account,
+                "other1@test.com,other2@test.com");
+    }
+
+    @Test(expected = ServiceException.class)
+    public void testMultipleAddressesContainingSelfShouldThrowException()
+            throws Exception {
+
+        MailForwardingUtil.validateSelfForwarding(
+                account,
+                "other@test.com,user@test.com");
+    }
+
+    @Test
+    public void testNullForwardingAddressShouldNotThrowException()
+            throws Exception {
+
+        MailForwardingUtil.validateSelfForwarding(
+                account,
+                null);
+    }
+
+    @Test
+    public void testEmptyForwardingAddressShouldNotThrowException()
+            throws Exception {
+
+        MailForwardingUtil.validateSelfForwarding(
+                account,
+                "");
+    }
+}

--- a/store/src/java-test/com/zimbra/cs/account/package-info.java
+++ b/store/src/java-test/com/zimbra/cs/account/package-info.java
@@ -1,4 +1,3 @@
-
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Web Client

--- a/store/src/java-test/com/zimbra/cs/account/package-info.java
+++ b/store/src/java-test/com/zimbra/cs/account/package-info.java
@@ -1,0 +1,6 @@
+ /*
+  * ***** BEGIN LICENSE BLOCK *****
+  * Zimbra Collaboration Suite, Network Edition.
+  * Copyright (C) 2026 Synacor, Inc.  All Rights Reserved.
+  * ***** END LICENSE BLOCK *****
+  */

--- a/store/src/java/com/zimbra/cs/account/MailForwardingUtil.java
+++ b/store/src/java/com/zimbra/cs/account/MailForwardingUtil.java
@@ -1,0 +1,52 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite, Network Edition.
+ * Copyright (C) 2026 Synacor, Inc.  All Rights Reserved.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.account;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public final class MailForwardingUtil {
+    private MailForwardingUtil() {
+    }
+
+    public static void validateSelfForwarding(
+            Account account,
+            String forwardingAddresses)
+            throws ServiceException {
+
+        if (account == null || forwardingAddresses == null) {
+            return;
+        }
+
+        Set<String> normalizedAccountAddresses =
+                account.getAllAddrsSet()
+                        .stream()
+                        .map(String::toLowerCase)
+                        .collect(Collectors.toSet());
+
+        for (String addr : forwardingAddresses.split(",")) {
+
+            String normalizedAddr = addr.trim().toLowerCase();
+
+            if (!normalizedAddr.isEmpty()
+                    && normalizedAccountAddresses.contains(normalizedAddr)) {
+
+                ZimbraLog.account.warn(
+                        "Attempt to set self-forwarding for account: %s, forwarding address: %s",
+                        account.getName(),
+                        addr);
+
+                throw ServiceException.INVALID_REQUEST(
+                        "Cannot set forwarding address to the same account",
+                        null);
+            }
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/account/callback/PrefMailForwardingAddress.java
+++ b/store/src/java/com/zimbra/cs/account/callback/PrefMailForwardingAddress.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2009, 2010, 2011, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2009, 2010, 2011, 2013, 2014, 2016, 2026 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -23,6 +23,7 @@ import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.AttributeCallback;
 import com.zimbra.cs.account.Entry;
+import com.zimbra.cs.account.MailForwardingUtil;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.callback.CallbackContext.DataKey;
 
@@ -85,16 +86,16 @@ public class PrefMailForwardingAddress extends AttributeCallback {
         
         if (maxAddrs == -1)
             maxAddrs = account.getMailForwardingAddressMaxNumAddrs();
-        
+
         String newValue = mod.value();
-        
+        String[] addrs = newValue.split(",");
+        MailForwardingUtil.validateSelfForwarding(account, newValue);
         if (newValue.length() > maxLen) {
             throw ServiceException.INVALID_REQUEST("value is too long, the limit(" + 
                     Provisioning.A_zimbraMailForwardingAddressMaxLength + ") is " + 
                     maxLen, null);
         }
-        
-        String[] addrs = newValue.split(",");
+
         if (addrs.length > maxAddrs) {
             throw ServiceException.INVALID_REQUEST("value is too long, the limit(" + 
                     Provisioning.A_zimbraMailForwardingAddressMaxNumAddrs + ") is " + 

--- a/store/src/java/com/zimbra/cs/account/package-info.java
+++ b/store/src/java/com/zimbra/cs/account/package-info.java
@@ -1,0 +1,6 @@
+ /*
+    * ***** BEGIN LICENSE BLOCK *****
+    * Zimbra Collaboration Suite, Network Edition.
+    * Copyright (C) 2026 Synacor, Inc.  All Rights Reserved.
+    * ***** END LICENSE BLOCK *****
+    */

--- a/store/src/java/com/zimbra/cs/service/admin/ModifyAccount.java
+++ b/store/src/java/com/zimbra/cs/service/admin/ModifyAccount.java
@@ -1,7 +1,7 @@
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
- * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016 Synacor, Inc.
+ * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2026 Synacor, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -38,6 +38,7 @@ import com.zimbra.cs.account.AccountServiceException;
 import com.zimbra.cs.account.AuthToken;
 import com.zimbra.cs.account.Cos;
 import com.zimbra.cs.account.Domain;
+import com.zimbra.cs.account.MailForwardingUtil;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.Provisioning.CacheEntry;
 import com.zimbra.cs.account.Server;
@@ -229,6 +230,10 @@ public class ModifyAccount extends AdminDocumentHandler {
         }
 
         try {
+            String forwardingAddress = getStringAttrNewValue(Provisioning.A_zimbraMailForwardingAddress, attrs);
+            if (forwardingAddress != null) {
+                MailForwardingUtil.validateSelfForwarding(account, forwardingAddress);
+            }
             // pass in true to checkImmutable
             prov.modifyAttrs(account, attrs, true);
 


### PR DESCRIPTION
**Problem**:
Currently, the system allows users to configure mail forwarding to their own email address.

**Solution**:
Added validation to prevent users from setting their own email address as a forwarding destination.
The system now rejects such configurations across supported entry points. 