### PR TITLE
ZCS-19497: Add IRopcCredCache with Guava cache and SSHA512 hashing for non-EAS protocol credential caching

### DIFF
--- a/store/src/java-test/com/zimbra/cs/account/auth/IRopcCredCacheTest.java
+++ b/store/src/java-test/com/zimbra/cs/account/auth/IRopcCredCacheTest.java
@@ -1,0 +1,170 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2026 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.account.auth;
+
+import com.zimbra.cs.account.AccountServiceException.AuthFailedServiceException;
+import com.zimbra.cs.account.auth.ropc.IRopcCredCache;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for IRopcCredCache focusing on composite key isolation,
+ * the IP Bridge logic for device ID changes, and MFA rejection tracking.
+ */
+public class IRopcCredCacheTest {
+
+    // --- Constants for test context ---
+    private static final String EMAIL = "user@test.com";
+
+    private static final String PASSWORD = "password123";
+
+    private static final String UA = "Outlook-iOS-Android/1.0 (com.microsoft.office.outlook/1.0.1)";
+
+    private static final String PROTOCOL = "zsync";
+
+    private static final String PROVIDER = "okta";
+
+    private static final String IP = "192.168.1.100";
+
+    private static final String DEVICE_ID = "fef5eb84";
+
+    private static final long EXPIRY = 3600000L;
+
+    @Before
+    public void setUp() {
+        // Ensure a fresh cache state for every test run
+        IRopcCredCache.clearAll();
+    }
+
+    // ========================================================
+    // 1. Basic Store and Validate
+    // ========================================================
+
+    @Test
+    public void testStoreAndValidateSuccess() {
+        IRopcCredCache.store(EMAIL, PASSWORD, UA, PROTOCOL, PROVIDER, IP, DEVICE_ID, EXPIRY);
+        assertTrue("Cache should return true for valid credentials and context",
+                IRopcCredCache.isValid(EMAIL, PASSWORD, UA, PROTOCOL, PROVIDER, IP, DEVICE_ID));
+    }
+
+    @Test
+    public void testWrongPasswordReturnsFalse() {
+        IRopcCredCache.store(EMAIL, PASSWORD, UA, PROTOCOL, PROVIDER, IP, DEVICE_ID, EXPIRY);
+        assertFalse("Cache should return false for incorrect password",
+                IRopcCredCache.isValid(EMAIL, "wrongPass", UA, PROTOCOL, PROVIDER, IP, DEVICE_ID));
+    }
+
+    // ========================================================
+    // 2. Key Isolation (UA HashCode & Context)
+    // ========================================================
+
+    @Test
+    public void testDifferentUserAgentDoesNotMatch() {
+        IRopcCredCache.store(EMAIL, PASSWORD, "Outlook-UA", PROTOCOL, PROVIDER, IP, DEVICE_ID, EXPIRY);
+        // Different UA should result in a different hashCode and a cache miss
+        assertFalse(IRopcCredCache.isValid(EMAIL, PASSWORD, "Gmail-UA", PROTOCOL, PROVIDER, IP, DEVICE_ID));
+    }
+
+    @Test
+    public void testEmailNormalization() {
+        IRopcCredCache.store("  User@Test.Com  ", PASSWORD, UA, PROTOCOL, PROVIDER, IP, DEVICE_ID, EXPIRY);
+        assertTrue("Cache should handle email trimming and case-insensitivity",
+                IRopcCredCache.isValid("user@test.com", PASSWORD, UA, PROTOCOL, PROVIDER, IP, DEVICE_ID));
+    }
+
+    // ========================================================
+    // 3. IP Bridge Logic (Scenario A: Missing Device ID)
+    // ========================================================
+
+    @Test
+    public void testIpBridgeAndRealDeviceId() {
+        // Step 1: App connects with no Device ID (e.g. Native iOS OPTIONS)
+        IRopcCredCache.store(EMAIL, PASSWORD, UA, PROTOCOL, PROVIDER, IP, null, EXPIRY);
+
+        // Step 2: App connects with real Device ID. System should bridge via IP.
+        assertTrue("System should bridge the session using the IP address",
+                IRopcCredCache.isValid(EMAIL, PASSWORD, UA, PROTOCOL, PROVIDER, IP, "real-device-id-123"));
+    }
+
+    // ========================================================
+    // 4. IP Bridge Logic (Scenario B: Changing Device ID)
+    // ========================================================
+
+    @Test
+    public void testIpBridgeOutlookDeviceIdChange() {
+        // Step 1: Outlook sends temporary ID (OPCC...)
+        IRopcCredCache.store(EMAIL, PASSWORD, UA, PROTOCOL, PROVIDER, IP, "OPCC-TEMP-ID", EXPIRY);
+
+        // Step 2: Outlook sends permanent ID (fef5...). System bridges via IP.
+        assertTrue("System should bridge the session when Outlook changes Device ID",
+                IRopcCredCache.isValid(EMAIL, PASSWORD, UA, PROTOCOL, PROVIDER, IP, "fef5-perm-id"));
+    }
+
+    @Test
+    public void testIpBridgeRemovedAfterUpgrade() {
+        IRopcCredCache.store(EMAIL, PASSWORD, UA, PROTOCOL, PROVIDER, IP, "OPCC-TEMP-ID", EXPIRY);
+
+        // First upgrade works
+        assertTrue(IRopcCredCache.isValid(EMAIL, PASSWORD, UA, PROTOCOL, PROVIDER, IP, "fef5-perm-id"));
+
+        // The IP bridge should be deleted after one use. A third ID should fail.
+        assertFalse("IP bridge should be removed after a successful upgrade",
+                IRopcCredCache.isValid(EMAIL, PASSWORD, UA, PROTOCOL, PROVIDER, IP, "third-device-id"));
+    }
+
+    // ========================================================
+    // 5. Rejection Tracking (Anti-Flood)
+    // ========================================================
+
+    @Test(expected = AuthFailedServiceException.class)
+    public void testThirdRejectionBlocksRequest() throws Exception {
+        IRopcCredCache.storeRejection(EMAIL, UA, PROTOCOL, PROVIDER, IP, DEVICE_ID);
+        IRopcCredCache.storeRejection(EMAIL, UA, PROTOCOL, PROVIDER, IP, DEVICE_ID);
+        IRopcCredCache.storeRejection(EMAIL, UA, PROTOCOL, PROVIDER, IP, DEVICE_ID);
+
+        // Should throw AuthFailedServiceException due to limit reached
+        IRopcCredCache.checkRejectionLimit(EMAIL, UA, PROTOCOL, PROVIDER, IP, DEVICE_ID);
+    }
+
+    @Test
+    public void testSuccessfulLoginResetsRejections() throws Exception {
+        IRopcCredCache.storeRejection(EMAIL, UA, PROTOCOL, PROVIDER, IP, DEVICE_ID);
+        IRopcCredCache.storeRejection(EMAIL, UA, PROTOCOL, PROVIDER, IP, DEVICE_ID);
+
+        // Successful login resets the counter
+        IRopcCredCache.store(EMAIL, PASSWORD, UA, PROTOCOL, PROVIDER, IP, DEVICE_ID, EXPIRY);
+
+        // Should not throw
+        IRopcCredCache.checkRejectionLimit(EMAIL, UA, PROTOCOL, PROVIDER, IP, DEVICE_ID);
+    }
+
+    // ========================================================
+    // 6. Invalidation
+    // ========================================================
+
+    @Test
+    public void testInvalidateRemovesSession() {
+        IRopcCredCache.store(EMAIL, PASSWORD, UA, PROTOCOL, PROVIDER, IP, DEVICE_ID, EXPIRY);
+        IRopcCredCache.invalidate(EMAIL, UA, PROTOCOL, PROVIDER, IP, DEVICE_ID);
+
+        assertFalse("Session should be removed after invalidation",
+                IRopcCredCache.isValid(EMAIL, PASSWORD, UA, PROTOCOL, PROVIDER, IP, DEVICE_ID));
+    }
+}

