### PR TITLE
ZCS-19498: Configurable fallback auth routing for non-EAS protocols

### DIFF
--- a/store/src/java-test/com/zimbra/cs/account/auth/AuthMechanismFallbackRoutingTest.java
+++ b/store/src/java-test/com/zimbra/cs/account/auth/AuthMechanismFallbackRoutingTest.java
@@ -1,0 +1,105 @@
+package com.zimbra.cs.account.auth;
+
+import com.zimbra.common.account.Key;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.auth.AuthMechanism.AuthMech;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * ZCS-19498: Tests for configurable fallback auth routing in AuthMechanism.newInstance().
+ * Verifies that IDP_ROPC correctly routes to MFA for EAS and to fallback for other protocols,
+ * while ensuring standard and non-ROPC custom mechanisms remain unaffected.
+ */
+public class AuthMechanismFallbackRoutingTest {
+
+    private Provisioning prov;
+
+    @Before
+    public void setUp() throws Exception {
+        MailboxTestUtil.initProvisioning();
+        prov = Provisioning.getInstance();
+    }
+
+    private Account createAccountWithAuthMech(String domainName, String authMech) throws Exception {
+        Map<String, Object> domainAttrs = new HashMap<>();
+        domainAttrs.put(Provisioning.A_zimbraAuthMech, authMech);
+        prov.createDomain(domainName, domainAttrs);
+        Map<String, Object> acctAttrs = new HashMap<>();
+        prov.createAccount("testuser@" + domainName, "password", acctAttrs);
+        return prov.get(Key.AccountBy.name, "testuser@" + domainName);
+    }
+
+    private Map<String, Object> createEASContext() {
+        Map<String, Object> ctx = new HashMap<>();
+        ctx.put(AuthContext.AC_PROTOCOL, AuthContext.Protocol.zsync);
+        ctx.put(AuthContext.AC_SUB_PROTOCOL, AuthContext.SubProtocol.eas);
+        return ctx;
+    }
+
+    @Test
+    public void testRopcRoutingLogic() throws Exception {
+        // Test Case: fallback:ad custom:idp-ropc ...
+        Account account = createAccountWithAuthMech("ropc-test.com", "fallback:ad custom:idp-ropc arg1");
+
+        // 1. EAS Protocol -> Must route to CustomAuth (MFA)
+        assertEquals("EAS must route to custom auth", AuthMech.custom,
+                AuthMechanism.newInstance(account, createEASContext()).getMechanism());
+
+        // 2. Non-EAS Protocol -> Must route to Fallback (AD)
+        assertEquals("Non-EAS must route to fallback (AD)", AuthMech.ad,
+                AuthMechanism.newInstance(account, new HashMap<>()).getMechanism());
+
+        // 3. Null Context -> Must handle gracefully and route to Fallback
+        assertEquals("Null context must route to fallback", AuthMech.ad,
+                AuthMechanism.newInstance(account, null).getMechanism());
+    }
+
+    @Test
+    public void testPassThroughMechanisms() throws Exception {
+        // 1. Standard mechanism (zimbra) -> Should bypass custom logic
+        Account zimbraAcct = createAccountWithAuthMech("std-zimbra.com", "zimbra");
+        assertEquals("Standard zimbra must route directly", AuthMech.zimbra,
+                AuthMechanism.newInstance(zimbraAcct, null).getMechanism());
+
+        // 2. Non-ROPC custom mechanism -> Should bypass fallback logic
+        Account customAcct = createAccountWithAuthMech("std-custom.com", "custom:saml handler1");
+        assertEquals("Non-ROPC custom must route to CustomAuth", AuthMech.custom,
+                AuthMechanism.newInstance(customAcct, new HashMap<>()).getMechanism());
+    }
+
+    @Test
+    public void testInvalidAndMalformedConfigs() throws Exception {
+        Map<String, Object> ctx = new HashMap<>();
+
+        // 1. No fallback prefix for ROPC + Non-EAS -> Must throw
+        Account noFallback = createAccountWithAuthMech("err-nofb.com", "custom:idp-ropc arg1");
+        try {
+            AuthMechanism.newInstance(noFallback, ctx);
+            fail("Missing fallback prefix must throw");
+        } catch (ServiceException e) {
+            assertTrue(e.getMessage().contains("authentication failed"));
+        }
+
+        // 2. Invalid fallback type (custom) -> Must throw (via resolveFallbackMech)
+        Account badFallback = createAccountWithAuthMech("err-badfb.com",
+                "fallback:custom custom:idp-ropc");
+        try {
+            AuthMechanism.newInstance(badFallback, ctx);
+            fail("Invalid fallback type must throw");
+        } catch (ServiceException e) {
+            assertTrue(e.getMessage().contains("authentication failed"));
+        }
+
+        // 3. Malformed prefix (no space) -> Must fall back to default ZimbraAuth
+        Account malformed = createAccountWithAuthMech("err-malformed.com", "fallback:ad");
+        assertEquals("Malformed config must return default zimbra", AuthMech.zimbra,
+                AuthMechanism.newInstance(malformed, ctx).getMechanism());
+    }
+}

