### PR TITLE
ZBUG 4975: zimbraHideInGal - Auto complete not working for external gal

### DIFF
--- a/store/src/java-test/com/zimbra/cs/mailbox/ContactAutoCompleteTest.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/ContactAutoCompleteTest.java
@@ -376,7 +376,8 @@ public final class ContactAutoCompleteTest {
         Account account = Provisioning.getInstance().getAccountByName("testContAC@zimbra.com");
         Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
         ContactAutoComplete contactAutoComplete = new ContactAutoComplete(account, new OperationContext(mbox));
-        Set<String> eligibleEmails = contactAutoComplete.extractEligibleEmailsListForAccount(attrs, true);
+        Set<String> eligibleEmails = contactAutoComplete.extractEligibleEmailsListForAccount(attrs,
+                true, false);
         Assert.assertEquals(3, eligibleEmails.size());
     }
 
@@ -456,6 +457,42 @@ public final class ContactAutoCompleteTest {
         );
 
         comp.addMatchedContacts("first last", attrs, ContactAutoComplete.FOLDER_ID_GAL, null, result, false);
+        Assert.assertEquals(1, result.entries.size());
+    }
+
+    @Test
+    public void testExternalGALIsSuggestedInAutocompleteIfHideInGalIsTrue() throws Exception {
+        Account account = Provisioning.getInstance().getAccountByName("test3@zimbra.com");
+        ContactAutoComplete comp = new ContactAutoComplete(account, null);
+        ContactAutoComplete.AutoCompleteResult result = new ContactAutoComplete.AutoCompleteResult(10);
+        result.rankings = new ContactRankings(MockProvisioning.DEFAULT_ACCOUNT_ID);
+
+        Map<String, Object> attrs = ImmutableMap.<String, Object>of(
+                ContactConstants.A_firstName, "First",
+                ContactConstants.A_lastName, "Last",
+                ContactConstants.A_email, "testAccountWithGalHideTrue@zimbra.com"
+        );
+
+        comp.addMatchedContacts("first last", attrs, ContactAutoComplete.FOLDER_ID_GAL, null, result,
+                false, true);
+        Assert.assertEquals(1, result.entries.size());
+    }
+
+    @Test
+    public void testExternalGALIsSuggestedInAutocompleteIfHideInGalIsFalse() throws Exception {
+        Account account = Provisioning.getInstance().getAccountByName("test3@zimbra.com");
+        ContactAutoComplete comp = new ContactAutoComplete(account, null);
+        ContactAutoComplete.AutoCompleteResult result = new ContactAutoComplete.AutoCompleteResult(10);
+        result.rankings = new ContactRankings(MockProvisioning.DEFAULT_ACCOUNT_ID);
+
+        Map<String, Object> attrs = ImmutableMap.<String, Object>of(
+                ContactConstants.A_firstName, "First",
+                ContactConstants.A_lastName, "Last",
+                ContactConstants.A_email, "testAccountWithGalHideFalse@zimbra.com"
+        );
+
+        comp.addMatchedContacts("first last", attrs, ContactAutoComplete.FOLDER_ID_GAL, null, result,
+                false, true);
         Assert.assertEquals(1, result.entries.size());
     }
 }

