### PR TITLE
ZBUG-5421 : prevented malicious mail attachment

### DIFF
--- a/store/src/java-test/com/zimbra/cs/html/DefangFactoryTest.java
+++ b/store/src/java-test/com/zimbra/cs/html/DefangFactoryTest.java
@@ -1,0 +1,123 @@
+
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2026 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.html;
+
+import org.junit.Test;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test class for DefangFactory.isDefangXmlContentType method.
+ * This test specifically verifies that the method correctly identifies
+ * application/mathml+xml and application/rdf+xml as defang XML content types,
+ * which is used in NativeFormatter.handleMessagePart method.
+ */
+public class DefangFactoryTest {
+
+    @Test
+    public void testDefangXmlContentTypeMathMl() {
+        // Test the specific content type mentioned in the requirement
+        assertTrue("application/mathml+xml should be recognized as defang XML content type",
+                DefangFactory.isDefangXmlContentType("application/mathml+xml"));
+    }
+
+    @Test
+    public void testDefangXmlContentTypeRdf() {
+        // Test the specific content type mentioned in the requirement
+        assertTrue("application/rdf+xml should be recognized as defang XML content type",
+                DefangFactory.isDefangXmlContentType("application/rdf+xml"));
+    }
+
+    @Test
+    public void testAllDefaultDefangXmlContentTypes() {
+        // Test all content types from LC.DEFANG_XML_CONTENT_TYPES default value
+        String[] defangXmlTypes = {
+                "application/rss+xml",
+                "application/atom+xml",
+                "application/svg+xml",
+                "application/mathml+xml",
+                "application/xhtml+xml",
+                "application/xslt+xml",
+                "application/xsd+xml",
+                "application/gml+xml",
+                "application/rdf+xml"
+        };
+
+        for (String contentType : defangXmlTypes) {
+            assertTrue(contentType + " should be recognized as defang XML content type",
+                    DefangFactory.isDefangXmlContentType(contentType));
+        }
+    }
+
+    @Test
+    public void testNonDefangXmlContentTypes() {
+        // Test content types that should NOT be recognized as defang XML
+        String[] nonDefangTypes = {
+                "text/plain",
+                "text/html",
+                "text/xml",  // Note: text/xml is handled separately, not through defang XML types
+                "application/pdf",
+                "image/jpeg",
+                "image/png",
+                "application/octet-stream",
+                "application/json",
+                "application/javascript"
+        };
+
+        for (String contentType : nonDefangTypes) {
+            assertFalse(contentType + " should NOT be recognized as defang XML content type",
+                    DefangFactory.isDefangXmlContentType(contentType));
+        }
+    }
+
+    @Test
+    public void testCaseSensitivityDefangXmlContentType() {
+        // Test that the method is case sensitive (as it should be)
+        assertTrue("application/mathml+xml should be recognized",
+                DefangFactory.isDefangXmlContentType("application/mathml+xml"));
+
+        // These should fail if the method is case sensitive
+        assertFalse("APPLICATION/mathml+xml should NOT be recognized (wrong case)",
+                DefangFactory.isDefangXmlContentType("APPLICATION/mathml+xml"));
+        assertFalse("Application/MathMl+xml should NOT be recognized (wrong case)",
+                DefangFactory.isDefangXmlContentType("Application/MathMl+xml"));
+    }
+
+    @Test
+    public void testNullAndEmptyDefangXmlContentType() {
+        // Test edge cases
+        assertFalse("Null content type should not be recognized",
+                DefangFactory.isDefangXmlContentType(null));
+        assertFalse("Empty content type should not be recognized",
+                DefangFactory.isDefangXmlContentType(""));
+        assertFalse("Whitespace content type should not be recognized",
+                DefangFactory.isDefangXmlContentType("   "));
+    }
+
+    @Test
+    public void testPartialMatchesForDefangXmlContentType() {
+        // Test that partial matches don't work
+        assertFalse("Partial match should not work",
+                DefangFactory.isDefangXmlContentType("mathml+xml"));
+        assertFalse("Partial match should not work",
+                DefangFactory.isDefangXmlContentType("application/mathml"));
+        assertFalse("Extra content should not match",
+                DefangFactory.isDefangXmlContentType("application/mathml+xml; charset=utf-8"));
+    }
+}

--- a/store/src/java-test/com/zimbra/cs/html/package-info.java
+++ b/store/src/java-test/com/zimbra/cs/html/package-info.java
@@ -1,0 +1,22 @@
+
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2026 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+/**
+ * Test package for HTML processing utilities.
+ */
+package com.zimbra.cs.html;

--- a/store/src/java/com/zimbra/cs/service/formatter/NativeFormatter.java
+++ b/store/src/java/com/zimbra/cs/service/formatter/NativeFormatter.java
@@ -216,11 +216,15 @@ public final class NativeFormatter extends Formatter {
 
             if (contentType == null) {
                 contentType = MimeConstants.CT_TEXT_PLAIN;
+            } else if (DefangFactory.isDefangXmlContentType(shortContentType)) {
+                contentType = MimeConstants.CT_APPLICATION_OCTET_STREAM;
             } else if (shortContentType.equalsIgnoreCase(MimeConstants.CT_APPLICATION_OCTET_STREAM)) {
-                if ((contentType = MimeDetect.getMimeDetect().detect(Mime.getFilename(mp), mp.getInputStream())) == null)
+                if ((contentType = MimeDetect.getMimeDetect()
+                        .detect(Mime.getFilename(mp), mp.getInputStream())) == null) {
                     contentType = MimeConstants.CT_APPLICATION_OCTET_STREAM;
-                else
+                } else {
                     shortContentType = contentType;
+                }
             }
             // CR or LF in Content-Type causes Chrome to barf, unfortunately
             contentType = contentType.replace('\r', ' ').replace('\n', ' ');


### PR DESCRIPTION
**Jira**: [ZCS-19572](https://synacor.atlassian.net/browse/ZCS-19572)

Added filter to defang xml content types and also supporting unit test case

[ZCS-19572]: https://synacor.atlassian.net/browse/ZCS-19572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Ref PR: https://github.com/Zimbra/zm-mailbox-ghsa-q3vf-vm67-6xj5/pull/1