### PR TITLE
ZCS 20105: Added LDAP attributes zimbraSamlSpSigningKey and zimbraSamlSpSigningCertificate

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -16909,6 +16909,23 @@ public class ZAttrProvisioning {
     public static final String A_zimbraRevokeAppSpecificPasswordsOnPasswordChange = "zimbraRevokeAppSpecificPasswordsOnPasswordChange";
 
     /**
+     * Certificate used to verify signed SAML SP requests
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4166)
+    public static final String A_zimbraSamlSpSigningCertificate = "zimbraSamlSpSigningCertificate";
+
+    /**
+     * Key used to sign SP-generated SAML requests. SAML requests are
+     * unsigned if empty
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4165)
+    public static final String A_zimbraSamlSpSigningKey = "zimbraSamlSpSigningKey";
+
+    /**
      * whether TLS is required for IMAP/POP GSSAPI auth
      *
      * @since ZCS 5.0.20

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10644,4 +10644,12 @@ TODO: delete them permanently from here
   <desc>Soft quota limit percentage applied over zimbraMailQuota</desc>
 </attr>
 
+<attr id="4165" name="zimbraSamlSpSigningKey" type="astring" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21">
+    <desc>Key used to sign SP-generated SAML requests. SAML requests are unsigned if empty</desc>
+</attr>
+
+<attr id="4166" name="zimbraSamlSpSigningCertificate" type="astring" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21">
+    <desc>Certificate used to verify signed SAML SP requests</desc>
+</attr>
+
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -72683,6 +72683,155 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Certificate used to verify signed SAML SP requests
+     *
+     * @return zimbraSamlSpSigningCertificate, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4166)
+    public String getSamlSpSigningCertificate() {
+        return getAttr(Provisioning.A_zimbraSamlSpSigningCertificate, null, true);
+    }
+
+    /**
+     * Certificate used to verify signed SAML SP requests
+     *
+     * @param zimbraSamlSpSigningCertificate new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4166)
+    public void setSamlSpSigningCertificate(String zimbraSamlSpSigningCertificate) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningCertificate, zimbraSamlSpSigningCertificate);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Certificate used to verify signed SAML SP requests
+     *
+     * @param zimbraSamlSpSigningCertificate new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4166)
+    public Map<String,Object> setSamlSpSigningCertificate(String zimbraSamlSpSigningCertificate, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningCertificate, zimbraSamlSpSigningCertificate);
+        return attrs;
+    }
+
+    /**
+     * Certificate used to verify signed SAML SP requests
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4166)
+    public void unsetSamlSpSigningCertificate() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningCertificate, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Certificate used to verify signed SAML SP requests
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4166)
+    public Map<String,Object> unsetSamlSpSigningCertificate(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningCertificate, "");
+        return attrs;
+    }
+
+    /**
+     * Key used to sign SP-generated SAML requests. SAML requests are
+     * unsigned if empty
+     *
+     * @return zimbraSamlSpSigningKey, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4165)
+    public String getSamlSpSigningKey() {
+        return getAttr(Provisioning.A_zimbraSamlSpSigningKey, null, true);
+    }
+
+    /**
+     * Key used to sign SP-generated SAML requests. SAML requests are
+     * unsigned if empty
+     *
+     * @param zimbraSamlSpSigningKey new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4165)
+    public void setSamlSpSigningKey(String zimbraSamlSpSigningKey) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningKey, zimbraSamlSpSigningKey);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Key used to sign SP-generated SAML requests. SAML requests are
+     * unsigned if empty
+     *
+     * @param zimbraSamlSpSigningKey new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4165)
+    public Map<String,Object> setSamlSpSigningKey(String zimbraSamlSpSigningKey, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningKey, zimbraSamlSpSigningKey);
+        return attrs;
+    }
+
+    /**
+     * Key used to sign SP-generated SAML requests. SAML requests are
+     * unsigned if empty
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4165)
+    public void unsetSamlSpSigningKey() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningKey, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Key used to sign SP-generated SAML requests. SAML requests are
+     * unsigned if empty
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4165)
+    public Map<String,Object> unsetSamlSpSigningKey(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningKey, "");
+        return attrs;
+    }
+
+    /**
      * whether TLS is required for IMAP/POP GSSAPI auth
      *
      * @return zimbraSaslGssapiRequiresTls, or false if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -25279,6 +25279,155 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
+     * Certificate used to verify signed SAML SP requests
+     *
+     * @return zimbraSamlSpSigningCertificate, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4166)
+    public String getSamlSpSigningCertificate() {
+        return getAttr(Provisioning.A_zimbraSamlSpSigningCertificate, null, true);
+    }
+
+    /**
+     * Certificate used to verify signed SAML SP requests
+     *
+     * @param zimbraSamlSpSigningCertificate new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4166)
+    public void setSamlSpSigningCertificate(String zimbraSamlSpSigningCertificate) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningCertificate, zimbraSamlSpSigningCertificate);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Certificate used to verify signed SAML SP requests
+     *
+     * @param zimbraSamlSpSigningCertificate new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4166)
+    public Map<String,Object> setSamlSpSigningCertificate(String zimbraSamlSpSigningCertificate, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningCertificate, zimbraSamlSpSigningCertificate);
+        return attrs;
+    }
+
+    /**
+     * Certificate used to verify signed SAML SP requests
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4166)
+    public void unsetSamlSpSigningCertificate() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningCertificate, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Certificate used to verify signed SAML SP requests
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4166)
+    public Map<String,Object> unsetSamlSpSigningCertificate(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningCertificate, "");
+        return attrs;
+    }
+
+    /**
+     * Key used to sign SP-generated SAML requests. SAML requests are
+     * unsigned if empty
+     *
+     * @return zimbraSamlSpSigningKey, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4165)
+    public String getSamlSpSigningKey() {
+        return getAttr(Provisioning.A_zimbraSamlSpSigningKey, null, true);
+    }
+
+    /**
+     * Key used to sign SP-generated SAML requests. SAML requests are
+     * unsigned if empty
+     *
+     * @param zimbraSamlSpSigningKey new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4165)
+    public void setSamlSpSigningKey(String zimbraSamlSpSigningKey) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningKey, zimbraSamlSpSigningKey);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Key used to sign SP-generated SAML requests. SAML requests are
+     * unsigned if empty
+     *
+     * @param zimbraSamlSpSigningKey new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4165)
+    public Map<String,Object> setSamlSpSigningKey(String zimbraSamlSpSigningKey, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningKey, zimbraSamlSpSigningKey);
+        return attrs;
+    }
+
+    /**
+     * Key used to sign SP-generated SAML requests. SAML requests are
+     * unsigned if empty
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4165)
+    public void unsetSamlSpSigningKey() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningKey, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Key used to sign SP-generated SAML requests. SAML requests are
+     * unsigned if empty
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4165)
+    public Map<String,Object> unsetSamlSpSigningKey(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningKey, "");
+        return attrs;
+    }
+
+    /**
      * whether or not to show client Terms of Service
      *
      * @return zimbraShowClientTOS, or false if unset


### PR DESCRIPTION
Jira link: https://synacor.atlassian.net/browse/ZCS-20105

Adds two new LDAP attributes to zm-mailbox to support SAML SP request signing. These attributes will later be used for signing SP-generated requests (AuthnRequest, LogoutRequest), resolving signed-request issues with certain IdPs that require signed LogoutRequests from the SP.

