### PR TITLE
ZCS-20036: Add GenerateSamlTest admin SOAP API for SAML config test flow

### DIFF
--- a/common/src/java-test/com/zimbra/common/account/SamlTestNonceTest.java
+++ b/common/src/java-test/com/zimbra/common/account/SamlTestNonceTest.java
@@ -1,0 +1,138 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2026 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.common.account;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+public class SamlTestNonceTest {
+
+    private static final long NOW = 1_700_000_000_000L;
+
+    @Test
+    public void generateProducesUniqueUrlSafeValues() {
+        final String a = SamlTestNonce.generate();
+        final String b = SamlTestNonce.generate();
+        assertNotEquals(a, b);
+        assertFalse(a.isEmpty());
+        // URL-safe base64 without padding: no '+', '/', or '='
+        assertFalse(a.contains("+"));
+        assertFalse(a.contains("/"));
+        assertFalse(a.contains("="));
+    }
+
+    @Test
+    public void storedValueRoundTrips() {
+        final String value = SamlTestNonce.formatStoredValue("abc123", NOW);
+        assertEquals("abc123 notAfter=" + NOW, value);
+        final SamlTestNonce.Stored parsed = SamlTestNonce.parseStoredValue(value);
+        assertEquals("abc123", parsed.getNonce());
+        assertEquals(NOW, parsed.getNotAfterMillis());
+    }
+
+    @Test
+    public void parseMalformedReturnsNull() {
+        assertNull(SamlTestNonce.parseStoredValue(null));
+        assertNull(SamlTestNonce.parseStoredValue(""));
+        assertNull(SamlTestNonce.parseStoredValue("nonceWithoutMarker"));
+        assertNull(SamlTestNonce.parseStoredValue("abc notAfter=notANumber"));
+        assertNull(SamlTestNonce.parseStoredValue(" notAfter=123")); // empty nonce
+    }
+
+    @Test
+    public void hasActiveNonceReflectsExpiry() {
+        assertFalse(SamlTestNonce.hasActiveNonce(null, NOW));
+        assertFalse(SamlTestNonce.hasActiveNonce("", NOW));
+        assertTrue(SamlTestNonce.hasActiveNonce(SamlTestNonce.formatStoredValue("n", NOW + 1000), NOW));
+        assertFalse(SamlTestNonce.hasActiveNonce(SamlTestNonce.formatStoredValue("n", NOW - 1000), NOW));
+    }
+
+    @Test
+    public void isValidChecksMatchAndExpiry() {
+        final String stored = SamlTestNonce.formatStoredValue("secret", NOW + 1000);
+        assertTrue(SamlTestNonce.isValid("secret", stored, NOW));
+        // wrong nonce
+        assertFalse(SamlTestNonce.isValid("other", stored, NOW));
+        // empty candidate
+        assertFalse(SamlTestNonce.isValid("", stored, NOW));
+        assertFalse(SamlTestNonce.isValid(null, stored, NOW));
+        // expired
+        assertFalse(SamlTestNonce.isValid("secret", stored, NOW + 5000));
+        // no stored value
+        assertFalse(SamlTestNonce.isValid("secret", null, NOW));
+    }
+
+    @Test
+    public void relayStateRoundTripsNonceAndExtras() {
+        final Map<String, String> extras = new HashMap<>();
+        extras.put("domain", "example.com");
+        final String relayState = SamlTestNonce.encodeRelayState("my-nonce", extras);
+        // transport-safe: base64url only
+        assertFalse(relayState.contains("="));
+        assertFalse(relayState.contains("&"));
+
+        final Map<String, String> decoded = SamlTestNonce.decodeRelayState(relayState);
+        assertEquals("my-nonce", decoded.get("nonce"));
+        assertEquals("example.com", decoded.get("domain"));
+        assertEquals("my-nonce", SamlTestNonce.getNonceFromRelayState(relayState));
+    }
+
+    @Test
+    public void relayStatePreservesSpecialCharactersInExtras() {
+        final Map<String, String> extras = new HashMap<>();
+        extras.put("redirect", "https://host/path?a=b&c=d");
+        final String relayState = SamlTestNonce.encodeRelayState("n", extras);
+        final Map<String, String> decoded = SamlTestNonce.decodeRelayState(relayState);
+        assertEquals("n", decoded.get("nonce"));
+        assertEquals("https://host/path?a=b&c=d", decoded.get("redirect"));
+    }
+
+    @Test
+    public void encodeRelayStateWithNullExtrasCarriesOnlyNonce() {
+        final String relayState = SamlTestNonce.encodeRelayState("only-nonce", null);
+        final Map<String, String> decoded = SamlTestNonce.decodeRelayState(relayState);
+        assertEquals(1, decoded.size());
+        assertEquals("only-nonce", decoded.get("nonce"));
+    }
+
+    @Test
+    public void encodeRelayStateIgnoresNonceOverrideAndNullValues() {
+        final Map<String, String> extras = new HashMap<>();
+        extras.put("nonce", "attacker-supplied"); // must not override the real nonce
+        extras.put("empty", null);                // null values are skipped
+        final Map<String, String> decoded =
+                SamlTestNonce.decodeRelayState(SamlTestNonce.encodeRelayState("real", extras));
+        assertEquals("real", decoded.get("nonce"));
+        assertFalse(decoded.containsKey("empty"));
+    }
+
+    @Test
+    public void decodeGarbageReturnsEmptyMap() {
+        assertTrue(SamlTestNonce.decodeRelayState(null).isEmpty());
+        assertTrue(SamlTestNonce.decodeRelayState("").isEmpty());
+        // not valid base64url
+        assertNull(SamlTestNonce.getNonceFromRelayState("!!!not base64!!!"));
+    }
+}

