### PR TITLE
ZCS-19567: Admin SOAP API to fetch & parse SAML IdP metadata XML

### DIFF
--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -196,6 +196,10 @@ public final class AdminConstants {
     public static final String E_CHECK_DOMAIN_MX_RECORD_REQUEST = "CheckDomainMXRecordRequest";
     public static final String E_CHECK_DOMAIN_MX_RECORD_RESPONSE = "CheckDomainMXRecordResponse";
 
+    public static final String E_PARSE_SAML_METADATA_REQUEST = "ParseSAMLMetadataRequest";
+
+    public static final String E_PARSE_SAML_METADATA_RESPONSE = "ParseSAMLMetadataResponse";
+
     public static final String E_AUTO_COMPLETE_GAL_REQUEST = "AutoCompleteGalRequest";
     public static final String E_AUTO_COMPLETE_GAL_RESPONSE = "AutoCompleteGalResponse";
     public static final String E_SEARCH_GAL_REQUEST = "SearchGalRequest";
@@ -724,6 +728,10 @@ public final class AdminConstants {
     public static final QName CHECK_EXCHANGE_AUTH_RESPONSE = QName.get(E_CHECK_EXCHANGE_AUTH_RESPONSE, NAMESPACE);
     public static final QName CHECK_DOMAIN_MX_RECORD_REQUEST = QName.get(E_CHECK_DOMAIN_MX_RECORD_REQUEST, NAMESPACE);
     public static final QName CHECK_DOMAIN_MX_RECORD_RESPONSE = QName.get(E_CHECK_DOMAIN_MX_RECORD_RESPONSE, NAMESPACE);
+
+    public static final QName PARSE_SAML_METADATA_REQUEST = QName.get(E_PARSE_SAML_METADATA_REQUEST, NAMESPACE);
+
+    public static final QName PARSE_SAML_METADATA_RESPONSE = QName.get(E_PARSE_SAML_METADATA_RESPONSE, NAMESPACE);
 
     public static final QName AUTO_COMPLETE_GAL_REQUEST = QName.get(E_AUTO_COMPLETE_GAL_REQUEST, NAMESPACE);
     public static final QName AUTO_COMPLETE_GAL_RESPONSE = QName.get(E_AUTO_COMPLETE_GAL_RESPONSE, NAMESPACE);
@@ -1572,6 +1580,30 @@ public final class AdminConstants {
     public static final String A_RELEASE = "release";
     public static final String A_PLATFORM = "platform";
     public static final String A_BUILDTYPE = "buildtype";
+
+    // ZCS-19567 Multi-domain SAML - IdP metadata parsing (Admin SOAP)
+    // Note: A_URL ("url") and E_CONTENT ("content") are reused for the request input.
+    public static final String E_SAML_ENTITY_ID = "entityID";
+
+    public static final String E_SAML_SSO_URL = "ssoURL";
+
+    public static final String E_SAML_SLO_URL = "sloURL";
+
+    public static final String E_SAML_NAME_ID_FORMAT = "nameIdFormat";
+
+    public static final String E_SAML_CERTIFICATE = "certificate";
+
+    public static final String A_SAML_CERT_USE = "use";
+
+    public static final String A_SAML_THUMBPRINT = "thumbprint";
+
+    public static final String A_SAML_NOT_BEFORE = "notBefore";
+
+    public static final String A_SAML_NOT_AFTER = "notAfter";
+
+    public static final String A_SAML_SUBJECT_DN = "subjectDN";
+
+    public static final String A_SAML_ISSUER_DN = "issuerDN";
 
     // ZimbraLicenseExtenstion LicenseService and LicenseAdminService
     public static final String E_CONTENT = "content";

--- a/soap/src/java/com/zimbra/soap/JaxbUtil.java
+++ b/soap/src/java/com/zimbra/soap/JaxbUtil.java
@@ -263,6 +263,8 @@ public final class JaxbUtil {
             com.zimbra.soap.admin.message.CheckDirectoryResponse.class,
             com.zimbra.soap.admin.message.CheckDomainMXRecordRequest.class,
             com.zimbra.soap.admin.message.CheckDomainMXRecordResponse.class,
+            com.zimbra.soap.admin.message.ParseSAMLMetadataRequest.class,
+            com.zimbra.soap.admin.message.ParseSAMLMetadataResponse.class,
             com.zimbra.soap.admin.message.CheckExchangeAuthRequest.class,
             com.zimbra.soap.admin.message.CheckExchangeAuthResponse.class,
             com.zimbra.soap.admin.message.CheckGalConfigRequest.class,

--- a/soap/src/java/com/zimbra/soap/admin/message/ParseSAMLMetadataRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/ParseSAMLMetadataRequest.java
@@ -1,0 +1,91 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2026 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.soap.admin.type.DomainSelector;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @zm-api-command-auth-required true
+ * @zm-api-command-admin-auth-required true
+ * @zm-api-command-description Fetch and parse a SAML Identity Provider (IdP) metadata document and return the
+ *         extracted fields (IdP Entity ID, SSO URL, SLO URL, NameID format and signing/encryption X.509 certificates
+ *         with their thumbprint and validity). <br /> The metadata source is supplied either as a remote URL (fetched
+ *         server-side) via the {@code url} attribute, or as the raw metadata XML in the {@code &lt;content&gt;} element
+ *         (e.g. an uploaded metadata file). Exactly one of the two must be provided. An optional {@code &lt;domain&gt;}
+ *         scopes the authorization check to a specific domain.
+ */
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name = AdminConstants.E_PARSE_SAML_METADATA_REQUEST)
+public class ParseSAMLMetadataRequest {
+
+    /**
+     * @zm-api-field-description Domain the parsed metadata is intended for. When present, the caller must have
+     *         rights to modify this domain. When absent, the request is available to any authorized administrator.
+     */
+    @XmlElement(name = AdminConstants.E_DOMAIN, required = false)
+    private DomainSelector domain;
+
+    /**
+     * @zm-api-field-tag idp-metadata-url
+     * @zm-api-field-description URL of the IdP metadata document to fetch and parse server-side. Only
+     *         {@code http} and {@code https} URLs are supported. Mutually exclusive with {@code &lt;content&gt;}.
+     */
+    @XmlAttribute(name = AdminConstants.A_URL /* url */, required = false)
+    private String url;
+
+    /**
+     * @zm-api-field-tag idp-metadata-xml
+     * @zm-api-field-description Raw IdP metadata XML content to parse (e.g. from an uploaded file). Mutually
+     *         exclusive with the {@code url} attribute.
+     */
+    @XmlElement(name = AdminConstants.E_CONTENT /* content */, required = false)
+    private String content;
+
+    public ParseSAMLMetadataRequest() {
+    }
+
+    public DomainSelector getDomain() {
+        return domain;
+    }
+
+    public void setDomain(DomainSelector domain) {
+        this.domain = domain;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/ParseSAMLMetadataResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/ParseSAMLMetadataResponse.java
@@ -1,0 +1,138 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2026 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import com.google.common.collect.Lists;
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.soap.admin.type.SAMLIdpCertificateInfo;
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * Fields extracted from a parsed SAML IdP metadata document.
+ */
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name = AdminConstants.E_PARSE_SAML_METADATA_RESPONSE)
+@XmlType(propOrder = { "entityID", "ssoURL", "sloURL", "nameIdFormat", "certificates" })
+public class ParseSAMLMetadataResponse {
+
+    /**
+     * @zm-api-field-description IdP Entity ID ({@code EntityDescriptor/@entityID}).
+     */
+    @XmlElement(name = AdminConstants.E_SAML_ENTITY_ID, required = false)
+    private String entityID;
+
+    /**
+     * @zm-api-field-description All IdP Single Sign-On (SSO) service endpoints advertised in the metadata, one
+     *         element per binding, each formatted as {@code Binding=Location}.
+     */
+    @XmlElement(name = AdminConstants.E_SAML_SSO_URL, required = false)
+    private List<String> ssoURL = Lists.newArrayList();
+
+    /**
+     * @zm-api-field-description All IdP Single Logout (SLO) service endpoints advertised in the metadata, one
+     *         element per binding, each formatted as {@code Binding=Location}.
+     */
+    @XmlElement(name = AdminConstants.E_SAML_SLO_URL, required = false)
+    private List<String> sloURL = Lists.newArrayList();
+
+    /**
+     * @zm-api-field-description All NameID formats advertised by the IdP, one element each.
+     */
+    @XmlElement(name = AdminConstants.E_SAML_NAME_ID_FORMAT, required = false)
+    private List<String> nameIdFormat = Lists.newArrayList();
+
+    /**
+     * @zm-api-field-description X.509 certificates declared in the IdP metadata (signing / encryption).
+     */
+    @XmlElement(name = AdminConstants.E_SAML_CERTIFICATE, required = false)
+    private List<SAMLIdpCertificateInfo> certificates = Lists.newArrayList();
+
+    public ParseSAMLMetadataResponse() {
+    }
+
+    public String getEntityID() {
+        return entityID;
+    }
+
+    public void setEntityID(String entityID) {
+        this.entityID = entityID;
+    }
+
+    public List<String> getSsoURL() {
+        return ssoURL;
+    }
+
+    public void setSsoURL(List<String> ssoURL) {
+        this.ssoURL = (ssoURL == null) ? new ArrayList<String>() : ssoURL;
+    }
+
+    public void addSsoURL(String value) {
+        if (value != null) {
+            ssoURL.add(value);
+        }
+    }
+
+    public List<String> getSloURL() {
+        return sloURL;
+    }
+
+    public void setSloURL(List<String> sloURL) {
+        this.sloURL = (sloURL == null) ? new ArrayList<String>() : sloURL;
+    }
+
+    public void addSloURL(String value) {
+        if (value != null) {
+            sloURL.add(value);
+        }
+    }
+
+    public List<String> getNameIdFormat() {
+        return nameIdFormat;
+    }
+
+    public void setNameIdFormat(List<String> nameIdFormat) {
+        this.nameIdFormat = (nameIdFormat == null) ? new ArrayList<String>() : nameIdFormat;
+    }
+
+    public void addNameIdFormat(String value) {
+        if (value != null) {
+            nameIdFormat.add(value);
+        }
+    }
+
+    public List<SAMLIdpCertificateInfo> getCertificates() {
+        return certificates;
+    }
+
+    public void setCertificates(List<SAMLIdpCertificateInfo> certificates) {
+        this.certificates = (certificates == null) ? new ArrayList<SAMLIdpCertificateInfo>() : certificates;
+    }
+
+    public void addCertificate(SAMLIdpCertificateInfo cert) {
+        if (cert != null) {
+            certificates.add(cert);
+        }
+    }
+}

--- a/soap/src/java/com/zimbra/soap/admin/type/SAMLIdpCertificateInfo.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/SAMLIdpCertificateInfo.java
@@ -1,0 +1,143 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2026 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.type;
+
+import com.zimbra.common.soap.AdminConstants;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlValue;
+
+/**
+ * An X.509 certificate extracted from a SAML IdP metadata {@code <KeyDescriptor>} element, together with the metadata
+ * extracted from the certificate itself (thumbprint and validity window).
+ */
+@XmlAccessorType(XmlAccessType.NONE)
+public class SAMLIdpCertificateInfo {
+
+    /**
+     * @zm-api-field-tag cert-use
+     * @zm-api-field-description Intended use of the key as declared in the metadata {@code KeyDescriptor/@use}
+     *         (typically {@code signing} or {@code encryption}). Empty when the metadata does not specify a use.
+     */
+    @XmlAttribute(name = AdminConstants.A_SAML_CERT_USE /* use */, required = false)
+    private String use;
+
+    /**
+     * @zm-api-field-tag cert-thumbprint
+     * @zm-api-field-description SHA-256 thumbprint (fingerprint) of the DER-encoded certificate, as an
+     *         upper-case hex string.
+     */
+    @XmlAttribute(name = AdminConstants.A_SAML_THUMBPRINT /* thumbprint */, required = false)
+    private String thumbprint;
+
+    /**
+     * @zm-api-field-tag cert-not-before
+     * @zm-api-field-description Start of the certificate validity window (ISO-8601, UTC).
+     */
+    @XmlAttribute(name = AdminConstants.A_SAML_NOT_BEFORE /* notBefore */, required = false)
+    private String notBefore;
+
+    /**
+     * @zm-api-field-tag cert-not-after
+     * @zm-api-field-description End of the certificate validity window / expiry (ISO-8601, UTC).
+     */
+    @XmlAttribute(name = AdminConstants.A_SAML_NOT_AFTER /* notAfter */, required = false)
+    private String notAfter;
+
+    /**
+     * @zm-api-field-tag cert-subject-dn
+     * @zm-api-field-description Certificate subject distinguished name.
+     */
+    @XmlAttribute(name = AdminConstants.A_SAML_SUBJECT_DN /* subjectDN */, required = false)
+    private String subjectDN;
+
+    /**
+     * @zm-api-field-tag cert-issuer-dn
+     * @zm-api-field-description Certificate issuer distinguished name.
+     */
+    @XmlAttribute(name = AdminConstants.A_SAML_ISSUER_DN /* issuerDN */, required = false)
+    private String issuerDN;
+
+    /**
+     * @zm-api-field-tag cert-value
+     * @zm-api-field-description Base64-encoded DER X.509 certificate, exactly as it appears in the metadata
+     *         {@code X509Certificate} element (without PEM header/footer).
+     */
+    @XmlValue
+    private String value;
+
+    public SAMLIdpCertificateInfo() {
+    }
+
+    public String getUse() {
+        return use;
+    }
+
+    public void setUse(String use) {
+        this.use = use;
+    }
+
+    public String getThumbprint() {
+        return thumbprint;
+    }
+
+    public void setThumbprint(String thumbprint) {
+        this.thumbprint = thumbprint;
+    }
+
+    public String getNotBefore() {
+        return notBefore;
+    }
+
+    public void setNotBefore(String notBefore) {
+        this.notBefore = notBefore;
+    }
+
+    public String getNotAfter() {
+        return notAfter;
+    }
+
+    public void setNotAfter(String notAfter) {
+        this.notAfter = notAfter;
+    }
+
+    public String getSubjectDN() {
+        return subjectDN;
+    }
+
+    public void setSubjectDN(String subjectDN) {
+        this.subjectDN = subjectDN;
+    }
+
+    public String getIssuerDN() {
+        return issuerDN;
+    }
+
+    public void setIssuerDN(String issuerDN) {
+        this.issuerDN = issuerDN;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/store/src/java-test/com/zimbra/cs/service/admin/ParseSAMLMetadataTest.java
+++ b/store/src/java-test/com/zimbra/cs/service/admin/ParseSAMLMetadataTest.java
@@ -1,0 +1,208 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2026 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.service.admin;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.soap.JaxbUtil;
+import com.zimbra.soap.admin.message.ParseSAMLMetadataResponse;
+import com.zimbra.soap.admin.type.SAMLIdpCertificateInfo;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+
+ * Unit tests for {@link ParseSAMLMetadata} - exercises the IdP metadata XML extraction logic directly (the
+ * inline-content path, which needs neither a SOAP context nor provisioning). Uses a sample Keycloak IdP metadata
+ * document that advertises multiple SSO/SLO bindings.
+ */
+public class ParseSAMLMetadataTest {
+
+    private static final String ENTITY_ID = "https://keycloak.zimbradev.com/realms/zimbra";
+
+    private static final String SAML_ENDPOINT = "https://keycloak.zimbradev.com/realms/zimbra/protocol/saml";
+
+    // The signing certificate from the sample metadata (base64 DER, single line, as it appears in ds:X509Certificate).
+    private static final String TEST_CERT =
+            "MIICmzCCAYMCBgGeFxriADANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDDAZ6aW1icmEwHhcNMjYwNTExMTI1MzE4WhcN"
+            + "MzYwNTExMTI1NDU4WjARMQ8wDQYDVQQDDAZ6aW1icmEwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC4nJW/"
+            + "XmO+8zHtqpfO/KkX1KciLKzQB17civmferv1PrD6cTZ9PEBrwHeHFj+rVuDVMbx2QwM0EDpbSx2LjdjbOaYM3ODpwl6"
+            + "ForneL4Ib7e2zp0HgC+/HRF7BRl3peLEkzATZ4FPkcL/0dw/tISuyZqPMptCm5tAl/o+iT1p+JHQNZ/pTsa2ZDKbbS4"
+            + "wujeuxT5GXIzKEpa0lrkOxg6mKq9HeUoS1M36O9lDivZDnK9M9qg1jUZbrMxBy0kCF2h3R8ld6u+IZWZcg7QOG10hpJ"
+            + "e9nUsCAdYcrSLZmoSvuHKcvMoWoYCtSsyTu6byK4q9pZ1RR+D35eoYsnioqWKtbAgMBAAEwDQYJKoZIhvcNAQELBQAD"
+            + "ggEBAE8/oMEfEnZauULeVSUXMjWmTtymkBTO1G3sgox9TEGwo9uU4wA3TEG/Hr06pN7+JWZOA3D9KHtdO9gKLQBBRRK"
+            + "ScQ+V5txN7sBkNDCGV3wV3pY9JDMPsgoqM7qOv23alnWrmV0WQg+AuYkR8cot1QOVflPnqbU/NW3smc9HMAab5yh6BF"
+            + "aKEy13coYhA2o0OYgajITamszUYkpMjbOkCAwaGQGG3wmjY/2fUWJW82Mrwr1hY9fJTHPb2lAZxfeoTWThOVc8Dy5Vf"
+            + "UtvoFAQ9IPJhi46Fc5CKcAAAkeKwixLDzaeD4IrJUlZravBLJH/zCWgMs8dd531e1SlzIe0x2U=";
+
+    private static final String IDP_METADATA =
+            "<md:EntityDescriptor xmlns=\"urn:oasis:names:tc:SAML:2.0:metadata\""
+            + " xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\""
+            + " xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\""
+            + " xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" entityID=\"" + ENTITY_ID + "\">"
+            + "<md:IDPSSODescriptor WantAuthnRequestsSigned=\"true\""
+            + " protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\">"
+            + "<md:KeyDescriptor use=\"signing\"><ds:KeyInfo>"
+            + "<ds:KeyName>7ocJh5tFqdpnvtIy4IxgozmCEJ3jl07lOyDpg38DOtE</ds:KeyName>"
+            + "<ds:X509Data><ds:X509Certificate>" + TEST_CERT + "</ds:X509Certificate></ds:X509Data>"
+            + "</ds:KeyInfo></md:KeyDescriptor>"
+            + "<md:ArtifactResolutionService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:SOAP\""
+            + " Location=\"" + SAML_ENDPOINT + "/resolve\" index=\"0\"/>"
+            + "<md:SingleLogoutService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" Location=\""
+                    + SAML_ENDPOINT + "\"/>"
+            + "<md:SingleLogoutService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\" Location=\""
+                    + SAML_ENDPOINT + "\"/>"
+            + "<md:SingleLogoutService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact\" Location=\""
+                    + SAML_ENDPOINT + "\"/>"
+            + "<md:SingleLogoutService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:SOAP\" Location=\""
+                    + SAML_ENDPOINT + "\"/>"
+            + "<md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>"
+            + "<md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>"
+            + "<md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>"
+            + "<md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat>"
+            + "<md:SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" Location=\""
+                    + SAML_ENDPOINT + "\"/>"
+            + "<md:SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\" Location=\""
+                    + SAML_ENDPOINT + "\"/>"
+            + "<md:SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:SOAP\" Location=\""
+                    + SAML_ENDPOINT + "\"/>"
+            + "<md:SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact\" Location=\""
+                    + SAML_ENDPOINT + "\"/>"
+            + "</md:IDPSSODescriptor></md:EntityDescriptor>";
+
+    @Test
+    public void extractsAllFieldsFromIdpMetadata() throws Exception {
+        ParseSAMLMetadataResponse resp = new ParseSAMLMetadataResponse();
+        new ParseSAMLMetadata().parseMetadata(IDP_METADATA.getBytes(StandardCharsets.UTF_8), resp);
+
+        assertEquals(ENTITY_ID, resp.getEntityID());
+
+        // All four NameID formats are returned, in document order.
+        List<String> nameIdFormats = resp.getNameIdFormat();
+        assertEquals(4, nameIdFormats.size());
+        assertEquals("urn:oasis:names:tc:SAML:2.0:nameid-format:persistent", nameIdFormats.get(0));
+        assertEquals("urn:oasis:names:tc:SAML:2.0:nameid-format:transient", nameIdFormats.get(1));
+        assertEquals("urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified", nameIdFormats.get(2));
+        assertEquals("urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress", nameIdFormats.get(3));
+
+        // All four SSO bindings are returned as Binding=Location, in document order.
+        List<String> sso = resp.getSsoURL();
+        assertEquals(4, sso.size());
+        assertEquals("urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=" + SAML_ENDPOINT, sso.get(0));
+        assertEquals("urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=" + SAML_ENDPOINT, sso.get(1));
+        assertEquals("urn:oasis:names:tc:SAML:2.0:bindings:SOAP=" + SAML_ENDPOINT, sso.get(2));
+        assertEquals("urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact=" + SAML_ENDPOINT, sso.get(3));
+
+        // All four SLO bindings are returned as Binding=Location, in document order.
+        List<String> slo = resp.getSloURL();
+        assertEquals(4, slo.size());
+        assertEquals("urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=" + SAML_ENDPOINT, slo.get(0));
+        assertEquals("urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=" + SAML_ENDPOINT, slo.get(1));
+        assertEquals("urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact=" + SAML_ENDPOINT, slo.get(2));
+        assertEquals("urn:oasis:names:tc:SAML:2.0:bindings:SOAP=" + SAML_ENDPOINT, slo.get(3));
+
+        assertEquals(1, resp.getCertificates().size());
+        SAMLIdpCertificateInfo cert = resp.getCertificates().get(0);
+        assertEquals("signing", cert.getUse());
+
+        // The certificate value is returned in PEM (BEGIN/END) format.
+        String pem = cert.getValue();
+        assertTrue("should start with PEM header", pem.startsWith("-----BEGIN CERTIFICATE-----\n"));
+        assertTrue("should end with PEM footer", pem.endsWith("-----END CERTIFICATE-----"));
+        // Stripping the PEM armor and whitespace yields the original single-line base64.
+        String stripped = pem.replace("-----BEGIN CERTIFICATE-----", "")
+                .replace("-----END CERTIFICATE-----", "").replaceAll("\\s", "");
+        assertEquals(TEST_CERT, stripped);
+
+        assertNotNull(cert.getThumbprint());
+        assertEquals(64, cert.getThumbprint().length());
+        assertTrue(cert.getThumbprint().matches("[0-9A-F]+"));
+        assertNotNull(cert.getNotBefore());
+        assertTrue("expiry should be UTC ISO-8601", cert.getNotAfter().endsWith("Z"));
+        assertTrue(cert.getSubjectDN().contains("zimbra"));
+    }
+
+    @Test
+    public void responseMarshalsToSoapElement() throws Exception {
+        ParseSAMLMetadataResponse resp = new ParseSAMLMetadataResponse();
+        new ParseSAMLMetadata().parseMetadata(IDP_METADATA.getBytes(StandardCharsets.UTF_8), resp);
+
+        // Confirms the repeated ssoURL/sloURL elements and the @XmlValue certificate element serialize through
+        // Zimbra's JAXB layer.
+        Element el = JaxbUtil.jaxbToElement(resp);
+        assertEquals("ParseSAMLMetadataResponse", el.getName());
+        assertEquals(ENTITY_ID, el.getElement("entityID").getText());
+        assertEquals(4, el.listElements("ssoURL").size());
+        assertEquals(4, el.listElements("sloURL").size());
+        assertEquals(4, el.listElements("nameIdFormat").size());
+        assertEquals("urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=" + SAML_ENDPOINT,
+                el.listElements("ssoURL").get(0).getText());
+        Element certEl = el.getElement("certificate");
+        assertEquals("signing", certEl.getAttribute("use"));
+        assertEquals(64, certEl.getAttribute("thumbprint").length());
+        assertTrue(certEl.getText().contains("-----BEGIN CERTIFICATE-----"));
+    }
+
+    @Test
+    public void rejectsNonIdpMetadata() throws Exception {
+        String spOnly =
+                "<md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\"sp\">"
+                + "  <md:SPSSODescriptor protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\"/>"
+                + "</md:EntityDescriptor>";
+        try {
+            new ParseSAMLMetadata().parseMetadata(spOnly.getBytes(StandardCharsets.UTF_8),
+                    new ParseSAMLMetadataResponse());
+            fail("expected ServiceException for metadata without IDPSSODescriptor");
+        } catch (ServiceException e) {
+            assertTrue(e.getMessage(), e.getMessage().contains("IDPSSODescriptor"));
+        }
+    }
+
+    @Test
+    public void rejectsMalformedXml() throws Exception {
+        try {
+            new ParseSAMLMetadata().parseMetadata("<not-xml".getBytes(StandardCharsets.UTF_8),
+                    new ParseSAMLMetadataResponse());
+            fail("expected ServiceException for malformed XML");
+        } catch (ServiceException e) {
+            assertEquals(ServiceException.INVALID_REQUEST, e.getCode());
+        }
+    }
+
+    @Test
+    public void rejectsXxeDoctype() throws Exception {
+        // A DOCTYPE with an external entity must be rejected outright by the hardened parser (disallow-doctype-decl).
+        String xxe =
+                "<?xml version=\"1.0\"?>"
+                + "<!DOCTYPE foo [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]>"
+                + "<md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\"&xxe;\">"
+                + "  <md:IDPSSODescriptor/></md:EntityDescriptor>";
+        try {
+            new ParseSAMLMetadata().parseMetadata(xxe.getBytes(StandardCharsets.UTF_8),
+                    new ParseSAMLMetadataResponse());
+            fail("expected ServiceException - DOCTYPE declarations must be disallowed");
+        } catch (ServiceException e) {
+            assertEquals(ServiceException.INVALID_REQUEST, e.getCode());
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/service/admin/AdminService.java
+++ b/store/src/java/com/zimbra/cs/service/admin/AdminService.java
@@ -117,6 +117,7 @@ public class AdminService implements DocumentService {
         dispatcher.registerHandler(AdminConstants.CHECK_HOSTNAME_RESOLVE_REQUEST, new CheckHostnameResolve());
         dispatcher.registerHandler(AdminConstants.CHECK_EXCHANGE_AUTH_REQUEST, new CheckExchangeAuth());
         dispatcher.registerHandler(AdminConstants.CHECK_DOMAIN_MX_RECORD_REQUEST, new CheckDomainMXRecord ());
+        dispatcher.registerHandler(AdminConstants.PARSE_SAML_METADATA_REQUEST, new ParseSAMLMetadata());
 
         dispatcher.registerHandler(AdminConstants.CREATE_VOLUME_REQUEST, new CreateVolume());
         dispatcher.registerHandler(AdminConstants.GET_VOLUME_REQUEST, new GetVolume());

--- a/store/src/java/com/zimbra/cs/service/admin/ParseSAMLMetadata.java
+++ b/store/src/java/com/zimbra/cs/service/admin/ParseSAMLMetadata.java
@@ -1,0 +1,368 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2026 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.service.admin;
+
+import com.zimbra.common.account.Key.DomainBy;
+import com.zimbra.common.httpclient.HttpClientUtil;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ByteUtil;
+import com.zimbra.common.util.StringUtil;
+import com.zimbra.common.util.ZimbraHttpConnectionManager;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.AccountServiceException;
+import com.zimbra.cs.account.Domain;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.accesscontrol.AdminRight;
+import com.zimbra.cs.account.accesscontrol.Rights.Admin;
+import com.zimbra.soap.ZimbraSoapContext;
+import com.zimbra.soap.admin.message.ParseSAMLMetadataRequest;
+import com.zimbra.soap.admin.message.ParseSAMLMetadataResponse;
+import com.zimbra.soap.admin.type.DomainSelector;
+import com.zimbra.soap.admin.type.SAMLIdpCertificateInfo;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.HttpException;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * Admin SOAP handler for {@code ParseSAMLMetadataRequest} (ZCS-19567).
+ *
+ * <p>Accepts a SAML IdP metadata document either as a remote {@code url} (fetched server-side) or as inline XML
+ * {@code content}, parses it, and returns the extracted fields: IdP Entity ID, SSO URL, SLO URL, NameID format and
+ * the declared signing/encryption X.509 certificates (with SHA-256 thumbprint and validity window).</p>
+ *
+ * <p>The metadata XML is parsed with a hardened {@link DocumentBuilderFactory} (DTDs and external entities disabled)
+ * to protect against XXE / entity-expansion attacks.</p>
+ */
+public class ParseSAMLMetadata extends AdminDocumentHandler {
+
+    /** SAML 2.0 metadata namespace. */
+    private static final String MD_NS = "urn:oasis:names:tc:SAML:2.0:metadata";
+    /** XML digital signature namespace (KeyInfo / X509Data / X509Certificate). */
+
+    private static final String DS_NS = "http://www.w3.org/2000/09/xmldsig#";
+
+    /** Maximum size (bytes) of a fetched metadata document. */
+    private static final int MAX_METADATA_BYTES = 5 * 1024 * 1024;
+
+    @Override
+    public com.zimbra.common.soap.Element handle(com.zimbra.common.soap.Element request, Map<String, Object> context)
+            throws ServiceException {
+        ZimbraSoapContext zsc = getZimbraSoapContext(context);
+        ParseSAMLMetadataRequest req = zsc.elementToJaxb(request);
+
+        // Authorization: if a domain is supplied, the caller must be able to modify it; otherwise administrative
+        // authentication (already enforced by the admin SOAP service) is sufficient for this stateless parse.
+        DomainSelector domainSel = req.getDomain();
+        if (domainSel != null) {
+            DomainBy domainBy = domainSel.getBy().toKeyDomainBy();
+            Domain domain = Provisioning.getInstance().get(domainBy, domainSel.getKey());
+            if (domain == null) {
+                throw AccountServiceException.NO_SUCH_DOMAIN(domainSel.getKey());
+            }
+            checkDomainRight(zsc, domain, Admin.R_modifyDomain);
+        }
+
+        String url = StringUtil.isNullOrEmpty(req.getUrl()) ? null : req.getUrl().trim();
+        String content = StringUtil.isNullOrEmpty(req.getContent()) ? null : req.getContent();
+
+        if (url == null && content == null) {
+            throw ServiceException.INVALID_REQUEST("either 'url' attribute or <content> element is required", null);
+        }
+        if (url != null && content != null) {
+            throw ServiceException.INVALID_REQUEST("'url' attribute and <content> element are mutually exclusive",
+                    null);
+        }
+
+        byte[] metadataBytes;
+        if (url != null) {
+            metadataBytes = fetchMetadata(url);
+        } else {
+            metadataBytes = content.getBytes(StandardCharsets.UTF_8);
+            if (metadataBytes.length > MAX_METADATA_BYTES) {
+                throw ServiceException.INVALID_REQUEST(
+                        "IdP metadata document exceeds maximum size of " + MAX_METADATA_BYTES + " bytes", null);
+            }
+        }
+
+        ParseSAMLMetadataResponse resp = new ParseSAMLMetadataResponse();
+        parseMetadata(metadataBytes, resp);
+        return zsc.jaxbToElement(resp);
+    }
+
+    /**
+     * Fetch the metadata document from a remote http(s) URL.
+     * @param url the remote URL from which to fetch the IdP metadata XML document
+     * @return the raw bytes of the IdP metadata XML document
+     */
+    private byte[] fetchMetadata(String url) throws ServiceException {
+        URI uri;
+        try {
+            uri = new URI(url);
+        } catch (URISyntaxException e) {
+            throw ServiceException.INVALID_REQUEST("invalid metadata URL: " + url, e);
+        }
+        String scheme = uri.getScheme();
+        if (scheme == null || !(scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https"))) {
+            throw ServiceException.INVALID_REQUEST("only http/https metadata URLs are supported: " + url, null);
+        }
+
+        HttpClientBuilder clientBuilder = ZimbraHttpConnectionManager.getExternalHttpConnMgr().newHttpClient();
+        HttpClient client = clientBuilder.build();
+        HttpGet get = new HttpGet(url);
+        HttpResponse httpResp = null;
+        try {
+            httpResp = HttpClientUtil.executeMethod(client, get);
+            int statusCode = httpResp.getStatusLine().getStatusCode();
+            if (statusCode != HttpStatus.SC_OK) {
+                throw ServiceException.RESOURCE_UNREACHABLE(
+                        "failed to fetch IdP metadata (HTTP " + statusCode + ") from " + url, null);
+            }
+            // getContent closes the stream and throws IOException if the document exceeds MAX_METADATA_BYTES.
+            InputStream is = httpResp.getEntity().getContent();
+            byte[] data = ByteUtil.getContent(is, -1, (long) MAX_METADATA_BYTES);
+            if (data == null || data.length == 0) {
+                throw ServiceException.FAILURE("empty IdP metadata response from " + url, null);
+            }
+            return data;
+        } catch (HttpException | IOException e) {
+            throw ServiceException.RESOURCE_UNREACHABLE("failed to fetch IdP metadata from " + url, e);
+        } finally {
+            if (httpResp != null) {
+                EntityUtils.consumeQuietly(httpResp.getEntity());
+            }
+        }
+    }
+
+    /**
+     * Parse the SAML metadata document and populate the response. Package-visible for unit testing.
+     * @param metadataBytes the raw bytes of the SAML metadata XML document to parse
+     * @param resp          the response object to populate with the parsed metadata values
+     */
+    void parseMetadata(byte[] metadataBytes, ParseSAMLMetadataResponse resp) throws ServiceException {
+        Document doc;
+        try {
+            DocumentBuilder builder = newSecureDocumentBuilderFactory().newDocumentBuilder();
+            doc = builder.parse(new ByteArrayInputStream(metadataBytes));
+        } catch (Exception e) {
+            throw ServiceException.INVALID_REQUEST("unable to parse SAML metadata XML: " + e.getMessage(), e);
+        }
+
+        NodeList idpNodes = doc.getElementsByTagNameNS(MD_NS, "IDPSSODescriptor");
+        if (idpNodes.getLength() == 0) {
+            throw ServiceException.INVALID_REQUEST(
+                    "SAML metadata does not contain an IDPSSODescriptor (not an IdP metadata document)", null);
+        }
+        Element idp = (Element) idpNodes.item(0);
+
+        resp.setEntityID(resolveEntityId(idp, doc));
+        for (String endpoint : collectEndpoints(idp, "SingleSignOnService")) {
+            resp.addSsoURL(endpoint);
+        }
+        for (String endpoint : collectEndpoints(idp, "SingleLogoutService")) {
+            resp.addSloURL(endpoint);
+        }
+        NodeList nameIdFormats = idp.getElementsByTagNameNS(MD_NS, "NameIDFormat");
+        for (int i = 0; i < nameIdFormats.getLength(); i++) {
+            String text = nameIdFormats.item(i).getTextContent();
+            if (!StringUtil.isNullOrEmpty(text)) {
+                resp.addNameIdFormat(text.trim());
+            }
+        }
+
+        NodeList keyDescriptors = idp.getElementsByTagNameNS(MD_NS, "KeyDescriptor");
+        for (int i = 0; i < keyDescriptors.getLength(); i++) {
+            Element keyDescriptor = (Element) keyDescriptors.item(i);
+            String use = keyDescriptor.getAttribute("use");
+            NodeList certNodes = keyDescriptor.getElementsByTagNameNS(DS_NS, "X509Certificate");
+            for (int j = 0; j < certNodes.getLength(); j++) {
+                String certText = certNodes.item(j).getTextContent();
+                if (!StringUtil.isNullOrEmpty(certText)) {
+                    resp.addCertificate(buildCertificateInfo(use, certText));
+                }
+            }
+        }
+    }
+
+    /**
+     * The entityID lives on the ancestor {@code <EntityDescriptor>} of the IDPSSODescriptor.
+     * @param idp the {@code IDPSSODescriptor} {@link Element} from which to begin the ancestor
+     *            traversal
+     * @param doc the root {@link Document} used as a fallback to locate the
+     *            {@code <EntityDescriptor>} if ancestor traversal yields no result
+     * @return the {@code entityID} attribute value if found, or {@code null} if no
+     *         {@code <EntityDescriptor>} with a non-empty {@code entityID} exists in the document
+     */
+    private String resolveEntityId(Element idp, Document doc) {
+        Node node = idp.getParentNode();
+        while (node != null) {
+            if (node.getNodeType() == Node.ELEMENT_NODE && "EntityDescriptor".equals(node.getLocalName())
+                    && MD_NS.equals(node.getNamespaceURI())) {
+                String entityId = ((Element) node).getAttribute("entityID");
+                if (!StringUtil.isNullOrEmpty(entityId)) {
+                    return entityId;
+                }
+            }
+            node = node.getParentNode();
+        }
+        // Fallback: first EntityDescriptor in the document.
+        NodeList entities = doc.getElementsByTagNameNS(MD_NS, "EntityDescriptor");
+        if (entities.getLength() > 0) {
+            String entityId = ((Element) entities.item(0)).getAttribute("entityID");
+            return StringUtil.isNullOrEmpty(entityId) ? null : entityId;
+        }
+        return null;
+    }
+
+    /**
+     * Collect every advertised endpoint (SingleSignOnService / SingleLogoutService), one entry per binding, each
+     * formatted as {@code Binding=Location}.
+     * @param idp          the {@code IDPSSODescriptor} {@link Element} from which to collect
+     *                     the service endpoints
+     * @param endpointName the local name of the endpoint element to collect, typically
+     *                     {@code SingleSignOnService} or {@code SingleLogoutService}
+     * @return a {@link List} of {@code binding=location} strings, one per advertised endpoint;
+     *         never {@code null}, but may be empty if no matching endpoints are found or all
+     *         have missing {@code Location} attributes
+
+     */
+    private List<String> collectEndpoints(Element idp, String endpointName) {
+        List<String> result = new ArrayList<String>();
+        NodeList endpoints = idp.getElementsByTagNameNS(MD_NS, endpointName);
+        for (int i = 0; i < endpoints.getLength(); i++) {
+            Element endpoint = (Element) endpoints.item(i);
+            String binding = endpoint.getAttribute("Binding");
+            String location = endpoint.getAttribute("Location");
+            if (StringUtil.isNullOrEmpty(location)) {
+                continue;
+            }
+            result.add((StringUtil.isNullOrEmpty(binding) ? "" : binding) + "=" + location);
+        }
+        return result;
+    }
+
+    private SAMLIdpCertificateInfo buildCertificateInfo(String use, String base64Cert) throws ServiceException {
+        SAMLIdpCertificateInfo info = new SAMLIdpCertificateInfo();
+        if (!StringUtil.isNullOrEmpty(use)) {
+            info.setUse(use);
+        }
+        String cleaned = base64Cert.replaceAll("\\s", "");
+        info.setValue(toPem(cleaned));
+        try {
+            byte[] der = Base64.decodeBase64(cleaned);
+            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+            X509Certificate cert = (X509Certificate) cf.generateCertificate(new ByteArrayInputStream(der));
+
+            MessageDigest sha256 = MessageDigest.getInstance("SHA-256");
+            info.setThumbprint(toHex(sha256.digest(cert.getEncoded())));
+            info.setNotBefore(formatInstant(cert.getNotBefore()));
+            info.setNotAfter(formatInstant(cert.getNotAfter()));
+            info.setSubjectDN(cert.getSubjectX500Principal().getName());
+            info.setIssuerDN(cert.getIssuerX500Principal().getName());
+        } catch (CertificateException | java.security.NoSuchAlgorithmException e) {
+            // Return the raw certificate value even when the details can't be derived, but log the reason.
+            ZimbraLog.security.warn("ParseSAMLMetadata: unable to decode X.509 certificate from IdP metadata", e);
+        }
+        return info;
+    }
+
+    private static String formatInstant(Date date) {
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return sdf.format(date);
+    }
+
+    /**
+     * Wrap a single-line base64 DER certificate in standard PEM {@code -----BEGIN/END CERTIFICATE-----} headers,
+     * with the body split into 64-character lines.
+     * @param base64Der the raw single-line base64 DER-encoded certificate string, as extracted
+     *                  from the {@code <ds:X509Certificate>} element in the SAML metadata XML;
+     *                  must not be {@code null}
+     * @return a PEM-formatted certificate string with {@code -----BEGIN CERTIFICATE-----} and
+     *         {@code -----END CERTIFICATE-----} headers and the body wrapped at 64 characters
+     *         per line
+     */
+    private static String toPem(String base64Der) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("-----BEGIN CERTIFICATE-----\n");
+        for (int i = 0; i < base64Der.length(); i += 64) {
+            sb.append(base64Der, i, Math.min(i + 64, base64Der.length())).append('\n');
+        }
+        sb.append("-----END CERTIFICATE-----");
+        return sb.toString();
+    }
+
+    private static String toHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            sb.append(String.format("%02X", b));
+        }
+        return sb.toString();
+    }
+
+    private static DocumentBuilderFactory newSecureDocumentBuilderFactory() throws ServiceException {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        try {
+            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            dbf.setNamespaceAware(true);
+            dbf.setExpandEntityReferences(false);
+            dbf.setXIncludeAware(false);
+        } catch (Exception e) {
+            throw ServiceException.FAILURE("unable to configure secure XML parser", e);
+        }
+        return dbf;
+    }
+
+    @Override
+    public void docRights(List<AdminRight> relatedRights, List<String> notes) {
+        relatedRights.add(Admin.R_modifyDomain);
+        notes.add("Requires modify-domain right on the target domain when a <domain> is specified; "
+                + "otherwise administrative authentication is sufficient.");
+    }
+}

--- a/store/src/java/com/zimbra/cs/service/admin/package-info.java
+++ b/store/src/java/com/zimbra/cs/service/admin/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Web Client
+ * Copyright (C) 2026 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+/**
+ * Admin SOAP service handlers for Zimbra administration operations.
+ */
+package com.zimbra.cs.service.admin;


### PR DESCRIPTION
Add ParseSAMLMetadata admin SOAP API that accepts a SAML IdP metadata document either as a remote URL (fetched server-side) or as inline XML content, parses it, and returns the extracted fields: IdP Entity ID, SSO URL, SLO URL, NameID format, and signing/encryption X.509 certificates with SHA-256 thumbprint and validity window.

- AdminConstants: request/response + SAML field constants
- ParseSAMLMetadataRequest/Response and SAMLIdpCertificateInfo JAXB types
- ParseSAMLMetadata handler with XXE-hardened DOM parsing, HTTP-Redirect binding preference, and cert decoding via CertificateFactory
- Register handler in AdminService and JAXB classes in JaxbUtil
- Unit tests covering extraction, binding preference, cert decode, JAXB round-trip, and non-IdP / malformed-XML / XXE rejection