### PR TITLE
ZCS-19489: Implement ROPC auth engine, request builder, and outcome mapping

### DIFF
--- a/store/src/java-test/com/zimbra/cs/account/auth/IROPCHandlerRegistryTest.java
+++ b/store/src/java-test/com/zimbra/cs/account/auth/IROPCHandlerRegistryTest.java
@@ -18,25 +18,24 @@ package com.zimbra.cs.account.auth;
 
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.auth.ropc.*;
+import java.net.SocketTimeoutException;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class IROPCHandlerRegistryTest {
 
     @Test
     public void testOktaHandler() throws Exception {
         OktaRopcHandler handler = new OktaRopcHandler();
-        IRopcAuthRequest request = new IRopcAuthRequest.Builder()
-                                    .username("user")
-                                    .password("pass")
-                                    .provider("okta")
-                                    .build();
-
+        IRopcAuthRequest request = new IRopcAuthRequest.Builder().username("user").password("pass").provider("okta")
+                .build();
         assertEquals("okta", handler.getName());
-        assertTrue(handler.authenticate(request));
+        try {
+            boolean result = handler.authenticate(request);
+            assertTrue("Handler should return true", result);
+        } catch (SocketTimeoutException e) {
+            fail("Handler should not throw SocketTimeoutException: " + e.getMessage());
+        }
     }
 
     @Test

--- a/store/src/java-test/com/zimbra/cs/account/auth/IRopcAuthEngineTest.java
+++ b/store/src/java-test/com/zimbra/cs/account/auth/IRopcAuthEngineTest.java
@@ -1,0 +1,129 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2026 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.account.auth;
+
+import com.zimbra.cs.account.auth.ropc.*;
+import java.net.SocketTimeoutException;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class IRopcAuthEngineTest {
+
+    // Builder with all fields including protocolContext
+    @Test
+    public void testRequestBuilderSetsAllFields() {
+        IRopcAuthRequest request = new IRopcAuthRequest.Builder()
+                .username("user")
+                .password("secret")
+                .provider("okta")
+                .protocolContext("zsync")
+                .factorType(IRopcAuthRequest.FactorType.PUSH)
+                .build();
+
+        assertEquals("user", request.getUsername());
+        assertEquals("secret", request.getPassword());
+        assertEquals("okta", request.getProvider());
+        assertEquals("zsync", request.getProtocolContext());
+        assertEquals(IRopcAuthRequest.FactorType.PUSH, request.getFactorType());
+    }
+
+    @Test
+    public void testRequestDefaultFactorTypeIsNone() {
+        IRopcAuthRequest request = new IRopcAuthRequest.Builder()
+                .username("user")
+                .password("pass")
+                .provider("okta")
+                .build();
+
+        assertEquals(IRopcAuthRequest.FactorType.NONE, request.getFactorType());
+    }
+
+    // Builder validation
+    @Test(expected = IllegalArgumentException.class)
+    public void testRequestBuilderNullUsernameThrows() {
+        new IRopcAuthRequest.Builder().username(null).password("pass").provider("okta").build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRequestBuilderEmptyPasswordThrows() {
+        new IRopcAuthRequest.Builder().username("user").password("").provider("okta").build();
+    }
+
+    // FactorType.fromConfig
+    @Test
+    public void testFactorTypeFromConfigNullDefaultsPush() {
+        assertEquals(IRopcAuthRequest.FactorType.NONE,
+                IRopcAuthRequest.FactorType.fromConfig(null));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFactorTypeFromConfigInvalidThrows() {
+        IRopcAuthRequest.FactorType.fromConfig("sms");
+    }
+
+    // Handlers
+    @Test
+    public void testOktaHandler() throws Exception {
+        OktaRopcHandler handler = new OktaRopcHandler();
+        IRopcAuthRequest request = new IRopcAuthRequest.Builder().username("user").password("pass").provider("okta")
+                .build();
+        assertEquals("okta", handler.getName());
+        try {
+            boolean result = handler.authenticate(request);
+            assertTrue("Handler should return true", result);
+        } catch (SocketTimeoutException e) {
+            fail("Handler should not throw SocketTimeoutException: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testEngineReturnsSuccessForOkta() {
+        assertEquals(Outcome.SUCCESS, IRopcAuthEngine.authenticate("user", "pass", "okta",
+                "NONE", "zsync", null));
+    }
+
+    @Test
+    public void testEngineReturnsErrorForUnknownProvider() {
+        assertEquals(Outcome.ERROR, IRopcAuthEngine.authenticate("user", "pass", "unknown",
+                "NONE", "zsync", null));
+    }
+
+    @Test
+    public void testEngineReturnsErrorForNullProvider() {
+        assertEquals(Outcome.ERROR, IRopcAuthEngine.authenticate("user", "pass", null,
+                "NONE", "zsync", null));
+    }
+
+    @Test
+    public void testEngineReturnsErrorForInvalidFactor() {
+        assertEquals(Outcome.ERROR, IRopcAuthEngine.authenticate("user", "pass", "okta",
+                "sms", "zsync", null));
+    }
+
+    @Test
+    public void testEngineDefaultsFactorWhenConfigNull() {
+        assertEquals(Outcome.SUCCESS, IRopcAuthEngine.authenticate("user", "pass", "okta",
+                null, "zsync", null));
+    }
+
+    @Test
+    public void testCaseInsensitiveProviderResolution() {
+        assertEquals(Outcome.SUCCESS, IRopcAuthEngine.authenticate("user", "pass", "OKTA",
+                "NONE", "zsync", null));
+    }
+}

--- a/store/src/java-test/com/zimbra/cs/account/auth/IRopcCustomAuthTest.java
+++ b/store/src/java-test/com/zimbra/cs/account/auth/IRopcCustomAuthTest.java
@@ -76,14 +76,17 @@ public class IRopcCustomAuthTest {
 
     @Test
     public void testAuthenticateOutcomeSuccess() throws Exception {
-        doReturn(Outcome.SUCCESS).when(ropcCustomAuth).callAuthEngine(anyString(), anyString(), anyString());
+        doReturn(Outcome.SUCCESS).when(ropcCustomAuth)
+                .callAuthEngine(anyString(), anyString(), anyString(), anyString(), anyString(), anyString());
         ropcCustomAuth.authenticate(mockAccount, "password", mockContext, null);
-        verify(ropcCustomAuth, times(1)).callAuthEngine("user1@example.zimbra.com", "password", "device-123");
+        verify(ropcCustomAuth, times(1))
+                .callAuthEngine("user1@example.zimbra.com", "password", "okta", "NONE", "zsync", "device-123");
     }
 
     @Test
     public void testAuthenticateOutcomeInvalid() throws Exception {
-        doReturn(Outcome.INVALID).when(ropcCustomAuth).callAuthEngine(anyString(), anyString(), anyString());
+        doReturn(Outcome.INVALID).when(ropcCustomAuth)
+                .callAuthEngine(anyString(), anyString(), anyString(), anyString(), anyString(), anyString());
         try {
             ropcCustomAuth.authenticate(mockAccount, "password", mockContext, null);
             fail("Expected AuthFailedServiceException was not thrown");
@@ -95,7 +98,8 @@ public class IRopcCustomAuthTest {
 
     @Test
     public void testAuthenticateOutcomePolicyDenied() throws Exception {
-        doReturn(Outcome.POLICY_DENIED).when(ropcCustomAuth).callAuthEngine(anyString(), anyString(), anyString());
+        doReturn(Outcome.POLICY_DENIED).when(ropcCustomAuth)
+                .callAuthEngine(anyString(), anyString(), anyString(), anyString(), anyString(), anyString());
         try {
             ropcCustomAuth.authenticate(mockAccount, "password", mockContext, null);
             fail("Expected AuthFailedServiceException was not thrown");
@@ -107,7 +111,8 @@ public class IRopcCustomAuthTest {
 
     @Test
     public void testAuthenticateOutcomeMFATimeout() throws Exception {
-        doReturn(Outcome.MFA_TIMEOUT).when(ropcCustomAuth).callAuthEngine(anyString(), anyString(), anyString());
+        doReturn(Outcome.MFA_TIMEOUT).when(ropcCustomAuth)
+                .callAuthEngine(anyString(), anyString(), anyString(), anyString(), anyString(), anyString());
         try {
             ropcCustomAuth.authenticate(mockAccount, "password", mockContext, null);
             fail("Expected AuthFailedServiceException was not thrown");
@@ -119,7 +124,8 @@ public class IRopcCustomAuthTest {
 
     @Test
     public void testAuthenticateOutcomeDefaultError() throws Exception {
-        doReturn(Outcome.ERROR).when(ropcCustomAuth).callAuthEngine(anyString(), anyString(), anyString());
+        doReturn(Outcome.ERROR).when(ropcCustomAuth)
+                .callAuthEngine(anyString(), anyString(), anyString(), anyString(), anyString(), anyString());
         try {
             ropcCustomAuth.authenticate(mockAccount, "password", mockContext, null);
             fail("Expected ServiceException was not thrown");
@@ -133,15 +139,19 @@ public class IRopcCustomAuthTest {
     public void testAuthenticateCacheHitSkipEngineCall() throws Exception {
         doReturn(true).when(ropcCustomAuth).checkInCache(anyString(), anyString());
         ropcCustomAuth.authenticate(mockAccount, "password", mockContext, null);
-        verify(ropcCustomAuth, never()).callAuthEngine("user1@example.zimbra.com", "password", "device-123");
+        verify(ropcCustomAuth, never())
+                .callAuthEngine(anyString(), anyString(), anyString(), anyString(), anyString(), anyString());
     }
 
     @Test
-    public void testAuthenticateZsyncrotocolByPassCacheCheck() throws Exception {
+    public void testAuthenticateZsyncProtocolByPassCacheCheck() throws Exception {
         mockContext.put(AuthContext.AC_PROTOCOL, AuthContext.Protocol.zsync);
         doReturn(true).when(ropcCustomAuth).checkInCache(anyString(), anyString());
-        doReturn(Outcome.SUCCESS).when(ropcCustomAuth).callAuthEngine(anyString(), anyString(), anyString());
+        doReturn(Outcome.SUCCESS).when(ropcCustomAuth)
+                .callAuthEngine(anyString(), anyString(), anyString(), anyString(), anyString(), anyString());
         ropcCustomAuth.authenticate(mockAccount, "password", mockContext, null);
-        verify(ropcCustomAuth, times(1)).callAuthEngine("user1@example.zimbra.com", "password", "device-123");
+        verify(ropcCustomAuth, times(1))
+                .callAuthEngine("user1@example.zimbra.com", "password", "provider-1",
+                        "factorConfig-1", "eas", "device-123");
     }
 }

--- a/store/src/java/com/zimbra/cs/account/auth/IRopcCustomAuth.java
+++ b/store/src/java/com/zimbra/cs/account/auth/IRopcCustomAuth.java
@@ -38,14 +38,16 @@ public class IRopcCustomAuth extends ZimbraCustomAuth {
         String user = acct.getName();
         Protocol proto = (Protocol) context.get(AuthContext.AC_PROTOCOL);
         String deviceId = (String) context.get(AuthContext.AC_DEVICE_ID);
-
+        String factorConfig = "NONE";
+        String provider = "okta";
+        String protocolContext = (proto != null) ? proto.name() : "unknown";
         // protocol-aware caching — SKIP for zsync.
         boolean useCache = (proto != Protocol.zsync);
         if (useCache && checkInCache(user, password)) {
             return;
         }
 
-        Outcome outcome = callAuthEngine(user, password, deviceId);
+        Outcome outcome = callAuthEngine(user, password, provider, factorConfig, protocolContext, deviceId);
 
         switch (outcome) {
             case SUCCESS:
@@ -66,8 +68,9 @@ public class IRopcCustomAuth extends ZimbraCustomAuth {
         }
     }
 
-    protected Outcome callAuthEngine(String user, String password, String deviceId) {
-        return IRopcAuthEngine.authenticate(user, password, deviceId);
+    protected Outcome callAuthEngine(String username, String password, String provider, String factorConfig,
+            String protocolContext, String deviceId) {
+        return IRopcAuthEngine.authenticate(username, password, provider, factorConfig, protocolContext, deviceId);
     }
 
     protected boolean checkInCache(String user, String password) {

--- a/store/src/java/com/zimbra/cs/account/auth/ropc/IROPCHandlerRegistry.java
+++ b/store/src/java/com/zimbra/cs/account/auth/ropc/IROPCHandlerRegistry.java
@@ -1,3 +1,20 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2026 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
 package com.zimbra.cs.account.auth.ropc;
 
 import com.zimbra.common.service.ServiceException;
@@ -16,31 +33,32 @@ public final class IROPCHandlerRegistry {
 
     static {
         register(new OktaRopcHandler());
-        ZimbraLog.account.info("ROPC handler registry initialized with default providers");
+        ZimbraLog.account.info("ROPC provider registry initialized with default providers");
     }
 
     public static void register(IRopcHandler handler) {
         if (handler == null) {
-            throw new IllegalArgumentException("ROPC handler must not be null");
+            throw new IllegalArgumentException("ROPC provider must not be null");
         }
         String key = handler.getName().toLowerCase();
-        IRopcHandler existing = HANDLERS.put(key, handler);
+        IRopcHandler existing = HANDLERS.putIfAbsent(key, handler);
         if (existing != null) {
-            ZimbraLog.account.warn("ROPC handler already registered for: %s", key);
+            ZimbraLog.account.warn("ROPC provider already registered for: %s, skipping duplicate", key);
+        } else {
+            ZimbraLog.account.info("ROPC provider registered: %s", key);
         }
-        ZimbraLog.account.info("ROPC handler registered: %s", key);
     }
 
     public static IRopcHandler get(String name) throws ServiceException {
         if (name == null || name.trim().isEmpty()) {
-            throw ServiceException.INVALID_REQUEST("ROPC handler type/name must not be null or empty", null);
+            throw ServiceException.INVALID_REQUEST("ROPC provider type/name must not be null or empty", null);
         }
         String key = name.toLowerCase();
         IRopcHandler handler = HANDLERS.get(key);
         if (handler == null) {
-            throw ServiceException.INVALID_REQUEST("No ROPC handler registered for type: " + name, null);
+            throw ServiceException.INVALID_REQUEST("No ROPC provider registered for type: " + name, null);
         }
-        ZimbraLog.account.debug("Resolved ROPC handler type: %s", handler.getName());
+        ZimbraLog.account.debug("Resolved ROPC provider type: %s", handler.getName());
         return handler;
     }
 }

--- a/store/src/java/com/zimbra/cs/account/auth/ropc/IRopcAuthEngine.java
+++ b/store/src/java/com/zimbra/cs/account/auth/ropc/IRopcAuthEngine.java
@@ -17,12 +17,84 @@
 
 package com.zimbra.cs.account.auth.ropc;
 
+import com.zimbra.common.util.ZimbraLog;
+import java.net.SocketTimeoutException;
+
 public final class IRopcAuthEngine {
 
     private IRopcAuthEngine() {
     }
 
-    public static Outcome authenticate(String accountName, String basicPassword, String deviceId) {
-        return Outcome.SUCCESS;
+    public static Outcome authenticate(String username,
+            String password,
+            String provider,
+            String factorConfig,
+            String protocolContext,
+            String deviceId) {
+
+        try {
+            IRopcAuthRequest.FactorType factorType;
+            try {
+                factorType = IRopcAuthRequest.FactorType.fromConfig(factorConfig);
+            } catch (IllegalArgumentException e) {
+                ZimbraLog.account.warn(
+                        "ROPC auth: unsupported factor type '%s' for user=%s",
+                        factorConfig, username);
+                ZimbraLog.account.info("Authentication outcome: ERROR for user: %s", username);
+                return Outcome.ERROR;
+            }
+
+            ZimbraLog.account.debug(
+                    "ROPC auth: resolving provider=%s for user=%s, factorType=%s",
+                    provider, username, factorType);
+
+            IRopcHandler handler = IROPCHandlerRegistry.get(provider);
+
+            IRopcAuthRequest request = new IRopcAuthRequest.Builder()
+                    .username(username)
+                    .password(password)
+                    .provider(provider)
+                    .protocolContext(protocolContext)
+                    .factorType(factorType)
+                    .build();
+
+            ZimbraLog.account.info("Invoking handler: %s for user: %s",
+                    handler.getName(), username);
+
+            Boolean result = handler.authenticate(request);
+
+            if (result == null) {
+                ZimbraLog.account.warn(
+                        "ROPC auth: handler returned null for user: %s, provider: %s",
+                        username, provider);
+                ZimbraLog.account.info("Authentication outcome: ERROR for user: %s", username);
+                return Outcome.ERROR;
+            }
+
+            Outcome outcome;
+            if (result) {
+                outcome = Outcome.SUCCESS;
+            } else {
+                outcome = Outcome.INVALID;
+            }
+
+            ZimbraLog.account.info("Authentication outcome: %s for user: %s",
+                    outcome, username);
+            return outcome;
+
+        } catch (SocketTimeoutException e) {
+            ZimbraLog.account.error(
+                    "ROPC auth timeout for user: %s, provider: %s — %s",
+                    username, provider, e.getMessage(), e);
+            ZimbraLog.account.info("Authentication outcome: TIMEOUT for user: %s", username);
+            return Outcome.MFA_TIMEOUT;
+
+        } catch (Exception e) {
+            ZimbraLog.account.error(
+                    "ROPC auth error for user: %s, provider: %s — %s",
+                    username, provider, e.getMessage(), e);
+            ZimbraLog.account.info("Authentication outcome: ERROR for user: %s", username);
+            return Outcome.ERROR;
+        }
     }
 }

--- a/store/src/java/com/zimbra/cs/account/auth/ropc/IRopcAuthRequest.java
+++ b/store/src/java/com/zimbra/cs/account/auth/ropc/IRopcAuthRequest.java
@@ -1,0 +1,137 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2026 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.account.auth.ropc;
+
+public final class IRopcAuthRequest {
+
+    private final String username;
+
+    private final String password;
+
+    private final String provider;
+
+    private final String protocolContext;
+
+    private final FactorType factorType;
+
+    private final String deviceId;
+
+    public enum FactorType {
+        NONE, PUSH;
+
+        public static FactorType fromConfig(String value) {
+            if (value == null || value.trim().isEmpty()) {
+                return NONE;
+            }
+            String normalized = value.trim().toUpperCase();
+            try {
+                return FactorType.valueOf(normalized);
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("Unsupported factor type: " + value);
+            }
+        }
+    }
+
+    private IRopcAuthRequest(Builder builder) {
+        this.username = builder.username;
+        this.password = builder.password;
+        this.provider = builder.provider;
+        this.protocolContext = builder.protocolContext;
+        this.factorType = builder.factorType;
+        this.deviceId = builder.deviceId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getProvider() {
+        return provider;
+    }
+
+    public String getProtocolContext() {
+        return protocolContext;
+    }
+
+    public FactorType getFactorType() {
+        return factorType;
+    }
+
+    public String getDeviceId() {
+        return deviceId;
+    }
+
+    public static class Builder {
+
+        private String username;
+
+        private String password;
+
+        private String provider;
+
+        private String protocolContext;
+
+        private FactorType factorType = FactorType.NONE;
+
+        private String deviceId;
+
+        public Builder username(String username) {
+            this.username = username;
+            return this;
+        }
+
+        public Builder password(String password) {
+            this.password = password;
+            return this;
+        }
+
+        public Builder provider(String provider) {
+            this.provider = provider;
+            return this;
+        }
+
+        public Builder protocolContext(String protocolContext) {
+            this.protocolContext = protocolContext;
+            return this;
+        }
+
+        public Builder factorType(FactorType factorType) {
+            this.factorType = factorType;
+            return this;
+        }
+
+        public Builder deviceId(String deviceId) {
+            this.deviceId = deviceId;
+            return this;
+        }
+
+        public IRopcAuthRequest build() {
+            if (username == null || username.trim().isEmpty() || !username.contains("@")) {
+                throw new IllegalArgumentException("username must be a valid email address");
+            }
+            if (password == null || password.trim().isEmpty()) {
+                throw new IllegalArgumentException("password must not be null or empty");
+            }
+            return new IRopcAuthRequest(this);
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/account/auth/ropc/IRopcHandler.java
+++ b/store/src/java/com/zimbra/cs/account/auth/ropc/IRopcHandler.java
@@ -1,4 +1,23 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2026 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
 package com.zimbra.cs.account.auth.ropc;
+
+import java.net.SocketTimeoutException;
 
 /**
  * Contract for all ROPC provider handlers.
@@ -17,5 +36,5 @@ public interface IRopcHandler {
      * @param request the authentication request
      * @return true if authentication is successful, false otherwise   ← this line was added
      */
-    boolean authenticate(IRopcAuthRequest request);
+    boolean authenticate(IRopcAuthRequest request) throws SocketTimeoutException;
 }

--- a/store/src/java/com/zimbra/cs/account/auth/ropc/OktaRopcHandler.java
+++ b/store/src/java/com/zimbra/cs/account/auth/ropc/OktaRopcHandler.java
@@ -1,4 +1,23 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2026 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
 package com.zimbra.cs.account.auth.ropc;
+
+import java.net.SocketTimeoutException;
 
 /**
  * ROPC handler implementation for Okta.
@@ -13,7 +32,7 @@ public class OktaRopcHandler implements IRopcHandler {
     }
 
     @Override
-    public boolean authenticate(IRopcAuthRequest request) {
+    public boolean authenticate(IRopcAuthRequest request) throws SocketTimeoutException {
         // Stub implementation for this iteration.
         return true;
     }


### PR DESCRIPTION

- Add IRopcAuthEngine with ROPC auth flow orchestration
- Add immutable IRopcAuthRequest with Builder pattern
- Add Outcome enum (SUCCESS, INVALID, ERROR, TIMEOUT)