--- a/common/src/java/com/zimbra/common/account/SamlTestNonce.java
+++ b/common/src/java/com/zimbra/common/account/SamlTestNonce.java
@@ -1,0 +1,232 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2026 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.common.account;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.zimbra.common.util.StringUtil;
+
+/**
+ * Shared logic for the SAML "test config" flow, used by both the {@code GenerateSamlTest} admin
+ * SOAP handler (zm-mailbox) and the SAML consumer extension (zm-saml-consumer-store).
+ *
+ * <p>It owns three contracts that must stay in sync across those two jars:
+ * <ul>
+ *   <li>the nonce itself,</li>
+ *   <li>the value stored in {@code zimbraSamlTestNonce}: {@code "{nonce} notAfter={epochMillis}"},</li>
+ *   <li>the {@code RelayState} codec that carries the nonce (and optional extras) through the IdP.</li>
+ * </ul>
+ */
+public final class SamlTestNonce {
+
+    /** Validity window for a generated nonce (30 minutes). */
+    public static final long NONCE_VALIDITY_MS = 30 * 60 * 1000L;
+
+    /** The SAML {@code RelayState} query/form parameter name that carries the nonce round-trip. */
+    public static final String RELAY_STATE_PARAM = "RelayState";
+
+    private static final String NOT_AFTER_MARKER = " notAfter=";
+    private static final String RELAY_KEY_NONCE = "nonce";
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private SamlTestNonce() {
+    }
+
+    /** Generate a new cryptographically-random, URL-safe 128-bit nonce. */
+    public static String generate() {
+        final byte[] bytes = new byte[16];
+        RANDOM.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    /** Format the value persisted in {@code zimbraSamlTestNonce}. */
+    public static String formatStoredValue(String nonce, long notAfterMillis) {
+        return nonce + NOT_AFTER_MARKER + notAfterMillis;
+    }
+
+    /** Parsed representation of a stored {@code zimbraSamlTestNonce} value. */
+    public static final class Stored {
+        private final String nonce;
+        private final long notAfterMillis;
+
+        private Stored(String nonce, long notAfterMillis) {
+            this.nonce = nonce;
+            this.notAfterMillis = notAfterMillis;
+        }
+
+        public String getNonce() {
+            return nonce;
+        }
+
+        public long getNotAfterMillis() {
+            return notAfterMillis;
+        }
+    }
+
+    /**
+     * Parse {@code "{nonce} notAfter={epochMillis}"}.
+     *
+     * @return parsed value, or {@code null} if the input is empty or malformed
+     */
+    public static Stored parseStoredValue(String storedValue) {
+        if (StringUtil.isNullOrEmpty(storedValue)) {
+            return null;
+        }
+        final int idx = storedValue.indexOf(NOT_AFTER_MARKER);
+        if (idx <= 0) {
+            return null;
+        }
+        final String nonce = storedValue.substring(0, idx);
+        final String tsPart = storedValue.substring(idx + NOT_AFTER_MARKER.length()).trim();
+        if (StringUtil.isNullOrEmpty(nonce)) {
+            return null;
+        }
+        try {
+            return new Stored(nonce, Long.parseLong(tsPart));
+        } catch (final NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Whether a stored value represents a test that is still in progress (present and not expired).
+     * Used by the admin API to decide whether to prompt for a force-clear.
+     */
+    public static boolean hasActiveNonce(String storedValue, long nowMillis) {
+        final Stored stored = parseStoredValue(storedValue);
+        return stored != null && nowMillis < stored.getNotAfterMillis();
+    }
+
+    /**
+     * Validate a candidate nonce (typically decoded from RelayState) against the stored value.
+     * The comparison is constant-time and enforces the {@code notAfter} expiry.
+     */
+    public static boolean isValid(String candidateNonce, String storedValue, long nowMillis) {
+        if (StringUtil.isNullOrEmpty(candidateNonce)) {
+            return false;
+        }
+        final Stored stored = parseStoredValue(storedValue);
+        if (stored == null || nowMillis >= stored.getNotAfterMillis()) {
+            return false;
+        }
+        return MessageDigest.isEqual(candidateNonce.getBytes(StandardCharsets.UTF_8),
+                stored.getNonce().getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Returns {@code true} if the candidate nonce matches the stored nonce value but has expired
+     * (i.e. the 30-minute window elapsed). Used to detect abandoned/late test completions so we
+     * can record a "nonce expired" result rather than silently treating it as a normal login.
+     *
+     * @param candidateNonce nonce extracted from RelayState
+     * @param storedValue    raw {@code zimbraSamlTestNonce} value from LDAP
+     * @param nowMillis      current time in epoch millis
+     * @return {@code true} if the nonce matches but is past its {@code notAfter} deadline
+     */
+    public static boolean isMatchedButExpired(String candidateNonce, String storedValue, long nowMillis) {
+        if (StringUtil.isNullOrEmpty(candidateNonce)) {
+            return false;
+        }
+        final Stored stored = parseStoredValue(storedValue);
+        if (stored == null) {
+            return false;
+        }
+        // Must actually be expired
+        if (nowMillis < stored.getNotAfterMillis()) {
+            return false; // not expired — isValid() would handle this case
+        }
+        // Nonce value must match (constant-time comparison)
+        return MessageDigest.isEqual(
+                candidateNonce.getBytes(StandardCharsets.UTF_8),
+                stored.getNonce().getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Build the base64 RelayState payload carrying the nonce and any optional extra properties.
+     * The result is safe to place directly in a {@code RelayState} query parameter.
+     */
+    public static String encodeRelayState(String nonce, Map<String, String> extras) {
+        final StringBuilder payload = new StringBuilder();
+        payload.append(RELAY_KEY_NONCE).append('=').append(urlEncode(nonce));
+        if (extras != null) {
+            for (final Map.Entry<String, String> e : extras.entrySet()) {
+                if (RELAY_KEY_NONCE.equals(e.getKey()) || e.getValue() == null) {
+                    continue;
+                }
+                payload.append('&').append(urlEncode(e.getKey())).append('=').append(urlEncode(e.getValue()));
+            }
+        }
+        return Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(payload.toString().getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Decode a RelayState payload produced by {@link #encodeRelayState}.
+     *
+     * @return map of properties (never {@code null}); empty if the input is empty or undecodable
+     */
+    public static Map<String, String> decodeRelayState(String relayState) {
+        final Map<String, String> result = new LinkedHashMap<>();
+        if (StringUtil.isNullOrEmpty(relayState)) {
+            return result;
+        }
+        final String payload;
+        try {
+            payload = new String(Base64.getUrlDecoder().decode(relayState), StandardCharsets.UTF_8);
+        } catch (final IllegalArgumentException e) {
+            return result;
+        }
+        for (final String pair : payload.split("&")) {
+            final int eq = pair.indexOf('=');
+            if (eq <= 0) {
+                continue;
+            }
+            result.put(urlDecode(pair.substring(0, eq)), urlDecode(pair.substring(eq + 1)));
+        }
+        return result;
+    }
+
+    /** Convenience: extract just the nonce from a RelayState payload ({@code null} if absent). */
+    public static String getNonceFromRelayState(String relayState) {
+        return decodeRelayState(relayState).get(RELAY_KEY_NONCE);
+    }
+
+    private static String urlEncode(String value) {
+        try {
+            return URLEncoder.encode(value, StandardCharsets.UTF_8.name());
+        } catch (final UnsupportedEncodingException e) {
+            return value;
+        }
+    }
+
+    private static String urlDecode(String value) {
+        try {
+            return URLDecoder.decode(value, StandardCharsets.UTF_8.name());
+        } catch (final UnsupportedEncodingException | IllegalArgumentException e) {
+            return value;
+        }
+    }
+}

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -16917,6 +16917,145 @@ public class ZAttrProvisioning {
     public static final String A_zimbraRevokeAppSpecificPasswordsOnPasswordChange = "zimbraRevokeAppSpecificPasswordsOnPasswordChange";
 
     /**
+     * SAML Assertion Consumer Service URL. Replaces saml_acs from
+     * saml-config.properties. When set at domain level, enables per-domain
+     * ACS endpoint (e.g.
+     * https://mail.corp-a.com/service/extension/samlreceiver). Falls back to
+     * global config if not set on domain.
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4153)
+    public static final String A_zimbraSamlACSURL = "zimbraSamlACSURL";
+
+    /**
+     * SAML date format for instant timestamps. Replaces
+     * saml_date_format_instant from saml-config.properties. Falls back to
+     * global config if not set on domain.
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4157)
+    public static final String A_zimbraSamlDateFormat = "zimbraSamlDateFormat";
+
+    /**
+     * SAML document encoding. Replaces saml_document_encoding from
+     * saml-config.properties. Controls the character encoding used for SAML
+     * logout documents and login receiver parameter decoding. Falls back to
+     * global config if not set on domain.
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4159)
+    public static final String A_zimbraSamlDocumentEncoding = "zimbraSamlDocumentEncoding";
+
+    /**
+     * SAML error redirect URL. Replaces saml_error_redirect_url from
+     * saml-config.properties. When a SAML authentication error occurs, users
+     * are redirected to this URL with error_code and error_msg query
+     * parameters appended. If not set, the default HTTP error code pages are
+     * returned. Falls back to global config if not set on domain.
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4160)
+    public static final String A_zimbraSamlErrorURL = "zimbraSamlErrorURL";
+
+    /**
+     * SAML inactive account redirect URL. Replaces
+     * saml_inactive_account_redirect_url from saml-config.properties. When a
+     * SAML-authenticated user maps to a Zimbra account that is not in active
+     * status, the user is redirected to this URL. Falls back to global
+     * config if not set on domain.
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4161)
+    public static final String A_zimbraSamlInactiveAccountURL = "zimbraSamlInactiveAccountURL";
+
+    /**
+     * SAML logout landing redirect URL. Replaces
+     * saml_landing_logout_redirect_url from saml-config.properties. When the
+     * SAML extension is the landing page for a logout request, users are
+     * redirected to this URL after logout completes. Falls back to global
+     * config if not set on domain. Default is /.
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4158)
+    public static final String A_zimbraSamlLogoutLandingURL = "zimbraSamlLogoutLandingURL";
+
+    /**
+     * SAML NameID format. Replaces saml_name_id_format from
+     * saml-config.properties. Falls back to global config if not set on
+     * domain.
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4156)
+    public static final String A_zimbraSamlNameIdFormat = "zimbraSamlNameIdFormat";
+
+    /**
+     * SAML IdP Single Logout URL(s). Replaces
+     * saml_redirect_logout_destination and saml_post_logout_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/slo/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/slo/post
+     * The operating context determines which binding is used (e.g.
+     * front-channel logout uses HTTP-Redirect; back-channel logout may use
+     * SOAP). When set at domain level, routes SLO to the correct IdP per
+     * domain. Falls back to global config if not set on domain.
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4155)
+    public static final String A_zimbraSamlSLOURL = "zimbraSamlSLOURL";
+
+    /**
+     * SAML Service Provider Entity ID. Replaces saml_sp_entity_id from
+     * saml-config.properties. When set at domain level, enables per-domain
+     * SP metadata (e.g. https://mail.corp-a.com/saml/sp). Falls back to
+     * global config if not set on domain.
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4163)
+    public static final String A_zimbraSamlSpEntityId = "zimbraSamlSpEntityId";
+
+    /**
+     * SAML IdP Single Sign-On URL(s). Replaces
+     * saml_redirect_login_destination and saml_post_login_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/sso/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/sso/post
+     * The operating context determines which binding is used (e.g.
+     * SP-initiated login uses HTTP-Redirect; back-channel operations may use
+     * SOAP). When set at domain level, routes SSO login to the correct IdP
+     * per domain. Falls back to global config if not set on domain.
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4154)
+    public static final String A_zimbraSamlSSOURL = "zimbraSamlSSOURL";
+
+    /**
+     * SAML webclient-disabled account redirect URL. Replaces
+     * saml_webclient_disabled_account_redirect_url from
+     * saml-config.properties. After successful SAML authentication, if the
+     * account has zimbraFeatureWebClientEnabled set to FALSE, the user is
+     * redirected to this URL instead of the web client. Falls back to global
+     * config if not set on domain.
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4162)
+    public static final String A_zimbraSamlWebclientDisabledAccountUrl = "zimbraSamlWebclientDisabledAccountUrl";
+
+    /**
      * Certificate used to verify signed SAML SP requests
      *
      * @since ZCS 10.1.21

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -16917,6 +16917,23 @@ public class ZAttrProvisioning {
     public static final String A_zimbraRevokeAppSpecificPasswordsOnPasswordChange = "zimbraRevokeAppSpecificPasswordsOnPasswordChange";
 
     /**
+     * Certificate used to verify signed SAML SP requests
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4166)
+    public static final String A_zimbraSamlSpSigningCertificate = "zimbraSamlSpSigningCertificate";
+
+    /**
+     * Key used to sign SP-generated SAML requests. SAML requests are
+     * unsigned if empty
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4165)
+    public static final String A_zimbraSamlSpSigningKey = "zimbraSamlSpSigningKey";
+
+    /**
      * whether TLS is required for IMAP/POP GSSAPI auth
      *
      * @since ZCS 5.0.20

--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -17025,6 +17025,23 @@ public class ZAttrProvisioning {
     public static final String A_zimbraSamlSpEntityId = "zimbraSamlSpEntityId";
 
     /**
+     * Certificate used to verify signed SAML SP requests
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4166)
+    public static final String A_zimbraSamlSpSigningCertificate = "zimbraSamlSpSigningCertificate";
+
+    /**
+     * Key used to sign SP-generated SAML requests. SAML requests are
+     * unsigned if empty
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4165)
+    public static final String A_zimbraSamlSpSigningKey = "zimbraSamlSpSigningKey";
+
+    /**
      * SAML IdP Single Sign-On URL(s). Replaces
      * saml_redirect_login_destination and saml_post_login_destination from
      * saml-config.properties. Multi-valued to support multiple SAML
@@ -17043,6 +17060,32 @@ public class ZAttrProvisioning {
     public static final String A_zimbraSamlSSOURL = "zimbraSamlSSOURL";
 
     /**
+     * Error code for SAML test failure. Format: SSO:{message_key}. Empty
+     * implies success
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4168)
+    public static final String A_zimbraSamlTestErrorMessage = "zimbraSamlTestErrorMessage";
+
+    /**
+     * Secret nonce for an in-progress SAML test. Format: {nonce}
+     * notAfter={timestamp}
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4169)
+    public static final String A_zimbraSamlTestNonce = "zimbraSamlTestNonce";
+
+    /**
+     * Timestamp when the SAML test was completed
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4167)
+    public static final String A_zimbraSamlTestTimestamp = "zimbraSamlTestTimestamp";
+
+    /**
      * SAML webclient-disabled account redirect URL. Replaces
      * saml_webclient_disabled_account_redirect_url from
      * saml-config.properties. After successful SAML authentication, if the
@@ -17054,23 +17097,6 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=4162)
     public static final String A_zimbraSamlWebclientDisabledAccountUrl = "zimbraSamlWebclientDisabledAccountUrl";
-
-    /**
-     * Certificate used to verify signed SAML SP requests
-     *
-     * @since ZCS 10.1.21
-     */
-    @ZAttr(id=4166)
-    public static final String A_zimbraSamlSpSigningCertificate = "zimbraSamlSpSigningCertificate";
-
-    /**
-     * Key used to sign SP-generated SAML requests. SAML requests are
-     * unsigned if empty
-     *
-     * @since ZCS 10.1.21
-     */
-    @ZAttr(id=4165)
-    public static final String A_zimbraSamlSpSigningKey = "zimbraSamlSpSigningKey";
 
     /**
      * whether TLS is required for IMAP/POP GSSAPI auth

--- a/common/src/java/com/zimbra/common/soap/AdminConstants.java
+++ b/common/src/java/com/zimbra/common/soap/AdminConstants.java
@@ -498,6 +498,10 @@ public final class AdminConstants {
     public static final String E_NO_OP_REQUEST = "NoOpRequest";
     public static final String E_NO_OP_RESPONSE = "NoOpResponse";
 
+    // SAML test flow
+    public static final String E_GENERATE_SAML_TEST_REQUEST = "GenerateSamlTestRequest";
+    public static final String E_GENERATE_SAML_TEST_RESPONSE = "GenerateSamlTestResponse";
+
     // cookie
     public static final String E_CLEAR_COOKIE_REQUEST = "ClearCookieRequest";
     public static final String E_CLEAR_COOKIE_RESPONSE = "ClearCookieResponse";
@@ -1029,6 +1033,10 @@ public final class AdminConstants {
     public static final QName NO_OP_REQUEST = QName.get(E_NO_OP_REQUEST, NAMESPACE);
     public static final QName NO_OP_RESPONSE = QName.get(E_NO_OP_RESPONSE, NAMESPACE);
 
+    // SAML test flow
+    public static final QName GENERATE_SAML_TEST_REQUEST = QName.get(E_GENERATE_SAML_TEST_REQUEST, NAMESPACE);
+    public static final QName GENERATE_SAML_TEST_RESPONSE = QName.get(E_GENERATE_SAML_TEST_RESPONSE, NAMESPACE);
+
     // cookie
     public static final QName CLEAR_COOKIE_REQUEST = QName.get(E_CLEAR_COOKIE_REQUEST, NAMESPACE);
     public static final QName CLEAR_COOKIE_RESPONSE = QName.get(E_CLEAR_COOKIE_RESPONSE, NAMESPACE);
@@ -1518,6 +1526,8 @@ public final class AdminConstants {
     // CheckExchangeAuth
     public static final String E_AUTH = "auth";
     public static final String A_URL = "url";
+    public static final String A_FORCE = "force";
+    public static final String A_RELAY_STATE = "relayState";
     public static final String A_USER = "user";
     public static final String A_PASS = "pass";
     public static final String A_SCHEME = "scheme";

--- a/soap/src/java/com/zimbra/soap/JaxbUtil.java
+++ b/soap/src/java/com/zimbra/soap/JaxbUtil.java
@@ -655,6 +655,8 @@ public final class JaxbUtil {
             com.zimbra.soap.admin.message.MoveMailboxResponse.class,
             com.zimbra.soap.admin.message.NoOpRequest.class,
             com.zimbra.soap.admin.message.NoOpResponse.class,
+            com.zimbra.soap.admin.message.GenerateSamlTestRequest.class,
+            com.zimbra.soap.admin.message.GenerateSamlTestResponse.class,
             com.zimbra.soap.admin.message.PingRequest.class,
             com.zimbra.soap.admin.message.PingResponse.class,
             com.zimbra.soap.admin.message.PurgeAccountCalendarCacheRequest.class,

--- a/soap/src/java/com/zimbra/soap/admin/message/GenerateSamlTestRequest.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/GenerateSamlTestRequest.java
@@ -1,0 +1,72 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2026 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.soap.admin.type.DomainSelector;
+import com.zimbra.soap.type.ZmBoolean;
+
+/**
+ * @zm-api-command-auth-required true
+ * @zm-api-command-admin-auth-required true
+ * @zm-api-command-description Begin a SAML configuration test. Validates the test origin, generates
+ * a nonce (stored in <b>zimbraSamlTestNonce</b>), and returns the pop-up URL (with RelayState) that
+ * drives the test SSO flow through the SAML extension.
+ * <br />
+ * If a test is already in progress (<b>zimbraSamlTestNonce</b> is set and unexpired) the request
+ * fails unless <b>force</b> is set, in which case the existing nonce is overwritten.
+ */
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name=AdminConstants.E_GENERATE_SAML_TEST_REQUEST)
+@XmlType(propOrder = {})
+public class GenerateSamlTestRequest {
+
+    /**
+     * @zm-api-field-description Domain to test. If omitted, the global SAML configuration is tested.
+     */
+    @XmlElement(name=AdminConstants.E_DOMAIN, required=false)
+    private DomainSelector domain;
+
+    /**
+     * @zm-api-field-tag force
+     * @zm-api-field-description If set, overwrite an existing in-progress test nonce instead of failing.
+     */
+    @XmlAttribute(name=AdminConstants.A_FORCE, required=false)
+    private ZmBoolean force;
+
+    public GenerateSamlTestRequest() {
+    }
+
+    public GenerateSamlTestRequest(DomainSelector domain, Boolean force) {
+        this.domain = domain;
+        this.force = ZmBoolean.fromBool(force);
+    }
+
+    public void setDomain(DomainSelector domain) { this.domain = domain; }
+    public void setForce(Boolean force) { this.force = ZmBoolean.fromBool(force); }
+
+    public DomainSelector getDomain() { return domain; }
+    public Boolean getForce() { return ZmBoolean.toBool(force); }
+}

--- a/soap/src/java/com/zimbra/soap/admin/message/GenerateSamlTestResponse.java
+++ b/soap/src/java/com/zimbra/soap/admin/message/GenerateSamlTestResponse.java
@@ -1,0 +1,61 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2026 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.soap.admin.message;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.zimbra.common.soap.AdminConstants;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name=AdminConstants.E_GENERATE_SAML_TEST_RESPONSE)
+public class GenerateSamlTestResponse {
+
+    /**
+     * @zm-api-field-tag url
+     * @zm-api-field-description Pop-up URL that the admin console opens to begin the test SSO flow,
+     * of the form <b>&lt;testOrigin&gt;/service/extension/samllogin?RelayState=&lt;base64&gt;</b>.
+     */
+    @XmlAttribute(name=AdminConstants.A_URL, required=true)
+    private String url;
+
+    /**
+     * @zm-api-field-tag relayState
+     * @zm-api-field-description The base64 RelayState value embedded in the URL, echoed for convenience.
+     */
+    @XmlAttribute(name=AdminConstants.A_RELAY_STATE, required=false)
+    private String relayState;
+
+    @SuppressWarnings("unused")
+    private GenerateSamlTestResponse() {
+        this(null, null);
+    }
+
+    public GenerateSamlTestResponse(String url, String relayState) {
+        this.url = url;
+        this.relayState = relayState;
+    }
+
+    public void setUrl(String url) { this.url = url; }
+    public void setRelayState(String relayState) { this.relayState = relayState; }
+
+    public String getUrl() { return url; }
+    public String getRelayState() { return relayState; }
+}

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10648,4 +10648,12 @@ TODO: delete them permanently from here
   <desc>Secret key used in Mail Recall to make it more secure from spoof.</desc>
 </attr>
 
+<attr id="4165" name="zimbraSamlSpSigningKey" type="astring" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21">
+    <desc>Key used to sign SP-generated SAML requests. SAML requests are unsigned if empty</desc>
+</attr>
+
+<attr id="4166" name="zimbraSamlSpSigningCertificate" type="astring" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21">
+    <desc>Certificate used to verify signed SAML SP requests</desc>
+</attr>
+
 </attrs>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10648,6 +10648,112 @@ TODO: delete them permanently from here
   <desc>Secret key used in Mail Recall to make it more secure from spoof.</desc>
 </attr>
 
+<attr id="4153" name="zimbraSamlACSURL" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21">
+  <desc>
+    SAML Assertion Consumer Service URL. Replaces saml_acs from saml-config.properties.
+    When set at domain level, enables per-domain ACS endpoint (e.g. https://mail.corp-a.com/service/extension/samlreceiver).
+    Falls back to global config if not set on domain.
+  </desc>
+</attr>
+
+<attr id="4154" name="zimbraSamlSSOURL" type="string" cardinality="multi" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21">
+  <desc>
+    SAML IdP Single Sign-On URL(s). Replaces saml_redirect_login_destination
+    and saml_post_login_destination from saml-config.properties. Multi-valued to
+    support multiple SAML bindings. Each value uses a binding-URI prefix split on
+    the first '=' sign, e.g.
+    urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/sso/redirect
+    urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/sso/post
+    The operating context determines which binding is used (e.g. SP-initiated login
+    uses HTTP-Redirect; back-channel operations may use SOAP). When set at domain
+    level, routes SSO login to the correct IdP per domain. Falls back to global
+    config if not set on domain.
+  </desc>
+</attr>
+
+<attr id="4155" name="zimbraSamlSLOURL" type="string" cardinality="multi" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21">
+  <desc>
+    SAML IdP Single Logout URL(s). Replaces saml_redirect_logout_destination
+    and saml_post_logout_destination from saml-config.properties. Multi-valued to
+    support multiple SAML bindings. Each value uses a binding-URI prefix split on
+    the first '=' sign, e.g.
+    urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/slo/redirect
+    urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/slo/post
+    The operating context determines which binding is used (e.g. front-channel
+    logout uses HTTP-Redirect; back-channel logout may use SOAP). When set at
+    domain level, routes SLO to the correct IdP per domain. Falls back to global
+    config if not set on domain.
+  </desc>
+</attr>
+
+<attr id="4156" name="zimbraSamlNameIdFormat" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21">
+  <desc>
+    SAML NameID format. Replaces saml_name_id_format from saml-config.properties.
+    Falls back to global config if not set on domain.
+  </desc>
+</attr>
+
+<attr id="4157" name="zimbraSamlDateFormat" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21">
+  <desc>
+    SAML date format for instant timestamps. Replaces saml_date_format_instant from saml-config.properties.
+    Falls back to global config if not set on domain.
+  </desc>
+</attr>
+
+<attr id="4158" name="zimbraSamlLogoutLandingURL" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21">
+  <desc>
+    SAML logout landing redirect URL. Replaces saml_landing_logout_redirect_url
+    from saml-config.properties. When the SAML extension is the landing page for a
+    logout request, users are redirected to this URL after logout completes. Falls
+    back to global config if not set on domain. Default is /.
+  </desc>
+</attr>
+
+<attr id="4159" name="zimbraSamlDocumentEncoding" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21">
+  <desc>
+    SAML document encoding. Replaces saml_document_encoding from
+    saml-config.properties. Controls the character encoding used for SAML logout
+    documents and login receiver parameter decoding. Falls back to global config
+    if not set on domain.
+  </desc>
+</attr>
+
+<attr id="4160" name="zimbraSamlErrorURL" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21">
+  <desc>
+    SAML error redirect URL. Replaces saml_error_redirect_url from
+    saml-config.properties. When a SAML authentication error occurs, users are
+    redirected to this URL with error_code and error_msg query parameters appended.
+    If not set, the default HTTP error code pages are returned. Falls back to global
+    config if not set on domain.
+  </desc>
+</attr>
+
+<attr id="4161" name="zimbraSamlInactiveAccountURL" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21">
+  <desc>
+    SAML inactive account redirect URL. Replaces saml_inactive_account_redirect_url
+    from saml-config.properties. When a SAML-authenticated user maps to a Zimbra
+    account that is not in active status, the user is redirected to this URL. Falls
+    back to global config if not set on domain.
+  </desc>
+</attr>
+
+<attr id="4162" name="zimbraSamlWebclientDisabledAccountUrl" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21">
+  <desc>
+    SAML webclient-disabled account redirect URL. Replaces saml_webclient_disabled_account_redirect_url
+    from saml-config.properties. After successful SAML authentication, if the account has
+    zimbraFeatureWebClientEnabled set to FALSE, the user is redirected to this URL instead of
+    the web client. Falls back to global config if not set on domain.
+  </desc>
+</attr>
+
+<attr id="4163" name="zimbraSamlSpEntityId" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21">
+  <desc>
+    SAML Service Provider Entity ID. Replaces saml_sp_entity_id from saml-config.properties.
+    When set at domain level, enables per-domain SP metadata (e.g. https://mail.corp-a.com/saml/sp).
+    Falls back to global config if not set on domain.
+  </desc>
+</attr>
+
 <attr id="4165" name="zimbraSamlSpSigningKey" type="astring" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21">
     <desc>Key used to sign SP-generated SAML requests. SAML requests are unsigned if empty</desc>
 </attr>

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -10648,7 +10648,7 @@ TODO: delete them permanently from here
   <desc>Secret key used in Mail Recall to make it more secure from spoof.</desc>
 </attr>
 
-<attr id="4153" name="zimbraSamlACSURL" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21">
+<attr id="4153" name="zimbraSamlACSURL" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21" callback="SamlTestReset">
   <desc>
     SAML Assertion Consumer Service URL. Replaces saml_acs from saml-config.properties.
     When set at domain level, enables per-domain ACS endpoint (e.g. https://mail.corp-a.com/service/extension/samlreceiver).
@@ -10656,7 +10656,7 @@ TODO: delete them permanently from here
   </desc>
 </attr>
 
-<attr id="4154" name="zimbraSamlSSOURL" type="string" cardinality="multi" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21">
+<attr id="4154" name="zimbraSamlSSOURL" type="string" cardinality="multi" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21" callback="SamlTestReset">
   <desc>
     SAML IdP Single Sign-On URL(s). Replaces saml_redirect_login_destination
     and saml_post_login_destination from saml-config.properties. Multi-valued to
@@ -10671,7 +10671,7 @@ TODO: delete them permanently from here
   </desc>
 </attr>
 
-<attr id="4155" name="zimbraSamlSLOURL" type="string" cardinality="multi" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21">
+<attr id="4155" name="zimbraSamlSLOURL" type="string" cardinality="multi" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21" callback="SamlTestReset">
   <desc>
     SAML IdP Single Logout URL(s). Replaces saml_redirect_logout_destination
     and saml_post_logout_destination from saml-config.properties. Multi-valued to
@@ -10686,21 +10686,21 @@ TODO: delete them permanently from here
   </desc>
 </attr>
 
-<attr id="4156" name="zimbraSamlNameIdFormat" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21">
+<attr id="4156" name="zimbraSamlNameIdFormat" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21" callback="SamlTestReset">
   <desc>
     SAML NameID format. Replaces saml_name_id_format from saml-config.properties.
     Falls back to global config if not set on domain.
   </desc>
 </attr>
 
-<attr id="4157" name="zimbraSamlDateFormat" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21">
+<attr id="4157" name="zimbraSamlDateFormat" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21" callback="SamlTestReset">
   <desc>
     SAML date format for instant timestamps. Replaces saml_date_format_instant from saml-config.properties.
     Falls back to global config if not set on domain.
   </desc>
 </attr>
 
-<attr id="4158" name="zimbraSamlLogoutLandingURL" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21">
+<attr id="4158" name="zimbraSamlLogoutLandingURL" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21" callback="SamlTestReset">
   <desc>
     SAML logout landing redirect URL. Replaces saml_landing_logout_redirect_url
     from saml-config.properties. When the SAML extension is the landing page for a
@@ -10709,7 +10709,7 @@ TODO: delete them permanently from here
   </desc>
 </attr>
 
-<attr id="4159" name="zimbraSamlDocumentEncoding" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21">
+<attr id="4159" name="zimbraSamlDocumentEncoding" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21" callback="SamlTestReset">
   <desc>
     SAML document encoding. Replaces saml_document_encoding from
     saml-config.properties. Controls the character encoding used for SAML logout
@@ -10718,7 +10718,7 @@ TODO: delete them permanently from here
   </desc>
 </attr>
 
-<attr id="4160" name="zimbraSamlErrorURL" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21">
+<attr id="4160" name="zimbraSamlErrorURL" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21" callback="SamlTestReset">
   <desc>
     SAML error redirect URL. Replaces saml_error_redirect_url from
     saml-config.properties. When a SAML authentication error occurs, users are
@@ -10728,7 +10728,7 @@ TODO: delete them permanently from here
   </desc>
 </attr>
 
-<attr id="4161" name="zimbraSamlInactiveAccountURL" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21">
+<attr id="4161" name="zimbraSamlInactiveAccountURL" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21" callback="SamlTestReset">
   <desc>
     SAML inactive account redirect URL. Replaces saml_inactive_account_redirect_url
     from saml-config.properties. When a SAML-authenticated user maps to a Zimbra
@@ -10737,7 +10737,7 @@ TODO: delete them permanently from here
   </desc>
 </attr>
 
-<attr id="4162" name="zimbraSamlWebclientDisabledAccountUrl" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21">
+<attr id="4162" name="zimbraSamlWebclientDisabledAccountUrl" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21" callback="SamlTestReset">
   <desc>
     SAML webclient-disabled account redirect URL. Replaces saml_webclient_disabled_account_redirect_url
     from saml-config.properties. After successful SAML authentication, if the account has
@@ -10746,7 +10746,7 @@ TODO: delete them permanently from here
   </desc>
 </attr>
 
-<attr id="4163" name="zimbraSamlSpEntityId" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21">
+<attr id="4163" name="zimbraSamlSpEntityId" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21" callback="SamlTestReset">
   <desc>
     SAML Service Provider Entity ID. Replaces saml_sp_entity_id from saml-config.properties.
     When set at domain level, enables per-domain SP metadata (e.g. https://mail.corp-a.com/saml/sp).
@@ -10754,12 +10754,27 @@ TODO: delete them permanently from here
   </desc>
 </attr>
 
-<attr id="4165" name="zimbraSamlSpSigningKey" type="astring" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21">
+<attr id="4165" name="zimbraSamlSpSigningKey" type="astring" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21" callback="SamlTestReset">
     <desc>Key used to sign SP-generated SAML requests. SAML requests are unsigned if empty</desc>
 </attr>
 
-<attr id="4166" name="zimbraSamlSpSigningCertificate" type="astring" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21">
+<attr id="4166" name="zimbraSamlSpSigningCertificate" type="astring" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="10.1.21" callback="SamlTestReset">
     <desc>Certificate used to verify signed SAML SP requests</desc>
+</attr>
+
+<attr id="4167" name="zimbraSamlTestTimestamp" type="astring" cardinality="single"
+      optionalIn="globalConfig,domain" flags="domainAdminModifiable" immutable="1" since="10.1.21">
+    <desc>Timestamp when the SAML test was completed</desc>
+</attr>
+
+<attr id="4168" name="zimbraSamlTestErrorMessage" type="astring" cardinality="single"
+      optionalIn="globalConfig,domain" flags="domainAdminModifiable" immutable="1" since="10.1.21">
+    <desc>Error code for SAML test failure. Format: SSO:{message_key}. Empty implies success</desc>
+</attr>
+
+<attr id="4169" name="zimbraSamlTestNonce" type="astring" cardinality="single"
+      optionalIn="globalConfig,domain" flags="domainAdminModifiable" immutable="1" since="10.1.21">
+    <desc>Secret nonce for an in-progress SAML test. Format: {nonce} notAfter={timestamp}</desc>
 </attr>
 
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -72755,6 +72755,155 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Certificate used to verify signed SAML SP requests
+     *
+     * @return zimbraSamlSpSigningCertificate, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4166)
+    public String getSamlSpSigningCertificate() {
+        return getAttr(Provisioning.A_zimbraSamlSpSigningCertificate, null, true);
+    }
+
+    /**
+     * Certificate used to verify signed SAML SP requests
+     *
+     * @param zimbraSamlSpSigningCertificate new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4166)
+    public void setSamlSpSigningCertificate(String zimbraSamlSpSigningCertificate) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningCertificate, zimbraSamlSpSigningCertificate);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Certificate used to verify signed SAML SP requests
+     *
+     * @param zimbraSamlSpSigningCertificate new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4166)
+    public Map<String,Object> setSamlSpSigningCertificate(String zimbraSamlSpSigningCertificate, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningCertificate, zimbraSamlSpSigningCertificate);
+        return attrs;
+    }
+
+    /**
+     * Certificate used to verify signed SAML SP requests
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4166)
+    public void unsetSamlSpSigningCertificate() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningCertificate, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Certificate used to verify signed SAML SP requests
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4166)
+    public Map<String,Object> unsetSamlSpSigningCertificate(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningCertificate, "");
+        return attrs;
+    }
+
+    /**
+     * Key used to sign SP-generated SAML requests. SAML requests are
+     * unsigned if empty
+     *
+     * @return zimbraSamlSpSigningKey, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4165)
+    public String getSamlSpSigningKey() {
+        return getAttr(Provisioning.A_zimbraSamlSpSigningKey, null, true);
+    }
+
+    /**
+     * Key used to sign SP-generated SAML requests. SAML requests are
+     * unsigned if empty
+     *
+     * @param zimbraSamlSpSigningKey new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4165)
+    public void setSamlSpSigningKey(String zimbraSamlSpSigningKey) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningKey, zimbraSamlSpSigningKey);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Key used to sign SP-generated SAML requests. SAML requests are
+     * unsigned if empty
+     *
+     * @param zimbraSamlSpSigningKey new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4165)
+    public Map<String,Object> setSamlSpSigningKey(String zimbraSamlSpSigningKey, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningKey, zimbraSamlSpSigningKey);
+        return attrs;
+    }
+
+    /**
+     * Key used to sign SP-generated SAML requests. SAML requests are
+     * unsigned if empty
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4165)
+    public void unsetSamlSpSigningKey() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningKey, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Key used to sign SP-generated SAML requests. SAML requests are
+     * unsigned if empty
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4165)
+    public Map<String,Object> unsetSamlSpSigningKey(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningKey, "");
+        return attrs;
+    }
+
+    /**
      * whether TLS is required for IMAP/POP GSSAPI auth
      *
      * @return zimbraSaslGssapiRequiresTls, or false if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -73909,103 +73909,6 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * SAML webclient-disabled account redirect URL. Replaces
-     * saml_webclient_disabled_account_redirect_url from
-     * saml-config.properties. After successful SAML authentication, if the
-     * account has zimbraFeatureWebClientEnabled set to FALSE, the user is
-     * redirected to this URL instead of the web client. Falls back to global
-     * config if not set on domain.
-     *
-     * @return zimbraSamlWebclientDisabledAccountUrl, or null if unset
-     *
-     * @since ZCS 10.1.21
-     */
-    @ZAttr(id=4162)
-    public String getSamlWebclientDisabledAccountUrl() {
-        return getAttr(Provisioning.A_zimbraSamlWebclientDisabledAccountUrl, null, true);
-    }
-
-    /**
-     * SAML webclient-disabled account redirect URL. Replaces
-     * saml_webclient_disabled_account_redirect_url from
-     * saml-config.properties. After successful SAML authentication, if the
-     * account has zimbraFeatureWebClientEnabled set to FALSE, the user is
-     * redirected to this URL instead of the web client. Falls back to global
-     * config if not set on domain.
-     *
-     * @param zimbraSamlWebclientDisabledAccountUrl new value
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 10.1.21
-     */
-    @ZAttr(id=4162)
-    public void setSamlWebclientDisabledAccountUrl(String zimbraSamlWebclientDisabledAccountUrl) throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraSamlWebclientDisabledAccountUrl, zimbraSamlWebclientDisabledAccountUrl);
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * SAML webclient-disabled account redirect URL. Replaces
-     * saml_webclient_disabled_account_redirect_url from
-     * saml-config.properties. After successful SAML authentication, if the
-     * account has zimbraFeatureWebClientEnabled set to FALSE, the user is
-     * redirected to this URL instead of the web client. Falls back to global
-     * config if not set on domain.
-     *
-     * @param zimbraSamlWebclientDisabledAccountUrl new value
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 10.1.21
-     */
-    @ZAttr(id=4162)
-    public Map<String,Object> setSamlWebclientDisabledAccountUrl(String zimbraSamlWebclientDisabledAccountUrl, Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraSamlWebclientDisabledAccountUrl, zimbraSamlWebclientDisabledAccountUrl);
-        return attrs;
-    }
-
-    /**
-     * SAML webclient-disabled account redirect URL. Replaces
-     * saml_webclient_disabled_account_redirect_url from
-     * saml-config.properties. After successful SAML authentication, if the
-     * account has zimbraFeatureWebClientEnabled set to FALSE, the user is
-     * redirected to this URL instead of the web client. Falls back to global
-     * config if not set on domain.
-     *
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 10.1.21
-     */
-    @ZAttr(id=4162)
-    public void unsetSamlWebclientDisabledAccountUrl() throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraSamlWebclientDisabledAccountUrl, "");
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * SAML webclient-disabled account redirect URL. Replaces
-     * saml_webclient_disabled_account_redirect_url from
-     * saml-config.properties. After successful SAML authentication, if the
-     * account has zimbraFeatureWebClientEnabled set to FALSE, the user is
-     * redirected to this URL instead of the web client. Falls back to global
-     * config if not set on domain.
-     *
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 10.1.21
-     */
-    @ZAttr(id=4162)
-    public Map<String,Object> unsetSamlWebclientDisabledAccountUrl(Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraSamlWebclientDisabledAccountUrl, "");
-        return attrs;
-    }
-
-    /**
      * Certificate used to verify signed SAML SP requests
      *
      * @return zimbraSamlSpSigningCertificate, or null if unset
@@ -74151,6 +74054,329 @@ public abstract class ZAttrConfig extends Entry {
     public Map<String,Object> unsetSamlSpSigningKey(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSamlSpSigningKey, "");
+        return attrs;
+    }
+
+    /**
+     * Error code for SAML test failure. Format: SSO:{message_key}. Empty
+     * implies success
+     *
+     * @return zimbraSamlTestErrorMessage, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4168)
+    public String getSamlTestErrorMessage() {
+        return getAttr(Provisioning.A_zimbraSamlTestErrorMessage, null, true);
+    }
+
+    /**
+     * Error code for SAML test failure. Format: SSO:{message_key}. Empty
+     * implies success
+     *
+     * @param zimbraSamlTestErrorMessage new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4168)
+    public void setSamlTestErrorMessage(String zimbraSamlTestErrorMessage) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlTestErrorMessage, zimbraSamlTestErrorMessage);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Error code for SAML test failure. Format: SSO:{message_key}. Empty
+     * implies success
+     *
+     * @param zimbraSamlTestErrorMessage new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4168)
+    public Map<String,Object> setSamlTestErrorMessage(String zimbraSamlTestErrorMessage, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlTestErrorMessage, zimbraSamlTestErrorMessage);
+        return attrs;
+    }
+
+    /**
+     * Error code for SAML test failure. Format: SSO:{message_key}. Empty
+     * implies success
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4168)
+    public void unsetSamlTestErrorMessage() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlTestErrorMessage, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Error code for SAML test failure. Format: SSO:{message_key}. Empty
+     * implies success
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4168)
+    public Map<String,Object> unsetSamlTestErrorMessage(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlTestErrorMessage, "");
+        return attrs;
+    }
+
+    /**
+     * Secret nonce for an in-progress SAML test. Format: {nonce}
+     * notAfter={timestamp}
+     *
+     * @return zimbraSamlTestNonce, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4169)
+    public String getSamlTestNonce() {
+        return getAttr(Provisioning.A_zimbraSamlTestNonce, null, true);
+    }
+
+    /**
+     * Secret nonce for an in-progress SAML test. Format: {nonce}
+     * notAfter={timestamp}
+     *
+     * @param zimbraSamlTestNonce new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4169)
+    public void setSamlTestNonce(String zimbraSamlTestNonce) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlTestNonce, zimbraSamlTestNonce);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Secret nonce for an in-progress SAML test. Format: {nonce}
+     * notAfter={timestamp}
+     *
+     * @param zimbraSamlTestNonce new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4169)
+    public Map<String,Object> setSamlTestNonce(String zimbraSamlTestNonce, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlTestNonce, zimbraSamlTestNonce);
+        return attrs;
+    }
+
+    /**
+     * Secret nonce for an in-progress SAML test. Format: {nonce}
+     * notAfter={timestamp}
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4169)
+    public void unsetSamlTestNonce() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlTestNonce, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Secret nonce for an in-progress SAML test. Format: {nonce}
+     * notAfter={timestamp}
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4169)
+    public Map<String,Object> unsetSamlTestNonce(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlTestNonce, "");
+        return attrs;
+    }
+
+    /**
+     * Timestamp when the SAML test was completed
+     *
+     * @return zimbraSamlTestTimestamp, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4167)
+    public String getSamlTestTimestamp() {
+        return getAttr(Provisioning.A_zimbraSamlTestTimestamp, null, true);
+    }
+
+    /**
+     * Timestamp when the SAML test was completed
+     *
+     * @param zimbraSamlTestTimestamp new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4167)
+    public void setSamlTestTimestamp(String zimbraSamlTestTimestamp) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlTestTimestamp, zimbraSamlTestTimestamp);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Timestamp when the SAML test was completed
+     *
+     * @param zimbraSamlTestTimestamp new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4167)
+    public Map<String,Object> setSamlTestTimestamp(String zimbraSamlTestTimestamp, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlTestTimestamp, zimbraSamlTestTimestamp);
+        return attrs;
+    }
+
+    /**
+     * Timestamp when the SAML test was completed
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4167)
+    public void unsetSamlTestTimestamp() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlTestTimestamp, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Timestamp when the SAML test was completed
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4167)
+    public Map<String,Object> unsetSamlTestTimestamp(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlTestTimestamp, "");
+        return attrs;
+    }
+
+    /**
+     * SAML webclient-disabled account redirect URL. Replaces
+     * saml_webclient_disabled_account_redirect_url from
+     * saml-config.properties. After successful SAML authentication, if the
+     * account has zimbraFeatureWebClientEnabled set to FALSE, the user is
+     * redirected to this URL instead of the web client. Falls back to global
+     * config if not set on domain.
+     *
+     * @return zimbraSamlWebclientDisabledAccountUrl, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4162)
+    public String getSamlWebclientDisabledAccountUrl() {
+        return getAttr(Provisioning.A_zimbraSamlWebclientDisabledAccountUrl, null, true);
+    }
+
+    /**
+     * SAML webclient-disabled account redirect URL. Replaces
+     * saml_webclient_disabled_account_redirect_url from
+     * saml-config.properties. After successful SAML authentication, if the
+     * account has zimbraFeatureWebClientEnabled set to FALSE, the user is
+     * redirected to this URL instead of the web client. Falls back to global
+     * config if not set on domain.
+     *
+     * @param zimbraSamlWebclientDisabledAccountUrl new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4162)
+    public void setSamlWebclientDisabledAccountUrl(String zimbraSamlWebclientDisabledAccountUrl) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlWebclientDisabledAccountUrl, zimbraSamlWebclientDisabledAccountUrl);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML webclient-disabled account redirect URL. Replaces
+     * saml_webclient_disabled_account_redirect_url from
+     * saml-config.properties. After successful SAML authentication, if the
+     * account has zimbraFeatureWebClientEnabled set to FALSE, the user is
+     * redirected to this URL instead of the web client. Falls back to global
+     * config if not set on domain.
+     *
+     * @param zimbraSamlWebclientDisabledAccountUrl new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4162)
+    public Map<String,Object> setSamlWebclientDisabledAccountUrl(String zimbraSamlWebclientDisabledAccountUrl, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlWebclientDisabledAccountUrl, zimbraSamlWebclientDisabledAccountUrl);
+        return attrs;
+    }
+
+    /**
+     * SAML webclient-disabled account redirect URL. Replaces
+     * saml_webclient_disabled_account_redirect_url from
+     * saml-config.properties. After successful SAML authentication, if the
+     * account has zimbraFeatureWebClientEnabled set to FALSE, the user is
+     * redirected to this URL instead of the web client. Falls back to global
+     * config if not set on domain.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4162)
+    public void unsetSamlWebclientDisabledAccountUrl() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlWebclientDisabledAccountUrl, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML webclient-disabled account redirect URL. Replaces
+     * saml_webclient_disabled_account_redirect_url from
+     * saml-config.properties. After successful SAML authentication, if the
+     * account has zimbraFeatureWebClientEnabled set to FALSE, the user is
+     * redirected to this URL instead of the web client. Falls back to global
+     * config if not set on domain.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4162)
+    public Map<String,Object> unsetSamlWebclientDisabledAccountUrl(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlWebclientDisabledAccountUrl, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -72755,6 +72755,1257 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * SAML Assertion Consumer Service URL. Replaces saml_acs from
+     * saml-config.properties. When set at domain level, enables per-domain
+     * ACS endpoint (e.g.
+     * https://mail.corp-a.com/service/extension/samlreceiver). Falls back to
+     * global config if not set on domain.
+     *
+     * @return zimbraSamlACSURL, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4153)
+    public String getSamlACSURL() {
+        return getAttr(Provisioning.A_zimbraSamlACSURL, null, true);
+    }
+
+    /**
+     * SAML Assertion Consumer Service URL. Replaces saml_acs from
+     * saml-config.properties. When set at domain level, enables per-domain
+     * ACS endpoint (e.g.
+     * https://mail.corp-a.com/service/extension/samlreceiver). Falls back to
+     * global config if not set on domain.
+     *
+     * @param zimbraSamlACSURL new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4153)
+    public void setSamlACSURL(String zimbraSamlACSURL) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlACSURL, zimbraSamlACSURL);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML Assertion Consumer Service URL. Replaces saml_acs from
+     * saml-config.properties. When set at domain level, enables per-domain
+     * ACS endpoint (e.g.
+     * https://mail.corp-a.com/service/extension/samlreceiver). Falls back to
+     * global config if not set on domain.
+     *
+     * @param zimbraSamlACSURL new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4153)
+    public Map<String,Object> setSamlACSURL(String zimbraSamlACSURL, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlACSURL, zimbraSamlACSURL);
+        return attrs;
+    }
+
+    /**
+     * SAML Assertion Consumer Service URL. Replaces saml_acs from
+     * saml-config.properties. When set at domain level, enables per-domain
+     * ACS endpoint (e.g.
+     * https://mail.corp-a.com/service/extension/samlreceiver). Falls back to
+     * global config if not set on domain.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4153)
+    public void unsetSamlACSURL() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlACSURL, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML Assertion Consumer Service URL. Replaces saml_acs from
+     * saml-config.properties. When set at domain level, enables per-domain
+     * ACS endpoint (e.g.
+     * https://mail.corp-a.com/service/extension/samlreceiver). Falls back to
+     * global config if not set on domain.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4153)
+    public Map<String,Object> unsetSamlACSURL(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlACSURL, "");
+        return attrs;
+    }
+
+    /**
+     * SAML date format for instant timestamps. Replaces
+     * saml_date_format_instant from saml-config.properties. Falls back to
+     * global config if not set on domain.
+     *
+     * @return zimbraSamlDateFormat, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4157)
+    public String getSamlDateFormat() {
+        return getAttr(Provisioning.A_zimbraSamlDateFormat, null, true);
+    }
+
+    /**
+     * SAML date format for instant timestamps. Replaces
+     * saml_date_format_instant from saml-config.properties. Falls back to
+     * global config if not set on domain.
+     *
+     * @param zimbraSamlDateFormat new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4157)
+    public void setSamlDateFormat(String zimbraSamlDateFormat) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlDateFormat, zimbraSamlDateFormat);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML date format for instant timestamps. Replaces
+     * saml_date_format_instant from saml-config.properties. Falls back to
+     * global config if not set on domain.
+     *
+     * @param zimbraSamlDateFormat new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4157)
+    public Map<String,Object> setSamlDateFormat(String zimbraSamlDateFormat, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlDateFormat, zimbraSamlDateFormat);
+        return attrs;
+    }
+
+    /**
+     * SAML date format for instant timestamps. Replaces
+     * saml_date_format_instant from saml-config.properties. Falls back to
+     * global config if not set on domain.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4157)
+    public void unsetSamlDateFormat() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlDateFormat, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML date format for instant timestamps. Replaces
+     * saml_date_format_instant from saml-config.properties. Falls back to
+     * global config if not set on domain.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4157)
+    public Map<String,Object> unsetSamlDateFormat(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlDateFormat, "");
+        return attrs;
+    }
+
+    /**
+     * SAML document encoding. Replaces saml_document_encoding from
+     * saml-config.properties. Controls the character encoding used for SAML
+     * logout documents and login receiver parameter decoding. Falls back to
+     * global config if not set on domain.
+     *
+     * @return zimbraSamlDocumentEncoding, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4159)
+    public String getSamlDocumentEncoding() {
+        return getAttr(Provisioning.A_zimbraSamlDocumentEncoding, null, true);
+    }
+
+    /**
+     * SAML document encoding. Replaces saml_document_encoding from
+     * saml-config.properties. Controls the character encoding used for SAML
+     * logout documents and login receiver parameter decoding. Falls back to
+     * global config if not set on domain.
+     *
+     * @param zimbraSamlDocumentEncoding new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4159)
+    public void setSamlDocumentEncoding(String zimbraSamlDocumentEncoding) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlDocumentEncoding, zimbraSamlDocumentEncoding);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML document encoding. Replaces saml_document_encoding from
+     * saml-config.properties. Controls the character encoding used for SAML
+     * logout documents and login receiver parameter decoding. Falls back to
+     * global config if not set on domain.
+     *
+     * @param zimbraSamlDocumentEncoding new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4159)
+    public Map<String,Object> setSamlDocumentEncoding(String zimbraSamlDocumentEncoding, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlDocumentEncoding, zimbraSamlDocumentEncoding);
+        return attrs;
+    }
+
+    /**
+     * SAML document encoding. Replaces saml_document_encoding from
+     * saml-config.properties. Controls the character encoding used for SAML
+     * logout documents and login receiver parameter decoding. Falls back to
+     * global config if not set on domain.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4159)
+    public void unsetSamlDocumentEncoding() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlDocumentEncoding, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML document encoding. Replaces saml_document_encoding from
+     * saml-config.properties. Controls the character encoding used for SAML
+     * logout documents and login receiver parameter decoding. Falls back to
+     * global config if not set on domain.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4159)
+    public Map<String,Object> unsetSamlDocumentEncoding(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlDocumentEncoding, "");
+        return attrs;
+    }
+
+    /**
+     * SAML error redirect URL. Replaces saml_error_redirect_url from
+     * saml-config.properties. When a SAML authentication error occurs, users
+     * are redirected to this URL with error_code and error_msg query
+     * parameters appended. If not set, the default HTTP error code pages are
+     * returned. Falls back to global config if not set on domain.
+     *
+     * @return zimbraSamlErrorURL, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4160)
+    public String getSamlErrorURL() {
+        return getAttr(Provisioning.A_zimbraSamlErrorURL, null, true);
+    }
+
+    /**
+     * SAML error redirect URL. Replaces saml_error_redirect_url from
+     * saml-config.properties. When a SAML authentication error occurs, users
+     * are redirected to this URL with error_code and error_msg query
+     * parameters appended. If not set, the default HTTP error code pages are
+     * returned. Falls back to global config if not set on domain.
+     *
+     * @param zimbraSamlErrorURL new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4160)
+    public void setSamlErrorURL(String zimbraSamlErrorURL) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlErrorURL, zimbraSamlErrorURL);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML error redirect URL. Replaces saml_error_redirect_url from
+     * saml-config.properties. When a SAML authentication error occurs, users
+     * are redirected to this URL with error_code and error_msg query
+     * parameters appended. If not set, the default HTTP error code pages are
+     * returned. Falls back to global config if not set on domain.
+     *
+     * @param zimbraSamlErrorURL new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4160)
+    public Map<String,Object> setSamlErrorURL(String zimbraSamlErrorURL, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlErrorURL, zimbraSamlErrorURL);
+        return attrs;
+    }
+
+    /**
+     * SAML error redirect URL. Replaces saml_error_redirect_url from
+     * saml-config.properties. When a SAML authentication error occurs, users
+     * are redirected to this URL with error_code and error_msg query
+     * parameters appended. If not set, the default HTTP error code pages are
+     * returned. Falls back to global config if not set on domain.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4160)
+    public void unsetSamlErrorURL() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlErrorURL, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML error redirect URL. Replaces saml_error_redirect_url from
+     * saml-config.properties. When a SAML authentication error occurs, users
+     * are redirected to this URL with error_code and error_msg query
+     * parameters appended. If not set, the default HTTP error code pages are
+     * returned. Falls back to global config if not set on domain.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4160)
+    public Map<String,Object> unsetSamlErrorURL(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlErrorURL, "");
+        return attrs;
+    }
+
+    /**
+     * SAML inactive account redirect URL. Replaces
+     * saml_inactive_account_redirect_url from saml-config.properties. When a
+     * SAML-authenticated user maps to a Zimbra account that is not in active
+     * status, the user is redirected to this URL. Falls back to global
+     * config if not set on domain.
+     *
+     * @return zimbraSamlInactiveAccountURL, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4161)
+    public String getSamlInactiveAccountURL() {
+        return getAttr(Provisioning.A_zimbraSamlInactiveAccountURL, null, true);
+    }
+
+    /**
+     * SAML inactive account redirect URL. Replaces
+     * saml_inactive_account_redirect_url from saml-config.properties. When a
+     * SAML-authenticated user maps to a Zimbra account that is not in active
+     * status, the user is redirected to this URL. Falls back to global
+     * config if not set on domain.
+     *
+     * @param zimbraSamlInactiveAccountURL new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4161)
+    public void setSamlInactiveAccountURL(String zimbraSamlInactiveAccountURL) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlInactiveAccountURL, zimbraSamlInactiveAccountURL);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML inactive account redirect URL. Replaces
+     * saml_inactive_account_redirect_url from saml-config.properties. When a
+     * SAML-authenticated user maps to a Zimbra account that is not in active
+     * status, the user is redirected to this URL. Falls back to global
+     * config if not set on domain.
+     *
+     * @param zimbraSamlInactiveAccountURL new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4161)
+    public Map<String,Object> setSamlInactiveAccountURL(String zimbraSamlInactiveAccountURL, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlInactiveAccountURL, zimbraSamlInactiveAccountURL);
+        return attrs;
+    }
+
+    /**
+     * SAML inactive account redirect URL. Replaces
+     * saml_inactive_account_redirect_url from saml-config.properties. When a
+     * SAML-authenticated user maps to a Zimbra account that is not in active
+     * status, the user is redirected to this URL. Falls back to global
+     * config if not set on domain.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4161)
+    public void unsetSamlInactiveAccountURL() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlInactiveAccountURL, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML inactive account redirect URL. Replaces
+     * saml_inactive_account_redirect_url from saml-config.properties. When a
+     * SAML-authenticated user maps to a Zimbra account that is not in active
+     * status, the user is redirected to this URL. Falls back to global
+     * config if not set on domain.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4161)
+    public Map<String,Object> unsetSamlInactiveAccountURL(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlInactiveAccountURL, "");
+        return attrs;
+    }
+
+    /**
+     * SAML logout landing redirect URL. Replaces
+     * saml_landing_logout_redirect_url from saml-config.properties. When the
+     * SAML extension is the landing page for a logout request, users are
+     * redirected to this URL after logout completes. Falls back to global
+     * config if not set on domain. Default is /.
+     *
+     * @return zimbraSamlLogoutLandingURL, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4158)
+    public String getSamlLogoutLandingURL() {
+        return getAttr(Provisioning.A_zimbraSamlLogoutLandingURL, null, true);
+    }
+
+    /**
+     * SAML logout landing redirect URL. Replaces
+     * saml_landing_logout_redirect_url from saml-config.properties. When the
+     * SAML extension is the landing page for a logout request, users are
+     * redirected to this URL after logout completes. Falls back to global
+     * config if not set on domain. Default is /.
+     *
+     * @param zimbraSamlLogoutLandingURL new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4158)
+    public void setSamlLogoutLandingURL(String zimbraSamlLogoutLandingURL) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlLogoutLandingURL, zimbraSamlLogoutLandingURL);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML logout landing redirect URL. Replaces
+     * saml_landing_logout_redirect_url from saml-config.properties. When the
+     * SAML extension is the landing page for a logout request, users are
+     * redirected to this URL after logout completes. Falls back to global
+     * config if not set on domain. Default is /.
+     *
+     * @param zimbraSamlLogoutLandingURL new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4158)
+    public Map<String,Object> setSamlLogoutLandingURL(String zimbraSamlLogoutLandingURL, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlLogoutLandingURL, zimbraSamlLogoutLandingURL);
+        return attrs;
+    }
+
+    /**
+     * SAML logout landing redirect URL. Replaces
+     * saml_landing_logout_redirect_url from saml-config.properties. When the
+     * SAML extension is the landing page for a logout request, users are
+     * redirected to this URL after logout completes. Falls back to global
+     * config if not set on domain. Default is /.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4158)
+    public void unsetSamlLogoutLandingURL() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlLogoutLandingURL, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML logout landing redirect URL. Replaces
+     * saml_landing_logout_redirect_url from saml-config.properties. When the
+     * SAML extension is the landing page for a logout request, users are
+     * redirected to this URL after logout completes. Falls back to global
+     * config if not set on domain. Default is /.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4158)
+    public Map<String,Object> unsetSamlLogoutLandingURL(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlLogoutLandingURL, "");
+        return attrs;
+    }
+
+    /**
+     * SAML NameID format. Replaces saml_name_id_format from
+     * saml-config.properties. Falls back to global config if not set on
+     * domain.
+     *
+     * @return zimbraSamlNameIdFormat, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4156)
+    public String getSamlNameIdFormat() {
+        return getAttr(Provisioning.A_zimbraSamlNameIdFormat, null, true);
+    }
+
+    /**
+     * SAML NameID format. Replaces saml_name_id_format from
+     * saml-config.properties. Falls back to global config if not set on
+     * domain.
+     *
+     * @param zimbraSamlNameIdFormat new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4156)
+    public void setSamlNameIdFormat(String zimbraSamlNameIdFormat) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlNameIdFormat, zimbraSamlNameIdFormat);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML NameID format. Replaces saml_name_id_format from
+     * saml-config.properties. Falls back to global config if not set on
+     * domain.
+     *
+     * @param zimbraSamlNameIdFormat new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4156)
+    public Map<String,Object> setSamlNameIdFormat(String zimbraSamlNameIdFormat, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlNameIdFormat, zimbraSamlNameIdFormat);
+        return attrs;
+    }
+
+    /**
+     * SAML NameID format. Replaces saml_name_id_format from
+     * saml-config.properties. Falls back to global config if not set on
+     * domain.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4156)
+    public void unsetSamlNameIdFormat() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlNameIdFormat, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML NameID format. Replaces saml_name_id_format from
+     * saml-config.properties. Falls back to global config if not set on
+     * domain.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4156)
+    public Map<String,Object> unsetSamlNameIdFormat(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlNameIdFormat, "");
+        return attrs;
+    }
+
+    /**
+     * SAML IdP Single Logout URL(s). Replaces
+     * saml_redirect_logout_destination and saml_post_logout_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/slo/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/slo/post
+     * The operating context determines which binding is used (e.g.
+     * front-channel logout uses HTTP-Redirect; back-channel logout may use
+     * SOAP). When set at domain level, routes SLO to the correct IdP per
+     * domain. Falls back to global config if not set on domain.
+     *
+     * @return zimbraSamlSLOURL, or empty array if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4155)
+    public String[] getSamlSLOURL() {
+        return getMultiAttr(Provisioning.A_zimbraSamlSLOURL, true, true);
+    }
+
+    /**
+     * SAML IdP Single Logout URL(s). Replaces
+     * saml_redirect_logout_destination and saml_post_logout_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/slo/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/slo/post
+     * The operating context determines which binding is used (e.g.
+     * front-channel logout uses HTTP-Redirect; back-channel logout may use
+     * SOAP). When set at domain level, routes SLO to the correct IdP per
+     * domain. Falls back to global config if not set on domain.
+     *
+     * @param zimbraSamlSLOURL new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4155)
+    public void setSamlSLOURL(String[] zimbraSamlSLOURL) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSLOURL, zimbraSamlSLOURL);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML IdP Single Logout URL(s). Replaces
+     * saml_redirect_logout_destination and saml_post_logout_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/slo/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/slo/post
+     * The operating context determines which binding is used (e.g.
+     * front-channel logout uses HTTP-Redirect; back-channel logout may use
+     * SOAP). When set at domain level, routes SLO to the correct IdP per
+     * domain. Falls back to global config if not set on domain.
+     *
+     * @param zimbraSamlSLOURL new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4155)
+    public Map<String,Object> setSamlSLOURL(String[] zimbraSamlSLOURL, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSLOURL, zimbraSamlSLOURL);
+        return attrs;
+    }
+
+    /**
+     * SAML IdP Single Logout URL(s). Replaces
+     * saml_redirect_logout_destination and saml_post_logout_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/slo/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/slo/post
+     * The operating context determines which binding is used (e.g.
+     * front-channel logout uses HTTP-Redirect; back-channel logout may use
+     * SOAP). When set at domain level, routes SLO to the correct IdP per
+     * domain. Falls back to global config if not set on domain.
+     *
+     * @param zimbraSamlSLOURL new to add to existing values
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4155)
+    public void addSamlSLOURL(String zimbraSamlSLOURL) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraSamlSLOURL, zimbraSamlSLOURL);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML IdP Single Logout URL(s). Replaces
+     * saml_redirect_logout_destination and saml_post_logout_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/slo/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/slo/post
+     * The operating context determines which binding is used (e.g.
+     * front-channel logout uses HTTP-Redirect; back-channel logout may use
+     * SOAP). When set at domain level, routes SLO to the correct IdP per
+     * domain. Falls back to global config if not set on domain.
+     *
+     * @param zimbraSamlSLOURL new to add to existing values
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4155)
+    public Map<String,Object> addSamlSLOURL(String zimbraSamlSLOURL, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraSamlSLOURL, zimbraSamlSLOURL);
+        return attrs;
+    }
+
+    /**
+     * SAML IdP Single Logout URL(s). Replaces
+     * saml_redirect_logout_destination and saml_post_logout_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/slo/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/slo/post
+     * The operating context determines which binding is used (e.g.
+     * front-channel logout uses HTTP-Redirect; back-channel logout may use
+     * SOAP). When set at domain level, routes SLO to the correct IdP per
+     * domain. Falls back to global config if not set on domain.
+     *
+     * @param zimbraSamlSLOURL existing value to remove
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4155)
+    public void removeSamlSLOURL(String zimbraSamlSLOURL) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraSamlSLOURL, zimbraSamlSLOURL);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML IdP Single Logout URL(s). Replaces
+     * saml_redirect_logout_destination and saml_post_logout_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/slo/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/slo/post
+     * The operating context determines which binding is used (e.g.
+     * front-channel logout uses HTTP-Redirect; back-channel logout may use
+     * SOAP). When set at domain level, routes SLO to the correct IdP per
+     * domain. Falls back to global config if not set on domain.
+     *
+     * @param zimbraSamlSLOURL existing value to remove
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4155)
+    public Map<String,Object> removeSamlSLOURL(String zimbraSamlSLOURL, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraSamlSLOURL, zimbraSamlSLOURL);
+        return attrs;
+    }
+
+    /**
+     * SAML IdP Single Logout URL(s). Replaces
+     * saml_redirect_logout_destination and saml_post_logout_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/slo/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/slo/post
+     * The operating context determines which binding is used (e.g.
+     * front-channel logout uses HTTP-Redirect; back-channel logout may use
+     * SOAP). When set at domain level, routes SLO to the correct IdP per
+     * domain. Falls back to global config if not set on domain.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4155)
+    public void unsetSamlSLOURL() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSLOURL, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML IdP Single Logout URL(s). Replaces
+     * saml_redirect_logout_destination and saml_post_logout_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/slo/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/slo/post
+     * The operating context determines which binding is used (e.g.
+     * front-channel logout uses HTTP-Redirect; back-channel logout may use
+     * SOAP). When set at domain level, routes SLO to the correct IdP per
+     * domain. Falls back to global config if not set on domain.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4155)
+    public Map<String,Object> unsetSamlSLOURL(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSLOURL, "");
+        return attrs;
+    }
+
+    /**
+     * SAML IdP Single Sign-On URL(s). Replaces
+     * saml_redirect_login_destination and saml_post_login_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/sso/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/sso/post
+     * The operating context determines which binding is used (e.g.
+     * SP-initiated login uses HTTP-Redirect; back-channel operations may use
+     * SOAP). When set at domain level, routes SSO login to the correct IdP
+     * per domain. Falls back to global config if not set on domain.
+     *
+     * @return zimbraSamlSSOURL, or empty array if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4154)
+    public String[] getSamlSSOURL() {
+        return getMultiAttr(Provisioning.A_zimbraSamlSSOURL, true, true);
+    }
+
+    /**
+     * SAML IdP Single Sign-On URL(s). Replaces
+     * saml_redirect_login_destination and saml_post_login_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/sso/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/sso/post
+     * The operating context determines which binding is used (e.g.
+     * SP-initiated login uses HTTP-Redirect; back-channel operations may use
+     * SOAP). When set at domain level, routes SSO login to the correct IdP
+     * per domain. Falls back to global config if not set on domain.
+     *
+     * @param zimbraSamlSSOURL new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4154)
+    public void setSamlSSOURL(String[] zimbraSamlSSOURL) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSSOURL, zimbraSamlSSOURL);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML IdP Single Sign-On URL(s). Replaces
+     * saml_redirect_login_destination and saml_post_login_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/sso/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/sso/post
+     * The operating context determines which binding is used (e.g.
+     * SP-initiated login uses HTTP-Redirect; back-channel operations may use
+     * SOAP). When set at domain level, routes SSO login to the correct IdP
+     * per domain. Falls back to global config if not set on domain.
+     *
+     * @param zimbraSamlSSOURL new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4154)
+    public Map<String,Object> setSamlSSOURL(String[] zimbraSamlSSOURL, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSSOURL, zimbraSamlSSOURL);
+        return attrs;
+    }
+
+    /**
+     * SAML IdP Single Sign-On URL(s). Replaces
+     * saml_redirect_login_destination and saml_post_login_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/sso/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/sso/post
+     * The operating context determines which binding is used (e.g.
+     * SP-initiated login uses HTTP-Redirect; back-channel operations may use
+     * SOAP). When set at domain level, routes SSO login to the correct IdP
+     * per domain. Falls back to global config if not set on domain.
+     *
+     * @param zimbraSamlSSOURL new to add to existing values
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4154)
+    public void addSamlSSOURL(String zimbraSamlSSOURL) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraSamlSSOURL, zimbraSamlSSOURL);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML IdP Single Sign-On URL(s). Replaces
+     * saml_redirect_login_destination and saml_post_login_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/sso/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/sso/post
+     * The operating context determines which binding is used (e.g.
+     * SP-initiated login uses HTTP-Redirect; back-channel operations may use
+     * SOAP). When set at domain level, routes SSO login to the correct IdP
+     * per domain. Falls back to global config if not set on domain.
+     *
+     * @param zimbraSamlSSOURL new to add to existing values
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4154)
+    public Map<String,Object> addSamlSSOURL(String zimbraSamlSSOURL, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraSamlSSOURL, zimbraSamlSSOURL);
+        return attrs;
+    }
+
+    /**
+     * SAML IdP Single Sign-On URL(s). Replaces
+     * saml_redirect_login_destination and saml_post_login_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/sso/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/sso/post
+     * The operating context determines which binding is used (e.g.
+     * SP-initiated login uses HTTP-Redirect; back-channel operations may use
+     * SOAP). When set at domain level, routes SSO login to the correct IdP
+     * per domain. Falls back to global config if not set on domain.
+     *
+     * @param zimbraSamlSSOURL existing value to remove
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4154)
+    public void removeSamlSSOURL(String zimbraSamlSSOURL) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraSamlSSOURL, zimbraSamlSSOURL);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML IdP Single Sign-On URL(s). Replaces
+     * saml_redirect_login_destination and saml_post_login_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/sso/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/sso/post
+     * The operating context determines which binding is used (e.g.
+     * SP-initiated login uses HTTP-Redirect; back-channel operations may use
+     * SOAP). When set at domain level, routes SSO login to the correct IdP
+     * per domain. Falls back to global config if not set on domain.
+     *
+     * @param zimbraSamlSSOURL existing value to remove
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4154)
+    public Map<String,Object> removeSamlSSOURL(String zimbraSamlSSOURL, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraSamlSSOURL, zimbraSamlSSOURL);
+        return attrs;
+    }
+
+    /**
+     * SAML IdP Single Sign-On URL(s). Replaces
+     * saml_redirect_login_destination and saml_post_login_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/sso/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/sso/post
+     * The operating context determines which binding is used (e.g.
+     * SP-initiated login uses HTTP-Redirect; back-channel operations may use
+     * SOAP). When set at domain level, routes SSO login to the correct IdP
+     * per domain. Falls back to global config if not set on domain.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4154)
+    public void unsetSamlSSOURL() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSSOURL, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML IdP Single Sign-On URL(s). Replaces
+     * saml_redirect_login_destination and saml_post_login_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/sso/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/sso/post
+     * The operating context determines which binding is used (e.g.
+     * SP-initiated login uses HTTP-Redirect; back-channel operations may use
+     * SOAP). When set at domain level, routes SSO login to the correct IdP
+     * per domain. Falls back to global config if not set on domain.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4154)
+    public Map<String,Object> unsetSamlSSOURL(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSSOURL, "");
+        return attrs;
+    }
+
+    /**
+     * SAML Service Provider Entity ID. Replaces saml_sp_entity_id from
+     * saml-config.properties. When set at domain level, enables per-domain
+     * SP metadata (e.g. https://mail.corp-a.com/saml/sp). Falls back to
+     * global config if not set on domain.
+     *
+     * @return zimbraSamlSpEntityId, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4163)
+    public String getSamlSpEntityId() {
+        return getAttr(Provisioning.A_zimbraSamlSpEntityId, null, true);
+    }
+
+    /**
+     * SAML Service Provider Entity ID. Replaces saml_sp_entity_id from
+     * saml-config.properties. When set at domain level, enables per-domain
+     * SP metadata (e.g. https://mail.corp-a.com/saml/sp). Falls back to
+     * global config if not set on domain.
+     *
+     * @param zimbraSamlSpEntityId new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4163)
+    public void setSamlSpEntityId(String zimbraSamlSpEntityId) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpEntityId, zimbraSamlSpEntityId);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML Service Provider Entity ID. Replaces saml_sp_entity_id from
+     * saml-config.properties. When set at domain level, enables per-domain
+     * SP metadata (e.g. https://mail.corp-a.com/saml/sp). Falls back to
+     * global config if not set on domain.
+     *
+     * @param zimbraSamlSpEntityId new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4163)
+    public Map<String,Object> setSamlSpEntityId(String zimbraSamlSpEntityId, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpEntityId, zimbraSamlSpEntityId);
+        return attrs;
+    }
+
+    /**
+     * SAML Service Provider Entity ID. Replaces saml_sp_entity_id from
+     * saml-config.properties. When set at domain level, enables per-domain
+     * SP metadata (e.g. https://mail.corp-a.com/saml/sp). Falls back to
+     * global config if not set on domain.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4163)
+    public void unsetSamlSpEntityId() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpEntityId, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML Service Provider Entity ID. Replaces saml_sp_entity_id from
+     * saml-config.properties. When set at domain level, enables per-domain
+     * SP metadata (e.g. https://mail.corp-a.com/saml/sp). Falls back to
+     * global config if not set on domain.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4163)
+    public Map<String,Object> unsetSamlSpEntityId(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpEntityId, "");
+        return attrs;
+    }
+
+    /**
+     * SAML webclient-disabled account redirect URL. Replaces
+     * saml_webclient_disabled_account_redirect_url from
+     * saml-config.properties. After successful SAML authentication, if the
+     * account has zimbraFeatureWebClientEnabled set to FALSE, the user is
+     * redirected to this URL instead of the web client. Falls back to global
+     * config if not set on domain.
+     *
+     * @return zimbraSamlWebclientDisabledAccountUrl, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4162)
+    public String getSamlWebclientDisabledAccountUrl() {
+        return getAttr(Provisioning.A_zimbraSamlWebclientDisabledAccountUrl, null, true);
+    }
+
+    /**
+     * SAML webclient-disabled account redirect URL. Replaces
+     * saml_webclient_disabled_account_redirect_url from
+     * saml-config.properties. After successful SAML authentication, if the
+     * account has zimbraFeatureWebClientEnabled set to FALSE, the user is
+     * redirected to this URL instead of the web client. Falls back to global
+     * config if not set on domain.
+     *
+     * @param zimbraSamlWebclientDisabledAccountUrl new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4162)
+    public void setSamlWebclientDisabledAccountUrl(String zimbraSamlWebclientDisabledAccountUrl) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlWebclientDisabledAccountUrl, zimbraSamlWebclientDisabledAccountUrl);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML webclient-disabled account redirect URL. Replaces
+     * saml_webclient_disabled_account_redirect_url from
+     * saml-config.properties. After successful SAML authentication, if the
+     * account has zimbraFeatureWebClientEnabled set to FALSE, the user is
+     * redirected to this URL instead of the web client. Falls back to global
+     * config if not set on domain.
+     *
+     * @param zimbraSamlWebclientDisabledAccountUrl new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4162)
+    public Map<String,Object> setSamlWebclientDisabledAccountUrl(String zimbraSamlWebclientDisabledAccountUrl, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlWebclientDisabledAccountUrl, zimbraSamlWebclientDisabledAccountUrl);
+        return attrs;
+    }
+
+    /**
+     * SAML webclient-disabled account redirect URL. Replaces
+     * saml_webclient_disabled_account_redirect_url from
+     * saml-config.properties. After successful SAML authentication, if the
+     * account has zimbraFeatureWebClientEnabled set to FALSE, the user is
+     * redirected to this URL instead of the web client. Falls back to global
+     * config if not set on domain.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4162)
+    public void unsetSamlWebclientDisabledAccountUrl() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlWebclientDisabledAccountUrl, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML webclient-disabled account redirect URL. Replaces
+     * saml_webclient_disabled_account_redirect_url from
+     * saml-config.properties. After successful SAML authentication, if the
+     * account has zimbraFeatureWebClientEnabled set to FALSE, the user is
+     * redirected to this URL instead of the web client. Falls back to global
+     * config if not set on domain.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4162)
+    public Map<String,Object> unsetSamlWebclientDisabledAccountUrl(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlWebclientDisabledAccountUrl, "");
+        return attrs;
+    }
+
+    /**
      * Certificate used to verify signed SAML SP requests
      *
      * @return zimbraSamlSpSigningCertificate, or null if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -25279,6 +25279,155 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
+     * Certificate used to verify signed SAML SP requests
+     *
+     * @return zimbraSamlSpSigningCertificate, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4166)
+    public String getSamlSpSigningCertificate() {
+        return getAttr(Provisioning.A_zimbraSamlSpSigningCertificate, null, true);
+    }
+
+    /**
+     * Certificate used to verify signed SAML SP requests
+     *
+     * @param zimbraSamlSpSigningCertificate new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4166)
+    public void setSamlSpSigningCertificate(String zimbraSamlSpSigningCertificate) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningCertificate, zimbraSamlSpSigningCertificate);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Certificate used to verify signed SAML SP requests
+     *
+     * @param zimbraSamlSpSigningCertificate new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4166)
+    public Map<String,Object> setSamlSpSigningCertificate(String zimbraSamlSpSigningCertificate, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningCertificate, zimbraSamlSpSigningCertificate);
+        return attrs;
+    }
+
+    /**
+     * Certificate used to verify signed SAML SP requests
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4166)
+    public void unsetSamlSpSigningCertificate() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningCertificate, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Certificate used to verify signed SAML SP requests
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4166)
+    public Map<String,Object> unsetSamlSpSigningCertificate(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningCertificate, "");
+        return attrs;
+    }
+
+    /**
+     * Key used to sign SP-generated SAML requests. SAML requests are
+     * unsigned if empty
+     *
+     * @return zimbraSamlSpSigningKey, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4165)
+    public String getSamlSpSigningKey() {
+        return getAttr(Provisioning.A_zimbraSamlSpSigningKey, null, true);
+    }
+
+    /**
+     * Key used to sign SP-generated SAML requests. SAML requests are
+     * unsigned if empty
+     *
+     * @param zimbraSamlSpSigningKey new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4165)
+    public void setSamlSpSigningKey(String zimbraSamlSpSigningKey) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningKey, zimbraSamlSpSigningKey);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Key used to sign SP-generated SAML requests. SAML requests are
+     * unsigned if empty
+     *
+     * @param zimbraSamlSpSigningKey new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4165)
+    public Map<String,Object> setSamlSpSigningKey(String zimbraSamlSpSigningKey, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningKey, zimbraSamlSpSigningKey);
+        return attrs;
+    }
+
+    /**
+     * Key used to sign SP-generated SAML requests. SAML requests are
+     * unsigned if empty
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4165)
+    public void unsetSamlSpSigningKey() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningKey, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Key used to sign SP-generated SAML requests. SAML requests are
+     * unsigned if empty
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4165)
+    public Map<String,Object> unsetSamlSpSigningKey(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpSigningKey, "");
+        return attrs;
+    }
+
+    /**
      * whether or not to show client Terms of Service
      *
      * @return zimbraShowClientTOS, or false if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -26433,103 +26433,6 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * SAML webclient-disabled account redirect URL. Replaces
-     * saml_webclient_disabled_account_redirect_url from
-     * saml-config.properties. After successful SAML authentication, if the
-     * account has zimbraFeatureWebClientEnabled set to FALSE, the user is
-     * redirected to this URL instead of the web client. Falls back to global
-     * config if not set on domain.
-     *
-     * @return zimbraSamlWebclientDisabledAccountUrl, or null if unset
-     *
-     * @since ZCS 10.1.21
-     */
-    @ZAttr(id=4162)
-    public String getSamlWebclientDisabledAccountUrl() {
-        return getAttr(Provisioning.A_zimbraSamlWebclientDisabledAccountUrl, null, true);
-    }
-
-    /**
-     * SAML webclient-disabled account redirect URL. Replaces
-     * saml_webclient_disabled_account_redirect_url from
-     * saml-config.properties. After successful SAML authentication, if the
-     * account has zimbraFeatureWebClientEnabled set to FALSE, the user is
-     * redirected to this URL instead of the web client. Falls back to global
-     * config if not set on domain.
-     *
-     * @param zimbraSamlWebclientDisabledAccountUrl new value
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 10.1.21
-     */
-    @ZAttr(id=4162)
-    public void setSamlWebclientDisabledAccountUrl(String zimbraSamlWebclientDisabledAccountUrl) throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraSamlWebclientDisabledAccountUrl, zimbraSamlWebclientDisabledAccountUrl);
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * SAML webclient-disabled account redirect URL. Replaces
-     * saml_webclient_disabled_account_redirect_url from
-     * saml-config.properties. After successful SAML authentication, if the
-     * account has zimbraFeatureWebClientEnabled set to FALSE, the user is
-     * redirected to this URL instead of the web client. Falls back to global
-     * config if not set on domain.
-     *
-     * @param zimbraSamlWebclientDisabledAccountUrl new value
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 10.1.21
-     */
-    @ZAttr(id=4162)
-    public Map<String,Object> setSamlWebclientDisabledAccountUrl(String zimbraSamlWebclientDisabledAccountUrl, Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraSamlWebclientDisabledAccountUrl, zimbraSamlWebclientDisabledAccountUrl);
-        return attrs;
-    }
-
-    /**
-     * SAML webclient-disabled account redirect URL. Replaces
-     * saml_webclient_disabled_account_redirect_url from
-     * saml-config.properties. After successful SAML authentication, if the
-     * account has zimbraFeatureWebClientEnabled set to FALSE, the user is
-     * redirected to this URL instead of the web client. Falls back to global
-     * config if not set on domain.
-     *
-     * @throws com.zimbra.common.service.ServiceException if error during update
-     *
-     * @since ZCS 10.1.21
-     */
-    @ZAttr(id=4162)
-    public void unsetSamlWebclientDisabledAccountUrl() throws com.zimbra.common.service.ServiceException {
-        HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraSamlWebclientDisabledAccountUrl, "");
-        getProvisioning().modifyAttrs(this, attrs);
-    }
-
-    /**
-     * SAML webclient-disabled account redirect URL. Replaces
-     * saml_webclient_disabled_account_redirect_url from
-     * saml-config.properties. After successful SAML authentication, if the
-     * account has zimbraFeatureWebClientEnabled set to FALSE, the user is
-     * redirected to this URL instead of the web client. Falls back to global
-     * config if not set on domain.
-     *
-     * @param attrs existing map to populate, or null to create a new map
-     * @return populated map to pass into Provisioning.modifyAttrs
-     *
-     * @since ZCS 10.1.21
-     */
-    @ZAttr(id=4162)
-    public Map<String,Object> unsetSamlWebclientDisabledAccountUrl(Map<String,Object> attrs) {
-        if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_zimbraSamlWebclientDisabledAccountUrl, "");
-        return attrs;
-    }
-
-    /**
      * Certificate used to verify signed SAML SP requests
      *
      * @return zimbraSamlSpSigningCertificate, or null if unset
@@ -26675,6 +26578,329 @@ public abstract class ZAttrDomain extends NamedEntry {
     public Map<String,Object> unsetSamlSpSigningKey(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_zimbraSamlSpSigningKey, "");
+        return attrs;
+    }
+
+    /**
+     * Error code for SAML test failure. Format: SSO:{message_key}. Empty
+     * implies success
+     *
+     * @return zimbraSamlTestErrorMessage, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4168)
+    public String getSamlTestErrorMessage() {
+        return getAttr(Provisioning.A_zimbraSamlTestErrorMessage, null, true);
+    }
+
+    /**
+     * Error code for SAML test failure. Format: SSO:{message_key}. Empty
+     * implies success
+     *
+     * @param zimbraSamlTestErrorMessage new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4168)
+    public void setSamlTestErrorMessage(String zimbraSamlTestErrorMessage) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlTestErrorMessage, zimbraSamlTestErrorMessage);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Error code for SAML test failure. Format: SSO:{message_key}. Empty
+     * implies success
+     *
+     * @param zimbraSamlTestErrorMessage new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4168)
+    public Map<String,Object> setSamlTestErrorMessage(String zimbraSamlTestErrorMessage, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlTestErrorMessage, zimbraSamlTestErrorMessage);
+        return attrs;
+    }
+
+    /**
+     * Error code for SAML test failure. Format: SSO:{message_key}. Empty
+     * implies success
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4168)
+    public void unsetSamlTestErrorMessage() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlTestErrorMessage, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Error code for SAML test failure. Format: SSO:{message_key}. Empty
+     * implies success
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4168)
+    public Map<String,Object> unsetSamlTestErrorMessage(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlTestErrorMessage, "");
+        return attrs;
+    }
+
+    /**
+     * Secret nonce for an in-progress SAML test. Format: {nonce}
+     * notAfter={timestamp}
+     *
+     * @return zimbraSamlTestNonce, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4169)
+    public String getSamlTestNonce() {
+        return getAttr(Provisioning.A_zimbraSamlTestNonce, null, true);
+    }
+
+    /**
+     * Secret nonce for an in-progress SAML test. Format: {nonce}
+     * notAfter={timestamp}
+     *
+     * @param zimbraSamlTestNonce new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4169)
+    public void setSamlTestNonce(String zimbraSamlTestNonce) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlTestNonce, zimbraSamlTestNonce);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Secret nonce for an in-progress SAML test. Format: {nonce}
+     * notAfter={timestamp}
+     *
+     * @param zimbraSamlTestNonce new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4169)
+    public Map<String,Object> setSamlTestNonce(String zimbraSamlTestNonce, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlTestNonce, zimbraSamlTestNonce);
+        return attrs;
+    }
+
+    /**
+     * Secret nonce for an in-progress SAML test. Format: {nonce}
+     * notAfter={timestamp}
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4169)
+    public void unsetSamlTestNonce() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlTestNonce, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Secret nonce for an in-progress SAML test. Format: {nonce}
+     * notAfter={timestamp}
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4169)
+    public Map<String,Object> unsetSamlTestNonce(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlTestNonce, "");
+        return attrs;
+    }
+
+    /**
+     * Timestamp when the SAML test was completed
+     *
+     * @return zimbraSamlTestTimestamp, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4167)
+    public String getSamlTestTimestamp() {
+        return getAttr(Provisioning.A_zimbraSamlTestTimestamp, null, true);
+    }
+
+    /**
+     * Timestamp when the SAML test was completed
+     *
+     * @param zimbraSamlTestTimestamp new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4167)
+    public void setSamlTestTimestamp(String zimbraSamlTestTimestamp) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlTestTimestamp, zimbraSamlTestTimestamp);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Timestamp when the SAML test was completed
+     *
+     * @param zimbraSamlTestTimestamp new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4167)
+    public Map<String,Object> setSamlTestTimestamp(String zimbraSamlTestTimestamp, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlTestTimestamp, zimbraSamlTestTimestamp);
+        return attrs;
+    }
+
+    /**
+     * Timestamp when the SAML test was completed
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4167)
+    public void unsetSamlTestTimestamp() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlTestTimestamp, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Timestamp when the SAML test was completed
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4167)
+    public Map<String,Object> unsetSamlTestTimestamp(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlTestTimestamp, "");
+        return attrs;
+    }
+
+    /**
+     * SAML webclient-disabled account redirect URL. Replaces
+     * saml_webclient_disabled_account_redirect_url from
+     * saml-config.properties. After successful SAML authentication, if the
+     * account has zimbraFeatureWebClientEnabled set to FALSE, the user is
+     * redirected to this URL instead of the web client. Falls back to global
+     * config if not set on domain.
+     *
+     * @return zimbraSamlWebclientDisabledAccountUrl, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4162)
+    public String getSamlWebclientDisabledAccountUrl() {
+        return getAttr(Provisioning.A_zimbraSamlWebclientDisabledAccountUrl, null, true);
+    }
+
+    /**
+     * SAML webclient-disabled account redirect URL. Replaces
+     * saml_webclient_disabled_account_redirect_url from
+     * saml-config.properties. After successful SAML authentication, if the
+     * account has zimbraFeatureWebClientEnabled set to FALSE, the user is
+     * redirected to this URL instead of the web client. Falls back to global
+     * config if not set on domain.
+     *
+     * @param zimbraSamlWebclientDisabledAccountUrl new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4162)
+    public void setSamlWebclientDisabledAccountUrl(String zimbraSamlWebclientDisabledAccountUrl) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlWebclientDisabledAccountUrl, zimbraSamlWebclientDisabledAccountUrl);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML webclient-disabled account redirect URL. Replaces
+     * saml_webclient_disabled_account_redirect_url from
+     * saml-config.properties. After successful SAML authentication, if the
+     * account has zimbraFeatureWebClientEnabled set to FALSE, the user is
+     * redirected to this URL instead of the web client. Falls back to global
+     * config if not set on domain.
+     *
+     * @param zimbraSamlWebclientDisabledAccountUrl new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4162)
+    public Map<String,Object> setSamlWebclientDisabledAccountUrl(String zimbraSamlWebclientDisabledAccountUrl, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlWebclientDisabledAccountUrl, zimbraSamlWebclientDisabledAccountUrl);
+        return attrs;
+    }
+
+    /**
+     * SAML webclient-disabled account redirect URL. Replaces
+     * saml_webclient_disabled_account_redirect_url from
+     * saml-config.properties. After successful SAML authentication, if the
+     * account has zimbraFeatureWebClientEnabled set to FALSE, the user is
+     * redirected to this URL instead of the web client. Falls back to global
+     * config if not set on domain.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4162)
+    public void unsetSamlWebclientDisabledAccountUrl() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlWebclientDisabledAccountUrl, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML webclient-disabled account redirect URL. Replaces
+     * saml_webclient_disabled_account_redirect_url from
+     * saml-config.properties. After successful SAML authentication, if the
+     * account has zimbraFeatureWebClientEnabled set to FALSE, the user is
+     * redirected to this URL instead of the web client. Falls back to global
+     * config if not set on domain.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4162)
+    public Map<String,Object> unsetSamlWebclientDisabledAccountUrl(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlWebclientDisabledAccountUrl, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -25279,6 +25279,1257 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
+     * SAML Assertion Consumer Service URL. Replaces saml_acs from
+     * saml-config.properties. When set at domain level, enables per-domain
+     * ACS endpoint (e.g.
+     * https://mail.corp-a.com/service/extension/samlreceiver). Falls back to
+     * global config if not set on domain.
+     *
+     * @return zimbraSamlACSURL, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4153)
+    public String getSamlACSURL() {
+        return getAttr(Provisioning.A_zimbraSamlACSURL, null, true);
+    }
+
+    /**
+     * SAML Assertion Consumer Service URL. Replaces saml_acs from
+     * saml-config.properties. When set at domain level, enables per-domain
+     * ACS endpoint (e.g.
+     * https://mail.corp-a.com/service/extension/samlreceiver). Falls back to
+     * global config if not set on domain.
+     *
+     * @param zimbraSamlACSURL new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4153)
+    public void setSamlACSURL(String zimbraSamlACSURL) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlACSURL, zimbraSamlACSURL);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML Assertion Consumer Service URL. Replaces saml_acs from
+     * saml-config.properties. When set at domain level, enables per-domain
+     * ACS endpoint (e.g.
+     * https://mail.corp-a.com/service/extension/samlreceiver). Falls back to
+     * global config if not set on domain.
+     *
+     * @param zimbraSamlACSURL new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4153)
+    public Map<String,Object> setSamlACSURL(String zimbraSamlACSURL, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlACSURL, zimbraSamlACSURL);
+        return attrs;
+    }
+
+    /**
+     * SAML Assertion Consumer Service URL. Replaces saml_acs from
+     * saml-config.properties. When set at domain level, enables per-domain
+     * ACS endpoint (e.g.
+     * https://mail.corp-a.com/service/extension/samlreceiver). Falls back to
+     * global config if not set on domain.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4153)
+    public void unsetSamlACSURL() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlACSURL, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML Assertion Consumer Service URL. Replaces saml_acs from
+     * saml-config.properties. When set at domain level, enables per-domain
+     * ACS endpoint (e.g.
+     * https://mail.corp-a.com/service/extension/samlreceiver). Falls back to
+     * global config if not set on domain.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4153)
+    public Map<String,Object> unsetSamlACSURL(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlACSURL, "");
+        return attrs;
+    }
+
+    /**
+     * SAML date format for instant timestamps. Replaces
+     * saml_date_format_instant from saml-config.properties. Falls back to
+     * global config if not set on domain.
+     *
+     * @return zimbraSamlDateFormat, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4157)
+    public String getSamlDateFormat() {
+        return getAttr(Provisioning.A_zimbraSamlDateFormat, null, true);
+    }
+
+    /**
+     * SAML date format for instant timestamps. Replaces
+     * saml_date_format_instant from saml-config.properties. Falls back to
+     * global config if not set on domain.
+     *
+     * @param zimbraSamlDateFormat new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4157)
+    public void setSamlDateFormat(String zimbraSamlDateFormat) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlDateFormat, zimbraSamlDateFormat);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML date format for instant timestamps. Replaces
+     * saml_date_format_instant from saml-config.properties. Falls back to
+     * global config if not set on domain.
+     *
+     * @param zimbraSamlDateFormat new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4157)
+    public Map<String,Object> setSamlDateFormat(String zimbraSamlDateFormat, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlDateFormat, zimbraSamlDateFormat);
+        return attrs;
+    }
+
+    /**
+     * SAML date format for instant timestamps. Replaces
+     * saml_date_format_instant from saml-config.properties. Falls back to
+     * global config if not set on domain.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4157)
+    public void unsetSamlDateFormat() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlDateFormat, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML date format for instant timestamps. Replaces
+     * saml_date_format_instant from saml-config.properties. Falls back to
+     * global config if not set on domain.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4157)
+    public Map<String,Object> unsetSamlDateFormat(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlDateFormat, "");
+        return attrs;
+    }
+
+    /**
+     * SAML document encoding. Replaces saml_document_encoding from
+     * saml-config.properties. Controls the character encoding used for SAML
+     * logout documents and login receiver parameter decoding. Falls back to
+     * global config if not set on domain.
+     *
+     * @return zimbraSamlDocumentEncoding, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4159)
+    public String getSamlDocumentEncoding() {
+        return getAttr(Provisioning.A_zimbraSamlDocumentEncoding, null, true);
+    }
+
+    /**
+     * SAML document encoding. Replaces saml_document_encoding from
+     * saml-config.properties. Controls the character encoding used for SAML
+     * logout documents and login receiver parameter decoding. Falls back to
+     * global config if not set on domain.
+     *
+     * @param zimbraSamlDocumentEncoding new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4159)
+    public void setSamlDocumentEncoding(String zimbraSamlDocumentEncoding) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlDocumentEncoding, zimbraSamlDocumentEncoding);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML document encoding. Replaces saml_document_encoding from
+     * saml-config.properties. Controls the character encoding used for SAML
+     * logout documents and login receiver parameter decoding. Falls back to
+     * global config if not set on domain.
+     *
+     * @param zimbraSamlDocumentEncoding new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4159)
+    public Map<String,Object> setSamlDocumentEncoding(String zimbraSamlDocumentEncoding, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlDocumentEncoding, zimbraSamlDocumentEncoding);
+        return attrs;
+    }
+
+    /**
+     * SAML document encoding. Replaces saml_document_encoding from
+     * saml-config.properties. Controls the character encoding used for SAML
+     * logout documents and login receiver parameter decoding. Falls back to
+     * global config if not set on domain.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4159)
+    public void unsetSamlDocumentEncoding() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlDocumentEncoding, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML document encoding. Replaces saml_document_encoding from
+     * saml-config.properties. Controls the character encoding used for SAML
+     * logout documents and login receiver parameter decoding. Falls back to
+     * global config if not set on domain.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4159)
+    public Map<String,Object> unsetSamlDocumentEncoding(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlDocumentEncoding, "");
+        return attrs;
+    }
+
+    /**
+     * SAML error redirect URL. Replaces saml_error_redirect_url from
+     * saml-config.properties. When a SAML authentication error occurs, users
+     * are redirected to this URL with error_code and error_msg query
+     * parameters appended. If not set, the default HTTP error code pages are
+     * returned. Falls back to global config if not set on domain.
+     *
+     * @return zimbraSamlErrorURL, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4160)
+    public String getSamlErrorURL() {
+        return getAttr(Provisioning.A_zimbraSamlErrorURL, null, true);
+    }
+
+    /**
+     * SAML error redirect URL. Replaces saml_error_redirect_url from
+     * saml-config.properties. When a SAML authentication error occurs, users
+     * are redirected to this URL with error_code and error_msg query
+     * parameters appended. If not set, the default HTTP error code pages are
+     * returned. Falls back to global config if not set on domain.
+     *
+     * @param zimbraSamlErrorURL new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4160)
+    public void setSamlErrorURL(String zimbraSamlErrorURL) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlErrorURL, zimbraSamlErrorURL);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML error redirect URL. Replaces saml_error_redirect_url from
+     * saml-config.properties. When a SAML authentication error occurs, users
+     * are redirected to this URL with error_code and error_msg query
+     * parameters appended. If not set, the default HTTP error code pages are
+     * returned. Falls back to global config if not set on domain.
+     *
+     * @param zimbraSamlErrorURL new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4160)
+    public Map<String,Object> setSamlErrorURL(String zimbraSamlErrorURL, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlErrorURL, zimbraSamlErrorURL);
+        return attrs;
+    }
+
+    /**
+     * SAML error redirect URL. Replaces saml_error_redirect_url from
+     * saml-config.properties. When a SAML authentication error occurs, users
+     * are redirected to this URL with error_code and error_msg query
+     * parameters appended. If not set, the default HTTP error code pages are
+     * returned. Falls back to global config if not set on domain.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4160)
+    public void unsetSamlErrorURL() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlErrorURL, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML error redirect URL. Replaces saml_error_redirect_url from
+     * saml-config.properties. When a SAML authentication error occurs, users
+     * are redirected to this URL with error_code and error_msg query
+     * parameters appended. If not set, the default HTTP error code pages are
+     * returned. Falls back to global config if not set on domain.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4160)
+    public Map<String,Object> unsetSamlErrorURL(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlErrorURL, "");
+        return attrs;
+    }
+
+    /**
+     * SAML inactive account redirect URL. Replaces
+     * saml_inactive_account_redirect_url from saml-config.properties. When a
+     * SAML-authenticated user maps to a Zimbra account that is not in active
+     * status, the user is redirected to this URL. Falls back to global
+     * config if not set on domain.
+     *
+     * @return zimbraSamlInactiveAccountURL, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4161)
+    public String getSamlInactiveAccountURL() {
+        return getAttr(Provisioning.A_zimbraSamlInactiveAccountURL, null, true);
+    }
+
+    /**
+     * SAML inactive account redirect URL. Replaces
+     * saml_inactive_account_redirect_url from saml-config.properties. When a
+     * SAML-authenticated user maps to a Zimbra account that is not in active
+     * status, the user is redirected to this URL. Falls back to global
+     * config if not set on domain.
+     *
+     * @param zimbraSamlInactiveAccountURL new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4161)
+    public void setSamlInactiveAccountURL(String zimbraSamlInactiveAccountURL) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlInactiveAccountURL, zimbraSamlInactiveAccountURL);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML inactive account redirect URL. Replaces
+     * saml_inactive_account_redirect_url from saml-config.properties. When a
+     * SAML-authenticated user maps to a Zimbra account that is not in active
+     * status, the user is redirected to this URL. Falls back to global
+     * config if not set on domain.
+     *
+     * @param zimbraSamlInactiveAccountURL new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4161)
+    public Map<String,Object> setSamlInactiveAccountURL(String zimbraSamlInactiveAccountURL, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlInactiveAccountURL, zimbraSamlInactiveAccountURL);
+        return attrs;
+    }
+
+    /**
+     * SAML inactive account redirect URL. Replaces
+     * saml_inactive_account_redirect_url from saml-config.properties. When a
+     * SAML-authenticated user maps to a Zimbra account that is not in active
+     * status, the user is redirected to this URL. Falls back to global
+     * config if not set on domain.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4161)
+    public void unsetSamlInactiveAccountURL() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlInactiveAccountURL, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML inactive account redirect URL. Replaces
+     * saml_inactive_account_redirect_url from saml-config.properties. When a
+     * SAML-authenticated user maps to a Zimbra account that is not in active
+     * status, the user is redirected to this URL. Falls back to global
+     * config if not set on domain.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4161)
+    public Map<String,Object> unsetSamlInactiveAccountURL(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlInactiveAccountURL, "");
+        return attrs;
+    }
+
+    /**
+     * SAML logout landing redirect URL. Replaces
+     * saml_landing_logout_redirect_url from saml-config.properties. When the
+     * SAML extension is the landing page for a logout request, users are
+     * redirected to this URL after logout completes. Falls back to global
+     * config if not set on domain. Default is /.
+     *
+     * @return zimbraSamlLogoutLandingURL, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4158)
+    public String getSamlLogoutLandingURL() {
+        return getAttr(Provisioning.A_zimbraSamlLogoutLandingURL, null, true);
+    }
+
+    /**
+     * SAML logout landing redirect URL. Replaces
+     * saml_landing_logout_redirect_url from saml-config.properties. When the
+     * SAML extension is the landing page for a logout request, users are
+     * redirected to this URL after logout completes. Falls back to global
+     * config if not set on domain. Default is /.
+     *
+     * @param zimbraSamlLogoutLandingURL new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4158)
+    public void setSamlLogoutLandingURL(String zimbraSamlLogoutLandingURL) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlLogoutLandingURL, zimbraSamlLogoutLandingURL);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML logout landing redirect URL. Replaces
+     * saml_landing_logout_redirect_url from saml-config.properties. When the
+     * SAML extension is the landing page for a logout request, users are
+     * redirected to this URL after logout completes. Falls back to global
+     * config if not set on domain. Default is /.
+     *
+     * @param zimbraSamlLogoutLandingURL new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4158)
+    public Map<String,Object> setSamlLogoutLandingURL(String zimbraSamlLogoutLandingURL, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlLogoutLandingURL, zimbraSamlLogoutLandingURL);
+        return attrs;
+    }
+
+    /**
+     * SAML logout landing redirect URL. Replaces
+     * saml_landing_logout_redirect_url from saml-config.properties. When the
+     * SAML extension is the landing page for a logout request, users are
+     * redirected to this URL after logout completes. Falls back to global
+     * config if not set on domain. Default is /.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4158)
+    public void unsetSamlLogoutLandingURL() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlLogoutLandingURL, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML logout landing redirect URL. Replaces
+     * saml_landing_logout_redirect_url from saml-config.properties. When the
+     * SAML extension is the landing page for a logout request, users are
+     * redirected to this URL after logout completes. Falls back to global
+     * config if not set on domain. Default is /.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4158)
+    public Map<String,Object> unsetSamlLogoutLandingURL(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlLogoutLandingURL, "");
+        return attrs;
+    }
+
+    /**
+     * SAML NameID format. Replaces saml_name_id_format from
+     * saml-config.properties. Falls back to global config if not set on
+     * domain.
+     *
+     * @return zimbraSamlNameIdFormat, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4156)
+    public String getSamlNameIdFormat() {
+        return getAttr(Provisioning.A_zimbraSamlNameIdFormat, null, true);
+    }
+
+    /**
+     * SAML NameID format. Replaces saml_name_id_format from
+     * saml-config.properties. Falls back to global config if not set on
+     * domain.
+     *
+     * @param zimbraSamlNameIdFormat new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4156)
+    public void setSamlNameIdFormat(String zimbraSamlNameIdFormat) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlNameIdFormat, zimbraSamlNameIdFormat);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML NameID format. Replaces saml_name_id_format from
+     * saml-config.properties. Falls back to global config if not set on
+     * domain.
+     *
+     * @param zimbraSamlNameIdFormat new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4156)
+    public Map<String,Object> setSamlNameIdFormat(String zimbraSamlNameIdFormat, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlNameIdFormat, zimbraSamlNameIdFormat);
+        return attrs;
+    }
+
+    /**
+     * SAML NameID format. Replaces saml_name_id_format from
+     * saml-config.properties. Falls back to global config if not set on
+     * domain.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4156)
+    public void unsetSamlNameIdFormat() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlNameIdFormat, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML NameID format. Replaces saml_name_id_format from
+     * saml-config.properties. Falls back to global config if not set on
+     * domain.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4156)
+    public Map<String,Object> unsetSamlNameIdFormat(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlNameIdFormat, "");
+        return attrs;
+    }
+
+    /**
+     * SAML IdP Single Logout URL(s). Replaces
+     * saml_redirect_logout_destination and saml_post_logout_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/slo/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/slo/post
+     * The operating context determines which binding is used (e.g.
+     * front-channel logout uses HTTP-Redirect; back-channel logout may use
+     * SOAP). When set at domain level, routes SLO to the correct IdP per
+     * domain. Falls back to global config if not set on domain.
+     *
+     * @return zimbraSamlSLOURL, or empty array if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4155)
+    public String[] getSamlSLOURL() {
+        return getMultiAttr(Provisioning.A_zimbraSamlSLOURL, true, true);
+    }
+
+    /**
+     * SAML IdP Single Logout URL(s). Replaces
+     * saml_redirect_logout_destination and saml_post_logout_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/slo/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/slo/post
+     * The operating context determines which binding is used (e.g.
+     * front-channel logout uses HTTP-Redirect; back-channel logout may use
+     * SOAP). When set at domain level, routes SLO to the correct IdP per
+     * domain. Falls back to global config if not set on domain.
+     *
+     * @param zimbraSamlSLOURL new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4155)
+    public void setSamlSLOURL(String[] zimbraSamlSLOURL) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSLOURL, zimbraSamlSLOURL);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML IdP Single Logout URL(s). Replaces
+     * saml_redirect_logout_destination and saml_post_logout_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/slo/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/slo/post
+     * The operating context determines which binding is used (e.g.
+     * front-channel logout uses HTTP-Redirect; back-channel logout may use
+     * SOAP). When set at domain level, routes SLO to the correct IdP per
+     * domain. Falls back to global config if not set on domain.
+     *
+     * @param zimbraSamlSLOURL new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4155)
+    public Map<String,Object> setSamlSLOURL(String[] zimbraSamlSLOURL, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSLOURL, zimbraSamlSLOURL);
+        return attrs;
+    }
+
+    /**
+     * SAML IdP Single Logout URL(s). Replaces
+     * saml_redirect_logout_destination and saml_post_logout_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/slo/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/slo/post
+     * The operating context determines which binding is used (e.g.
+     * front-channel logout uses HTTP-Redirect; back-channel logout may use
+     * SOAP). When set at domain level, routes SLO to the correct IdP per
+     * domain. Falls back to global config if not set on domain.
+     *
+     * @param zimbraSamlSLOURL new to add to existing values
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4155)
+    public void addSamlSLOURL(String zimbraSamlSLOURL) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraSamlSLOURL, zimbraSamlSLOURL);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML IdP Single Logout URL(s). Replaces
+     * saml_redirect_logout_destination and saml_post_logout_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/slo/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/slo/post
+     * The operating context determines which binding is used (e.g.
+     * front-channel logout uses HTTP-Redirect; back-channel logout may use
+     * SOAP). When set at domain level, routes SLO to the correct IdP per
+     * domain. Falls back to global config if not set on domain.
+     *
+     * @param zimbraSamlSLOURL new to add to existing values
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4155)
+    public Map<String,Object> addSamlSLOURL(String zimbraSamlSLOURL, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraSamlSLOURL, zimbraSamlSLOURL);
+        return attrs;
+    }
+
+    /**
+     * SAML IdP Single Logout URL(s). Replaces
+     * saml_redirect_logout_destination and saml_post_logout_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/slo/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/slo/post
+     * The operating context determines which binding is used (e.g.
+     * front-channel logout uses HTTP-Redirect; back-channel logout may use
+     * SOAP). When set at domain level, routes SLO to the correct IdP per
+     * domain. Falls back to global config if not set on domain.
+     *
+     * @param zimbraSamlSLOURL existing value to remove
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4155)
+    public void removeSamlSLOURL(String zimbraSamlSLOURL) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraSamlSLOURL, zimbraSamlSLOURL);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML IdP Single Logout URL(s). Replaces
+     * saml_redirect_logout_destination and saml_post_logout_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/slo/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/slo/post
+     * The operating context determines which binding is used (e.g.
+     * front-channel logout uses HTTP-Redirect; back-channel logout may use
+     * SOAP). When set at domain level, routes SLO to the correct IdP per
+     * domain. Falls back to global config if not set on domain.
+     *
+     * @param zimbraSamlSLOURL existing value to remove
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4155)
+    public Map<String,Object> removeSamlSLOURL(String zimbraSamlSLOURL, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraSamlSLOURL, zimbraSamlSLOURL);
+        return attrs;
+    }
+
+    /**
+     * SAML IdP Single Logout URL(s). Replaces
+     * saml_redirect_logout_destination and saml_post_logout_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/slo/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/slo/post
+     * The operating context determines which binding is used (e.g.
+     * front-channel logout uses HTTP-Redirect; back-channel logout may use
+     * SOAP). When set at domain level, routes SLO to the correct IdP per
+     * domain. Falls back to global config if not set on domain.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4155)
+    public void unsetSamlSLOURL() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSLOURL, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML IdP Single Logout URL(s). Replaces
+     * saml_redirect_logout_destination and saml_post_logout_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/slo/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/slo/post
+     * The operating context determines which binding is used (e.g.
+     * front-channel logout uses HTTP-Redirect; back-channel logout may use
+     * SOAP). When set at domain level, routes SLO to the correct IdP per
+     * domain. Falls back to global config if not set on domain.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4155)
+    public Map<String,Object> unsetSamlSLOURL(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSLOURL, "");
+        return attrs;
+    }
+
+    /**
+     * SAML IdP Single Sign-On URL(s). Replaces
+     * saml_redirect_login_destination and saml_post_login_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/sso/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/sso/post
+     * The operating context determines which binding is used (e.g.
+     * SP-initiated login uses HTTP-Redirect; back-channel operations may use
+     * SOAP). When set at domain level, routes SSO login to the correct IdP
+     * per domain. Falls back to global config if not set on domain.
+     *
+     * @return zimbraSamlSSOURL, or empty array if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4154)
+    public String[] getSamlSSOURL() {
+        return getMultiAttr(Provisioning.A_zimbraSamlSSOURL, true, true);
+    }
+
+    /**
+     * SAML IdP Single Sign-On URL(s). Replaces
+     * saml_redirect_login_destination and saml_post_login_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/sso/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/sso/post
+     * The operating context determines which binding is used (e.g.
+     * SP-initiated login uses HTTP-Redirect; back-channel operations may use
+     * SOAP). When set at domain level, routes SSO login to the correct IdP
+     * per domain. Falls back to global config if not set on domain.
+     *
+     * @param zimbraSamlSSOURL new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4154)
+    public void setSamlSSOURL(String[] zimbraSamlSSOURL) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSSOURL, zimbraSamlSSOURL);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML IdP Single Sign-On URL(s). Replaces
+     * saml_redirect_login_destination and saml_post_login_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/sso/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/sso/post
+     * The operating context determines which binding is used (e.g.
+     * SP-initiated login uses HTTP-Redirect; back-channel operations may use
+     * SOAP). When set at domain level, routes SSO login to the correct IdP
+     * per domain. Falls back to global config if not set on domain.
+     *
+     * @param zimbraSamlSSOURL new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4154)
+    public Map<String,Object> setSamlSSOURL(String[] zimbraSamlSSOURL, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSSOURL, zimbraSamlSSOURL);
+        return attrs;
+    }
+
+    /**
+     * SAML IdP Single Sign-On URL(s). Replaces
+     * saml_redirect_login_destination and saml_post_login_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/sso/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/sso/post
+     * The operating context determines which binding is used (e.g.
+     * SP-initiated login uses HTTP-Redirect; back-channel operations may use
+     * SOAP). When set at domain level, routes SSO login to the correct IdP
+     * per domain. Falls back to global config if not set on domain.
+     *
+     * @param zimbraSamlSSOURL new to add to existing values
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4154)
+    public void addSamlSSOURL(String zimbraSamlSSOURL) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraSamlSSOURL, zimbraSamlSSOURL);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML IdP Single Sign-On URL(s). Replaces
+     * saml_redirect_login_destination and saml_post_login_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/sso/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/sso/post
+     * The operating context determines which binding is used (e.g.
+     * SP-initiated login uses HTTP-Redirect; back-channel operations may use
+     * SOAP). When set at domain level, routes SSO login to the correct IdP
+     * per domain. Falls back to global config if not set on domain.
+     *
+     * @param zimbraSamlSSOURL new to add to existing values
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4154)
+    public Map<String,Object> addSamlSSOURL(String zimbraSamlSSOURL, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "+" + Provisioning.A_zimbraSamlSSOURL, zimbraSamlSSOURL);
+        return attrs;
+    }
+
+    /**
+     * SAML IdP Single Sign-On URL(s). Replaces
+     * saml_redirect_login_destination and saml_post_login_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/sso/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/sso/post
+     * The operating context determines which binding is used (e.g.
+     * SP-initiated login uses HTTP-Redirect; back-channel operations may use
+     * SOAP). When set at domain level, routes SSO login to the correct IdP
+     * per domain. Falls back to global config if not set on domain.
+     *
+     * @param zimbraSamlSSOURL existing value to remove
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4154)
+    public void removeSamlSSOURL(String zimbraSamlSSOURL) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraSamlSSOURL, zimbraSamlSSOURL);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML IdP Single Sign-On URL(s). Replaces
+     * saml_redirect_login_destination and saml_post_login_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/sso/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/sso/post
+     * The operating context determines which binding is used (e.g.
+     * SP-initiated login uses HTTP-Redirect; back-channel operations may use
+     * SOAP). When set at domain level, routes SSO login to the correct IdP
+     * per domain. Falls back to global config if not set on domain.
+     *
+     * @param zimbraSamlSSOURL existing value to remove
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4154)
+    public Map<String,Object> removeSamlSSOURL(String zimbraSamlSSOURL, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        StringUtil.addToMultiMap(attrs, "-" + Provisioning.A_zimbraSamlSSOURL, zimbraSamlSSOURL);
+        return attrs;
+    }
+
+    /**
+     * SAML IdP Single Sign-On URL(s). Replaces
+     * saml_redirect_login_destination and saml_post_login_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/sso/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/sso/post
+     * The operating context determines which binding is used (e.g.
+     * SP-initiated login uses HTTP-Redirect; back-channel operations may use
+     * SOAP). When set at domain level, routes SSO login to the correct IdP
+     * per domain. Falls back to global config if not set on domain.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4154)
+    public void unsetSamlSSOURL() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSSOURL, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML IdP Single Sign-On URL(s). Replaces
+     * saml_redirect_login_destination and saml_post_login_destination from
+     * saml-config.properties. Multi-valued to support multiple SAML
+     * bindings. Each value uses a binding-URI prefix split on the first
+     * &#039;=&#039; sign, e.g.
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect=https://idp.example.com/sso/redirect
+     * urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST=https://idp.example.com/sso/post
+     * The operating context determines which binding is used (e.g.
+     * SP-initiated login uses HTTP-Redirect; back-channel operations may use
+     * SOAP). When set at domain level, routes SSO login to the correct IdP
+     * per domain. Falls back to global config if not set on domain.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4154)
+    public Map<String,Object> unsetSamlSSOURL(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSSOURL, "");
+        return attrs;
+    }
+
+    /**
+     * SAML Service Provider Entity ID. Replaces saml_sp_entity_id from
+     * saml-config.properties. When set at domain level, enables per-domain
+     * SP metadata (e.g. https://mail.corp-a.com/saml/sp). Falls back to
+     * global config if not set on domain.
+     *
+     * @return zimbraSamlSpEntityId, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4163)
+    public String getSamlSpEntityId() {
+        return getAttr(Provisioning.A_zimbraSamlSpEntityId, null, true);
+    }
+
+    /**
+     * SAML Service Provider Entity ID. Replaces saml_sp_entity_id from
+     * saml-config.properties. When set at domain level, enables per-domain
+     * SP metadata (e.g. https://mail.corp-a.com/saml/sp). Falls back to
+     * global config if not set on domain.
+     *
+     * @param zimbraSamlSpEntityId new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4163)
+    public void setSamlSpEntityId(String zimbraSamlSpEntityId) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpEntityId, zimbraSamlSpEntityId);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML Service Provider Entity ID. Replaces saml_sp_entity_id from
+     * saml-config.properties. When set at domain level, enables per-domain
+     * SP metadata (e.g. https://mail.corp-a.com/saml/sp). Falls back to
+     * global config if not set on domain.
+     *
+     * @param zimbraSamlSpEntityId new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4163)
+    public Map<String,Object> setSamlSpEntityId(String zimbraSamlSpEntityId, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpEntityId, zimbraSamlSpEntityId);
+        return attrs;
+    }
+
+    /**
+     * SAML Service Provider Entity ID. Replaces saml_sp_entity_id from
+     * saml-config.properties. When set at domain level, enables per-domain
+     * SP metadata (e.g. https://mail.corp-a.com/saml/sp). Falls back to
+     * global config if not set on domain.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4163)
+    public void unsetSamlSpEntityId() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpEntityId, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML Service Provider Entity ID. Replaces saml_sp_entity_id from
+     * saml-config.properties. When set at domain level, enables per-domain
+     * SP metadata (e.g. https://mail.corp-a.com/saml/sp). Falls back to
+     * global config if not set on domain.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4163)
+    public Map<String,Object> unsetSamlSpEntityId(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlSpEntityId, "");
+        return attrs;
+    }
+
+    /**
+     * SAML webclient-disabled account redirect URL. Replaces
+     * saml_webclient_disabled_account_redirect_url from
+     * saml-config.properties. After successful SAML authentication, if the
+     * account has zimbraFeatureWebClientEnabled set to FALSE, the user is
+     * redirected to this URL instead of the web client. Falls back to global
+     * config if not set on domain.
+     *
+     * @return zimbraSamlWebclientDisabledAccountUrl, or null if unset
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4162)
+    public String getSamlWebclientDisabledAccountUrl() {
+        return getAttr(Provisioning.A_zimbraSamlWebclientDisabledAccountUrl, null, true);
+    }
+
+    /**
+     * SAML webclient-disabled account redirect URL. Replaces
+     * saml_webclient_disabled_account_redirect_url from
+     * saml-config.properties. After successful SAML authentication, if the
+     * account has zimbraFeatureWebClientEnabled set to FALSE, the user is
+     * redirected to this URL instead of the web client. Falls back to global
+     * config if not set on domain.
+     *
+     * @param zimbraSamlWebclientDisabledAccountUrl new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4162)
+    public void setSamlWebclientDisabledAccountUrl(String zimbraSamlWebclientDisabledAccountUrl) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlWebclientDisabledAccountUrl, zimbraSamlWebclientDisabledAccountUrl);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML webclient-disabled account redirect URL. Replaces
+     * saml_webclient_disabled_account_redirect_url from
+     * saml-config.properties. After successful SAML authentication, if the
+     * account has zimbraFeatureWebClientEnabled set to FALSE, the user is
+     * redirected to this URL instead of the web client. Falls back to global
+     * config if not set on domain.
+     *
+     * @param zimbraSamlWebclientDisabledAccountUrl new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4162)
+    public Map<String,Object> setSamlWebclientDisabledAccountUrl(String zimbraSamlWebclientDisabledAccountUrl, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlWebclientDisabledAccountUrl, zimbraSamlWebclientDisabledAccountUrl);
+        return attrs;
+    }
+
+    /**
+     * SAML webclient-disabled account redirect URL. Replaces
+     * saml_webclient_disabled_account_redirect_url from
+     * saml-config.properties. After successful SAML authentication, if the
+     * account has zimbraFeatureWebClientEnabled set to FALSE, the user is
+     * redirected to this URL instead of the web client. Falls back to global
+     * config if not set on domain.
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4162)
+    public void unsetSamlWebclientDisabledAccountUrl() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlWebclientDisabledAccountUrl, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * SAML webclient-disabled account redirect URL. Replaces
+     * saml_webclient_disabled_account_redirect_url from
+     * saml-config.properties. After successful SAML authentication, if the
+     * account has zimbraFeatureWebClientEnabled set to FALSE, the user is
+     * redirected to this URL instead of the web client. Falls back to global
+     * config if not set on domain.
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 10.1.21
+     */
+    @ZAttr(id=4162)
+    public Map<String,Object> unsetSamlWebclientDisabledAccountUrl(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_zimbraSamlWebclientDisabledAccountUrl, "");
+        return attrs;
+    }
+
+    /**
      * Certificate used to verify signed SAML SP requests
      *
      * @return zimbraSamlSpSigningCertificate, or null if unset

--- a/store/src/java/com/zimbra/cs/account/callback/SamlTestReset.java
+++ b/store/src/java/com/zimbra/cs/account/callback/SamlTestReset.java
@@ -1,0 +1,55 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2007, 2008, 2009, 2010, 2011, 2013, 2014, 2016 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.account.callback;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.AttributeCallback;
+import com.zimbra.cs.account.Entry;
+import com.zimbra.cs.account.Provisioning;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SamlTestReset extends AttributeCallback {
+    @Override
+    public void preModify(CallbackContext context, String attrName, Object attrValue,
+            Map attrsToModify, Entry entry) throws ServiceException {
+        // no pre-modify validation needed
+    }
+
+    @Override
+    public void postModify(CallbackContext context, String attrName, Entry entry) {
+        // fire only once per batch
+        if (context.isDoneAndSetIfNot(SamlTestReset.class)) {
+            return;
+        }
+        if (entry == null) {
+            return;
+        }
+        // clear all 3 test attributes — invalidate ongoing test + stale results
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put(Provisioning.A_zimbraSamlTestTimestamp, "");
+        attrs.put(Provisioning.A_zimbraSamlTestErrorMessage, "");
+        attrs.put(Provisioning.A_zimbraSamlTestNonce, "");
+        try {
+            Provisioning.getInstance().modifyAttrs(entry, attrs);
+        } catch (ServiceException e) {
+            ZimbraLog.account.warn("Failed to reset SAML test status on " + entry.getLabel(), e);
+        }
+    }
+}

--- a/store/src/java/com/zimbra/cs/account/callback/package-info.java
+++ b/store/src/java/com/zimbra/cs/account/callback/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2007, 2008, 2009, 2010, 2011, 2013, 2014, 2016 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+/**
+ * Callback functions triggered on LDAP attribute modification.
+ */
+package com.zimbra.cs.account.callback;

--- a/store/src/java/com/zimbra/cs/service/admin/AdminService.java
+++ b/store/src/java/com/zimbra/cs/service/admin/AdminService.java
@@ -282,7 +282,6 @@ public class AdminService implements DocumentService {
 
         // noop
         dispatcher.registerHandler(AdminConstants.NO_OP_REQUEST, new NoOp());
-
         // cookie and authtoken maintenance
         dispatcher.registerHandler(AdminConstants.CLEAR_COOKIE_REQUEST, new ClearCookie());
         dispatcher.registerHandler(AdminConstants.LOCKOUT_MAILBOX_REQUEST, new LockoutMailbox());


### PR DESCRIPTION
Problem: Admins lacked a way to validate SAML settings; 

Solution: Added a nonce-based SOAP API to securely initiate and track SAML configuration tests.