### PR TITLE
Zcs 19946:Add domain flags to zimbraCsrfAllowedRefererHosts and enable per-domain lookup in CsrfFilter

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -1588,6 +1588,15 @@ public final class LC {
     @Reloadable
     public static final KnownKey zimbra_forward_servlet_allowed_paths = KnownKey.newKey("");
 
+    // Explicit CsrfFilter domainAllowedRefHosts cache max size
+    // Falls back to ldap_cache_domain_maxsize on parsing error
+    public static final KnownKey csrf_filter_domain_allowed_ref_hosts_max_size = KnownKey.newKey(1000);
+
+    // TTL for CsrfFilter domainAllowedRefHosts cache entries (in minutes)
+    // After this duration, a stale entry is evicted and reloaded from LDAP on next access
+    // Falls back to 60 minutes if parsing fails
+    public static final KnownKey csrf_filter_domain_allowed_ref_hosts_cache_expiry_mins = KnownKey.newKey(60);
+
     static {
         // Automatically set the key name with the variable name.
         for (Field field : LC.class.getFields()) {

--- a/store-conf/conf/msgs/ZsMsg.properties
+++ b/store-conf/conf/msgs/ZsMsg.properties
@@ -571,6 +571,8 @@ ldap_cache_zimlet_maxsize = Maximum number of zimlet objects to cache.
 ldap_cache_zimlet_maxage = Maximum age (in minutes) of zimlet objects in cache.
 ldap_cache_custom_dynamic_group_membership_maxage_ms = Maximum age (in milliseconds) to cache which dynamic groups \
   an account is a member of for those groups whose membership is determind using a custom MemberURL.
+csrf_filter_domain_allowed_ref_hosts_max_size = Maximum number of domain entries in the CsrfFilter per-domain allowedRefererHosts cache. Falls back to ldap_cache_domain_maxsize on parsing error.
+csrf_filter_domain_allowed_ref_hosts_cache_expiry_mins = Maximum age (in minutes) of entries in the CsrfFilter per-domain allowedRefererHosts cache. After expiry, the entry is evicted and reloaded from LDAP on the next request. Falls back to 60 minutes on parsing error.
 mysql_directory = Location of MySQL installation.
 mysql_data_directory = Directory in which MySQL data should reside.
 mysql_errlogfile = MySQL/MariaDB error log.

--- a/store/conf/attrs/zimbra-attrs.xml
+++ b/store/conf/attrs/zimbra-attrs.xml
@@ -8241,7 +8241,7 @@ TODO: delete them permanently from here
 </attr>
 
 <attr id="1630" name="zimbraCsrfAllowedRefererHosts" type="string"
-  cardinality="multi" optionalIn="globalConfig,domain" since="8.5.0">
+  cardinality="multi" optionalIn="globalConfig,domain" since="8.5.0" flags="domainAdminModifiable">
   <desc>A list of hosts like www.abc.com, www.xyz.com. These are used while doing CSRF referer check.</desc>
 </attr>
 

--- a/store/src/java-test/com/zimbra/cs/servlet/CsrfFilterTest.java
+++ b/store/src/java-test/com/zimbra/cs/servlet/CsrfFilterTest.java
@@ -1,0 +1,151 @@
+package com.zimbra.cs.servlet;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import com.google.common.cache.LoadingCache;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+
+/**
+ * Test class for {@link CsrfFilter} domain and global CSRF allowed referer hosts configuration.
+ */
+public class CsrfFilterTest {
+
+    private Provisioning prov;
+
+    private static String[] originalGlobalAllowedHosts;
+
+    private static final String[] SINGLE_HOST = new String[] {"oidc-idp01.example.local" };
+
+    private static final String[] MULTIPLE_HOSTS = new String[] {"idp01.example.local", "idp02.example.local",
+            "idp03.example.local" };
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        MailboxTestUtil.initServer();
+
+        final Provisioning provisioning = Provisioning.getInstance();
+
+        // Preserve original global config to restore after test suite completion
+        originalGlobalAllowedHosts = provisioning.getConfig().getCsrfAllowedRefererHosts();
+
+        final Map<String, Object> singleHostAttr = new HashMap<>();
+        singleHostAttr.put(Provisioning.A_zimbraCsrfAllowedRefererHosts, SINGLE_HOST);
+
+        final Map<String, Object> multipleHostAttr = new HashMap<>();
+        multipleHostAttr.put(Provisioning.A_zimbraCsrfAllowedRefererHosts, MULTIPLE_HOSTS);
+
+        // Setup test domains
+        provisioning.createDomain("example.local", singleHostAttr);
+        provisioning.createDomain("zimbra.com", multipleHostAttr);
+        provisioning.createDomain("empty.example.local", new HashMap<>());
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+        if (originalGlobalAllowedHosts != null) {
+            Provisioning.getInstance().getConfig().setCsrfAllowedRefererHosts(originalGlobalAllowedHosts);
+        }
+    }
+
+    @Before
+    public void setup() throws Exception {
+        prov = Provisioning.getInstance();
+        // Reset global config before each test method for test isolation
+        prov.getConfig().setCsrfAllowedRefererHosts(new String[0]);
+    }
+
+    /**
+     * Test domain-level configuration with a single allowed referer host.
+     */
+    @Test
+    public void testDomainLevelSingleHostConfig() throws Exception {
+        final CsrfFilter filter = new CsrfFilter();
+        filter.init(null);
+
+        final Set<String> expected = new HashSet<>(Arrays.asList(SINGLE_HOST));
+        final Set<String> actual = getDomainAllowedHosts(filter, "example.local");
+
+        Assert.assertEquals(expected, actual);
+    }
+
+    /**
+     * Test domain-level configuration with multiple allowed referer hosts.
+     */
+    @Test
+    public void testDomainLevelMultipleHostsConfig() throws Exception {
+        final CsrfFilter filter = new CsrfFilter();
+        filter.init(null);
+
+        final Set<String> expected = new HashSet<>(Arrays.asList(MULTIPLE_HOSTS));
+        final Set<String> actual = getDomainAllowedHosts(filter, "zimbra.com");
+
+        Assert.assertEquals(expected, actual);
+    }
+
+    /**
+     * Test domain-level configuration for a domain with no configured allowed hosts.
+     */
+    @Test
+    public void testDomainLevelEmptyConfig() throws Exception {
+        final CsrfFilter filter = new CsrfFilter();
+        filter.init(null);
+
+        final Set<String> actual = getDomainAllowedHosts(filter, "empty.example.local");
+
+        Assert.assertTrue(actual.isEmpty());
+    }
+
+    /**
+     * Test global-level configuration loading.
+     */
+    @Test
+    public void testGlobalLevelHostConfig() throws Exception {
+        prov.getConfig().setCsrfAllowedRefererHosts(MULTIPLE_HOSTS);
+
+        final CsrfFilter filter = new CsrfFilter();
+        filter.init(null);
+
+        final Set<String> expected = new HashSet<>(Arrays.asList(MULTIPLE_HOSTS));
+        final Set<String> actual = getGlobalAllowedHosts(filter);
+
+        Assert.assertEquals(expected, actual);
+    }
+
+    /**
+     * Test query for a non-existent domain falling back safely to empty set.
+     */
+    @Test
+    public void testNonExistentDomainLookup() throws Exception {
+        final CsrfFilter filter = new CsrfFilter();
+        filter.init(null);
+
+        final Set<String> actualDomain = getDomainAllowedHosts(filter, "nonexist.example.local");
+
+        Assert.assertTrue(actualDomain.isEmpty());
+    }
+
+    @SuppressWarnings("unchecked")
+    private Set<String> getGlobalAllowedHosts(CsrfFilter filter) throws Exception {
+        final Field field = CsrfFilter.class.getDeclaredField("allowedRefHostsSet");
+        field.setAccessible(true);
+        return (Set<String>) field.get(filter);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Set<String> getDomainAllowedHosts(CsrfFilter filter, String virtualHost) throws Exception {
+        final Field field = CsrfFilter.class.getDeclaredField("domainAllowedRefHosts");
+        field.setAccessible(true);
+        final LoadingCache<String, Set<String>> cache = (LoadingCache<String, Set<String>>) field.get(filter);
+        return cache.get(virtualHost);
+    }
+}

--- a/store/src/java-test/com/zimbra/cs/servlet/package-info.java
+++ b/store/src/java-test/com/zimbra/cs/servlet/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Unit tests for servlet-related classes.
+ */
+package com.zimbra.cs.servlet;

--- a/store/src/java-test/com/zimbra/cs/servlet/util/CsrfUtilTest.java
+++ b/store/src/java-test/com/zimbra/cs/servlet/util/CsrfUtilTest.java
@@ -23,10 +23,14 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 
 import javax.servlet.http.HttpServletRequest;
@@ -394,4 +398,164 @@ public class CsrfUtilTest {
         }
     }
 
+    @Test
+    public final void testIsCsrfRequestBasedOnReferrerWithSetsRefererInGlobalSet() {
+        Set<String> globalHosts = new HashSet<>(Arrays.asList("www.trusted.com"));
+        Set<String> domainHosts = Collections.emptySet();
+
+        HttpServletRequest request = EasyMock.createMock(HttpServletRequest.class);
+        EasyMock.expect(request.getHeader(HttpHeaders.HOST)).andReturn("example.com");
+        EasyMock.expect(request.getServerName()).andReturn("example.com");
+        EasyMock.expect(request.getHeader("X-Forwarded-Host")).andReturn(null);
+        EasyMock.expect(request.getHeader(HttpHeaders.REFERER)).andReturn("http://www.trusted.com/page");
+        EasyMock.expect(request.getMethod()).andReturn("POST");
+
+        try {
+            EasyMock.replay(request);
+            boolean csrfReq = CsrfUtil.isCsrfRequestBasedOnReferrer(request, globalHosts, domainHosts);
+            assertEquals(false, csrfReq);
+        } catch (IOException e) {
+            fail("Should not throw exception.");
+        }
+    }
+
+    @Test
+    public final void testIsCsrfRequestBasedOnReferrerWithSetsRefererInDomainSet() {
+        Set<String> globalHosts = Collections.emptySet();
+        Set<String> domainHosts = new HashSet<>(Arrays.asList("www.domaintrusted.com"));
+
+        HttpServletRequest request = EasyMock.createMock(HttpServletRequest.class);
+        EasyMock.expect(request.getHeader(HttpHeaders.HOST)).andReturn("example.com");
+        EasyMock.expect(request.getServerName()).andReturn("example.com");
+        EasyMock.expect(request.getHeader("X-Forwarded-Host")).andReturn(null);
+        EasyMock.expect(request.getHeader(HttpHeaders.REFERER)).andReturn("http://www.domaintrusted.com/page");
+        EasyMock.expect(request.getMethod()).andReturn("POST");
+
+        try {
+            EasyMock.replay(request);
+            boolean csrfReq = CsrfUtil.isCsrfRequestBasedOnReferrer(request, globalHosts, domainHosts);
+            assertEquals(false, csrfReq);
+        } catch (IOException e) {
+            fail("Should not throw exception.");
+        }
+    }
+
+    @Test
+    public final void testIsCsrfRequestBasedOnReferrerWithSetsRefererInNeitherSet() {
+        Set<String> globalHosts = new HashSet<>(Arrays.asList("www.trusted.com"));
+        Set<String> domainHosts = new HashSet<>(Arrays.asList("www.domaintrusted.com"));
+
+        HttpServletRequest request = EasyMock.createMock(HttpServletRequest.class);
+        EasyMock.expect(request.getHeader(HttpHeaders.HOST)).andReturn("example.com");
+        EasyMock.expect(request.getServerName()).andReturn("example.com");
+        EasyMock.expect(request.getHeader("X-Forwarded-Host")).andReturn(null);
+        EasyMock.expect(request.getHeader(HttpHeaders.REFERER)).andReturn("http://www.malicious.com/attack");
+        EasyMock.expect(request.getMethod()).andReturn("POST");
+
+        try {
+            EasyMock.replay(request);
+            boolean csrfReq = CsrfUtil.isCsrfRequestBasedOnReferrer(request, globalHosts, domainHosts);
+            assertEquals(true, csrfReq);
+        } catch (IOException e) {
+            fail("Should not throw exception.");
+        }
+    }
+
+    @Test
+    public final void testIsCsrfRequestBasedOnReferrerWithSetsNonPostRequest() {
+        Set<String> globalHosts = Collections.emptySet();
+        Set<String> domainHosts = Collections.emptySet();
+
+        HttpServletRequest request = EasyMock.createMock(HttpServletRequest.class);
+        EasyMock.expect(request.getMethod()).andReturn("GET");
+
+        try {
+            EasyMock.replay(request);
+            boolean csrfReq = CsrfUtil.isCsrfRequestBasedOnReferrer(request, globalHosts, domainHosts);
+            assertEquals(false, csrfReq);
+        } catch (IOException e) {
+            fail("Should not throw exception.");
+        }
+    }
+
+    @Test
+    public final void testIsCsrfRequestBasedOnReferrerWithSetsNullReferer() {
+        Set<String> globalHosts = new HashSet<>(Arrays.asList("www.trusted.com"));
+        Set<String> domainHosts = Collections.emptySet();
+
+        HttpServletRequest request = EasyMock.createMock(HttpServletRequest.class);
+        EasyMock.expect(request.getHeader(HttpHeaders.HOST)).andReturn("example.com");
+        EasyMock.expect(request.getServerName()).andReturn("example.com");
+        EasyMock.expect(request.getServerName()).andReturn("example.com");
+        EasyMock.expect(request.getHeader("X-Forwarded-Host")).andReturn(null);
+        EasyMock.expect(request.getMethod()).andReturn("POST");
+        EasyMock.expect(request.getHeader(HttpHeaders.REFERER)).andReturn(null);
+
+        try {
+            EasyMock.replay(request);
+            boolean csrfReq = CsrfUtil.isCsrfRequestBasedOnReferrer(request, globalHosts, domainHosts);
+            assertEquals(false, csrfReq);
+        } catch (IOException e) {
+            fail("Should not throw exception.");
+        }
+    }
+
+    @Test
+    public final void testIsCsrfRequestBasedOnReferrerWithSetsSameHost() {
+        Set<String> globalHosts = Collections.emptySet();
+        Set<String> domainHosts = Collections.emptySet();
+
+        HttpServletRequest request = EasyMock.createMock(HttpServletRequest.class);
+        EasyMock.expect(request.getHeader(HttpHeaders.HOST)).andReturn("www.example.com");
+        EasyMock.expect(request.getServerName()).andReturn("www.example.com");
+        EasyMock.expect(request.getHeader("X-Forwarded-Host")).andReturn(null);
+        EasyMock.expect(request.getHeader(HttpHeaders.REFERER)).andReturn("http://www.example.com/page");
+        EasyMock.expect(request.getMethod()).andReturn("POST");
+
+        try {
+            EasyMock.replay(request);
+            boolean csrfReq = CsrfUtil.isCsrfRequestBasedOnReferrer(request, globalHosts, domainHosts);
+            assertEquals(false, csrfReq);
+        } catch (IOException e) {
+            fail("Should not throw exception.");
+        }
+    }
+
+    @Test
+    public final void testIsCsrfRequestBasedOnReferrerWithSetsBothSetsEmptyNonMatchingHost() {
+        Set<String> globalHosts = Collections.emptySet();
+        Set<String> domainHosts = Collections.emptySet();
+
+        HttpServletRequest request = EasyMock.createMock(HttpServletRequest.class);
+        EasyMock.expect(request.getHeader(HttpHeaders.HOST)).andReturn("example.com");
+        EasyMock.expect(request.getServerName()).andReturn("example.com");
+        EasyMock.expect(request.getHeader("X-Forwarded-Host")).andReturn(null);
+        EasyMock.expect(request.getHeader(HttpHeaders.REFERER)).andReturn("http://www.attacker.com");
+        EasyMock.expect(request.getMethod()).andReturn("POST");
+
+        try {
+            EasyMock.replay(request);
+            boolean csrfReq = CsrfUtil.isCsrfRequestBasedOnReferrer(request, globalHosts, domainHosts);
+            assertEquals(true, csrfReq);
+        } catch (IOException e) {
+            fail("Should not throw exception.");
+        }
+    }
+
+    @Test
+    public final void testIsCsrfRequestBasedOnReferrerWithSetsXForwardedHost() {
+        Set<String> globalHosts = Collections.emptySet();
+        Set<String> domainHosts = Collections.emptySet();
+        HttpServletRequest request = EasyMock.createMock(HttpServletRequest.class);
+        EasyMock.expect(request.getHeader("X-Forwarded-Host")).andReturn("mail.zimbra.com");
+        EasyMock.expect(request.getHeader(HttpHeaders.REFERER)).andReturn("https://mail.zimbra.com/zimbra/");
+        EasyMock.expect(request.getMethod()).andReturn("POST");
+        try {
+            EasyMock.replay(request);
+            boolean csrfReq = CsrfUtil.isCsrfRequestBasedOnReferrer(request, globalHosts, domainHosts);
+            assertEquals(false, csrfReq);
+        } catch (IOException e) {
+            fail("Should not throw exception.");
+        }
+    }
 }

--- a/store/src/java/com/zimbra/cs/servlet/CsrfFilter.java
+++ b/store/src/java/com/zimbra/cs/servlet/CsrfFilter.java
@@ -20,9 +20,14 @@ package com.zimbra.cs.servlet;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -34,12 +39,17 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import com.google.common.base.Joiner;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.google.common.net.HttpHeaders;
+import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.AuthToken;
 import com.zimbra.cs.account.CsrfTokenKey;
+import com.zimbra.cs.account.Domain;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.servlet.util.CsrfUtil;
 import com.zimbra.soap.RequestContext;
@@ -54,11 +64,37 @@ public class CsrfFilter implements Filter {
      *
      */
     public static final String CSRF_SALT = "CSRF_SALT";
-    private String[] allowedRefHosts = null;
+
+    /**
+     * Global CSRF allowed referer hosts built once at init() as an immutable Set
+     * for O(1) contains() lookups on every request.
+     * volatile ensures safe publication if a future config-reload path
+     * reassigns the reference from another thread.
+     */
+    private volatile Set<String> allowedRefHostsSet = Collections.emptySet();
+
+    /** Kept for debug logging only; no functional use on the hot path. */
+    private String[] allowedRefHostsRaw = null;
+
+    /**
+     * Per-domain CSRF allowed referer hosts cache.
+     * Stores {@code Set<String>} (not {@code String[]}) so that domain-level lookups are O(1) contains()
+     * with no per-request merge or array allocation.
+     */
+    private LoadingCache<String, Set<String>> domainAllowedRefHosts = null;
+
     public static final String AUTH_TOKEN = "AuthToken";
+
     public static final String CSRF_TOKEN_CHECK = "CsrfTokenCheck";
+
     protected int maxCsrfTokenValidityInMs;
+
     private Random nonceGen = null;
+
+    /** Sentinel: domain has no configured hosts; cached to avoid repeated LDAP misses. */
+    private static final Set<String> EMPTY_SET = Collections.emptySet();
+
+    private static final int DEFAULT_DOMAIN_CACHE_EXPIRY_MINS = 60;
 
     /*
      * (non-Javadoc)
@@ -70,18 +106,20 @@ public class CsrfFilter implements Filter {
         // Initialize the parameters related to CSRF check
         Provisioning prov = Provisioning.getInstance();
         try {
-            this.allowedRefHosts = prov.getConfig().getCsrfAllowedRefererHosts();
+            // Build Set<String> once at startup — O(n) here, O(1) on every subsequent request.
+            allowedRefHostsRaw = prov.getConfig().getCsrfAllowedRefererHosts();
+            allowedRefHostsSet = buildImmutableSet(allowedRefHostsRaw);
+            this.domainAllowedRefHosts = buildDomainAllowedReferrerHostsCache();
             nonceGen = new Random();
             CsrfTokenKey.getCurrentKey();
             if (ZimbraLog.misc.isInfoEnabled()) {
                 ZimbraLog.misc.info("CSRF filter was initialized: "
-                        + "CSRFAllowedRefHost: [" + Joiner.on(", ").join(this.allowedRefHosts) + "]");
+                        + "CSRFAllowedRefHost: [" + Joiner.on(", ").join(allowedRefHostsSet) + "]");
             }
         } catch (ServiceException e) {
             throw new ServletException("Error initializing CSRF filter: "
-                + e.getMessage(), e);
+                    + e.getMessage(), e);
         }
-
     }
 
     /*
@@ -91,9 +129,7 @@ public class CsrfFilter implements Filter {
      */
     @Override
     public void destroy() {
-
         ZimbraLog.filter.info("Destroying CSRF filter.");
-
     }
 
     /*
@@ -104,7 +140,7 @@ public class CsrfFilter implements Filter {
      */
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
-        throws IOException, ServletException {
+            throws IOException, ServletException {
         ZimbraLog.clearContext();
 
         HttpServletRequest req = (HttpServletRequest) request;
@@ -112,7 +148,7 @@ public class CsrfFilter implements Filter {
         req.setAttribute(CSRF_SALT, nonceGen.nextInt() + 1);
 
         if (ZimbraLog.misc.isDebugEnabled()) {
-             ZimbraLog.misc.debug("CSRF Request URI: " + req.getRequestURI());
+            ZimbraLog.misc.debug("CSRF Request URI: " + req.getRequestURI());
         }
 
         boolean csrfCheckEnabled = Boolean.FALSE;
@@ -126,11 +162,13 @@ public class CsrfFilter implements Filter {
         }
 
         if (ZimbraLog.misc.isDebugEnabled()) {
-            ZimbraLog.misc.debug("CSRF filter was initialized : "
-            + "CSRFcheck enabled: " +  csrfCheckEnabled
-            + "CSRF referer check enabled: " +  csrfRefererCheckEnabled
-            + ", CSRFAllowedRefHost: [" +  Joiner.on(", ").join(this.allowedRefHosts) + "]"
-            + ", CSRFTokenValidity " +  this.maxCsrfTokenValidityInMs + "ms.");
+            ZimbraLog.misc.debug(
+                    "CSRF filter was initialized : " + "CSRFcheck enabled: " +
+                            csrfCheckEnabled + "CSRF referer check enabled: " +
+                            csrfRefererCheckEnabled + ", CSRFAllowedRefHost: [" +
+                            Joiner.on(", ").join(allowedRefHostsSet) + "]"
+                            + ", CSRFTokenValidity " + this.maxCsrfTokenValidityInMs +
+                            "ms." + " (domain-level overrides, if any, are logged per-request)");
         }
 
         if (ZimbraLog.misc.isTraceEnabled()) {
@@ -145,18 +183,19 @@ public class CsrfFilter implements Filter {
             }
         }
 
+        // host resolved once here; passed to referer check and DefangFilter.
+        String host = CsrfUtil.getRequestHost(req);
         if (csrfRefererCheckEnabled) {
-            if (!allowReqBasedOnRefererHeaderCheck(req)) {
+            if (!allowReqBasedOnRefererHeaderCheck(req, host)) {
                 ZimbraLog.misc.info("CSRF referer check failed");
                 resp.sendError(HttpServletResponse.SC_FORBIDDEN);
                 return;
             }
         }
 
-        // We need virtual host information in DefangFilter
-        // Set them in ThreadLocal here
+        // we need virtual host information in DefangFilter
+        // set them in ThreadLocal here
         RequestContext reqCtxt = new RequestContext();
-        String host = CsrfUtil.getRequestHost(req);
         reqCtxt.setVirtualHost(host);
         ZThreadLocal.setContext(reqCtxt);
         if (!csrfCheckEnabled) {
@@ -175,7 +214,6 @@ public class CsrfFilter implements Filter {
             chain.doFilter(req, resp);
         }
         ZThreadLocal.unset();
-
     }
 
     /**
@@ -194,11 +232,32 @@ public class CsrfFilter implements Filter {
         return urls;
     }
 
-
-    private boolean allowReqBasedOnRefererHeaderCheck(HttpServletRequest req) {
-
+    /**
+     * Returns true if the request should be allowed based on its Referer header;
+     * false if the request should be denied (CSRF).
+     * Performs two independent O(1) Set.contains() checks — first against the
+     * global allowed hosts set, then against the domain-level set from cache.
+     * No array merge or Stream allocation occurs on the hot path.
+     * Fail-closed guarantee: if the domain cache lookup throws, the method falls
+     * back to the global set only — it never silently allows all traffic.
+     *
+     * @param req         the current HTTP request
+     * @param virtualHost the pre-resolved virtual host from CsrfUtil.getRequestHost()
+     * @return true to allow; false to deny with 403
+     */
+    private boolean allowReqBasedOnRefererHeaderCheck(HttpServletRequest req, String virtualHost) {
         try {
-            if (CsrfUtil.isCsrfRequestBasedOnReferrer(req, allowedRefHosts)) {
+            Set<String> domainHosts = EMPTY_SET;
+            if (!StringUtil.isNullOrEmpty(virtualHost)) {
+                try {
+                    domainHosts = domainAllowedRefHosts.get(virtualHost);
+                } catch (ExecutionException e) {
+                    ZimbraLog.misc.warn(
+                            "CSRF: domain cache lookup failed for virtualHost=%s, "
+                                    + "falling back to global-only check.", virtualHost, e);
+                }
+            }
+            if (CsrfUtil.isCsrfRequestBasedOnReferrer(req, allowedRefHostsSet, domainHosts)) {
                 return false;
             }
         } catch (MalformedURLException e) {
@@ -206,7 +265,101 @@ public class CsrfFilter implements Filter {
             return false;
         }
         return true;
+    }
 
+    /**
+     * Builds the cache for domain level zimbraCsrfAllowedRefererHosts.
+     * Max cache size is configurable by LC.csrf_filter_domain_allowed_ref_hosts_max_size.
+     * Cache entries expire after LC.csrf_filter_domain_allowed_ref_hosts_cache_expiry_mins minutes.
+     *
+     * The cache now stores {@code Set<String>} instead of {@code String[]} so that domain-level
+     * lookups are O(1) contains() with no per-request merge or array allocation.
+     * On LDAP miss or domain-not-found, EMPTY_SET is cached to prevent repeated lookups.
+     *
+     * @return LoadingCache for each accessed domain's zimbraCsrfAllowedRefererHosts as a Set
+     **/
+    protected LoadingCache<String, Set<String>> buildDomainAllowedReferrerHostsCache() {
+        int maxCacheSize;
+        try {
+            maxCacheSize = LC.csrf_filter_domain_allowed_ref_hosts_max_size.intValue();
+        } catch (NumberFormatException e) {
+            ZimbraLog.misc.warn("Failed to determine CsrfFilter.domainAllowedRefHosts cache max size from" +
+                    "LC.csrf_filter_domain_allowed_ref_hosts_max_size value, " +
+                    "falling back to LC.ldap_cache_domain_maxsize", e);
+            maxCacheSize = LC.ldap_cache_domain_maxsize.intValue();
+        }
+        int expiryMins;
+        try {
+            expiryMins = LC.csrf_filter_domain_allowed_ref_hosts_cache_expiry_mins.intValue();
+            if (expiryMins <= 0) {
+                ZimbraLog.misc.warn("CsrfFilter.domainAllowedRefHosts cache expiry must be > 0," +
+                        " falling back to " + DEFAULT_DOMAIN_CACHE_EXPIRY_MINS + " minutes");
+                expiryMins = DEFAULT_DOMAIN_CACHE_EXPIRY_MINS;
+            }
+        } catch (NumberFormatException e) {
+            ZimbraLog.misc.warn("Failed to determine CsrfFilter.domainAllowedRefHosts cache expiry from "
+                    + "LC.csrf_filter_domain_allowed_ref_hosts_cache_expiry_mins, falling back to  "
+                    + DEFAULT_DOMAIN_CACHE_EXPIRY_MINS + " minutes", e);
+            expiryMins = DEFAULT_DOMAIN_CACHE_EXPIRY_MINS;
+        }
+
+        return CacheBuilder.newBuilder()
+                .maximumSize(maxCacheSize)
+                .expireAfterWrite(expiryMins, TimeUnit.MINUTES)
+                .build(new CacheLoader<String, Set<String>>() {
+                    // lazy load each domain's zimbraCsrfAllowedRefererHosts as an immutable Set
+                    @Override
+                    public Set<String> load(String virtualHost) throws Exception {
+                        try {
+                            Provisioning prov = Provisioning.getInstance();
+                            Domain domain = prov.getDomainByVirtualHostname(virtualHost);
+                            if (domain == null) {
+                                domain = prov.getDomainByName(virtualHost);
+                            }
+                            if (domain != null) { // null if no vhost set and name isn't a domain
+                                String[] domainHosts = domain.getCsrfAllowedRefererHosts();
+                                if (domainHosts != null && domainHosts.length > 0) {
+                                    Set<String> result = buildImmutableSet(domainHosts);
+                                    ZimbraLog.misc.debug(
+                                            "CSRF: additionally using domain-level allowedRefererHosts for "
+                                                    + "virtualHost=%s, hosts=[%s]", virtualHost,
+                                            Joiner.on(", ").join(result));
+                                    return result;
+                                }
+                            }
+                        } catch (ServiceException e) {
+                            ZimbraLog.misc.warn(
+                                    "CSRF: failed to resolve domain-level allowedRefererHosts for "
+                                            + "virtualHost=%s, falling back to globalConfig.",
+                                    virtualHost, e);
+                        }
+                        // always cache the absence to prevent subsequent LDAP misses for this virtual host
+                        return EMPTY_SET;
+                    }
+                });
+    }
+
+    /**
+     * Builds an unmodifiable Set from a String[] array.
+     *
+     * Called at init() for the global list and inside the cache loader for each domain.
+     * The resulting sets are the foundation of the O(1) lookup path, replacing the
+     * per-request Stream merge and linear array scan from the previous implementation.
+     *
+     * @param hosts source array (may be null or empty)
+     * @return unmodifiable Set; never null
+     */
+    private static Set<String> buildImmutableSet(String[] hosts) {
+        if (hosts == null || hosts.length == 0) {
+            return Collections.emptySet();
+        }
+        Set<String> set = new HashSet<>((int) (hosts.length / 0.75f) + 1);
+        for (String h : hosts) {
+            if (!StringUtil.isNullOrEmpty(h)) {
+                set.add(h);
+            }
+        }
+        return Collections.unmodifiableSet(set);
     }
 
 }

--- a/store/src/java/com/zimbra/cs/servlet/util/CsrfUtil.java
+++ b/store/src/java/com/zimbra/cs/servlet/util/CsrfUtil.java
@@ -23,6 +23,7 @@ import java.security.InvalidAlgorithmParameterException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -77,6 +78,28 @@ public final class CsrfUtil {
 
     }
 
+    /**
+     * Extracts and normalizes the host from the Referer header of the request.
+     * Handles both absolute URLs (with http/https) and bare hostnames.
+     *
+     * @param req the current HTTP request
+     * @return lowercase host from the Referer header, or null if Referer is absent
+     * @throws MalformedURLException if the Referer header contains an invalid URL
+     */
+    private static String extractRefererHost(HttpServletRequest req) throws MalformedURLException {
+        String referrer = req.getHeader(HttpHeaders.REFERER);
+        if (StringUtil.isNullOrEmpty(referrer)) {
+            return null;
+        }
+        URL refURL;
+        if (referrer.contains("http") || referrer.contains("https")) {
+            refURL = new URL(referrer);
+        } else {
+            refURL = new URL("http://" + referrer);
+        }
+        return refURL.getHost().toLowerCase();
+    }
+
    /**
     *
     * @param req
@@ -97,19 +120,7 @@ public final class CsrfUtil {
        }
 
        String host = getRequestHost(req);
-       String referrer = req.getHeader(HttpHeaders.REFERER);
-       String refHost = null;
-
-
-       if (!StringUtil.isNullOrEmpty(referrer)) {
-           URL refURL = null;
-           if (referrer.contains("http") || referrer.contains("https")) {
-               refURL = new URL(referrer);
-           } else {
-               refURL = new URL("http://" + referrer);
-           }
-           refHost = refURL.getHost().toLowerCase();
-       }
+        String refHost = extractRefererHost(req);
 
        if (refHost == null) {
            csrfReq = false;
@@ -129,7 +140,57 @@ public final class CsrfUtil {
        }
 
        return csrfReq;
-   }
+    }
+
+    /**
+     * Overload of {@link #isCsrfRequestBasedOnReferrer(HttpServletRequest, String[])} that accepts pre-built Sets for
+     * O(1) lookups. Used by CsrfFilter to avoid per-request array merge.
+     *
+     * @param req
+     *         the current HTTP request
+     * @param globalAllowedRefHosts
+     *         global CSRF allowed referer hosts from global config
+     * @param domainAllowedRefHosts
+     *         domain-level CSRF allowed referer hosts from domain config
+     * @return true if the request is a CSRF request based on the Referer header, false otherwise
+     * @throws MalformedURLException
+     *         if the Referer header contains an invalid URL
+     */
+    public static boolean isCsrfRequestBasedOnReferrer(final HttpServletRequest req,
+            final Set<String> globalAllowedRefHosts, final Set<String> domainAllowedRefHosts)
+            throws MalformedURLException {
+
+        boolean csrfReq = false;
+
+        String method = req.getMethod();
+        if (!method.equalsIgnoreCase("POST")) {
+            csrfReq = false;
+            return csrfReq;
+        }
+
+        String host = getRequestHost(req);
+        String refHost = extractRefererHost(req);
+
+        if (refHost == null) {
+            csrfReq = false;
+        } else if (refHost.equalsIgnoreCase(host)) {
+            csrfReq = false;
+        } else {
+            if (globalAllowedRefHosts.contains(refHost) || domainAllowedRefHosts.contains(refHost)) {
+                csrfReq = false;
+            } else {
+                csrfReq = true;
+            }
+        }
+
+        if (ZimbraLog.soap.isDebugEnabled()) {
+            ZimbraLog.soap.debug("Host : %s, Referrer host :%s, Allowed Hosts:[global=%s, domain=%s] Soap req is %s",
+                    host, refHost, Joiner.on(',').join(globalAllowedRefHosts),
+                    Joiner.on(',').join(domainAllowedRefHosts), (csrfReq ? " not allowed." : " allowed."));
+        }
+
+        return csrfReq;
+    }
 
    /**
    *


### PR DESCRIPTION
**Problem**:
zimbraCsrfAllowedRefererHosts lacked domain-level flags, causing domain config to be ignored.
**Solution**:
Added missing flags in attrs.xml
Updated CsrfFilter to resolve config per-domain at runtime



