### PR TITLE
ZCS-19353 : Include full certificate chain in S/MIME signature block

### DIFF
--- a/common/src/java/com/zimbra/common/soap/SmimeConstants.java
+++ b/common/src/java/com/zimbra/common/soap/SmimeConstants.java
@@ -45,6 +45,7 @@ public class SmimeConstants {
     public static final String A_DEFAULT = "default";
     public static final String A_DECRYPTION_ERROR_CODE = "decryptionErrorCode";
 
+    public static final String CERT_CHAIN = "certChain";
     public static final String E_CERTIFICATE = "certificate";
     public static final String E_EMAIL_ADDR = "emailAddress";
     public static final String E_SUBJECT_DN = "issuedTo";

--- a/store/src/java-test/com/zimbra/cs/util/CertValidationUtilTest.java
+++ b/store/src/java-test/com/zimbra/cs/util/CertValidationUtilTest.java
@@ -1,0 +1,182 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2026 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.util;
+
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Security;
+import java.security.cert.CertPathValidatorException;
+import java.security.cert.TrustAnchor;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class CertValidationUtilTest {
+
+    private static X509Certificate rootCert;
+
+    private static X509Certificate intermediateCert;
+
+    private static X509Certificate leafCert;
+
+    private static Set<TrustAnchor> trustAnchors;
+
+    private static KeyPair intermediateKeyPair;
+
+    private static X509Certificate intermediate1Cert;
+
+    private static X509Certificate intermediate2Cert;
+
+    private static X509Certificate deepLeafCert;
+
+    private static KeyPair intermediate1KeyPair;
+
+    private static KeyPair intermediate2KeyPair;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        Security.addProvider(new BouncyCastleProvider());
+
+        // root CA — isCA = true
+        KeyPair rootKeyPair = generateKeyPair();
+        rootCert = generateCert(rootKeyPair, "CN=Test Root CA",
+                rootKeyPair, "CN=Test Root CA", -1, 365, true);
+
+        // intermediate CA — isCA = true
+        intermediateKeyPair = generateKeyPair();
+        intermediateCert = generateCert(intermediateKeyPair,
+                "CN=Test Intermediate CA",
+                rootKeyPair, "CN=Test Root CA", -1, 365, true);
+
+        // leaf cert — isCA = false
+        KeyPair leafKeyPair = generateKeyPair();
+        leafCert = generateCert(leafKeyPair, "CN=test@example.com",
+                intermediateKeyPair, "CN=Test Intermediate CA",
+                -1, 365, false);
+
+        // Deeper chain: Root → Int1 → Int2 → DeepLeaf
+        intermediate1KeyPair = generateKeyPair();
+        intermediate1Cert = generateCert(intermediate1KeyPair,
+                "CN=Test Intermediate CA L1",
+                rootKeyPair, "CN=Test Root CA", -1, 365, true);
+
+        intermediate2KeyPair = generateKeyPair();
+        intermediate2Cert = generateCert(intermediate2KeyPair,
+                "CN=Test Intermediate CA L2",
+                intermediate1KeyPair, "CN=Test Intermediate CA L1",
+                -1, 365, true);
+
+        KeyPair deepLeafKeyPair = generateKeyPair();
+        deepLeafCert = generateCert(deepLeafKeyPair,
+                "CN=deep@example.com",
+                intermediate2KeyPair, "CN=Test Intermediate CA L2",
+                -1, 365, false);
+
+        trustAnchors = new HashSet<>();
+        trustAnchors.add(new TrustAnchor(rootCert, null));
+    }
+
+    // without intermediate cert, PKIX chain building fails with CertPathValidatorException
+    @Test(expected = CertPathValidatorException.class)
+    public void testValidateWithoutIntermediateCertFails() throws Exception {
+        CertValidationUtil.validateCertificate(leafCert, true, trustAnchors, null);
+    }
+
+    // empty intermediate list behaves same as null — no NPE, no crash
+    @Test
+    public void testValidateWithEmptyIntermediates() throws Exception {
+        CertValidationUtil.validateCertificate(leafCert, false, trustAnchors, new ArrayList<X509Certificate>());
+    }
+
+    // leaf + single intermediate — PKIX chain builds successfully
+    @Test
+    public void testValidateWithIntermediateCertSucceeds()
+            throws Exception {
+        List<X509Certificate> intermediates = new ArrayList<>();
+        intermediates.add(intermediateCert);
+        CertValidationUtil.validateCertificate(
+                leafCert, false, trustAnchors, intermediates);
+    }
+
+    // deeper chain: leaf + two intermediate certs — PKIX chain builds
+    @Test
+    public void testValidateWithMultipleIntermediateCertsSucceeds()
+            throws Exception {
+        List<X509Certificate> intermediates = new ArrayList<>();
+        intermediates.add(intermediate2Cert);
+        intermediates.add(intermediate1Cert);
+        CertValidationUtil.validateCertificate(
+                deepLeafCert, false, trustAnchors, intermediates);
+    }
+
+    // deeper chain with missing intermediate — chain building fails
+    @Test(expected = CertPathValidatorException.class)
+    public void testValidateWithIncompleteChainFails()
+            throws Exception {
+        // only provide intermediate2, skip intermediate1
+        List<X509Certificate> intermediates = new ArrayList<>();
+        intermediates.add(intermediate2Cert);
+        CertValidationUtil.validateCertificate(
+                deepLeafCert, true, trustAnchors, intermediates);
+    }
+
+    // helper methods to generate test certificates
+    private static KeyPair generateKeyPair() throws Exception {
+        KeyPairGenerator gen = KeyPairGenerator.getInstance("RSA");
+        gen.initialize(2048);
+        return gen.generateKeyPair();
+    }
+
+    private static X509Certificate generateCert(KeyPair subjectKP, String subjectDn, KeyPair issuerKP, String issuerDn,
+            int startDaysOffset, int validDays, boolean isCA) throws Exception {
+        long now = System.currentTimeMillis();
+        long day = 86400000L;
+        Date start = new Date(now + startDaysOffset * day);
+        Date end = new Date(now + validDays * day);
+        X509v3CertificateBuilder builder =
+                new JcaX509v3CertificateBuilder(
+                        new X500Name(issuerDn),
+                        BigInteger.valueOf(
+                                now + subjectDn.hashCode()),
+                        start, end,
+                        new X500Name(subjectDn),
+                        subjectKP.getPublic());
+        // add BasicConstraints: CA:TRUE for CA certs, CA:FALSE for leaf
+        builder.addExtension(Extension.basicConstraints,
+                true, new BasicConstraints(isCA));
+        return new JcaX509CertificateConverter().setProvider("BC")
+                .getCertificate(builder.build(
+                        new JcaContentSignerBuilder("SHA256WithRSA")
+                                .setProvider("BC")
+                                .build(issuerKP.getPrivate())));
+    }
+}

