### PR TITLE
ZBUG-5535 Read receipt (MDN) missing In-Reply-To and References headers

### DIFF
--- a/store/src/java-test/com/zimbra/cs/service/mail/SendDeliveryReportTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/mail/SendDeliveryReportTest.java
@@ -1,0 +1,64 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite, Network Edition.
+ * Copyright (C) 2026 Synacor, Inc.  All Rights Reserved.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.service.mail;
+
+import java.lang.reflect.Method;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class SendDeliveryReportTest {
+
+    @Test
+    public void testGetRefHeader() throws Exception {
+        Method method = com.zimbra.cs.service.mail.SendDeliveryReport.class.getDeclaredMethod(
+                "getRefHeader",
+                String[].class,
+                String.class);
+
+        method.setAccessible(true);
+        String[] refs = {"<oldref@test.com>"};
+        String result = (String) method.invoke(
+                null,
+                refs,
+                "<msg@test.com>");
+
+        assertEquals("<oldref@test.com> <msg@test.com>", result);
+    }
+
+    @Test
+    public void testGetRefHeaderWithoutRefs() throws Exception {
+        Method method = com.zimbra.cs.service.mail.SendDeliveryReport.class.getDeclaredMethod(
+                "getRefHeader",
+                String[].class,
+                String.class);
+        method.setAccessible(true);
+        String result = (String) method.invoke(
+                null,
+                null,
+                "<msg@test.com>");
+
+        assertEquals("<msg@test.com>", result);
+    }
+
+    @Test
+    public void testGetRefHeaderTrim() throws Exception {
+        Method method = com.zimbra.cs.service.mail.SendDeliveryReport.class.getDeclaredMethod(
+                "getRefHeader",
+                String[].class,
+                String.class);
+
+        method.setAccessible(true);
+        String[] refs = {"      <oldref@test.com>      "};
+        String result = (String) method.invoke(
+                null,
+                refs,
+                "      <msg@test.com>      ");
+
+        assertEquals("<oldref@test.com> <msg@test.com>", result);
+    }
+}

--- a/store/src/java-test/com/zimbra/cs/service/mail/package-info.java
+++ b/store/src/java-test/com/zimbra/cs/service/mail/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Tests for mail service functionality.
+ */
+package com.zimbra.cs.service.mail;

--- a/store/src/java/com/zimbra/cs/service/mail/SendDeliveryReport.java
+++ b/store/src/java/com/zimbra/cs/service/mail/SendDeliveryReport.java
@@ -40,6 +40,7 @@ import com.zimbra.common.util.CharsetUtil;
 import com.zimbra.common.util.DateUtil;
 import com.zimbra.common.util.L10nUtil;
 import com.zimbra.common.util.L10nUtil.MsgKey;
+import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.zmime.ZMimeBodyPart;
 import com.zimbra.common.zmime.ZMimeMultipart;
 import com.zimbra.cs.account.Account;
@@ -116,6 +117,12 @@ public class SendDeliveryReport extends MailDocumentHandler {
             report.setSentDate(new Date());
             report.setFrom(AccountUtil.getFriendlyEmailAddress(authAccount));
             report.addRecipients(javax.mail.Message.RecipientType.TO, recipients);
+            String origMessageID = mm.getMessageID();
+            if (!StringUtil.isNullOrEmpty(origMessageID)) {
+                report.setHeader("In-Reply-To", origMessageID.trim());
+                report.setHeader("References", getRefHeader(mm.getHeader("References"), mm.getMessageID()));
+            }
+
             report.setHeader("Auto-Submitted", "auto-replied (zimbra; read-receipt)");
             report.setHeader("Precedence", "bulk");
 
@@ -158,6 +165,15 @@ public class SendDeliveryReport extends MailDocumentHandler {
         } catch (MessagingException me) {
             throw ServiceException.FAILURE("error while sending read receipt", me);
         }
+    }
+
+    private static String getRefHeader(String[] incomingRefs, String origMessageID) {
+        StringBuilder refs = new StringBuilder();
+        if (incomingRefs != null && incomingRefs.length > 0) {
+            refs.append(incomingRefs[0].trim()).append(" ");
+        }
+        refs.append(origMessageID.trim());
+        return refs.toString();
     }
 
     public static String generateTextPart(Account owner, MimeMessage mm, Locale lc) throws MessagingException {


### PR DESCRIPTION
Fix: Added In-Reply-To and References headers to Read-Receipt emails.