### PR TITLE
ZBUG-5488: Delete LDAP entry only on local server to prevent data loss on proxy timeout during large account deletion

### DIFF
--- a/store/src/java-test/com/zimbra/cs/account/MockProvisioning.java
+++ b/store/src/java-test/com/zimbra/cs/account/MockProvisioning.java
@@ -399,8 +399,10 @@ public final class MockProvisioning extends Provisioning {
     }
 
     @Override
-    public void modifyAccountStatus(Account acct, String newStatus) {
-        throw new UnsupportedOperationException();
+    public void modifyAccountStatus(Account acct, String newStatus) throws ServiceException {
+        HashMap<String, String> attrs = new HashMap<String, String>();
+        attrs.put(Provisioning.A_zimbraAccountStatus, newStatus);
+        modifyAttrs(acct, attrs);
     }
 
     @Override

--- a/store/src/java-test/com/zimbra/cs/service/admin/DeleteAccountTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/admin/DeleteAccountTest.java
@@ -1,0 +1,104 @@
+package com.zimbra.cs.service.admin;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.common.soap.Element;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.Server;
+import com.zimbra.cs.account.accesscontrol.RightManager;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.service.mail.ServiceTestUtil;
+import java.security.SecureRandom;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DeleteAccountTest {
+
+    private Provisioning prov;
+
+    private Account adminAccount;
+
+    @Before
+    public void setUp() throws Exception {
+        MailboxTestUtil.initServer();
+        setupAuthTokenKey();
+        prov = Provisioning.getInstance();
+        Map<String, Object> adminAttrs = new HashMap<>();
+        adminAttrs.put(Provisioning.A_zimbraIsAdminAccount, "TRUE");
+        adminAccount = prov.createAccount("admin@test.zimbra.com", "adminpass", adminAttrs);
+        RightManager.getInstance().getAllAdminRights();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        MailboxTestUtil.clearData();
+    }
+
+    private static void setupAuthTokenKey() throws Exception {
+        // directly set the static field via reflection as absolute fallback
+        byte[] keyBytes = new byte[32];
+        new SecureRandom().nextBytes(keyBytes);
+        java.lang.reflect.Constructor<?> ctor =
+                com.zimbra.cs.account.AuthTokenKey.class.getDeclaredConstructor(long.class, byte[].class);
+        ctor.setAccessible(true);
+        Object testKey = ctor.newInstance(0L, keyBytes);
+        java.lang.reflect.Field field =
+                com.zimbra.cs.account.AuthTokenKey.class.getDeclaredField("sLatestKey");
+        field.setAccessible(true);
+        field.set(null, testKey);
+    }
+
+    private Element buildDeleteAccountRequest(String accountId) {
+        Element request = Element.XMLElement.mFactory.createElement(AdminConstants.DELETE_ACCOUNT_REQUEST);
+        request.addNonUniqueElement(AdminConstants.E_ID).setText(accountId);
+        return request;
+    }
+
+    private String getLocalServerName() throws ServiceException {
+        Server localServer = prov.getLocalServer();
+        return localServer.getAttr(Provisioning.A_zimbraServiceHostname, "localhost");
+    }
+
+    @Test
+    public void testDeleteAccountOnLocalServer() throws Exception {
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put(Provisioning.A_zimbraMailHost, getLocalServerName());
+        attrs.put(Provisioning.A_zimbraId, "localUserId");
+        Account target = prov.createAccount("local-user@test.zimbra.com", "password", attrs);
+        String targetId = target.getId();
+
+        Assert.assertNotNull("Precondition: account must exist", prov.getAccountById(targetId));
+
+        Element request = buildDeleteAccountRequest(targetId);
+        DeleteAccount handler = new DeleteAccount();
+        Map<String, Object> context = ServiceTestUtil.getRequestContext(adminAccount);
+        handler.handle(request, context);
+
+        Assert.assertNull("Account should be deleted when hosted on local server",
+                prov.getAccountById(targetId));
+    }
+
+    @Test
+    public void testRemoteAccountNotDeletedLocally() throws Exception {
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put(Provisioning.A_zimbraMailHost, "remote-mbox-node.example.com");
+        attrs.put(Provisioning.A_zimbraId, "remoteUserId");
+        Account target = prov.createAccount("remote-user@test.zimbra.com", "password", attrs);
+        String targetId = target.getId();
+
+        Assert.assertNotNull("Precondition: account must exist", prov.getAccountById(targetId));
+
+        Element request = buildDeleteAccountRequest(targetId);
+        DeleteAccount handler = new DeleteAccount();
+        Map<String, Object> context = ServiceTestUtil.getRequestContext(adminAccount);
+        handler.handle(request, context);
+
+        Assert.assertNotNull("Remote server account must not be deleted locally",
+                prov.getAccountById(targetId));
+    }
+}

--- a/store/src/java/com/zimbra/cs/service/admin/DeleteAccount.java
+++ b/store/src/java/com/zimbra/cs/service/admin/DeleteAccount.java
@@ -114,7 +114,9 @@ public class DeleteAccount extends AdminDocumentHandler {
             if (mbox != null) {
                 mbox.deleteMailbox();
             }
-            prov.deleteAccount(id);
+            if (Provisioning.onLocalServer(account)) {
+                prov.deleteAccount(id);
+            }
         } catch (ServiceException se) {
             if (rollbackOnFailure) {
                 ZimbraLog.account.warn("Account deletion failed, restoring account status back to \"%s\" from maintenance.", accountStatus);


### PR DESCRIPTION
**Ticket:** https://synacor.atlassian.net/browse/ZBUG-5488

**Problem:** When DeleteAccount is proxied to another mailbox node and the operation times out (e.g., large blob count on S3), the proxy node falls back to the local handler and deletes the LDAP entry — even though the actual mailbox server is still cleaning up blobs. This causes orphaned data or newly created accounts with the same address to get deleted.

**Fix:** Made LDAP entry deletion conditional on Provisioning.onLocalServer(account), ensuring only the actual mailbox server performs the LDAP deletion after completing mailbox cleanup.