--- a/store/src/java/com/zimbra/cs/util/CertValidationUtil.java
+++ b/store/src/java/com/zimbra/cs/util/CertValidationUtil.java
@@ -43,6 +43,8 @@ import com.zimbra.common.util.ZimbraLog;
 
 public class CertValidationUtil {
 
+    private static final String X509_CERT_TYPE = "X509";
+
     public static void validateCertificate(X509Certificate cert, boolean revocationCheckEnabled, Set<TrustAnchor> trustedCertsSet)
             throws CertificateException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, CertPathValidatorException {
 
@@ -53,7 +55,7 @@ public class CertValidationUtil {
                 certificates.add(cert);
                 CertificateFactory cf;
                 CertPath cp;
-                cf = CertificateFactory.getInstance("X509");
+                cf = CertificateFactory.getInstance(X509_CERT_TYPE);
                 cp = cf.generateCertPath(certificates);
 
                 // init PKIX parameters
@@ -67,6 +69,38 @@ public class CertValidationUtil {
                 PKIXCertPathValidatorResult cpv_result = (PKIXCertPathValidatorResult) cpv.validate(cp, params);
                 ZimbraLog.account.debug("Certificate Validation Result %s", cpv_result.toString());
             }
+    }
+
+    // overloaded method — adds intermediate certificate support for PKIX chain building
+    public static void validateCertificate(X509Certificate cert, boolean revocationCheckEnabled, Set<TrustAnchor>
+                    trustedCertsSet, List<X509Certificate> intermediateCerts) throws CertificateException,
+            InvalidAlgorithmParameterException, NoSuchAlgorithmException, CertPathValidatorException {
+
+        cert.checkValidity();
+
+        if (revocationCheckEnabled) {
+            List<X509Certificate> certificates = new ArrayList<>();
+            certificates.add(cert);
+
+            // add intermediate certs to the path, filtering out self-signed roots and duplicate leaf
+            if (intermediateCerts != null) {
+                for (X509Certificate ic : intermediateCerts) {
+                    if (!ic.equals(cert)
+                            && !ic.getSubjectX500Principal().equals(ic.getIssuerX500Principal())) {
+                        certificates.add(ic);
+                    }
+                }
+            }
+
+            CertificateFactory certFactory = CertificateFactory.getInstance(X509_CERT_TYPE);
+            CertPath certPath = certFactory.generateCertPath(certificates);
+
+            PKIXParameters params = new PKIXParameters(trustedCertsSet);
+            params.setRevocationEnabled(revocationCheckEnabled);
+
+            CertPathValidator cpv = CertPathValidator.getInstance("PKIX");
+            cpv.validate(certPath, params);
+        }
     }
 
     public static Set<TrustAnchor> loadTrustedAnchors(char[] pass, String keystorePath) throws KeyStoreException,


### PR DESCRIPTION
## Problem
Outgoing S/MIME signed emails were not including the complete certificate chain 
in the PKCS#7 signature block. This caused signature validation failures on 
the recipient side, as the receiving mail client or server could not build a 
trust path back to the root CA.

## Root Cause
During PKCS#7 signature block construction, only the sender's leaf certificate 
was being embedded. The intermediate and root CA certificates from the user's 
PKCS#12 keystore were not carried over into the signed message.

## Fix
Updated the signature generation logic to extract and include the full 
certificate chain (leaf + intermediate + root) from the user's PKCS#12 
certificate store when constructing the PKCS#7 signature block.
