### PR TITLE
ZCS-19043: Implementation ticket for IMAP Move

### DIFF
--- a/client/src/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/java/com/zimbra/client/ZMailbox.java
@@ -6597,6 +6597,16 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
         return invokeJaxb(req);
     }
 
+    public ItemActionResponse moveItemAction(ItemIdentifier targetFolder, List<ItemIdentifier> idList)
+            throws ServiceException {
+        String ids = Joiner.on(',').join(idList);
+        ActionSelector action = ActionSelector.createForIdsAndOperation(ids, MailConstants.OP_MOVE);
+        action.setFolder(targetFolder.toString(this.getAccountId()));
+        action.setNewlyCreatedIds(true);
+        ItemActionRequest req = new ItemActionRequest(action);
+        return invokeJaxb(req);
+    }
+
     /**
      * Copies the items identified in {@link idlist} to folder {@link targetFolder}
      * @param idlist - list of item ids for items to copy
@@ -6606,6 +6616,13 @@ public class ZMailbox implements ToZJSONObject, MailboxStore {
     public List<String> copyItemAction(OpContext ctxt, ItemIdentifier targetFolder, List<ItemIdentifier> idlist)
     throws ServiceException {
         ItemActionResponse resp = copyItemAction(targetFolder, idlist);
+        return Lists.newArrayList(resp.getAction().getNewlyCreatedIds());
+    }
+
+    @Override
+    public List<String> moveItemAction(OpContext ctxt, ItemIdentifier targetFolder, List<ItemIdentifier> idlist)
+            throws ServiceException {
+        ItemActionResponse resp = moveItemAction(targetFolder, idlist);
         return Lists.newArrayList(resp.getAction().getNewlyCreatedIds());
     }
 

--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -699,6 +699,7 @@ public final class LC {
     public static final KnownKey imap_max_request_size = KnownKey.newKey(10 * 1024);
     public static final KnownKey imap_max_nesting_in_search_request = KnownKey.newKey(100);
     public static final KnownKey imap_max_items_in_copy = KnownKey.newKey(1000);
+    public static final KnownKey imap_max_items_in_move = KnownKey.newKey(1000);
 
     @Supported
     @Reloadable

--- a/common/src/java/com/zimbra/common/mailbox/MailboxStore.java
+++ b/common/src/java/com/zimbra/common/mailbox/MailboxStore.java
@@ -36,6 +36,8 @@ public interface MailboxStore {
      */
     public List<String> copyItemAction(OpContext ctxt, ItemIdentifier targetFolder, List<ItemIdentifier> idlist)
             throws ServiceException;
+    public List<String> moveItemAction(OpContext ctxt, ItemIdentifier targetFolder, List<ItemIdentifier> idlist)
+            throws ServiceException;
     public void createFolderForMsgs(OpContext octxt, String path) throws ServiceException;
     public void renameFolder(OpContext octxt, FolderStore folder, String path) throws ServiceException;
     public void deleteFolder(OpContext octxt, String itemId) throws ServiceException;

--- a/store/src/java/com/zimbra/cs/db/DbMailItem.java
+++ b/store/src/java/com/zimbra/cs/db/DbMailItem.java
@@ -398,6 +398,50 @@ public class DbMailItem {
         }
     }
 