--- a/store/src/java-test/com/zimbra/cs/account/auth/IRopcCustomAuthTest.java
+++ b/store/src/java-test/com/zimbra/cs/account/auth/IRopcCustomAuthTest.java
@@ -21,6 +21,7 @@ import com.zimbra.common.account.Key;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.AccountServiceException;
 import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.auth.ropc.IRopcCredCache;
 import com.zimbra.cs.account.auth.ropc.Outcome;
 import com.zimbra.cs.mailbox.MailboxTestUtil;
 import java.util.ArrayList;
@@ -29,7 +30,9 @@ import java.util.List;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
+import static com.zimbra.cs.account.auth.AuthContext.AC_DEVICE_ID;
 import static com.zimbra.cs.account.auth.AuthContext.AC_ORIGINATING_CLIENT_IP;
+import static com.zimbra.cs.account.auth.AuthContext.AC_PROTOCOL;
 import static com.zimbra.cs.account.auth.AuthContext.AC_USER_AGENT;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -45,6 +48,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 public class IRopcCustomAuthTest {
+
     private IRopcCustomAuth ropcCustomAuth;
 
     private Account mockAccount;
@@ -60,12 +64,23 @@ public class IRopcCustomAuthTest {
         IRopcCustomAuth target = new IRopcCustomAuth();
         ropcCustomAuth = spy(target);
         MailboxTestUtil.initProvisioning();
-        Provisioning.getInstance().createAccount("user1@example.zimbra.com", "password",
-                new HashMap<String, Object>());
-        mockAccount = Provisioning.getInstance().get(Key.AccountBy.name, "user1@example.zimbra.com");
+        IRopcCredCache.clearAll();
+
+        Provisioning prov = Provisioning.getInstance();
+
+        // Create domain FIRST with zimbraAuthMech — shouldSkipEasPassCache reads from domain
+        HashMap<String, Object> domainAttrs = new HashMap<>();
+        domainAttrs.put(Provisioning.A_zimbraAuthMech, "custom:idp-ropc");
+        prov.createDomain("example.zimbra.com", domainAttrs);
+
+        // Create account in that domain
+        HashMap<String, Object> attrs = new HashMap<>();
+        prov.createAccount("user1@example.zimbra.com", "password", attrs);
+        mockAccount = prov.get(Key.AccountBy.name, "user1@example.zimbra.com");
+
         mockContext = new HashMap<String, Object>();
-        mockContext.put("did", "device-123");
-        mockContext.put("proto", AuthContext.Protocol.zsync);
+        mockContext.put(AC_DEVICE_ID, "device-123");
+        mockContext.put(AC_PROTOCOL, AuthContext.Protocol.zsync);
         mockContext.put(AC_ORIGINATING_CLIENT_IP, "1234425");
         mockContext.put(AC_USER_AGENT, "userAgent");
 
@@ -87,14 +102,13 @@ public class IRopcCustomAuthTest {
     @Test
     public void testAuthenticateValidCallDoesnotThrowException() {
         doReturn(Outcome.SUCCESS).when(ropcCustomAuth)
-                .callAuthEngine(anyString(), anyString(), anyString(), any(), anyString(),
-                        anyString(), anyMapOf(String.class, String.class));
+                .callAuthEngine(anyString(), anyString(), anyString(), any(), anyString(), anyString(),
+                        anyMapOf(String.class, String.class));
         try {
             ropcCustomAuth.authenticate(mockAccount, "password", mockContext, args);
         } catch (Exception e) {
-            fail("Auth should not throw a exception");
+            fail("Auth should not throw a exception: " + e.getMessage());
         }
-
     }
 
     @Test
@@ -105,19 +119,20 @@ public class IRopcCustomAuthTest {
     @Test
     public void testAuthenticateOutcomeSuccess() throws Exception {
         doReturn(Outcome.SUCCESS).when(ropcCustomAuth)
-                .callAuthEngine(anyString(), anyString(), anyString(), any(), anyString(),
-                anyString(), anyMapOf(String.class, String.class));
+                .callAuthEngine(anyString(), anyString(), anyString(), any(), anyString(), anyString(),
+                        anyMapOf(String.class, String.class));
+
         ropcCustomAuth.authenticate(mockAccount, "password", mockContext, args);
-        verify(ropcCustomAuth, times(1))
-                .callAuthEngine("user1@example.zimbra.com", "password", "device-123",
-                        AuthContext.Protocol.zsync, "userAgent", "1234425", validConfig);
+
+        verify(ropcCustomAuth, times(1)).callAuthEngine("user1@example.zimbra.com", "password", "device-123",
+                AuthContext.Protocol.zsync, "userAgent", "1234425", validConfig);
     }
 
     @Test
     public void testAuthenticateOutcomeInvalid() throws Exception {
         doReturn(Outcome.INVALID).when(ropcCustomAuth)
-                .callAuthEngine(anyString(), anyString(), anyString(), any(), anyString(),
-                        anyString(), anyMapOf(String.class, String.class));
+                .callAuthEngine(anyString(), anyString(), anyString(), any(), anyString(), anyString(),
+                        anyMapOf(String.class, String.class));
         try {
             ropcCustomAuth.authenticate(mockAccount, "password", mockContext, args);
             fail("Expected AuthFailedServiceException was not thrown");
@@ -130,8 +145,8 @@ public class IRopcCustomAuthTest {
     @Test
     public void testAuthenticateOutcomePolicyDenied() throws Exception {
         doReturn(Outcome.POLICY_DENIED).when(ropcCustomAuth)
-                .callAuthEngine(anyString(), anyString(), anyString(), any(), anyString(),
-                        anyString(), anyMapOf(String.class, String.class));
+                .callAuthEngine(anyString(), anyString(), anyString(), any(), anyString(), anyString(),
+                        anyMapOf(String.class, String.class));
         try {
             ropcCustomAuth.authenticate(mockAccount, "password", mockContext, args);
             fail("Expected AuthFailedServiceException was not thrown");
@@ -144,8 +159,8 @@ public class IRopcCustomAuthTest {
     @Test
     public void testAuthenticateOutcomeMFATimeout() throws Exception {
         doReturn(Outcome.MFA_TIMEOUT).when(ropcCustomAuth)
-                .callAuthEngine(anyString(), anyString(), anyString(), any(), anyString(),
-                        anyString(), anyMapOf(String.class, String.class));
+                .callAuthEngine(anyString(), anyString(), anyString(), any(), anyString(), anyString(),
+                        anyMapOf(String.class, String.class));
         try {
             ropcCustomAuth.authenticate(mockAccount, "password", mockContext, args);
             fail("Expected AuthFailedServiceException was not thrown");
@@ -157,24 +172,35 @@ public class IRopcCustomAuthTest {
 
     @Test
     public void testAuthenticateCacheHitSkipEngineCall() throws Exception {
-        doReturn(true).when(ropcCustomAuth).checkInCache(anyString(), anyString());
-        mockContext.put("proto", AuthContext.Protocol.soap);
+        // Updated to match the new 7-parameter signature of checkInCache
+        doReturn(true).when(ropcCustomAuth)
+                .checkInCache(anyString(), anyString(), anyString(), any(), anyString(), anyString(),
+                        anyString());
+
+        mockContext.put(AC_PROTOCOL, AuthContext.Protocol.soap);
+
         ropcCustomAuth.authenticate(mockAccount, "password", mockContext, args);
-        verify(ropcCustomAuth, never())
-                .callAuthEngine(anyString(), anyString(), anyString(), any(), anyString(),
-                        anyString(), anyMapOf(String.class, String.class));
+
+        verify(ropcCustomAuth, never()).callAuthEngine(anyString(), anyString(), anyString(), any(), anyString(),
+                anyString(), anyMapOf(String.class, String.class));
     }
 
     @Test
-    public void testAuthenticateZsyncProtocolByPassCacheCheck() throws Exception {
-        mockContext.put(AuthContext.AC_PROTOCOL, AuthContext.Protocol.zsync);
-        doReturn(true).when(ropcCustomAuth).checkInCache(anyString(), anyString());
+    public void testAuthenticateZsyncProtocolCacheCheck() throws Exception {
+        mockContext.put(AC_PROTOCOL, AuthContext.Protocol.zsync);
+
+        // Mock a cache miss to ensure engine is called
+        doReturn(false).when(ropcCustomAuth)
+                .checkInCache(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(),
+                        anyString());
+
         doReturn(Outcome.SUCCESS).when(ropcCustomAuth)
-                .callAuthEngine(anyString(), anyString(), anyString(), any(), anyString(),
-                        anyString(), anyMapOf(String.class, String.class));
+                .callAuthEngine(anyString(), anyString(), anyString(), any(), anyString(), anyString(),
+                        anyMapOf(String.class, String.class));
+
         ropcCustomAuth.authenticate(mockAccount, "password", mockContext, args);
-        verify(ropcCustomAuth, times(1))
-                .callAuthEngine("user1@example.zimbra.com", "password", "device-123",
-                        AuthContext.Protocol.zsync, "userAgent", "1234425", validConfig);
+
+        verify(ropcCustomAuth, times(1)).callAuthEngine("user1@example.zimbra.com", "password", "device-123",
+                AuthContext.Protocol.zsync, "userAgent", "1234425", validConfig);
     }
 }

--- a/store/src/java/com/zimbra/cs/account/auth/IRopcCustomAuth.java
+++ b/store/src/java/com/zimbra/cs/account/auth/IRopcCustomAuth.java
@@ -21,8 +21,12 @@ import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.AccountServiceException.AuthFailedServiceException;
+import com.zimbra.cs.account.Domain;
+import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.auth.AuthContext.Protocol;
 import com.zimbra.cs.account.auth.ropc.IRopcAuthEngine;
+import com.zimbra.cs.account.auth.ropc.IRopcConstants;
+import com.zimbra.cs.account.auth.ropc.IRopcCredCache;
 import com.zimbra.cs.account.auth.ropc.Outcome;
 import com.zimbra.cs.account.auth.ropc.util.IRopcUtil;
 import java.util.List;
@@ -46,12 +50,20 @@ public class IRopcCustomAuth extends ZimbraCustomAuth {
         String userAgent = (String) context.get(AuthContext.AC_USER_AGENT);
         String ipAddress = (String) context.get(AuthContext.AC_ORIGINATING_CLIENT_IP);
         Map<String, String> configs = IRopcUtil.extractConfigsFromArgs(args);
+        //Extract configs to get the 'provider' for the composite cache key
+        String provider = configs.get(IRopcConstants.PROVIDER);
+        String protocolStr = (proto != null) ? proto.name() : null;
 
-        // protocol-aware caching — SKIP for zsync.
-        boolean useCache = (proto != Protocol.zsync);
-        if (useCache && checkInCache(user, password)) {
+        ZimbraLog.account.info("IRopcCustomAuth: auth request for %s "
+                        + "[protocol=%s, ua=%s, deviceId=%s, ip=%s, provider=%s]",
+                user, protocolStr, userAgent, deviceId, ipAddress, provider);
+
+        // Implementation of the cache check using composite keys
+        if (checkInCache(user, password, userAgent, protocolStr, provider, ipAddress, deviceId)) {
+            ZimbraLog.account.info("IRopcCustomAuth: cache hit for %s [protocol=%s]", user, protocolStr);
             return;
         }
+        IRopcCredCache.checkRejectionLimit(user, userAgent, protocolStr, provider, ipAddress, deviceId);
 
         Outcome outcome = callAuthEngine(user, password, deviceId, proto, userAgent, ipAddress, configs);
 
@@ -59,6 +71,7 @@ public class IRopcCustomAuth extends ZimbraCustomAuth {
             case SUCCESS:
                 break;
             case REJECTED:
+                IRopcCredCache.storeRejection(user, userAgent, protocolStr, provider, ipAddress, deviceId);
                 throw AuthFailedServiceException.AUTH_FAILED(user,
                         "Authentication failed : Challenge denied by user");
             case INVALID:
@@ -74,10 +87,11 @@ public class IRopcCustomAuth extends ZimbraCustomAuth {
             default:
                 throw ServiceException.FAILURE("Authentication service temporarily unavailable.", null);
         }
+        long expires_in = 3600000L;
 
-        if (useCache) {
-            // TODO : logic to store password in cache
-        }
+        IRopcCredCache.store(user, password, userAgent, protocolStr, provider, ipAddress, deviceId, expires_in);
+        ZimbraLog.account.info("IRopcCustomAuth: IdP auth successful for %s [protocol=%s]", user, protocolStr);
+
     }
 
     protected Outcome callAuthEngine(String userName, String password, String deviceId, Protocol protocol,
@@ -85,8 +99,9 @@ public class IRopcCustomAuth extends ZimbraCustomAuth {
         return IRopcAuthEngine.authenticate(userName, password, deviceId, protocol, userAgent, ip, configs);
     }
 
-    protected boolean checkInCache(String user, String password) {
-        return false;
+    protected boolean checkInCache(String user, String password, String ua, String proto,
+            String prov, String ip, String did) {
+        return IRopcCredCache.isValid(user, password, ua, proto, prov, ip, did);
     }
 
     @Override
@@ -112,5 +127,21 @@ public class IRopcCustomAuth extends ZimbraCustomAuth {
             ZimbraLog.account.warn("Failure while checking the protocol isSupported.", e);
             return false;
         }
+    }
+
+    public static boolean shouldSkipEasPassCache(Account account) {
+        try {
+            Provisioning prov = Provisioning.getInstance();
+            Domain domain = prov.getDomain(account);
+            if (domain != null) {
+                String authMech = domain.getAuthMech();
+                if (authMech != null && authMech.contains(EXTENSION_NAME)) {
+                    return true;
+                }
+            }
+        } catch (Exception e) {
+            ZimbraLog.account.warn("IRopcCustomAuth: failed to check authMech for %s", account.getName(), e);
+        }
+        return false;
     }
 }

--- a/store/src/java/com/zimbra/cs/account/auth/ropc/IRopcConstants.java
+++ b/store/src/java/com/zimbra/cs/account/auth/ropc/IRopcConstants.java
@@ -124,4 +124,6 @@ public final class IRopcConstants {
 
     public static final long CONVERT_TO_MILLI = 1000L;
 
+    public static final long TTL_MS = 3600000L;
+
 }

--- a/store/src/java/com/zimbra/cs/account/auth/ropc/IRopcCredCache.java
+++ b/store/src/java/com/zimbra/cs/account/auth/ropc/IRopcCredCache.java
@@ -1,0 +1,335 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2026 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.account.auth.ropc;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.AccountServiceException.AuthFailedServiceException;
+import com.zimbra.cs.account.auth.PasswordUtil.SSHA512;
+import java.util.concurrent.TimeUnit;
+
+import static com.zimbra.cs.account.auth.ropc.IRopcConstants.TTL_MS;
+
+/**
+ * protocol-aware credential cache for IdP ROPC (MFA) authentication.
+ *
+ * <h3>design:</h3>
+ * <p>Uses two caches: one for credentials, one for rejection tracking.</p>
+ * <ul>
+ *   <li><b>CRED_CACHE:</b> Stores {@link CacheEntry} (SSHA512 hash + per-entry expiry
+ *       timestamp) keyed by device or IP context. No size limit — bounded naturally by
+ *       TTL expiry. Guava TTL acts as a safety net; real expiry is driven by Okta's
+ *       {@code expires_in} stored per entry.</li>
+ *   <li><b>REJECTION_CACHE:</b> Tracks push rejection counts per device/IP context.
+ *       Separate from credentials for type safety and isolation.</li>
+ * </ul>
+ *
+ * <h3>Key format:</h3>
+ * <ul>
+ *   <li>With deviceId:    email|uaHash|protocol|provider|deviceId</li>
+ *   <li>Without deviceId: email|uaHash|protocol|provider|ip (IP key)</li>
+ * </ul>
+ *
+ * <h3>behaviors:</h3>
+ * <ul>
+ *   <li><b>IP-to-Device Upgrade:</b> Handles the transition from IP-only
+ *       requests (like OPTIONS) to DeviceId-based requests (like SYNC).</li>
+ *   <li><b>Single Device Logout:</b> Invalidation is context-aware.</li>
+ *   <li><b>Anti-Flood:</b> Tracks push rejections in a separate REJECTION_CACHE.</li>
+ *   <li><b>Per-entry expiry:</b> Each entry respects Okta's {@code expires_in}.
+ *       Expired entries are invalidated immediately on access.</li>
+ * </ul>
+ */
+public final class IRopcCredCache {
+
+    private static final int MAX_REJECTION_COUNT = 3;
+
+    private static final int REJECTION_MAX_SIZE = 5000;
+
+    /**
+     * credential cache: device key or IP key to {@link CacheEntry}.
+     * Guava TTL is a safety net only; real expiry is per-entry via
+     * {@link CacheEntry#isExpired()}.
+     */
+    private static final Cache<String, CacheEntry> CRED_CACHE = CacheBuilder.newBuilder()
+            .expireAfterWrite(TTL_MS, TimeUnit.MILLISECONDS)
+            .build();
+
+    /**
+     * rejection counter cache: device/IP key to rejection count.
+     * Separate from credentials for type safety.
+     * Resets on successful Okta auth via store().
+     */
+    private static final Cache<String, Integer> REJECTION_CACHE = CacheBuilder.newBuilder()
+            .maximumSize(REJECTION_MAX_SIZE)
+            .expireAfterWrite(TTL_MS, TimeUnit.MILLISECONDS)
+            .build();
+
+    private IRopcCredCache() {
+    }
+
+    /**
+     * holds a salted password hash and its per-entry expiry timestamp.
+     * expiry is derived from Okta's {@code expires_in} (seconds) at the time of store.
+     * falls back to {@code TTL_MS} if {@code expires_in} is not provided.
+     */
+    private static final class CacheEntry {
+
+        final String hash;
+
+        /**
+         * absolute wall-clock timestamp (ms) after which this entry is considered expired.
+         * computed as: System.currentTimeMillis() + (expiresInSeconds * 1000)
+         */
+        final long expiryTimestamp;
+
+        CacheEntry(String hash, long expiresInSeconds) {
+            this.hash = hash;
+            this.expiryTimestamp = System.currentTimeMillis() + (expiresInSeconds * 1000);
+        }
+
+        boolean isExpired() {
+            return System.currentTimeMillis() > expiryTimestamp;
+        }
+    }
+
+    /**
+     * stores the successful credential in the cache and resets rejection counts.
+     *
+     * @param email            the user's email address
+     * @param password         the user's password
+     * @param userAgent        the client's user agent string
+     * @param protocol         the protocol being used
+     * @param provider         the authentication provider
+     * @param ip               the originating client IP address
+     * @param deviceId         the unique device identifier
+     * @param expiresInSeconds token lifetime from Okta's expires_in (0 = use TTL_MS)
+     */
+    public static void store(String email, String password, String userAgent,
+            String protocol, String provider, String ip, String deviceId,
+            long expiresInSeconds) {
+        if (email == null || password == null) {
+            return;
+        }
+
+        long ttl = (expiresInSeconds > 0)
+                ? expiresInSeconds
+                : TimeUnit.MILLISECONDS.toSeconds(TTL_MS);
+
+        String effectivePassword = getEffectivePassword(password);
+        String key = buildKey(email, userAgent, protocol, provider, ip, deviceId);
+
+        // store the successful credential
+        String saltedHash = SSHA512.generateSSHA512(effectivePassword, null);
+        CacheEntry entry = new CacheEntry(saltedHash, ttl);
+        CRED_CACHE.put(key, entry);
+
+        // store IP key when deviceId is present
+        if (isNotEmpty(deviceId) && isNotEmpty(ip)) {
+            String ipKey = buildKey(email, userAgent, protocol, provider, ip, null);
+            CRED_CACHE.put(ipKey, entry);
+        }
+
+        // Reset rejection count on successful Okta auth
+        REJECTION_CACHE.invalidate(key);
+        if (isNotEmpty(ip)) {
+            String ipKey = buildKey(email, userAgent, protocol, provider, ip, null);
+            REJECTION_CACHE.invalidate(ipKey);
+        }
+
+        ZimbraLog.account.debug(
+                "IRopcCredCache: stored credential for %s, expires in %ds",
+                email, ttl);
+    }
+
+    /**
+     * validates the password against the cache. Handles IP-to-Device upgrades.
+     * expired entries are invalidated immediately on access.
+     *
+     * @param email     the user's email address
+     * @param password  the user's password
+     * @param userAgent the client's user agent string
+     * @param protocol  the protocol being used
+     * @param provider  the authentication provider
+     * @param ip        the originating client IP address
+     * @param deviceId  the unique device identifier
+     * @return true if the cached credential matches and is not expired, false otherwise
+     */
+    public static boolean isValid(String email, String password, String userAgent,
+            String protocol, String provider, String ip, String deviceId) {
+        if (email == null || password == null) {
+            return false;
+        }
+        String effectivePassword = getEffectivePassword(password);
+        String deviceKey = buildKey(email, userAgent, protocol, provider, ip, deviceId);
+
+        // 1. Direct hit — device key (Outlook) or IP key (native)
+        CacheEntry entry = CRED_CACHE.getIfPresent(deviceKey);
+        if (isMatch(entry, deviceKey, effectivePassword)) {
+            ZimbraLog.account.debug("IRopcCredCache: direct cache hit for %s", email);
+            return true;
+        }
+
+        // 2. IP bridge fallback — upgrade to device key (OPCC to real deviceId)
+        if (isNotEmpty(deviceId) && isNotEmpty(ip)) {
+            String ipKey = buildKey(email, userAgent, protocol, provider, ip, null);
+            CacheEntry ipEntry = CRED_CACHE.getIfPresent(ipKey);
+
+            if (isMatch(ipEntry, ipKey, effectivePassword)) {
+                CRED_CACHE.put(deviceKey, ipEntry);
+                CRED_CACHE.invalidate(ipKey);
+                ZimbraLog.account.debug(
+                        "IRopcCredCache: upgraded IP-based cache to DeviceId for %s", email);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * invalidates the cache for a specific device context (Logout).
+     *
+     * @param email     the user's email address
+     * @param userAgent the client's user agent string
+     * @param protocol  the protocol being used
+     * @param provider  the authentication provider
+     * @param ip        the originating client IP address
+     * @param deviceId  the unique device identifier
+     */
+    public static void invalidate(String email, String userAgent, String protocol,
+            String provider, String ip, String deviceId) {
+        if (email == null) {
+            return;
+        }
+        String key = buildKey(email, userAgent, protocol, provider, ip, deviceId);
+        CRED_CACHE.invalidate(key);
+        REJECTION_CACHE.invalidate(key);
+
+        // Also remove the IP bridge entry to prevent fallback after invalidation
+        if (isNotEmpty(ip)) {
+            String ipBridgeKey = buildKey(email, userAgent, protocol, provider, ip, null);
+            CRED_CACHE.invalidate(ipBridgeKey);
+            REJECTION_CACHE.invalidate(ipBridgeKey);
+        }
+
+        ZimbraLog.account.info(
+                "IRopcCredCache: invalidated session and rejection blocks for %s", email);
+    }
+
+    /**
+     * records a push rejection for this context.
+     *
+     * @param email     the user's email address
+     * @param userAgent the client's user agent string
+     * @param protocol  the protocol being used
+     * @param provider  the authentication provider
+     * @param ip        the originating client IP address
+     * @param deviceId  the unique device identifier
+     */
+    public static void storeRejection(String email, String userAgent, String protocol,
+            String provider, String ip, String deviceId) {
+        if (email == null) {
+            return;
+        }
+        String key = buildKey(email, userAgent, protocol, provider, ip, deviceId);
+        Integer val = REJECTION_CACHE.getIfPresent(key);
+        int count = (val == null) ? 1 : val + 1;
+        REJECTION_CACHE.put(key, count);
+        ZimbraLog.account.info(
+                "IRopcCredCache: recorded push rejection #%d for %s", count, email);
+    }
+
+    /**
+     * checks if the user has exceeded the rejection limit.
+     *
+     * @param email     the user's email address
+     * @param userAgent the client's user agent string
+     * @param protocol  the protocol being used
+     * @param provider  the authentication provider
+     * @param ip        the originating client IP address
+     * @param deviceId  the unique device identifier
+     * @throws AuthFailedServiceException if the rejection limit is reached
+     */
+    public static void checkRejectionLimit(String email, String userAgent, String protocol,
+            String provider, String ip, String deviceId) throws AuthFailedServiceException {
+        if (email == null) {
+            return;
+        }
+        String key = buildKey(email, userAgent, protocol, provider, ip, deviceId);
+        Integer count = REJECTION_CACHE.getIfPresent(key);
+        if (count != null && count >= MAX_REJECTION_COUNT) {
+            ZimbraLog.account.warn(
+                    "IRopcCredCache: auth blocked for %s;"
+                            + " push rejection limit reached (%d)", email, count);
+            throw AuthFailedServiceException.AUTH_FAILED(
+                    email, "MFA push rejection limit reached");
+        }
+    }
+
+    /**
+     * clears all caches. Used for testing only.
+     */
+    public static void clearAll() {
+        CRED_CACHE.invalidateAll();
+        REJECTION_CACHE.invalidateAll();
+    }
+
+    // Internal Helpers
+
+    private static String getEffectivePassword(String passwordField) {
+        return passwordField; // Future: strip TOTP here
+    }
+
+    /**
+     * validates entry against password. Immediately invalidates expired entries.
+     */
+    private static boolean isMatch(CacheEntry entry, String key, String password) {
+        if (entry == null) {
+            return false;
+        }
+        if (entry.isExpired()) {
+            CRED_CACHE.invalidate(key); // remove immediately, don't wait for safety net
+            return false;
+        }
+        try {
+            return SSHA512.verifySSHA512(entry.hash, password);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static String buildKey(String email, String ua, String proto,
+            String prov, String ip, String did) {
+        String normEmail = (email != null) ? email.trim().toLowerCase() : "unknown";
+        StringBuilder sb = new StringBuilder(normEmail);
+        sb.append('|').append(ua != null ? ua.hashCode() : "");
+        sb.append('|').append(proto != null ? proto : "");
+        sb.append('|').append(prov != null ? prov : "");
+        if (isNotEmpty(did)) {
+            sb.append('|').append(did);
+        } else {
+            sb.append('|').append(ip != null ? ip : "");
+        }
+        return sb.toString();
+    }
+
+    private static boolean isNotEmpty(String s) {
+        return s != null && !s.trim().isEmpty();
+    }
+}


### PR DESCRIPTION
ZCS-19497: Add Guava credential cache for IRopc non-EAS protocols

- Introduced IRopcCredCache with SSHA512 hashing (aligned with EAS PassCache)
- TTL: 1hr, max size: 10000, configurable via named constants
- Integrated cache lookup and store in IRopcCustomAuth
- Cache skipped for zsync protocol (EAS uses its own PassCache)