### PR TITLE
ZRFE-1285: Include full certificate chain in S/MIME SignedData

### DIFF
--- a/common/src/java/com/zimbra/common/soap/SmimeConstants.java
+++ b/common/src/java/com/zimbra/common/soap/SmimeConstants.java
@@ -81,6 +81,7 @@ public class SmimeConstants {
 
     public static final String PUB_CERT = "pubCert";
     public static final String PVT_KEY = "pvtKey";
+    public static final String CERT_CHAIN = "certChain";
     public static final String ALIAS = "alias";
     public static final String CERT_FOLDER_NAME = "-smimecertificates";
     public static final String SUBJECT_DN_KEY = "it_";

--- a/store/src/java/com/zimbra/cs/service/util/DataSigner.java
+++ b/store/src/java/com/zimbra/cs/service/util/DataSigner.java
@@ -25,10 +25,12 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.Security;
 import java.security.UnrecoverableKeyException;
+import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
 
@@ -63,30 +65,34 @@ public class DataSigner {
             for (Enumeration<String> en = pkcs12Store.aliases(); en.hasMoreElements();) {
                 alias = (String) en.nextElement();
             }
-            X509Certificate cert = (X509Certificate) pkcs12Store.getCertificate(alias);
+            Certificate[] chain = pkcs12Store.getCertificateChain(alias);
+            X509Certificate[] x509Chain = (chain != null && chain.length > 0)
+                    ? Arrays.copyOf(chain, chain.length, X509Certificate[].class)
+                    : new X509Certificate[]{(X509Certificate) pkcs12Store.getCertificate(alias)};
             PrivateKey privKey = (PrivateKey) pkcs12Store.getKey(alias, expPass);
-            signedData = signData(data, cert, privKey);
+            signedData = signData(data, x509Chain, privKey);
         }
         return signedData;
     }
 
-    public static byte[] signData(byte[] data, X509Certificate signingCertificate, PrivateKey signingKey)
+    public static byte[] signData(byte[] data, X509Certificate[] certChain, PrivateKey signingKey)
             throws CertificateEncodingException, OperatorCreationException, CMSException, IOException {
-        byte[] signedData = null;
         CMSTypedData cmsData = new CMSProcessableByteArray(data);
-        List<X509Certificate> certList = new ArrayList<X509Certificate>();
-        certList.add(signingCertificate);
-
+        List<X509Certificate> certList = new ArrayList<>(Arrays.asList(certChain));
         Store certs = new JcaCertStore(certList);
         CMSSignedDataGenerator cmsGenerator = new CMSSignedDataGenerator();
         ContentSigner contentSigner = new JcaContentSignerBuilder("SHA256withRSA").build(signingKey);
         cmsGenerator.addSignerInfoGenerator(
                 new JcaSignerInfoGeneratorBuilder(new JcaDigestCalculatorProviderBuilder().setProvider("BC").build())
-                        .build(contentSigner, signingCertificate));
+                        .build(contentSigner, certChain[0]));
         cmsGenerator.addCertificates(certs);
         CMSSignedData cms = cmsGenerator.generate(cmsData, true);
-        signedData = cms.getEncoded();
-        return signedData;
+        return cms.getEncoded();
+    }
+
+    public static byte[] signData(byte[] data, X509Certificate signingCertificate, PrivateKey signingKey)
+            throws CertificateEncodingException, OperatorCreationException, CMSException, IOException {
+        return signData(data, new X509Certificate[]{signingCertificate}, signingKey);
     }
 
 }


### PR DESCRIPTION
## Summary

- **`SmimeConstants.java`**: Added `CERT_CHAIN` constant used to pass the full chain through `certMap`.
- **`DataSigner.signData(byte[],byte[],char[])`**: Uses `KeyStore.getCertificateChain()` instead of `getCertificate()` so intermediate CA certs from the PKCS12 are captured.
- **`DataSigner.signData(byte[],X509Certificate[],PrivateKey)`**: New overload that adds all chain certs to `JcaCertStore` and passes them to `CMSSignedDataGenerator.addCertificates()`, embedding them in the PKCS#7 `SignedData.certificates` collection per RFC 5652.
- **`DataSigner.signData(byte[],X509Certificate,PrivateKey)`**: Now delegates to the array overload — backward-compatible for `MobileConfigFormatter`.

## Background

ZRFE-1285: When a user uploads a commercial S/MIME certificate (PKCS12 bundle with leaf + intermediate CA), Zimbra's server-side signing only embedded the leaf certificate. Recipients whose clients lacked the intermediate CA in their trust store flagged the signature as untrusted.

See companion PR in `zm-smime-store` for the core email-signing fix.

## Test plan
- [ ] Existing `DataSignerTest.testSignData()` passes (backward-compat — single-cert PKCS12)
- [ ] With a chain PKCS12: `openssl pkcs7 -print_certs` on the generated `.p7s` shows both leaf and intermediate cert
- [ ] `MobileConfigFormatter` signing is unaffected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)