--- a/store/src/java/com/zimbra/cs/gal/GalSearchControl.java
+++ b/store/src/java/com/zimbra/cs/gal/GalSearchControl.java
@@ -508,6 +508,16 @@ public class GalSearchControl {
         try {
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(galAcct);
             SearchParams searchParams = mParams.getSearchParams();
+            HashSet<Integer> externalFolderIds = new HashSet<>();
+            List<DataSource> sources = galAcct.getAllDataSources();
+            for (DataSource ds : sources) {
+                if (ds.getType() != DataSourceType.gal) {
+                    continue;
+                }
+                if (ds.getAttr(Provisioning.A_zimbraGalType).compareTo("ldap") == 0) {
+                    externalFolderIds.add(ds.getFolderId());
+                }
+            }
             try (ZimbraQueryResults zqr = mbox.index.search(SoapProtocol.Soap12,
                 new OperationContext(mbox), searchParams)) {
                 ResultsPager pager = ResultsPager.create(zqr, searchParams);
@@ -516,8 +526,13 @@ public class GalSearchControl {
                 while (pager.hasNext()) {
                     ZimbraHit hit = pager.getNextHit();
                     if (hit instanceof ContactHit) {
+                        ContactHit contactHit = (ContactHit) hit;
+                        int folderId = contactHit.getContact().getFolderId();
+                        if (null != externalFolderIds) {
+                            contactHit.getContact().setExternalContactForGAL(externalFolderIds.contains(folderId));
+                        }
                         Element contactElem = callback
-                            .handleContact(((ContactHit) hit).getContact());
+                                .handleContact((contactHit).getContact());
                         if (contactElem != null)
                             contactElem.addAttribute(MailConstants.A_SORT_FIELD,
                                 hit.getSortField(pager.getSortOrder()).toString());

--- a/store/src/java/com/zimbra/cs/mailbox/Contact.java
+++ b/store/src/java/com/zimbra/cs/mailbox/Contact.java
@@ -203,6 +203,16 @@ public class Contact extends MailItem {
     private Map<String, String> fields;
     private List<Attachment> attachments;
 
+    private boolean isExternalContactForGAL;
+
+    public boolean isExternalContactForGAL() {
+        return isExternalContactForGAL;
+    }
+
+    public void setExternalContactForGAL(boolean externalContactForGAL) {
+        isExternalContactForGAL = externalContactForGAL;
+    }
+
     // The list of all *simple* "email" fields in the contact's map
     // IMPORTANT NOTE - does not include the Contact Group 'dlist' entry, which is a multi-value entry (comma-separated)
     private static final String[] EMAIL_FIELDS = new String[] {

--- a/store/src/java/com/zimbra/cs/mailbox/ContactAutoComplete.java
+++ b/store/src/java/com/zimbra/cs/mailbox/ContactAutoComplete.java
@@ -504,27 +504,32 @@ public class ContactAutoComplete {
             this.str = str;
         }
 
+        private void handleContactAttrs(Map<String, ? extends Object> attrs,
+                                       boolean isExternalGal) throws ServiceException {
+            addMatchedContacts(str, attrs, FOLDER_ID_GAL, null, result, false, isExternalGal);
+        }
+
         public void handleContactAttrs(Map<String, ? extends Object> attrs) throws ServiceException {
-            addMatchedContacts(str, attrs, FOLDER_ID_GAL, null, result, false);
+            handleContactAttrs( attrs, false);
         }
 
         @Override
         public Element handleContact(Contact c) throws ServiceException {
             ZimbraLog.gal.debug("gal entry: %d", c.getId());
-            handleContactAttrs(c.getFields());
+            handleContactAttrs(c.getFields(), c.isExternalContactForGAL());
             return null;
         }
 
         @Override
         public void visit(GalContact c) throws ServiceException {
             ZimbraLog.gal.debug("gal entry: %s", c.getId());
-            handleContactAttrs(c.getAttrs());
+            handleContactAttrs(c.getAttrs(), !c.isZimbraGal());
         }
 
         @Override
         public void handleElement(Element e) throws ServiceException {
             ZimbraLog.gal.debug("gal entry: %s", e.getAttribute(MailConstants.A_ID));
-            handleContactAttrs(parseContactElement(e));
+            handleContactAttrs(parseContactElement(e), false);
         }
 
         @Override
@@ -668,7 +673,13 @@ public class ContactAutoComplete {
     }
 
     public void addMatchedContacts(String query, Map<String, ? extends Object> attrs, int folderId, ItemId id,
-            AutoCompleteResult result, boolean isFromContactFolder) throws ServiceException {
+                                   AutoCompleteResult result, boolean isFromContactFolder) throws ServiceException {
+        addMatchedContacts(query, attrs, FOLDER_ID_GAL, null, result, false, false);
+    }
+
+    protected void addMatchedContacts(String query, Map<String, ? extends Object> attrs, int folderId, ItemId id,
+                                   AutoCompleteResult result, boolean isFromContactFolder,
+                                   boolean isExternalGal) throws ServiceException {
         if (!result.canBeCached) {
             return;
         }
@@ -701,7 +712,8 @@ public class ContactAutoComplete {
             if (Strings.isNullOrEmpty(displayName)) {
                 displayName = Joiner.on(' ').skipNulls().join(first, middle, last);
             }
-            Set<String> eligibleEmailsForAccount = extractEligibleEmailsListForAccount(attrs, isFromContactFolder);
+            Set<String> eligibleEmailsForAccount = extractEligibleEmailsListForAccount(attrs, isFromContactFolder,
+                    isExternalGal);
             for (String email : eligibleEmailsForAccount) {
                 if (email != null && (nameMatches || matchesEmail(tokens, email))) {
                     ContactEntry entry = new ContactEntry();
@@ -751,18 +763,22 @@ public class ContactAutoComplete {
 
     /**
      * Identifies the eligible results for GAL Autocomplete for an account
+     *
      * @param attrs
      * @param isFromContactFolder true if the entry originates from a local/shared contact folder,
      *                            false if the entry originates from GAL
+     * @param isExternalGal true if the entry originates from an External GAL,
+     *                             false if the entry originates from Zimbra GAL
      * @return a set of email addresses that are eligible for autocomplete suggestions
      * @throws ServiceException
      */
     protected Set<String> extractEligibleEmailsListForAccount(Map<String, ?> attrs,
-                                                              boolean isFromContactFolder) throws ServiceException {
+                                                              boolean isFromContactFolder,
+                                                              boolean isExternalGal) throws ServiceException {
         Set<String> eligibleEmailsForAccount = new HashSet<>();
         String primaryEmail = getFieldAsString(attrs, ContactConstants.A_email);
         Account account = Provisioning.getInstance().get(Key.AccountBy.name, primaryEmail);
-        populateEligibleEmails(attrs, eligibleEmailsForAccount, account, isFromContactFolder);
+        populateEligibleEmails(attrs, eligibleEmailsForAccount, account, isFromContactFolder, isExternalGal);
         return eligibleEmailsForAccount;
     }
 
@@ -773,17 +789,20 @@ public class ContactAutoComplete {
      * @param account
      * @param isFromContactFolder true if the entry originates from a local/shared contact folder,
      *                            false if the entry originates from GAL
+     * @param isExternalGal true if the entry originates from an External GAL,
+     *                             false if the entry originates from Zimbra GAL
      * @throws ServiceException
      */
     private void populateEligibleEmails(Map<String, ?> attrs, Set<String> eligibleEmailsForAccount, Account account,
-                                        boolean isFromContactFolder) throws ServiceException {
+                                        boolean isFromContactFolder, boolean isExternalGal) throws ServiceException {
         for (String emailKey : mEmailKeys) {
             // when account is null, its external contact.Below alias logic is not applicable.
             if (null != account) {
                 // apply zimbraHideInGal restriction only to GAL results.
                 // local contacts should still be suggested regardless of the zimbraHideInGal setting.
-                if (!isFromContactFolder
-                        && ContactConstants.A_email.equalsIgnoreCase(emailKey) && account.isHideInGal()) {
+                // ZBUG-4975 : external gal shouldn't get affected by zimbraHideInGal setting.
+                if (!isFromContactFolder && ContactConstants.A_email.equalsIgnoreCase(emailKey)
+                        && account.isHideInGal() && !isExternalGal) {
                     ZimbraLog.gal.debug("Skipping account %s from autocomplete", getFieldAsString(attrs, emailKey));
                     continue;
                 }
@@ -893,7 +912,7 @@ public class ContactAutoComplete {
                     continue;
                 }
 
-                addMatchedContacts(str, fields, fid, id, result, true);
+                addMatchedContacts(str, fields, fid, id, result, true, false);
                 if (!result.canBeCached) {
                     return;
                 }


### PR DESCRIPTION
Issue : Due to the changes in ZCS-15617, external gal was also filtered by zimbraHideInGal while autocomplete.

Fix : Created a map of data source folder Id and isExternalContact. Using this filtered external contact for a gal and exempted it from the above condition.