+    public static void imove(MailItem item, Folder folder, int moveId) throws ServiceException {
+        Mailbox mbox = item.getMailbox();
+        if (mbox != folder.getMailbox()) {
+            throw MailServiceException.WRONG_MAILBOX();
+        }
+        checkNamingConstraint(mbox, folder.getId(), item.getName(), item.getId());
+
+        DbConnection conn = mbox.getOperationConnection();
+        PreparedStatement stmt = null;
+        try {
+            String imapRenumber = mbox.isTrackingImap()
+                    ? ", imap_id = CASE WHEN imap_id IS NULL THEN NULL ELSE ? " + " END"
+                    : "";
+            int pos = 1;
+            stmt = conn.prepareStatement("UPDATE " + getMailItemTableName(item) +
+                    " SET folder_id = ?, prev_folders = ?, index_id = ?, mod_metadata = ?, change_date = ? "
+                    + imapRenumber + " WHERE " + IN_THIS_MAILBOX_AND + "id = ?");
+            stmt.setInt(pos++, folder.getId());
+            int modseq = mbox.getOperationChangeID();
+            String prevFolders = findPrevFolders(item, modseq);
+            stmt.setString(pos++, prevFolders);
+            if (item.getIndexStatus() == MailItem.IndexStatus.NO) {
+                stmt.setNull(pos++, Types.INTEGER);
+            } else {
+                stmt.setInt(pos++, item.getIndexId());
+            }
+            stmt.setInt(pos++, modseq);
+            stmt.setInt(pos++, mbox.getOperationTimestamp());
+            stmt.setInt(pos++, moveId);
+            pos = setMailboxId(stmt, mbox, pos);
+            stmt.setInt(pos++, item.getId());
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            // catch item_id uniqueness constraint violation and return failure
+            if (Db.errorMatches(e, Db.Error.DUPLICATE_ROW)) {
+                throw MailServiceException.ALREADY_EXISTS(item.getName(), e);
+            } else {
+                throw ServiceException.FAILURE("writing new imove data for item " + item.getId(), e);
+            }
+        } finally {
+            DbPool.closeStatement(stmt);
+        }
+    }
+
     public static void icopy(MailItem source, UnderlyingData data, boolean shared) throws ServiceException {
         Mailbox mbox = source.getMailbox();
         if (data == null || data.id <= 0 || data.folderId <= 0 || data.parentId == 0) {

--- a/store/src/java/com/zimbra/cs/imap/ImapHandler.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapHandler.java
@@ -144,10 +144,10 @@ public abstract class ImapHandler {
     protected enum ImapExtension { CONDSTORE, QRESYNC }
 
     private static final Set<String> SUPPORTED_EXTENSIONS = new LinkedHashSet<String>(Arrays.asList(
-        "ACL", "BINARY", "CATENATE", "CHILDREN", "CONDSTORE", "ENABLE", "ESEARCH", "ESORT",
-        "I18NLEVEL=1", "ID", "IDLE", "LIST-EXTENDED", "LIST-STATUS", "LITERAL+", "LOGIN-REFERRALS",
-        "MULTIAPPEND", "NAMESPACE", "QRESYNC", "QUOTA", "RIGHTS=ektx", "SASL-IR", "SEARCHRES",
-            "SORT", "THREAD=ORDEREDSUBJECT", "UIDPLUS", "UNSELECT", "WITHIN", "XLIST", "INPROGRESS"
+            "ACL", "BINARY", "CATENATE", "CHILDREN", "CONDSTORE", "ENABLE", "ESEARCH", "ESORT",
+            "I18NLEVEL=1", "ID", "IDLE", "INPROGRESS", "LIST-EXTENDED", "LIST-STATUS", "LITERAL+", "LOGIN-REFERRALS",
+            "MOVE", "MULTIAPPEND", "NAMESPACE", "QRESYNC", "QUOTA", "RIGHTS=ektx", "SASL-IR", "SEARCHRES",
+            "SORT", "THREAD=ORDEREDSUBJECT", "UIDPLUS", "UNSELECT", "WITHIN", "XLIST"
     ));
 
     private static final long MAXIMUM_IDLE_PROCESSING_MILLIS = 10 * Constants.MILLIS_PER_SECOND;
@@ -294,6 +294,7 @@ public abstract class ImapHandler {
         commandCount.put("CREATE",0);
         commandCount.put("DELETE",0);
         commandCount.put("LOGOUT",0);
+        commandCount.put("MOVE", 0);
         mailboxSize = 0;
         inboxNumMessages = 0;
         trashNumMessages = 0;
@@ -804,7 +805,15 @@ public abstract class ImapHandler {
                 }
                 break;
             case 'M':
-                if (command.equals("MYRIGHTS") && extensionEnabled("ACL")) {
+                if (command.equals("MOVE") && extensionEnabled("ACL")) {
+                    req.skipSpace();
+                    String sequence = req.readSequence();
+                    req.skipSpace();
+                    ImapPath path = new ImapPath(req.readFolder(), credentials);
+                    checkEOF(tag, req);
+                    incrementCommandCounter("MOVE", req);
+                    return isProxied ? imapProxy.proxy(req) : doMOVE(tag, sequence, path, byUID);
+                } else if (command.equals("MYRIGHTS") && extensionEnabled("ACL")) {
                     req.skipSpace();
                     ImapPath path = new ImapPath(req.readFolder(), credentials);
                     checkEOF(tag, req);
@@ -1018,7 +1027,7 @@ public abstract class ImapHandler {
             case 'U':
                 if (command.equals("UID")) {
                     req.skipSpace();  command = req.readATOM();
-                    if (command.equals("FETCH") || command.equals("SEARCH") || command.equals("COPY") || command.equals("STORE") ||
+                    if (command.equals("FETCH") || command.equals("SEARCH") || command.equals("COPY") || command.equals("MOVE") || command.equals("STORE") ||
                             (command.equals("EXPUNGE") && extensionEnabled("UIDPLUS")) || (command.equals("SORT") && extensionEnabled("SORT")) ||
                             (command.equals("THREAD") && extensionEnabled("THREAD=ORDEREDSUBJECT"))) {
                         byUID = true;
@@ -1305,10 +1314,12 @@ public abstract class ImapHandler {
         // [I18NLEVEL=1]      RFC 5255: Internet Message Access Protocol Internationalization
         // [ID]               RFC 2971: IMAP4 ID Extension
         // [IDLE]             RFC 2177: IMAP4 IDLE command
+        // [INPROGRESS]       RFC 9585: IMAP Response Code for Command Progress Notifications
         // [LIST-EXTENDED]    RFC 5258: Internet Message Access Protocol version 4 - LIST Command Extensions
         // [LIST-STATUS]      RFC 5819: IMAP4 Extension for Returning STATUS Information in Extended LIST
         // [LITERAL+]         RFC 2088: IMAP4 non-synchronizing literals
         // [LOGIN-REFERRALS]  RFC 2221: IMAP4 Login Referrals
+        // [MOVE]             RFC 6851: IMAP MOVE Extension
         // [MULTIAPPEND]      RFC 3502: Internet Message Access Protocol (IMAP) - MULTIAPPEND Extension
         // [NAMESPACE]        RFC 2342: IMAP4 Namespace
         // [QRESYNC]          RFC 5162: IMAP4 Extensions for Quick Mailbox Resynchronization
@@ -4641,6 +4652,171 @@ public abstract class ImapHandler {
         return true;
     }
 
+    protected boolean doMOVE(String tag, String sequenceSet, ImapPath path, boolean byUID)
+            throws IOException, ImapException {
+        checkCommandThrottle(new MoveCommand(sequenceSet, path));
+        if (!checkState(tag, State.SELECTED)) {
+            return true;
+        }
+        String command = (byUID ? "UID MOVE" : "MOVE");
+        String moveuid = "";
+
+        ImapFolder i4folder = getSelectedFolder();
+        if (i4folder == null) {
+            throw new ImapSessionClosedException();
+        }
+
+        if (!i4folder.isWritable()) {
+            sendNO(tag, "mailbox selected READ-ONLY");
+            return true;
+        }
+
+        MailboxStore mbox = i4folder.getMailbox();
+        Set<ImapMessage> i4set;
+        mbox.lock(false);
+        try {
+            i4set = i4folder.getSubsequence(tag, sequenceSet, byUID);
+        } catch (ImapParseException ipe) {
+            ZimbraLog.imap.error(ipe);
+            throw ipe;
+        } finally {
+            mbox.unlock();
+        }
+
+        if (i4set.size() > LC.imap_max_items_in_move.intValue()) {
+            sendNO(tag, "MOVE rejected, too many items in move request");
+            return true;
+        }
+
+        // RFC 6851 3.3: extensions that affect COPY affect MOVE in the same way.
+        // RFC 2180 4.4.1: "The server MAY disallow the COPY of messages in a multi-
+        //                  accessed mailbox that contains expunged messages."
+        if (!byUID && i4set.contains(null)) {
+            sendNO(tag, "MOVE rejected because some of the requested messages were expunged");
+            return true;
+        }
+        i4set.remove(null);
+
+        try {
+            // check target folder permissions before attempting the move
+            if (!i4folder.getPath().isWritable(ACL.RIGHT_DELETE)) {
+                throw ServiceException.PERM_DENIED(
+                        "you do not have permission to delete messages from the selected folder");
+            } else if (!i4folder.getPath().isWritable(ACL.RIGHT_WRITE)) {
+                throw ServiceException.PERM_DENIED(
+                        "you do not have write permission on the source folder");
+            }
+
+            if (!path.isVisible()) {
+                throw ImapServiceException.FOLDER_NOT_VISIBLE(path.asImapPath());
+            } else if (!path.isWritable(ACL.RIGHT_INSERT)) {
+                throw ImapServiceException.FOLDER_NOT_WRITABLE(path.asImapPath());
+            }
+            MailboxStore mbxStore = path.getOwnerMailbox();
+            if (null == mbxStore) {
+                throw AccountServiceException.NO_SUCH_ACCOUNT(path.getOwner());
+            }
+            FolderStore targetFolder = path.getFolder();
+            FolderStore selectedFolder = null;
+            try {
+                selectedFolder = i4folder.getFolder();
+            } catch (ServiceException e1) {
+                ZimbraLog.imap.error("Problem with selected folder %s during doMOVE", e1.getMessage());
+                return true;
+            }
+
+            ImapMailboxStore selectedImapMboxStore = i4folder.getImapMailboxStore();
+            boolean sameMailbox = selectedImapMboxStore.getAccountId().equalsIgnoreCase(mbxStore.getAccountId());
+            boolean selectedFolderInOtherMailbox;
+            ItemIdentifier fromFolderId;
+            if (selectedFolder instanceof MountpointStore) {
+                selectedFolderInOtherMailbox = true;
+                fromFolderId = ((MountpointStore) selectedFolder).getTargetItemIdentifier();
+            } else if (selectedFolder instanceof ZSharedFolder) {
+                selectedFolderInOtherMailbox = true;
+                fromFolderId = selectedFolder.getFolderItemIdentifier();
+            } else {
+                selectedFolderInOtherMailbox = false;
+                fromFolderId = selectedFolder.getFolderItemIdentifier();
+            }
+            int uvv = targetFolder.getUIDValidity();
+            ItemId iidTarget = new ItemId(targetFolder, path.getOwnerAccount().getId());
+            ItemIdentifier targetIdentifier = iidTarget.toItemIdentifier();
+
+            List<Integer> moveUIDs = extensionEnabled("UIDPLUS") ? Lists.newArrayListWithCapacity(i4set.size()) : null;
+            final List<ImapMessage> i4list = Lists.newArrayList(i4set);
+            final List<List<ImapMessage>> batches =
+                    Lists.partition(i4list, LC.imap_suggested_batch_copy_size.intValue());
+
+            OperationProgress moveStatus = new OperationProgress(0, i4set.size(), tag, true);
+            ScheduledFuture<?> notifier = sendInProgressResponses(moveStatus);
+            try {
+                for (List<ImapMessage> batch : batches) {
+                    if (sameMailbox && !selectedFolderInOtherMailbox) {
+                        moveOwnItems(selectedImapMboxStore, batch, iidTarget, moveUIDs);
+                    } else {
+                        moveItemsBetweenMailboxes(selectedImapMboxStore, batch, fromFolderId, targetIdentifier,
+                                moveUIDs);
+                    }
+                    moveStatus.setCompletedCount(moveStatus.getCompletedCount() + batch.size());
+                }
+            } finally {
+                // stop sending from the notifier thread after this point for safety
+                moveStatus.setIsRunning(false);
+                if (notifier != null) {
+                    notifier.cancel(true);
+                }
+            }
+
+            if (uvv > 0 && moveUIDs != null && moveUIDs.size() > 0) {
+                List<Integer> srcUIDs = Lists.newArrayListWithCapacity(i4set.size());
+                for (ImapMessage i4msg : i4set) {
+                    srcUIDs.add(i4msg.imapUid);
+                }
+                // RFC 6851 4.3 Servers supporting UIDPLUS [RFC4315] SHOULD send COPYUID in response
+                //   to a UID MOVE command.
+                moveuid = "[COPYUID " + uvv + ' ' + ImapFolder.encodeSubsequence(srcUIDs) + ' ' +
+                        ImapFolder.encodeSubsequence(moveUIDs) + "] ";
+            }
+        } catch (ServiceException e) {
+            // 3.3 : "The server MUST leave each message in a state where
+            //         it is in at least one of the source or target mailboxes."
+            String rcode = "";
+            if (e.getCode().equals(MailServiceException.NO_SUCH_FOLDER)) {
+                ZimbraLog.imap.info("%s failed: no such folder: %s", command, path);
+                if (path.isCreatable()) {
+                    rcode = "[TRYCREATE] ";
+                }
+            } else if (e.getCode().equals(ImapServiceException.FOLDER_NOT_VISIBLE)) {
+                ZimbraLog.imap.info("%s failed: folder not visible: %s", command, path);
+            } else if (e.getCode().equals(ImapServiceException.FOLDER_NOT_WRITABLE)) {
+                ZimbraLog.imap.info("%s failed: folder not writable: %s", command, path);
+            } else {
+                ZimbraLog.imap.warn("%s failed", command, e);
+            }
+            sendNO(tag, rcode + command + " failed");
+            return canContinue(e);
+        }
+
+        // RFC 6851 4.4: "COPY is the only IMAP4 sequence number command that is safe to allow
+        //                an EXPUNGE response on.  This is because a client is not permitted
+        //                to cascade several COPY commands together."
+        sendNotifications(true, false);
+
+        String status = "";
+        try {
+            if (byUID && !i4folder.isVirtual() && sessionActivated(ImapExtension.QRESYNC)) {
+                status = "[HIGHESTMODSEQ " + i4folder.getCurrentMODSEQ() + "] ";
+                sendUntagged("OK " + status);
+            }
+        } catch (ServiceException e) {
+            ZimbraLog.imap.info("error while determining HIGHESTMODSEQ of selected folder", e);
+        }
+
+        sendOK(tag, moveuid + command + " completed");
+        return true;
+    }
+
     private ScheduledFuture<?> sendInProgressResponses(OperationProgress copyStatus) {
         return INPROGRESS_SCHEDULER.scheduleAtFixedRate(() -> {
             setLoggingContext();
@@ -4698,6 +4874,36 @@ public abstract class ImapHandler {
         }
     }
 
+    private void moveOwnItems(ImapMailboxStore selectedImapMboxStore, List<ImapMessage> batch, ItemId iidTarget,
+                              List<Integer> moveUIDs) throws ServiceException {
+        List<Integer> moveMsgUids;
+        try {
+            MailItemType type = MailItemType.UNKNOWN;
+            int[] mItemIds = new int[batch.size()];
+            int counter  = 0;
+            for (ImapMessage curMsg : batch) {
+                mItemIds[counter++] = curMsg.msgId;
+                if (counter == 1) {
+                    type = curMsg.getMailItemType();
+                } else if (curMsg.getMailItemType() != type) {
+                    type = MailItemType.UNKNOWN;
+                }
+            }
+            // Can't use this across mailboxes as mItemIds is not mailbox aware
+            moveMsgUids = selectedImapMboxStore.imapMove(getContext(), mItemIds, type, iidTarget.getId());
+        } catch (IOException e) {
+            throw ServiceException.FAILURE("Caught IOException executing " + this, e);
+        }
+        if (moveMsgUids.size() != batch.size()) {
+            throw ServiceException.FAILURE(
+                    String.format("mismatch between original (%s) and target (%s) count during IMAP MOVE",
+                            batch.size(), moveMsgUids.size()), null);
+        }
+        if (moveUIDs != null) {
+            moveUIDs.addAll(moveMsgUids);
+        }
+    }
+
     private void copyItemsBetweenMailboxes(ImapMailboxStore selectedImapMboxStore, List<ImapMessage> batch,
             ItemIdentifier fromFolderId, ItemIdentifier targetIdentifier, List<Integer> copyUIDs)
     throws ServiceException {
@@ -4726,6 +4932,35 @@ public abstract class ImapHandler {
         }
     }
 
+    private void moveItemsBetweenMailboxes(ImapMailboxStore selectedImapMboxStore, List<ImapMessage> batch,
+                                           ItemIdentifier fromFolderId, ItemIdentifier targetIdentifier,
+                                           List<Integer> moveUIDs)
+            throws ServiceException {
+        List<ItemIdentifier> identList = Lists.newArrayListWithCapacity(batch.size());
+        List<Integer> createdList = Lists.newArrayListWithCapacity(batch.size());
+        for (ImapMessage i4msg : batch) {
+            identList.add(ItemIdentifier.fromAccountIdAndItemId(fromFolderId.accountId, i4msg.msgId));
+        }
+        MailboxStore selectedStore = selectedImapMboxStore.getMailboxStore();
+        List<String>moveIds = selectedStore.moveItemAction(getContext(), targetIdentifier, identList);
+        for (String moveId : moveIds) {
+            if (moveId.isEmpty()) {
+                continue;
+            }
+            // For newly created items, the UID is the same as the id in the target mailbox
+            ItemIdentifier itemIdentifier = new ItemIdentifier(moveId, (String) null /* defaultAccountId */);
+            createdList.add(itemIdentifier.id);
+        }
+        if (createdList.size() != identList.size()) {
+            throw ServiceException.FAILURE(
+                    String.format("mismatch between original (%s) and target (%s) count during IMAP COPY",
+                            identList.size(), createdList.size()), null);
+        }
+        if (moveUIDs != null) {
+            moveUIDs.addAll(createdList);
+        }
+    }
+
     private void checkCommandThrottle(ImapCommand command) throws ImapThrottledException {
         if (reqThrottle.isIpWhitelisted(getOrigRemoteIp()) || reqThrottle.isIpWhitelisted(getRemoteIp())) {
             return;
@@ -4743,7 +4978,7 @@ public abstract class ImapHandler {
         }
 
         ImapListener i4selected = getCurrentImapListener();
-        if (i4selected == null || !i4selected.hasNotifications()) {
+        if (i4selected == null /*|| !i4selected.hasNotifications()*/) {
             return;
         }
         MailboxStore mbox = i4selected.getMailbox();

--- a/store/src/java/com/zimbra/cs/imap/ImapMailboxStore.java
+++ b/store/src/java/com/zimbra/cs/imap/ImapMailboxStore.java
@@ -88,6 +88,9 @@ public abstract class ImapMailboxStore {
      */
     public abstract List<Integer> imapCopy(OperationContext octxt, int[] itemIds, MailItemType type, int folderId)
             throws IOException, ServiceException;
+
+    public abstract List<Integer> imapMove(OperationContext octxt, int[] itemIds, MailItemType type, int folderId)
+            throws IOException, ServiceException;
     public abstract InputStreamWithSize getByImapId(OperationContext octxt, int imapId, String folderId, String resolvedPath)
             throws ServiceException;
     public abstract void checkAppendMessageFlags(OperationContext octxt, List<AppendMessage> appends) throws ServiceException;

--- a/store/src/java/com/zimbra/cs/imap/LocalImapMailboxStore.java
+++ b/store/src/java/com/zimbra/cs/imap/LocalImapMailboxStore.java
@@ -146,6 +146,20 @@ public class LocalImapMailboxStore extends ImapMailboxStore {
     }
 
     @Override
+    public List<Integer> imapMove(OperationContext octxt, int[] itemIds, MailItemType type, int folderId)
+            throws IOException, ServiceException {
+        List<MailItem> mis = mailbox.imapMove(octxt, itemIds, MailItem.Type.fromCommon(type), folderId, null);
+        if (null == mis) {
+            return Collections.emptyList();
+        }
+        List<Integer> uids = Lists.newArrayListWithCapacity(mis.size());
+        for (MailItem mi : mis) {
+            uids.add(mi.getImapUid());
+        }
+        return uids;
+    }
+
+    @Override
     public InputStreamWithSize getByImapId(OperationContext octxt, int imapId, String folderId, String resolvedPath)
     throws ServiceException {
         MailItem mitem = mailbox.getItemByImapId(octxt, imapId, Integer.parseInt(folderId));

--- a/store/src/java/com/zimbra/cs/imap/MoveCommand.java
+++ b/store/src/java/com/zimbra/cs/imap/MoveCommand.java
@@ -1,0 +1,70 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2026 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.imap;
+
+public class MoveCommand extends ImapCommand {
+
+    private ImapPath destPath;
+
+    private String sequenceSet;
+
+    public MoveCommand(String sequenceSet, ImapPath destPath) {
+        super();
+        this.destPath = destPath;
+        this.sequenceSet = sequenceSet;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((sequenceSet == null) ? 0 : sequenceSet.hashCode());
+        result = prime * result + ((destPath == null) ? 0 : destPath.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        MoveCommand other = (MoveCommand) obj;
+        if (sequenceSet == null) {
+            if (other.sequenceSet != null) {
+                return false;
+            }
+        } else if (!sequenceSet.equals(other.sequenceSet)) {
+            return false;
+        }
+        if (destPath == null) {
+            if (other.destPath != null) {
+                return false;
+            }
+        } else if (!destPath.equals(other.destPath)) {
+            return false;
+        }
+        return true;
+    }
+}
+

--- a/store/src/java/com/zimbra/cs/imap/RemoteImapMailboxStore.java
+++ b/store/src/java/com/zimbra/cs/imap/RemoteImapMailboxStore.java
@@ -133,6 +133,11 @@ public class RemoteImapMailboxStore extends ImapMailboxStore {
         return zMailbox.imapCopy(itemIds, type, folderId);
     }
 
+    public List<Integer> imapMove(OperationContext octxt, int[] itemIds, MailItemType type, int folderId)
+            throws IOException, ServiceException {
+        throw ServiceException.UNSUPPORTED(); // TODO
+    }
+
     @Override
     public InputStreamWithSize getByImapId(OperationContext octxt, int imapId, String folderId, String resolvedPath)
     throws ServiceException {

--- a/store/src/java/com/zimbra/cs/mailbox/MailItem.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailItem.java
@@ -2823,6 +2823,70 @@ public abstract class MailItem implements Comparable<MailItem>, ScheduledTaskRes
         return copy;
     }
 
+    MailItem imove(Folder target, int moveId, String copyUuid) throws ServiceException, IOException {
+        if (!isCopyable()) {
+            throw MailServiceException.CANNOT_COPY(mId);
+        }
+        if (!target.canContain(this)) {
+            throw MailServiceException.CANNOT_CONTAIN();
+        }
+
+        if (!isMovable()) {
+            throw MailServiceException.IMMUTABLE_OBJECT(mId);
+        }
+
+        // permissions required are the same as for copy()
+        if (!canAccess(ACL.RIGHT_READ)) {
+            throw ServiceException.PERM_DENIED("you do not have the required rights on the item");
+        }
+        if (!target.canAccess(ACL.RIGHT_INSERT)) {
+            throw ServiceException.PERM_DENIED("you do not have the required rights on the target folder");
+        }
+
+        // fetch the parent *before* changing the DB
+        MailItem parent = getParent();
+        Folder oldFolder = getFolder();
+
+        if (isLeafNode()) {
+            boolean isDeleted = isTagged(Flag.FlagInfo.DELETED);
+            oldFolder.updateSize(-1, isDeleted ? -1 : 0, -getTotalSize());
+            target.updateSize(1, isDeleted ? 1 : 0, getTotalSize());
+        }
+
+        if (!inTrash() && target.inTrash()) {
+            // moving something to Trash also marks it as read
+            if (mData.unreadCount > 0) {
+                alterUnread(false);
+            }
+        } else {
+            boolean isDeleted = isTagged(Flag.FlagInfo.DELETED);
+            oldFolder.updateUnread(-mData.unreadCount, isDeleted ? -mData.unreadCount : 0);
+            target.updateUnread(mData.unreadCount, isDeleted ? mData.unreadCount : 0);
+        }
+        // moving a message (etc.) to Spam removes it from its conversation
+        if (!inSpam() && target.inSpam()) {
+            detach();
+        }
+        // item moved out of spam, so update the index id (will be written to DB in DbMailItem.setFolder());
+        if (inSpam() && !target.inSpam() && getIndexStatus() == IndexStatus.DONE) {
+            mMailbox.index.add(this);
+        }
+
+        ZimbraLog.mailop.info("Performing IMAP move of %s: copyId=%d, folderId=%d, folderName=%s, parentId.",
+                getMailopContext(this), moveId, target.getId(), target.getName());
+        DbMailItem.imove(this, target, moveId);
+        iFolderChanged(target, moveId);
+
+        if (parent != null && parent.getId() > 0) {
+            markItemModified(Change.PARENT);
+            parent.markItemModified(Change.CHILDREN);
+            mData.parentId = mData.type == Type.MESSAGE.toByte() ? -mId : -1;
+            metadataChanged();
+        }
+
+        return this;
+    }
+
     /** The regexp defining printable characters not permitted in item
      *  names.  These are: ':', '/', '"', '\t', '\r', and '\n'. */
     private static final String INVALID_NAME_CHARACTERS = "[:/\"\t\r\n]";
@@ -3061,6 +3125,24 @@ public abstract class MailItem implements Comparable<MailItem>, ScheduledTaskRes
         markItemModified(Change.FOLDER);
         mData.folderId = newFolder.getId();
         mData.imapId   = mMailbox.isTrackingImap() ? imapId : mData.imapId;
+        metadataChanged();
+    }
+
+    /** Records all relevant changes to the in-memory object for when an item
+     *  gets moved to a new {@link Folder} through imap.  Does <u>not</u> persist
+     *  those changes to the database.
+     *
+     * @param newFolder  The folder the item is being moved to.
+     * @param imapId     The new IMAP ID for the item after the operation.
+     * @throws ServiceException if we're not in a transaction */
+    void iFolderChanged(Folder newFolder, int imapId) throws ServiceException {
+        // only mark as modified when moving to the same folder because  TODO
+        if (mData.folderId == newFolder.getId()) {
+            markItemModified(Change.IMAP_UID);
+        }
+        markItemModified(Change.FOLDER);
+        mData.imapId   = mMailbox.isTrackingImap() ? imapId : mData.imapId;
+        mData.folderId = newFolder.getId();
         metadataChanged();
     }
 

--- a/store/src/java/com/zimbra/cs/mailbox/MailServiceException.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailServiceException.java
@@ -60,6 +60,7 @@ public class MailServiceException extends ServiceException {
     public static final String IS_NOT_CHILD    = "mail.IS_NOT_CHILD";
     public static final String CANNOT_CONTAIN  = "mail.CANNOT_CONTAIN";
     public static final String CANNOT_COPY     = "mail.CANNOT_COPY";
+    public static final String CANNOT_MOVE     = "mail.CANNOT_MOVE";
     public static final String CANNOT_TAG      = "mail.CANNOT_TAG";
     public static final String CANNOT_PARENT   = "mail.CANNOT_PARENT";
     public static final String CANNOT_RENAME   = "mail.CANNOT_RENAME";
@@ -441,6 +442,11 @@ public class MailServiceException extends ServiceException {
 
     public static MailServiceException CANNOT_COPY(int id) {
         return new MailServiceException("cannot copy object: " + id, CANNOT_COPY, SENDERS_FAULT, new Argument(ITEM_ID, id, Argument.Type.IID));
+    }
+
+    public static MailServiceException CANNOT_MOVE(int id) {
+        return new MailServiceException("cannot copy object: " + id, CANNOT_MOVE, SENDERS_FAULT,
+                new Argument(ITEM_ID, id, Argument.Type.IID));
     }
 
     public static MailServiceException CANNOT_PARENT() {

--- a/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -212,6 +212,7 @@ import com.zimbra.cs.redolog.op.FixCalendarItemTZ;
 import com.zimbra.cs.redolog.op.GrantAccess;
 import com.zimbra.cs.redolog.op.ICalReply;
 import com.zimbra.cs.redolog.op.ImapCopyItem;
+import com.zimbra.cs.redolog.op.ImapMoveItem;
 import com.zimbra.cs.redolog.op.LockItem;
 import com.zimbra.cs.redolog.op.ModifyContact;
 import com.zimbra.cs.redolog.op.ModifyInvitePartStat;
@@ -253,6 +254,7 @@ import com.zimbra.cs.service.AuthProvider;
 import com.zimbra.cs.service.FeedManager;
 import com.zimbra.cs.service.mail.CopyActionResult;
 import com.zimbra.cs.service.mail.ItemActionHelper;
+import com.zimbra.cs.service.mail.MoveActionResult;
 import com.zimbra.cs.service.mail.SendDeliveryReport;
 import com.zimbra.cs.service.util.ItemData;
 import com.zimbra.cs.service.util.ItemId;
@@ -7547,7 +7549,7 @@ public class Mailbox implements MailboxStore {
      * @perms {@link ACL#RIGHT_INSERT} on the target folder,
      *        {@link ACL#RIGHT_DELETE} on all the the source folders
      * @param octxt     The context for this request (e.g. auth user id).
-     * @param itemId    A list of the IDs of the items to move.
+     * @param itemIds    A list of the IDs of the items to move.
      * @param type      The type of the items or {@link MailItem.Type#UNKNOWN}.
      * @param targetId  The ID of the target folder for the move.
      * @param tcon      An optional constraint on the items being moved. */
@@ -7587,6 +7589,26 @@ public class Mailbox implements MailboxStore {
         }
     }
 
+    public List<MailItem> imapMove(OperationContext octxt, int[] itemIds, MailItem.Type type, int targetId,
+                                   TargetConstraint tcon) throws ServiceException {
+        beginTrackingImap();
+        lock.lock();
+        List<MailItem> result = new ArrayList<>();
+        try {
+            try {
+                return iMove(octxt, itemIds, type, targetId, tcon);
+            } catch (ServiceException e) {
+                // make sure that move-to-Trash never fails with a naming conflict
+                if (!e.getCode().equals(MailServiceException.ALREADY_EXISTS) || targetId != ID_FOLDER_TRASH) {
+                    throw e;
+                }
+            }
+        } finally {
+            lock.release();
+        }
+        return result;
+    }
+
     private String generateAlternativeItemName(OperationContext octxt, int id, MailItem.Type type)
     throws ServiceException {
         String name = getItemById(octxt, id, type).getName();
@@ -7598,9 +7620,59 @@ public class Mailbox implements MailboxStore {
         }
     }
 
-    private void moveInternal(OperationContext octxt, int[] itemIds, MailItem.Type type, int targetId,
+    private List<MailItem> iMove(OperationContext octxt, int[] itemIds, MailItem.Type type, int targetId,
             TargetConstraint tcon)
     throws ServiceException {
+        ImapMoveItem redoRecorder = new ImapMoveItem(mId, type, targetId);
+        boolean success = false;
+        List<MailItem> result = new ArrayList<>();
+        try {
+            beginTransaction("move", octxt, redoRecorder);
+            setOperationTargetConstraint(tcon);
+
+            Folder target = getFolderById(targetId);
+
+            for (int itemId : itemIds) {
+                MailItem item = getItemById(itemId, type);
+                checkItemChangeID(item);
+
+                int oldUIDNEXT = target.getImapUIDNEXT();
+                boolean resetUIDNEXT = false;
+
+                // train the spam filter if necessary...
+                trainSpamFilter(octxt, item, target, "move");
+
+                // ...do the move...
+                ImapMoveItem redoPlayer = (ImapMoveItem) currentChange().getRedoPlayer();
+                int newId = getNextItemId(redoPlayer == null ? ID_AUTO_INCREMENT : redoPlayer.getDestId(itemId));
+                String newUuid = redoPlayer == null ? UUIDUtil.generateUUID() : redoPlayer.getDestUuid(itemId);
+                int srcId = item.getId();
+                result.add(item.imove(target, newId, newUuid));
+
+                // ...and determine whether the move needs to cause an UIDNEXT change
+                if ((item instanceof Conversation || item instanceof Message || item instanceof Contact)) {
+                    resetUIDNEXT = true;
+                }
+
+                // if this operation should cause the target folder's UIDNEXT value to change
+                // but it hasn't yet, do it here
+                if (resetUIDNEXT && oldUIDNEXT == target.getImapUIDNEXT()) {
+                    redoRecorder.setDest(srcId, newId, newUuid);
+                    target.updateUIDNEXT();
+                }
+            }
+            success = true;
+        } catch (IOException e) {
+            throw ServiceException.FAILURE("IOException while moving items for IMAP", e);
+        } finally {
+            endTransaction(success);
+        }
+        return result;
+    }
+
+    private void moveInternal(OperationContext octxt, int[] itemIds, MailItem.Type type, int targetId,
+                              TargetConstraint tcon)
+            throws ServiceException {
         MoveItem redoRecorder = new MoveItem(mId, itemIds, type, targetId, tcon);
 
         boolean success = false;
@@ -10903,6 +10975,34 @@ public class Mailbox implements MailboxStore {
                 MailItem.Type.UNKNOWN, null, new ItemId(targetFolder));
         CopyActionResult caResult = (CopyActionResult) op.getResult();
         return caResult.getCreatedIds();
+    }
+
+    /**
+     * Moves the items identified in {@link idlist} to folder {@link targetFolder}
+     * @param idlist - list of item ids for items to copy
+     * @param targetFolder - Destination folder
+     * @return The item IDs of the created items - these may be full item IDs in the case of remote folders
+     */
+    @Override
+    public List<String> moveItemAction(OpContext ctxt, ItemIdentifier targetFolder, List<ItemIdentifier> idlist)
+            throws ServiceException {
+        if ((idlist == null) || idlist.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<Integer> ids = Lists.newArrayListWithExpectedSize(idlist.size());
+        for (ItemIdentifier ident : idlist) {
+            if (this.referencesOtherMailbox(ident)) {
+                // Mailbox doesn't support copying from another mailbox because ItemActionHelper
+                // only supports a list of int ids.  This isn't a problem for local IMAP because
+                // requests are proxied to the selected folder's owner.
+                throw ServiceException.FAILURE("Unexpected attempt to copy item from mountpoint", null);
+            }
+            ids.add(ident.id);
+        }
+        ItemActionHelper op = ItemActionHelper.MOVE((OperationContext) ctxt, this, null, ids,
+                MailItem.Type.UNKNOWN, null, new ItemId(targetFolder));
+        MoveActionResult moveActionResult = (MoveActionResult) op.getResult();
+        return moveActionResult.getCreatedIds();
     }
 
     @Override

--- a/store/src/java/com/zimbra/cs/mailbox/MailboxOperation.java
+++ b/store/src/java/com/zimbra/cs/mailbox/MailboxOperation.java
@@ -112,7 +112,8 @@ public enum MailboxOperation {
     SetWebOfflineSyncDays(92),
     DeleteConfig(93),
     View(94),
-    SetPop3Uid(95);
+    SetPop3Uid(95),
+    ImapMoveItem(96);
 
     private MailboxOperation(int c) {
         code = c;

--- a/store/src/java/com/zimbra/cs/redolog/op/ImapMoveItem.java
+++ b/store/src/java/com/zimbra/cs/redolog/op/ImapMoveItem.java
@@ -1,0 +1,141 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2026 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.redolog.op;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailbox.MailboxOperation;
+import com.zimbra.cs.mailbox.MailItem;
+import com.zimbra.cs.mailbox.MailServiceException;
+import com.zimbra.cs.redolog.RedoLogInput;
+import com.zimbra.cs.redolog.RedoLogOutput;
+
+public class ImapMoveItem extends RedoableOp {
+
+    private Map<Integer, Integer> mDestIds = new HashMap<Integer, Integer>();
+
+    private Map<Integer, String> mDestUuids = new HashMap<Integer, String>();
+
+    private MailItem.Type type;
+
+    private int mDestFolderId;
+
+    public ImapMoveItem() {
+        super(MailboxOperation.ImapMoveItem);
+        type = MailItem.Type.UNKNOWN;
+        mDestFolderId = 0;
+    }
+
+    public ImapMoveItem(int mailboxId, MailItem.Type type, int folderId) {
+        this();
+        setMailboxId(mailboxId);
+        this.type = type;
+        mDestFolderId = folderId;
+    }
+
+    /**
+     * Sets the ID of the moved item.
+     * @param srcId
+     * @param destId
+     * @param destUuid
+     */
+    public void setDest(int srcId, int destId, String destUuid) {
+        mDestIds.put(srcId, destId);
+        mDestUuids.put(srcId, destUuid);
+    }
+
+    public int getDestId(int srcId) {
+        Integer destId = mDestIds.get(srcId);
+        return destId == null ? -1 : destId;
+    }
+
+    public String getDestUuid(int srcId) {
+        return mDestUuids.get(srcId);
+    }
+
+    @Override
+    protected String getPrintableData() {
+        StringBuilder sb = new StringBuilder("type=").append(type);
+        sb.append(", destFolder=").append(mDestFolderId);
+        sb.append(", [srcId, destId, destUuid]=");
+        for (Map.Entry<Integer, Integer> entry : mDestIds.entrySet()) {
+            int srcId = entry.getKey();
+            sb.append('[').append(srcId).append(',').append(entry.getValue());
+            sb.append(',').append(mDestUuids.get(srcId)).append(']');
+        }
+        return sb.toString();
+    }
+
+    @Override
+    protected void serializeData(RedoLogOutput out) throws IOException {
+        out.writeByte(type.toByte());
+        out.writeInt(mDestFolderId);
+        out.writeShort((short) -1);
+        out.writeInt(mDestIds.size());
+        for (Map.Entry<Integer, Integer> entry : mDestIds.entrySet()) {
+            Integer srcId = entry.getKey();
+            out.writeInt(srcId);
+            out.writeInt(entry.getValue());
+            out.writeInt(-1);                    // now unused; don't break the old format...
+            if (getVersion().atLeast(1, 37)) {
+                out.writeUTF(mDestUuids.get(srcId));
+            }
+        }
+    }
+
+    @Override
+    protected void deserializeData(RedoLogInput in) throws IOException {
+        type = MailItem.Type.of(in.readByte());
+        mDestFolderId = in.readInt();
+        in.readShort();
+        int count = in.readInt();
+        for (int i = 0; i < count; i++) {
+            Integer srcId = in.readInt();
+            mDestIds.put(srcId, in.readInt());
+            in.readInt();                        // now unused; don't break the old format...
+            if (getVersion().atLeast(1, 37)) {
+                mDestUuids.put(srcId,  in.readUTF());
+            }
+        }
+    }
+
+    @Override
+    public void redo() throws Exception {
+        int mboxId = getMailboxId();
+        Mailbox mbox = MailboxManager.getInstance().getMailboxById(mboxId);
+
+        int i = 0, itemIds[] = new int[mDestIds.size()];
+        for (int id : mDestIds.keySet()) {
+            itemIds[i++] = id;
+        }
+        try {
+            mbox.imapMove(getOperationContext(), itemIds, type, mDestFolderId, null);
+        } catch (MailServiceException e) {
+            if (e.getCode() == MailServiceException.ALREADY_EXISTS) {
+                mLog.info("Item is already in mailbox " + mboxId);
+                return;
+            } else {
+                throw e;
+            }
+        }
+    }
+}
+

--- a/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemActionHelper.java
@@ -575,6 +575,8 @@ public class ItemActionHelper {
             localResult.appendSuccessIds(batchResult.getSuccessIds());
             if (Op.COPY == mOperation) {
                 ((CopyActionResult)localResult).appendCreatedIds(batchResult);
+            } else if (Op.MOVE == mOperation) {
+                ((MoveActionResult) localResult).appendCreatedIds(batchResult);
             } else if (Op.HARD_DELETE == mOperation) {
                 ((DeleteActionResult)localResult).appendNonExistentIds(batchResult);
             }
@@ -864,6 +866,10 @@ public class ItemActionHelper {
         }
         else if (Op.COPY.equals(mOperation)) {
             ((CopyActionResult)result).setCreatedIds(createdIds);
+        }
+        else if (Op.MOVE.equals(mOperation)) {
+            ((MoveActionResult) result).setCreatedIds(createdIds);
+
         }
 
         for (int itemId : itemIds) {

--- a/store/src/java/com/zimbra/cs/service/mail/ItemActionResult.java
+++ b/store/src/java/com/zimbra/cs/service/mail/ItemActionResult.java
@@ -44,14 +44,15 @@ public class ItemActionResult {
     }
 
     public static ItemActionResult create(ItemActionHelper.Op operation) {
-        switch (operation)
-        {
-        case COPY:
-            return new CopyActionResult();
-        case HARD_DELETE:
-            return new DeleteActionResult();
-        default:
-            return new ItemActionResult();
+        switch (operation) {
+            case COPY:
+                return new CopyActionResult();
+            case MOVE:
+                return new MoveActionResult();
+            case HARD_DELETE:
+                return new DeleteActionResult();
+            default:
+                return new ItemActionResult();
         }
     }
 
@@ -60,6 +61,8 @@ public class ItemActionResult {
             return new CopyActionResult();
         } else if (MailConstants.OP_HARD_DELETE.equalsIgnoreCase(operation)) {
             return new DeleteActionResult();
+        } else if (MailConstants.OP_MOVE.equalsIgnoreCase(operation)) {
+            return new MoveActionResult();
         }
         return new ItemActionResult();
     }

--- a/store/src/java/com/zimbra/cs/service/mail/MoveActionResult.java
+++ b/store/src/java/com/zimbra/cs/service/mail/MoveActionResult.java
@@ -1,0 +1,58 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2026 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.service.mail;
+
+import com.google.common.collect.Lists;
+import java.util.List;
+
+public class MoveActionResult extends ItemActionResult {
+
+    private final List<String> mCreatedIds = Lists.newArrayList();
+
+    public MoveActionResult() {
+        super();
+    }
+
+    public MoveActionResult(List<String> ids, List<String> createdIds) {
+        super();
+        setSuccessIds(ids);
+    }
+
+    public List<String> getCreatedIds() {
+        return mCreatedIds;
+    }
+
+    public void addCreatedId(String createdId) {
+        this.mCreatedIds.add(createdId);
+    }
+
+    public void setCreatedIds(List<String> createdIds) {
+        this.mCreatedIds.clear();
+        appendCreatedIds(createdIds);
+    }
+
+    public void appendCreatedIds(List<String> createdIds) {
+        this.mCreatedIds.addAll(createdIds);
+    }
+
+    public void appendCreatedIds(ItemActionResult iar) {
+        if (iar instanceof CopyActionResult) {
+            appendCreatedIds(((CopyActionResult) iar).getCreatedIds());
+        }
+    }
+}


### PR DESCRIPTION
Issue : The imap clients in Zimbra were using COPY, STORE and EXPUNGE flow for IMAP MOVE.

Fix : Implemented RFC 6851 (https://datatracker.ietf.org/doc/html/rfc6851) i.e. IMAP MOVE Extension.

Impact : 

Atomicity: The MOVE flow is atomic. COPY + STORE + EXPUNGE requires three steps. This multi-step process risks partial failure if the connection drops.

Side Effects: Standard EXPUNGE clears all deleted messages in the mailbox. This risks destroying unrelated emails. MOVE targets only the selected messages.

State Cleanliness: MOVE prevents other clients from seeing messy intermediate flags or duplicate unread states during processing.

Performance: MOVE allows servers to optimize actions via internal back-end pointer updates instead of duplicating data.