--- a/store/src/java/com/zimbra/cs/account/auth/AuthMechanism.java
+++ b/store/src/java/com/zimbra/cs/account/auth/AuthMechanism.java
@@ -17,13 +17,9 @@
 
 package com.zimbra.cs.account.auth;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.StringTokenizer;
-
 import javax.security.auth.login.LoginException;
-
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.QuotedStringParser;
 import com.zimbra.common.util.StringUtil;
@@ -95,6 +91,8 @@ public abstract class AuthMechanism {
 
     private static String IDP_ROPC = "idp-ropc";
 
+    private static final String FALLBACK_PREFIX = "fallback:";
+
     protected AuthMechanism(AuthMech authMech) {
         this.authMech = authMech;
     }
@@ -128,37 +126,80 @@ public abstract class AuthMechanism {
                 }
             }
         }
-
-
-        if (authMechStr.startsWith(AuthMech.custom.name() + ":")) {
-            boolean hasIdpRopc = authMechStr.contains(IDP_ROPC);
-
-            if (hasIdpRopc && !IRopcCustomAuth.isSupported(context)) {
+        // parse fallback prefix from zimbraAuthMech
+        // format: "fallback:<zimbra|ad|kerberos5> custom:idp-ropc arg1 arg2"
+        String fallbackMech = null;
+        if (authMechStr.startsWith(FALLBACK_PREFIX)) {
+            int spaceIdx = authMechStr.indexOf(' ');
+            if (spaceIdx > 0) {
+                fallbackMech = authMechStr.substring(FALLBACK_PREFIX.length(), spaceIdx);
+                authMechStr = authMechStr.substring(spaceIdx + 1).trim();
+            } else {
+                ZimbraLog.account.warn("Invalid auth mech config: %s — no auth mechanism after fallback prefix",
+                        authMechStr);
                 return new ZimbraAuth(AuthMech.zimbra);
             }
-            return new CustomAuth(AuthMech.custom, authMechStr);
-        } else {
-            try {
-                AuthMech authMech = AuthMech.fromString(authMechStr);
-
-                switch (authMech) {
-                    case zimbra:
-                        return new ZimbraAuth(authMech);
-                    case ldap:
-                    case ad:
-                        return new LdapAuth(authMech);
-                    case kerberos5:
-                        return new Kerberos5Auth(authMech);
-                }
-            } catch (ServiceException e) {
-                ZimbraLog.account.warn("invalid auth mech", e);
-            }
-
-            ZimbraLog.account.warn("unknown value for " + Provisioning.A_zimbraAuthMech+": "
-                    + authMechStr+", falling back to default mech");
-            return new ZimbraAuth(AuthMech.zimbra);
         }
+        if (authMechStr.startsWith(AuthMech.custom.name() + ":")) {
+            // if IdP ROPC is used with an unsupported protocol, switch to the fallback mechanism
+            if (authMechStr.contains(IDP_ROPC) && !IRopcCustomAuth.isSupported(context)) {
+                if (fallbackMech != null) {
+                    AuthMech fallback = resolveFallbackMech(fallbackMech);
+                    ZimbraLog.account.info("Protocol not supported by IdP ROPC, using fallback: %s", fallback);
+                    authMechStr = fallback.name();
+                } else {
+                    ZimbraLog.account.error("Protocol not supported by IdP ROPC and no fallback configured for %s",
+                            acct.getName());
+                    throw AuthFailedServiceException.AUTH_FAILED(acct.getName(), namePassedIn(context),
+                            "No fallback auth mechanism configured for this protocol");
+                }
+            } else {
+                // supported ROPC (EAS) or any other custom mechanism
+                return new CustomAuth(AuthMech.custom, authMechStr);
+            }
+        }
+        // standard mechanisms (zimbra, ldap, ad, kerberos5)
+        try {
+            AuthMech authMech = AuthMech.fromString(authMechStr);
+            switch (authMech) {
+                case zimbra:
+                    return new ZimbraAuth(authMech);
+                case ldap:
+                case ad:
+                    return new LdapAuth(authMech);
+                case kerberos5:
+                    return new Kerberos5Auth(authMech);
+            }
+        } catch (ServiceException e) {
+            ZimbraLog.account.warn("invalid auth mech: " + authMechStr, e);
+        }
+        ZimbraLog.account.warn(
+                "unknown value for " + Provisioning.A_zimbraAuthMech + ": " + authMechStr
+                        + ", falling back to default mech");
+        return new ZimbraAuth(AuthMech.zimbra);
+    }
 
+    /**
+     * Resolves and validates the fallback authentication mechanism from a string.
+     *
+     * @param mechName
+     *         The name of the fallback mechanism (e.g., "zimbra", "ad", "ldap", "kerberos5").
+     * @return The resolved {@link AuthMech} enum value.
+     * @throws ServiceException
+     *         If the mechanism name is invalid or is a "custom" type.
+     */
+    private static AuthMech resolveFallbackMech(String mechName) throws ServiceException {
+        if (mechName.startsWith("custom")) {
+            ZimbraLog.account.error(
+                    "Fallback to custom auth not supported: %s. Supported values: zimbra, ad, kerberos5", mechName);
+            throw AuthFailedServiceException.AUTH_FAILED("", "", "Unsupported fallback auth mechanism: " + mechName);
+        }
+        try {
+            return AuthMech.fromString(mechName);
+        } catch (ServiceException e) {
+            ZimbraLog.account.error("Unknown fallback auth mech: %s", mechName);
+            throw AuthFailedServiceException.AUTH_FAILED("", "", "Unknown fallback auth mechanism: " + mechName);
+        }
     }
 
     public static void doZimbraAuth(LdapProv prov, Domain domain, Account acct, String password,

--- a/store/src/java/com/zimbra/cs/account/callback/AuthMech.java
+++ b/store/src/java/com/zimbra/cs/account/callback/AuthMech.java
@@ -26,6 +26,8 @@ import com.zimbra.cs.account.auth.AuthMechanism;
 
 public class AuthMech extends AttributeCallback {
 
+    private static final String FALLBACK_PREFIX = "fallback:";
+
     @Override
     public void preModify(CallbackContext context, String attrName, Object attrValue,
             Map attrsToModify, Entry entry)
@@ -44,11 +46,45 @@ public class AuthMech extends AttributeCallback {
             } else if (authMech.startsWith(AuthMechanism.AuthMech.custom.name())) {
                 valid = true;
             } else {
-                try {
-                    AuthMechanism.AuthMech mech = AuthMechanism.AuthMech.fromString(authMech);
+                // allow an optional "fallback:<zimbra|ad|kerberos5> " prefix in front of the
+                // real auth mech value, e.g. "fallback:zimbra custom:idp-ropc arg1 arg2".
+                String mechToValidate = authMech;
+
+                if (mechToValidate.startsWith(FALLBACK_PREFIX)) {
+                    int spaceIdx = mechToValidate.indexOf(' ');
+                    if (spaceIdx > 0) {
+                        String fallbackMech = mechToValidate.substring(FALLBACK_PREFIX.length(), spaceIdx);
+                        // fallback to another custom auth mech is not supported
+                        if (fallbackMech.startsWith(AuthMechanism.AuthMech.custom.name())) {
+                            ZimbraLog.account.error("fallback to custom auth not supported: " + fallbackMech);
+                            throw ServiceException.INVALID_REQUEST(
+                                    "invalid value: " + authMech + " — fallback to custom auth not supported", null);
+                        }
+                        // fallback mech must be one of the standard AuthMech values
+                        try {
+                            AuthMechanism.AuthMech.fromString(fallbackMech);
+                        } catch (ServiceException e) {
+                            ZimbraLog.account.error("invalid fallback auth mech: " + fallbackMech, e);
+                            throw ServiceException.INVALID_REQUEST("invalid value: " + authMech, null);
+                        }
+
+                        // strip "fallback:<mech> " off, leaving the real mech (e.g. "custom:idp-ropc ...")
+                        mechToValidate = mechToValidate.substring(spaceIdx + 1).trim();
+                    } else {
+                        ZimbraLog.account.error(
+                                "invalid auth mech config: no mechanism after fallback prefix: " + authMech);
+                        throw ServiceException.INVALID_REQUEST("invalid value: " + authMech, null);
+                    }
+                }
+                if (mechToValidate.startsWith(AuthMechanism.AuthMech.custom.name())) {
                     valid = true;
-                } catch (ServiceException e) {
-                    ZimbraLog.account.error("invalid auth mech", e);
+                } else {
+                    try {
+                        AuthMechanism.AuthMech mech = AuthMechanism.AuthMech.fromString(mechToValidate);
+                        valid = true;
+                    } catch (ServiceException e) {
+                        ZimbraLog.account.error("invalid auth mech", e);
+                    }
                 }
             }
 


### PR DESCRIPTION
- Parse "fallback:<zimbra|ad|kerberos5>" prefix from zimbraAuthMech
- EAS routes to custom auth (MFA/IdP ROPC), non-EAS routes to fallback
- Add AuthMechanismFallbackRoutingTest 